### PR TITLE
simply `cfg::Send` constructor

### DIFF
--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -125,11 +125,9 @@ Send::Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core:
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
             args.size());
 
-    this->args.resize(args.size());
-    int i = 0;
+    this->args.reserve(args.size());
     for (const auto &e : args) {
-        this->args[i].variable = e;
-        i++;
+        this->args.emplace_back(e);
     }
     categoryCounterInc("cfg", "send");
     histogramInc("cfg.send.args", this->args.size());


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm not sure why the constructor was written this way originally (maybe before the `VariableUseSite(LocalRef)` constructor existed?), but doing it this was is more idiomatic and should be epsilon smaller/faster.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
