### PR TITLE
Use parent class type members' variance in glb

### DIFF
--- a/test/testdata/infer/result.rb
+++ b/test/testdata/infer/result.rb
@@ -1,0 +1,53 @@
+# typed: true
+extend T::Sig
+
+module Result
+  extend T::Sig
+  extend T::Generic
+  sealed!
+
+  OkType = type_member(:out)
+  ErrType = type_member(:out)
+
+  class Ok < T::Struct
+    extend T::Generic
+    include Result
+
+    OkType = type_member
+    ErrType = type_member {{fixed: T.noreturn}}
+
+    prop :val, OkType
+  end
+
+  class Err < T::Struct
+    extend T::Generic
+    include Result
+
+    OkType = type_member {{fixed: T.noreturn}}
+    ErrType = type_member
+
+    prop :error, ErrType
+  end
+end
+
+class SomethingElse; end
+
+sig {params(res: Result[Integer, TypeError]).void}
+def example(res)
+  case res
+  when Result::Ok
+    T.reveal_type(res) # error: `Result::Ok[Integer]`
+    T.reveal_type(res.val) # error: `Integer`
+
+    # Can widen the type to anything else (covariance)
+    _unused = T.let(res, Result[Integer, SomethingElse])
+  when Result::Err
+    T.reveal_type(res) # error: `Result::Err[TypeError]`
+    T.reveal_type(res.error) # error: `TypeError`
+
+    # Can widen the type to anything else (covariance)
+    _unused = T.let(res, Result[SomethingElse, TypeError])
+  else
+    T.absurd(res)
+  end
+end

--- a/test/testdata/infer/sealed_list_fixed_noreturn.rb
+++ b/test/testdata/infer/sealed_list_fixed_noreturn.rb
@@ -43,10 +43,8 @@ def list_integer_to_list_string(xs)
   when List::Cons
     List::Cons[String].new(head: xs.head.to_s, tail: list_integer_to_list_string(xs))
   when List::Nil
-    T.reveal_type(xs) # error: Revealed type: `T.all(List[Integer], List::Nil)`
+    T.reveal_type(xs) # error: Revealed type: `List::Nil`
 
-    # Even though the T.all doesn't collapse above, it appears that type can
-    # still be used like an empty list.
     _unused = T.let(xs, List[String])
     0.times do
       puts(xs.head) # error: This code is unreachable


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This allows the `result.rb` test to typecheck, and fixes one of our `List`
tests.

### Explanation

The intuition is that the result `ret` of `Types::all(gs, t1, t2)` must be a
subtype of both `t1` and `t2` (this is `ENFORCE`'d in the code).

Consider

```ruby
T.all(Result::Ok[T.untyped], Result[Integer, TypeError])
```

Intuitively, we would like this to be `Result::Ok[Integer]`. This intuition is
confirmed by the fact that it's the variance of the parent's type members that
are used when checking subtyping: since `OkType` and `ErrType` are covariant,
subtyping should be allowed, so since `T.noreturn <: TypeError` holds,
`Result::Ok[Integer, T.noreturn] <: Result[Integer, TypeError]` holds.

Due to what looks to me like an accident, `glb` was using the variance of the
child to determine whether it could collapse a type argument to a subtype, which
is now changed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.