### PR TITLE
Fork with a block returns an integer

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -728,7 +728,7 @@ module Kernel
     params(
         blk: T.proc.returns(BasicObject),
     )
-    .returns(T.nilable(Integer))
+    .returns(Integer)
   end
   def fork(&blk); end
 


### PR DESCRIPTION
When called without a block, you get nil or an integer, to tell you which process you are. With a block, the return value only exists in the parent, so it's an integer.

### Motivation
Avoids `T.must { fork {} )`.