### PR TITLE
[RFC] Use a specific error code when exiting with type errors

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -957,7 +957,7 @@ int realmain(int argc, char *argv[]) {
     if (!gs || gs->hadCriticalError() || (gsForMinimize && gsForMinimize->hadCriticalError())) {
         returnCode = 10;
     } else if (returnCode == 0 && gs->totalErrors() > 0 && !opts.supressNonCriticalErrors) {
-        returnCode = 1;
+        returnCode = 100;
     }
 
     opts.flushPrinters();


### PR DESCRIPTION
### Motivation

Right now, tools using Sorbet have no way to discriminate when Sorbet finishes with a type error vs. another "unexpected" error:

With a type error:

```
$ sorbet --no-config -e "foo(42)"
-e:1: Method foo does not exist on T.class_of(<root>) https://srb.help/7003
     1 |foo(42)
        ^^^
Errors: 1
$ echo $?
1
```

With an unexpected error:

```
$ sorbet --fsdfsdf
Option ‘fsdfsdf’ does not exist. To see all available options pass `--help`.
$ echo $?
1
```

Changing the error code when Sorbet finishes "normally" but with type errors would make it easier to know from other tools what is happening.

Currently, all errors will return the exit code `1` except for a critical error where it returns `10`: https://github.com/sorbet/sorbet/blob/master/main/realmain.cc#L958

In this PR I propose to use `100` when exiting normally but with type errors.

What do you think?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
