### PR TITLE
Reword generics disclaimer

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -46,12 +46,12 @@
       "noreturn",
       "attached-class",
       "intersection-types",
+      "generics",
       "non-forcing-constants"
     ],
     "Experimental Features": [
       "tuples",
       "shapes",
-      "generics",
       "requires-ancestor"
     ]
   },


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The "shortcomings of generic methods" example actually does the right thing now.

I still think it's useful to have something show up when people search our docs
for `<top>` so I've left the rest of the section.

Also I don't think we have to be so melodramatic in terms of bugginess, but I
think that the other advice is still good, general advice so I've reworded the
intro.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a