### PR TITLE
copy less when formatting documentation

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -432,7 +432,10 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
     }
 
     string documentation = absl::StrJoin(documentation_lines.rbegin(), documentation_lines.rend(), "\n");
-    documentation = string(absl::StripTrailingAsciiWhitespace(documentation));
+    string_view stripped = absl::StripTrailingAsciiWhitespace(documentation);
+    if (stripped.size() != documentation.size()) {
+        documentation.resize(stripped.size());
+    }
 
     if (documentation.empty()) {
         return nullopt;


### PR DESCRIPTION
There's no reason to construct an entirely new string here.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Suspicion that LSP completion on stdlib methods is slower than it could be because of extra string copies.  (There are other reasons, too, but we might as well start here.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
