### PR TITLE
tighten up the code for copying trees

### DIFF
--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -72,11 +72,11 @@ Rescue::Rescue(const void *avoid, const Rescue *exp)
 }
 
 Local::Local(const void *avoid, const Local *exp)
-    : loc(exp->loc) localVariable(exp->localVariable) {
+    : loc(exp->loc), localVariable(exp->localVariable) {
 }
 
 UnresolvedIdent::UnresolvedIdent(const void *avoid, const UnresolvedIdent *exp)
-    : loc(exp->loc), kind(exp->kind), name(exp->name) {
+    : loc(exp->loc), name(exp->name), kind(exp->kind) {
 }
 
 RestArg::RestArg(const void *avoid, const RestArg *exp)
@@ -101,6 +101,46 @@ ShadowArg::ShadowArg(const void *avoid, const ShadowArg *exp)
 
 Assign::Assign(const void *avoid, const Assign *exp)
     : loc(exp->loc), lhs(ast::deepCopy(avoid, exp->lhs)), rhs(ast::deepCopy(avoid, exp->rhs)) {
+}
+
+Cast::Cast(const void *avoid, const Cast *exp)
+    : loc(exp->loc), cast(exp->cast), type(exp->type), arg(ast::deepCopy(avoid, exp->arg)) {
+}
+
+Hash::Hash(const void *avoid, const Hash *exp)
+    : loc(exp->loc), keys(deepCopyVec(avoid, exp->keys)), values(deepCopyVec(avoid, exp->values)) {
+}
+
+Array::Array(const void *avoid, const Array *exp)
+    : loc(exp->loc), elems(deepCopyVec(avoid, exp->elems)) {
+}
+
+Literal::Literal(const void *avoid, const Literal *exp)
+    : loc(exp->loc), value(exp->value) {
+}
+
+UnresolvedConstantLit::UnresolvedConstantLit(const void *avoid, const UnresolvedConstantLit *exp)
+    : loc(exp->loc), cnst(exp->cnst), scope(ast::deepCopy(avoid, exp->scope)) {
+}
+
+ConstantLit::ConstantLit(const void *avoid, const ConstantLit *exp)
+    : loc(exp->loc), symbol(exp->symbol), original(exp->original == nullptr ? nullptr : ast::deepCopy(avoid, exp->original)) {
+}
+
+ZSuperArgs::ZSuperArgs(const void *avoid, const ZSuperArgs *exp)
+    : loc(exp->loc) {
+}
+
+Block::Block(const void *avoid, const Block *exp)
+    : loc(exp->loc), args(deepCopyVec(avoid, exp->args)), body(ast::deepCopy(avoid, exp->body)) {
+}
+
+InsSeq::InsSeq(const void *avoid, const InsSeq *exp)
+    : loc(exp->loc), stats(deepCopyVec(avoid, exp->stats)), expr(ast::deepCopy(avoid, exp->expr)) {
+}
+
+RuntimeMethodDefinition::RuntimeMethodDefinition(const void *avoid, const RuntimeMethodDefinition *exp)
+    : loc(exp->loc), name(exp->name), isSelfMethod(exp->isSelfMethod) {
 }
 
 class TreeCopier {
@@ -146,105 +186,102 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
 
         case Tag::While: {
             auto *exp = reinterpret_cast<const While *>(tree);
-            return make_expression<While>(exp->loc, deepCopy(avoid, exp->cond), deepCopy(avoid, exp->body));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Break: {
             auto *exp = reinterpret_cast<const Break *>(tree);
-            return make_expression<Break>(exp->loc, deepCopy(avoid, exp->expr));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Retry: {
             auto *exp = reinterpret_cast<const Retry *>(tree);
-            return make_expression<Retry>(exp->loc);
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Next: {
             auto *exp = reinterpret_cast<const Next *>(tree);
-            return make_expression<Next>(exp->loc, deepCopy(avoid, exp->expr));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Return: {
             auto *exp = reinterpret_cast<const Return *>(tree);
-            return make_expression<Return>(exp->loc, deepCopy(avoid, exp->expr));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::RescueCase: {
             auto *exp = reinterpret_cast<const RescueCase *>(tree);
-            return make_expression<RescueCase>(exp->loc, deepCopyVec(avoid, exp->exceptions), deepCopy(avoid, exp->var),
-                                               deepCopy(avoid, exp->body));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Rescue: {
             auto *exp = reinterpret_cast<const Rescue *>(tree);
-            return make_expression<Rescue>(exp->loc, deepCopy(avoid, exp->body),
-                                           deepCopyVec<Rescue::RESCUE_CASE_store>(avoid, exp->rescueCases),
-                                           deepCopy(avoid, exp->else_), deepCopy(avoid, exp->ensure));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Local: {
             auto *exp = reinterpret_cast<const Local *>(tree);
-            return make_expression<Local>(exp->loc, exp->localVariable);
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::UnresolvedIdent: {
             auto *exp = reinterpret_cast<const UnresolvedIdent *>(tree);
-            return make_expression<UnresolvedIdent>(exp->loc, exp->kind, exp->name);
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::RestArg: {
             auto *exp = reinterpret_cast<const RestArg *>(tree);
-            return make_expression<RestArg>(exp->loc, deepCopy(avoid, exp->expr));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::KeywordArg: {
             auto *exp = reinterpret_cast<const KeywordArg *>(tree);
-            return make_expression<KeywordArg>(exp->loc, deepCopy(avoid, exp->expr));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::OptionalArg: {
             auto *exp = reinterpret_cast<const OptionalArg *>(tree);
-            return make_expression<OptionalArg>(exp->loc, deepCopy(avoid, exp->expr), deepCopy(avoid, exp->default_));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::BlockArg: {
             auto *exp = reinterpret_cast<const BlockArg *>(tree);
-            return make_expression<BlockArg>(exp->loc, deepCopy(avoid, exp->expr));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::ShadowArg: {
             auto *exp = reinterpret_cast<const ShadowArg *>(tree);
-            return make_expression<ShadowArg>(exp->loc, deepCopy(avoid, exp->expr));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Assign: {
             auto *exp = reinterpret_cast<const Assign *>(tree);
-            return make_expression<Assign>(exp->loc, deepCopy(avoid, exp->lhs), deepCopy(avoid, exp->rhs));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Cast: {
             auto *exp = reinterpret_cast<const Cast *>(tree);
-            return make_expression<Cast>(exp->loc, exp->type, deepCopy(avoid, exp->arg), exp->cast);
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Hash: {
             auto *exp = reinterpret_cast<const Hash *>(tree);
-            return make_expression<Hash>(exp->loc, deepCopyVec(avoid, exp->keys), deepCopyVec(avoid, exp->values));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Array: {
             auto *exp = reinterpret_cast<const Array *>(tree);
-            return make_expression<Array>(exp->loc, deepCopyVec(avoid, exp->elems));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Literal: {
             auto *exp = reinterpret_cast<const Literal *>(tree);
-            return make_expression<Literal>(exp->loc, exp->value);
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::UnresolvedConstantLit: {
             auto *exp = reinterpret_cast<const UnresolvedConstantLit *>(tree);
-            return make_expression<UnresolvedConstantLit>(exp->loc, deepCopy(avoid, exp->scope), exp->cnst);
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::ConstantLit: {
@@ -253,27 +290,27 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
             if (exp->original) {
                 originalC = deepCopy(avoid, exp->original);
             }
-            return make_expression<ConstantLit>(exp->loc, exp->symbol, move(originalC));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::ZSuperArgs: {
             auto *exp = reinterpret_cast<const ZSuperArgs *>(tree);
-            return make_expression<ZSuperArgs>(exp->loc);
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::Block: {
             auto *exp = reinterpret_cast<const Block *>(tree);
-            return make_expression<Block>(exp->loc, deepCopyVec(avoid, exp->args), deepCopy(avoid, exp->body));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::InsSeq: {
             auto *exp = reinterpret_cast<const InsSeq *>(tree);
-            return make_expression<InsSeq>(exp->loc, deepCopyVec(avoid, exp->stats), deepCopy(avoid, exp->expr));
+            return TreeCopier::copy(avoid, exp);
         }
 
         case Tag::RuntimeMethodDefinition: {
             auto *exp = reinterpret_cast<const RuntimeMethodDefinition *>(tree);
-            return make_expression<RuntimeMethodDefinition>(exp->loc, exp->name, exp->isSelfMethod);
+            return TreeCopier::copy(avoid, exp);
         }
     }
 }

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1261,9 +1261,6 @@ public:
     std::string nodeName();
 
     void _sanityCheck();
-private:
-    friend TreeCopier;
-    EmptyTree(const void *avoid, const EmptyTree *exp);
 };
 CheckSize(EmptyTree, 8, 8);
 


### PR DESCRIPTION
Tree copying creates a lot of unnecessary temporaries that the compiler doesn't appear to be able to optimize away.  Not sure if this change will make a difference, but at least the assembly looks a lot cleaner.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
