### PR TITLE
Add a sig to `type_member`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1809,6 +1809,16 @@ public:
     }
 } T_attached_class;
 
+class T_type_parameter : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        // Proper typing of this should have been in builder_walk by translating `T.type_parameter`
+        // calls to `Alias` instructions. This just makes it so that e.g. sigs that use
+        // `T.type_parameter(:U)` can be used at `# typed: strong`
+        res.returnType = make_type<MetaType>(Types::untypedUntracked());
+    }
+} T_type_parameter;
+
 class T_must : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
@@ -4010,6 +4020,7 @@ const vector<Intrinsic> intrinsics{
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::classOf(), &T_class_of},
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::selfType(), &T_self_type},
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::attachedClass(), &T_attached_class},
+    {Symbols::T(), Intrinsic::Kind::Singleton, Names::typeParameter(), &T_type_parameter},
 
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::proc(), &T_proc},
     {Symbols::DeclBuilderForProcs(), Intrinsic::Kind::Singleton, Names::params(), &T_proc_params},

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -71,7 +71,9 @@ end
 module T::Generic
   include T::Helpers
 
+  sig {params(variance: Symbol, blk: T.untyped).returns(T::Types::TypeMember)}
   def type_member(variance=:invariant, &blk); end
+  sig {params(variance: Symbol, blk: T.untyped).returns(T::Types::TypeTemplate)}
   def type_template(variance=:invariant, &blk); end
   def [](*types); end
 end

--- a/test/cli/autocorrect-requires-ancestor-block/test.out
+++ b/test/cli/autocorrect-requires-ancestor-block/test.out
@@ -28,8 +28,8 @@ autocorrect-requires-ancestor-block.rb:14: `requires_ancestor` only accepts a bl
 autocorrect-requires-ancestor-block.rb:12: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
     12 |  requires_ancestor RA1
                             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: `requires_ancestor` defined here
-     107 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L109: `requires_ancestor` defined here
+     109 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     autocorrect-requires-ancestor-block.rb:12: Deleted
@@ -39,15 +39,15 @@ autocorrect-requires-ancestor-block.rb:12: Too many arguments provided for metho
 autocorrect-requires-ancestor-block.rb:12: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
     12 |  requires_ancestor RA1
                                ^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: defined here
-     107 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L109: defined here
+     109 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 autocorrect-requires-ancestor-block.rb:13: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `2` https://srb.help/7004
     13 |  requires_ancestor RA2, RA3
                             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: `requires_ancestor` defined here
-     107 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L109: `requires_ancestor` defined here
+     109 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     autocorrect-requires-ancestor-block.rb:13: Deleted
@@ -57,15 +57,15 @@ autocorrect-requires-ancestor-block.rb:13: Too many arguments provided for metho
 autocorrect-requires-ancestor-block.rb:13: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
     13 |  requires_ancestor RA2, RA3
                                     ^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: defined here
-     107 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L109: defined here
+     109 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 autocorrect-requires-ancestor-block.rb:14: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
     14 |  requires_ancestor(RA4) { RA5 }
                             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: `requires_ancestor` defined here
-     107 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L109: `requires_ancestor` defined here
+     109 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     autocorrect-requires-ancestor-block.rb:14: Deleted

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -216,7 +216,7 @@ bb0[rubyRegionId=0, firstDead=7]():
     <cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>
     <cfgAlias>$8: T.class_of(T) = alias <C T>
     <statTemp>$3: T.class_of(Base)[T.class_of(Base)::Klass] = <self>: T.class_of(Base)[T.class_of(Base)::Klass].extend(<cfgAlias>$6: T.class_of(T::Generic))
-    <C Klass>$10: T.untyped = <self>: T.class_of(Base)[T.class_of(Base)::Klass].type_template()
+    <C Klass>$10: T::Types::TypeTemplate = <self>: T.class_of(Base)[T.class_of(Base)::Klass].type_template()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -254,7 +254,7 @@ bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Concrete), <block-pre-call-
 # backedges
 # - bb2(rubyRegionId=1)
 bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
-    <C Klass>$10: T.untyped = Solve<<block-pre-call-temp>$12, type_template>
+    <C Klass>$10: T::Types::TypeTemplate = Solve<<block-pre-call-temp>$12, type_template>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -266,7 +266,7 @@ bb3[rubyRegionId=0, firstDead=7](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <cfgAlias>$22: T.class_of(T::Generic) = alias <C Generic>
     <cfgAlias>$24: T.class_of(T) = alias <C T>
     <statTemp>$19: T.class_of(Generic) = <self>: T.class_of(Generic).extend(<cfgAlias>$22: T.class_of(T::Generic))
-    <C TM>$26: T.untyped = <self>: T.class_of(Generic).type_member()
+    <C TM>$26: T::Types::TypeMember = <self>: T.class_of(Generic).type_member()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 

--- a/test/testdata/namer/type_member_eager_to_lazy.rb
+++ b/test/testdata/namer/type_member_eager_to_lazy.rb
@@ -4,16 +4,32 @@ module A
   extend T::Generic
 
   A1 = type_member()
-  A2 = type_member(fixed: Integer) # error: syntax for bounds has changed
-  A3 = type_member(lower: Integer) # error: syntax for bounds has changed
-  A4 = type_member(upper: Integer) # error: syntax for bounds has changed
-  A5 = type_member(lower: Integer, upper: Integer) # error: syntax for bounds has changed
+  A2 = type_member(fixed: Integer)
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{fixed: T.class_of(Integer)}` for argument `variance`
+  A3 = type_member(lower: Integer)
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer)}` for argument `variance`
+  A4 = type_member(upper: Integer)
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{upper: T.class_of(Integer)}` for argument `variance`
+  A5 = type_member(lower: Integer, upper: Integer)
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer), upper: T.class_of(Integer)}` for argument `variance`
 
   B1 = type_member
-  B2 = type_member fixed: Integer # error: syntax for bounds has changed
-  B3 = type_member lower: Integer # error: syntax for bounds has changed
-  B4 = type_member upper: Integer # error: syntax for bounds has changed
-  B5 = type_member lower: Integer, upper: Integer # error: syntax for bounds has changed
+  B2 = type_member fixed: Integer
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{fixed: T.class_of(Integer)}` for argument `variance`
+  B3 = type_member lower: Integer
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer)}` for argument `variance`
+  B4 = type_member upper: Integer
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{upper: T.class_of(Integer)}` for argument `variance`
+  B5 = type_member lower: Integer, upper: Integer
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer), upper: T.class_of(Integer)}` for argument `variance`
 
   C1 = type_member(:out)
   C2 = type_member(:out, fixed: Integer) # error: syntax for bounds has changed

--- a/test/testdata/namer/type_member_eager_to_lazy.rb.autocorrects.exp
+++ b/test/testdata/namer/type_member_eager_to_lazy.rb.autocorrects.exp
@@ -5,16 +5,32 @@ module A
   extend T::Generic
 
   A1 = type_member()
-  A2 = type_member {{fixed: Integer}} # error: syntax for bounds has changed
-  A3 = type_member {{lower: Integer}} # error: syntax for bounds has changed
-  A4 = type_member {{upper: Integer}} # error: syntax for bounds has changed
-  A5 = type_member {{lower: Integer, upper: Integer}} # error: syntax for bounds has changed
+  A2 = type_member {{fixed: Integer}}
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{fixed: T.class_of(Integer)}` for argument `variance`
+  A3 = type_member {{lower: Integer}}
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer)}` for argument `variance`
+  A4 = type_member {{upper: Integer}}
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{upper: T.class_of(Integer)}` for argument `variance`
+  A5 = type_member {{lower: Integer, upper: Integer}}
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer), upper: T.class_of(Integer)}` for argument `variance`
 
   B1 = type_member
-  B2 = type_member {{fixed: Integer}} # error: syntax for bounds has changed
-  B3 = type_member {{lower: Integer}} # error: syntax for bounds has changed
-  B4 = type_member {{upper: Integer}} # error: syntax for bounds has changed
-  B5 = type_member {{lower: Integer, upper: Integer}} # error: syntax for bounds has changed
+  B2 = type_member {{fixed: Integer}}
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{fixed: T.class_of(Integer)}` for argument `variance`
+  B3 = type_member {{lower: Integer}}
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer)}` for argument `variance`
+  B4 = type_member {{upper: Integer}}
+  #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{upper: T.class_of(Integer)}` for argument `variance`
+  B5 = type_member {{lower: Integer, upper: Integer}}
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: syntax for bounds has changed
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer), upper: T.class_of(Integer)}` for argument `variance`
 
   C1 = type_member(:out)
   C2 = type_member(:out) {{fixed: Integer}} # error: syntax for bounds has changed

--- a/test/testdata/namer/type_member_redefs__1.rb
+++ b/test/testdata/namer/type_member_redefs__1.rb
@@ -8,7 +8,7 @@ end
 
 class B
   extend T::Generic
-  R = type_member
+  R = type_member # error: Expected `Integer` but found `T::Types::TypeMember` for field
   R = 1 # error: Redefining constant `R`
 end
 

--- a/test/testdata/resolver/type_members.rb
+++ b/test/testdata/resolver/type_members.rb
@@ -8,10 +8,14 @@ end
 class Invalids
   extend T::Generic
   Exp = type_member(1+1) # error: Invalid param, must be a :symbol
+  #                 ^^^ error: Expected `Symbol` but found `Integer` for argument `variance`
   Baz = type_member(:baz) # error: Invalid variance kind, only `:out` and `:in` are supported
   Mama = type_member("mama") # error: Invalid param, must be a :symbol
+  #                  ^^^^^^ error: Expected `Symbol` but found `String("mama")` for argument `variance`
   One = type_member(1) # error: Invalid param, must be a :symbol
+  #                 ^ error: Expected `Symbol` but found `Integer(1)` for argument `variance`
   ArrOne = type_member([1]) # error: Invalid param, must be a :symbol
+  #                    ^^^ error: Expected `Symbol` but found `[Integer(1)]` for argument `variance`
   BadArg = type_member {{junk: 1}}
   #                      ^^^^ error: Unknown key `junk` provided in block to `type_member`
   #                            ^ error: Unsupported literal in type syntax


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This silences some `# typed: strong` errors.

Can be useful when trying to hunt down where `T.untyped` is in a file to
know that these are not your fault.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.