### PR TITLE
wip: Require type arguments for generic class instantiation

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -3,6 +3,7 @@
 #include "cfg/builder/builder.h"
 #include "common/typecase.h"
 #include "core/Names.h"
+#include "core/TypeErrorDiagnostics.h"
 #include "core/errors/cfg.h"
 #include "core/errors/internal.h"
 
@@ -510,6 +511,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                                 e.setHeader("`{}` is a generic class, and requires being instantiated with explicit "
                                             "type arguments",
                                             klass.show(cctx.ctx));
+                                auto replaceLoc = cctx.ctx.locAt(s.recv.loc());
+                                core::TypeErrorDiagnostics::insertUntypedTypeArguments(cctx.ctx, e, klass, replaceLoc);
                             }
                         }
                     }

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -527,7 +527,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                             !isLegacyStdlibGenericOrChild(cctx.ctx, klass)) {
                             auto errLoc = (s.funLoc.exists() && !s.funLoc.empty()) ? s.funLoc : s.loc;
                             if (auto e = cctx.ctx.beginError(errLoc, core::errors::CFG::TypeArgsGenericClassNew)) {
-                                e.setHeader("`{}` is a generic class, and requires being instantiated with explicit "
+                                e.setHeader("`{}` is a generic class and requires being instantiated with explicit "
                                             "type arguments",
                                             klass.show(cctx.ctx));
                                 auto replaceLoc = cctx.ctx.locAt(s.recv.loc());

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -150,6 +150,8 @@ TypePtr ClassOrModule::unsafeComputeExternalType(GlobalState &gs) {
                 // this will behave a bit like a unification variable with
                 // Types::glb.
                 targs.emplace_back(Types::untyped(gs, ref));
+                // This flag is an optimization so that we don't have to recompute all the logic this
+                // method computes when checking whether to allow a call to `new` on a generic class.
                 flags.externalTypeImplicitlyUntyped = true;
             } else {
                 // The remaining case is a contravariant parameter, which

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -354,13 +354,15 @@ public:
         bool isPrivate : 1;
         bool isUndeclared : 1;
         bool isExported : 1;
+        bool externalTypeImplicitlyUntyped : 1;
 
-        constexpr static uint16_t NUMBER_OF_FLAGS = 10;
+        constexpr static uint16_t NUMBER_OF_FLAGS = 11;
         constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         Flags() noexcept
             : isClass(false), isModule(false), isAbstract(false), isInterface(false), isLinearizationComputed(false),
-              isFinal(false), isSealed(false), isPrivate(false), isUndeclared(false), isExported(false) {}
+              isFinal(false), isSealed(false), isPrivate(false), isUndeclared(false), isExported(false),
+              externalTypeImplicitlyUntyped(false) {}
 
         uint16_t serialize() const {
             // Can replace this with std::bit_cast in C++20

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -100,16 +100,16 @@ void TypeErrorDiagnostics::insertUntypedTypeArguments(const GlobalState &gs, Err
 
     auto loc = replaceLoc;
     if (loc.exists()) {
-        if (klass == core::Symbols::Hash() || klass == core::Symbols::T_Hash()) {
+        if (unwrapped == core::Symbols::Hash() || unwrapped == core::Symbols::T_Hash()) {
             // Hash is special because it has arity 3 but you're only supposed to write the first 2
             e.replaceWith("Add type arguments", loc, "{}[T.untyped, T.untyped]", typePrefixSym.show(gs));
         } else {
-            auto numTypeArgs = klass.data(gs)->typeArity(gs);
+            auto numTypeArgs = unwrapped.data(gs)->typeArity(gs);
             vector<string> untypeds;
             for (int i = 0; i < numTypeArgs; i++) {
                 untypeds.emplace_back("T.untyped");
             }
-            if (typePrefixSym == klass) {
+            if (typePrefixSym == unwrapped) {
                 e.replaceWith("Insert type arguments", loc.copyEndWithZeroLength(), "[{}]",
                               absl::StrJoin(untypeds, ", "));
             } else {

--- a/core/errors/cfg.h
+++ b/core/errors/cfg.h
@@ -9,5 +9,6 @@ constexpr ErrorClass UndeclaredVariable{6002, StrictLevel::Strict};
 constexpr ErrorClass MalformedTAbsurd{6004, StrictLevel::True};
 constexpr ErrorClass MalformedTBind{6005, StrictLevel::False};
 constexpr ErrorClass UnknownTypeParameter{6006, StrictLevel::True};
+constexpr ErrorClass TypeArgsGenericClassNew{6007, StrictLevel::True};
 } // namespace sorbet::core::errors::CFG
 #endif

--- a/test/testdata/infer/bad_child_class.rb
+++ b/test/testdata/infer/bad_child_class.rb
@@ -16,4 +16,5 @@ class Parent
   sig {returns(K)}
   def foo; T.unsafe(nil); end
   puts PreChild.new.foo() # this line previously caused a failed ENFORCE in LambdaParam::_instantiate
+  #             ^^^ error: `PreChild` is a generic class and requires being instantiated with explicit type arguments
 end

--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -108,9 +108,9 @@ end
 integer_pairs = T.let([IntegerPair.new(1, 2), IntegerPair.new(3, 4)], T::Array[IntegerPair])
 super_pairs = T.let([SuperPair.new(1, 2)], T::Array[SuperPair])
 
-generic_pairs = T.let([GenericPair.new(1, 2), GenericPair.new(3, 4)], T::Array[GenericPair[Integer]])
+generic_pairs = T.let([GenericPair[Integer].new(1, 2), GenericPair[Integer].new(3, 4)], T::Array[GenericPair[Integer]])
 nested_generic_pairs = T.let(
-  [GenericPair.new(GenericPair.new(1, 2), GenericPair.new(3, 4))],
+  [GenericPair[GenericPair[Integer]].new(GenericPair[Integer].new(1, 2), GenericPair[Integer].new(3, 4))],
   T::Array[GenericPair[GenericPair[Integer]]]
 )
 

--- a/test/testdata/infer/generics/bad_required_type_args.rb
+++ b/test/testdata/infer/generics/bad_required_type_args.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 extend T::Sig
 
 # All of the examples in this file showcase current limitations in how we've
@@ -23,6 +23,13 @@ class Box
     T.reveal_type(res) # error: `T.attached_class (of Box)`
     res
   end
+
+  sig {returns(T.self_type)}
+  def another
+    res = self.class.new
+    T.reveal_type(res) # error: `Box[T.untyped]`
+    res
+  end
 end
 
 sig {params(box_class: T.class_of(Box)).void}
@@ -36,4 +43,10 @@ def example
   box_class = Box
   box = box_class.new
   T.reveal_type(box) # error: `Box[T.untyped]`
+
+  box = Box.make
+  T.reveal_type(box) # error: `Box[T.untyped]`
+
+  box2 = box.another
+  T.reveal_type(box2) # error: `Box[T.untyped]`
 end

--- a/test/testdata/infer/generics/bad_required_type_args.rb
+++ b/test/testdata/infer/generics/bad_required_type_args.rb
@@ -1,0 +1,39 @@
+# typed: true
+extend T::Sig
+
+# All of the examples in this file showcase current limitations in how we've
+# chosen to implement the requirement that a generic class be provided type
+# arguments on instantiation.
+#
+# The check is currently syntactic, which means it fails in ways that you might
+# expect Sorbet to be able to detect using full inference.
+#
+# This is a tradeoff, because implementing something was better than nothing.
+
+class Box
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member
+
+  sig {returns(T.attached_class)}
+  def self.make
+    res = self.new
+    T.reveal_type(res) # error: `T.attached_class (of Box)`
+    res = new
+    T.reveal_type(res) # error: `T.attached_class (of Box)`
+    res
+  end
+end
+
+sig {params(box_class: T.class_of(Box)).void}
+def make_box(box_class)
+  box = box_class.new
+  T.reveal_type(box) # error: `Box[T.untyped]`
+end
+
+sig {void}
+def example
+  box_class = Box
+  box = box_class.new
+  T.reveal_type(box) # error: `Box[T.untyped]`
+end

--- a/test/testdata/infer/generics/drop_literal_before_remember.rb
+++ b/test/testdata/infer/generics/drop_literal_before_remember.rb
@@ -17,7 +17,12 @@ sig do
   .returns(Box[T.type_parameter(:T)])
 end
 def build_a(v)
-  Box.new(v)
+  box = Box.new(v)
+  #         ^^^ error: `Box` is a generic class and requires being instantiated with explicit type arguments
+  T.reveal_type(box) # error: `Box[T.untyped]`
+  res = Box[T.type_parameter(:T)].new(v)
+  T.reveal_type(res) # error: `Box[T.type_parameter(:T) (of Object#build_a)]`
+  res
 end
 
 sig { params(v: Box[Integer]).void }

--- a/test/testdata/infer/generics/enumerable.rb
+++ b/test/testdata/infer/generics/enumerable.rb
@@ -19,5 +19,7 @@
  module Foo
     def bar
        MySet.new() - MySet.new()
+       #     ^^^ error: `MySet` is a generic class and requires being instantiated with explicit type arguments
+       #                   ^^^ error: `MySet` is a generic class and requires being instantiated with explicit type arguments
     end
  end

--- a/test/testdata/infer/generics/fixed_noreturn.rb
+++ b/test/testdata/infer/generics/fixed_noreturn.rb
@@ -53,4 +53,7 @@ end
 T.reveal_type(Nil.new) # error: `Nil`
 empty = T.let(Nil.new, List[Integer])
 T.let(Cons.new(head: 0, tail: empty), List[Integer])
-T.let(Cons.new(head: 0, tail: Nil.new), List[Integer])
+#          ^^^ error: `Cons` is a generic class and requires being instantiated with explicit type arguments
+T.let(Cons[Integer].new(head: 0, tail: Nil.new), List[Integer])
+T.let(Cons[String].new(head: 0, tail: Nil.new), List[Integer]) # error: Argument does not have asserted type `List[Integer]`
+#                            ^ error: Expected `String` but found `Integer(0)` for argument `head`

--- a/test/testdata/infer/metatype_new.rb
+++ b/test/testdata/infer/metatype_new.rb
@@ -14,11 +14,12 @@ end
 
 MyArrayString = T.type_alias {T::Array[String]}
 
-# -- good --
+# -- good from the perspective of "call to `new` is allowed" --
 
 String.new
 T::Array[String].new
 MyGeneric.new
+#         ^^^ error: `MyGeneric` is a generic class and requires being instantiated with explicit type arguments
 MyGeneric[Integer].new
 MyOtherGeneric.new
 

--- a/test/testdata/lsp/go_to_type_definition_applied.rb
+++ b/test/testdata/lsp/go_to_type_definition_applied.rb
@@ -23,6 +23,7 @@ class TestClass
   #    ^ type: AB
 
   bare_box_a = BoxA.new
+  #                 ^^^ error: `BoxA` is a generic class and requires being instantiated with explicit type arguments
   puts T.reveal_type(bare_box_a) # error: Revealed type: `BoxA[T.untyped]`
   #                  ^ type: BoxA
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -2695,6 +2695,43 @@ no such `T.type_parameter` in scope.
 For more information, see the docs for
 [Generic methods](generics.md#generic-methods).
 
+## 6007
+
+User-defined generic classes require type arguments when instantiated. For
+example:
+
+```ruby
+class Box
+  extend T::Generic
+  Elem = type_member
+end
+
+Box.new          # error
+Box[Integer].new # okay
+```
+
+Sorbet does not (cannot, in general) use the arguments to the constructor to
+attempt to infer the type arguments when instantiating a generic class.
+
+This requirement to pass type arguments to generic classes does not apply to
+generic classes defined in the standard library, in order to allow easier
+interoperation with pre-existing Ruby codebases, the same error is not reported
+when instantiating standard library classes.
+
+For example:
+
+```ruby
+arr = Array.new(10)
+T.reveal_type()
+set = Set.new([0])
+T.reveal_type(set) # => `T::Set[T.untyped]`
+set = T::Set[Integer].new([0])
+T.reveal_type(set) # => `T::Set[Integer]`
+```
+
+Note that when no type arguments are provided, Sorbet defaults to using
+`T.untyped` for the element type of the generic class.
+
 ## 7001
 
 Sorbet does not allow reassigning a variable to a different type within a loop


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes #4978

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm open to pushback on this PR, as there are some annoying things about how it works:

- It lurks another bit onto `core::ClassOrModule` to avoid having to recompute something that was already computed. (My justification was vaguely that I didn't want to have to slow down every call to `new` on all generic classes, but I did not test whether recomputing the logic that `unsafeComputeExternalType` computes was slow or not.)

- It does not actually detect all cases that you might expect it to be able to. (My justification: I had an earlier implementation of these changes, and they ran into issues attempting to work around the problems demonstrated in `bad_required_type_args.rb`. I ran out of my timebox trying to find a clever solution to these cases. It's hard to tell the difference between things like `self.new` and `self.class.new` from `Box.new` in `calls.cc`)

Despite this, I think that it is at least better than nothing, and will do a lot to get people to be using generics the right way by providing explicit type arguments.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.