### PR TITLE
move `SymbolRef` liveness checks to a per-type basis

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1784,6 +1784,10 @@ unsigned int GlobalState::typeMembersUsed() const {
     return typeMembers.size();
 }
 
+unsigned int GlobalState::typeParametersUsed() const {
+    return typeArgumentsUsed() + typeMembersUsed();
+}
+
 unsigned int GlobalState::filesUsed() const {
     return files.size();
 }

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -183,6 +183,7 @@ public:
     unsigned int fieldsUsed() const;
     unsigned int typeArgumentsUsed() const;
     unsigned int typeMembersUsed() const;
+    unsigned int typeParametersUsed() const;
     unsigned int filesUsed() const;
     unsigned int symbolsUsedTotal() const;
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -13,9 +13,11 @@ class Loc;
 class TypePtr;
 struct SymbolDataDebugCheck {
     const GlobalState &gs;
+    typedef unsigned int (GlobalState::*SymbolsUsedFunc)() const;
+    const SymbolsUsedFunc fn;
     const unsigned int symbolCountAtCreation;
 
-    SymbolDataDebugCheck(const GlobalState &gs);
+    SymbolDataDebugCheck(const GlobalState &gs, SymbolsUsedFunc fn);
     void check() const;
 };
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2563,16 +2563,16 @@ vector<std::pair<NameRef, SymbolRef>> ClassOrModule::membersStableOrderSlow(cons
     return result;
 }
 
-ClassOrModuleData::ClassOrModuleData(ClassOrModule &ref, GlobalState &gs) : DebugOnlyCheck(gs), symbol(ref) {}
+ClassOrModuleData::ClassOrModuleData(ClassOrModule &ref, GlobalState &gs) : DebugOnlyCheck(gs, &GlobalState::classAndModulesUsed), symbol(ref) {}
 
 ConstClassOrModuleData::ConstClassOrModuleData(const ClassOrModule &ref, const GlobalState &gs)
-    : DebugOnlyCheck(gs), symbol(ref) {}
+    : DebugOnlyCheck(gs, &GlobalState::classAndModulesUsed), symbol(ref) {}
 
-SymbolDataDebugCheck::SymbolDataDebugCheck(const GlobalState &gs)
-    : gs(gs), symbolCountAtCreation(gs.symbolsUsedTotal()) {}
+SymbolDataDebugCheck::SymbolDataDebugCheck(const GlobalState &gs, SymbolsUsedFunc fn)
+    : gs(gs), fn(fn), symbolCountAtCreation((gs.*fn)()) {}
 
 void SymbolDataDebugCheck::check() const {
-    ENFORCE_NO_TIMER(symbolCountAtCreation == gs.symbolsUsedTotal());
+    ENFORCE_NO_TIMER(symbolCountAtCreation == (gs.*fn)());
 }
 
 ClassOrModule *ClassOrModuleData::operator->() {
@@ -2590,9 +2590,9 @@ const ClassOrModule *ConstClassOrModuleData::operator->() const {
     return &symbol;
 };
 
-MethodData::MethodData(Method &ref, GlobalState &gs) : DebugOnlyCheck(gs), method(ref) {}
+MethodData::MethodData(Method &ref, GlobalState &gs) : DebugOnlyCheck(gs, &GlobalState::methodsUsed), method(ref) {}
 
-ConstMethodData::ConstMethodData(const Method &ref, const GlobalState &gs) : DebugOnlyCheck(gs), method(ref) {}
+ConstMethodData::ConstMethodData(const Method &ref, const GlobalState &gs) : DebugOnlyCheck(gs, &GlobalState::methodsUsed), method(ref) {}
 
 Method *MethodData::operator->() {
     runDebugOnlyCheck();
@@ -2609,9 +2609,9 @@ const Method *ConstMethodData::operator->() const {
     return &method;
 };
 
-FieldData::FieldData(Field &ref, GlobalState &gs) : DebugOnlyCheck(gs), field(ref) {}
+FieldData::FieldData(Field &ref, GlobalState &gs) : DebugOnlyCheck(gs, &GlobalState::fieldsUsed), field(ref) {}
 
-ConstFieldData::ConstFieldData(const Field &ref, const GlobalState &gs) : DebugOnlyCheck(gs), field(ref) {}
+ConstFieldData::ConstFieldData(const Field &ref, const GlobalState &gs) : DebugOnlyCheck(gs, &GlobalState::fieldsUsed), field(ref) {}
 
 Field *FieldData::operator->() {
     runDebugOnlyCheck();
@@ -2628,10 +2628,10 @@ const Field *ConstFieldData::operator->() const {
     return &field;
 };
 
-TypeParameterData::TypeParameterData(TypeParameter &ref, GlobalState &gs) : DebugOnlyCheck(gs), typeParam(ref) {}
+TypeParameterData::TypeParameterData(TypeParameter &ref, GlobalState &gs) : DebugOnlyCheck(gs, &GlobalState::typeParametersUsed), typeParam(ref) {}
 
 ConstTypeParameterData::ConstTypeParameterData(const TypeParameter &ref, const GlobalState &gs)
-    : DebugOnlyCheck(gs), typeParam(ref) {}
+    : DebugOnlyCheck(gs, &GlobalState::typeParametersUsed), typeParam(ref) {}
 
 TypeParameter *TypeParameterData::operator->() {
     runDebugOnlyCheck();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`SymbolRef` (or, really, all the concrete subtypes of `SymbolRef` now that we have per-type symbols) has a debugging check that ensures we don't use the reference across the point where the size of the symbol table might have changed.  This is a weak approximation to actual liveness checking ala Rust or similar, but it is very useful.

It's also slightly out of date since we now have several arrays in which symbols live, and changes in e.g. the size of the type parameters array shouldn't affect whether a `MethodRef` is still valid.  We can do better by making `SymbolDataDebugCheck` aware of the kind of symbol it's checking for and therefore the matching array in `GlobalState` that it needs to check.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More intuitive hoisting of `sym.data(ctx)` and similar.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
