### PR TITLE
Fix crash and add support for `T.type_parameter` in proc in body

### DIFF
--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -313,7 +313,6 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                 if (!maybeBind.has_value()) {
                     if (auto e =
                             ctx.beginError(send->getPosArg(0).loc(), core::errors::Resolver::InvalidMethodSignature)) {
-                        // TODO(jez) Test this branch
                         e.setHeader("Cannot use `{}` inside `{}`", "T.type_parameter", "bind");
                         bind = core::Types::untypedUntracked();
                     }

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -311,11 +311,7 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                 auto maybeBind = getResultTypeWithSelfTypeParams(ctx, send->getPosArg(0), *parent, args);
                 core::TypePtr bind;
                 if (!maybeBind.has_value()) {
-                    if (auto e =
-                            ctx.beginError(send->getPosArg(0).loc(), core::errors::Resolver::InvalidMethodSignature)) {
-                        e.setHeader("Cannot use `{}` inside `{}`", "T.type_parameter", "bind");
-                        bind = core::Types::untypedUntracked();
-                    }
+                    validBind = false;
                 } else {
                     bind = move(maybeBind.value());
                 }

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -81,6 +81,10 @@ struct TypeSyntaxArgs {
     TypeSyntaxArgs withoutTypeMember() const {
         return TypeSyntaxArgs{allowSelfType, allowRebind, false, allowUnspecifiedTypeParameter, untypedBlame};
     }
+
+    TypeSyntaxArgs withoutUnspecifiedTypeParameter() const {
+        return TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember, false, untypedBlame};
+    }
 };
 
 class TypeSyntax {

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -88,9 +88,10 @@ struct TypeSyntaxArgs {
 };
 
 class TypeSyntax {
+    static ParsedSig parseSig(core::Context ctx, const ast::Send &send, const ParsedSig *parent, TypeSyntaxArgs args);
+
 public:
     static bool isSig(core::Context ctx, const ast::Send &send);
-    static ParsedSig parseSig(core::Context ctx, const ast::Send &send, const ParsedSig *parent, TypeSyntaxArgs args);
     static ParsedSig parseSigTop(core::Context ctx, const ast::Send &send, core::SymbolRef blameSymbol);
 
     struct ResultType {

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -81,14 +81,11 @@ struct TypeSyntaxArgs {
     TypeSyntaxArgs withoutTypeMember() const {
         return TypeSyntaxArgs{allowSelfType, allowRebind, false, allowUnspecifiedTypeParameter, untypedBlame};
     }
-
-    TypeSyntaxArgs withoutUnspecifiedTypeParameter() const {
-        return TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember, false, untypedBlame};
-    }
 };
 
 class TypeSyntax {
-    static ParsedSig parseSig(core::Context ctx, const ast::Send &send, const ParsedSig *parent, TypeSyntaxArgs args);
+    static std::optional<ParsedSig> parseSig(core::Context ctx, const ast::Send &send, const ParsedSig *parent,
+                                             TypeSyntaxArgs args);
 
 public:
     static bool isSig(core::Context ctx, const ast::Send &send);

--- a/test/testdata/infer/t_let_proc_type_parameter.rb
+++ b/test/testdata/infer/t_let_proc_type_parameter.rb
@@ -1,0 +1,46 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig do
+    type_parameters(:U)
+      .params(
+        x: T.type_parameter(:U),
+        f: T.proc.params(y: T.type_parameter(:U)).void,
+      )
+      .returns(T.proc.params(z: T.type_parameter(:U)).returns(T.type_parameter(:U)))
+  end
+  def self.example(x, f)
+    res1 = f.call(x)
+    T.reveal_type(res1) # error: `Sorbet::Private::Static::Void`
+
+    g = T.let(->(z) { x }, T.proc.params(z: T.type_parameter(:U)).returns(T.type_parameter(:U)))
+
+    res2 = g.call(x)
+    T.reveal_type(res2) # error: `T.type_parameter(:U) (of A.example)`
+    res3 = f.call(res2)
+    T.reveal_type(res3) # error: `Sorbet::Private::Static::Void`
+    g
+  end
+
+  sig do
+    type_parameters(:U)
+      .params(
+        blk: T.proc.bind(T.type_parameter(:U)).void # error: Malformed `bind`: Can only bind to simple class names
+      )
+      .returns(T.proc.bind(T.type_parameter(:U)).void) # error: Malformed `bind`: Can only bind to simple class names
+  end
+  def self.example_bad(&blk)
+    f = T.let(blk, T.proc.bind(T.type_parameter(:U)).void)
+    #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Using `bind` is not permitted here
+    #                          ^^^^^^^^^^^^^^^^^^^^error: Cannot use `T.type_parameter` inside `bind`
+    f
+  end
+end
+
+int = T.let(0, Integer)
+takes_int_or_str = T.let(->(x) {}, T.proc.params(y: T.any(Integer, String)).void)
+res_f = A.example(int, takes_int_or_str)
+# TypeScript on an equivalent example infers `(z: number) => number`, instead
+T.reveal_type(res_f) # error: `T.proc.params(arg0: T.any(Integer, String)).returns(T.any(Integer, String))`

--- a/test/testdata/infer/t_let_proc_type_parameter.rb
+++ b/test/testdata/infer/t_let_proc_type_parameter.rb
@@ -33,8 +33,7 @@ class A
   end
   def self.example_bad(&blk)
     f = T.let(blk, T.proc.bind(T.type_parameter(:U)).void)
-    #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Using `bind` is not permitted here
-    #                          ^^^^^^^^^^^^^^^^^^^^error: Cannot use `T.type_parameter` inside `bind`
+    #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `bind`: Can only bind to simple class names
     f
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

As a consequence of #6034, I accidentally called `.value()` on an `optional`
somewhere that I shouldn't have. This meant that any code trying to exercise
that branch would raise a runtime exception when the `.value()` call happened,
instead of reporting a user-visible error.

This change fixes that.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.