### PR TITLE
hoist check for exp file higher in `update_testdata_exp.sh`

### DIFF
--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -117,6 +117,9 @@ for this_src in "${rb_src[@]}" DUMMY; do
     fi
     for pass in "${passes[@]}"; do
       candidate="$basename.$pass.exp"
+      if ! [ -e "$candidate" ]; then
+        continue
+      fi
       if $needs_requires_ancestor; then
         args=("--enable-experimental-requires-ancestor")
       else
@@ -148,9 +151,6 @@ for this_src in "${rb_src[@]}" DUMMY; do
             args+=("--extra-package-files-directory-prefix-slash" "${prefix}")
           done
         fi
-      fi
-      if ! [ -e "$candidate" ]; then
-        continue
       fi
       case "$pass" in
         document-symbols)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want this script to go away, but in the meantime, we can make it significantly faster by not doing a bunch of unnecessary work if the exp file doesn't exist for a particular set of files.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
