### PR TITLE
add the ability to have multi-file + multi-exp-file document-symbols tests

### DIFF
--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -48,7 +48,7 @@ pair<string, vector<string>> findEditsToApply(string_view filePath) {
     return make_pair(uri, move(fileContents));
 }
 
-int printDocumentSymbols(string_view filePath) {
+int printDocumentSymbols(string_view filePath, int numFiles, char **files) {
     auto lspWrapper = SingleThreadedLSPWrapper::create();
     lspWrapper->enableAllExperimentalFeatures();
     int nextId = 0;
@@ -145,10 +145,10 @@ int printDocumentSymbols(string_view filePath) {
 } // namespace sorbet::realmain::lsp
 
 int main(int argc, char *argv[]) {
-    if (argc != 2) {
-        std::cout << "Usage: print_document_symbols path/to/file.rb\n";
+    if (argc != 3) {
+        std::cout << "Usage: print_document_symbols path/to/file/for/symbols.rb path/to/file1.rb path/to/file2.rb ...\n";
         return 1;
     }
 
-    return sorbet::realmain::lsp::printDocumentSymbols(argv[1]);
+    return sorbet::realmain::lsp::printDocumentSymbols(argv[1], argc - 2, &argv[2]);
 }

--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -2,6 +2,10 @@
 #include "main/lsp/LSPMessage.h"
 #include "main/lsp/json_types.h"
 #include "main/lsp/wrapper.h"
+
+#include "absl/algorithm/container.h"
+#include "absl/strings/match.h"
+
 #include <iostream>
 #include <memory>
 
@@ -147,6 +151,17 @@ int printDocumentSymbols(string_view filePath, int numFiles, char **files) {
 int main(int argc, char *argv[]) {
     if (argc != 3) {
         std::cout << "Usage: print_document_symbols path/to/file/for/symbols.rb path/to/file1.rb path/to/file2.rb ...\n";
+        return 1;
+    }
+
+    int numFiles = argc - 2;
+    char **files = &argv[2];
+
+    int rbupdates = std::count_if(files, &files[numFiles], [](const char *f) {
+            return absl::EndsWith(f, "rbupdate");
+        });
+    if (rbupdates > 1) {
+        std::cout << "multiple updated files not supported at this time\n";
         return 1;
     }
 

--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -163,7 +163,7 @@ int printDocumentSymbols(string_view chosenFile, const vector<string> &files) {
 } // namespace sorbet::realmain::lsp
 
 int main(int argc, char *argv[]) {
-    if (argc != 3) {
+    if (argc < 3) {
         std::cout << "Usage: print_document_symbols path/to/file/for/symbols.rb path/to/file1.rb path/to/file2.rb ...\n";
         return 1;
     }

--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -52,7 +52,7 @@ pair<string, vector<string>> findEditsToApply(string_view filePath) {
     return make_pair(uri, move(fileContents));
 }
 
-int printDocumentSymbols(string_view filePath, int numFiles, char **files) {
+int printDocumentSymbols(string_view filePath, const vector<string> &files) {
     auto lspWrapper = SingleThreadedLSPWrapper::create();
     lspWrapper->enableAllExperimentalFeatures();
     int nextId = 0;
@@ -156,8 +156,12 @@ int main(int argc, char *argv[]) {
 
     int numFiles = argc - 2;
     char **files = &argv[2];
+    std::vector<std::string> filenames;
+    for (int i = 0; i < numFiles; ++i) {
+        filenames.emplace_back(files[i]);
+    }
 
-    int rbupdates = std::count_if(files, &files[numFiles], [](const char *f) {
+    int rbupdates = absl::c_count_if(filenames, [](const auto &f) {
             return absl::EndsWith(f, "rbupdate");
         });
     if (rbupdates > 1) {
@@ -165,5 +169,5 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    return sorbet::realmain::lsp::printDocumentSymbols(argv[1], argc - 2, &argv[2]);
+    return sorbet::realmain::lsp::printDocumentSymbols(argv[1], filenames);
 }

--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -22,7 +22,7 @@ struct TestFile {
     vector<string> edits;
 };
 
-UnorderedMap<string, TestFile> loadFiles(const vector<string>& files) {
+UnorderedMap<string, TestFile> loadFiles(const vector<string> &files) {
     UnorderedMap<string, TestFile> data;
     for (const auto &f : files) {
         string_view filePath{f};
@@ -119,8 +119,8 @@ int printDocumentSymbols(string_view chosenFile, const vector<string> &files) {
     {
         // Initialize empty files.
         for (auto &filename : files) {
-            auto params =
-                make_unique<DidOpenTextDocumentParams>(make_unique<TextDocumentItem>(testdata[filename].uri, "ruby", fileId++, ""));
+            auto params = make_unique<DidOpenTextDocumentParams>(
+                make_unique<TextDocumentItem>(testdata[filename].uri, "ruby", fileId++, ""));
             auto notif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidOpen, move(params));
             // Discard responses.
             lspWrapper->getLSPResponsesFor(make_unique<LSPMessage>(move(notif)));
@@ -139,7 +139,8 @@ int printDocumentSymbols(string_view chosenFile, const vector<string> &files) {
         }
     }
 
-    auto docSymbolParams = make_unique<DocumentSymbolParams>(make_unique<TextDocumentIdentifier>(testdata[chosenFile].uri));
+    auto docSymbolParams =
+        make_unique<DocumentSymbolParams>(make_unique<TextDocumentIdentifier>(testdata[chosenFile].uri));
     auto req =
         make_unique<RequestMessage>("2.0", nextId++, LSPMethod::TextDocumentDocumentSymbol, move(docSymbolParams));
     // Make documentSymbol request.
@@ -165,7 +166,8 @@ int printDocumentSymbols(string_view chosenFile, const vector<string> &files) {
 
 int main(int argc, char *argv[]) {
     if (argc < 3) {
-        std::cout << "Usage: print_document_symbols path/to/file/for/symbols.rb path/to/file1.rb path/to/file2.rb ...\n";
+        std::cout
+            << "Usage: print_document_symbols path/to/file/for/symbols.rb path/to/file1.rb path/to/file2.rb ...\n";
         return 1;
     }
 
@@ -176,9 +178,7 @@ int main(int argc, char *argv[]) {
         filenames.emplace_back(files[i]);
     }
 
-    int rbupdates = absl::c_count_if(filenames, [](const auto &f) {
-            return absl::EndsWith(f, "rbupdate");
-        });
+    int rbupdates = absl::c_count_if(filenames, [](const auto &f) { return absl::EndsWith(f, "rbupdate"); });
     if (rbupdates > 1) {
         std::cout << "multiple updated files not supported at this time\n";
         return 1;

--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -118,16 +118,17 @@ int printDocumentSymbols(string_view chosenFile, const vector<string> &files) {
 
     {
         // Initialize empty files.
-        for (auto &[filename, testfile] : testdata) {
+        for (auto &filename : files) {
             auto params =
-                make_unique<DidOpenTextDocumentParams>(make_unique<TextDocumentItem>(testfile.uri, "ruby", fileId++, ""));
+                make_unique<DidOpenTextDocumentParams>(make_unique<TextDocumentItem>(testdata[filename].uri, "ruby", fileId++, ""));
             auto notif = make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentDidOpen, move(params));
             // Discard responses.
             lspWrapper->getLSPResponsesFor(make_unique<LSPMessage>(move(notif)));
         }
     }
 
-    for (auto &[filename, testfile] : testdata) {
+    for (auto &filename : files) {
+        auto &testfile = testdata[filename];
         for (auto &fileEdit : testfile.edits) {
             vector<unique_ptr<TextDocumentContentChangeEvent>> edits;
             edits.push_back(make_unique<TextDocumentContentChangeEvent>(fileEdit));

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Top::Upper::Lower
+  module Bottom
+    def func; end
+  end
+end

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
@@ -59,12 +59,12 @@
                             "kind": 2,
                             "range": {
                                 "start": {
-                                    "line": 3,
-                                    "character": 2
+                                    "line": 2,
+                                    "character": 0
                                 },
                                 "end": {
-                                    "line": 3,
-                                    "character": 14
+                                    "line": 6,
+                                    "character": 3
                                 }
                             },
                             "selectionRange": {
@@ -88,8 +88,8 @@
                                             "character": 2
                                         },
                                         "end": {
-                                            "line": 3,
-                                            "character": 15
+                                            "line": 5,
+                                            "character": 5
                                         }
                                     },
                                     "selectionRange": {
@@ -114,7 +114,7 @@
                                                 },
                                                 "end": {
                                                     "line": 4,
-                                                    "character": 12
+                                                    "character": 17
                                                 }
                                             },
                                             "selectionRange": {

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
@@ -1,0 +1,141 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "Top",
+            "detail": "",
+            "kind": 2,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 10
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 10
+                }
+            },
+            "children": [
+                {
+                    "name": "Upper",
+                    "detail": "",
+                    "kind": 2,
+                    "range": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 14
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 14
+                        }
+                    },
+                    "children": [
+                        {
+                            "name": "Lower",
+                            "detail": "",
+                            "kind": 2,
+                            "range": {
+                                "start": {
+                                    "line": 3,
+                                    "character": 2
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "character": 14
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 3,
+                                    "character": 2
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "character": 14
+                                }
+                            },
+                            "children": [
+                                {
+                                    "name": "Bottom",
+                                    "detail": "",
+                                    "kind": 2,
+                                    "range": {
+                                        "start": {
+                                            "line": 3,
+                                            "character": 2
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "character": 15
+                                        }
+                                    },
+                                    "selectionRange": {
+                                        "start": {
+                                            "line": 3,
+                                            "character": 2
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "character": 15
+                                        }
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "func",
+                                            "detail": "",
+                                            "kind": 6,
+                                            "range": {
+                                                "start": {
+                                                    "line": 4,
+                                                    "character": 4
+                                                },
+                                                "end": {
+                                                    "line": 4,
+                                                    "character": 12
+                                                }
+                                            },
+                                            "selectionRange": {
+                                                "start": {
+                                                    "line": 4,
+                                                    "character": 4
+                                                },
+                                                "end": {
+                                                    "line": 4,
+                                                    "character": 12
+                                                }
+                                            },
+                                            "children": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__2.rb
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__2.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module Top::Upper
+  module Lower
+  end
+end

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__2.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__2.rb.document-symbols.exp
@@ -1,0 +1,60 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "Upper",
+            "detail": "",
+            "kind": 2,
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 2
+                },
+                "end": {
+                    "line": 3,
+                    "character": 14
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 3,
+                    "character": 2
+                },
+                "end": {
+                    "line": 3,
+                    "character": 14
+                }
+            },
+            "children": [
+                {
+                    "name": "Lower",
+                    "detail": "",
+                    "kind": 2,
+                    "range": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 14
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 14
+                        }
+                    },
+                    "children": []
+                }
+            ]
+        }
+    ]
+}

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__2.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__2.rb.document-symbols.exp
@@ -9,12 +9,12 @@
             "kind": 2,
             "range": {
                 "start": {
-                    "line": 3,
-                    "character": 2
+                    "line": 2,
+                    "character": 0
                 },
                 "end": {
-                    "line": 3,
-                    "character": 14
+                    "line": 5,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -38,8 +38,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 3,
-                            "character": 14
+                            "line": 4,
+                            "character": 5
                         }
                     },
                     "selectionRange": {

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__3.rb
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__3.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module Top
+  module Upper
+  end
+end

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__3.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__3.rb.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
-                    "character": 10
+                    "line": 5,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -38,8 +38,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 3,
-                            "character": 14
+                            "line": 4,
+                            "character": 5
                         }
                     },
                     "selectionRange": {

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__3.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__3.rb.document-symbols.exp
@@ -1,0 +1,60 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "Top",
+            "detail": "",
+            "kind": 2,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 10
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 10
+                }
+            },
+            "children": [
+                {
+                    "name": "Upper",
+                    "detail": "",
+                    "kind": 2,
+                    "range": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 14
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 14
+                        }
+                    },
+                    "children": []
+                }
+            ]
+        }
+    ]
+}

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -144,6 +144,10 @@ for this_src in "${rb_src[@]}" DUMMY; do
 
         document_symbols_candidates=()
         for src in "${srcs[@]}"; do
+          if [[ "$src" =~ .*.exp ]]; then
+            continue
+          fi
+
           src_candidate="$src.document-symbols.exp"
           if [ -e "$src_candidate" ]; then
             document_symbols_candidates=("${document_symbols_candidates[@]}" "$src_candidate")
@@ -192,6 +196,7 @@ for this_src in "${rb_src[@]}" DUMMY; do
           # See above for why this case is weird.
           for exp in "${document_symbols_candidates[@]}"; do
             wanted_file="${exp%.document-symbols.exp}"
+            # `srcs` contains all of the exp files, too, but including them should be harmless.
             echo bazel-bin/test/print_document_symbols \
               "$wanted_file" "${srcs[@]}" \
               \> "$exp" \

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -155,7 +155,7 @@ for this_src in "${rb_src[@]}" DUMMY; do
       case "$pass" in
         document-symbols)
           echo bazel-bin/test/print_document_symbols \
-            "${srcs[@]}" \
+            "${srcs[@]}" "${srcs[@]}" \
             \> "$candidate" \
             2\>/dev/null \
             >>"$COMMAND_FILE"


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We need a better document symbols test harness to move the corresponding feature to a stable LSP feature, rather than an experimental one.

The comments in `update_testdata_exp.sh` explain why document symbols is weird for the purposes of exp tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I verified that these changes + the test give the wrong (duplicated) results before #6094, giving some confidence that that PR fixed the things it said it did.

* [x] Figure out why character positions are different (but only in some cases) between the printer and the actual test harness.