### PR TITLE
eliminate some unnecessary `asTypeMemberRef`

### DIFF
--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -101,8 +101,8 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
 
         auto tps = parent.data(gs)->typeMembers();
         bool foundAll = true;
-        for (core::SymbolRef tp : tps) {
-            bool foundThis = resolveTypeMember(gs, parent, tp.asTypeMemberRef(), sym, typeAliases);
+        for (auto tp : tps) {
+            bool foundThis = resolveTypeMember(gs, parent, tp, sym, typeAliases);
             foundAll = foundAll && foundThis;
         }
         if (foundAll) {
@@ -137,14 +137,13 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
     for (auto mixin : sym.data(gs)->mixins()) {
         resolveTypeMembers(gs, mixin, typeAliases, resolved);
         auto typeMembers = mixin.data(gs)->typeMembers();
-        for (core::SymbolRef tp : typeMembers) {
-            resolveTypeMember(gs, mixin, tp.asTypeMemberRef(), sym, typeAliases);
+        for (auto tm : typeMembers) {
+            resolveTypeMember(gs, mixin, tm, sym, typeAliases);
         }
     }
 
     if (sym.data(gs)->isClass()) {
-        for (core::SymbolRef tp : sym.data(gs)->typeMembers()) {
-            auto tm = tp.asTypeMemberRef();
+        for (auto tm : sym.data(gs)->typeMembers()) {
             // AttachedClass is covariant, but not controlled by the user.
             if (tm.data(gs)->name == core::Names::Constants::AttachedClass()) {
                 continue;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Now that `typeMembers()` has a properly-typed symbol type, we don't need these `asTypeMemberRef` casts anymore.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
