### PR TITLE
Allow `--stop-after=cfg --print=cfg`

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -63,13 +63,12 @@ public:
         auto &print = opts.print;
         auto cfg = cfg::CFGBuilder::buildFor(ctx.withOwner(m.symbol), m);
 
-        if (opts.stopAfterPhase == options::Phase::CFG) {
-            return;
-        }
-        cfg = infer::Inference::run(ctx.withOwner(cfg->symbol), move(cfg));
-        if (cfg) {
-            for (auto &extension : ctx.state.semanticExtensions) {
-                extension->typecheck(ctx, ctx.file, *cfg, m);
+        if (opts.stopAfterPhase != options::Phase::CFG) {
+            cfg = infer::Inference::run(ctx.withOwner(cfg->symbol), move(cfg));
+            if (cfg) {
+                for (auto &extension : ctx.state.semanticExtensions) {
+                    extension->typecheck(ctx, ctx.file, *cfg, m);
+                }
             }
         }
         if (print.CFG.enabled) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If there's a crash in inference, it's useful to print the CFG it was running on.
The previous behavior only printed a CFG after inference. You couldn't even use
`--stop-after=cfg` to get around this, because that would entirely short circuit
from `typecheckOne`, skipping the printing code at the end of the method body.

Now you can use `--stop-after=cfg -p cfg` to see the CFG that inference is
crashing on.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested locally.