### PR TITLE
Revert "ignore exp files in `update_testdata_exp.sh` (#6114)"

### DIFF
--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -97,11 +97,6 @@ basename=
 srcs=()
 
 for this_src in "${rb_src[@]}" DUMMY; do
-  # We will discover the exp files for relevant source files below.
-  if [[ "$this_src" =~ .*.exp ]]; then
-    continue
-  fi
-
   # Packager tests are folder based.
   if [[ "$this_src" =~ (.*/packager/([^/]+)/).* ]]; then
     # Basename for all .exp files in packager folder is "pass.$pass.exp"


### PR DESCRIPTION
This reverts commit 1c72b45a33de328798bbd8acbf417d28f3d87dea.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For reasons I do not understand, this change makes test updating produce slightly different results for one packager test, which I was too dumb to notice.  It's not obvious to me *why* this is the case, and it doesn't seem worth debugging it.  I think a better route might be to integrate test updating with bazel (something like #5367, but not quite), so that we have significantly less logic in shell.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
