### PR TITLE
Maybe fix crash with addLocLine

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -111,11 +111,11 @@ void addLocLine(stringstream &buf, int line, const File &file, int tabs, int pos
     buf << rang::fgB::black << leftPad(to_string(line + 1), posWidth) << " |" << rang::style::reset;
     ENFORCE(file.lineBreaks().size() > line + 1);
     auto endPos = file.lineBreaks()[line + 1];
-    auto numToWrite = endPos - file.lineBreaks()[line];
+    auto numToWrite = endPos - file.lineBreaks()[line] - 1;
     if (numToWrite <= 0) {
         return;
     }
-    buf.write(file.source().data() + file.lineBreaks()[line] + 1, numToWrite - 1);
+    buf.write(file.source().data() + file.lineBreaks()[line] + 1, numToWrite);
 }
 } // namespace
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I saw a segfault in our production logs that looked like it was centered
on this call to `buf.write`. I didn't bother to try to minimize and
reproduce a crash, but this refactoring should be equivalent and maybe
fixes the crash.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

existing tests to see if there's a regression

untested to see if it fixes the root crash