### PR TITLE
Fix crash in lub with tuples

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -263,7 +263,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         auto t1d = underlying(gs, t1);
         auto t2filtered = dropLubComponents(gs, t2, t1d);
         if (t2filtered != t2) {
-            return lub(gs, t1, t2filtered);
+            return lub(gs, t1d, t2filtered);
         }
         if (isa_type<OrType>(t1)) {
             return lubDistributeOr(gs, t1, t2);

--- a/test/testdata/infer/lub_tuple_array.rb
+++ b/test/testdata/infer/lub_tuple_array.rb
@@ -1,0 +1,27 @@
+# typed: true
+extend T::Sig
+
+sig {
+  type_parameters(:U)
+  .params(
+    x: T.any(
+      T.type_parameter(:U),
+      T::Array[T.type_parameter(:U)]
+    )
+  )
+  .returns(T::Array[T.type_parameter(:U)])
+}
+def foo(x)
+  res = case x
+  when Array
+    # This type is particularly unweildly, and I'd love to make it smaller if possible.
+    # But this test used to crash us, and at least it doesn't do that anymore.
+    T.reveal_type(x) # error: `T.all(T::Array[T.untyped], T.any(T::Array[T.type_parameter(:U) (of Object#foo)], T.type_parameter(:U) (of Object#foo)))`
+
+  else
+    T.reveal_type(x) # error: `T.type_parameter(:U) (of Object#foo)`
+    [x]
+  end
+
+  T.reveal_type(res) # error: `T::Array[T.type_parameter(:U) (of Object#foo)]`
+end

--- a/test/testdata/infer/lub_tuple_array.rb
+++ b/test/testdata/infer/lub_tuple_array.rb
@@ -14,7 +14,7 @@ sig {
 def foo(x)
   res = case x
   when Array
-    # This type is particularly unweildly, and I'd love to make it smaller if possible.
+    # This type is particularly unwieldy, and I'd love to make it smaller if possible.
     # But this test used to crash us, and at least it doesn't do that anymore.
     T.reveal_type(x) # error: `T.all(T::Array[T.untyped], T.any(T::Array[T.type_parameter(:U) (of Object#foo)], T.type_parameter(:U) (of Object#foo)))`
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The idea is that if we have to widen a proxy type to its underlying type
in order to attempt to collapse it with the other half of the `lub`, we
want to make that widening permanent.

If the code hadn't crashed via the ENFORCE, the revealed type in the
test would have been `[T.type_parameter(:U)] (1-tuple)`, which would
have been wrong, because the `when Array` branch doesn not necessarily
return a 1-tuple (that is what the ENFORCE correctly caught).

The crash looked like this:

    [2022-07-23 00:42:41.802] [fatalFallback] [error] Exception::raise(): core/types/subtyping.cc:49 enforced condition Types::isSubType(gs, t1, ret) has failed:
    TupleType {
      0 = SelfTypeParam(<C <U Object>>#<U foo>#<T <U U> $1>)
    }
    is not a super type of
    AppliedType {
          klass = <C <U Array>>
          targs = [
            <C <U Elem>> = T.untyped
          ]
        } & (AppliedType {
              klass = <C <U Array>>
              targs = [
                <C <U Elem>> = SelfTypeParam(<C <U Object>>#<U foo>#<T <U U> $1>)
              ]
            } | SelfTypeParam(<C <U Object>>#<U foo>#<T <U U> $1>))
    was lubbing with TupleType {
      0 = SelfTypeParam(<C <U Object>>#<U foo>#<T <U U> $1>)
    }


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5286

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.