### PR TITLE
track more information for better ranges on document symbols

### DIFF
--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -95,7 +95,8 @@ public:
     core::FileRef fref;
     UnorderedMap<core::SymbolRef, core::Loc> &mapping;
 
-    DefinitionLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, core::Loc> &mapping) : fref(fref), mapping(mapping) {}
+    DefinitionLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, core::Loc> &mapping)
+        : fref(fref), mapping(mapping) {}
 
     void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &expr) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(expr);

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -8,6 +8,7 @@
 using namespace std;
 
 namespace sorbet::realmain::lsp {
+namespace {
 std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef,
                                                          core::FileRef filter);
 
@@ -73,6 +74,7 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
     result->children = move(children);
     return result;
 }
+} // namespace
 
 DocumentSymbolTask::DocumentSymbolTask(const LSPConfiguration &config, MessageId id,
                                        std::unique_ptr<DocumentSymbolParams> params)

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/requests/document_symbol.h"
+#include "ast/treemap/treemap.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
@@ -10,9 +11,11 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 namespace {
 std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef,
-                                                         core::FileRef filter);
+                                                         core::FileRef filter,
+                                                         const UnorderedMap<core::SymbolRef, core::Loc> &defMapping);
 
 void symbolRef2DocumentSymbolWalkMembers(const core::GlobalState &gs, core::SymbolRef sym, core::FileRef filter,
+                                         const UnorderedMap<core::SymbolRef, core::Loc> &defMapping,
                                          vector<unique_ptr<DocumentSymbol>> &out) {
     if (!sym.isClassOrModule()) {
         return;
@@ -25,7 +28,7 @@ void symbolRef2DocumentSymbolWalkMembers(const core::GlobalState &gs, core::Symb
         if (!absl::c_any_of(mem.second.locs(gs), [&filter](const auto &loc) { return loc.file() == filter; })) {
             continue;
         }
-        auto inner = symbolRef2DocumentSymbol(gs, mem.second, filter);
+        auto inner = symbolRef2DocumentSymbol(gs, mem.second, filter, defMapping);
         if (inner) {
             out.push_back(move(inner));
         }
@@ -33,7 +36,8 @@ void symbolRef2DocumentSymbolWalkMembers(const core::GlobalState &gs, core::Symb
 }
 
 std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef,
-                                                         core::FileRef filter) {
+                                                         core::FileRef filter,
+                                                         const UnorderedMap<core::SymbolRef, core::Loc> &defMapping) {
     if (!symRef.exists()) {
         return nullptr;
     }
@@ -42,8 +46,14 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
         return nullptr;
     }
     auto kind = symbolRef2SymbolKind(gs, symRef);
-    // TODO: this range should cover body. Currently it doesn't.
-    auto range = Range::fromLoc(gs, loc);
+    auto it = defMapping.find(symRef);
+    unique_ptr<Range> range;
+    if (it != defMapping.end()) {
+        range = Range::fromLoc(gs, it->second);
+    }
+    if (range == nullptr) {
+        range = Range::fromLoc(gs, loc);
+    }
     auto selectionRange = Range::fromLoc(gs, loc);
     if (range == nullptr || selectionRange == nullptr) {
         return nullptr;
@@ -64,16 +74,48 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
     result->detail = "";
 
     vector<unique_ptr<DocumentSymbol>> children;
-    symbolRef2DocumentSymbolWalkMembers(gs, symRef, filter, children);
+    symbolRef2DocumentSymbolWalkMembers(gs, symRef, filter, defMapping, children);
     if (symRef.isClassOrModule()) {
         auto singleton = symRef.asClassOrModuleRef().data(gs)->lookupSingletonClass(gs);
         if (singleton.exists()) {
-            symbolRef2DocumentSymbolWalkMembers(gs, singleton, filter, children);
+            symbolRef2DocumentSymbolWalkMembers(gs, singleton, filter, defMapping, children);
         }
     }
     result->children = move(children);
     return result;
 }
+
+// Document symbols in the LSP spec include two different ranges: one that covers
+// the entire extent of the definition and one that covers just what should be
+// shown when the symbol is selected.  Sorbet's loc for a symbol covers the latter.
+// We do store the former, but that loc lives in the AST, not in the symbol table,
+// so we build a separate temporary mapping with this tree walker.
+class DefLocSaver {
+public:
+    core::FileRef fref;
+    UnorderedMap<core::SymbolRef, core::Loc> &mapping;
+
+    DefLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, core::Loc> &mapping) : fref(fref), mapping(mapping) {}
+
+    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &expr) {
+        auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(expr);
+        if (!klass.symbol.exists()) {
+            return;
+        }
+
+        mapping[klass.symbol] = core::Loc{fref, klass.loc};
+    }
+
+    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &expr) {
+        auto &method = ast::cast_tree_nonnull<ast::MethodDef>(expr);
+        if (!method.symbol.exists()) {
+            return;
+        }
+
+        mapping[method.symbol] = core::Loc{fref, method.loc};
+    }
+};
+
 } // namespace
 
 DocumentSymbolTask::DocumentSymbolTask(const LSPConfiguration &config, MessageId id,
@@ -160,8 +202,14 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
                        [&deduplicatedCandidates](const auto ref) { return !deduplicatedCandidates.contains(ref); }),
         candidates.end());
 
+    UnorderedMap<core::SymbolRef, core::Loc> defMapping;
+    DefLocSaver saver{fref, defMapping};
+    core::Context ctx{gs, core::Symbols::root(), fref};
+    auto resolved = typechecker.getResolved({fref});
+    ast::TreeWalk::apply(ctx, saver, resolved[0].tree);
+
     for (auto ref : candidates) {
-        auto data = symbolRef2DocumentSymbol(gs, ref, fref);
+        auto data = symbolRef2DocumentSymbol(gs, ref, fref, defMapping);
         if (data) {
             result.push_back(move(data));
         }

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -90,12 +90,12 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
 // shown when the symbol is selected.  Sorbet's loc for a symbol covers the latter.
 // We do store the former, but that loc lives in the AST, not in the symbol table,
 // so we build a separate temporary mapping with this tree walker.
-class DefLocSaver {
+class DefinitionLocSaver {
 public:
     core::FileRef fref;
     UnorderedMap<core::SymbolRef, core::Loc> &mapping;
 
-    DefLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, core::Loc> &mapping) : fref(fref), mapping(mapping) {}
+    DefinitionLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, core::Loc> &mapping) : fref(fref), mapping(mapping) {}
 
     void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &expr) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(expr);
@@ -203,7 +203,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
         candidates.end());
 
     UnorderedMap<core::SymbolRef, core::Loc> defMapping;
-    DefLocSaver saver{fref, defMapping};
+    DefinitionLocSaver saver{fref, defMapping};
     core::Context ctx{gs, core::Symbols::root(), fref};
     auto resolved = typechecker.getResolved({fref});
     ast::TreeWalk::apply(ctx, saver, resolved[0].tree);

--- a/test/testdata/lsp/bad_field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/bad_field_edits.1.rbupdate.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
-                    "character": 7
+                    "line": 4,
+                    "character": 3
                 }
             },
             "selectionRange": {

--- a/test/testdata/lsp/bad_field_edits.rb.document-symbols.exp
+++ b/test/testdata/lsp/bad_field_edits.rb.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
-                    "character": 7
+                    "line": 4,
+                    "character": 3
                 }
             },
             "selectionRange": {

--- a/test/testdata/lsp/document_symbols.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols.rb.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
-                    "character": 7
+                    "line": 21,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -64,8 +64,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 6,
-                            "character": 16
+                            "line": 8,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
@@ -90,8 +90,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 11,
-                            "character": 10
+                            "line": 15,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
@@ -116,8 +116,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 18,
-                            "character": 14
+                            "line": 20,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
@@ -144,8 +144,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 23,
-                    "character": 8
+                    "line": 41,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -195,8 +195,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 37,
-                            "character": 12
+                            "line": 40,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
@@ -221,8 +221,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 32,
-                            "character": 11
+                            "line": 34,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
@@ -249,8 +249,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 43,
-                    "character": 12
+                    "line": 60,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -274,8 +274,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 58,
-                            "character": 51
+                            "line": 59,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
@@ -302,8 +302,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 62,
-                    "character": 20
+                    "line": 78,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -327,8 +327,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 75,
-                            "character": 51
+                            "line": 77,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
@@ -355,8 +355,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 80,
-                    "character": 16
+                    "line": 83,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -381,7 +381,7 @@
                         },
                         "end": {
                             "line": 81,
-                            "character": 18
+                            "character": 23
                         }
                     },
                     "selectionRange": {
@@ -407,7 +407,7 @@
                         },
                         "end": {
                             "line": 82,
-                            "character": 20
+                            "character": 25
                         }
                     },
                     "selectionRange": {
@@ -434,8 +434,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 85,
-                    "character": 17
+                    "line": 88,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -460,7 +460,7 @@
                         },
                         "end": {
                             "line": 86,
-                            "character": 18
+                            "character": 23
                         }
                     },
                     "selectionRange": {
@@ -486,7 +486,7 @@
                         },
                         "end": {
                             "line": 87,
-                            "character": 20
+                            "character": 25
                         }
                     },
                     "selectionRange": {

--- a/test/testdata/lsp/document_symbols_crash.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_crash.1.rbupdate.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 1,
-                    "character": 7
+                    "line": 3,
+                    "character": 3
                 }
             },
             "selectionRange": {

--- a/test/testdata/lsp/document_symbols_crash.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_crash.rb.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 1,
-                    "character": 7
+                    "line": 3,
+                    "character": 3
                 }
             },
             "selectionRange": {

--- a/test/testdata/lsp/field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.1.rbupdate.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
-                    "character": 7
+                    "line": 8,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -64,8 +64,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 5,
-                            "character": 9
+                            "line": 7,
+                            "character": 5
                         }
                     },
                     "selectionRange": {

--- a/test/testdata/lsp/field_edits.2.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.2.rbupdate.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
-                    "character": 7
+                    "line": 8,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -64,8 +64,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 5,
-                            "character": 9
+                            "line": 7,
+                            "character": 5
                         }
                     },
                     "selectionRange": {

--- a/test/testdata/lsp/field_edits.rb.document-symbols.exp
+++ b/test/testdata/lsp/field_edits.rb.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 1,
-                    "character": 7
+                    "line": 7,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -64,8 +64,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 4,
-                            "character": 9
+                            "line": 6,
+                            "character": 5
                         }
                     },
                     "selectionRange": {

--- a/test/testdata/lsp/good_field_edits.1.rbupdate.document-symbols.exp
+++ b/test/testdata/lsp/good_field_edits.1.rbupdate.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
-                    "character": 7
+                    "line": 8,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -64,8 +64,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 5,
-                            "character": 9
+                            "line": 7,
+                            "character": 5
                         }
                     },
                     "selectionRange": {

--- a/test/testdata/lsp/good_field_edits.rb.document-symbols.exp
+++ b/test/testdata/lsp/good_field_edits.rb.document-symbols.exp
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 1,
-                    "character": 7
+                    "line": 7,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -64,8 +64,8 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 4,
-                            "character": 9
+                            "line": 6,
+                            "character": 5
                         }
                     },
                     "selectionRange": {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

[Document symbols in the LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol) include two different ranges: one that covers the entire extent of the symbol, and one that covers what should be selected when the symbol is shown.  Sorbet tracks both of these, but only the latter is recorded in the symbol table.  To get the former, we need to walk the AST for the requested file.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

* [x] The hypothesis here is that this change will enable VSCode to show you more precisely where you are in the file.  Verify that.