### PR TITLE
wip POC: Allow arbitrary type member applications

### DIFF
--- a/test/testdata/lsp/type_arg_syntax.rb
+++ b/test/testdata/lsp/type_arg_syntax.rb
@@ -1,0 +1,23 @@
+# typed: true
+class ParentBox
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member
+
+  sig {returns(T.attached_class)}
+  def self.make
+    x = new
+    T.reveal_type(x) # error: `T.attached_class (of ParentBox)`
+    x
+  end
+end
+
+class ChildBox < ParentBox
+  Elem = type_member
+end
+
+T.reveal_type(ParentBox.new)           # error: `ParentBox[T.untyped]`
+T.reveal_type(ParentBox[Integer].make) # error: `ParentBox[Integer]`
+
+T.reveal_type(ChildBox.new)           # error: `ChildBox[T.untyped]`
+T.reveal_type(ChildBox[Integer].make) # error: `ChildBox[Integer]`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Right now you can only provide an explicit type application when calling
`.new` on a generic class. But every method that is typed as returning
`T.attached_class` could benefit from this syntax. This is a sketch of
an idea for how we could support it.

I haven't yet made up my mind on whether this is correct or even
desirable to implement this way. There are also some TODOs and code
cleanliness problems (duplication, variable names, etc.) that I have not
taken any time to address.

**Update** After further thought, this clearly breaks down when you start to work with constructors that take arguments. Those arguments have to match the type of `new`, but nothing about the implementation guarantees or even allows checking that the argument types of `make` match up with new (which then match up with `initialize)`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.