### PR TITLE
permit keywords for a limited set of overloaded methods

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3406,15 +3406,15 @@ private:
             defParams.push_back(local);
 
             auto spec = absl::c_find_if(sig.argTypes, [&](const auto &spec) { return spec.name == treeArgName; });
-            bool isBlkArg = arg.name == core::Names::blkArg();
+            bool isSyntheticBlkArg = arg.name == core::Names::blkArg();
 
             if (spec != sig.argTypes.end()) {
                 ENFORCE(spec->type != nullptr);
 
                 // It would be nice to remove the restriction on more than these two specific binds, but that would
                 // raise a lot more errors
-                if (!isBlkArg && (spec->rebind == core::Symbols::MagicBindToAttachedClass() ||
-                                  spec->rebind == core::Symbols::MagicBindToSelfType())) {
+                if (!isSyntheticBlkArg && (spec->rebind == core::Symbols::MagicBindToAttachedClass() ||
+                                           spec->rebind == core::Symbols::MagicBindToSelfType())) {
                     if (auto e = ctx.state.beginError(spec->loc, core::errors::Resolver::BindNonBlockParameter)) {
                         e.setHeader("Using `{}` is not permitted here", "bind");
                         e.addErrorNote("Only block arguments can use `{}`", "bind");
@@ -3431,7 +3431,7 @@ private:
                 }
 
                 // We silence the "type not specified" error when a sig does not mention the synthesized block arg.
-                if (!isOverloaded && !isBlkArg && (sig.seen.params || sig.seen.returns || sig.seen.void_)) {
+                if (!isOverloaded && !isSyntheticBlkArg && (sig.seen.params || sig.seen.returns || sig.seen.void_)) {
                     // Only error if we have any types
                     if (auto e = ctx.state.beginError(arg.loc, core::errors::Resolver::InvalidMethodSignature)) {
                         e.setHeader("Malformed `{}`. Type not specified for argument `{}`", "sig",

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3408,8 +3408,9 @@ private:
                     seenOptional = true;
                 } else if (seenOptional && isReq) {
                     if (auto e = ctx.state.beginError(arg.loc, core::errors::Resolver::BadParameterOrdering)) {
-                        e.setHeader("Malformed `{}`. Required parameter `{}` must be declared before all the optional ones",
-                                    "sig", treeArgName.show(ctx));
+                        e.setHeader(
+                            "Malformed `{}`. Required parameter `{}` must be declared before all the optional ones",
+                            "sig", treeArgName.show(ctx));
                         e.addErrorLine(ctx.locAt(exprLoc), "Signature");
                     }
                 }
@@ -3763,8 +3764,8 @@ public:
                 for (auto &argv : kwArgs) {
                     for (auto &arg : argv) {
                         if (auto e = ctx.state.beginError(arg.loc, core::errors::Resolver::InvalidMethodSignature)) {
-                            e.setHeader("Malformed `{}`. Overloaded functions cannot have keyword arguments:  `{}`", "sig",
-                                        arg.name.show(ctx));
+                            e.setHeader("Malformed `{}`. Overloaded functions cannot have keyword arguments:  `{}`",
+                                        "sig", arg.name.show(ctx));
                         }
                     }
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3303,6 +3303,7 @@ private:
         bool hasKwArgs = false;
         // Optimistically assume this.
         bool allArgsMatched = true;
+        bool hasMissingArgument = false;
     };
 
     static SigInformation fillInInfoFromSig(core::MutableContext ctx, core::MethodRef method, core::LocOffsets exprLoc,
@@ -3407,6 +3408,7 @@ private:
 
             auto spec = absl::c_find_if(sig.argTypes, [&](const auto &spec) { return spec.name == treeArgName; });
             bool isSyntheticBlkArg = arg.name == core::Names::blkArg();
+            bool isBlkArg = arg.flags.isBlock;
 
             if (spec != sig.argTypes.end()) {
                 ENFORCE(spec->type != nullptr);
@@ -3426,6 +3428,10 @@ private:
                 arg.rebind = spec->rebind;
                 sig.argTypes.erase(spec);
             } else {
+                if (!isBlkArg) {
+                    info.hasMissingArgument = true;
+                }
+
                 if (arg.type == nullptr) {
                     arg.type = core::Types::untyped(ctx, method);
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3788,8 +3788,6 @@ public:
         // * They differ solely in the presence of a block argument.
         //
         // This usually comes up in the standard library (e.g. `String#each_line`).
-        //
-        // TODO(froydnj): what to use as the location for the error?
         ENFORCE(combinedInfo.has_value());
         if (isOverloaded && combinedInfo->hasKwArgs) {
             if (!hasCompatibleOverloadedSigsWithKwArgs(ctx, sigs.size(), *combinedInfo, args)) {

--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -40,14 +40,14 @@ class HasOverloads
   sig do
     params(
       a: Class,  # error: Malformed `sig`
-      b: String, # error: Malformed `sig`
+      b: String,
     )
     .returns(Integer)
   end
   sig do
     params(
-      b: Class,  # error: Malformed `sig`
-      a: String, # error: Malformed `sig`
+      b: Class,
+      a: String,
     )
     .returns(Symbol)
   end

--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -40,14 +40,14 @@ class HasOverloads
   sig do
     params(
       a: Class,  # error: Malformed `sig`
-      b: String,
+      b: String, # error: Malformed `sig`
     )
     .returns(Integer)
   end
   sig do
     params(
-      b: Class,
-      a: String,
+      b: Class,  # error: Malformed `sig`
+      a: String, # error: Malformed `sig`
     )
     .returns(Symbol)
   end

--- a/test/testdata/resolver/overloads_test.rb
+++ b/test/testdata/resolver/overloads_test.rb
@@ -33,13 +33,23 @@ class Wrap1
   sig {params(x: Integer, y: String, blk: T.proc.returns(Integer)).void}
   def two_kw(x:, y:, &blk); end
 
-  sig {params(x: Integer, y: String).void} # error: Unknown argument name
-  sig {params(x: Integer, y: String, blk: T.proc.returns(Integer)).void} # error: Unknown argument name
+  sig {params(x: Integer, y: String).void}
+#             ^ error: Overloaded functions cannot have keyword arguments
+#                         ^ error: Unknown argument name
+  sig {params(x: Integer, y: String, blk: T.proc.returns(Integer)).void}
+#             ^ error: Overloaded functions cannot have keyword arguments
+#                         ^ error: Unknown argument name
   def arg_in_sig_but_not_method(x:, &blk); end
 
   sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   sig {params(y: String, x: Integer).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   def keyword_ordering_matters(x:, y:); end # error-with-dupes: Bad parameter ordering
+
+  sig {params(x: T::Boolean).void}
+#             ^ error: Overloaded functions cannot have keyword arguments
+  sig {params(x: FalseClass, blk: T.proc.returns(Integer)).void}
+#             ^ error: Overloaded functions cannot have keyword arguments
+  def arg_types_must_match(x:, &blk); end
 end
 
 Wrap1.new.opt_kw()
@@ -53,7 +63,6 @@ Wrap1.new.opt_pos_opt_kw(x: 7.0) # error: Expected `Integer` but found
 class Wrap2
   extend T::Sig
 
-  # Furthermore, the errors at infer time are somewhat nonsensical.
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   def missing_kw1(x:, y: ''); end
@@ -68,6 +77,14 @@ class Wrap2
   sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer, y: String, z: Float).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   def multiple_missing_kw(x:, y: '', z: 0.0); end
+
+  sig {params(z: String, x: Integer).void} # error: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
+  def mismatched_positional_args1(z='', x:); end
+
+  sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
+  sig {params(z: String, x: Integer).void} # error: Overloaded functions cannot have keyword arguments
+  def mismatched_positional_args2(z='', x:); end
 end
 
 Wrap2.new.missing_kw1(x: 0, y: 'foo') # error: Unrecognized keyword argument
@@ -77,3 +94,9 @@ Wrap2.new.missing_kw2(x: 0)
 
 Wrap2.new.multiple_missing_kw(x: 1)
 Wrap2.new.multiple_missing_kw(x: 1, y: 'bar', z: 0.1) # error-with-dupes: Unrecognized keyword argument
+
+# These errors are wrong; they are artifacts of overload matching ignoring keyword arguments.
+Wrap2.new.mismatched_positional_args1('z', x: 0) # error: Too many positional arguments
+Wrap2.new.mismatched_positional_args1(x: 0)
+Wrap2.new.mismatched_positional_args2('z', x: 0) # error: Too many positional arguments
+Wrap2.new.mismatched_positional_args2(x: 0)

--- a/test/testdata/resolver/overloads_test.rb
+++ b/test/testdata/resolver/overloads_test.rb
@@ -50,6 +50,69 @@ class Wrap1
   sig {params(x: FalseClass, blk: T.proc.returns(Integer)).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
   def arg_types_must_match(x:, &blk); end
+
+  sig {params(x: Integer, blk: T.proc.returns(Integer)).void}
+#             ^ error: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer, blk: T.proc.returns(String)).void}
+#             ^ error: Overloaded functions cannot have keyword arguments
+  def only_one_block_per_pair(x:, &blk); end
+
+  sig {params(x: Integer).void}
+#             ^ error: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer).void}
+#             ^ error: Overloaded functions cannot have keyword arguments
+  def needs_one_block_per_pair(x:); end
+
+  # We currently require type equivalence for parameters in sigs for overloaded methods
+  # with keyword arguments.  This is probably a little too strong, but fixing it would
+  # require some careful thought.
+  sig do
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U), y: Integer) # error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  sig do
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U), y: Integer, blk: T.proc.returns(Integer).void) # error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  def matching_positional_type_parameters_not_allowed(x, y:, &blk); end
+
+  sig do
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U), y: Integer) # error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  sig do
+    type_parameters(:V)
+      .params(x: T.type_parameter(:V), y: Integer, blk: T.proc.returns(Integer).void) # error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  def mismatched_positional_type_parameters_not_allowed(x, y:, &blk); end
+
+  sig do
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U)) # error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  sig do
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U), blk: T.proc.returns(Integer).void) # error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  def matching_kwarg_type_parameters_not_allowed(x:, &blk); end
+
+  sig do
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U)) # error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  sig do
+    type_parameters(:V)
+      .params(x: T.type_parameter(:V), blk: T.proc.returns(Integer).void) # error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  def mismatched_kwargs_type_parameters_not_allowed(x:, &blk); end
 end
 
 Wrap1.new.opt_kw()
@@ -100,3 +163,123 @@ Wrap2.new.mismatched_positional_args1('z', x: 0) # error: Too many positional ar
 Wrap2.new.mismatched_positional_args1(x: 0)
 Wrap2.new.mismatched_positional_args2('z', x: 0) # error: Too many positional arguments
 Wrap2.new.mismatched_positional_args2(x: 0)
+
+class WrapGeneric1
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig do
+    params(x: Elem, y: Integer)
+      .void
+  end
+  sig do
+    params(x: Elem, y: Integer, blk: T.proc.returns(Integer).void)
+      .void
+  end
+  def matching_positional_type_members(x, y:, &blk); end
+
+  sig do
+    params(x: Elem)
+      .void
+  end
+  sig do
+    params(x: Elem, blk: T.proc.returns(Integer).void)
+      .void
+  end
+  def matching_kwarg_type_members(x:, &blk); end
+end
+
+class WrapGeneric2
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_template
+
+  sig do
+    params(x: Elem, y: Integer)
+      .void
+  end
+  sig do
+    params(x: Elem, y: Integer, blk: T.proc.returns(Integer).void)
+      .void
+  end
+  def self.matching_positional_type_templates(x, y:, &blk); end
+
+  sig do
+    params(x: Elem)
+      .void
+  end
+  sig do
+    params(x: Elem, blk: T.proc.returns(Integer).void)
+      .void
+  end
+  def self.matching_kwarg_type_templates(x:, &blk); end
+end
+
+class WrapGeneric3
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+  Mele = type_member
+
+  sig do
+    params(x: Elem, y: Integer)
+#                   ^ error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  sig do
+    params(x: Mele, y: Integer, blk: T.proc.returns(Integer).void)
+#                   ^ error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  def mismatched_positional_type_members(x, y:, &blk); end
+
+  sig do
+    params(x: Elem)
+#          ^ error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  sig do
+    params(x: Mele, blk: T.proc.returns(Integer).void)
+#          ^ error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  def mismatched_kwarg_type_members(x:, &blk); end
+end
+
+class WrapGeneric4
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_template
+  Mele = type_template
+
+  sig do
+    params(x: Elem, y: Integer)
+#                   ^ error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  sig do
+    params(x: Mele, y: Integer, blk: T.proc.returns(Integer).void)
+#                   ^ error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  def self.mismatched_positional_type_templates(x, y:, &blk); end
+
+  sig do
+    params(x: Elem)
+#          ^ error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  sig do
+    params(x: Mele, blk: T.proc.returns(Integer).void)
+#          ^ error: Overloaded functions cannot have keyword arguments
+      .void
+  end
+  def self.mismatched_kwarg_type_templates(x:, &blk); end
+end
+
+

--- a/test/testdata/resolver/overloads_test.rb
+++ b/test/testdata/resolver/overloads_test.rb
@@ -13,3 +13,69 @@ f(0) # error: Expected `Symbol`
 f('') # error: Expected `Symbol`
 f(:s)
 f(0.0)
+
+class Wrap1
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, blk: T.proc.returns(Integer)).void}
+  def one_kw(x:, &blk); end
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, blk: T.proc.returns(Integer)).void}
+  def opt_kw(x: 0, &blk); end
+
+  sig {params(s: String, x: Integer).void}
+  sig {params(s: String, x: Integer, blk: T.proc.returns(Integer)).void}
+  def opt_pos_opt_kw(s='', x: 0, &blk); end
+
+  sig {params(x: Integer, y: String).void}
+  sig {params(x: Integer, y: String, blk: T.proc.returns(Integer)).void}
+  def two_kw(x:, y:, &blk); end
+
+  sig {params(x: Integer, y: String).void} # error: Unknown argument name
+  sig {params(x: Integer, y: String, blk: T.proc.returns(Integer)).void} # error: Unknown argument name
+  def arg_in_sig_but_not_method(x:, &blk); end
+
+  sig {params(x: Integer, y: String).void} # error: Overloaded functions cannot have keyword arguments
+  sig {params(y: String, x: Integer).void}
+  def keyword_ordering_matters(x:, y:); end # error-with-dupes: Bad parameter ordering
+end
+
+Wrap1.new.opt_kw()
+Wrap1.new.opt_kw(x: 1)
+Wrap1.new.opt_pos_opt_kw()
+Wrap1.new.opt_pos_opt_kw('foo')
+Wrap1.new.opt_pos_opt_kw('foo', x: 5)
+Wrap1.new.opt_pos_opt_kw(x: 6)
+Wrap1.new.opt_pos_opt_kw(x: 7.0) # error: Expected `Integer` but found
+
+class Wrap2
+  extend T::Sig
+
+  # TODO(froydnj): this was intended to error at resolve time but actually errors at infer time.
+  # Furthermore, the errors at infer time are somewhat nonsensical.
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  def missing_kw1(x:, y: ''); end
+
+  # TODO(froydnj): likewise...but the single-keyword sig apparently wins in both cases, which is weird.
+  sig {params(x: Integer, y: String).void}
+  sig {params(x: Integer).void}
+  def missing_kw2(x:, y: ''); end
+
+  # Same pattern as the above, but 3 sigs will error where two will not.
+  # TODO(froydnj): can we test what happens when the relevant error is suppressed?
+  sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer, y: String).void}
+  sig {params(x: Integer, y: String, z: Float).void}
+  def multiple_missing_kw(x:, y: '', z: 0.0); end
+end
+
+Wrap2.new.missing_kw1(x: 0, y: 'foo') # error: Unrecognized keyword argument
+Wrap2.new.missing_kw1(x: 0)
+Wrap2.new.missing_kw2(x: 0, y: 'foo') # error: Unrecognized keyword argument
+Wrap2.new.missing_kw2(x: 0)
+
+Wrap2.new.multiple_missing_kw(x: 1)
+Wrap2.new.multiple_missing_kw(x: 1, y: 'bar', z: 0.1) # error-with-dupes: Unrecognized keyword argument

--- a/test/testdata/resolver/overloads_test.rb
+++ b/test/testdata/resolver/overloads_test.rb
@@ -37,8 +37,8 @@ class Wrap1
   sig {params(x: Integer, y: String, blk: T.proc.returns(Integer)).void} # error: Unknown argument name
   def arg_in_sig_but_not_method(x:, &blk); end
 
-  sig {params(x: Integer, y: String).void} # error: Overloaded functions cannot have keyword arguments
-  sig {params(y: String, x: Integer).void}
+  sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
+  sig {params(y: String, x: Integer).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   def keyword_ordering_matters(x:, y:); end # error-with-dupes: Bad parameter ordering
 end
 
@@ -53,22 +53,20 @@ Wrap1.new.opt_pos_opt_kw(x: 7.0) # error: Expected `Integer` but found
 class Wrap2
   extend T::Sig
 
-  # TODO(froydnj): this was intended to error at resolve time but actually errors at infer time.
   # Furthermore, the errors at infer time are somewhat nonsensical.
-  sig {params(x: Integer).void}
-  sig {params(x: Integer, y: String).void}
+  sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   def missing_kw1(x:, y: ''); end
 
-  # TODO(froydnj): likewise...but the single-keyword sig apparently wins in both cases, which is weird.
-  sig {params(x: Integer, y: String).void}
-  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
   def missing_kw2(x:, y: ''); end
 
   # Same pattern as the above, but 3 sigs will error where two will not.
   # TODO(froydnj): can we test what happens when the relevant error is suppressed?
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
-  sig {params(x: Integer, y: String).void}
-  sig {params(x: Integer, y: String, z: Float).void}
+  sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer, y: String, z: Float).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   def multiple_missing_kw(x:, y: '', z: 0.0); end
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Full support for keyword arguments in overloaded methods has been a requested feature for a long time (#37).  Actually writing the PR to fix that is liable to be a substantial investment of time that we do not have time to scope out right now.

But we thought of a more limited way to make things work: if a method has multiple signatures, we can permit keyword arguments if there are only two signatures and the signatures have identical arguments except for the block argument.  (I suppose it's possible we could have more than two signatures, but I think pairwise checking all of them to ensure some hand-wavy set of constraints gets expensive, quickly.)

This PR is an attempt to implement that idea.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Trying to address usecases for typing a limited subset of methods in the stdlib like #6062.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This PR includes some tests.  We probably also want tests where there is an actual block arg, and there are some tests that require checking for compatibility between signatures, not just checking for signature/method definition compatibility.

This PR does make things slightly worse insofar as we no longer call out all keyword arguments in overloaded methods for each sig, just the first keyword argument on the first sig.  We could retain the old behavior at the cost of some extra allocations to record all keyword arguments, which did not seem worth it at this point.