### PR TITLE
Suggest `T.untyped` for non-stdlib generics too

### DIFF
--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -164,6 +164,29 @@ public:
     // Given any other symbol, returns false.
     // Also returns false if called on core::Symbols::noClassOrModule().
     bool isPackageSpecSymbol(const GlobalState &gs) const;
+
+    // Certain classes that need to be generic in the standard library already have a definition for
+    // the `[]` method, which would otherwise be the way to apply type arguments to a generic class.
+    // For example, `Set[1, 2, 3]` creates a `Set` of `Integer`s.
+    //
+    // To allow people to continue this syntax, we create certain forwarder classes under the `T::`
+    // namespace so that the `[]` method does not conflict with any existing method.
+    //
+    // This method tells whether the current ClassOrModuleRef is one of those forwarder classes.
+    bool isBuiltinGenericForwarder() const;
+    // Unwraps things like `T::Hash` to `Hash`, otherwise returns itself.
+    ClassOrModuleRef maybeUnwrapBuiltinGenericForwarder() const;
+    // Gets the `T::` forwarder class for the builtin generic (like `::Array` -> `::T::Array`)
+    // Returns Symbols::noClassOrModule if there is no forwarder.
+    ClassOrModuleRef forwarderForBuiltinGeneric() const;
+
+    // Before stabilizing Sorbet's type syntax (indeed, before Sorbet even supported generic type
+    // syntax), it was allowed to use `Array` in place of `T::Array[T.untyped]`. Out of a desire to
+    // avoid a large code migration, we preserve that behavior for the select stdlib classes it
+    // applied to at the time.
+    //
+    // The set of stdlib classes receiving this special behavior should not grow over time.
+    bool isLegacyStdlibGeneric() const;
 };
 CheckSize(ClassOrModuleRef, 4, 4);
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -579,6 +579,60 @@ bool ClassOrModuleRef::isPackageSpecSymbol(const GlobalState &gs) const {
     return false;
 }
 
+bool ClassOrModuleRef::isBuiltinGenericForwarder() const {
+    return *this == Symbols::T_Hash() || *this == Symbols::T_Array() || *this == Symbols::T_Set() ||
+           *this == Symbols::T_Range() || *this == Symbols::T_Enumerable() || *this == Symbols::T_Enumerator() ||
+           *this == Symbols::T_Enumerator_Lazy();
+}
+
+ClassOrModuleRef ClassOrModuleRef::maybeUnwrapBuiltinGenericForwarder() const {
+    if (*this == Symbols::T_Array()) {
+        return Symbols::Array();
+    } else if (*this == Symbols::T_Hash()) {
+        return Symbols::Hash();
+    } else if (*this == Symbols::T_Enumerable()) {
+        return Symbols::Enumerable();
+    } else if (*this == Symbols::T_Enumerator()) {
+        return Symbols::Enumerator();
+    } else if (*this == Symbols::T_Enumerator_Lazy()) {
+        return Symbols::Enumerator_Lazy();
+    } else if (*this == Symbols::T_Range()) {
+        return Symbols::Range();
+    } else if (*this == Symbols::T_Set()) {
+        return Symbols::Set();
+    } else {
+        return *this;
+    }
+}
+
+ClassOrModuleRef ClassOrModuleRef::forwarderForBuiltinGeneric() const {
+    if (*this == Symbols::Array()) {
+        return Symbols::T_Array();
+    } else if (*this == Symbols::Hash()) {
+        return Symbols::T_Hash();
+    } else if (*this == Symbols::Enumerable()) {
+        return Symbols::T_Enumerable();
+    } else if (*this == Symbols::Enumerator()) {
+        return Symbols::T_Enumerator();
+    } else if (*this == Symbols::Enumerator_Lazy()) {
+        return Symbols::T_Enumerator_Lazy();
+    } else if (*this == Symbols::Range()) {
+        return Symbols::T_Range();
+    } else if (*this == Symbols::Set()) {
+        return Symbols::T_Set();
+    } else {
+        return Symbols::noClassOrModule();
+    }
+}
+
+// See the comment in the header.
+// !! The set of stdlib classes receiving this special behavior should NOT grow over time !!
+bool ClassOrModuleRef::isLegacyStdlibGeneric() const {
+    return *this == Symbols::Hash() || *this == Symbols::Array() || *this == Symbols::Set() ||
+           *this == Symbols::Range() || *this == Symbols::Enumerable() || *this == Symbols::Enumerator() ||
+           *this == Symbols::Enumerator_Lazy();
+}
+
 namespace {
 MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrModuleRef owner, NameRef name,
                                                int maxDepth) {

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -92,6 +92,7 @@ void TypeErrorDiagnostics::insertUntypedTypeArguments(const GlobalState &gs, Err
                                                       core::Loc replaceLoc) {
     // if we're looking at `Array`, we want the autocorrect to include `T::`, but we don't need to
     // if we're already looking at `T::Array` instead.
+    klass = klass.maybeUnwrapBuiltinGenericForwarder();
     auto typePrefixSym = klass.forwarderForBuiltinGeneric();
     if (!typePrefixSym.exists()) {
         typePrefixSym = klass;

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -21,6 +21,9 @@ public:
 
     static void explainTypeMismatch(const GlobalState &gs, ErrorBuilder &e, const TypePtr &expected,
                                     const TypePtr &got);
+
+    static void insertUntypedTypeArguments(const GlobalState &gs, ErrorBuilder &e, ClassOrModuleRef klass,
+                                           core::Loc replaceLoc);
 };
 
 } // namespace sorbet::core

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -209,7 +209,7 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
             return emptyResult;
         }
         auto funLoc = args.funLoc();
-        auto errLoc = (funLoc.exists() && !funLoc.empty()) ? args.funLoc() : args.callLoc();
+        auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
         auto e = gs.beginError(errLoc, errors::Infer::CallOnTypeArgument);
         if (e) {
             auto thisStr = args.thisType.show(gs);
@@ -236,7 +236,7 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
             }
 
             auto funLoc = args.funLoc();
-            auto errLoc = (funLoc.exists() && !funLoc.empty()) ? args.funLoc() : args.callLoc();
+            auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
             auto e = gs.beginError(errLoc, errors::Infer::CallOnUnboundedTypeMember);
             if (e) {
                 auto member = typeMember.data(gs)->owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()
@@ -685,7 +685,7 @@ const ShapeType *fromKwargsHash(const GlobalState &gs, const TypePtr &ty) {
 DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &args, core::ClassOrModuleRef symbol,
                                   const vector<TypePtr> &targs) {
     auto funLoc = args.funLoc();
-    auto errLoc = (funLoc.exists() && !funLoc.empty()) ? args.funLoc() : args.callLoc();
+    auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
     if (symbol == core::Symbols::untyped()) {
         return DispatchResult(Types::untyped(gs, args.thisType.untypedBlame()), std::move(args.selfType),
                               Symbols::noMethod());
@@ -1591,7 +1591,7 @@ bool canCallNew(const GlobalState &gs, const TypePtr &wrapped) {
 
 DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
     auto funLoc = args.funLoc();
-    auto errLoc = (funLoc.exists() && !funLoc.empty()) ? args.funLoc() : args.callLoc();
+    auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
     switch (args.name.rawId()) {
         case Names::new_().rawId(): {
             if (!canCallNew(gs, wrapped)) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1938,21 +1938,7 @@ public:
             return;
         }
 
-        if (attachedClass == Symbols::T_Array()) {
-            attachedClass = Symbols::Array();
-        } else if (attachedClass == Symbols::T_Hash()) {
-            attachedClass = Symbols::Hash();
-        } else if (attachedClass == Symbols::T_Enumerable()) {
-            attachedClass = Symbols::Enumerable();
-        } else if (attachedClass == Symbols::T_Enumerator()) {
-            attachedClass = Symbols::Enumerator();
-        } else if (attachedClass == Symbols::T_Enumerator_Lazy()) {
-            attachedClass = Symbols::Enumerator_Lazy();
-        } else if (attachedClass == Symbols::T_Range()) {
-            attachedClass = Symbols::Range();
-        } else if (attachedClass == Symbols::T_Set()) {
-            attachedClass = Symbols::Set();
-        }
+        attachedClass = attachedClass.maybeUnwrapBuiltinGenericForwarder();
 
         if (attachedClass.data(gs)->typeMembers().empty()) {
             return;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2692,21 +2692,7 @@ public:
                 // This is the same as the implementation of T::Generic.[] in calls.cc
                 // NOTE: the type members of these symbols will only be depended on during payload construction, as
                 // after that their bounds will have been fully resolved.
-                if (klass == core::Symbols::T_Array()) {
-                    klass = core::Symbols::Array();
-                } else if (klass == core::Symbols::T_Hash()) {
-                    klass = core::Symbols::Hash();
-                } else if (klass == core::Symbols::T_Enumerable()) {
-                    klass = core::Symbols::Enumerable();
-                } else if (klass == core::Symbols::T_Enumerator()) {
-                    klass = core::Symbols::Enumerator();
-                } else if (klass == core::Symbols::T_Enumerator_Lazy()) {
-                    klass = core::Symbols::Enumerator_Lazy();
-                } else if (klass == core::Symbols::T_Range()) {
-                    klass = core::Symbols::Range();
-                } else if (klass == core::Symbols::T_Set()) {
-                    klass = core::Symbols::Set();
-                }
+                klass = klass.maybeUnwrapBuiltinGenericForwarder();
 
                 // crawl up uses of `T.class_of` to find the right singleton symbol.
                 // This is for cases like `T.class_of(T.class_of(A))`.

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -4,6 +4,7 @@
 #include "common/typecase.h"
 #include "core/Names.h"
 #include "core/Symbols.h"
+#include "core/TypeErrorDiagnostics.h"
 #include "core/core.h"
 #include "core/errors/resolver.h"
 
@@ -872,36 +873,14 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 auto klass = sym.asClassOrModuleRef();
                 // the T::Type generics internally have a typeArity of 0, so this allows us to check against them in the
                 // same way that we check against types like `Array`
-                bool isBuiltinGeneric = klass.isBuiltinGenericForwarder();
-                if (isBuiltinGeneric || klass.data(ctx)->typeArity(ctx) > 0) {
-                    auto isStdlibWhitelisted = klass.isLegacyStdlibGeneric();
-                    auto level = isStdlibWhitelisted ? core::errors::Resolver::GenericClassWithoutTypeArgsStdlib
-                                                     : core::errors::Resolver::GenericClassWithoutTypeArgs;
+                if (klass.isBuiltinGenericForwarder() || klass.data(ctx)->typeArity(ctx) > 0) {
+                    auto level = klass.isLegacyStdlibGeneric()
+                                     ? core::errors::Resolver::GenericClassWithoutTypeArgsStdlib
+                                     : core::errors::Resolver::GenericClassWithoutTypeArgs;
                     if (auto e = ctx.beginError(i.loc, level)) {
                         e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",
                                     klass.show(ctx));
-                        // if we're looking at `Array`, we want the autocorrect to include `T::`, but we don't need to
-                        // if we're already looking at `T::Array` instead.
-                        auto typePrefix = isBuiltinGeneric ? "" : "T::";
-
-                        auto loc = ctx.locAt(i.loc);
-                        if (auto locSource = loc.source(ctx)) {
-                            if (klass == core::Symbols::Hash() || klass == core::Symbols::T_Hash()) {
-                                // Hash is special because it has arity 3 but you're only supposed to write the first 2
-                                e.replaceWith("Add type arguments", loc, "{}{}[T.untyped, T.untyped]", typePrefix,
-                                              locSource.value());
-                            } else if (isStdlibWhitelisted || isBuiltinGeneric) {
-                                // the default provided here for builtin generic types is 1, and that might need to
-                                // change if we add other builtin generics (but ideally we should never need to do so!)
-                                auto numTypeArgs = isBuiltinGeneric ? 1 : klass.data(ctx)->typeArity(ctx);
-                                vector<string> untypeds;
-                                for (int i = 0; i < numTypeArgs; i++) {
-                                    untypeds.emplace_back("T.untyped");
-                                }
-                                e.replaceWith("Add type arguments", loc, "{}{}[{}]", typePrefix, locSource.value(),
-                                              absl::StrJoin(untypeds, ", "));
-                            }
-                        }
+                        core::TypeErrorDiagnostics::insertUntypedTypeArguments(ctx, e, klass, ctx.locAt(i.loc));
                     }
                 }
                 if (klass == core::Symbols::StubModule()) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -872,18 +872,9 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 auto klass = sym.asClassOrModuleRef();
                 // the T::Type generics internally have a typeArity of 0, so this allows us to check against them in the
                 // same way that we check against types like `Array`
-                bool isBuiltinGeneric = klass == core::Symbols::T_Hash() || klass == core::Symbols::T_Array() ||
-                                        klass == core::Symbols::T_Set() || klass == core::Symbols::T_Range() ||
-                                        klass == core::Symbols::T_Enumerable() ||
-                                        klass == core::Symbols::T_Enumerator() ||
-                                        klass == core::Symbols::T_Enumerator_Lazy();
-
+                bool isBuiltinGeneric = klass.isBuiltinGenericForwarder();
                 if (isBuiltinGeneric || klass.data(ctx)->typeArity(ctx) > 0) {
-                    // This set **should not** grow over time.
-                    bool isStdlibWhitelisted = klass == core::Symbols::Hash() || klass == core::Symbols::Array() ||
-                                               klass == core::Symbols::Set() || klass == core::Symbols::Range() ||
-                                               klass == core::Symbols::Enumerable() ||
-                                               klass == core::Symbols::Enumerator();
+                    auto isStdlibWhitelisted = klass.isLegacyStdlibGeneric();
                     auto level = isStdlibWhitelisted ? core::errors::Resolver::GenericClassWithoutTypeArgsStdlib
                                                      : core::errors::Resolver::GenericClassWithoutTypeArgs;
                     if (auto e = ctx.beginError(i.loc, level)) {
@@ -1127,20 +1118,8 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             }
 
             core::SymbolRef corrected;
-            if (recvi->symbol == core::Symbols::Array()) {
-                corrected = core::Symbols::T_Array();
-            } else if (recvi->symbol == core::Symbols::Hash()) {
-                corrected = core::Symbols::T_Hash();
-            } else if (recvi->symbol == core::Symbols::Enumerable()) {
-                corrected = core::Symbols::T_Enumerable();
-            } else if (recvi->symbol == core::Symbols::Enumerator()) {
-                corrected = core::Symbols::T_Enumerator();
-            } else if (recvi->symbol == core::Symbols::Enumerator_Lazy()) {
-                corrected = core::Symbols::T_Enumerator_Lazy();
-            } else if (recvi->symbol == core::Symbols::Range()) {
-                corrected = core::Symbols::T_Range();
-            } else if (recvi->symbol == core::Symbols::Set()) {
-                corrected = core::Symbols::T_Set();
+            if (recvi->symbol.isClassOrModule()) {
+                corrected = recvi->symbol.asClassOrModuleRef().forwarderForBuiltinGeneric();
             }
             if (corrected.exists()) {
                 if (auto e = ctx.beginError(s.loc, core::errors::Resolver::BadStdlibGeneric)) {

--- a/test/testdata/resolver/missing_type_args.rb
+++ b/test/testdata/resolver/missing_type_args.rb
@@ -1,0 +1,37 @@
+# typed: strict
+extend T::Sig
+
+class Box
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member
+
+  sig {returns(Elem)}
+  def elem; raise; end
+end
+
+class IntBox < Box
+  Elem = type_member {{fixed: Integer}}
+  Another = type_member
+
+  sig {returns(Another)}
+  def another; raise; end
+end
+
+sig do
+  params(
+    a: Box,
+    #  ^^^ error: Malformed type declaration. Generic class without type arguments `Box`
+    b: IntBox,
+    #  ^^^^^^ error: Malformed type declaration. Generic class without type arguments `IntBox`
+    c: IntBox[String],
+    d: Array,
+    #  ^^^^^ error: Malformed type declaration. Generic class without type arguments `Array`
+  )
+  .void
+end
+def example(a, b, c, d)
+  T.reveal_type(a.elem) # error: `T.untyped`
+  T.reveal_type(b.elem) # error: `Integer`
+  T.reveal_type(c.another) # error: `String`
+end

--- a/test/testdata/resolver/missing_type_args.rb.autocorrects.exp
+++ b/test/testdata/resolver/missing_type_args.rb.autocorrects.exp
@@ -1,0 +1,39 @@
+# -- test/testdata/resolver/missing_type_args.rb --
+# typed: strict
+extend T::Sig
+
+class Box
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member
+
+  sig {returns(Elem)}
+  def elem; raise; end
+end
+
+class IntBox < Box
+  Elem = type_member {{fixed: Integer}}
+  Another = type_member
+
+  sig {returns(Another)}
+  def another; raise; end
+end
+
+sig do
+  params(
+    a: Box,
+    #  ^^^ error: Malformed type declaration. Generic class without type arguments `Box`
+    b: IntBox,
+    #  ^^^^^^ error: Malformed type declaration. Generic class without type arguments `IntBox`
+    c: IntBox[String],
+    d: T::Array[T.untyped],
+    #  ^^^^^ error: Malformed type declaration. Generic class without type arguments `Array`
+  )
+  .void
+end
+def example(a, b, c, d)
+  T.reveal_type(a.elem) # error: `T.untyped`
+  T.reveal_type(b.elem) # error: `Integer`
+  T.reveal_type(c.another) # error: `String`
+end
+# ------------------------------

--- a/test/testdata/resolver/missing_type_args.rb.autocorrects.exp
+++ b/test/testdata/resolver/missing_type_args.rb.autocorrects.exp
@@ -21,9 +21,9 @@ end
 
 sig do
   params(
-    a: Box,
+    a: Box[T.untyped],
     #  ^^^ error: Malformed type declaration. Generic class without type arguments `Box`
-    b: IntBox,
+    b: IntBox[T.untyped],
     #  ^^^^^^ error: Malformed type declaration. Generic class without type arguments `IntBox`
     c: IntBox[String],
     d: T::Array[T.untyped],


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes #5512

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- I was working on a fix for #4978 / #4450, and was hoping to use this helper
  function.
- But then I got side tracked, as my initial implementation for those tickets
  didn't quite work out.
- Along the way, I made the autocorrect work for all generic classes, not just
  ones in the standard library.

So I'd like to get that autocorrect fix in. Also I think that it's useful to
have all these special stdlib classes all in one place, because if you add
another one, you don't have to track everything down.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.