### PR TITLE
use the pre-existing file information to determine package-ness

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1370,7 +1370,7 @@ vector<ast::ParsedFile> Packager::findPackages(core::GlobalState &gs, WorkerPool
         core::UnfreezeNameTable unfreeze(gs);
         core::packages::UnfreezePackages packages = gs.unfreezePackages();
         for (auto &file : files) {
-            if (FileOps::getFileName(file.file.data(gs).path()) != PACKAGE_FILE_NAME) {
+            if (!file.file.data(gs).isPackage()) {
                 continue;
             }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already compute this information when we construct the files, there's no reason to do string comparisons here.

This speeds up the serial portion of packaging quite nicely.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
