### PR TITLE
loop through method args rather than recursing

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -10,33 +10,37 @@ namespace sorbet::ast {
 namespace {
 core::ParsedArg parseArg(const ast::ExpressionPtr &arg) {
     core::ParsedArg parsedArg;
+    auto *cursor = &arg;
 
-    typecase(
-        arg,
-        [&](const ast::RestArg &rest) {
-            parsedArg = parseArg(rest.expr);
-            parsedArg.flags.isRepeated = true;
-        },
-        [&](const ast::KeywordArg &kw) {
-            parsedArg = parseArg(kw.expr);
-            parsedArg.flags.isKeyword = true;
-        },
-        [&](const ast::OptionalArg &opt) {
-            parsedArg = parseArg(opt.expr);
-            parsedArg.flags.isDefault = true;
-        },
-        [&](const ast::BlockArg &blk) {
-            parsedArg = parseArg(blk.expr);
-            parsedArg.flags.isBlock = true;
-        },
-        [&](const ast::ShadowArg &shadow) {
-            parsedArg = parseArg(shadow.expr);
-            parsedArg.flags.isShadow = true;
-        },
-        [&](const ast::Local &local) {
-            parsedArg.local = local.localVariable;
-            parsedArg.loc = local.loc;
-        });
+    while (cursor != nullptr) {
+        typecase(
+            *cursor,
+            [&](const ast::RestArg &rest) {
+                parsedArg.flags.isRepeated = true;
+                cursor = &rest.expr;
+            },
+            [&](const ast::KeywordArg &kw) {
+                parsedArg.flags.isKeyword = true;
+                cursor = &kw.expr;
+            },
+            [&](const ast::OptionalArg &opt) {
+                parsedArg.flags.isDefault = true;
+                cursor = &opt.expr;
+            },
+            [&](const ast::BlockArg &blk) {
+                parsedArg.flags.isBlock = true;
+                cursor = &blk.expr;
+            },
+            [&](const ast::ShadowArg &shadow) {
+                parsedArg.flags.isShadow = true;
+                cursor = &shadow.expr;
+            },
+            [&](const ast::Local &local) {
+                parsedArg.local = local.localVariable;
+                parsedArg.loc = local.loc;
+                cursor = nullptr;
+            });
+    }
 
     return parsedArg;
 }

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -49,46 +49,45 @@ class LocalNameInserter {
     // the outer structure for the namer proper.
     NamedArg nameArg(ast::ExpressionPtr arg) {
         NamedArg named;
+        auto *cursor = &arg;
 
-        typecase(
-            arg,
-            [&](ast::UnresolvedIdent &nm) {
-                named.name = nm.name;
-                named.local = enterLocal(named.name);
-                named.loc = nm.loc;
-                named.expr = ast::make_expression<ast::Local>(nm.loc, named.local);
-            },
-            [&](ast::RestArg &rest) {
-                named = nameArg(move(rest.expr));
-                named.expr = ast::MK::RestArg(rest.loc, move(named.expr));
-                named.flags.repeated = true;
-            },
-            [&](ast::KeywordArg &kw) {
-                named = nameArg(move(kw.expr));
-                named.expr = ast::make_expression<ast::KeywordArg>(kw.loc, move(named.expr));
-                named.flags.keyword = true;
-            },
-            [&](ast::OptionalArg &opt) {
-                named = nameArg(move(opt.expr));
-                named.expr = ast::MK::OptionalArg(opt.loc, move(named.expr), move(opt.default_));
-            },
-            [&](ast::BlockArg &blk) {
-                named = nameArg(move(blk.expr));
-                named.expr = ast::MK::BlockArg(blk.loc, move(named.expr));
-                named.flags.block = true;
-            },
-            [&](ast::ShadowArg &shadow) {
-                named = nameArg(move(shadow.expr));
-                named.expr = ast::MK::ShadowArg(shadow.loc, move(named.expr));
-                named.flags.shadow = true;
-            },
-            [&](const ast::Local &local) {
-                named.name = local.localVariable._name;
-                named.local = enterLocal(named.name);
-                named.loc = local.loc;
-                named.expr = ast::make_expression<ast::Local>(local.loc, named.local);
-            });
+        while (cursor != nullptr) {
+            typecase(
+                *cursor,
+                [&](ast::UnresolvedIdent &nm) {
+                    named.name = nm.name;
+                    named.local = enterLocal(nm.name);
+                    named.loc = nm.loc;
+                    *cursor = ast::make_expression<ast::Local>(nm.loc, named.local);
+                    cursor = nullptr;
+                },
+                [&](ast::RestArg &rest) {
+                    named.flags.repeated = true;
+                    cursor = &rest.expr;
+                },
+                [&](ast::KeywordArg &kw) {
+                    named.flags.keyword = true;
+                    cursor = &kw.expr;
+                },
+                [&](ast::OptionalArg &opt) { cursor = &opt.expr; },
+                [&](ast::BlockArg &blk) {
+                    named.flags.block = true;
+                    cursor = &blk.expr;
+                },
+                [&](ast::ShadowArg &shadow) {
+                    named.flags.shadow = true;
+                    cursor = &shadow.expr;
+                },
+                [&](const ast::Local &local) {
+                    named.name = local.localVariable._name;
+                    named.local = enterLocal(local.localVariable._name);
+                    named.loc = local.loc;
+                    *cursor = ast::make_expression<ast::Local>(local.loc, named.local);
+                    cursor = nullptr;
+                });
+        }
 
+        named.expr = move(arg);
         return named;
     }
 

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -39,10 +39,10 @@ class LocalNameInserter {
 
     struct NamedArg {
         core::NameRef name;
+        ArgFlags flags;
         core::LocalVariable local;
         core::LocOffsets loc;
         ast::ExpressionPtr expr;
-        ArgFlags flags;
     };
 
     // Map through the reference structure, naming the locals, and preserving


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes local vars (and therefore indexing) and the symbolization phase of namer slightly faster.  We tack on a small structure shrinkage too.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
