### PR TITLE
Use upper bound from type_member in method autocomplete suggestions

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -194,6 +194,10 @@ SimilarMethodsByName similarMethodsForReceiver(const core::GlobalState &gs, cons
             result = mergeSimilarMethods(similarMethodsForReceiver(gs, type.left, prefix),
                                          similarMethodsForReceiver(gs, type.right, prefix));
         },
+        [&](const core::LambdaParam &type) { result = similarMethodsForReceiver(gs, type.upperBound, prefix); },
+        [&](const core::SelfTypeParam &type) {
+            result = similarMethodsForReceiver(gs, type.definition.resultType(gs), prefix);
+        },
         [&](const core::TypePtr &type) {
             if (is_proxy_type(receiver)) {
                 result = similarMethodsForReceiver(gs, receiver.underlying(gs), prefix);

--- a/test/testdata/lsp/completion/type_member_upper.rb
+++ b/test/testdata/lsp/completion/type_member_upper.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+class A
+  def method_on_a; end
+end
+
+class BoxA
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member {{upper: A}}
+
+  sig {params(x: Elem).void}
+  def example(x)
+    x.method_on_  # error: does not exist
+    #           ^ completion: method_on_a
+  end
+end


### PR DESCRIPTION
Autocomplete suggestions for methods from the upper bound type when the receiver is a `type_member` with an upper bound.

### Motivation
Fixes https://github.com/sorbet/sorbet/issues/6041


### Test plan
See included automated tests.
