### PR TITLE
avoid duplication in LSP document symbols

### DIFF
--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -102,6 +102,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
         {core::SymbolRef::Kind::TypeArgument, gs.typeArgumentsUsed()},
         {core::SymbolRef::Kind::TypeMember, gs.typeMembersUsed()},
     };
+    vector<core::SymbolRef> candidates;
     for (auto [kind, used] : symbolTypes) {
         for (uint32_t idx = 1; idx < used; idx++) {
             core::SymbolRef ref(gs, kind, idx);
@@ -122,12 +123,14 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
                     continue;
                 }
 
-                auto data = symbolRef2DocumentSymbol(gs, ref, fref);
-                if (data) {
-                    result.push_back(move(data));
-                    break;
-                }
+                candidates.emplace_back(ref);
             }
+        }
+    }
+    for (auto ref : candidates) {
+        auto data = symbolRef2DocumentSymbol(gs, ref, fref);
+        if (data) {
+            result.push_back(move(data));
         }
     }
     response->result = move(result);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This has come up both as a known bug in Sorbet's document symbol implementation and as a bug pointed out by people experimenting with document symbols.  The problematic case is laid out in comments in the commits for this PR.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I don't know that our test harness is equipped to handle this case: we want multiple files, but we only want to test the output of some LSP operation on a single file.

I plan to test this on Stripe's codebase using files that people have pointed out as having this problem.

I am not 100% sure that the refactoring that retains a list of candidates is behavior-preserving, since our test harness doesn't test multi-file cases at the moment.