### PR TITLE
avoid producing resolved sigs in non-compiled files

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3157,8 +3157,11 @@ private:
                                       const ast::MethodDef &mdef) {
         // Later passes are going to separate the sig and the method definition.
         // Record some information in the sig call itself so that we can reassociate
-        // them later.
-        //
+        // them later in the compiler.
+        if (ctx.file.data(ctx).compiledLevel != core::CompiledLevel::True) {
+            return;
+        }
+
         // Note that the sig still needs to send to a method called "sig" so that
         // code completion in LSP works.  We change the receiver, below, so that
         // sigs that don't pass through here still reflect the user's intent.

--- a/test/testdata/cfg/array.rb.cfg-text.exp
+++ b/test/testdata/cfg/array.rb.cfg-text.exp
@@ -75,11 +75,9 @@ method ::<Class:TestArray>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(TestArray) = cast(<self>: NilClass, T.class_of(TestArray));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:an_int) = :an_int
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(TestArray), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:an_int))
-    <selfRestore>$10: T.class_of(TestArray) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(TestArray))
+    <selfRestore>$8: T.class_of(TestArray) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -90,58 +88,56 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(TestArray)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(TestArray)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(TestArray) = <selfRestore>$10
-    <cfgAlias>$19: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$21: FalseClass = false
-    <statTemp>$22: Symbol(:a_string) = :a_string
-    <block-pre-call-temp>$23: Sorbet::Private::Static::Void = <cfgAlias>$19: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(TestArray), <statTemp>$21: FalseClass, <statTemp>$22: Symbol(:a_string))
-    <selfRestore>$24: T.class_of(TestArray) = <self>
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(TestArray) = <selfRestore>$8
+    <cfgAlias>$17: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$19: Sorbet::Private::Static::Void = <cfgAlias>$17: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(TestArray))
+    <selfRestore>$20: T.class_of(TestArray) = <self>
     <unconditional> -> bb6
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(TestArray)):
+bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <cfgAlias>$15: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$15: T.class_of(Integer))
-    <blockReturnTemp>$16: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <cfgAlias>$13: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$13: T.class_of(Integer))
+    <blockReturnTemp>$14: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=0)
 # - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(TestArray)):
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$19: Sorbet::Private::Static::Void, <selfRestore>$20: T.class_of(TestArray)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(TestArray)):
-    <statTemp>$17: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$23, sig>
-    <self>: T.class_of(TestArray) = <selfRestore>$24
-    <cfgAlias>$34: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$36: T.class_of(T) = alias <C T>
-    <statTemp>$31: T.class_of(TestArray) = <self>: T.class_of(TestArray).extend(<cfgAlias>$34: T.class_of(T::Sig))
+bb7[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$19: Sorbet::Private::Static::Void, <selfRestore>$20: T.class_of(TestArray)):
+    <statTemp>$15: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$19, sig>
+    <self>: T.class_of(TestArray) = <selfRestore>$20
+    <cfgAlias>$30: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$32: T.class_of(T) = alias <C T>
+    <statTemp>$27: T.class_of(TestArray) = <self>: T.class_of(TestArray).extend(<cfgAlias>$30: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(TestArray)):
+bb9[rubyRegionId=2, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$19: Sorbet::Private::Static::Void, <selfRestore>$20: T.class_of(TestArray)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <cfgAlias>$29: T.class_of(String) = alias <C String>
-    <blockReturnTemp>$26: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$29: T.class_of(String))
-    <blockReturnTemp>$30: T.noreturn = blockreturn<sig> <blockReturnTemp>$26: T::Private::Methods::DeclBuilder
+    <cfgAlias>$25: T.class_of(String) = alias <C String>
+    <blockReturnTemp>$22: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$25: T.class_of(String))
+    <blockReturnTemp>$26: T.noreturn = blockreturn<sig> <blockReturnTemp>$22: T::Private::Methods::DeclBuilder
     <unconditional> -> bb6
 
 }

--- a/test/testdata/cfg/break.rb.cfg-text.exp
+++ b/test/testdata/cfg/break.rb.cfg-text.exp
@@ -71,11 +71,9 @@ method ::<Class:<root>>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:bar) = :bar
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(<root>), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:bar))
-    <selfRestore>$10: T.class_of(<root>) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(<root>))
+    <selfRestore>$8: T.class_of(<root>) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -86,145 +84,145 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(<root>) = <selfRestore>$10
-    <cfgAlias>$32: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$34: T.class_of(T) = alias <C T>
-    <statTemp>$29: T.class_of(<root>) = <self>: T.class_of(<root>).extend(<cfgAlias>$32: T.class_of(T::Sig))
-    <statTemp>$38: T.untyped = <self>: T.class_of(<root>).foo()
-    <statTemp>$36: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$38: T.untyped)
-    <block-pre-call-temp>$43: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).bar()
-    <selfRestore>$44: T.class_of(<root>) = <self>
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(<root>) = <selfRestore>$8
+    <cfgAlias>$30: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$32: T.class_of(T) = alias <C T>
+    <statTemp>$27: T.class_of(<root>) = <self>: T.class_of(<root>).extend(<cfgAlias>$30: T.class_of(T::Sig))
+    <statTemp>$36: T.untyped = <self>: T.class_of(<root>).foo()
+    <statTemp>$34: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$36: T.untyped)
+    <block-pre-call-temp>$41: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).bar()
+    <selfRestore>$42: T.class_of(<root>) = <self>
     <unconditional> -> bb6
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=13](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+bb5[rubyRegionId=1, firstDead=13](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$15: Symbol(:blk) = :blk
-    <cfgAlias>$20: T.class_of(T) = alias <C T>
-    <statTemp>$18: T.class_of(T.proc) = <cfgAlias>$20: T.class_of(T).proc()
-    <hashTemp>$21: Symbol(:x) = :x
-    <cfgAlias>$23: T.class_of(Integer) = alias <C Integer>
-    <statTemp>$17: T.class_of(T.proc) = <statTemp>$18: T.class_of(T.proc).params(<hashTemp>$21: Symbol(:x), <cfgAlias>$23: T.class_of(Integer))
+    <hashTemp>$13: Symbol(:blk) = :blk
+    <cfgAlias>$18: T.class_of(T) = alias <C T>
+    <statTemp>$16: T.class_of(T.proc) = <cfgAlias>$18: T.class_of(T).proc()
+    <hashTemp>$19: Symbol(:x) = :x
+    <cfgAlias>$21: T.class_of(Integer) = alias <C Integer>
+    <statTemp>$15: T.class_of(T.proc) = <statTemp>$16: T.class_of(T.proc).params(<hashTemp>$19: Symbol(:x), <cfgAlias>$21: T.class_of(Integer))
+    <cfgAlias>$23: T.class_of(String) = alias <C String>
+    <hashTemp>$14: T.class_of(T.proc) = <statTemp>$15: T.class_of(T.proc).returns(<cfgAlias>$23: T.class_of(String))
+    <statTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$13: Symbol(:blk), <hashTemp>$14: T.class_of(T.proc))
     <cfgAlias>$25: T.class_of(String) = alias <C String>
-    <hashTemp>$16: T.class_of(T.proc) = <statTemp>$17: T.class_of(T.proc).returns(<cfgAlias>$25: T.class_of(String))
-    <statTemp>$13: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$15: Symbol(:blk), <hashTemp>$16: T.class_of(T.proc))
-    <cfgAlias>$27: T.class_of(String) = alias <C String>
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <statTemp>$13: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$27: T.class_of(String))
-    <blockReturnTemp>$28: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <statTemp>$11: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$25: T.class_of(String))
+    <blockReturnTemp>$26: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=0)
 # - bb11(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$43: Sorbet::Private::Static::Void, <selfRestore>$44: T.class_of(<root>)):
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$43: Sorbet::Private::Static::Void, <selfRestore>$44: T.class_of(<root>)):
-    a: String = Solve<<block-pre-call-temp>$43, bar>
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(<root>)):
+    a: String = Solve<<block-pre-call-temp>$41, bar>
     <unconditional> -> bb8
 
 # backedges
 # - bb7(rubyRegionId=0)
 # - bb10(rubyRegionId=2)
-bb8[rubyRegionId=0, firstDead=-1](a: T.any(String, Integer), <selfRestore>$44: T.class_of(<root>)):
-    <self>: T.class_of(<root>) = <selfRestore>$44
-    <cfgAlias>$58: T.class_of(T) = alias <C T>
-    <statTemp>$56: T.any(String, Integer) = <cfgAlias>$58: T.class_of(T).reveal_type(a: T.any(String, Integer))
-    <block-pre-call-temp>$62: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).bar()
-    <selfRestore>$63: T.class_of(<root>) = <self>
+bb8[rubyRegionId=0, firstDead=-1](a: T.any(String, Integer), <selfRestore>$42: T.class_of(<root>)):
+    <self>: T.class_of(<root>) = <selfRestore>$42
+    <cfgAlias>$56: T.class_of(T) = alias <C T>
+    <statTemp>$54: T.any(String, Integer) = <cfgAlias>$56: T.class_of(T).reveal_type(a: T.any(String, Integer))
+    <block-pre-call-temp>$60: Sorbet::Private::Static::Void = <self>: T.class_of(<root>).bar()
+    <selfRestore>$61: T.class_of(<root>) = <self>
     <unconditional> -> bb12
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$43: Sorbet::Private::Static::Void, <selfRestore>$44: T.class_of(<root>)):
+bb9[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf(bar)
-    <blk>$45: [Integer] = load_yield_params(bar)
-    x$2: Integer = yield_load_arg(0, <blk>$45: [Integer])
-    <statTemp>$50: Integer(5) = 5
-    <ifTemp>$48: T::Boolean = x$2: Integer.>(<statTemp>$50: Integer(5))
-    <ifTemp>$48 -> (T::Boolean ? bb10 : bb11)
+    <blk>$43: [Integer] = load_yield_params(bar)
+    x$2: Integer = yield_load_arg(0, <blk>$43: [Integer])
+    <statTemp>$48: Integer(5) = 5
+    <ifTemp>$46: T::Boolean = x$2: Integer.>(<statTemp>$48: Integer(5))
+    <ifTemp>$46 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
 # - bb9(rubyRegionId=2)
-bb10[rubyRegionId=2, firstDead=-1](<selfRestore>$44: T.class_of(<root>)):
+bb10[rubyRegionId=2, firstDead=-1](<selfRestore>$42: T.class_of(<root>)):
     # outerLoops: 1
-    <returnTemp>$51: Integer(10) = 10
-    <block-break-assign>$52: Integer(10) = <returnTemp>$51
-    <magic>$53: T.class_of(<Magic>) = alias <C <Magic>>
-    <block-break>$54: T.untyped = <magic>$53: T.class_of(<Magic>).<block-break>(<returnTemp>$51: Integer(10))
-    a: Integer(10) = <block-break-assign>$52
+    <returnTemp>$49: Integer(10) = 10
+    <block-break-assign>$50: Integer(10) = <returnTemp>$49
+    <magic>$51: T.class_of(<Magic>) = alias <C <Magic>>
+    <block-break>$52: T.untyped = <magic>$51: T.class_of(<Magic>).<block-break>(<returnTemp>$49: Integer(10))
+    a: Integer(10) = <block-break-assign>$50
     <unconditional> -> bb8
 
 # backedges
 # - bb9(rubyRegionId=2)
-bb11[rubyRegionId=2, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$43: Sorbet::Private::Static::Void, <selfRestore>$44: T.class_of(<root>)):
+bb11[rubyRegionId=2, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(<root>)):
     # outerLoops: 1
-    <blockReturnTemp>$46: String("test") = "test"
-    <blockReturnTemp>$55: T.noreturn = blockreturn<bar> <blockReturnTemp>$46: String("test")
+    <blockReturnTemp>$44: String("test") = "test"
+    <blockReturnTemp>$53: T.noreturn = blockreturn<bar> <blockReturnTemp>$44: String("test")
     <unconditional> -> bb6
 
 # backedges
 # - bb8(rubyRegionId=0)
 # - bb17(rubyRegionId=3)
-bb12[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(<root>)):
+bb12[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$60: Sorbet::Private::Static::Void, <selfRestore>$61: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb15 : bb13)
 
 # backedges
 # - bb12(rubyRegionId=3)
-bb13[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(<root>)):
-    b: String = Solve<<block-pre-call-temp>$62, bar>
+bb13[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$60: Sorbet::Private::Static::Void, <selfRestore>$61: T.class_of(<root>)):
+    b: String = Solve<<block-pre-call-temp>$60, bar>
     <unconditional> -> bb14
 
 # backedges
 # - bb13(rubyRegionId=0)
 # - bb16(rubyRegionId=3)
-bb14[rubyRegionId=0, firstDead=-1](b: T.nilable(String), <selfRestore>$63: T.class_of(<root>)):
-    <cfgAlias>$77: T.class_of(T) = alias <C T>
-    <statTemp>$75: T.nilable(String) = <cfgAlias>$77: T.class_of(T).reveal_type(b: T.nilable(String))
+bb14[rubyRegionId=0, firstDead=-1](b: T.nilable(String), <selfRestore>$61: T.class_of(<root>)):
+    <cfgAlias>$75: T.class_of(T) = alias <C T>
+    <statTemp>$73: T.nilable(String) = <cfgAlias>$75: T.class_of(T).reveal_type(b: T.nilable(String))
     <unconditional> -> bb18
 
 # backedges
 # - bb12(rubyRegionId=3)
-bb15[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(<root>)):
+bb15[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$60: Sorbet::Private::Static::Void, <selfRestore>$61: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf(bar)
-    <blk>$64: [Integer] = load_yield_params(bar)
-    x$3: Integer = yield_load_arg(0, <blk>$64: [Integer])
-    <statTemp>$69: Integer(5) = 5
-    <ifTemp>$67: T::Boolean = x$3: Integer.>(<statTemp>$69: Integer(5))
-    <ifTemp>$67 -> (T::Boolean ? bb16 : bb17)
+    <blk>$62: [Integer] = load_yield_params(bar)
+    x$3: Integer = yield_load_arg(0, <blk>$62: [Integer])
+    <statTemp>$67: Integer(5) = 5
+    <ifTemp>$65: T::Boolean = x$3: Integer.>(<statTemp>$67: Integer(5))
+    <ifTemp>$65 -> (T::Boolean ? bb16 : bb17)
 
 # backedges
 # - bb15(rubyRegionId=3)
-bb16[rubyRegionId=3, firstDead=-1](<selfRestore>$63: T.class_of(<root>)):
+bb16[rubyRegionId=3, firstDead=-1](<selfRestore>$61: T.class_of(<root>)):
     # outerLoops: 1
-    <block-break-assign>$71: NilClass = <returnTemp>$70
-    <magic>$72: T.class_of(<Magic>) = alias <C <Magic>>
-    <block-break>$73: T.untyped = <magic>$72: T.class_of(<Magic>).<block-break>(<returnTemp>$70: NilClass)
-    b: NilClass = <block-break-assign>$71
+    <block-break-assign>$69: NilClass = <returnTemp>$68
+    <magic>$70: T.class_of(<Magic>) = alias <C <Magic>>
+    <block-break>$71: T.untyped = <magic>$70: T.class_of(<Magic>).<block-break>(<returnTemp>$68: NilClass)
+    b: NilClass = <block-break-assign>$69
     <unconditional> -> bb14
 
 # backedges
 # - bb15(rubyRegionId=3)
-bb17[rubyRegionId=3, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(<root>)):
+bb17[rubyRegionId=3, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$60: Sorbet::Private::Static::Void, <selfRestore>$61: T.class_of(<root>)):
     # outerLoops: 1
-    <blockReturnTemp>$65: String("test") = "test"
-    <blockReturnTemp>$74: T.noreturn = blockreturn<bar> <blockReturnTemp>$65: String("test")
+    <blockReturnTemp>$63: String("test") = "test"
+    <blockReturnTemp>$72: T.noreturn = blockreturn<bar> <blockReturnTemp>$63: String("test")
     <unconditional> -> bb12
 
 # backedges
@@ -232,11 +230,11 @@ bb17[rubyRegionId=3, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-te
 # - bb21(rubyRegionId=0)
 bb18[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
-    <statTemp>$82: Integer(1) = 1
-    <statTemp>$81: String = <statTemp>$82: Integer(1).to_s()
-    <statTemp>$83: String("") = ""
-    <whileTemp>$80: T::Boolean = <statTemp>$81: String.==(<statTemp>$83: String(""))
-    <whileTemp>$80 -> (T::Boolean ? bb21 : bb19)
+    <statTemp>$80: Integer(1) = 1
+    <statTemp>$79: String = <statTemp>$80: Integer(1).to_s()
+    <statTemp>$81: String("") = ""
+    <whileTemp>$78: T::Boolean = <statTemp>$79: String.==(<statTemp>$81: String(""))
+    <whileTemp>$78 -> (T::Boolean ? bb21 : bb19)
 
 # backedges
 # - bb18(rubyRegionId=0)
@@ -248,8 +246,8 @@ bb19[rubyRegionId=0, firstDead=-1]():
 # - bb19(rubyRegionId=0)
 # - bb22(rubyRegionId=0)
 bb20[rubyRegionId=0, firstDead=3](c: T.nilable(Symbol)):
-    <cfgAlias>$93: T.class_of(T) = alias <C T>
-    <statTemp>$91: T.nilable(Symbol) = <cfgAlias>$93: T.class_of(T).reveal_type(c: T.nilable(Symbol))
+    <cfgAlias>$91: T.class_of(T) = alias <C T>
+    <statTemp>$89: T.nilable(Symbol) = <cfgAlias>$91: T.class_of(T).reveal_type(c: T.nilable(Symbol))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -257,19 +255,19 @@ bb20[rubyRegionId=0, firstDead=3](c: T.nilable(Symbol)):
 # - bb18(rubyRegionId=0)
 bb21[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
-    <statTemp>$87: Integer(1) = 1
-    <statTemp>$86: String = <statTemp>$87: Integer(1).to_s()
-    <statTemp>$88: String("") = ""
-    <ifTemp>$85: T::Boolean = <statTemp>$86: String.==(<statTemp>$88: String(""))
-    <ifTemp>$85 -> (T::Boolean ? bb22 : bb18)
+    <statTemp>$85: Integer(1) = 1
+    <statTemp>$84: String = <statTemp>$85: Integer(1).to_s()
+    <statTemp>$86: String("") = ""
+    <ifTemp>$83: T::Boolean = <statTemp>$84: String.==(<statTemp>$86: String(""))
+    <ifTemp>$83 -> (T::Boolean ? bb22 : bb18)
 
 # backedges
 # - bb21(rubyRegionId=0)
 bb22[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
-    <returnTemp>$89: Symbol(:abc) = :abc
-    <block-break-assign>$90: Symbol(:abc) = <returnTemp>$89
-    c: Symbol(:abc) = <block-break-assign>$90
+    <returnTemp>$87: Symbol(:abc) = :abc
+    <block-break-assign>$88: Symbol(:abc) = <returnTemp>$87
+    c: Symbol(:abc) = <block-break-assign>$88
     <unconditional> -> bb20
 
 }

--- a/test/testdata/cfg/default_args_cases.rb.cfg-text.exp
+++ b/test/testdata/cfg/default_args_cases.rb.cfg-text.exp
@@ -199,11 +199,9 @@ method ::<Class:Test>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Test) = cast(<self>: NilClass, T.class_of(Test));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:test1) = :test1
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Test), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:test1))
-    <selfRestore>$10: T.class_of(Test) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Test))
+    <selfRestore>$8: T.class_of(Test) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -214,119 +212,115 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Test)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Test)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(Test) = <selfRestore>$10
-    <cfgAlias>$41: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$43: FalseClass = false
-    <statTemp>$44: Symbol(:test2) = :test2
-    <block-pre-call-temp>$45: Sorbet::Private::Static::Void = <cfgAlias>$41: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Test), <statTemp>$43: FalseClass, <statTemp>$44: Symbol(:test2))
-    <selfRestore>$46: T.class_of(Test) = <self>
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(Test) = <selfRestore>$8
+    <cfgAlias>$39: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$41: Sorbet::Private::Static::Void = <cfgAlias>$39: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Test))
+    <selfRestore>$42: T.class_of(Test) = <self>
     <unconditional> -> bb6
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Test)):
+bb5[rubyRegionId=1, firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$15: Symbol(:a) = :a
-    <cfgAlias>$17: T.class_of(Integer) = alias <C Integer>
-    <hashTemp>$18: Symbol(:b) = :b
-    <cfgAlias>$20: T.class_of(Integer) = alias <C Integer>
-    <hashTemp>$21: Symbol(:c) = :c
-    <cfgAlias>$23: T.class_of(Integer) = alias <C Integer>
-    <hashTemp>$24: Symbol(:d) = :d
-    <cfgAlias>$26: T.class_of(Integer) = alias <C Integer>
-    <hashTemp>$27: Symbol(:e) = :e
-    <cfgAlias>$29: T.class_of(Integer) = alias <C Integer>
-    <hashTemp>$30: Symbol(:f) = :f
-    <cfgAlias>$32: T.class_of(String) = alias <C String>
-    <hashTemp>$33: Symbol(:blk) = :blk
-    <cfgAlias>$37: T.class_of(T) = alias <C T>
-    <statTemp>$35: T.class_of(T.proc) = <cfgAlias>$37: T.class_of(T).proc()
-    <hashTemp>$34: T.class_of(T.proc) = <statTemp>$35: T.class_of(T.proc).void()
-    <statTemp>$13: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$15: Symbol(:a), <cfgAlias>$17: T.class_of(Integer), <hashTemp>$18: Symbol(:b), <cfgAlias>$20: T.class_of(Integer), <hashTemp>$21: Symbol(:c), <cfgAlias>$23: T.class_of(Integer), <hashTemp>$24: Symbol(:d), <cfgAlias>$26: T.class_of(Integer), <hashTemp>$27: Symbol(:e), <cfgAlias>$29: T.class_of(Integer), <hashTemp>$30: Symbol(:f), <cfgAlias>$32: T.class_of(String), <hashTemp>$33: Symbol(:blk), <hashTemp>$34: T.class_of(T.proc))
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <statTemp>$13: T::Private::Methods::DeclBuilder.void()
-    <blockReturnTemp>$38: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <hashTemp>$13: Symbol(:a) = :a
+    <cfgAlias>$15: T.class_of(Integer) = alias <C Integer>
+    <hashTemp>$16: Symbol(:b) = :b
+    <cfgAlias>$18: T.class_of(Integer) = alias <C Integer>
+    <hashTemp>$19: Symbol(:c) = :c
+    <cfgAlias>$21: T.class_of(Integer) = alias <C Integer>
+    <hashTemp>$22: Symbol(:d) = :d
+    <cfgAlias>$24: T.class_of(Integer) = alias <C Integer>
+    <hashTemp>$25: Symbol(:e) = :e
+    <cfgAlias>$27: T.class_of(Integer) = alias <C Integer>
+    <hashTemp>$28: Symbol(:f) = :f
+    <cfgAlias>$30: T.class_of(String) = alias <C String>
+    <hashTemp>$31: Symbol(:blk) = :blk
+    <cfgAlias>$35: T.class_of(T) = alias <C T>
+    <statTemp>$33: T.class_of(T.proc) = <cfgAlias>$35: T.class_of(T).proc()
+    <hashTemp>$32: T.class_of(T.proc) = <statTemp>$33: T.class_of(T.proc).void()
+    <statTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$13: Symbol(:a), <cfgAlias>$15: T.class_of(Integer), <hashTemp>$16: Symbol(:b), <cfgAlias>$18: T.class_of(Integer), <hashTemp>$19: Symbol(:c), <cfgAlias>$21: T.class_of(Integer), <hashTemp>$22: Symbol(:d), <cfgAlias>$24: T.class_of(Integer), <hashTemp>$25: Symbol(:e), <cfgAlias>$27: T.class_of(Integer), <hashTemp>$28: Symbol(:f), <cfgAlias>$30: T.class_of(String), <hashTemp>$31: Symbol(:blk), <hashTemp>$32: T.class_of(T.proc))
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <statTemp>$11: T::Private::Methods::DeclBuilder.void()
+    <blockReturnTemp>$36: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=0)
 # - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Test)):
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(Test)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Test)):
-    <statTemp>$39: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$45, sig>
-    <self>: T.class_of(Test) = <selfRestore>$46
-    <cfgAlias>$65: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$67: FalseClass = false
-    <statTemp>$68: Symbol(:test3) = :test3
-    <block-pre-call-temp>$69: Sorbet::Private::Static::Void = <cfgAlias>$65: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Test), <statTemp>$67: FalseClass, <statTemp>$68: Symbol(:test3))
-    <selfRestore>$70: T.class_of(Test) = <self>
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(Test)):
+    <statTemp>$37: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$41, sig>
+    <self>: T.class_of(Test) = <selfRestore>$42
+    <cfgAlias>$61: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$63: Sorbet::Private::Static::Void = <cfgAlias>$61: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Test))
+    <selfRestore>$64: T.class_of(Test) = <self>
     <unconditional> -> bb10
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Test)):
+bb9[rubyRegionId=2, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(Test)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$51: Symbol(:x) = :x
-    <cfgAlias>$53: T.class_of(Integer) = alias <C Integer>
-    <hashTemp>$54: Symbol(:rest) = :rest
-    <cfgAlias>$56: T.class_of(Integer) = alias <C Integer>
-    <hashTemp>$57: Symbol(:blk) = :blk
-    <cfgAlias>$61: T.class_of(T) = alias <C T>
-    <statTemp>$59: T.class_of(T.proc) = <cfgAlias>$61: T.class_of(T).proc()
-    <hashTemp>$58: T.class_of(T.proc) = <statTemp>$59: T.class_of(T.proc).void()
-    <statTemp>$49: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$51: Symbol(:x), <cfgAlias>$53: T.class_of(Integer), <hashTemp>$54: Symbol(:rest), <cfgAlias>$56: T.class_of(Integer), <hashTemp>$57: Symbol(:blk), <hashTemp>$58: T.class_of(T.proc))
-    <blockReturnTemp>$48: T::Private::Methods::DeclBuilder = <statTemp>$49: T::Private::Methods::DeclBuilder.void()
-    <blockReturnTemp>$62: T.noreturn = blockreturn<sig> <blockReturnTemp>$48: T::Private::Methods::DeclBuilder
+    <hashTemp>$47: Symbol(:x) = :x
+    <cfgAlias>$49: T.class_of(Integer) = alias <C Integer>
+    <hashTemp>$50: Symbol(:rest) = :rest
+    <cfgAlias>$52: T.class_of(Integer) = alias <C Integer>
+    <hashTemp>$53: Symbol(:blk) = :blk
+    <cfgAlias>$57: T.class_of(T) = alias <C T>
+    <statTemp>$55: T.class_of(T.proc) = <cfgAlias>$57: T.class_of(T).proc()
+    <hashTemp>$54: T.class_of(T.proc) = <statTemp>$55: T.class_of(T.proc).void()
+    <statTemp>$45: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$47: Symbol(:x), <cfgAlias>$49: T.class_of(Integer), <hashTemp>$50: Symbol(:rest), <cfgAlias>$52: T.class_of(Integer), <hashTemp>$53: Symbol(:blk), <hashTemp>$54: T.class_of(T.proc))
+    <blockReturnTemp>$44: T::Private::Methods::DeclBuilder = <statTemp>$45: T::Private::Methods::DeclBuilder.void()
+    <blockReturnTemp>$58: T.noreturn = blockreturn<sig> <blockReturnTemp>$44: T::Private::Methods::DeclBuilder
     <unconditional> -> bb6
 
 # backedges
 # - bb7(rubyRegionId=0)
 # - bb13(rubyRegionId=3)
-bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Test)):
+bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Test)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
 # - bb10(rubyRegionId=3)
-bb11[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Test)):
-    <statTemp>$63: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$69, sig>
-    <self>: T.class_of(Test) = <selfRestore>$70
-    <cfgAlias>$90: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$92: T.class_of(T) = alias <C T>
-    <statTemp>$87: T.class_of(Test) = <self>: T.class_of(Test).extend(<cfgAlias>$90: T.class_of(T::Sig))
+bb11[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Test)):
+    <statTemp>$59: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$63, sig>
+    <self>: T.class_of(Test) = <selfRestore>$64
+    <cfgAlias>$84: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$86: T.class_of(T) = alias <C T>
+    <statTemp>$81: T.class_of(Test) = <self>: T.class_of(Test).extend(<cfgAlias>$84: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb10(rubyRegionId=3)
-bb13[rubyRegionId=3, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Test)):
+bb13[rubyRegionId=3, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Test)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$75: Symbol(:x) = :x
-    <cfgAlias>$77: T.class_of(Integer) = alias <C Integer>
-    <hashTemp>$78: Symbol(:rest) = :rest
-    <cfgAlias>$80: T.class_of(Integer) = alias <C Integer>
-    <hashTemp>$81: Symbol(:blk) = :blk
-    <cfgAlias>$85: T.class_of(T) = alias <C T>
-    <statTemp>$83: T.class_of(T.proc) = <cfgAlias>$85: T.class_of(T).proc()
-    <hashTemp>$82: T.class_of(T.proc) = <statTemp>$83: T.class_of(T.proc).void()
-    <statTemp>$73: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$75: Symbol(:x), <cfgAlias>$77: T.class_of(Integer), <hashTemp>$78: Symbol(:rest), <cfgAlias>$80: T.class_of(Integer), <hashTemp>$81: Symbol(:blk), <hashTemp>$82: T.class_of(T.proc))
-    <blockReturnTemp>$72: T::Private::Methods::DeclBuilder = <statTemp>$73: T::Private::Methods::DeclBuilder.void()
-    <blockReturnTemp>$86: T.noreturn = blockreturn<sig> <blockReturnTemp>$72: T::Private::Methods::DeclBuilder
+    <hashTemp>$69: Symbol(:x) = :x
+    <cfgAlias>$71: T.class_of(Integer) = alias <C Integer>
+    <hashTemp>$72: Symbol(:rest) = :rest
+    <cfgAlias>$74: T.class_of(Integer) = alias <C Integer>
+    <hashTemp>$75: Symbol(:blk) = :blk
+    <cfgAlias>$79: T.class_of(T) = alias <C T>
+    <statTemp>$77: T.class_of(T.proc) = <cfgAlias>$79: T.class_of(T).proc()
+    <hashTemp>$76: T.class_of(T.proc) = <statTemp>$77: T.class_of(T.proc).void()
+    <statTemp>$67: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$69: Symbol(:x), <cfgAlias>$71: T.class_of(Integer), <hashTemp>$72: Symbol(:rest), <cfgAlias>$74: T.class_of(Integer), <hashTemp>$75: Symbol(:blk), <hashTemp>$76: T.class_of(T.proc))
+    <blockReturnTemp>$66: T::Private::Methods::DeclBuilder = <statTemp>$67: T::Private::Methods::DeclBuilder.void()
+    <blockReturnTemp>$80: T.noreturn = blockreturn<sig> <blockReturnTemp>$66: T::Private::Methods::DeclBuilder
     <unconditional> -> bb10
 
 }

--- a/test/testdata/desugar/sclass.rb.flatten-tree.exp
+++ b/test/testdata/desugar/sclass.rb.flatten-tree.exp
@@ -152,7 +152,7 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :f=) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:f, ::Integer).returns(::Integer)
         end
         <runtime method definition of initialize>

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -593,11 +593,9 @@ method ::<Class:B>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: TrueClass = true
-    <statTemp>$8: Symbol(:class_helper) = :class_helper
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(B), <statTemp>$7: TrueClass, <statTemp>$8: Symbol(:class_helper))
-    <selfRestore>$10: T.class_of(B) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))
+    <selfRestore>$8: T.class_of(B) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -608,33 +606,33 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(B) = <selfRestore>$10
-    <cfgAlias>$24: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$26: T.class_of(T) = alias <C T>
-    <statTemp>$21: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$24: T.class_of(T::Sig))
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(B) = <selfRestore>$8
+    <cfgAlias>$22: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$24: T.class_of(T) = alias <C T>
+    <statTemp>$19: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$22: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$15: Symbol(:blk) = :blk
-    <cfgAlias>$19: T.class_of(T) = alias <C T>
-    <statTemp>$17: T.class_of(T.proc) = <cfgAlias>$19: T.class_of(T).proc()
-    <hashTemp>$16: T.class_of(T.proc) = <statTemp>$17: T.class_of(T.proc).void()
-    <statTemp>$13: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$15: Symbol(:blk), <hashTemp>$16: T.class_of(T.proc))
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <statTemp>$13: T::Private::Methods::DeclBuilder.void()
-    <blockReturnTemp>$20: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <hashTemp>$13: Symbol(:blk) = :blk
+    <cfgAlias>$17: T.class_of(T) = alias <C T>
+    <statTemp>$15: T.class_of(T.proc) = <cfgAlias>$17: T.class_of(T).proc()
+    <hashTemp>$14: T.class_of(T.proc) = <statTemp>$15: T.class_of(T.proc).void()
+    <statTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$13: Symbol(:blk), <hashTemp>$14: T.class_of(T.proc))
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <statTemp>$11: T::Private::Methods::DeclBuilder.void()
+    <blockReturnTemp>$18: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }

--- a/test/testdata/infer/control_flow/simple.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/simple.rb.cfg-text.exp
@@ -350,11 +350,9 @@ method ::<Class:ControlFlow>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(ControlFlow) = cast(<self>: NilClass, T.class_of(ControlFlow));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:orZero0) = :orZero0
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(ControlFlow), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:orZero0))
-    <selfRestore>$10: T.class_of(ControlFlow) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
+    <selfRestore>$8: T.class_of(ControlFlow) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -365,312 +363,296 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(ControlFlow)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(ControlFlow)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(ControlFlow) = <selfRestore>$10
-    <cfgAlias>$28: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$30: FalseClass = false
-    <statTemp>$31: Symbol(:orZero0a) = :orZero0a
-    <block-pre-call-temp>$32: Sorbet::Private::Static::Void = <cfgAlias>$28: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(ControlFlow), <statTemp>$30: FalseClass, <statTemp>$31: Symbol(:orZero0a))
-    <selfRestore>$33: T.class_of(ControlFlow) = <self>
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(ControlFlow) = <selfRestore>$8
+    <cfgAlias>$26: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$28: Sorbet::Private::Static::Void = <cfgAlias>$26: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
+    <selfRestore>$29: T.class_of(ControlFlow) = <self>
     <unconditional> -> bb6
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(ControlFlow)):
+bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$15: Symbol(:a) = :a
-    <cfgAlias>$18: T.class_of(T) = alias <C T>
-    <cfgAlias>$20: T.class_of(Integer) = alias <C Integer>
-    <cfgAlias>$22: T.class_of(NilClass) = alias <C NilClass>
-    <hashTemp>$16: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$18: T.class_of(T).any(<cfgAlias>$20: T.class_of(Integer), <cfgAlias>$22: T.class_of(NilClass))
-    <statTemp>$13: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$15: Symbol(:a), <hashTemp>$16: Runtime object representing type: T.nilable(Integer))
-    <cfgAlias>$24: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <statTemp>$13: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$24: T.class_of(Integer))
-    <blockReturnTemp>$25: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <hashTemp>$13: Symbol(:a) = :a
+    <cfgAlias>$16: T.class_of(T) = alias <C T>
+    <cfgAlias>$18: T.class_of(Integer) = alias <C Integer>
+    <cfgAlias>$20: T.class_of(NilClass) = alias <C NilClass>
+    <hashTemp>$14: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$16: T.class_of(T).any(<cfgAlias>$18: T.class_of(Integer), <cfgAlias>$20: T.class_of(NilClass))
+    <statTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$13: Symbol(:a), <hashTemp>$14: Runtime object representing type: T.nilable(Integer))
+    <cfgAlias>$22: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <statTemp>$11: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$22: T.class_of(Integer))
+    <blockReturnTemp>$23: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=0)
 # - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(ControlFlow)):
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$28: Sorbet::Private::Static::Void, <selfRestore>$29: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(ControlFlow)):
-    <statTemp>$26: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$32, sig>
-    <self>: T.class_of(ControlFlow) = <selfRestore>$33
-    <cfgAlias>$46: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$48: FalseClass = false
-    <statTemp>$49: Symbol(:orZero0n) = :orZero0n
-    <block-pre-call-temp>$50: Sorbet::Private::Static::Void = <cfgAlias>$46: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(ControlFlow), <statTemp>$48: FalseClass, <statTemp>$49: Symbol(:orZero0n))
-    <selfRestore>$51: T.class_of(ControlFlow) = <self>
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$28: Sorbet::Private::Static::Void, <selfRestore>$29: T.class_of(ControlFlow)):
+    <statTemp>$24: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$28, sig>
+    <self>: T.class_of(ControlFlow) = <selfRestore>$29
+    <cfgAlias>$42: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$44: Sorbet::Private::Static::Void = <cfgAlias>$42: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
+    <selfRestore>$45: T.class_of(ControlFlow) = <self>
     <unconditional> -> bb10
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(ControlFlow)):
+bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$28: Sorbet::Private::Static::Void, <selfRestore>$29: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$38: Symbol(:a) = :a
-    <cfgAlias>$40: T.class_of(Integer) = alias <C Integer>
-    <statTemp>$36: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$38: Symbol(:a), <cfgAlias>$40: T.class_of(Integer))
-    <cfgAlias>$42: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$35: T::Private::Methods::DeclBuilder = <statTemp>$36: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$42: T.class_of(Integer))
-    <blockReturnTemp>$43: T.noreturn = blockreturn<sig> <blockReturnTemp>$35: T::Private::Methods::DeclBuilder
+    <hashTemp>$34: Symbol(:a) = :a
+    <cfgAlias>$36: T.class_of(Integer) = alias <C Integer>
+    <statTemp>$32: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$34: Symbol(:a), <cfgAlias>$36: T.class_of(Integer))
+    <cfgAlias>$38: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$31: T::Private::Methods::DeclBuilder = <statTemp>$32: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$38: T.class_of(Integer))
+    <blockReturnTemp>$39: T.noreturn = blockreturn<sig> <blockReturnTemp>$31: T::Private::Methods::DeclBuilder
     <unconditional> -> bb6
 
 # backedges
 # - bb7(rubyRegionId=0)
 # - bb13(rubyRegionId=3)
-bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$50: Sorbet::Private::Static::Void, <selfRestore>$51: T.class_of(ControlFlow)):
+bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$44: Sorbet::Private::Static::Void, <selfRestore>$45: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
 # - bb10(rubyRegionId=3)
-bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$50: Sorbet::Private::Static::Void, <selfRestore>$51: T.class_of(ControlFlow)):
-    <statTemp>$44: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$50, sig>
-    <self>: T.class_of(ControlFlow) = <selfRestore>$51
-    <cfgAlias>$69: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$71: FalseClass = false
-    <statTemp>$72: Symbol(:orZero1n) = :orZero1n
-    <block-pre-call-temp>$73: Sorbet::Private::Static::Void = <cfgAlias>$69: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(ControlFlow), <statTemp>$71: FalseClass, <statTemp>$72: Symbol(:orZero1n))
-    <selfRestore>$74: T.class_of(ControlFlow) = <self>
+bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$44: Sorbet::Private::Static::Void, <selfRestore>$45: T.class_of(ControlFlow)):
+    <statTemp>$40: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$44, sig>
+    <self>: T.class_of(ControlFlow) = <selfRestore>$45
+    <cfgAlias>$63: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$65: Sorbet::Private::Static::Void = <cfgAlias>$63: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
+    <selfRestore>$66: T.class_of(ControlFlow) = <self>
     <unconditional> -> bb14
 
 # backedges
 # - bb10(rubyRegionId=3)
-bb13[rubyRegionId=3, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$50: Sorbet::Private::Static::Void, <selfRestore>$51: T.class_of(ControlFlow)):
+bb13[rubyRegionId=3, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$44: Sorbet::Private::Static::Void, <selfRestore>$45: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$56: Symbol(:a) = :a
-    <cfgAlias>$59: T.class_of(T) = alias <C T>
-    <cfgAlias>$61: T.class_of(Integer) = alias <C Integer>
-    <cfgAlias>$63: T.class_of(NilClass) = alias <C NilClass>
-    <hashTemp>$57: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$59: T.class_of(T).any(<cfgAlias>$61: T.class_of(Integer), <cfgAlias>$63: T.class_of(NilClass))
-    <statTemp>$54: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$56: Symbol(:a), <hashTemp>$57: Runtime object representing type: T.nilable(Integer))
-    <cfgAlias>$65: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$53: T::Private::Methods::DeclBuilder = <statTemp>$54: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$65: T.class_of(Integer))
-    <blockReturnTemp>$66: T.noreturn = blockreturn<sig> <blockReturnTemp>$53: T::Private::Methods::DeclBuilder
+    <hashTemp>$50: Symbol(:a) = :a
+    <cfgAlias>$53: T.class_of(T) = alias <C T>
+    <cfgAlias>$55: T.class_of(Integer) = alias <C Integer>
+    <cfgAlias>$57: T.class_of(NilClass) = alias <C NilClass>
+    <hashTemp>$51: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$53: T.class_of(T).any(<cfgAlias>$55: T.class_of(Integer), <cfgAlias>$57: T.class_of(NilClass))
+    <statTemp>$48: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$50: Symbol(:a), <hashTemp>$51: Runtime object representing type: T.nilable(Integer))
+    <cfgAlias>$59: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$47: T::Private::Methods::DeclBuilder = <statTemp>$48: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$59: T.class_of(Integer))
+    <blockReturnTemp>$60: T.noreturn = blockreturn<sig> <blockReturnTemp>$47: T::Private::Methods::DeclBuilder
     <unconditional> -> bb10
 
 # backedges
 # - bb11(rubyRegionId=0)
 # - bb17(rubyRegionId=4)
-bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$73: Sorbet::Private::Static::Void, <selfRestore>$74: T.class_of(ControlFlow)):
+bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$65: Sorbet::Private::Static::Void, <selfRestore>$66: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
 # - bb14(rubyRegionId=4)
-bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$73: Sorbet::Private::Static::Void, <selfRestore>$74: T.class_of(ControlFlow)):
-    <statTemp>$67: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$73, sig>
-    <self>: T.class_of(ControlFlow) = <selfRestore>$74
-    <cfgAlias>$92: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$94: FalseClass = false
-    <statTemp>$95: Symbol(:orZero2) = :orZero2
-    <block-pre-call-temp>$96: Sorbet::Private::Static::Void = <cfgAlias>$92: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(ControlFlow), <statTemp>$94: FalseClass, <statTemp>$95: Symbol(:orZero2))
-    <selfRestore>$97: T.class_of(ControlFlow) = <self>
+bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$65: Sorbet::Private::Static::Void, <selfRestore>$66: T.class_of(ControlFlow)):
+    <statTemp>$61: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$65, sig>
+    <self>: T.class_of(ControlFlow) = <selfRestore>$66
+    <cfgAlias>$84: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$86: Sorbet::Private::Static::Void = <cfgAlias>$84: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
+    <selfRestore>$87: T.class_of(ControlFlow) = <self>
     <unconditional> -> bb18
 
 # backedges
 # - bb14(rubyRegionId=4)
-bb17[rubyRegionId=4, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$73: Sorbet::Private::Static::Void, <selfRestore>$74: T.class_of(ControlFlow)):
+bb17[rubyRegionId=4, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$65: Sorbet::Private::Static::Void, <selfRestore>$66: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$79: Symbol(:a) = :a
-    <cfgAlias>$82: T.class_of(T) = alias <C T>
-    <cfgAlias>$84: T.class_of(Integer) = alias <C Integer>
-    <cfgAlias>$86: T.class_of(NilClass) = alias <C NilClass>
-    <hashTemp>$80: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$82: T.class_of(T).any(<cfgAlias>$84: T.class_of(Integer), <cfgAlias>$86: T.class_of(NilClass))
-    <statTemp>$77: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$79: Symbol(:a), <hashTemp>$80: Runtime object representing type: T.nilable(Integer))
-    <cfgAlias>$88: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$76: T::Private::Methods::DeclBuilder = <statTemp>$77: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$88: T.class_of(Integer))
-    <blockReturnTemp>$89: T.noreturn = blockreturn<sig> <blockReturnTemp>$76: T::Private::Methods::DeclBuilder
+    <hashTemp>$71: Symbol(:a) = :a
+    <cfgAlias>$74: T.class_of(T) = alias <C T>
+    <cfgAlias>$76: T.class_of(Integer) = alias <C Integer>
+    <cfgAlias>$78: T.class_of(NilClass) = alias <C NilClass>
+    <hashTemp>$72: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$74: T.class_of(T).any(<cfgAlias>$76: T.class_of(Integer), <cfgAlias>$78: T.class_of(NilClass))
+    <statTemp>$69: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$71: Symbol(:a), <hashTemp>$72: Runtime object representing type: T.nilable(Integer))
+    <cfgAlias>$80: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$68: T::Private::Methods::DeclBuilder = <statTemp>$69: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$80: T.class_of(Integer))
+    <blockReturnTemp>$81: T.noreturn = blockreturn<sig> <blockReturnTemp>$68: T::Private::Methods::DeclBuilder
     <unconditional> -> bb14
 
 # backedges
 # - bb15(rubyRegionId=0)
 # - bb21(rubyRegionId=5)
-bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(ControlFlow)):
+bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$86: Sorbet::Private::Static::Void, <selfRestore>$87: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
 # - bb18(rubyRegionId=5)
-bb19[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(ControlFlow)):
-    <statTemp>$90: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$96, sig>
-    <self>: T.class_of(ControlFlow) = <selfRestore>$97
-    <cfgAlias>$115: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$117: FalseClass = false
-    <statTemp>$118: Symbol(:orZero3) = :orZero3
-    <block-pre-call-temp>$119: Sorbet::Private::Static::Void = <cfgAlias>$115: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(ControlFlow), <statTemp>$117: FalseClass, <statTemp>$118: Symbol(:orZero3))
-    <selfRestore>$120: T.class_of(ControlFlow) = <self>
+bb19[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$86: Sorbet::Private::Static::Void, <selfRestore>$87: T.class_of(ControlFlow)):
+    <statTemp>$82: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$86, sig>
+    <self>: T.class_of(ControlFlow) = <selfRestore>$87
+    <cfgAlias>$105: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$107: Sorbet::Private::Static::Void = <cfgAlias>$105: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
+    <selfRestore>$108: T.class_of(ControlFlow) = <self>
     <unconditional> -> bb22
 
 # backedges
 # - bb18(rubyRegionId=5)
-bb21[rubyRegionId=5, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(ControlFlow)):
+bb21[rubyRegionId=5, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$86: Sorbet::Private::Static::Void, <selfRestore>$87: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$102: Symbol(:a) = :a
-    <cfgAlias>$105: T.class_of(T) = alias <C T>
-    <cfgAlias>$107: T.class_of(Integer) = alias <C Integer>
-    <cfgAlias>$109: T.class_of(NilClass) = alias <C NilClass>
-    <hashTemp>$103: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$105: T.class_of(T).any(<cfgAlias>$107: T.class_of(Integer), <cfgAlias>$109: T.class_of(NilClass))
-    <statTemp>$100: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$102: Symbol(:a), <hashTemp>$103: Runtime object representing type: T.nilable(Integer))
-    <cfgAlias>$111: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$99: T::Private::Methods::DeclBuilder = <statTemp>$100: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$111: T.class_of(Integer))
-    <blockReturnTemp>$112: T.noreturn = blockreturn<sig> <blockReturnTemp>$99: T::Private::Methods::DeclBuilder
+    <hashTemp>$92: Symbol(:a) = :a
+    <cfgAlias>$95: T.class_of(T) = alias <C T>
+    <cfgAlias>$97: T.class_of(Integer) = alias <C Integer>
+    <cfgAlias>$99: T.class_of(NilClass) = alias <C NilClass>
+    <hashTemp>$93: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$95: T.class_of(T).any(<cfgAlias>$97: T.class_of(Integer), <cfgAlias>$99: T.class_of(NilClass))
+    <statTemp>$90: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$92: Symbol(:a), <hashTemp>$93: Runtime object representing type: T.nilable(Integer))
+    <cfgAlias>$101: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$89: T::Private::Methods::DeclBuilder = <statTemp>$90: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$101: T.class_of(Integer))
+    <blockReturnTemp>$102: T.noreturn = blockreturn<sig> <blockReturnTemp>$89: T::Private::Methods::DeclBuilder
     <unconditional> -> bb18
 
 # backedges
 # - bb19(rubyRegionId=0)
 # - bb25(rubyRegionId=6)
-bb22[rubyRegionId=6, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(ControlFlow)):
+bb22[rubyRegionId=6, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$107: Sorbet::Private::Static::Void, <selfRestore>$108: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb25 : bb23)
 
 # backedges
 # - bb22(rubyRegionId=6)
-bb23[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(ControlFlow)):
-    <statTemp>$113: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$119, sig>
-    <self>: T.class_of(ControlFlow) = <selfRestore>$120
-    <cfgAlias>$138: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$140: FalseClass = false
-    <statTemp>$141: Symbol(:orZero3n) = :orZero3n
-    <block-pre-call-temp>$142: Sorbet::Private::Static::Void = <cfgAlias>$138: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(ControlFlow), <statTemp>$140: FalseClass, <statTemp>$141: Symbol(:orZero3n))
-    <selfRestore>$143: T.class_of(ControlFlow) = <self>
+bb23[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$107: Sorbet::Private::Static::Void, <selfRestore>$108: T.class_of(ControlFlow)):
+    <statTemp>$103: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$107, sig>
+    <self>: T.class_of(ControlFlow) = <selfRestore>$108
+    <cfgAlias>$126: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$128: Sorbet::Private::Static::Void = <cfgAlias>$126: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
+    <selfRestore>$129: T.class_of(ControlFlow) = <self>
     <unconditional> -> bb26
 
 # backedges
 # - bb22(rubyRegionId=6)
-bb25[rubyRegionId=6, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(ControlFlow)):
+bb25[rubyRegionId=6, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$107: Sorbet::Private::Static::Void, <selfRestore>$108: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$125: Symbol(:a) = :a
-    <cfgAlias>$128: T.class_of(T) = alias <C T>
-    <cfgAlias>$130: T.class_of(Integer) = alias <C Integer>
-    <cfgAlias>$132: T.class_of(NilClass) = alias <C NilClass>
-    <hashTemp>$126: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$128: T.class_of(T).any(<cfgAlias>$130: T.class_of(Integer), <cfgAlias>$132: T.class_of(NilClass))
-    <statTemp>$123: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$125: Symbol(:a), <hashTemp>$126: Runtime object representing type: T.nilable(Integer))
-    <cfgAlias>$134: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$122: T::Private::Methods::DeclBuilder = <statTemp>$123: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$134: T.class_of(Integer))
-    <blockReturnTemp>$135: T.noreturn = blockreturn<sig> <blockReturnTemp>$122: T::Private::Methods::DeclBuilder
+    <hashTemp>$113: Symbol(:a) = :a
+    <cfgAlias>$116: T.class_of(T) = alias <C T>
+    <cfgAlias>$118: T.class_of(Integer) = alias <C Integer>
+    <cfgAlias>$120: T.class_of(NilClass) = alias <C NilClass>
+    <hashTemp>$114: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$116: T.class_of(T).any(<cfgAlias>$118: T.class_of(Integer), <cfgAlias>$120: T.class_of(NilClass))
+    <statTemp>$111: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$113: Symbol(:a), <hashTemp>$114: Runtime object representing type: T.nilable(Integer))
+    <cfgAlias>$122: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$110: T::Private::Methods::DeclBuilder = <statTemp>$111: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$122: T.class_of(Integer))
+    <blockReturnTemp>$123: T.noreturn = blockreturn<sig> <blockReturnTemp>$110: T::Private::Methods::DeclBuilder
     <unconditional> -> bb22
 
 # backedges
 # - bb23(rubyRegionId=0)
 # - bb29(rubyRegionId=7)
-bb26[rubyRegionId=7, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
+bb26[rubyRegionId=7, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$128: Sorbet::Private::Static::Void, <selfRestore>$129: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb29 : bb27)
 
 # backedges
 # - bb26(rubyRegionId=7)
-bb27[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
-    <statTemp>$136: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$142, sig>
-    <self>: T.class_of(ControlFlow) = <selfRestore>$143
-    <cfgAlias>$161: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$163: FalseClass = false
-    <statTemp>$164: Symbol(:orZero4) = :orZero4
-    <block-pre-call-temp>$165: Sorbet::Private::Static::Void = <cfgAlias>$161: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(ControlFlow), <statTemp>$163: FalseClass, <statTemp>$164: Symbol(:orZero4))
-    <selfRestore>$166: T.class_of(ControlFlow) = <self>
+bb27[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$128: Sorbet::Private::Static::Void, <selfRestore>$129: T.class_of(ControlFlow)):
+    <statTemp>$124: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$128, sig>
+    <self>: T.class_of(ControlFlow) = <selfRestore>$129
+    <cfgAlias>$147: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$149: Sorbet::Private::Static::Void = <cfgAlias>$147: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
+    <selfRestore>$150: T.class_of(ControlFlow) = <self>
     <unconditional> -> bb30
 
 # backedges
 # - bb26(rubyRegionId=7)
-bb29[rubyRegionId=7, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
+bb29[rubyRegionId=7, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$128: Sorbet::Private::Static::Void, <selfRestore>$129: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$148: Symbol(:a) = :a
-    <cfgAlias>$151: T.class_of(T) = alias <C T>
-    <cfgAlias>$153: T.class_of(Integer) = alias <C Integer>
-    <cfgAlias>$155: T.class_of(NilClass) = alias <C NilClass>
-    <hashTemp>$149: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$151: T.class_of(T).any(<cfgAlias>$153: T.class_of(Integer), <cfgAlias>$155: T.class_of(NilClass))
-    <statTemp>$146: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$148: Symbol(:a), <hashTemp>$149: Runtime object representing type: T.nilable(Integer))
-    <cfgAlias>$157: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$145: T::Private::Methods::DeclBuilder = <statTemp>$146: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$157: T.class_of(Integer))
-    <blockReturnTemp>$158: T.noreturn = blockreturn<sig> <blockReturnTemp>$145: T::Private::Methods::DeclBuilder
+    <hashTemp>$134: Symbol(:a) = :a
+    <cfgAlias>$137: T.class_of(T) = alias <C T>
+    <cfgAlias>$139: T.class_of(Integer) = alias <C Integer>
+    <cfgAlias>$141: T.class_of(NilClass) = alias <C NilClass>
+    <hashTemp>$135: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$137: T.class_of(T).any(<cfgAlias>$139: T.class_of(Integer), <cfgAlias>$141: T.class_of(NilClass))
+    <statTemp>$132: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$134: Symbol(:a), <hashTemp>$135: Runtime object representing type: T.nilable(Integer))
+    <cfgAlias>$143: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$131: T::Private::Methods::DeclBuilder = <statTemp>$132: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$143: T.class_of(Integer))
+    <blockReturnTemp>$144: T.noreturn = blockreturn<sig> <blockReturnTemp>$131: T::Private::Methods::DeclBuilder
     <unconditional> -> bb26
 
 # backedges
 # - bb27(rubyRegionId=0)
 # - bb33(rubyRegionId=8)
-bb30[rubyRegionId=8, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$165: Sorbet::Private::Static::Void, <selfRestore>$166: T.class_of(ControlFlow)):
+bb30[rubyRegionId=8, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$149: Sorbet::Private::Static::Void, <selfRestore>$150: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb33 : bb31)
 
 # backedges
 # - bb30(rubyRegionId=8)
-bb31[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$165: Sorbet::Private::Static::Void, <selfRestore>$166: T.class_of(ControlFlow)):
-    <statTemp>$159: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$165, sig>
-    <self>: T.class_of(ControlFlow) = <selfRestore>$166
-    <cfgAlias>$184: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$186: FalseClass = false
-    <statTemp>$187: Symbol(:orZero5) = :orZero5
-    <block-pre-call-temp>$188: Sorbet::Private::Static::Void = <cfgAlias>$184: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(ControlFlow), <statTemp>$186: FalseClass, <statTemp>$187: Symbol(:orZero5))
-    <selfRestore>$189: T.class_of(ControlFlow) = <self>
+bb31[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$149: Sorbet::Private::Static::Void, <selfRestore>$150: T.class_of(ControlFlow)):
+    <statTemp>$145: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$149, sig>
+    <self>: T.class_of(ControlFlow) = <selfRestore>$150
+    <cfgAlias>$168: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$170: Sorbet::Private::Static::Void = <cfgAlias>$168: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
+    <selfRestore>$171: T.class_of(ControlFlow) = <self>
     <unconditional> -> bb34
 
 # backedges
 # - bb30(rubyRegionId=8)
-bb33[rubyRegionId=8, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$165: Sorbet::Private::Static::Void, <selfRestore>$166: T.class_of(ControlFlow)):
+bb33[rubyRegionId=8, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$149: Sorbet::Private::Static::Void, <selfRestore>$150: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$171: Symbol(:a) = :a
-    <cfgAlias>$174: T.class_of(T) = alias <C T>
-    <cfgAlias>$176: T.class_of(Integer) = alias <C Integer>
-    <cfgAlias>$178: T.class_of(NilClass) = alias <C NilClass>
-    <hashTemp>$172: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$174: T.class_of(T).any(<cfgAlias>$176: T.class_of(Integer), <cfgAlias>$178: T.class_of(NilClass))
-    <statTemp>$169: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$171: Symbol(:a), <hashTemp>$172: Runtime object representing type: T.nilable(Integer))
-    <cfgAlias>$180: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$168: T::Private::Methods::DeclBuilder = <statTemp>$169: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$180: T.class_of(Integer))
-    <blockReturnTemp>$181: T.noreturn = blockreturn<sig> <blockReturnTemp>$168: T::Private::Methods::DeclBuilder
+    <hashTemp>$155: Symbol(:a) = :a
+    <cfgAlias>$158: T.class_of(T) = alias <C T>
+    <cfgAlias>$160: T.class_of(Integer) = alias <C Integer>
+    <cfgAlias>$162: T.class_of(NilClass) = alias <C NilClass>
+    <hashTemp>$156: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$158: T.class_of(T).any(<cfgAlias>$160: T.class_of(Integer), <cfgAlias>$162: T.class_of(NilClass))
+    <statTemp>$153: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$155: Symbol(:a), <hashTemp>$156: Runtime object representing type: T.nilable(Integer))
+    <cfgAlias>$164: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$152: T::Private::Methods::DeclBuilder = <statTemp>$153: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$164: T.class_of(Integer))
+    <blockReturnTemp>$165: T.noreturn = blockreturn<sig> <blockReturnTemp>$152: T::Private::Methods::DeclBuilder
     <unconditional> -> bb30
 
 # backedges
 # - bb31(rubyRegionId=0)
 # - bb37(rubyRegionId=9)
-bb34[rubyRegionId=9, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(ControlFlow)):
+bb34[rubyRegionId=9, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$170: Sorbet::Private::Static::Void, <selfRestore>$171: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb37 : bb35)
 
 # backedges
 # - bb34(rubyRegionId=9)
-bb35[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(ControlFlow)):
-    <statTemp>$182: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$188, sig>
-    <self>: T.class_of(ControlFlow) = <selfRestore>$189
-    <cfgAlias>$208: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$210: T.class_of(T) = alias <C T>
-    <statTemp>$205: T.class_of(ControlFlow) = <self>: T.class_of(ControlFlow).extend(<cfgAlias>$208: T.class_of(T::Sig))
+bb35[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$170: Sorbet::Private::Static::Void, <selfRestore>$171: T.class_of(ControlFlow)):
+    <statTemp>$166: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$170, sig>
+    <self>: T.class_of(ControlFlow) = <selfRestore>$171
+    <cfgAlias>$190: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$192: T.class_of(T) = alias <C T>
+    <statTemp>$187: T.class_of(ControlFlow) = <self>: T.class_of(ControlFlow).extend(<cfgAlias>$190: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb34(rubyRegionId=9)
-bb37[rubyRegionId=9, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(ControlFlow)):
+bb37[rubyRegionId=9, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$170: Sorbet::Private::Static::Void, <selfRestore>$171: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$194: Symbol(:a) = :a
-    <cfgAlias>$197: T.class_of(T) = alias <C T>
-    <cfgAlias>$199: T.class_of(Integer) = alias <C Integer>
-    <cfgAlias>$201: T.class_of(NilClass) = alias <C NilClass>
-    <hashTemp>$195: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$197: T.class_of(T).any(<cfgAlias>$199: T.class_of(Integer), <cfgAlias>$201: T.class_of(NilClass))
-    <statTemp>$192: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$194: Symbol(:a), <hashTemp>$195: Runtime object representing type: T.nilable(Integer))
-    <cfgAlias>$203: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$191: T::Private::Methods::DeclBuilder = <statTemp>$192: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$203: T.class_of(Integer))
-    <blockReturnTemp>$204: T.noreturn = blockreturn<sig> <blockReturnTemp>$191: T::Private::Methods::DeclBuilder
+    <hashTemp>$176: Symbol(:a) = :a
+    <cfgAlias>$179: T.class_of(T) = alias <C T>
+    <cfgAlias>$181: T.class_of(Integer) = alias <C Integer>
+    <cfgAlias>$183: T.class_of(NilClass) = alias <C NilClass>
+    <hashTemp>$177: Runtime object representing type: T.nilable(Integer) = <cfgAlias>$179: T.class_of(T).any(<cfgAlias>$181: T.class_of(Integer), <cfgAlias>$183: T.class_of(NilClass))
+    <statTemp>$174: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$176: Symbol(:a), <hashTemp>$177: Runtime object representing type: T.nilable(Integer))
+    <cfgAlias>$185: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$173: T::Private::Methods::DeclBuilder = <statTemp>$174: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$185: T.class_of(Integer))
+    <blockReturnTemp>$186: T.noreturn = blockreturn<sig> <blockReturnTemp>$173: T::Private::Methods::DeclBuilder
     <unconditional> -> bb34
 
 }

--- a/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
@@ -29,10 +29,10 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :takes_integer_static) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:x, ::Integer).void()
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :takes_integer_instance) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:x, ::Integer).void()
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/infer/flatten_private.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_private.rb.flatten-tree.exp
@@ -36,10 +36,10 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :private) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:arg0, ::Integer).void()
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :private_class_method) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:arg0, ::Integer).void()
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -119,11 +119,9 @@ method ::<Class:<root>>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:f) = :f
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(<root>), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:f))
-    <selfRestore>$10: T.class_of(<root>) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(<root>))
+    <selfRestore>$8: T.class_of(<root>) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -134,80 +132,78 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(<root>) = <selfRestore>$10
-    <cfgAlias>$26: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$28: FalseClass = false
-    <statTemp>$29: Symbol(:f2) = :f2
-    <block-pre-call-temp>$30: Sorbet::Private::Static::Void = <cfgAlias>$26: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(<root>), <statTemp>$28: FalseClass, <statTemp>$29: Symbol(:f2))
-    <selfRestore>$31: T.class_of(<root>) = <self>
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(<root>) = <selfRestore>$8
+    <cfgAlias>$24: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$26: Sorbet::Private::Static::Void = <cfgAlias>$24: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(<root>))
+    <selfRestore>$27: T.class_of(<root>) = <self>
     <unconditional> -> bb6
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$15: Symbol(:x) = :x
-    <cfgAlias>$18: T.class_of(T) = alias <C T>
-    <cfgAlias>$20: T.class_of(Concrete) = alias <C Concrete>
-    <cfgAlias>$22: T.class_of(Other) = alias <C Other>
-    <hashTemp>$16: Runtime object representing type: T.any(Concrete, Other) = <cfgAlias>$18: T.class_of(T).any(<cfgAlias>$20: T.class_of(Concrete), <cfgAlias>$22: T.class_of(Other))
-    <statTemp>$13: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$15: Symbol(:x), <hashTemp>$16: Runtime object representing type: T.any(Concrete, Other))
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <statTemp>$13: T::Private::Methods::DeclBuilder.void()
-    <blockReturnTemp>$23: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <hashTemp>$13: Symbol(:x) = :x
+    <cfgAlias>$16: T.class_of(T) = alias <C T>
+    <cfgAlias>$18: T.class_of(Concrete) = alias <C Concrete>
+    <cfgAlias>$20: T.class_of(Other) = alias <C Other>
+    <hashTemp>$14: Runtime object representing type: T.any(Concrete, Other) = <cfgAlias>$16: T.class_of(T).any(<cfgAlias>$18: T.class_of(Concrete), <cfgAlias>$20: T.class_of(Other))
+    <statTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$13: Symbol(:x), <hashTemp>$14: Runtime object representing type: T.any(Concrete, Other))
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <statTemp>$11: T::Private::Methods::DeclBuilder.void()
+    <blockReturnTemp>$21: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=0)
 # - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$30: Sorbet::Private::Static::Void, <selfRestore>$31: T.class_of(<root>)):
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$26: Sorbet::Private::Static::Void, <selfRestore>$27: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=18](<block-pre-call-temp>$30: Sorbet::Private::Static::Void, <selfRestore>$31: T.class_of(<root>)):
-    <statTemp>$24: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$30, sig>
-    <self>: T.class_of(<root>) = <selfRestore>$31
-    <cfgAlias>$48: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$50: T.class_of(T) = alias <C T>
-    <statTemp>$45: T.class_of(<root>) = <self>: T.class_of(<root>).extend(<cfgAlias>$48: T.class_of(T::Sig))
-    <cfgAlias>$55: T.class_of(Sorbet::Private::Static) = alias <C Static>
-    <cfgAlias>$57: T.class_of(Base)[T.untyped] = alias <C Base>
-    <statTemp>$53: Sorbet::Private::Static::Void = <cfgAlias>$55: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$57: T.class_of(Base)[T.untyped])
-    <cfgAlias>$62: T.class_of(Sorbet::Private::Static) = alias <C Static>
-    <cfgAlias>$64: T.class_of(Concrete) = alias <C Concrete>
-    <statTemp>$60: Sorbet::Private::Static::Void = <cfgAlias>$62: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$64: T.class_of(Concrete))
-    <cfgAlias>$67: T.class_of(Sorbet::Private::Static) = alias <C Static>
-    <cfgAlias>$69: T.class_of(Base)[T.untyped] = alias <C Base>
-    <statTemp>$65: Sorbet::Private::Static::Void = <cfgAlias>$67: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$69: T.class_of(Base)[T.untyped])
-    <cfgAlias>$74: T.class_of(Sorbet::Private::Static) = alias <C Static>
-    <cfgAlias>$76: T.class_of(Other) = alias <C Other>
-    <statTemp>$72: Sorbet::Private::Static::Void = <cfgAlias>$74: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$76: T.class_of(Other))
+bb7[rubyRegionId=0, firstDead=18](<block-pre-call-temp>$26: Sorbet::Private::Static::Void, <selfRestore>$27: T.class_of(<root>)):
+    <statTemp>$22: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$26, sig>
+    <self>: T.class_of(<root>) = <selfRestore>$27
+    <cfgAlias>$44: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$46: T.class_of(T) = alias <C T>
+    <statTemp>$41: T.class_of(<root>) = <self>: T.class_of(<root>).extend(<cfgAlias>$44: T.class_of(T::Sig))
+    <cfgAlias>$51: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <cfgAlias>$53: T.class_of(Base)[T.untyped] = alias <C Base>
+    <statTemp>$49: Sorbet::Private::Static::Void = <cfgAlias>$51: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$53: T.class_of(Base)[T.untyped])
+    <cfgAlias>$58: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <cfgAlias>$60: T.class_of(Concrete) = alias <C Concrete>
+    <statTemp>$56: Sorbet::Private::Static::Void = <cfgAlias>$58: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$60: T.class_of(Concrete))
+    <cfgAlias>$63: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <cfgAlias>$65: T.class_of(Base)[T.untyped] = alias <C Base>
+    <statTemp>$61: Sorbet::Private::Static::Void = <cfgAlias>$63: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$65: T.class_of(Base)[T.untyped])
+    <cfgAlias>$70: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <cfgAlias>$72: T.class_of(Other) = alias <C Other>
+    <statTemp>$68: Sorbet::Private::Static::Void = <cfgAlias>$70: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$72: T.class_of(Other))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$30: Sorbet::Private::Static::Void, <selfRestore>$31: T.class_of(<root>)):
+bb9[rubyRegionId=2, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$26: Sorbet::Private::Static::Void, <selfRestore>$27: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$36: Symbol(:x) = :x
-    <cfgAlias>$39: T.class_of(T) = alias <C T>
-    <cfgAlias>$41: T.class_of(Base)[T.untyped] = alias <C Base>
-    <cfgAlias>$43: T.class_of(Other) = alias <C Other>
-    <hashTemp>$37: Runtime object representing type: T.any(Base, Other) = <cfgAlias>$39: T.class_of(T).any(<cfgAlias>$41: T.class_of(Base)[T.untyped], <cfgAlias>$43: T.class_of(Other))
-    <statTemp>$34: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$36: Symbol(:x), <hashTemp>$37: Runtime object representing type: T.any(Base, Other))
-    <blockReturnTemp>$33: T::Private::Methods::DeclBuilder = <statTemp>$34: T::Private::Methods::DeclBuilder.void()
-    <blockReturnTemp>$44: T.noreturn = blockreturn<sig> <blockReturnTemp>$33: T::Private::Methods::DeclBuilder
+    <hashTemp>$32: Symbol(:x) = :x
+    <cfgAlias>$35: T.class_of(T) = alias <C T>
+    <cfgAlias>$37: T.class_of(Base)[T.untyped] = alias <C Base>
+    <cfgAlias>$39: T.class_of(Other) = alias <C Other>
+    <hashTemp>$33: Runtime object representing type: T.any(Base, Other) = <cfgAlias>$35: T.class_of(T).any(<cfgAlias>$37: T.class_of(Base)[T.untyped], <cfgAlias>$39: T.class_of(Other))
+    <statTemp>$30: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$32: Symbol(:x), <hashTemp>$33: Runtime object representing type: T.any(Base, Other))
+    <blockReturnTemp>$29: T::Private::Methods::DeclBuilder = <statTemp>$30: T::Private::Methods::DeclBuilder.void()
+    <blockReturnTemp>$40: T.noreturn = blockreturn<sig> <blockReturnTemp>$29: T::Private::Methods::DeclBuilder
     <unconditional> -> bb6
 
 }

--- a/test/testdata/infer/numbered_parameters.rb.flatten-tree.exp
+++ b/test/testdata/infer/numbered_parameters.rb.flatten-tree.exp
@@ -7,7 +7,7 @@ begin
 
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :foo) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:blk, ::T.proc().params(:a, ::Integer, :b, ::String).void()).void()
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/infer/rebind.rb.cfg-text.exp
+++ b/test/testdata/infer/rebind.rb.cfg-text.exp
@@ -71,11 +71,9 @@ method ::<Class:B>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:only_on_B) = :only_on_B
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(B), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:only_on_B))
-    <selfRestore>$10: T.class_of(B) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))
+    <selfRestore>$8: T.class_of(B) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -86,35 +84,35 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(B) = <selfRestore>$10
-    <cfgAlias>$27: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$29: T.class_of(T) = alias <C T>
-    <statTemp>$24: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$27: T.class_of(T::Sig))
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(B) = <selfRestore>$8
+    <cfgAlias>$25: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$27: T.class_of(T) = alias <C T>
+    <statTemp>$22: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$25: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$15: Symbol(:blk) = :blk
-    <cfgAlias>$20: T.class_of(T) = alias <C T>
-    <statTemp>$18: T.class_of(T.proc) = <cfgAlias>$20: T.class_of(T).proc()
-    <cfgAlias>$22: T.class_of(C) = alias <C C>
-    <statTemp>$17: T.class_of(T.proc) = <statTemp>$18: T.class_of(T.proc).bind(<cfgAlias>$22: T.class_of(C))
-    <hashTemp>$16: T.class_of(T.proc) = <statTemp>$17: T.class_of(T.proc).void()
-    <statTemp>$13: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$15: Symbol(:blk), <hashTemp>$16: T.class_of(T.proc))
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <statTemp>$13: T::Private::Methods::DeclBuilder.void()
-    <blockReturnTemp>$23: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <hashTemp>$13: Symbol(:blk) = :blk
+    <cfgAlias>$18: T.class_of(T) = alias <C T>
+    <statTemp>$16: T.class_of(T.proc) = <cfgAlias>$18: T.class_of(T).proc()
+    <cfgAlias>$20: T.class_of(C) = alias <C C>
+    <statTemp>$15: T.class_of(T.proc) = <statTemp>$16: T.class_of(T.proc).bind(<cfgAlias>$20: T.class_of(C))
+    <hashTemp>$14: T.class_of(T.proc) = <statTemp>$15: T.class_of(T.proc).void()
+    <statTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$13: Symbol(:blk), <hashTemp>$14: T.class_of(T.proc))
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <statTemp>$11: T::Private::Methods::DeclBuilder.void()
+    <blockReturnTemp>$21: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }
@@ -137,11 +135,9 @@ method ::<Class:A>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: TrueClass = true
-    <statTemp>$8: Symbol(:mySig) = :mySig
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(A), <statTemp>$7: TrueClass, <statTemp>$8: Symbol(:mySig))
-    <selfRestore>$10: T.class_of(A) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(A))
+    <selfRestore>$8: T.class_of(A) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -152,35 +148,35 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(A) = <selfRestore>$10
-    <cfgAlias>$27: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$29: T.class_of(T) = alias <C T>
-    <statTemp>$24: T.class_of(A) = <self>: T.class_of(A).extend(<cfgAlias>$27: T.class_of(T::Sig))
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(A) = <selfRestore>$8
+    <cfgAlias>$25: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$27: T.class_of(T) = alias <C T>
+    <statTemp>$22: T.class_of(A) = <self>: T.class_of(A).extend(<cfgAlias>$25: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$15: Symbol(:blk) = :blk
-    <cfgAlias>$20: T.class_of(T) = alias <C T>
-    <statTemp>$18: T.class_of(T.proc) = <cfgAlias>$20: T.class_of(T).proc()
-    <cfgAlias>$22: T.class_of(B) = alias <C B>
-    <statTemp>$17: T.class_of(T.proc) = <statTemp>$18: T.class_of(T.proc).bind(<cfgAlias>$22: T.class_of(B))
-    <hashTemp>$16: T.class_of(T.proc) = <statTemp>$17: T.class_of(T.proc).void()
-    <statTemp>$13: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$15: Symbol(:blk), <hashTemp>$16: T.class_of(T.proc))
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <statTemp>$13: T::Private::Methods::DeclBuilder.void()
-    <blockReturnTemp>$23: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <hashTemp>$13: Symbol(:blk) = :blk
+    <cfgAlias>$18: T.class_of(T) = alias <C T>
+    <statTemp>$16: T.class_of(T.proc) = <cfgAlias>$18: T.class_of(T).proc()
+    <cfgAlias>$20: T.class_of(B) = alias <C B>
+    <statTemp>$15: T.class_of(T.proc) = <statTemp>$16: T.class_of(T.proc).bind(<cfgAlias>$20: T.class_of(B))
+    <hashTemp>$14: T.class_of(T.proc) = <statTemp>$15: T.class_of(T.proc).void()
+    <statTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$13: Symbol(:blk), <hashTemp>$14: T.class_of(T.proc))
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <statTemp>$11: T::Private::Methods::DeclBuilder.void()
+    <blockReturnTemp>$21: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -162,11 +162,9 @@ method ::<Class:Parent>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Parent) = cast(<self>: NilClass, T.class_of(Parent));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:returns_self) = :returns_self
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Parent), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:returns_self))
-    <selfRestore>$10: T.class_of(Parent) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Parent))
+    <selfRestore>$8: T.class_of(Parent) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -177,30 +175,30 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Parent), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Parent)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Parent), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Parent)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(Parent) = <selfRestore>$10
-    <cfgAlias>$21: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$23: T.class_of(T) = alias <C T>
-    <statTemp>$18: T.class_of(Parent) = <self>: T.class_of(Parent).extend(<cfgAlias>$21: T.class_of(T::Sig))
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(Parent) = <selfRestore>$8
+    <cfgAlias>$19: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$21: T.class_of(T) = alias <C T>
+    <statTemp>$16: T.class_of(Parent) = <self>: T.class_of(Parent).extend(<cfgAlias>$19: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Parent), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Parent)):
+bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Parent), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <cfgAlias>$16: T.class_of(T) = alias <C T>
-    <statTemp>$14: Runtime object representing type: T.untyped = <cfgAlias>$16: T.class_of(T).self_type()
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$14: Runtime object representing type: T.untyped)
-    <blockReturnTemp>$17: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <cfgAlias>$14: T.class_of(T) = alias <C T>
+    <statTemp>$12: Runtime object representing type: T.untyped = <cfgAlias>$14: T.class_of(T).self_type()
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$12: Runtime object representing type: T.untyped)
+    <blockReturnTemp>$15: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }
@@ -241,13 +239,11 @@ bb1[rubyRegionId=0, firstDead=-1]():
 method ::<Class:Generic>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
-    <C TM>$28: Runtime object representing type: Generic::TM = alias <C TM>
+    <C TM>$26: Runtime object representing type: Generic::TM = alias <C TM>
     <self>: T.class_of(Generic) = cast(<self>: NilClass, T.class_of(Generic));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:bad) = :bad
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Generic), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:bad))
-    <selfRestore>$10: T.class_of(Generic) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Generic))
+    <selfRestore>$8: T.class_of(Generic) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -258,33 +254,33 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Generic), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=7](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(Generic) = <selfRestore>$10
-    <cfgAlias>$24: T.class_of(T::Generic) = alias <C Generic>
-    <cfgAlias>$26: T.class_of(T) = alias <C T>
-    <statTemp>$21: T.class_of(Generic) = <self>: T.class_of(Generic).extend(<cfgAlias>$24: T.class_of(T::Generic))
-    <C TM>$28: T.untyped = <self>: T.class_of(Generic).type_member()
+bb3[rubyRegionId=0, firstDead=7](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(Generic) = <selfRestore>$8
+    <cfgAlias>$22: T.class_of(T::Generic) = alias <C Generic>
+    <cfgAlias>$24: T.class_of(T) = alias <C T>
+    <statTemp>$19: T.class_of(Generic) = <self>: T.class_of(Generic).extend(<cfgAlias>$22: T.class_of(T::Generic))
+    <C TM>$26: T.untyped = <self>: T.class_of(Generic).type_member()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic)):
+bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Generic), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <cfgAlias>$16: T.class_of(Generic) = alias <C Generic>
-    <cfgAlias>$19: T.class_of(T) = alias <C T>
-    <statTemp>$17: Runtime object representing type: T.untyped = <cfgAlias>$19: T.class_of(T).self_type()
-    <statTemp>$14: Runtime object representing type: Generic[T.untyped] = <cfgAlias>$16: T.class_of(Generic).[](<statTemp>$17: Runtime object representing type: T.untyped)
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$14: Runtime object representing type: Generic[T.untyped])
-    <blockReturnTemp>$20: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <cfgAlias>$14: T.class_of(Generic) = alias <C Generic>
+    <cfgAlias>$17: T.class_of(T) = alias <C T>
+    <statTemp>$15: Runtime object representing type: T.untyped = <cfgAlias>$17: T.class_of(T).self_type()
+    <statTemp>$12: Runtime object representing type: Generic[T.untyped] = <cfgAlias>$14: T.class_of(Generic).[](<statTemp>$15: Runtime object representing type: T.untyped)
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$12: Runtime object representing type: Generic[T.untyped])
+    <blockReturnTemp>$18: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }
@@ -322,11 +318,9 @@ method ::<Class:Array>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Array) = cast(<self>: NilClass, T.class_of(Array));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:returns_self) = :returns_self
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Array), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:returns_self))
-    <selfRestore>$10: T.class_of(Array) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Array))
+    <selfRestore>$8: T.class_of(Array) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -337,30 +331,30 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Array), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Array)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Array), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Array)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(Array) = <selfRestore>$10
-    <cfgAlias>$21: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$23: T.class_of(T) = alias <C T>
-    <statTemp>$18: T.class_of(Array) = <self>: T.class_of(Array).extend(<cfgAlias>$21: T.class_of(T::Sig))
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(Array) = <selfRestore>$8
+    <cfgAlias>$19: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$21: T.class_of(T) = alias <C T>
+    <statTemp>$16: T.class_of(Array) = <self>: T.class_of(Array).extend(<cfgAlias>$19: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Array), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Array)):
+bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Array), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <cfgAlias>$16: T.class_of(T) = alias <C T>
-    <statTemp>$14: Runtime object representing type: T.untyped = <cfgAlias>$16: T.class_of(T).self_type()
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$14: Runtime object representing type: T.untyped)
-    <blockReturnTemp>$17: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <cfgAlias>$14: T.class_of(T) = alias <C T>
+    <statTemp>$12: Runtime object representing type: T.untyped = <cfgAlias>$14: T.class_of(T).self_type()
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$12: Runtime object representing type: T.untyped)
+    <blockReturnTemp>$15: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }
@@ -398,11 +392,9 @@ method ::<Class:B>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:returns_self) = :returns_self
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(B), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:returns_self))
-    <selfRestore>$10: T.class_of(B) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))
+    <selfRestore>$8: T.class_of(B) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -413,30 +405,30 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(B) = <selfRestore>$10
-    <cfgAlias>$21: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$23: T.class_of(T) = alias <C T>
-    <statTemp>$18: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$21: T.class_of(T::Sig))
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(B) = <selfRestore>$8
+    <cfgAlias>$19: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$21: T.class_of(T) = alias <C T>
+    <statTemp>$16: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$19: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <cfgAlias>$16: T.class_of(T) = alias <C T>
-    <statTemp>$14: Runtime object representing type: T.untyped = <cfgAlias>$16: T.class_of(T).self_type()
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$14: Runtime object representing type: T.untyped)
-    <blockReturnTemp>$17: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <cfgAlias>$14: T.class_of(T) = alias <C T>
+    <statTemp>$12: Runtime object representing type: T.untyped = <cfgAlias>$14: T.class_of(T).self_type()
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$12: Runtime object representing type: T.untyped)
+    <blockReturnTemp>$15: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }

--- a/test/testdata/infer/transitive.rb.cfg-text.exp
+++ b/test/testdata/infer/transitive.rb.cfg-text.exp
@@ -39,11 +39,9 @@ method ::<Class:A>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:foo) = :foo
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(A), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:foo))
-    <selfRestore>$10: T.class_of(A) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(A))
+    <selfRestore>$8: T.class_of(A) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -54,29 +52,29 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(A) = <selfRestore>$10
-    <cfgAlias>$20: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$22: T.class_of(T) = alias <C T>
-    <statTemp>$17: T.class_of(A) = <self>: T.class_of(A).extend(<cfgAlias>$20: T.class_of(T::Sig))
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(A) = <selfRestore>$8
+    <cfgAlias>$18: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$20: T.class_of(T) = alias <C T>
+    <statTemp>$15: T.class_of(A) = <self>: T.class_of(A).extend(<cfgAlias>$18: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <cfgAlias>$15: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$15: T.class_of(Integer))
-    <blockReturnTemp>$16: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <cfgAlias>$13: T.class_of(Integer) = alias <C Integer>
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$13: T.class_of(Integer))
+    <blockReturnTemp>$14: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }
@@ -100,11 +98,9 @@ method ::<Class:Bar>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Bar) = cast(<self>: NilClass, T.class_of(Bar));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:baz) = :baz
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Bar), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:baz))
-    <selfRestore>$10: T.class_of(Bar) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Bar))
+    <selfRestore>$8: T.class_of(Bar) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -115,32 +111,32 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Bar), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Bar)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Bar), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Bar)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(Bar) = <selfRestore>$10
-    <cfgAlias>$24: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$26: T.class_of(T) = alias <C T>
-    <statTemp>$21: T.class_of(Bar) = <self>: T.class_of(Bar).extend(<cfgAlias>$24: T.class_of(T::Sig))
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(Bar) = <selfRestore>$8
+    <cfgAlias>$22: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$24: T.class_of(T) = alias <C T>
+    <statTemp>$19: T.class_of(Bar) = <self>: T.class_of(Bar).extend(<cfgAlias>$22: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Bar), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Bar)):
+bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Bar), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$15: Symbol(:arg) = :arg
+    <hashTemp>$13: Symbol(:arg) = :arg
+    <cfgAlias>$15: T.class_of(Integer) = alias <C Integer>
+    <statTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$13: Symbol(:arg), <cfgAlias>$15: T.class_of(Integer))
     <cfgAlias>$17: T.class_of(Integer) = alias <C Integer>
-    <statTemp>$13: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$15: Symbol(:arg), <cfgAlias>$17: T.class_of(Integer))
-    <cfgAlias>$19: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <statTemp>$13: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$19: T.class_of(Integer))
-    <blockReturnTemp>$20: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <statTemp>$11: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$17: T.class_of(Integer))
+    <blockReturnTemp>$18: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }

--- a/test/testdata/namer/alias_cross_file.flatten-tree.exp
+++ b/test/testdata/namer/alias_cross_file.flatten-tree.exp
@@ -16,7 +16,7 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :test_resolve) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.returns(::T2)
         end
         <runtime method definition of test_resolve>

--- a/test/testdata/namer/module_function.rb.cfg-text.exp
+++ b/test/testdata/namer/module_function.rb.cfg-text.exp
@@ -116,11 +116,9 @@ method ::<Class:Funcs>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Funcs) = cast(<self>: NilClass, T.class_of(Funcs));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: FalseClass = false
-    <statTemp>$8: Symbol(:f) = :f
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Funcs), <statTemp>$7: FalseClass, <statTemp>$8: Symbol(:f))
-    <selfRestore>$10: T.class_of(Funcs) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))
+    <selfRestore>$8: T.class_of(Funcs) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -131,166 +129,158 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Funcs)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Funcs)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(Funcs) = <selfRestore>$10
-    <cfgAlias>$23: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$25: FalseClass = false
-    <statTemp>$26: Symbol(:g) = :g
-    <block-pre-call-temp>$27: Sorbet::Private::Static::Void = <cfgAlias>$23: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Funcs), <statTemp>$25: FalseClass, <statTemp>$26: Symbol(:g))
-    <selfRestore>$28: T.class_of(Funcs) = <self>
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(Funcs) = <selfRestore>$8
+    <cfgAlias>$21: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$23: Sorbet::Private::Static::Void = <cfgAlias>$21: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))
+    <selfRestore>$24: T.class_of(Funcs) = <self>
     <unconditional> -> bb6
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Funcs)):
+bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$15: Symbol(:x) = :x
+    <hashTemp>$13: Symbol(:x) = :x
+    <cfgAlias>$15: T.class_of(Integer) = alias <C Integer>
+    <statTemp>$11: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$13: Symbol(:x), <cfgAlias>$15: T.class_of(Integer))
     <cfgAlias>$17: T.class_of(Integer) = alias <C Integer>
-    <statTemp>$13: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$15: Symbol(:x), <cfgAlias>$17: T.class_of(Integer))
-    <cfgAlias>$19: T.class_of(Integer) = alias <C Integer>
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <statTemp>$13: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$19: T.class_of(Integer))
-    <blockReturnTemp>$20: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <statTemp>$11: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$17: T.class_of(Integer))
+    <blockReturnTemp>$18: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=0)
 # - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(Funcs)):
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(Funcs)):
-    <statTemp>$21: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$27, sig>
-    <self>: T.class_of(Funcs) = <selfRestore>$28
-    <cfgAlias>$41: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$43: TrueClass = true
-    <statTemp>$44: Symbol(:g) = :g
-    <block-pre-call-temp>$45: Sorbet::Private::Static::Void = <cfgAlias>$41: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Funcs), <statTemp>$43: TrueClass, <statTemp>$44: Symbol(:g))
-    <selfRestore>$46: T.class_of(Funcs) = <self>
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(Funcs)):
+    <statTemp>$19: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$23, sig>
+    <self>: T.class_of(Funcs) = <selfRestore>$24
+    <cfgAlias>$37: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$39: Sorbet::Private::Static::Void = <cfgAlias>$37: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))
+    <selfRestore>$40: T.class_of(Funcs) = <self>
     <unconditional> -> bb10
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(Funcs)):
+bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$33: Symbol(:s) = :s
-    <cfgAlias>$35: T.class_of(Symbol) = alias <C Symbol>
-    <statTemp>$31: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$33: Symbol(:s), <cfgAlias>$35: T.class_of(Symbol))
-    <cfgAlias>$37: T.class_of(Symbol) = alias <C Symbol>
-    <blockReturnTemp>$30: T::Private::Methods::DeclBuilder = <statTemp>$31: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$37: T.class_of(Symbol))
-    <blockReturnTemp>$38: T.noreturn = blockreturn<sig> <blockReturnTemp>$30: T::Private::Methods::DeclBuilder
+    <hashTemp>$29: Symbol(:s) = :s
+    <cfgAlias>$31: T.class_of(Symbol) = alias <C Symbol>
+    <statTemp>$27: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$29: Symbol(:s), <cfgAlias>$31: T.class_of(Symbol))
+    <cfgAlias>$33: T.class_of(Symbol) = alias <C Symbol>
+    <blockReturnTemp>$26: T::Private::Methods::DeclBuilder = <statTemp>$27: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$33: T.class_of(Symbol))
+    <blockReturnTemp>$34: T.noreturn = blockreturn<sig> <blockReturnTemp>$26: T::Private::Methods::DeclBuilder
     <unconditional> -> bb6
 
 # backedges
 # - bb7(rubyRegionId=0)
 # - bb13(rubyRegionId=3)
-bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Funcs)):
+bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$39: Sorbet::Private::Static::Void, <selfRestore>$40: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
 # - bb10(rubyRegionId=3)
-bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Funcs)):
-    <statTemp>$39: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$45, sig>
-    <self>: T.class_of(Funcs) = <selfRestore>$46
-    <cfgAlias>$59: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$61: FalseClass = false
-    <statTemp>$62: Symbol(:h) = :h
-    <block-pre-call-temp>$63: Sorbet::Private::Static::Void = <cfgAlias>$59: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Funcs), <statTemp>$61: FalseClass, <statTemp>$62: Symbol(:h))
-    <selfRestore>$64: T.class_of(Funcs) = <self>
+bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$39: Sorbet::Private::Static::Void, <selfRestore>$40: T.class_of(Funcs)):
+    <statTemp>$35: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$39, sig>
+    <self>: T.class_of(Funcs) = <selfRestore>$40
+    <cfgAlias>$53: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$55: Sorbet::Private::Static::Void = <cfgAlias>$53: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))
+    <selfRestore>$56: T.class_of(Funcs) = <self>
     <unconditional> -> bb14
 
 # backedges
 # - bb10(rubyRegionId=3)
-bb13[rubyRegionId=3, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Funcs)):
+bb13[rubyRegionId=3, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$39: Sorbet::Private::Static::Void, <selfRestore>$40: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$51: Symbol(:s) = :s
-    <cfgAlias>$53: T.class_of(Symbol) = alias <C Symbol>
-    <statTemp>$49: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$51: Symbol(:s), <cfgAlias>$53: T.class_of(Symbol))
-    <cfgAlias>$55: T.class_of(Symbol) = alias <C Symbol>
-    <blockReturnTemp>$48: T::Private::Methods::DeclBuilder = <statTemp>$49: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$55: T.class_of(Symbol))
-    <blockReturnTemp>$56: T.noreturn = blockreturn<sig> <blockReturnTemp>$48: T::Private::Methods::DeclBuilder
+    <hashTemp>$45: Symbol(:s) = :s
+    <cfgAlias>$47: T.class_of(Symbol) = alias <C Symbol>
+    <statTemp>$43: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$45: Symbol(:s), <cfgAlias>$47: T.class_of(Symbol))
+    <cfgAlias>$49: T.class_of(Symbol) = alias <C Symbol>
+    <blockReturnTemp>$42: T::Private::Methods::DeclBuilder = <statTemp>$43: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$49: T.class_of(Symbol))
+    <blockReturnTemp>$50: T.noreturn = blockreturn<sig> <blockReturnTemp>$42: T::Private::Methods::DeclBuilder
     <unconditional> -> bb10
 
 # backedges
 # - bb11(rubyRegionId=0)
 # - bb17(rubyRegionId=4)
-bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Funcs)):
+bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$55: Sorbet::Private::Static::Void, <selfRestore>$56: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
 # - bb14(rubyRegionId=4)
-bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Funcs)):
-    <statTemp>$57: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$63, sig>
-    <self>: T.class_of(Funcs) = <selfRestore>$64
-    <cfgAlias>$77: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$79: TrueClass = true
-    <statTemp>$80: Symbol(:h) = :h
-    <block-pre-call-temp>$81: Sorbet::Private::Static::Void = <cfgAlias>$77: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(Funcs), <statTemp>$79: TrueClass, <statTemp>$80: Symbol(:h))
-    <selfRestore>$82: T.class_of(Funcs) = <self>
+bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$55: Sorbet::Private::Static::Void, <selfRestore>$56: T.class_of(Funcs)):
+    <statTemp>$51: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$55, sig>
+    <self>: T.class_of(Funcs) = <selfRestore>$56
+    <cfgAlias>$69: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$71: Sorbet::Private::Static::Void = <cfgAlias>$69: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))
+    <selfRestore>$72: T.class_of(Funcs) = <self>
     <unconditional> -> bb18
 
 # backedges
 # - bb14(rubyRegionId=4)
-bb17[rubyRegionId=4, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Funcs)):
+bb17[rubyRegionId=4, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$55: Sorbet::Private::Static::Void, <selfRestore>$56: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$69: Symbol(:s) = :s
-    <cfgAlias>$71: T.class_of(String) = alias <C String>
-    <statTemp>$67: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$69: Symbol(:s), <cfgAlias>$71: T.class_of(String))
-    <cfgAlias>$73: T.class_of(String) = alias <C String>
-    <blockReturnTemp>$66: T::Private::Methods::DeclBuilder = <statTemp>$67: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$73: T.class_of(String))
-    <blockReturnTemp>$74: T.noreturn = blockreturn<sig> <blockReturnTemp>$66: T::Private::Methods::DeclBuilder
+    <hashTemp>$61: Symbol(:s) = :s
+    <cfgAlias>$63: T.class_of(String) = alias <C String>
+    <statTemp>$59: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$61: Symbol(:s), <cfgAlias>$63: T.class_of(String))
+    <cfgAlias>$65: T.class_of(String) = alias <C String>
+    <blockReturnTemp>$58: T::Private::Methods::DeclBuilder = <statTemp>$59: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$65: T.class_of(String))
+    <blockReturnTemp>$66: T.noreturn = blockreturn<sig> <blockReturnTemp>$58: T::Private::Methods::DeclBuilder
     <unconditional> -> bb14
 
 # backedges
 # - bb15(rubyRegionId=0)
 # - bb21(rubyRegionId=5)
-bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$81: Sorbet::Private::Static::Void, <selfRestore>$82: T.class_of(Funcs)):
+bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$71: Sorbet::Private::Static::Void, <selfRestore>$72: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
 # - bb18(rubyRegionId=5)
-bb19[rubyRegionId=0, firstDead=12](<block-pre-call-temp>$81: Sorbet::Private::Static::Void, <selfRestore>$82: T.class_of(Funcs)):
-    <statTemp>$75: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$81, sig>
-    <self>: T.class_of(Funcs) = <selfRestore>$82
-    <cfgAlias>$96: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$98: T.class_of(T) = alias <C T>
-    <statTemp>$93: T.class_of(Funcs) = <self>: T.class_of(Funcs).extend(<cfgAlias>$96: T.class_of(T::Sig))
-    <statTemp>$102: Symbol(:f) = :f
-    <statTemp>$100: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$102: Symbol(:f))
-    <statTemp>$106: Symbol(:g) = :g
-    <statTemp>$104: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$106: Symbol(:g))
-    <statTemp>$110: Symbol(:h) = :h
-    <statTemp>$108: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$110: Symbol(:h))
+bb19[rubyRegionId=0, firstDead=12](<block-pre-call-temp>$71: Sorbet::Private::Static::Void, <selfRestore>$72: T.class_of(Funcs)):
+    <statTemp>$67: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$71, sig>
+    <self>: T.class_of(Funcs) = <selfRestore>$72
+    <cfgAlias>$86: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$88: T.class_of(T) = alias <C T>
+    <statTemp>$83: T.class_of(Funcs) = <self>: T.class_of(Funcs).extend(<cfgAlias>$86: T.class_of(T::Sig))
+    <statTemp>$92: Symbol(:f) = :f
+    <statTemp>$90: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$92: Symbol(:f))
+    <statTemp>$96: Symbol(:g) = :g
+    <statTemp>$94: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$96: Symbol(:g))
+    <statTemp>$100: Symbol(:h) = :h
+    <statTemp>$98: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$100: Symbol(:h))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb18(rubyRegionId=5)
-bb21[rubyRegionId=5, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$81: Sorbet::Private::Static::Void, <selfRestore>$82: T.class_of(Funcs)):
+bb21[rubyRegionId=5, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$71: Sorbet::Private::Static::Void, <selfRestore>$72: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <hashTemp>$87: Symbol(:s) = :s
-    <cfgAlias>$89: T.class_of(String) = alias <C String>
-    <statTemp>$85: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$87: Symbol(:s), <cfgAlias>$89: T.class_of(String))
-    <cfgAlias>$91: T.class_of(String) = alias <C String>
-    <blockReturnTemp>$84: T::Private::Methods::DeclBuilder = <statTemp>$85: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$91: T.class_of(String))
-    <blockReturnTemp>$92: T.noreturn = blockreturn<sig> <blockReturnTemp>$84: T::Private::Methods::DeclBuilder
+    <hashTemp>$77: Symbol(:s) = :s
+    <cfgAlias>$79: T.class_of(String) = alias <C String>
+    <statTemp>$75: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.params(<hashTemp>$77: Symbol(:s), <cfgAlias>$79: T.class_of(String))
+    <cfgAlias>$81: T.class_of(String) = alias <C String>
+    <blockReturnTemp>$74: T::Private::Methods::DeclBuilder = <statTemp>$75: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$81: T.class_of(String))
+    <blockReturnTemp>$82: T.noreturn = blockreturn<sig> <blockReturnTemp>$74: T::Private::Methods::DeclBuilder
     <unconditional> -> bb18
 
 }

--- a/test/testdata/namer/redefinition_method.rb.flatten-tree.exp
+++ b/test/testdata/namer/redefinition_method.rb.flatten-tree.exp
@@ -24,7 +24,7 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :foo) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:a, ::Integer).returns(::Integer)
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
+++ b/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
@@ -28,16 +28,16 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :foo) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:x, ::String).returns(::String)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :bar) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:y, ::String).returns(::String)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :qux) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:z, ::String).returns(::String)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :baz) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:w, ::String).returns(::String)
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/rewriter/attr.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/attr.rb.flatten-tree.exp
@@ -85,34 +85,34 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :initialize) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.void()
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :v1) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.returns(::Integer)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :v1=) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:v1, ::Integer).returns(::Integer)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :v2) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.returns(::String)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :v2=) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:v2, ::String).returns(::String)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :v3) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.returns(::String)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :strv7) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.returns(::Float)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :strv8=) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:strv8, ::Float).returns(::Float)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :strv9) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.returns(::Float)
         end
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :strv9=) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.params(:strv9, ::Float).returns(::Float)
         end
         <self>.extend(::T::Sig)

--- a/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
@@ -66,11 +66,9 @@ method ::<Class:A>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
-    <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
-    <statTemp>$7: TrueClass = true
-    <statTemp>$8: Symbol(:make) = :make
-    <block-pre-call-temp>$9: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig).sig(<self>: T.class_of(A), <statTemp>$7: TrueClass, <statTemp>$8: Symbol(:make))
-    <selfRestore>$10: T.class_of(A) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(A))
+    <selfRestore>$8: T.class_of(A) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -81,28 +79,28 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
-    <self>: T.class_of(A) = <selfRestore>$10
-    <cfgAlias>$18: T.class_of(T::Sig) = alias <C Sig>
-    <cfgAlias>$20: T.class_of(T) = alias <C T>
-    <statTemp>$15: T.class_of(A) = <self>: T.class_of(A).extend(<cfgAlias>$18: T.class_of(T::Sig))
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(A) = <selfRestore>$8
+    <cfgAlias>$16: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$18: T.class_of(T) = alias <C T>
+    <statTemp>$13: T.class_of(A) = <self>: T.class_of(A).extend(<cfgAlias>$16: T.class_of(T::Sig))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=3](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+bb5[rubyRegionId=1, firstDead=3](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
-    <blockReturnTemp>$12: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.void()
-    <blockReturnTemp>$14: T.noreturn = blockreturn<sig> <blockReturnTemp>$12: T::Private::Methods::DeclBuilder
+    <blockReturnTemp>$10: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.void()
+    <blockReturnTemp>$12: T.noreturn = blockreturn<sig> <blockReturnTemp>$10: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
 
 }

--- a/test/testdata/rewriter/class_new_strict.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.flatten-tree.exp
@@ -29,7 +29,7 @@ begin
 
     def self.<static-init>(<blk>)
       begin
-        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :make) do ||
+        ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.void()
         end
         <self>.extend(::T::Sig)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

We originally introduced `Sorbet::Private::Static::ResolvedSig.sig` as a way of passing enough information to the compiler so that compiled methods could have the same set of runtime type information about their signature as interpreted methods did.

Turns out that this munging is actually kind of expensive, so we should avoid doing it in non-compiled files.  This saves ~20% of the (serial!) time resolving sigs on Stripe's codebase.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Zoom.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
