### PR TITLE
Extend ambiguous definitions check to include casgns

### DIFF
--- a/rbi/stdlib/rdoc.rbi
+++ b/rbi/stdlib/rdoc.rbi
@@ -930,7 +930,7 @@ end
 
 # A constant
 class RDoc::Constant < ::RDoc::CodeObject
-  RDoc::Constant::MARSHAL_VERSION = T.let(T.unsafe(nil), Integer)
+  ::RDoc::Constant::MARSHAL_VERSION = T.let(T.unsafe(nil), Integer)
 
   # Creates a new constant with `name`, `value` and `comment`
   def self.new(name, value, comment); end

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1280,8 +1280,8 @@ public:
         }
 
         // Check for ambiguous definitions.
-        if (checkAmbiguousDefinition(ctx)) {
-            const auto ambigDef = findAnyDefinitionAmbiguousWithCurrent(ctx);
+        if (checkAmbiguousDefinition(ctx, nesting_->scope, nesting_->parent)) {
+            const auto ambigDef = findAnyDefinitionAmbiguousWithCurrent(ctx, nesting_->scope, nesting_->parent);
             if (ambigDef.exists()) {
                 if (auto e = ctx.beginError(original.declLoc, core::errors::Resolver::AmbiguousDefinitionError)) {
                     auto name = klass.data(ctx)->name.show(ctx);
@@ -1298,7 +1298,7 @@ public:
         nesting_ = nesting_->parent;
     }
 
-    const bool checkAmbiguousDefinition(core::Context ctx) {
+    const bool checkAmbiguousDefinition(core::Context ctx, core::SymbolRef curSym, shared_ptr<Nesting> curNesting) {
         if (ctx.state.runningUnderAutogen) {
             // no need to check in autogen
             return false;
@@ -1309,24 +1309,23 @@ public:
             return false;
         }
 
-        if (nesting_->scope == core::Symbols::root()) {
+        if (curSym == core::Symbols::root()) {
             // no need to check <root> def itself
             return false;
         }
 
         // Can't be ambiguous if current definition is single-part, don't check in this case.
-        const core::SymbolRef curOwner = nesting_->scope.owner(ctx);
-        if (curOwner == nesting_->parent->scope) {
+        const core::SymbolRef curOwner = curSym.owner(ctx);
+        if (curOwner == curNesting->scope) {
             return false;
         }
 
         return true;
     }
 
-    const core::SymbolRef findAnyDefinitionAmbiguousWithCurrent(core::Context ctx) {
+    const core::SymbolRef findAnyDefinitionAmbiguousWithCurrent(core::Context ctx, core::SymbolRef curSym,
+                                                                shared_ptr<Nesting> curNesting) {
         const core::SymbolRef defaultSymbol;
-        auto curSym = nesting_->scope;
-        auto curNesting = nesting_->parent;
         if (curNesting == nullptr || curNesting->scope == core::Symbols::root()) {
             // can't be ambiguous if nested directly under root scope
             return defaultSymbol;
@@ -1409,6 +1408,22 @@ public:
             // we'll still emit a warning when the rhs of a type alias doesn't resolve.
             this->todo_.emplace_back(nesting_, id);
             return;
+        }
+
+        // Check for ambiguous definitions.
+        if (checkAmbiguousDefinition(ctx, id->symbol, nesting_)) {
+            const auto ambigDef = findAnyDefinitionAmbiguousWithCurrent(ctx, id->symbol, nesting_);
+            if (ambigDef.exists()) {
+                if (auto e = ctx.beginError(asgn.loc, core::errors::Resolver::AmbiguousDefinitionError)) {
+                    auto name = id->symbol.name(ctx).show(ctx);
+                    e.setHeader("Definition of `{}` is ambiguous", name);
+                    auto casgnOwner = id->symbol.owner(ctx);
+                    auto option1 = fmt::format("{}::{}", casgnOwner.show(ctx), name);
+                    e.addErrorLine(casgnOwner.loc(ctx), "Could mean `{}` if nested under here", option1);
+                    auto option2 = fmt::format("{}::{}", ambigDef.show(ctx), name);
+                    e.addErrorLine(ambigDef.loc(ctx), "Or could mean `{}` if nested under here", option2);
+                }
+            }
         }
 
         auto *rhs = ast::cast_tree<ast::ConstantLit>(asgn.rhs);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1298,7 +1298,8 @@ public:
         nesting_ = nesting_->parent;
     }
 
-    const bool checkAmbiguousDefinition(core::Context ctx, core::SymbolRef curSym, shared_ptr<Nesting> curNesting) {
+    const bool checkAmbiguousDefinition(core::Context ctx, core::SymbolRef curSym,
+                                        const shared_ptr<Nesting> &curNesting) {
         if (ctx.state.runningUnderAutogen) {
             // no need to check in autogen
             return false;
@@ -1324,7 +1325,7 @@ public:
     }
 
     const core::SymbolRef findAnyDefinitionAmbiguousWithCurrent(core::Context ctx, core::SymbolRef curSym,
-                                                                shared_ptr<Nesting> curNesting) {
+                                                                const shared_ptr<Nesting> &curNesting) {
         const core::SymbolRef defaultSymbol;
         if (curNesting == nullptr || curNesting->scope == core::Symbols::root()) {
             // can't be ambiguous if nested directly under root scope
@@ -1359,10 +1360,10 @@ public:
         core::NameRef filler = precedingSymForCurDef.name(ctx);
 
         // Look for filler name in all nestings above current nesting.
-        curNesting = curNesting->parent;
-        while (curNesting != nullptr) {
-            if (curNesting->scope.isClassOrModule()) {
-                auto scopeSym = curNesting->scope.asClassOrModuleRef().data(ctx);
+        auto searchNesting = curNesting->parent;
+        while (searchNesting != nullptr) {
+            if (searchNesting->scope.isClassOrModule()) {
+                auto scopeSym = searchNesting->scope.asClassOrModuleRef().data(ctx);
                 const auto ambigDef = scopeSym->findMember(ctx, filler);
                 if (ambigDef.exists()) {
                     // Filler name found! Definition is ambiguous.
@@ -1370,7 +1371,7 @@ public:
                 }
             }
 
-            curNesting = curNesting->parent;
+            searchNesting = searchNesting->parent;
         }
 
         return defaultSymbol;

--- a/test/cli/ambiguous-definitions/baz.rb
+++ b/test/cli/ambiguous-definitions/baz.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Opus
+  module Baz
+    Baz::C = 1 # ambiguous
+  end
+end
+

--- a/test/cli/ambiguous-definitions/test.out
+++ b/test/cli/ambiguous-definitions/test.out
@@ -1,10 +1,20 @@
-test/cli/ambiguous-definitions/foo.rb:5: Definition of `Bar` is ambiguous https://srb.help/5068
+foo.rb:5: Definition of `Bar` is ambiguous https://srb.help/5068
      5 |    module Foo::Bar # ambiguous
             ^^^^^^^^^^^^^^^
-    test/cli/ambiguous-definitions/foo.rb:5: Could mean `Opus::Foo::Foo::Bar` if nested under here
+    foo.rb:5: Could mean `Opus::Foo::Foo::Bar` if nested under here
      5 |    module Foo::Bar # ambiguous
                    ^^^
-    test/cli/ambiguous-definitions/foo.rb:4: Or could mean `Opus::Foo::Bar` if nested under here
+    foo.rb:4: Or could mean `Opus::Foo::Bar` if nested under here
      4 |  module Foo
           ^^^^^^^^^^
-Errors: 1
+
+baz.rb:5: Definition of `C` is ambiguous https://srb.help/5068
+     5 |    Baz::C = 1 # ambiguous
+            ^^^^^^^^^^
+    baz.rb:5: Could mean `Opus::Baz::Baz::C` if nested under here
+     5 |    Baz::C = 1 # ambiguous
+            ^^^
+    baz.rb:4: Or could mean `Opus::Baz::C` if nested under here
+     4 |  module Baz
+          ^^^^^^^^^^
+Errors: 2

--- a/test/cli/ambiguous-definitions/test.sh
+++ b/test/cli/ambiguous-definitions/test.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-main/sorbet --silence-dev-message test/cli/ambiguous-definitions/foo.rb 2>&1
+main/sorbet --silence-dev-message test/cli/ambiguous-definitions/ 2>&1
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -2439,8 +2439,8 @@ resolvable to a class, not a module.
 
 ## 5068
 
-Sorbet requires that class or module definitions be namespaced unambiguously.
-For example, in this code:
+Sorbet requires that class, module or constant definitions be namespaced
+unambiguously. For example, in this code:
 
 ```ruby
 # typed: true


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Extends the check for "ambiguous definitions" in the resolver to also include casgns.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The ambiguous definitions [check](https://sorbet.org/docs/error-reference#5068) was added to prevent namespace conflict/ambiguity in the Stripe codebase at runtime. There was a gap in the enforcement -- in that it did not prevent casgns from being ambiguously namespaced. This change closes that gap.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.
