### PR TITLE
Use polarity of type variable to approximate type

### DIFF
--- a/core/Polarity.h
+++ b/core/Polarity.h
@@ -1,0 +1,70 @@
+#ifndef SORBET_POLARITY_H
+#define SORBET_POLARITY_H
+
+#include <string>
+
+namespace sorbet::core {
+
+enum class Variance {
+    CoVariant = 1,
+    ContraVariant = -1,
+    Invariant = 0,
+};
+
+enum class Polarity {
+    Positive = 1,
+    Neutral = 0,
+    Negative = -1,
+};
+
+class Polarities final {
+public:
+    // Show a Polarity using the same in/out notation as Variance.
+    static std::string showPolarity(const Polarity polarity) {
+        switch (polarity) {
+            case Polarity::Positive:
+                return ":out";
+            case Polarity::Neutral:
+                return ":invariant";
+            case Polarity::Negative:
+                return ":in";
+        }
+    }
+
+    static Polarity negatePolarity(const Polarity polarity) {
+        switch (polarity) {
+            case Polarity::Positive:
+                return Polarity::Negative;
+            case Polarity::Neutral:
+                return Polarity::Neutral;
+            case Polarity::Negative:
+                return Polarity::Positive;
+        }
+    }
+
+    static std::string showVariance(const core::Variance variance) {
+        switch (variance) {
+            case core::Variance::CoVariant:
+                return ":out";
+            case core::Variance::Invariant:
+                return ":invariant";
+            case core::Variance::ContraVariant:
+                return ":in";
+        }
+    }
+
+    static bool hasCompatibleVariance(const Polarity polarity, const core::Variance argVariance) {
+        switch (polarity) {
+            case Polarity::Positive:
+                return argVariance != core::Variance::ContraVariant;
+            case Polarity::Neutral:
+                return true;
+            case Polarity::Negative:
+                return argVariance != core::Variance::CoVariant;
+        }
+    }
+};
+
+} // namespace sorbet::core
+
+#endif

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -5,6 +5,7 @@
 #include "core/ArityHash.h"
 #include "core/Loc.h"
 #include "core/Names.h"
+#include "core/Polarity.h"
 #include "core/SymbolRef.h"
 #include "core/Types.h"
 #include <memory>
@@ -30,8 +31,6 @@ class IntrinsicMethod {
 public:
     virtual void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const = 0;
 };
-
-enum class Variance { CoVariant = 1, ContraVariant = -1, Invariant = 0 };
 
 enum class Visibility : uint8_t {
     Public = 1,

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -40,7 +40,7 @@ bool TypeConstraint::solve(const GlobalState &gs) {
         if (bound == Types::top()) {
             continue;
         }
-        auto approximation = bound._approximate(gs, *this);
+        auto approximation = bound._approximate(gs, *this, core::Polarity::Positive);
         if (approximation) {
             findSolution(tv) = approximation;
         } else {
@@ -56,7 +56,7 @@ bool TypeConstraint::solve(const GlobalState &gs) {
         if (sol) {
             continue;
         }
-        auto approximation = bound._approximate(gs, *this);
+        auto approximation = bound._approximate(gs, *this, core::Polarity::Positive);
         if (approximation) {
             sol = approximation;
         } else {

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -50,7 +50,8 @@ GENERATE_CALL_MEMBER(_instantiate, return nullptr, std::declval<const GlobalStat
 
 GENERATE_CALL_MEMBER(_replaceSelfType, return nullptr, declval<const GlobalState &>(), declval<const TypePtr &>())
 
-GENERATE_CALL_MEMBER(_approximate, return nullptr, declval<const GlobalState &>(), declval<const TypeConstraint &>())
+GENERATE_CALL_MEMBER(_approximate, return nullptr, declval<const GlobalState &>(), declval<const TypeConstraint &>(),
+                     declval<core::Polarity>())
 
 GENERATE_CALL_MEMBER(underlying,
                      Exception::raise("TypePtr::underlying called on non-proxy-type `{}`",
@@ -275,8 +276,8 @@ TypePtr TypePtr::getCallArguments(const GlobalState &gs, NameRef name) const {
     }
 }
 
-TypePtr TypePtr::_approximate(const GlobalState &gs, const TypeConstraint &tc) const {
-#define _APPROXIMATE(T) return CALL_MEMBER__approximate<const T>::call(cast_type_nonnull<T>(*this), gs, tc);
+TypePtr TypePtr::_approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const {
+#define _APPROXIMATE(T) return CALL_MEMBER__approximate<const T>::call(cast_type_nonnull<T>(*this), gs, tc, polarity);
     GENERATE_TAG_SWITCH(tag(), _APPROXIMATE)
 #undef _APPROXIMATE
 }

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -3,6 +3,7 @@
 #include "absl/types/span.h"
 #include "common/common.h"
 #include "core/NameRef.h"
+#include "core/Polarity.h"
 #include "core/ShowOptions.h"
 #include "core/SymbolRef.h"
 #include <memory>
@@ -270,7 +271,7 @@ public:
     // for use with LoadYieldParams
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
 
-    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
+    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
 
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -621,7 +621,7 @@ public:
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
-    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
+    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 };
 CheckSize(TypeVar, 8, 8);
@@ -645,7 +645,7 @@ public:
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
-    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
+    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
 
@@ -703,7 +703,7 @@ public:
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
-    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
+    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
 private:
@@ -748,7 +748,7 @@ public:
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
-    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
+    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const;
@@ -782,7 +782,7 @@ public:
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
-    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
+    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
     // Return the type of the underlying array that this tuple decays into
@@ -814,7 +814,7 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
-    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
+    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 };
 CheckSize(AppliedType, 32, 8);
@@ -847,7 +847,7 @@ public:
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
 
-    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
+    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr underlying(const GlobalState &gs) const;
 };
 CheckSize(MetaType, 16, 8);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1055,6 +1055,7 @@ void compareToUntyped(const GlobalState &gs, TypeConstraint &constr, const TypeP
         compareToUntyped(gs, constr, t->right, blame);
     } else if (auto *t = cast_type<TypeVar>(ty)) {
         constr.rememberIsSubtype(gs, ty, blame);
+        constr.rememberIsSubtype(gs, blame, ty);
     }
 }
 

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -50,6 +50,11 @@ TypePtr TypeVar::_approximate(const GlobalState &gs, const TypeConstraint &tc) c
         if (bound.isFullyDefined()) {
             return bound;
         }
+    } else if (tc.hasLowerBound(sym)) {
+        auto bound = tc.findLowerBound(sym);
+        if (bound.isFullyDefined() && !bound.isBottom()) {
+            return bound;
+        }
     }
     // TODO: in many languages this method is a huge adhoc heuristic
     // let's see if we can keep it small

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -676,7 +676,7 @@ bool MetaType::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const 
     return false;
 }
 
-TypePtr MetaType::_approximate(const GlobalState &gs, const TypeConstraint &tc) const {
+TypePtr MetaType::_approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const {
     // dispatchCall is invoked on them in resolver
     return nullptr;
 }

--- a/test/cli/invariant_type_parameter/test.out
+++ b/test/cli/invariant_type_parameter/test.out
@@ -1,14 +1,14 @@
-test/cli/invariant_type_parameter/test.rb:60: Revealed type: `Box[T.noreturn]` https://srb.help/7014
+test/cli/invariant_type_parameter/test.rb:60: Revealed type: `Box[T.any(Integer, String)]` https://srb.help/7014
     60 |  T.reveal_type(box)
           ^^^^^^^^^^^^^^^^^^
-  Got `Box[T.noreturn]` originating from:
+  Got `Box[T.any(Integer, String)]` originating from:
     test/cli/invariant_type_parameter/test.rb:58:
     58 |box_example(Box[Integer].new, takes_box_string) do |box|
                                                             ^^^
 
 test/cli/invariant_type_parameter/test.rb:58: Could not find valid instantiation of type parameters for `Object#box_example` https://srb.help/7020
     58 |box_example(Box[Integer].new, takes_box_string) do |box|
-    59 |  # Solution takes the upper bound, regardless of whether it solves, I guess?
+    59 |  # Approximate solution takes the lower bound because `box` has negative polarity
     60 |  T.reveal_type(box)
     61 |end
     test/cli/invariant_type_parameter/test.rb:27: `Object#box_example` defined here
@@ -38,18 +38,18 @@ test/cli/invariant_type_parameter/test.rb:75: Expected `Box[T.type_parameter(:U)
     71 |ibox_m = T.let(Box[M].new, IBox[M])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/invariant_type_parameter/test.rb:76: Revealed type: `Box[N]` https://srb.help/7014
+test/cli/invariant_type_parameter/test.rb:76: Revealed type: `Box[T.noreturn]` https://srb.help/7014
     76 |  T.reveal_type(box)
           ^^^^^^^^^^^^^^^^^^
-  Got `Box[N]` originating from:
+  Got `Box[T.noreturn]` originating from:
     test/cli/invariant_type_parameter/test.rb:75:
     75 |box_example(ibox_m, takes_ibox_n) do |box|
                                               ^^^
 
-test/cli/invariant_type_parameter/test.rb:82: Revealed type: `IBox[N]` https://srb.help/7014
+test/cli/invariant_type_parameter/test.rb:82: Revealed type: `IBox[String]` https://srb.help/7014
     82 |  T.reveal_type(box)
           ^^^^^^^^^^^^^^^^^^
-  Got `IBox[N]` originating from:
+  Got `IBox[String]` originating from:
     test/cli/invariant_type_parameter/test.rb:81:
     81 |ibox_example(Box[String].new, takes_ibox_n) do |box|
                                                         ^^^
@@ -64,10 +64,10 @@ test/cli/invariant_type_parameter/test.rb:81: Could not find valid instantiation
   Found no solution for these constraints:
     `String` must be a subtype of `T.type_parameter(:U)` which must be a subtype of `N`
 
-test/cli/invariant_type_parameter/test.rb:85: Revealed type: `IBox[N]` https://srb.help/7014
+test/cli/invariant_type_parameter/test.rb:85: Revealed type: `IBox[M]` https://srb.help/7014
     85 |  T.reveal_type(box)
           ^^^^^^^^^^^^^^^^^^
-  Got `IBox[N]` originating from:
+  Got `IBox[M]` originating from:
     test/cli/invariant_type_parameter/test.rb:84:
     84 |ibox_example(ibox_m, takes_ibox_n) do |box|
                                                ^^^
@@ -82,10 +82,10 @@ test/cli/invariant_type_parameter/test.rb:84: Could not find valid instantiation
   Found no solution for these constraints:
     `M` must be a subtype of `T.type_parameter(:U)` which must be a subtype of `N`
 
-test/cli/invariant_type_parameter/test.rb:88: Revealed type: `IBox[N]` https://srb.help/7014
+test/cli/invariant_type_parameter/test.rb:88: Revealed type: `IBox[Integer]` https://srb.help/7014
     88 |  T.reveal_type(box)
           ^^^^^^^^^^^^^^^^^^
-  Got `IBox[N]` originating from:
+  Got `IBox[Integer]` originating from:
     test/cli/invariant_type_parameter/test.rb:87:
     87 |ibox_example(ibox_integer, takes_ibox_string) do |box|
                                                           ^^^

--- a/test/cli/invariant_type_parameter/test.rb
+++ b/test/cli/invariant_type_parameter/test.rb
@@ -56,7 +56,7 @@ takes_ibox_string = T.let(->(box) {}, T.proc.params(box: IBox[N]).void)
 #   T.any(Integer, String) <: T.type_parameter(:U) (of Object#box_example) <: T.noreturn
 # because `T.all(Integer, String)` collapses to `T.noreturn`
 box_example(Box[Integer].new, takes_box_string) do |box|
-  # Solution takes the upper bound, regardless of whether it solves, I guess?
+  # Approximate solution takes the lower bound because `box` has negative polarity
   T.reveal_type(box)
 end
 

--- a/test/testdata/infer/generic_methods/constraints_crosstalk.rb
+++ b/test/testdata/infer/generic_methods/constraints_crosstalk.rb
@@ -5,8 +5,11 @@ class Test
   sig {params(value: T.any(A, B)).returns(NilClass)}
   private def serialize_value(value)
       # this is a horrible example. We hate to solve constraint that comes from multiple methods at once.
-      #
+      # As far as I can tell, this error is actually correct: given the blk types,
+      # it's not possible for either `A#map` or `B#map` to call their block,
+      # because neither one of them has a way to produce a value of type `T.type_parameter(:U)` to the block.
       T.let(value.map {|val| 1}, T.any(T::Array[Integer], Integer))
+      #                      ^ error: This code is unreachable
       nil
   end
 end

--- a/test/testdata/infer/generics/apply_f.rb
+++ b/test/testdata/infer/generics/apply_f.rb
@@ -42,13 +42,13 @@ end
 sig {params(y: T.any(Integer, String)).void}
 def takes_any_int_string(y)
   x = apply_f(y) do |x|
-    T.reveal_type(x) # error: `Integer`
+    T.reveal_type(x) # error: `T.any(Integer, String)`
   end
-  T.reveal_type(x) # error: `Integer`
+  T.reveal_type(x) # error: `T.any(Integer, String)`
 
-  x = apply_f_int(y) do |x|
-    #             ^ error: Could not find valid instantiation of type parameters for `Object#apply_f_int`
+  x = apply_f_int(y) do |x| # error: Could not find valid instantiation of type parameters for `Object#apply_f_int`
+    #             ^ error: Expected `T.all(Integer, T.type_parameter(:U))` but found `T.any(Integer, String)` for argument `x`
     T.reveal_type(x) # error: `Integer`
   end
-  T.reveal_type(x) # error: `Integer`
+  T.reveal_type(x) # error: `T.untyped`
 end

--- a/test/testdata/infer/generics/apply_f.rb
+++ b/test/testdata/infer/generics/apply_f.rb
@@ -1,0 +1,54 @@
+# typed: true
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(
+      x: T.type_parameter(:U),
+      f: T.proc.params(x: T.type_parameter(:U)).returns(T.type_parameter(:U))
+    )
+    .returns(T.type_parameter(:U))
+end
+def apply_f(x, &f)
+  yield x
+end
+
+sig do
+  type_parameters(:U)
+    .params(
+      x: T.all(T.type_parameter(:U), Integer),
+      f: T.proc.params(x: T.type_parameter(:U)).returns(T.type_parameter(:U))
+    )
+    .returns(T.type_parameter(:U))
+end
+def apply_f_int(x, &f)
+  yield x
+end
+
+
+sig {params(int: Integer).void}
+def example(int)
+  x = apply_f(int) do |x|
+    T.reveal_type(x) # error: `Integer`
+  end
+  T.reveal_type(x) # error: `Integer`
+
+  x = apply_f_int(int) do |x|
+    T.reveal_type(x) # error: `Integer`
+  end
+  T.reveal_type(x) # error: `Integer`
+end
+
+sig {params(y: T.any(Integer, String)).void}
+def takes_any_int_string(y)
+  x = apply_f(y) do |x|
+    T.reveal_type(x) # error: `Integer`
+  end
+  T.reveal_type(x) # error: `Integer`
+
+  x = apply_f_int(y) do |x|
+    #             ^ error: Could not find valid instantiation of type parameters for `Object#apply_f_int`
+    T.reveal_type(x) # error: `Integer`
+  end
+  T.reveal_type(x) # error: `Integer`
+end

--- a/test/testdata/infer/generics/option.rb
+++ b/test/testdata/infer/generics/option.rb
@@ -1,0 +1,190 @@
+# typed: strict
+
+class Module
+  include T::Sig
+end
+
+module Option
+  extend T::Generic
+  sealed!
+  abstract!
+
+  Elem = type_member(:out)
+
+  sig do
+    abstract
+      .type_parameters(:U)
+      .params(blk: T.proc.params(x: Elem).returns(T.type_parameter(:U)))
+      .returns(Option[T.type_parameter(:U)])
+  end
+  def map(&blk); end
+
+  sig do
+    abstract
+      .type_parameters(:U)
+      .params(blk: T.proc.params(x: Elem).returns(Option[T.type_parameter(:U)]))
+      .returns(Option[T.type_parameter(:U)])
+  end
+  def and_then(&blk); end
+
+  sig {abstract.returns(Elem)}
+  def unwrap!(&blk); end
+
+  sig {abstract.params(msg: String).returns(Elem)}
+  def expect!(msg, &blk); end
+
+  class Some < T::Struct
+    extend T::Generic
+    include Option
+    Elem = type_member
+
+    prop :val, Elem
+
+    sig do
+      override
+        .type_parameters(:U)
+        .params(blk: T.proc.params(x: Elem).returns(T.type_parameter(:U)))
+        .returns(Some[T.type_parameter(:U)])
+    end
+    def map(&blk)
+      new_val = yield self.val
+      T.reveal_type(new_val) # error: `T.type_parameter(:U) (of Option::Some#map)`
+      res = Some[T.type_parameter(:U)].new(val: new_val)
+      T.reveal_type(res) # error: `Option::Some[T.type_parameter(:U) (of Option::Some#map)]`
+      res
+    end
+
+    sig do
+      override
+        .type_parameters(:U)
+        .params(blk: T.proc.params(x: Elem).returns(Option[T.type_parameter(:U)]))
+        .returns(Option[T.type_parameter(:U)])
+    end
+    def and_then(&blk)
+      new_opt = yield self.val
+      T.reveal_type(new_opt) # error: `Option[T.type_parameter(:U) (of Option::Some#and_then)]`
+      new_opt
+    end
+
+    sig {override.returns(Elem)}
+    def unwrap!(&blk)
+      T.reveal_type(self.val) # error: `Option::Some::Elem`
+    end
+
+    sig {override.params(msg: String).returns(Elem)}
+    def expect!(msg, &blk)
+      T.reveal_type(self.val) # error: `Option::Some::Elem`
+    end
+  end
+
+  class None < T::Struct
+    extend T::Generic
+    include Option
+    Elem = type_member {{fixed: T.noreturn}}
+
+    sig do
+      override
+        .type_parameters(:U)
+        .params(blk: T.proc.params(x: Elem).returns(T.type_parameter(:U)))
+        .returns(None)
+    end
+    def map(&blk)
+      T.reveal_type(self) # error: `Option::None`
+    end
+
+    sig do
+      override
+        .type_parameters(:U)
+        .params(blk: T.proc.params(x: Elem).returns(Option[T.type_parameter(:U)]))
+        .returns(Option[T.type_parameter(:U)])
+    end
+    def and_then(&blk)
+      T.reveal_type(self) # error: `Option::None`
+    end
+
+    sig {override.returns(T.noreturn)}
+    def unwrap!(&blk)
+      raise ArgumentError.new("Called Option#unwrap! on a None value")
+    end
+
+    sig {override.params(msg: String).returns(Elem)}
+    def expect!(msg, &blk)
+      raise ArgumentError.new(msg)
+    end
+  end
+end
+
+sig {params(maybe_int: Option[Integer]).void}
+def example(maybe_int)
+  maybe_str = maybe_int.map do |int|
+    T.reveal_type(int) # error: `Integer`
+    T.reveal_type(int.to_s) # error: `String`
+  end
+  T.reveal_type(maybe_str) # error: `Option[String]`
+
+  res = maybe_str.and_then do |str|
+    T.reveal_type(str) # error: `String`
+    if str.empty?
+      Option::None.new
+    else
+      Option::Some[Integer].new(val: str.length.even?)
+      #                              ^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `T::Boolean` for argument `val`
+    end
+  end
+
+  T.reveal_type(res) # error: `Option[Integer]`
+
+  maybe_str.and_then {|str| Option::None} # error: Expected `Option[T.type_parameter(:U)]` but found `T.class_of(Option::None)` for block result type
+
+  1.times do |x|
+    Option::None.new.unwrap!
+    puts x # error: This code is unreachable
+  end
+
+  case maybe_int
+  when Option::Some
+    T.reveal_type(maybe_int.val) # error: `Integer`
+  when Option::None
+    T.reveal_type(maybe_int) # error: `Option::None`
+  else
+    T.absurd(maybe_int)
+  end
+
+  case maybe_int
+  when Option::None
+    T.reveal_type(maybe_int) # error: `Option::None`
+  when Option::Some
+    T.reveal_type(maybe_int.val) # error: `Integer`
+  else
+    T.absurd(maybe_int)
+  end
+
+  case maybe_int
+  when Option::Some
+  else
+    T.absurd(maybe_int) # error: the type `Option::None` wasn't handled
+  end
+
+  case maybe_int
+  when Option::None
+  else
+    T.absurd(maybe_int) # error: the type `Option::Some[Integer]` wasn't handled
+  end
+end
+
+sig do
+  type_parameters(:U, :V)
+    .params(
+      x: Option[T.type_parameter(:U)],
+      blk: T.proc.params(y: T.type_parameter(:U)).returns(T.type_parameter(:V))
+    )
+    .returns(Option[T.type_parameter(:V)])
+end
+def map_over_option(x, &blk)
+  x.map(&blk)
+end
+
+maybe_is_even = map_over_option(Option::Some[Integer].new(val: 0)) do |x|
+  T.reveal_type(x.even?) # error: `T::Boolean`
+end
+T.reveal_type(maybe_is_even) # error: `Option[T::Boolean]`

--- a/test/testdata/infer/generics/passes_block_along.rb
+++ b/test/testdata/infer/generics/passes_block_along.rb
@@ -1,0 +1,19 @@
+# typed: true
+extend T::Sig
+
+sig do
+  type_parameters(:X, :Y)
+    .params(blk: T.proc.params(x: T.type_parameter(:X)).returns(T.type_parameter(:Y)))
+    .void
+end
+def takes_generic_block(&blk); end
+
+sig do
+  type_parameters(:X, :Y)
+    .params(blk: T.proc.params(x: T.type_parameter(:X)).returns(T.type_parameter(:Y)))
+    .void
+end
+def passes_along_generic_block(&blk)
+  T.reveal_type(blk)
+  takes_generic_block(&blk)
+end

--- a/test/testdata/infer/generics/passes_block_along.rb
+++ b/test/testdata/infer/generics/passes_block_along.rb
@@ -14,6 +14,6 @@ sig do
     .void
 end
 def passes_along_generic_block(&blk)
-  T.reveal_type(blk)
+  T.reveal_type(blk) # error: `T.proc.params(arg0: T.type_parameter(:X) (of Object#passes_along_generic_block)).returns(T.type_parameter(:Y) (of Object#passes_along_generic_block))`
   takes_generic_block(&blk)
 end

--- a/test/testdata/infer/generics/type_var_upper_bound.rb
+++ b/test/testdata/infer/generics/type_var_upper_bound.rb
@@ -1,0 +1,27 @@
+# typed: strict
+extend T::Sig
+
+class UpperBound; end
+
+class Box < T::Struct
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member {{upper: UpperBound}}
+
+  prop :val, Elem
+end
+
+sig do
+  type_parameters(:U)
+  .params(
+    x: Box[T.type_parameter(:U)], # error: `T.type_parameter(:<todo typeargument>)` is not a subtype of upper bound of type member `::Box::Elem`
+    y: T.type_parameter(:U),
+  )
+  .void
+end
+def example(x, y)
+  T.let(y, UpperBound) # error: Argument does not have asserted type `UpperBound`
+
+  x.val = y
+end

--- a/test/testdata/infer/sealed_list_module.rb
+++ b/test/testdata/infer/sealed_list_module.rb
@@ -127,8 +127,7 @@ def list_map_blk(xs, &blk)
   case xs
   when List::Cons
     head = yield xs.head
-    # This error is a bug. Just capturing the existing behavior.
-    tail = list_map_blk(xs.tail, &blk) # error: Expected `T.proc.params(arg0: <top>).returns(<top>)`
+    tail = list_map_blk(xs.tail, &blk)
     List::Cons[T.type_parameter(:V)].new(head: head, tail: tail)
   when List::Nil
     List::Nil[T.type_parameter(:V)].new
@@ -154,8 +153,8 @@ T.reveal_type(res1) # error: Revealed type: `List[T.untyped]`
 # This error is a bug. Just capturing the existing behavior.
 res2 = list_map_blk(xs) do |x|
   # This error is a bug. Just capturing the existing behavior.
-  T.reveal_type(x) # error: Revealed type: `<top>`
+  T.reveal_type(x) # error: Revealed type: `Integer`
   # This error is a bug. Just capturing the existing behavior.
-  x.even? # error: Method `even?` does not exist on `<top>`
+  x.even?
 end
-T.reveal_type(res2) # error: Revealed type: `List[T.untyped]`
+T.reveal_type(res2) # error: Revealed type: `List[T::Boolean]`

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -211,7 +211,9 @@ class MyTest
     end
   end
 
-  test_each_hash([1, 2, 3]) do |k, v| # error: Expected `T::Hash[T.type_parameter(:K), T.type_parameter(:V)]`
+  test_each_hash([1, 2, 3]) do |k, v|
+    #            ^^^^^^^^^ error: Expected `T::Hash[T.type_parameter(:K), T.type_parameter(:V)]`
+    #                              ^ error: This code is unreachable
     it "fails to typecheck with non-hash arguments to `test_each-hash`" do
       puts k, v
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This eliminates basically ever class of generic method errors that show `<top>`.

This directly:

Fixes #38
Fixes #3053

and will unblock letting us land changes for some methods in the standard
library that suffered from this bug, including: `Enumerable#reduce` (#2770),
`Enumerable#zip` (#2848), `Enumerable#inject` (#1361),
`Enumerable#each_with_object` (#1098), `Hash#merge` (#1098).

### Explanation

The intuition is basically that given:

```ruby
def foo(x); end
foo(0)
```

Sorbet will check whether `0 <: x` under the given constraints. If `x` has type
`T.type_parameter(:U)`, and the constraint is not yet solved, then it will
remember that `0` must be a lower bound for `T.type_parameter(:U)` in order for
the constraint to solve. It will **not** record an upper bound for that type
parameter unless you did something like

```ruby
def foo(x, f); end
f = T.let(->(x) {}, T.proc.params(x: Integer).void)
foo(0, f)
```

which would ask

```ruby
T.proc.params(x: Integer).void  <:  T.proc.params(x: T.type_parameter(:U)).void
# and then, because the Arg0 type member on `Proc1` is contravariant, will ask:
T.type_parameter(:U)  <:  Integer
```

which then places an upper bound.

In that case, `f` was a positional proc argument, so it participates in argument
subtype checking.

But we attempt to infer types for block arguments, so we neither ask whether a
block has a type nor whether that type is a subtype of the `&blk` type
declaration in the sig. Instead, we attempt to use the bounds accumulated so far
to approximate the type before beginning to typecheck the block.

Intuitively, instead of unconditionally using the upper bound to approximate
type variables in the block type, we need to make approximate aware of which
position in the proc type the variable occurred in. If it occurred in the
`.returns` of the proc we can use the upper bound like before, but if it occurs
in the argument type of the proc, we want to approximate the type to its lower
bound instead of defaulting to `<top>`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.