### PR TITLE
Allow using `T.type_parameter` in `T.let`

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1646,9 +1646,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                     // variable came from some other source (e.g. a function argument)
                                     auto suggest =
                                         core::Types::any(ctx, dropConstructor(ctx, tp.origins[0], tp.type), cur.type);
-                                    e.replaceWith(fmt::format("Initialize as `{}`", suggest.show(ctx)), cur.origins[0],
-                                                  "T.let({}, {})", cur.origins[0].source(ctx).value(),
-                                                  suggest.show(ctx));
+                                    auto replacement = suggest.show(ctx, core::ShowOptions().withShowForRBI());
+                                    e.replaceWith(fmt::format("Initialize as `{}`", replacement), cur.origins[0],
+                                                  "T.let({}, {})", cur.origins[0].source(ctx).value(), replacement);
                                 } else {
                                     e.addErrorSection(core::ErrorSection("Original type from:",
                                                                          cur.origins2Explanations(ctx, ownerLoc)));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3684,7 +3684,7 @@ public:
 };
 
 template <typename StateType>
-ast::ParsedFilesOrCancelled resolveSigs(StateType &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
+vector<ast::ParsedFile> resolveSigs(StateType &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
     static_assert(std::is_same_v<remove_const_t<StateType>, core::GlobalState>);
     constexpr bool isConstStateType = std::is_const_v<StateType>;
 
@@ -3798,10 +3798,7 @@ ast::ParsedFilesOrCancelled runIncrementalImpl(StateType &gs, vector<ast::Parsed
     verifyLinearizationComputed(gs);
     trees = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), *workers);
     auto result = resolveSigs(gs, std::move(trees), *workers);
-    if (!result.hasResult()) {
-        return result;
-    }
-    sanityCheck(gs, result.result());
+    sanityCheck(gs, result);
     // This check is FAR too slow to run on large codebases, especially with sanitizers on.
     // But it can be super useful to uncomment when debugging certain issues.
     // ctx.state.sanityCheck();
@@ -3831,10 +3828,7 @@ ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::Par
     }
 
     auto result = resolveSigs(gs, std::move(trees), workers);
-    if (!result.hasResult()) {
-        return result;
-    }
-    sanityCheck(gs, result.result());
+    sanityCheck(gs, result);
 
     return result;
 }

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -807,8 +807,9 @@ core::TypePtr getResultTypeWithSelfTypeParams(core::Context ctx, const ast::Expr
     return getResultTypeAndBindWithSelfTypeParams(ctx, expr, sigBeingParsed, args.withoutRebind()).type;
 }
 
-TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx, const ast::ExpressionPtr &expr,
-                                                              const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
+TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParamsImpl(core::Context ctx, const ast::ExpressionPtr &expr,
+                                                                  const ParsedSig &sigBeingParsed,
+                                                                  TypeSyntaxArgs args) {
     // Ensure that we only check types from a class context
     ENFORCE(ctx.owner.isClassOrModule(), "getResultTypeAndBind wasn't called with a class owner");
     auto ctxOwnerData = ctx.owner.asClassOrModuleRef().data(ctx);
@@ -1206,10 +1207,17 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             }
             result.type = core::Types::untypedUntracked();
         });
-    ENFORCE(result.type != nullptr);
-    result.type.sanityCheck(ctx);
     return result;
 }
+
+TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx, const ast::ExpressionPtr &expr,
+                                                              const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
+    auto result = getResultTypeAndBindWithSelfTypeParamsImpl(ctx, expr, sigBeingParsed, args);
+    ENFORCE(result.type != nullptr);
+    DEBUG_ONLY(result.type.sanityCheck(ctx));
+    return result;
+}
+
 } // namespace
 
 ParsedSig::TypeArgSpec &ParsedSig::enterTypeArgByName(core::NameRef name) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -815,402 +815,393 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParamsImpl(core::Context 
     auto ctxOwnerData = ctx.owner.asClassOrModuleRef().data(ctx);
 
     TypeSyntax::ResultType result;
-        if (ast::isa_tree<ast::Array>(expr)) {
-            const auto &arr = ast::cast_tree_nonnull<ast::Array>(expr);
-            vector<core::TypePtr> elems;
-            for (auto &el : arr.elems) {
-                elems.emplace_back(getResultTypeWithSelfTypeParams(ctx, el, sigBeingParsed, args.withoutSelfType()));
-            }
-            result.type = core::make_type<core::TupleType>(move(elems));
+    if (ast::isa_tree<ast::Array>(expr)) {
+        const auto &arr = ast::cast_tree_nonnull<ast::Array>(expr);
+        vector<core::TypePtr> elems;
+        for (auto &el : arr.elems) {
+            elems.emplace_back(getResultTypeWithSelfTypeParams(ctx, el, sigBeingParsed, args.withoutSelfType()));
         }
-        else if (ast::isa_tree<ast::Hash>(expr)) {
-            const auto &hash = ast::cast_tree_nonnull<ast::Hash>(expr);
-            vector<core::TypePtr> keys;
-            vector<core::TypePtr> values;
+        result.type = core::make_type<core::TupleType>(move(elems));
+    } else if (ast::isa_tree<ast::Hash>(expr)) {
+        const auto &hash = ast::cast_tree_nonnull<ast::Hash>(expr);
+        vector<core::TypePtr> keys;
+        vector<core::TypePtr> values;
 
-            for (auto &ktree : hash.keys) {
-                auto &vtree = hash.values[&ktree - &hash.keys.front()];
-                auto val = getResultTypeWithSelfTypeParams(ctx, vtree, sigBeingParsed, args.withoutSelfType());
-                auto lit = ast::cast_tree<ast::Literal>(ktree);
-                if (lit && (lit->isSymbol() || lit->isString())) {
-                    ENFORCE(core::isa_type<core::NamedLiteralType>(lit->value));
-                    keys.emplace_back(lit->value);
-                    values.emplace_back(val);
-                } else {
-                    if (auto e = ctx.beginError(ktree.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
-                        e.setHeader("Malformed type declaration. Shape keys must be literals");
-                    }
+        for (auto &ktree : hash.keys) {
+            auto &vtree = hash.values[&ktree - &hash.keys.front()];
+            auto val = getResultTypeWithSelfTypeParams(ctx, vtree, sigBeingParsed, args.withoutSelfType());
+            auto lit = ast::cast_tree<ast::Literal>(ktree);
+            if (lit && (lit->isSymbol() || lit->isString())) {
+                ENFORCE(core::isa_type<core::NamedLiteralType>(lit->value));
+                keys.emplace_back(lit->value);
+                values.emplace_back(val);
+            } else {
+                if (auto e = ctx.beginError(ktree.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
+                    e.setHeader("Malformed type declaration. Shape keys must be literals");
                 }
             }
-            result.type = core::make_type<core::ShapeType>(move(keys), move(values));
         }
-        else if (ast::isa_tree<ast::ConstantLit>(expr)) {
-            const auto &i = ast::cast_tree_nonnull<ast::ConstantLit>(expr);
-            auto maybeAliased = i.symbol;
-            ENFORCE(maybeAliased.exists());
+        result.type = core::make_type<core::ShapeType>(move(keys), move(values));
+    } else if (ast::isa_tree<ast::ConstantLit>(expr)) {
+        const auto &i = ast::cast_tree_nonnull<ast::ConstantLit>(expr);
+        auto maybeAliased = i.symbol;
+        ENFORCE(maybeAliased.exists());
 
-            if (maybeAliased.isTypeAlias(ctx)) {
+        if (maybeAliased.isTypeAlias(ctx)) {
+            result.type = maybeAliased.resultType(ctx);
+            return result;
+        }
+
+        // Only T::Enum singletons are allowed to be in type syntax because there is only one
+        // non-alias constant for an instance of a particular T::Enum--it was created with
+        // `new` and immediately assigned into a constant. Any further ConstantLits of this enum's
+        // type must be either class aliases (banned in type syntax) or type aliases.
+        //
+        // This is not the case for arbitrary singletons: MySingleton.instance can be called as many
+        // times as wanted, and assigned into different constants each time. As much as possible, we
+        // want there to be one name for every type; making an alias for a type should always be
+        // syntactically declared with T.type_alias.
+        if (core::isa_type<core::ClassType>(maybeAliased.resultType(ctx))) {
+            auto resultType = core::cast_type_nonnull<core::ClassType>(maybeAliased.resultType(ctx));
+            if (resultType.symbol.data(ctx)->derivesFrom(ctx, core::Symbols::T_Enum())) {
                 result.type = maybeAliased.resultType(ctx);
                 return result;
             }
-
-            // Only T::Enum singletons are allowed to be in type syntax because there is only one
-            // non-alias constant for an instance of a particular T::Enum--it was created with
-            // `new` and immediately assigned into a constant. Any further ConstantLits of this enum's
-            // type must be either class aliases (banned in type syntax) or type aliases.
-            //
-            // This is not the case for arbitrary singletons: MySingleton.instance can be called as many
-            // times as wanted, and assigned into different constants each time. As much as possible, we
-            // want there to be one name for every type; making an alias for a type should always be
-            // syntactically declared with T.type_alias.
-            if (core::isa_type<core::ClassType>(maybeAliased.resultType(ctx))) {
-                auto resultType = core::cast_type_nonnull<core::ClassType>(maybeAliased.resultType(ctx));
-                if (resultType.symbol.data(ctx)->derivesFrom(ctx, core::Symbols::T_Enum())) {
-                    result.type = maybeAliased.resultType(ctx);
-                    return result;
-                }
-            }
-
-            auto sym = maybeAliased.dealias(ctx);
-            if (sym.isClassOrModule()) {
-                auto klass = sym.asClassOrModuleRef();
-                // the T::Type generics internally have a typeArity of 0, so this allows us to check against them in the
-                // same way that we check against types like `Array`
-                if (klass.isBuiltinGenericForwarder() || klass.data(ctx)->typeArity(ctx) > 0) {
-                    auto level = klass.isLegacyStdlibGeneric()
-                                     ? core::errors::Resolver::GenericClassWithoutTypeArgsStdlib
-                                     : core::errors::Resolver::GenericClassWithoutTypeArgs;
-                    if (auto e = ctx.beginError(i.loc, level)) {
-                        e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",
-                                    klass.show(ctx));
-                        core::TypeErrorDiagnostics::insertUntypedTypeArguments(ctx, e, klass, ctx.locAt(i.loc));
-                    }
-                }
-                if (klass == core::Symbols::StubModule()) {
-                    // Though for normal types _and_ stub types `infer` should use `externalType`,
-                    // using `externalType` for stub types here will lead to incorrect handling of global state hashing,
-                    // where we won't see difference between two different unresolved stubs(or a mistyped stub). thus,
-                    // while normally we would treat stubs as untyped, in `sig`s we treat them as proper types, so that
-                    // we can correctly hash them.
-                    auto unresolvedPath = i.fullUnresolvedPath(ctx);
-                    ENFORCE(unresolvedPath.has_value());
-                    result.type =
-                        core::make_type<core::UnresolvedClassType>(unresolvedPath->first, move(unresolvedPath->second));
-                } else {
-                    result.type = klass.data(ctx)->externalType();
-                }
-            } else if (sym.isTypeMember()) {
-                auto tm = sym.asTypeMemberRef();
-                auto symData = tm.data(ctx);
-                auto symOwner = symData->owner.asClassOrModuleRef().data(ctx);
-
-                bool isTypeTemplate = symOwner->isSingletonClass(ctx);
-
-                if (args.allowTypeMember) {
-                    bool ctxIsSingleton = ctxOwnerData->isSingletonClass(ctx);
-
-                    // Check if we're processing a type within the class that
-                    // defines this type member by comparing the singleton class of
-                    // the context, and the singleton class of the type member's
-                    // owner.
-                    core::SymbolRef symOwnerSingleton =
-                        isTypeTemplate ? symData->owner : symOwner->lookupSingletonClass(ctx);
-                    core::SymbolRef ctxSingleton = ctxIsSingleton ? ctx.owner : ctxOwnerData->lookupSingletonClass(ctx);
-                    bool usedOnSourceClass = symOwnerSingleton == ctxSingleton;
-
-                    // For this to be a valid use of a member or template type, this
-                    // must:
-                    //
-                    // 1. be used in the context of the class that defines it
-                    // 2. if it's a type_template type, be used in a singleton
-                    //    method
-                    // 3. if it's a type_member type, be used in an instance method
-                    if (usedOnSourceClass &&
-                        ((isTypeTemplate && ctxIsSingleton) || !(isTypeTemplate || ctxIsSingleton))) {
-                        // At this point, we maake a skolemized variable that will be unwrapped at the end of type
-                        // parsing using Types::unwrapSkolemVariables. The justification for this is that type
-                        // constructors like `Types::any` do not expect to see bound variables, and will panic.
-                        result.type = core::make_type<core::SelfTypeParam>(sym);
-                    } else {
-                        if (auto e = ctx.beginError(i.loc, core::errors::Resolver::TypeMemberScopeMismatch)) {
-                            string typeSource = isTypeTemplate ? "type_template" : "type_member";
-                            string typeStr = usedOnSourceClass ? symData->name.show(ctx) : sym.show(ctx);
-
-                            if (usedOnSourceClass) {
-                                // Autocorrects here are awkward, because we want to offer the autocorrect at the
-                                // definition of the type_member or type_template and we only have access to the use of
-                                // the type_member or type_template here.  We could examine the source and attempt to
-                                // identify the location for the autocorrect, but that gets messy.
-                                //
-                                // Plus, it's not absolutely clear that the definition is really at fault: it might be
-                                // that the user is using the wrong type_member/type_template constant for the given
-                                // context, or they need to change the definition of the method this use is associated
-                                // with.  Try to give them enough of a hint to decide what to do on their own.
-                                if (ctxIsSingleton) {
-                                    e.setHeader("`{}` type `{}` used in a singleton method definition", typeSource,
-                                                typeStr);
-                                    e.addErrorLine(symData->loc(), "`{}` defined here", typeStr);
-                                    e.addErrorNote("Only a `{}` can be used in a singleton method definition.",
-                                                   "type_template");
-                                } else {
-                                    e.setHeader("`{}` type `{}` used in an instance method definition", typeSource,
-                                                typeStr);
-                                    e.addErrorLine(symData->loc(), "`{}` defined here", typeStr);
-                                    e.addErrorNote("Only a `{}` can be used in an instance method definition.",
-                                                   "type_member");
-                                }
-                            } else {
-                                e.setHeader("`{}` type `{}` used outside of the class definition", typeSource, typeStr);
-                                e.addErrorLine(symData->loc(), "{} defined here", typeStr);
-                            }
-                        }
-                        result.type = core::Types::untypedUntracked();
-                    }
-                } else {
-                    // a type member has occurred in a context that doesn't allow them
-                    if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                        auto flavor = isTypeTemplate ? "type_template"sv : "type_member"sv;
-                        e.setHeader("`{}` `{}` is not allowed in this context", flavor, sym.show(ctx));
-                    }
-                    result.type = core::Types::untypedUntracked();
-                }
-            } else if (sym.isStaticField(ctx)) {
-                if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                    e.setHeader("Constant `{}` is not a class or type alias", maybeAliased.show(ctx));
-                    e.addErrorLine(sym.loc(ctx), "If you are trying to define a type alias, you should use `{}` here",
-                                   "T.type_alias");
-                }
-                result.type = core::Types::untypedUntracked();
-            } else {
-                if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                    e.setHeader("Malformed type declaration. Not a class type `{}`", maybeAliased.show(ctx));
-                }
-                result.type = core::Types::untypedUntracked();
-            }
         }
-        else if (ast::isa_tree<ast::Send>(expr)) {
-            const auto &s = ast::cast_tree_nonnull<ast::Send>(expr);
-            if (isTProc(ctx, &s)) {
-                auto sig = parseSigWithSelfTypeParams(ctx, s, &sigBeingParsed, args);
-                if (sig.bind.exists()) {
-                    if (!args.allowRebind) {
-                        if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                            e.setHeader("Using `{}` is not permitted here", "bind");
-                        }
-                    } else {
-                        result.rebind = sig.bind;
-                    }
+
+        auto sym = maybeAliased.dealias(ctx);
+        if (sym.isClassOrModule()) {
+            auto klass = sym.asClassOrModuleRef();
+            // the T::Type generics internally have a typeArity of 0, so this allows us to check against them in the
+            // same way that we check against types like `Array`
+            if (klass.isBuiltinGenericForwarder() || klass.data(ctx)->typeArity(ctx) > 0) {
+                auto level = klass.isLegacyStdlibGeneric() ? core::errors::Resolver::GenericClassWithoutTypeArgsStdlib
+                                                           : core::errors::Resolver::GenericClassWithoutTypeArgs;
+                if (auto e = ctx.beginError(i.loc, level)) {
+                    e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",
+                                klass.show(ctx));
+                    core::TypeErrorDiagnostics::insertUntypedTypeArguments(ctx, e, klass, ctx.locAt(i.loc));
                 }
+            }
+            if (klass == core::Symbols::StubModule()) {
+                // Though for normal types _and_ stub types `infer` should use `externalType`,
+                // using `externalType` for stub types here will lead to incorrect handling of global state hashing,
+                // where we won't see difference between two different unresolved stubs(or a mistyped stub). thus,
+                // while normally we would treat stubs as untyped, in `sig`s we treat them as proper types, so that
+                // we can correctly hash them.
+                auto unresolvedPath = i.fullUnresolvedPath(ctx);
+                ENFORCE(unresolvedPath.has_value());
+                result.type =
+                    core::make_type<core::UnresolvedClassType>(unresolvedPath->first, move(unresolvedPath->second));
+            } else {
+                result.type = klass.data(ctx)->externalType();
+            }
+        } else if (sym.isTypeMember()) {
+            auto tm = sym.asTypeMemberRef();
+            auto symData = tm.data(ctx);
+            auto symOwner = symData->owner.asClassOrModuleRef().data(ctx);
 
-                vector<core::TypePtr> targs;
+            bool isTypeTemplate = symOwner->isSingletonClass(ctx);
 
-                if (sig.returns == nullptr) {
-                    if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                        e.setHeader("Malformed T.proc: You must specify a return type");
-                    }
-                    targs.emplace_back(core::Types::untypedUntracked());
+            if (args.allowTypeMember) {
+                bool ctxIsSingleton = ctxOwnerData->isSingletonClass(ctx);
+
+                // Check if we're processing a type within the class that
+                // defines this type member by comparing the singleton class of
+                // the context, and the singleton class of the type member's
+                // owner.
+                core::SymbolRef symOwnerSingleton =
+                    isTypeTemplate ? symData->owner : symOwner->lookupSingletonClass(ctx);
+                core::SymbolRef ctxSingleton = ctxIsSingleton ? ctx.owner : ctxOwnerData->lookupSingletonClass(ctx);
+                bool usedOnSourceClass = symOwnerSingleton == ctxSingleton;
+
+                // For this to be a valid use of a member or template type, this
+                // must:
+                //
+                // 1. be used in the context of the class that defines it
+                // 2. if it's a type_template type, be used in a singleton
+                //    method
+                // 3. if it's a type_member type, be used in an instance method
+                if (usedOnSourceClass && ((isTypeTemplate && ctxIsSingleton) || !(isTypeTemplate || ctxIsSingleton))) {
+                    // At this point, we maake a skolemized variable that will be unwrapped at the end of type
+                    // parsing using Types::unwrapSkolemVariables. The justification for this is that type
+                    // constructors like `Types::any` do not expect to see bound variables, and will panic.
+                    result.type = core::make_type<core::SelfTypeParam>(sym);
                 } else {
-                    targs.emplace_back(sig.returns);
-                }
+                    if (auto e = ctx.beginError(i.loc, core::errors::Resolver::TypeMemberScopeMismatch)) {
+                        string typeSource = isTypeTemplate ? "type_template" : "type_member";
+                        string typeStr = usedOnSourceClass ? symData->name.show(ctx) : sym.show(ctx);
 
-                for (auto &arg : sig.argTypes) {
-                    targs.emplace_back(arg.type);
-                }
-
-                auto arity = targs.size() - 1;
-                if (arity > core::Symbols::MAX_PROC_ARITY) {
-                    if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                        e.setHeader("Malformed T.proc: Too many arguments (max `{}`)", core::Symbols::MAX_PROC_ARITY);
+                        if (usedOnSourceClass) {
+                            // Autocorrects here are awkward, because we want to offer the autocorrect at the
+                            // definition of the type_member or type_template and we only have access to the use of
+                            // the type_member or type_template here.  We could examine the source and attempt to
+                            // identify the location for the autocorrect, but that gets messy.
+                            //
+                            // Plus, it's not absolutely clear that the definition is really at fault: it might be
+                            // that the user is using the wrong type_member/type_template constant for the given
+                            // context, or they need to change the definition of the method this use is associated
+                            // with.  Try to give them enough of a hint to decide what to do on their own.
+                            if (ctxIsSingleton) {
+                                e.setHeader("`{}` type `{}` used in a singleton method definition", typeSource,
+                                            typeStr);
+                                e.addErrorLine(symData->loc(), "`{}` defined here", typeStr);
+                                e.addErrorNote("Only a `{}` can be used in a singleton method definition.",
+                                               "type_template");
+                            } else {
+                                e.setHeader("`{}` type `{}` used in an instance method definition", typeSource,
+                                            typeStr);
+                                e.addErrorLine(symData->loc(), "`{}` defined here", typeStr);
+                                e.addErrorNote("Only a `{}` can be used in an instance method definition.",
+                                               "type_member");
+                            }
+                        } else {
+                            e.setHeader("`{}` type `{}` used outside of the class definition", typeSource, typeStr);
+                            e.addErrorLine(symData->loc(), "{} defined here", typeStr);
+                        }
                     }
                     result.type = core::Types::untypedUntracked();
-                    return result;
                 }
-                auto sym = core::Symbols::Proc(arity);
-
-                result.type = core::make_type<core::AppliedType>(sym, move(targs));
-                return result;
-            }
-
-            auto *recvi = ast::cast_tree<ast::ConstantLit>(s.recv);
-            if (recvi == nullptr) {
-                if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                    e.setHeader("Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func>");
-                }
-                result.type = core::Types::untypedUntracked();
-                return result;
-            }
-            if (recvi->symbol == core::Symbols::T()) {
-                result = interpretTCombinator(ctx, s, sigBeingParsed, args);
-                return result;
-            }
-
-            if (recvi->symbol == core::Symbols::Magic() && s.fun == core::Names::callWithSplat()) {
-                if (auto e = ctx.beginError(recvi->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                    e.setHeader("Malformed type declaration: splats cannot be used in types");
-                }
-                result.type = core::Types::untypedUntracked();
-                return result;
-            }
-
-            if (s.fun != core::Names::squareBrackets()) {
-                if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                    e.setHeader("Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func>");
-                }
-                result.type = core::Types::untypedUntracked();
-                return result;
-            }
-
-            InlinedVector<core::TypeAndOrigins, 2> holders;
-            InlinedVector<const core::TypeAndOrigins *, 2> targs;
-            InlinedVector<core::LocOffsets, 2> argLocs;
-            const auto argSize = s.numPosArgs() + (2 * s.numKwArgs()) + (s.hasKwSplat() ? 1 : 0);
-            targs.reserve(argSize);
-            argLocs.reserve(argSize);
-            holders.reserve(argSize);
-
-            for (auto &arg : s.posArgs()) {
-                auto type = core::make_type<core::MetaType>(
-                    getResultTypeWithSelfTypeParams(ctx, arg, sigBeingParsed, args.withoutSelfType()));
-                auto &argtao = holders.emplace_back(std::move(type), ctx.locAt(arg.loc()));
-                targs.emplace_back(&argtao);
-                argLocs.emplace_back(arg.loc());
-            }
-
-            const auto numKwArgs = s.numKwArgs();
-            for (auto i = 0; i < numKwArgs; ++i) {
-                auto &kw = s.getKwKey(i);
-                auto &val = s.getKwValue(i);
-
-                // Fill the keyword and val args in with a dummy type. We don't want to parse this as type
-                // syntax because we already know it's garbage.
-                // But we still want to record some sort of arg (for the loc specifically) so
-                // that the calls.cc intrinsic can craft an autocorrect.
-                auto &kwtao = holders.emplace_back(core::Types::untypedUntracked(), ctx.locAt(kw.loc()));
-                targs.emplace_back(&kwtao);
-                argLocs.emplace_back(kw.loc());
-
-                auto &valtao = holders.emplace_back(core::Types::untypedUntracked(), ctx.locAt(val.loc()));
-                targs.emplace_back(&valtao);
-                argLocs.emplace_back(val.loc());
-            }
-
-            if (auto *splat = s.kwSplat()) {
-                auto &splattao = holders.emplace_back(core::Types::untypedUntracked(), ctx.locAt(splat->loc()));
-                targs.emplace_back(&splattao);
-                argLocs.emplace_back(splat->loc());
-            }
-
-            core::SymbolRef corrected;
-            if (recvi->symbol.isClassOrModule()) {
-                corrected = recvi->symbol.asClassOrModuleRef().forwarderForBuiltinGeneric();
-            }
-            if (corrected.exists()) {
-                if (auto e = ctx.beginError(s.loc, core::errors::Resolver::BadStdlibGeneric)) {
-                    e.setHeader("Use `{}`, not `{}` to declare a typed `{}`", corrected.show(ctx) + "[...]",
-                                recvi->symbol.show(ctx) + "[...]", recvi->symbol.show(ctx));
-                    e.addErrorNote(
-                        "`{}` will raise at runtime because this generic was defined in the standard library",
-                        recvi->symbol.show(ctx) + "[...]");
-                    e.replaceWith(fmt::format("Change `{}` to `{}`", recvi->symbol.show(ctx), corrected.show(ctx)),
-                                  ctx.locAt(recvi->loc), "{}", corrected.show(ctx));
-                }
-                result.type = core::Types::untypedUntracked();
-                return result;
             } else {
-                corrected = recvi->symbol;
+                // a type member has occurred in a context that doesn't allow them
+                if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                    auto flavor = isTypeTemplate ? "type_template"sv : "type_member"sv;
+                    e.setHeader("`{}` `{}` is not allowed in this context", flavor, sym.show(ctx));
+                }
+                result.type = core::Types::untypedUntracked();
             }
-            corrected = corrected.dealias(ctx);
+        } else if (sym.isStaticField(ctx)) {
+            if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                e.setHeader("Constant `{}` is not a class or type alias", maybeAliased.show(ctx));
+                e.addErrorLine(sym.loc(ctx), "If you are trying to define a type alias, you should use `{}` here",
+                               "T.type_alias");
+            }
+            result.type = core::Types::untypedUntracked();
+        } else {
+            if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                e.setHeader("Malformed type declaration. Not a class type `{}`", maybeAliased.show(ctx));
+            }
+            result.type = core::Types::untypedUntracked();
+        }
+    } else if (ast::isa_tree<ast::Send>(expr)) {
+        const auto &s = ast::cast_tree_nonnull<ast::Send>(expr);
+        if (isTProc(ctx, &s)) {
+            auto sig = parseSigWithSelfTypeParams(ctx, s, &sigBeingParsed, args);
+            if (sig.bind.exists()) {
+                if (!args.allowRebind) {
+                    if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                        e.setHeader("Using `{}` is not permitted here", "bind");
+                    }
+                } else {
+                    result.rebind = sig.bind;
+                }
+            }
 
-            if (!corrected.isClassOrModule()) {
+            vector<core::TypePtr> targs;
+
+            if (sig.returns == nullptr) {
                 if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                    e.setHeader("Expected a class or module");
+                    e.setHeader("Malformed T.proc: You must specify a return type");
+                }
+                targs.emplace_back(core::Types::untypedUntracked());
+            } else {
+                targs.emplace_back(sig.returns);
+            }
+
+            for (auto &arg : sig.argTypes) {
+                targs.emplace_back(arg.type);
+            }
+
+            auto arity = targs.size() - 1;
+            if (arity > core::Symbols::MAX_PROC_ARITY) {
+                if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                    e.setHeader("Malformed T.proc: Too many arguments (max `{}`)", core::Symbols::MAX_PROC_ARITY);
                 }
                 result.type = core::Types::untypedUntracked();
                 return result;
             }
+            auto sym = core::Symbols::Proc(arity);
 
-            auto correctedSingleton = corrected.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx);
-            ENFORCE_NO_TIMER(correctedSingleton.exists());
-            auto ctype = core::make_type<core::ClassType>(correctedSingleton);
-            core::TypeAndOrigins ctypeAndOrigins{ctype, ctx.locAt(s.loc)};
-            // In `dispatchArgs` this is ordinarily used to specify the origin tag for
-            // uninitialized variables. Inside of a signature we shouldn't need this:
-            auto originForUninitialized = core::Loc::none();
-            core::CallLocs locs{
-                ctx.file, s.loc, recvi->loc, s.loc.copyWithZeroLength(), argLocs,
-            };
-            auto suppressErrors = false;
-            core::DispatchArgs dispatchArgs{core::Names::squareBrackets(),
-                                            locs,
-                                            s.numPosArgs(),
-                                            targs,
-                                            ctype,
-                                            ctypeAndOrigins,
-                                            ctype,
-                                            nullptr,
-                                            originForUninitialized,
-                                            s.flags.isPrivateOk,
-                                            suppressErrors};
-            auto out = core::Types::dispatchCallWithoutBlock(ctx, ctype, dispatchArgs);
+            result.type = core::make_type<core::AppliedType>(sym, move(targs));
+            return result;
+        }
 
-            if (out.isUntyped()) {
-                // Using a generic untyped type here will lead to incorrect handling of global state hashing,
-                // where we won't see difference between types with generic arguments.
-                // Thus, while normally we would treat these as untyped, in `sig`s we treat them as proper types, so
-                // that we can correctly hash them.
-                vector<core::TypePtr> targPtrs;
-                targPtrs.reserve(targs.size());
-                for (auto &targ : targs) {
-                    targPtrs.push_back(targ->type);
-                }
-                result.type = core::make_type<core::UnresolvedAppliedType>(correctedSingleton, move(targPtrs));
-                return result;
-            }
-            if (auto *mt = core::cast_type<core::MetaType>(out)) {
-                result.type = mt->wrapped;
-                return result;
-            }
-
+        auto *recvi = ast::cast_tree<ast::ConstantLit>(s.recv);
+        if (recvi == nullptr) {
             if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func>");
             }
             result.type = core::Types::untypedUntracked();
+            return result;
         }
-        else if (ast::isa_tree<ast::Local>(expr)) {
-            const auto &slf = ast::cast_tree_nonnull<ast::Local>(expr);
-            if (expr.isSelfReference()) {
-                result.type = ctxOwnerData->selfType(ctx);
-            } else {
-                if (auto e = ctx.beginError(slf.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                    e.setHeader("Unsupported type syntax");
-                }
-                result.type = core::Types::untypedUntracked();
-            }
+        if (recvi->symbol == core::Symbols::T()) {
+            result = interpretTCombinator(ctx, s, sigBeingParsed, args);
+            return result;
         }
-        else if (ast::isa_tree<ast::Literal>(expr)) {
-            const auto &lit = ast::cast_tree_nonnull<ast::Literal>(expr);
-            core::TypePtr underlying;
-            if (core::isa_type<core::NamedLiteralType>(lit.value)) {
-                underlying = lit.value.underlying(ctx);
-            } else if (core::isa_type<core::IntegerLiteralType>(lit.value)) {
-                underlying = lit.value.underlying(ctx);
-            } else if (core::isa_type<core::FloatLiteralType>(lit.value)) {
-                underlying = lit.value.underlying(ctx);
-            } else {
-                underlying = lit.value;
+
+        if (recvi->symbol == core::Symbols::Magic() && s.fun == core::Names::callWithSplat()) {
+            if (auto e = ctx.beginError(recvi->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                e.setHeader("Malformed type declaration: splats cannot be used in types");
             }
-            if (auto e = ctx.beginError(lit.loc, core::errors::Resolver::InvalidMethodSignature)) {
-                e.setHeader("Unsupported literal in type syntax", lit.value.show(ctx));
-                e.replaceWith("Replace with underlying type", ctx.locAt(lit.loc), "{}", underlying.show(ctx));
-            }
-            result.type = underlying;
+            result.type = core::Types::untypedUntracked();
+            return result;
         }
-        else {
-            if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
+
+        if (s.fun != core::Names::squareBrackets()) {
+            if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                e.setHeader("Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func>");
+            }
+            result.type = core::Types::untypedUntracked();
+            return result;
+        }
+
+        InlinedVector<core::TypeAndOrigins, 2> holders;
+        InlinedVector<const core::TypeAndOrigins *, 2> targs;
+        InlinedVector<core::LocOffsets, 2> argLocs;
+        const auto argSize = s.numPosArgs() + (2 * s.numKwArgs()) + (s.hasKwSplat() ? 1 : 0);
+        targs.reserve(argSize);
+        argLocs.reserve(argSize);
+        holders.reserve(argSize);
+
+        for (auto &arg : s.posArgs()) {
+            auto type = core::make_type<core::MetaType>(
+                getResultTypeWithSelfTypeParams(ctx, arg, sigBeingParsed, args.withoutSelfType()));
+            auto &argtao = holders.emplace_back(std::move(type), ctx.locAt(arg.loc()));
+            targs.emplace_back(&argtao);
+            argLocs.emplace_back(arg.loc());
+        }
+
+        const auto numKwArgs = s.numKwArgs();
+        for (auto i = 0; i < numKwArgs; ++i) {
+            auto &kw = s.getKwKey(i);
+            auto &val = s.getKwValue(i);
+
+            // Fill the keyword and val args in with a dummy type. We don't want to parse this as type
+            // syntax because we already know it's garbage.
+            // But we still want to record some sort of arg (for the loc specifically) so
+            // that the calls.cc intrinsic can craft an autocorrect.
+            auto &kwtao = holders.emplace_back(core::Types::untypedUntracked(), ctx.locAt(kw.loc()));
+            targs.emplace_back(&kwtao);
+            argLocs.emplace_back(kw.loc());
+
+            auto &valtao = holders.emplace_back(core::Types::untypedUntracked(), ctx.locAt(val.loc()));
+            targs.emplace_back(&valtao);
+            argLocs.emplace_back(val.loc());
+        }
+
+        if (auto *splat = s.kwSplat()) {
+            auto &splattao = holders.emplace_back(core::Types::untypedUntracked(), ctx.locAt(splat->loc()));
+            targs.emplace_back(&splattao);
+            argLocs.emplace_back(splat->loc());
+        }
+
+        core::SymbolRef corrected;
+        if (recvi->symbol.isClassOrModule()) {
+            corrected = recvi->symbol.asClassOrModuleRef().forwarderForBuiltinGeneric();
+        }
+        if (corrected.exists()) {
+            if (auto e = ctx.beginError(s.loc, core::errors::Resolver::BadStdlibGeneric)) {
+                e.setHeader("Use `{}`, not `{}` to declare a typed `{}`", corrected.show(ctx) + "[...]",
+                            recvi->symbol.show(ctx) + "[...]", recvi->symbol.show(ctx));
+                e.addErrorNote("`{}` will raise at runtime because this generic was defined in the standard library",
+                               recvi->symbol.show(ctx) + "[...]");
+                e.replaceWith(fmt::format("Change `{}` to `{}`", recvi->symbol.show(ctx), corrected.show(ctx)),
+                              ctx.locAt(recvi->loc), "{}", corrected.show(ctx));
+            }
+            result.type = core::Types::untypedUntracked();
+            return result;
+        } else {
+            corrected = recvi->symbol;
+        }
+        corrected = corrected.dealias(ctx);
+
+        if (!corrected.isClassOrModule()) {
+            if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                e.setHeader("Expected a class or module");
+            }
+            result.type = core::Types::untypedUntracked();
+            return result;
+        }
+
+        auto correctedSingleton = corrected.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx);
+        ENFORCE_NO_TIMER(correctedSingleton.exists());
+        auto ctype = core::make_type<core::ClassType>(correctedSingleton);
+        core::TypeAndOrigins ctypeAndOrigins{ctype, ctx.locAt(s.loc)};
+        // In `dispatchArgs` this is ordinarily used to specify the origin tag for
+        // uninitialized variables. Inside of a signature we shouldn't need this:
+        auto originForUninitialized = core::Loc::none();
+        core::CallLocs locs{
+            ctx.file, s.loc, recvi->loc, s.loc.copyWithZeroLength(), argLocs,
+        };
+        auto suppressErrors = false;
+        core::DispatchArgs dispatchArgs{core::Names::squareBrackets(),
+                                        locs,
+                                        s.numPosArgs(),
+                                        targs,
+                                        ctype,
+                                        ctypeAndOrigins,
+                                        ctype,
+                                        nullptr,
+                                        originForUninitialized,
+                                        s.flags.isPrivateOk,
+                                        suppressErrors};
+        auto out = core::Types::dispatchCallWithoutBlock(ctx, ctype, dispatchArgs);
+
+        if (out.isUntyped()) {
+            // Using a generic untyped type here will lead to incorrect handling of global state hashing,
+            // where we won't see difference between types with generic arguments.
+            // Thus, while normally we would treat these as untyped, in `sig`s we treat them as proper types, so
+            // that we can correctly hash them.
+            vector<core::TypePtr> targPtrs;
+            targPtrs.reserve(targs.size());
+            for (auto &targ : targs) {
+                targPtrs.push_back(targ->type);
+            }
+            result.type = core::make_type<core::UnresolvedAppliedType>(correctedSingleton, move(targPtrs));
+            return result;
+        }
+        if (auto *mt = core::cast_type<core::MetaType>(out)) {
+            result.type = mt->wrapped;
+            return result;
+        }
+
+        if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            e.setHeader("Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func>");
+        }
+        result.type = core::Types::untypedUntracked();
+    } else if (ast::isa_tree<ast::Local>(expr)) {
+        const auto &slf = ast::cast_tree_nonnull<ast::Local>(expr);
+        if (expr.isSelfReference()) {
+            result.type = ctxOwnerData->selfType(ctx);
+        } else {
+            if (auto e = ctx.beginError(slf.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type syntax");
             }
             result.type = core::Types::untypedUntracked();
         }
+    } else if (ast::isa_tree<ast::Literal>(expr)) {
+        const auto &lit = ast::cast_tree_nonnull<ast::Literal>(expr);
+        core::TypePtr underlying;
+        if (core::isa_type<core::NamedLiteralType>(lit.value)) {
+            underlying = lit.value.underlying(ctx);
+        } else if (core::isa_type<core::IntegerLiteralType>(lit.value)) {
+            underlying = lit.value.underlying(ctx);
+        } else if (core::isa_type<core::FloatLiteralType>(lit.value)) {
+            underlying = lit.value.underlying(ctx);
+        } else {
+            underlying = lit.value;
+        }
+        if (auto e = ctx.beginError(lit.loc, core::errors::Resolver::InvalidMethodSignature)) {
+            e.setHeader("Unsupported literal in type syntax", lit.value.show(ctx));
+            e.replaceWith("Replace with underlying type", ctx.locAt(lit.loc), "{}", underlying.show(ctx));
+        }
+        result.type = underlying;
+    } else {
+        if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
+            e.setHeader("Unsupported type syntax");
+        }
+        result.type = core::Types::untypedUntracked();
+    }
     return result;
 }
 

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -673,7 +673,8 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
             auto fnd = sig.findTypeArgByName(arr->asSymbol());
             if (!fnd.type) {
                 if (args.allowUnspecifiedTypeParameter) {
-                    return TypeSyntax::ResultType{core::Types::todo(), core::Symbols::noClassOrModule()};
+                    // Return nullopt, which will indicate that we couldn't parse the sig at this time.
+                    return nullopt;
                 } else {
                     if (auto e = ctx.beginError(arr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                         e.setHeader("Unspecified type parameter");

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -63,22 +63,23 @@ struct TypeSyntaxArgs {
     const bool allowSelfType = false;
     const bool allowRebind = false;
     const bool allowTypeMember = false;
+    const bool allowUnspecifiedTypeParameter = false;
     const core::SymbolRef untypedBlame;
 
     TypeSyntaxArgs withoutRebind() const {
-        return TypeSyntaxArgs{allowSelfType, false, allowTypeMember, untypedBlame};
+        return TypeSyntaxArgs{allowSelfType, false, allowTypeMember, allowUnspecifiedTypeParameter, untypedBlame};
     }
 
     TypeSyntaxArgs withRebind() const {
-        return TypeSyntaxArgs{allowSelfType, true, allowTypeMember, untypedBlame};
+        return TypeSyntaxArgs{allowSelfType, true, allowTypeMember, allowUnspecifiedTypeParameter, untypedBlame};
     }
 
     TypeSyntaxArgs withoutSelfType() const {
-        return TypeSyntaxArgs{false, allowRebind, allowTypeMember, untypedBlame};
+        return TypeSyntaxArgs{false, allowRebind, allowTypeMember, allowUnspecifiedTypeParameter, untypedBlame};
     }
 
     TypeSyntaxArgs withoutTypeMember() const {
-        return TypeSyntaxArgs{allowSelfType, allowRebind, false, untypedBlame};
+        return TypeSyntaxArgs{allowSelfType, allowRebind, false, allowUnspecifiedTypeParameter, untypedBlame};
     }
 };
 

--- a/test/testdata/infer/generic_methods/genericMethodsErrors.rb
+++ b/test/testdata/infer/generic_methods/genericMethodsErrors.rb
@@ -3,7 +3,8 @@ class Foo
   extend T::Generic
   extend T::Sig
 
-  sig {type_parameters(:A, :A).params(a: T.type_parameter(:A)).returns(T.type_parameter(:A))}  # error: Malformed `sig`
+  sig {type_parameters(:A, :A).params(a: T.type_parameter(:A)).returns(T.type_parameter(:A))}
+  #                        ^^ error: Malformed `sig`: Type argument `A` was specified twice
   def id0(a)
     a
   end
@@ -28,4 +29,40 @@ class Foo
   def map(&blk);
     [blk.call(1)]
   end
+end
+
+class Bad
+  extend T::Sig
+
+  X = T.let(nil, T.nilable(T.type_parameter(:U)))
+  #                                         ^^ error: Unspecified type parameter
+
+  @x = T.let(nil, T.nilable(T.type_parameter(:U)))
+  #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve declared type for `@x`
+  #                                          ^^ error: Unspecified type parameter
+
+  sig {type_parameters(:U).params(y: T.type_parameter(:U)).void}
+  def initialize(y)
+    @y1 = y
+
+    @y2 = T.let(y, T.type_parameter(:U))
+    #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve declared type for `@y2`
+    #                               ^^ error: Unspecified type parameter
+  end
+
+  def foo
+    T.reveal_type(@y1) # error: `T.untyped`
+    T.reveal_type(@y2) # error: `T.untyped`
+
+    @z = T.let(nil, T.nilable(T.type_parameter(:U)))
+    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve declared type for `@z`
+    #                                          ^^ error: Unspecified type parameter
+  end
+end
+
+class BadGeneric
+  extend T::Generic
+
+  Elem = type_member {{upper: T.type_parameter(:U)}}
+  #                                            ^^ error: Unspecified type parameter
 end

--- a/test/testdata/infer/pinning_type_parameter.rb
+++ b/test/testdata/infer/pinning_type_parameter.rb
@@ -1,0 +1,28 @@
+# typed: true
+
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(x: T.type_parameter(:U))
+    .returns(T.type_parameter(:U))
+end
+def example(x)
+  y = T.let(x, T.type_parameter(:U))
+  T.reveal_type(y) # error: `T.type_parameter(:U) (of Object#example)`
+
+  pinned = T.let(nil, T.nilable(T.type_parameter(:U)))
+  1.times do
+    pinned = x
+  end
+
+  needs_pin = nil
+  1.times do
+    needs_pin = x
+    #           ^ error: Changing the type of a variable in a loop is not permitted
+  end
+  puts needs_pin
+
+  T.reveal_type(pinned) # error: `T.nilable(T.type_parameter(:U) (of Object#example))`
+  y
+end

--- a/test/testdata/infer/pinning_type_parameter.rb.autocorrects.exp
+++ b/test/testdata/infer/pinning_type_parameter.rb.autocorrects.exp
@@ -1,0 +1,30 @@
+# -- test/testdata/infer/pinning_type_parameter.rb --
+# typed: true
+
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(x: T.type_parameter(:U))
+    .returns(T.type_parameter(:U))
+end
+def example(x)
+  y = T.let(x, T.type_parameter(:U))
+  T.reveal_type(y) # error: `T.type_parameter(:U) (of Object#example)`
+
+  pinned = T.let(nil, T.nilable(T.type_parameter(:U)))
+  1.times do
+    pinned = x
+  end
+
+  needs_pin = T.let(nil, T.nilable(T.type_parameter(:U)))
+  1.times do
+    needs_pin = x
+    #           ^ error: Changing the type of a variable in a loop is not permitted
+  end
+  puts needs_pin
+
+  T.reveal_type(pinned) # error: `T.nilable(T.type_parameter(:U) (of Object#example))`
+  y
+end
+# ------------------------------

--- a/test/testdata/lsp/foo.rb
+++ b/test/testdata/lsp/foo.rb
@@ -1,0 +1,11 @@
+# typed: true
+class Bad
+  extend T::Sig
+
+  sig {type_parameters(:U).params(y: T.type_parameter(:U)).void}
+  def initialize(y)
+    @y2 = T.let(y, T.type_parameter(:U))
+    #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve declared type for `@y2`
+    #                               ^^ error: Unspecified type parameter
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

<img width="698" alt="image" src="https://user-images.githubusercontent.com/5544532/179381944-76719d09-6623-4db7-a9bf-941065059b5e.png">


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #1715
Fixes #1848

### Commit summary

This PR has a lot of changes, but a lot of them are ancillary.

The diff looks better reviewing by commit, and certain commits also benefit from ignoring whitespace.

- **pre-work: Rename this struct to make room for another** (7d470579e)


- **pre-work: resolveSigs always returns a result** (142892257)


- **pre-work: Compute the owner centrally** (ca546d9f7)

  This change makes it so that job.owner is always the actual owner
  (sometimes a method, sometimes a class, depending on where the cast item
  is), and we only widen it to `enclosingClass` right before we create a
  `ctx` that we're going to pass into `getResultType`, which assumes that
  `ctx.owner` is always a class, not a method.

  This lets us use the method owner for future changes.

- **pre-work: Factor out `*Impl` function to check postcondition** (73694bc6d)


- **pre-work: Convert typecase to `if`** (6cd49b8a9)


- **pre-work: clang-format after previous change** (8f0e9ffb8)


- **Allow using `T.type_parameter` in `T.let`** (52f99c5eb)


- **no-op: Refactor to make everything optional** (8b9be460c)


- **Make use of new optional type** (44ec80812)


- **Ensure that `T.type_parameter` can't be used in ivar decls** (466eb5ddd)


- **Add a new test** (d177f7f6b)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] @jez Fix bug with todo (what you really want to be able to do is throw an exception all the way back out to the top of `getResultType`, because you'll have to bubble the `todo()` type all the way up at every call right now. Not sure what the best way to communicate the possibly-deeply-nested `T.type_parameter` failure back to the caller is.
- [x] @jez Write tests
  - [x] @jez Ensure this doesn't accidentally allow `T.type_parameter` in places
    where it shouldn't be, like static fields, type aliases, and field.
  - [x] @jez Write test for autocorrect with `T.type_parameter` #1848
- [x] @jez Measure performance on large codebase
  - This seems to account for an increase of about ~1% time. Personally that's within the threshold I'm comfortable regressing, if the measurement is accurate.

