### PR TITLE
Allow `T.all` to be `T.noreturn` if one is final class

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -626,6 +626,11 @@ TypePtr glbGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
         if (sym1.data(gs)->isClass() && sym2.data(gs)->isClass()) {
             categoryCounterInc("glb.<class>.collapsed", "bottom");
             return Types::bottom();
+        } else if (sym1.data(gs)->flags.isFinal || sym2.data(gs)->flags.isFinal) {
+            // If at least one of them is a module, the only way this type could ever be inhabited
+            // is if a descendant of one of the symbols later includes the module symbol. This can't
+            // happen if either one is final.
+            return Types::bottom();
         }
         categoryCounterInc("glb.<class>.collapsed", "no");
         return AndType::make_shared(t1, t2);
@@ -937,6 +942,11 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 // At this point, the two types are both classes, and unrelated
                 // to each other. Because ruby does not support multiple
                 // inheritance, this type is empty.
+                return Types::bottom();
+            } else if (a1->klass.data(gs)->flags.isFinal || a2->klass.data(gs)->flags.isFinal) {
+                // If at least one of them is a module, the only way this type could ever be
+                // inhabited is if a descendant of one of the symbols later includes the module
+                // symbol. This can't happen if either one is final.
                 return Types::bottom();
             } else {
                 return AndType::make_shared(t1, t2); // we can as well return nothing here?

--- a/test/testdata/infer/glb_final.rb
+++ b/test/testdata/infer/glb_final.rb
@@ -1,0 +1,45 @@
+# typed: true
+extend T::Sig
+
+class FinalClass
+  extend T::Helpers
+  final!
+end
+module NonFinalModule; end
+
+class NonFinalClass; end
+module FinalModule
+  extend T::Helpers
+  final!
+end
+
+sig {params(x: FinalClass).void}
+def example1(x)
+  case x
+  when NonFinalModule
+    puts(x) # error: This code is unreachable
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `FinalClass` wasn't handled
+  end
+end
+
+sig {params(x: NonFinalClass).void}
+def example2(x)
+  case x
+  when FinalModule
+    puts(x) # error: This code is unreachable
+  else
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `NonFinalClass` wasn't handled
+  end
+end
+
+sig do
+  params(
+    x: T::Array[T.all(FinalClass, NonFinalModule)],
+    y: T::Array[T.all(NonFinalClass, FinalModule)]
+  ).void
+end
+def example3(x, y)
+  T.reveal_type(x) # error: `T::Array[T.noreturn]`
+  T.reveal_type(y) # error: `T::Array[T.noreturn]`
+end

--- a/website/docs/intersection-types.md
+++ b/website/docs/intersection-types.md
@@ -3,7 +3,16 @@ id: intersection-types
 title: Intersection Types (T.all)
 ---
 
-> TODO: This page is still a fragment. Contributions welcome!
+<!--
+  TODO(jez) Fill this out into not a fragment
+
+  - Mention that `T.all(C1, C2)` is `T.noreturn`
+  - Mention that `T.all(C1, M1)` does not collapse, even if `C1` does not
+    include `M1`, because of the possibility of inheritance.
+  - Mention that in fact it will collapse if either of them is `final`
+  - Mention that the same logic applies with generic class types
+  - Doc for `T.noreturn` is also a fragment, might want to flesh that out too
+-->
 
 Intersection types can be useful to say, after the fact, that the input must
 implement two specific interfaces.

--- a/website/docs/intersection-types.md
+++ b/website/docs/intersection-types.md
@@ -3,67 +3,263 @@ id: intersection-types
 title: Intersection Types (T.all)
 ---
 
-<!--
-  TODO(jez) Fill this out into not a fragment
+Intersection types are how we overlap two types, declaring that an expression
+has the all properties of two or more types. The basic syntax for `T.all` is:
 
-  - Mention that `T.all(C1, C2)` is `T.noreturn`
-  - Mention that `T.all(C1, M1)` does not collapse, even if `C1` does not
-    include `M1`, because of the possibility of inheritance.
-  - Mention that in fact it will collapse if either of them is `final`
-  - Mention that the same logic applies with generic class types
-  - Doc for `T.noreturn` is also a fragment, might want to flesh that out too
--->
+```ruby
+T.all(Type1, Type2, ...)
+```
 
-Intersection types can be useful to say, after the fact, that the input must
-implement two specific interfaces.
+Note that `T.all` requires at least two arguments.
+
+Unlike union types (`T.any(Type1, Type2)`) which say that an expression is
+_either_ `Type1` _or_ the unrelated `Type2`, `T.all(Type1, Type2)` says that an
+expression has both of these two types at the same time. Some common use cases
+for intersection types:
+
+- Overlapping two otherwise unrelated interfaces, like
+  `T.all(Enumerable, Comparable)`.
+- Placing a constraint on a method's generic type parameter, like
+  `T.all(T.type_parameter(:U), Comparable)`. (For more, see
+  [Placing bounds on generic methods](generics.md#placing-bounds-on-generic-methods).)
+- Modeling [control flow-sensitive](flow-sensitive.md) type tests on certain
+  kinds of values (discussed below).
+
+As the names indicate, union types and intersection types can be understood by
+analogy to the related operations on sets. Given `Type1` and `Type2`:
+
+- `T.any(Type1, Type2)` is the union of the set of values that either have type
+  `Type1` or have type `Type2`.
+- `T.all(Type1, Type2)` is the intersection of the set of values that both have
+  type`Type1` and have type `Type2`.
+
+An example to make things more concrete:
 
 ```ruby
 # typed: true
 extend T::Sig
 
-module I1
-  def i1; end
+module Type1
+  def method1; end
 end
 
-module I2
-  def i2; end
+module Type2
+  def method2; end
 end
 
-class C
-  include I1
-  include I2
+class ExampleClass1
+  include Type1
+  include Type2
 end
 
-class D
-  include I1
-  include I2
+class ExampleClass2
+  include Type1
 end
 
-
-sig {params(x: T.all(I1, I2)).void}
-def foo(x)
-  x.i1
-  x.i2
+sig {params(x: T.all(Type1, Type2)).void}
+def requires_both(x)
+  x.method1 # ok
+  x.method2 # also ok
 end
 
-foo(C.new)
-foo(D.new)
+requires_both(ExampleClass1.new) # ok
+requires_both(ExampleClass2.new) # NOT ok, has Type1 but not Type2
 ```
 
-This is useful because we don't have to know ahead of time all the things that
-might implement these two interfaces. It also gets around the problem where we'd
-have to make a third interface, `I12`, like this:
+[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Amodule%20Type1%0A%20%20def%20method1%3B%20end%0Aend%0A%0Amodule%20Type2%0A%20%20def%20method2%3B%20end%0Aend%0A%0Aclass%20ExampleClass1%0A%20%20include%20Type1%0A%20%20include%20Type2%0Aend%0A%0Aclass%20ExampleClass2%0A%20%20include%20Type1%0Aend%0A%0Asig%20%7Bparams%28x%3A%20T.all%28Type1%2C%20Type2%29%29.void%7D%0Adef%20requires_both%28x%29%0A%20%20x.method1%20%23%20ok%0A%20%20x.method2%20%23%20also%20ok%0Aend%0A%0Arequires_both%28ExampleClass1.new%29%20%23%20ok%0Arequires_both%28ExampleClass2.new%29%20%23%20NOT%20ok%2C%20has%20Type1%20but%20not%20Type2)
+
+## Intersection types as ad hoc interfaces
+
+Intersections are useful because they don't require us to write an explicit
+interface that combines the requirements of two or more interfaces. For example,
+we might have imagined defining something like
 
 ```ruby
-module I12
-  include I1
-  include I2
+module Type1AndType2
+  include Type1
+  include Type2
 end
 ```
 
-and include this interface into `C` and `D` (because maybe we don't have control
-over what interfaces C and D can include).
+and then using `Type1AndType2` instead of `T.all(Type1, Type2)`.
 
-<a href="https://sorbet.run/#extend%20T%3A%3ASig%0A%0Amodule%20I1%0A%20%20def%20i1%3B%20end%0Aend%0A%0Amodule%20I2%0A%20%20def%20i2%3B%20end%0Aend%0A%0Aclass%20C%0A%20%20include%20I1%0A%20%20include%20I2%0Aend%0A%0Asig%20%7Bparams(x%3A%20T.all(I1%2C%20I2)).void%7D%0Adef%20foo(x)%0A%20%20x.i1%0A%20%20x.i2%0Aend%0A%0Afoo(C.new)%0A">
-  → View on sorbet.run
-</a>
+This can sometimes work, but only if we retroactively modify `ExampleClass1` to
+be defined like this instead of including the interfaces individually:
+
+```ruby
+class ExampleClass1
+  include Type1AndType2
+end
+```
+
+When working with classes and interfaces defined in the standard library, it's
+not possible to modify how a class was defined without resorting to monkey
+patching the class, which is undesirable.
+
+In this light, `T.all` can be understood as a way to define certain kinds of _ad
+hoc_ interfaces.
+
+(Importantly, interfaces do not on their own provide support for "duck typing,"
+because the classes in question still have to implement each interface
+individually. The only thing that is ad hoc is the combination of two or more
+already-implemented interfaces.)
+
+## Understanding how intersection types collapse
+
+In an attempt to both make error messages simpler and make Sorbet type check a
+codebase faster, Sorbet attempts to reduce or collapse intersection types to
+smaller types. For example:
+
+```ruby
+class Parent; end
+class Child < Parent; end
+
+sig {params(x: T.all(Parent, Child)).void}
+def example(x)
+  T.reveal_type(x) # => `Child`
+end
+```
+
+[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Aclass%20Parent%3B%20end%0Aclass%20Child%20%3C%20Parent%3B%20end%0A%0Asig%20%7Bparams%28x%3A%20T.all%28Parent%2C%20Child%29%29.void%7D%0Adef%20example%28x%29%0A%20%20T.reveal_type%28x%29%20%23%20%3D%3E%20%60Child%60%0Aend)
+
+In this example, Sorbet reveals that `x` has type `Child`, despite the method
+being declared as taking `T.all(Parent, Child)`.
+
+Given what it knows about which classes are defined and their super classes,
+Sorbet is smart enough to realize that every value with type `Child` already
+also has type `Parent` via inheritance. That makes `T.all(Child, Parent)`
+redundant, and it collapses the type to simply `Child`.
+
+Sorbet is quite smart at collapsing types like this. Some other examples of
+types that collapse:
+
+```ruby
+# typed: true
+extend T::Sig
+
+class A; end
+class B; end
+
+module M; end
+
+class FooParent; end
+class FooChild < FooParent; end
+class Bar; end
+
+module ImmutableBox
+  extend T::Generic
+  Elem = type_member(:out)
+end
+class MutableBox
+  extend T::Generic
+  Elem = type_member
+end
+
+sig {params(xs: T::Array[T.all(A, B)]).void}
+def example1(xs)
+  # Since A and B are unrelated classes, Sorbet notices that
+  # there are no values that satisfy `T.all(A, B)`, and thus
+  # collapses the type to `T.noreturn`
+  T.reveal_type(xs) # => T::Array[T.noreturn]
+end
+
+sig {params(x: T.all(A, M)).void}
+def example2(x)
+  # Even though A and M are unrelated, because M is a module
+  # (not a class) the type does not collapse. Why? There might
+  # be some subclasses of A that include M, and some that don't.
+  #
+  # In this example, A has no subclasses. If we explicitly
+  # declare to Sorbet that A has no subclasses with `final!`,
+  # it would collapse the type.
+  T.reveal_type(x) # => T.all(A, M)
+end
+
+sig {params(x: T.all(FooParent, T.any(FooChild, Bar))).void}
+def example3(x)
+  # Sorbet is smart enough to distribute over union types:
+  #    T.all(FooParent, T.any(FooChild, Bar))
+  # => T.any(T.all(FooParent, FooChild), T.all(FooParent, Bar))
+  # => T.any(FooChild                  , T.noreturn           )
+  # => FooChild
+  T.reveal_type(x) # => FooChild
+end
+```
+
+[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Aclass%20A%3B%20end%0Aclass%20B%3B%20end%0A%0Amodule%20M%3B%20end%0A%0Aclass%20FooParent%3B%20end%0Aclass%20FooChild%20%3C%20FooParent%3B%20end%0Aclass%20Bar%3B%20end%0A%0Amodule%20ImmutableBox%0A%20%20extend%20T%3A%3AGeneric%0A%20%20Elem%20%3D%20type_member%28%3Aout%29%0Aend%0Aclass%20MutableBox%0A%20%20extend%20T%3A%3AGeneric%0A%20%20Elem%20%3D%20type_member%0Aend%0A%0Asig%20%7Bparams%28xs%3A%20T%3A%3AArray%5BT.all%28A%2C%20B%29%5D%29.void%7D%0Adef%20example1%28xs%29%0A%20%20%23%20Since%20A%20and%20B%20are%20unrelated%20classes%2C%20Sorbet%20notices%20that%0A%20%20%23%20there%20are%20no%20values%20that%20satisfy%20%60T.all%28A%2C%20B%29%60%2C%20and%20thus%0A%20%20%23%20collapses%20the%20type%20to%20%60T.noreturn%60%0A%20%20T.reveal_type%28xs%29%20%23%20%3D%3E%20T%3A%3AArray%5BT.noreturn%5D%0Aend%0A%0Asig%20%7Bparams%28x%3A%20T.all%28A%2C%20M%29%29.void%7D%0Adef%20example2%28x%29%0A%20%20%23%20Even%20though%20A%20and%20M%20are%20unrelated%2C%20because%20M%20is%20a%20module%0A%20%20%23%20%28not%20a%20class%29%20the%20type%20does%20not%20collapse.%20Why%3F%20There%20might%0A%20%20%23%20be%20some%20subclasses%20of%20A%20that%20include%20M%2C%20and%20some%20that%20don't.%0A%20%20%23%20%0A%20%20%23%20In%20this%20example%2C%20A%20has%20no%20subclasses.%20If%20we%20explicitly%0A%20%20%23%20declare%20to%20Sorbet%20that%20A%20has%20no%20subclasses%20with%20%60final!%60%2C%0A%20%20%23%20it%20would%20collapse%20the%20type.%0A%20%20T.reveal_type%28x%29%20%23%20%3D%3E%20T.all%28A%2C%20M%29%0Aend%0A%0Asig%20%7Bparams%28x%3A%20T.all%28FooParent%2C%20T.any%28FooChild%2C%20Bar%29%29%29.void%7D%0Adef%20example3%28x%29%0A%20%20%23%20Sorbet%20is%20smart%20enough%20to%20distribute%20over%20union%20types%3A%0A%20%20%23%20%20%20%20T.all%28FooParent%2C%20T.any%28FooChild%2C%20Bar%29%29%0A%20%20%23%20%3D%3E%20T.any%28T.all%28FooParent%2C%20FooChild%29%2C%20T.all%28FooParent%2C%20Bar%29%29%0A%20%20%23%20%3D%3E%20T.any%28FooChild%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20T.noreturn%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%23%20%3D%3E%20FooChild%0A%20%20T.reveal_type%28x%29%20%23%20%3D%3E%20FooChild%0Aend)
+
+All the examples above use normal, non-generic classes and modules, however the
+same principles govern when intersection types involving generic classes and
+modules collapse as well.
+
+## Intersection types and control flow
+
+Without even realizing, you use intersection types almost every time you write
+code with Sorbet, _indirectly_ via [control flow-sensitive](flow-sensitive.md)
+typing. For example:
+
+```ruby
+class A; end
+class B; end
+
+# Note: `T.any` (either A or B)
+sig {params(x: T.any(A, B)).void}
+def example(x)
+  case x
+  when A
+    T.reveal_type(x) # => `A`
+  end
+end
+```
+
+In this example, due to flow sensitive typing Sorbet understands that `x` has
+type `A` within the `when A` clause. But it doesn't simply _ascribe_ that type
+to `x`: it arrives at that type using intersection types. Inside the `when`
+clause, Sorbet uses intersection types to say that `x` has "both the type it
+used to have and also `A`": `T.all(T.any(A, B), A)`.
+
+But as we know from the previous section, this type collapses:
+
+```ruby
+   T.all(T.any(A, B), A)
+=> T.any(T.all(A, A), T.all(B, A))
+=> T.any(A          , T.noreturn)
+=> A
+```
+
+We can witness that this is the case by using a control flow type test on an
+unrelated module:
+
+```ruby
+class A; end
+
+module M; end
+
+sig {params(x: A).void}
+def example(x)
+  case x
+  when M
+    T.reveal_type(x) # => `T.all(A, M)`
+  end
+end
+```
+
+In this example, the method signature said nothing about whether or not `x`
+implements the module `M`, but in the method body we ask at runtime whether it
+does or not. This is enough to let Sorbet know that if the type test were to
+pass at runtime and run the code inside the `when` branch, that `x` must now
+have all the methods that were defined on `A` _and_ all the methods defined on
+`M`. (And as mentioned in the previous section, this type does not collapse
+because `A` is not `final!`.)
+
+## What's next?
+
+- [`T.noreturn`](noreturn.md)
+
+  Use of intersection types can lead to (sometimes unwanted) `T.noreturn` types.
+  Read more about what `T.noreturn` represents, and when it is useful.
+
+- [`Abstract Classes and Interfaces`](abstract.md)
+
+  Intersection types are most commonly used in tandem with interface modules.
+  Read more about how to define composable abstract classes and interfaces.

--- a/website/docs/noreturn.md
+++ b/website/docs/noreturn.md
@@ -3,40 +3,152 @@ id: noreturn
 title: T.noreturn
 ---
 
-> TODO: This page is still a fragment. Contributions welcome!
+The type `T.noreturn` is an "impossible" type: zero values in the language have
+this type. This type has a number of key use cases.
+
+## Declaring that a method always raises
+
+`T.noreturn` can declare that a method never returns (for example, because it
+unconditionally raises).
 
 ```ruby
-T.noreturn
-```
-
-This indicates that a method never returns. Some examples of things that never
-return are: infinite loops, exiting the program, and raising exceptions.
-
-This powers dead code analysis. If you try to do something with a value of type
-`T.noreturn`, you will get an unreachable code error.
-
-```ruby
-# typed: true
-extend T::Sig
-
 sig {returns(T.noreturn)}
-def loop_forever
-  loop {}
+def raise_always
+  raise RuntimeError
 end
 
 sig {returns(T.noreturn)}
 def exit_program
   exit
 end
-
-sig {returns(T.noreturn)}
-def raise_always
-  raise RuntimeError
-end
-
-x = exit_program
-puts x # error: This code is unreachable
 ```
 
-`T.noreturn` is a subtype of every type, but no type except `T.noreturn`
-(trivially) and `T.untyped` is a subtype of `T.noreturn`.
+In fact, neither `raise` nor `exit` are keywords in Ruby but are in fact methods
+(defined on the `Kernel` module in the standard library). Sorbet uses an
+[RBI file](rbi.md) to declare that
+[`raise` and `exit` never returns](https://github.com/sorbet/sorbet/blob/a11ae1b427def972a6b6eb203c0d676f0f77ddae/rbi/core/kernel.rbi#L3104-L3127),
+among others.
+
+## Detecting unreachable code
+
+`T.noreturn` powers Sorbet's unreachable (dead) code analysis, because it is
+impossible to have a value of type `T.noreturn`. For example:
+
+```ruby
+sig {params(x: T.nilable(Integer)).void}
+def example(x)
+  if x.nil?
+    raise ""
+    puts(x) # error: This code is unreachable
+  end
+end
+```
+
+The call to `puts(x)` happens after the call to `raise`. Since Sorbet knows that
+`raise ""` evaluates to `T.noreturn`, it knows that the call to `puts(x)` will
+never run. (The error message makes no mention of `T.noreturn` explicitly, but
+this is in fact what powers the underlying analysis.)
+
+Note that it can be useful to assert that a given branch of control flow
+**must** be unreachable. For these cases, Sorbet provides
+[`T.absurd`](exhaustiveness.md#using-tabsurd-to-assert-a-dead-condition), which
+also handles exhaustiveness checking (a special case of asserting that a branch
+of code is unreachable).
+
+## Writing infinite loops
+
+Another way a method can never return is if it infinitely loops, either by using
+`loop {...}` or by using a `while` loop with an unconditionally `true`
+condition, neither of which ever `break` out of the loop:
+
+```ruby
+sig {returns(T.noreturn)}
+def loop_forever
+  loop do
+    # ...
+  end
+end
+
+sig {returns(T.noreturn)}
+def while_forever
+  while true
+    # ...
+  end
+end
+```
+
+Infinite loops like this occur frequently in long-lived processes that are
+designed to respond to user input indefinitely.
+
+Having type system support for this may not seem immediately useful at first,
+but ties into the previous section: Sorbet can detect code written after an
+infinite loop, and flag that the code is unreachable.
+
+## Detecting impossible-to-call methods
+
+Because of [intersection types](intersection-types.md), it is possible to create
+types for which there cannot be any values. If there are no values of a given
+type, and that type is used for an argument of a method, Sorbet flags the usage
+as dead code:
+
+```ruby
+class A; end
+class B; end
+
+sig {params(x: T.all(A, B)).void}
+def example(x)
+  puts(x) # error: This code is unreachable
+end
+```
+
+As discussed in
+[Understanding how intersection types collapse](intersection-types.md#understanding-how-intersection-types-collapse),
+`T.all(A, B)` collapses to `T.noreturn` because the classes `A` and `B` are
+completely unrelated, and it therefore impossible for a value to simultaneously
+be an instance of `A` and `B`.
+
+In these examples, Sorbet has caught an example of a method which is not
+possible to call.
+
+## `T.noreturn` and subtyping
+
+`T.noreturn` is a subtype of all other types. This can be useful in certain
+situations. For example, the type of the empty array is most accurately typed as
+`T::Array[T.noreturn]`. Because `T.noreturn` is a subtype of all other types,
+this means that `[]` has type `T::Array[Integer]` and `T::Array[String]` and
+`T::Array[T.any(Integer, String)]`, etc.
+
+This also allows Sorbet to detect when, for example, there's an incorrect
+attempt to access the first element of a known-empty list:
+
+```ruby
+xs = T::Array[T.noreturn].new
+x = xs.fetch(0)
+puts(x) # error: This code is unreachable
+```
+
+## `T.noreturn` and `T.untyped`
+
+Despite what we've claimed throughout this page, technically it **is** possible
+to have a value of type `T.noreturn` by way of `T.untyped`:
+
+```ruby
+sig {returns(T.noreturn)}
+def always_raises
+  T.unsafe("Just kidding, it actually does return")
+end
+```
+
+This is an unavoidable downside of Sorbet's use of [`T.untyped`](untyped.md) to
+implement a [gradual type system](gradual.md).
+
+This is a major reason why Sorbet's [runtime type checking](runtime.md) is
+valuable: in order for Sorbet's dead code analysis to be accurate, Sorbet relies
+on the fact that violations of the declared types will as a last resort be
+caught at runtime by checking [method signatures](sigs.md) and
+[type assertions](type-assertions.md).
+
+Disabling these checks at runtime can cause Sorbet to incorrectly judge which
+code is or is not reachable at runtime.
+
+[daemon processes]: https://en.wikipedia.org/wiki/Daemon_(computing)

--- a/website/docs/noreturn.md
+++ b/website/docs/noreturn.md
@@ -143,12 +143,14 @@ This is an unavoidable downside of Sorbet's use of [`T.untyped`](untyped.md) to
 implement a [gradual type system](gradual.md).
 
 This is a major reason why Sorbet's [runtime type checking](runtime.md) is
-valuable: in order for Sorbet's dead code analysis to be accurate, Sorbet relies
-on the fact that violations of the declared types will as a last resort be
-caught at runtime by checking [method signatures](sigs.md) and
+valuable: in order for Sorbet's static dead code analysis to be accurate, Sorbet
+relies on the fact that static violations of the declared types will be caught
+at runtime by checking [method signatures](sigs.md) and
 [type assertions](type-assertions.md).
 
-Disabling these checks at runtime can cause Sorbet to incorrectly judge which
-code is or is not reachable at runtime.
+Disabling runtime checks will not change anything about what Sorbet infers
+statically--in particular, Sorbet will still believe it is impossible to have a
+value of type `T.noreturn` and will still report the same unreachable code
+errors it normally would.
 
 [daemon processes]: https://en.wikipedia.org/wiki/Daemon_(computing)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There is further motivation in <https://github.com/sorbet/sorbet/issues/4123#issuecomment-1190997647>.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] @jez Write tests