### PR TITLE
use the low bits for the tag in `FoundDefinitionRef`

### DIFF
--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -34,13 +34,13 @@ public:
 
 private:
     struct Storage {
-        Kind kind;
         uint32_t id : 24; // We only support 2^24 (≈ 16M) definitions of any kind in a single file.
+        Kind kind;
     } _storage;
     CheckSize(Storage, 4, 4);
 
 public:
-    FoundDefinitionRef(FoundDefinitionRef::Kind kind, uint32_t idx) : _storage({kind, idx}) {}
+    FoundDefinitionRef(FoundDefinitionRef::Kind kind, uint32_t idx) : _storage({idx, kind}) {}
     FoundDefinitionRef() : FoundDefinitionRef(FoundDefinitionRef::Kind::Empty, 0) {}
     FoundDefinitionRef(const FoundDefinitionRef &nm) = default;
     FoundDefinitionRef(FoundDefinitionRef &&nm) = default;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is consistent with the way we use tags in `SymbolRef`, `NameRef`, `ExpressionPtr`, etc.  It also happens to be significantly faster, to the tune of 7-10% when defining symbols in namer.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
