### PR TITLE
Support `xs.reduce(0, &:+)` by desugaring to call-with-splat

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -194,9 +194,9 @@ public:
     }
 
     static ExpressionPtr CallWithSplat(core::LocOffsets loc, ExpressionPtr recv, core::NameRef name,
-                                       ExpressionPtr args) {
-        return Send3(loc, Magic(loc), core::Names::callWithSplat(), loc, std::move(recv), MK::Symbol(loc, name),
-                     std::move(args));
+                                       core::LocOffsets funLoc, ExpressionPtr splat) {
+        return Send4(loc, Magic(loc), core::Names::callWithSplat(), loc, std::move(recv), MK::Symbol(loc, name),
+                     std::move(splat), MK::Nil(loc.copyWithZeroLength()));
     }
 
     static ExpressionPtr InsSeq1(core::LocOffsets loc, ExpressionPtr stat, ExpressionPtr expr) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -783,8 +783,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     }
 
                     auto kwargs = node2TreeImpl(dctx, std::move(kwArray));
-                    auto method = MK::Literal(
-                        loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), send->method));
+                    auto method = MK::Symbol(send->methodLoc, send->method);
 
                     if (auto *array = cast_tree<Array>(kwargs)) {
                         DuplicateHashKeyCheck::checkSendArgs(dctx, 0, array->elems);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -783,7 +783,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     }
 
                     auto kwargs = node2TreeImpl(dctx, std::move(kwArray));
-                    auto method = MK::Symbol(send->methodLoc, send->method);
+                    auto method = MK::Symbol(locZeroLen, send->method);
 
                     if (auto *array = cast_tree<Array>(kwargs)) {
                         DuplicateHashKeyCheck::checkSendArgs(dctx, 0, array->elems);
@@ -796,7 +796,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     sendargs.emplace_back(std::move(kwargs));
                     ExpressionPtr res;
                     if (block == nullptr && !anonymousBlockPass) {
-                        res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), locZeroLen, 4,
+                        res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                        std::move(sendargs), flags);
                     } else {
                         ExpressionPtr convertedBlock;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2411,7 +2411,7 @@ public:
         InlinedVector<const TypeAndOrigins *, 2> sendArgs =
             Magic_callWithSplat::generateSendArgs(posTuple, kwTuple, sendArgStore, args.argLoc(2));
         InlinedVector<LocOffsets, 2> sendArgLocs(sendArgs.size(), args.locs.args[2]);
-        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.args[1], sendArgLocs};
         DispatchArgs innerArgs{fn,
                                sendLocs,
                                numPosArgs,
@@ -2427,15 +2427,14 @@ public:
         for (auto &err : dispatched.main.errors) {
             res.main.errors.emplace_back(std::move(err));
         }
-        dispatched.main.errors.clear();
+        dispatched.main.errors = move(res.main.errors);
 
-        // TODO(trevor) this should merge constrains from `res` and `dispatched` instead
+        // TODO(trevor) this should merge constraints from `res` and `dispatched` instead
         if ((dispatched.main.constr == nullptr) || dispatched.main.constr->isEmpty()) {
             dispatched.main.constr = move(res.main.constr);
         }
-        res.main = move(dispatched.main);
+        res = move(dispatched);
 
-        res.returnType = dispatched.returnType;
         return;
     }
 } Magic_callWithSplat;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1399,7 +1399,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                                    "`{}` has optional keyword arguments. Did you mean to provide a value for `{}`?",
                                    method.show(gs), possibleArg);
                     auto howManyExtra = numArgsGiven - hashArgsCount - maxPossiblePositional;
-                    if (howManyExtra == 1) {
+                    if (howManyExtra == 1 && extraArgsLoc.adjustLen(gs, -1, 2).source(gs) != "&:") {
                         e.replaceWith(fmt::format("Prefix with `{}:`", possibleArg), extraArgsLoc.copyWithZeroLength(),
                                       "{}: ", possibleArg);
                     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2411,7 +2411,7 @@ public:
         InlinedVector<const TypeAndOrigins *, 2> sendArgs =
             Magic_callWithSplat::generateSendArgs(posTuple, kwTuple, sendArgStore, args.argLoc(2));
         InlinedVector<LocOffsets, 2> sendArgLocs(sendArgs.size(), args.locs.args[2]);
-        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.args[1], sendArgLocs};
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
         DispatchArgs innerArgs{fn,
                                sendLocs,
                                numPosArgs,

--- a/test/testdata/compiler/splat_args_with_kwargs.rb
+++ b/test/testdata/compiler/splat_args_with_kwargs.rb
@@ -17,44 +17,46 @@ p(0,*[],**{})
 p(0,*[],c: 22,**{})
 p(*[],c: 22,**{})
 
-def f(a,b,c,d: 5)
-  yield (a+b+c+d)
+class A
+  def self.f(a,b,c,d: 5)
+    yield (a+b+c+d)
+  end
 end
 
-f(*[1,2,3],**{d:4}) { |x| p x }
-f(*[1,2,3],d: 4) { |x| p x }
-f(*[1,2,3]) { |x| p x }
-f(*[1,2,3,{}]) { |x| p x }
-f(*[1,2,3,{d: 10}]) { |x| p x }
+A.f(*[1,2,3],**{d:4}) { |x| p x }
+A.f(*[1,2,3],d: 4) { |x| p x }
+A.f(*[1,2,3]) { |x| p x }
+A.f(*[1,2,3,{}]) { |x| p x }
+A.f(*[1,2,3,{d: 10}]) { |x| p x }
 
 def expects_ArgumentError
   begin
     yield
   rescue ArgumentError => e
     p e.message
-  else
-    raise "Didn't get expected ArgumentError"
+  rescue => e
+    puts "Didn't get ArgumentError: #{e.class} #{e.message}"
   end
 end
 
 # Regular splat arguments are not re-processed as keyword args.
 expects_ArgumentError do
-  f(*[1,2,3,:d,10]) {|x| p x}
+  T.unsafe(A).f(*[1,2,3,:d,10]) {|x| p x}
 end
 expects_ArgumentError do
-  f(*[1,2,3,:d,10], d: 9) {|x| p x}
+  T.unsafe(A).f(*[1,2,3,:d,10], d: 9) {|x| p x}
 end
 # Splat args with a kwargs-style hash are not re-processed if the call has kwargs.
 expects_ArgumentError do
-  f(*[1,2,3,{d: 10}], d: 9) {|x| p x}
+  T.unsafe(A).f(*[1,2,3,{d: 10}], d: 9) {|x| p x}
 end
 # Splat args with a kwargs-style hash are not re-processed if the call has a kwsplat
 expects_ArgumentError do
-  f(*[1,2,3,{d: 10}], **{d: 9}) {|x| p x}
+  T.unsafe(A).f(*[1,2,3,{d: 10}], **{d: 9}) {|x| p x}
 end
 # Number of args checks are done before valid/invalid kwargs checks.
 expects_ArgumentError do
-  f(*[1,2,3,{d: 10}], e: 9) {|x| p x}
+  T.unsafe(A).f(*[1,2,3,{d: 10}], e: 9) {|x| p x}
 end
 
 def g(*args,**kwargs)

--- a/test/testdata/core/fuzz_unparseable.rb
+++ b/test/testdata/core/fuzz_unparseable.rb
@@ -1,4 +1,4 @@
 # typed: strict
-r *[1]g#typed:true
+r *[1]g# error: Method `r` does not exist
     # ^ error: unexpected token tIDENTIFIER
 m do # error: unexpected token "end of file"

--- a/test/testdata/desugar/blockpass.rb.desugar-tree.exp
+++ b/test/testdata/desugar/blockpass.rb.desugar-tree.exp
@@ -39,8 +39,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   def foo<<todo method>>(&blk)
     begin
-      <self>.calls_with_object() do |<block-pass>$2|
-        <block-pass>$2.meth()
+      <self>.calls_with_object() do |*<block-pass>$2|
+        ::<Magic>.<call-with-splat>(<block-pass>$2.[](0), :meth, ::<Magic>.<splat>(<block-pass>$2.[](1, 9223372036854775807)), nil)
       end
       <self>.calls_with_object() do |*args|
         ::<Magic>.<call-with-splat>(:meth.to_proc(), :call, ::<Magic>.<splat>(args), nil)
@@ -57,24 +57,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.calls_with_object() do |*args|
         ::<Magic>.<call-with-splat>(<emptyTree>::<C HasToProc>.new().to_proc(), :call, ::<Magic>.<splat>(args), nil)
       end
-      <emptyTree>::<C CallsWithObject>.calls_with_object() do |<block-pass>$3|
-        <block-pass>$3.meth()
+      <emptyTree>::<C CallsWithObject>.calls_with_object() do |*<block-pass>$3|
+        ::<Magic>.<call-with-splat>(<block-pass>$3.[](0), :meth, ::<Magic>.<splat>(<block-pass>$3.[](1, 9223372036854775807)), nil)
       end
       begin
         <assignTemp>$4 = <emptyTree>::<C CallsWithObject>
         if ::NilClass.===(<assignTemp>$4)
           ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$4)
         else
-          <assignTemp>$4.calls_with_object() do |<block-pass>$5|
-            <block-pass>$5.meth()
+          <assignTemp>$4.calls_with_object() do |*<block-pass>$5|
+            ::<Magic>.<call-with-splat>(<block-pass>$5.[](0), :meth, ::<Magic>.<splat>(<block-pass>$5.[](1, 9223372036854775807)), nil)
           end
         end
       end
-      <emptyTree>::<C CallsWithObjectChild>.calls_with_object() do |<block-pass>$6|
-        <block-pass>$6.meth()
+      <emptyTree>::<C CallsWithObjectChild>.calls_with_object() do |*<block-pass>$6|
+        ::<Magic>.<call-with-splat>(<block-pass>$6.[](0), :meth, ::<Magic>.<splat>(<block-pass>$6.[](1, 9223372036854775807)), nil)
       end
-      <self>.calls_arg_with_object(<emptyTree>::<C HasMeth>.new()) do |<block-pass>$7|
-        <block-pass>$7.meth()
+      <self>.calls_arg_with_object(<emptyTree>::<C HasMeth>.new()) do |*<block-pass>$7|
+        ::<Magic>.<call-with-splat>(<block-pass>$7.[](0), :meth, ::<Magic>.<splat>(<block-pass>$7.[](1, 9223372036854775807)), nil)
       end
       <self>.calls_arg_with_object(<emptyTree>::<C HasMeth>.new()) do |x|
         x.meth()

--- a/test/testdata/infer/block_pass_splat.rb
+++ b/test/testdata/infer/block_pass_splat.rb
@@ -1,0 +1,58 @@
+# typed: true
+extend T::Sig
+
+sig {params(xs: T::Array[Integer]).void}
+def example1(xs)
+  res = xs.map(&:even?)
+  T.reveal_type(res) # error: `T::Array[T::Boolean]`
+
+  xs.map(&:even)
+  #       ^^^^^ error: Method `even` does not exist on `Integer`
+end
+
+sig {params(xs: T::Array[T.nilable(Integer)]).void}
+def example2(xs)
+  xs.map(&:even?)
+  #       ^^^^^^ error: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)`
+end
+
+class A
+  extend T::Sig
+  sig {params(x: String).void}
+  def requires_keyword(x:)
+  end
+  sig {params(x: String).void}
+  def optional_keyword(x: '')
+  end
+
+  sig {params(blk: T.proc.params(a: A).void).void}
+  def self.example1(&blk)
+    yield A.new
+  end
+
+  # Not currently possible to say that a block will be yielded a keyword arg
+  sig {params(blk: T.proc.params(a: A, x: Integer).void).void}
+  def self.example2(&blk)
+    yield A.new, x: 0 # error: Expected `Integer` but found `{x: Integer(0)}` for argument `arg1`
+  end
+
+  # Can somewhat fake it with shape types
+  sig {params(blk: T.proc.params(a: A, kwargs: {x: Integer}).void).void}
+  def self.example3(&blk)
+    yield A.new, x: 0
+  end
+end
+
+A.example1(&:requires_keyword)
+#                            ^ error: Missing required keyword argument `x` for method `A#requires_keyword`
+A.example2(&:requires_keyword)
+#           ^ error: Missing required keyword argument `x` for method `A#requires_keyword`
+#           ^ error: Too many positional arguments provided for method `A#requires_keyword`. Expected: `0`, got: `1`
+A.example3(&:requires_keyword)
+#           ^^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer` for argument `x`
+
+A.example1(&:optional_keyword)
+A.example2(&:optional_keyword)
+#           ^ error: Too many positional arguments provided for method `A#optional_keyword`. Expected: `0`, got: `1`
+A.example3(&:optional_keyword)
+#           ^^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer` for argument `x`

--- a/test/testdata/infer/block_pass_splat.rb.autocorrects.exp
+++ b/test/testdata/infer/block_pass_splat.rb.autocorrects.exp
@@ -1,3 +1,4 @@
+# -- test/testdata/infer/block_pass_splat.rb --
 # typed: true
 extend T::Sig
 
@@ -15,7 +16,7 @@ end
 
 sig {params(xs: T::Array[T.nilable(Integer)]).void}
 def example2(xs)
-  xs.map(&:even?)
+  xs.map {|x| T.must(x).even?}
   #       ^^^^^^ error: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)`
 end
 
@@ -59,3 +60,4 @@ A.example2(&:optional_keyword)
 #           ^ error: Too many positional arguments provided for method `A#optional_keyword`. Expected: `0`, got: `1`
 A.example3(&:optional_keyword)
 #           ^^^^^^^^^^^^^^^^^ error: Expected `String` but found `Integer` for argument `x`
+# ------------------------------

--- a/test/testdata/infer/call_with_splat_tuple.rb
+++ b/test/testdata/infer/call_with_splat_tuple.rb
@@ -12,7 +12,7 @@ end
 sig {params(x: Integer).void}
 def example2(x)
   x.even()
-  # ^^^^^ error: Method `even` does not exist on `Integer`
+  # ^^^^ error: Method `even` does not exist on `Integer`
   x.even(*[])
-  # ^^^^^ error: Method `even` does not exist on `Integer`
+  # ^^^^ error: Method `even` does not exist on `Integer`
 end

--- a/test/testdata/infer/call_with_splat_tuple.rb
+++ b/test/testdata/infer/call_with_splat_tuple.rb
@@ -1,0 +1,9 @@
+# typed: true
+extend T::Sig
+
+sig {params(x: T.nilable(Integer)).void}
+def example(x)
+  x.even?()
+  # ^^^^^ error: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)`
+  x.even?(*[])
+end

--- a/test/testdata/infer/call_with_splat_tuple.rb.autocorrects.exp
+++ b/test/testdata/infer/call_with_splat_tuple.rb.autocorrects.exp
@@ -13,8 +13,8 @@ end
 sig {params(x: Integer).void}
 def example2(x)
   x.even?()
-  # ^^^^^ error: Method `even` does not exist on `Integer`
+  # ^^^^ error: Method `even` does not exist on `Integer`
   x.even?(*[])
-  # ^^^^^ error: Method `even` does not exist on `Integer`
+  # ^^^^ error: Method `even` does not exist on `Integer`
 end
 # ------------------------------

--- a/test/testdata/infer/call_with_splat_tuple.rb.autocorrects.exp
+++ b/test/testdata/infer/call_with_splat_tuple.rb.autocorrects.exp
@@ -1,18 +1,20 @@
+# -- test/testdata/infer/call_with_splat_tuple.rb --
 # typed: true
 extend T::Sig
 
 sig {params(x: T.nilable(Integer)).void}
 def example1(x)
-  x.even?()
+  T.must(x).even?()
   # ^^^^^ error: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)`
-  x.even?(*[])
+  T.must(x).even?(*[])
   # ^^^^^ error: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)`
 end
 
 sig {params(x: Integer).void}
 def example2(x)
-  x.even()
+  x.even?()
   # ^^^^^ error: Method `even` does not exist on `Integer`
-  x.even(*[])
+  x.even?(*[])
   # ^^^^^ error: Method `even` does not exist on `Integer`
 end
+# ------------------------------

--- a/test/testdata/infer/intrinsics_generics.rb
+++ b/test/testdata/infer/intrinsics_generics.rb
@@ -3,5 +3,6 @@ extend T::Sig
 sig {type_parameters(:A).params(a: T.type_parameter(:A)).void}
 def foo(a)
  a.foo(1, *[2, 3])
+ # ^^^ error: Call to method `foo` on unconstrained generic type `T.type_parameter(:A) (of Object#foo)`
 end
 


### PR DESCRIPTION
<img width="343" alt="Screen Shot 2022-07-29 at 1 54 33 PM" src="https://user-images.githubusercontent.com/5544532/181841678-093e7302-1d36-4c55-ae2b-2bcc74fb4bae.png">


Based on #6168 and #6169

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #6112

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] Separate this into the thing that adds the new intrinsic, and the thing that changes
      the desugaring, so that we can fix any type errors they would introduce independently
      of each other.
  - #6168
- [x] Write some comments explaining any non-obvious parts
- [x] Add tests, including:
  - [x] for all the different ways that the off-by-one errors could be wrong
    - #6168
  - for a method `&:foo` where `foo` has required or optional keyword args
    - my guess is that it's currently broken for those kinds of things today,
      and that this change doesn't make those cases worse (while making other
      cases better) so it's probably fine to land even if these cases weren't
      supported
  - [x] for the result type when given a `Range` like `args.slice(1..)`
    - #6168
- [x] ~~Factor things out to support `args[idx, len]` in addition to
  `args.slice(idx, len)`.~~ deferred to future date