### PR TITLE
Tweak intersection types docs

### DIFF
--- a/website/docs/intersection-types.md
+++ b/website/docs/intersection-types.md
@@ -28,10 +28,10 @@ for intersection types:
 As the names indicate, union types and intersection types can be understood by
 analogy to the related operations on sets. Given `Type1` and `Type2`:
 
-- `T.any(Type1, Type2)` is the set of values that either have type `Type1` or
-  have type `Type2`.
-- `T.all(Type1, Type2)` is the set of values that both have type `Type1` and
-  have type `Type2`.
+- `T.any(Type1, Type2)` is the union of the set of values in both types:
+  values that are either of `Type1`, or of type `Type2`.
+- `T.all(Type1, Type2)` is the intersection of the set of values in both types:
+  values that of `Type1` **and** of `Type2`.
 
 An example to make things more concrete:
 

--- a/website/docs/intersection-types.md
+++ b/website/docs/intersection-types.md
@@ -28,10 +28,10 @@ for intersection types:
 As the names indicate, union types and intersection types can be understood by
 analogy to the related operations on sets. Given `Type1` and `Type2`:
 
-- `T.any(Type1, Type2)` is the union of the set of values that either have type
-  `Type1` or have type `Type2`.
-- `T.all(Type1, Type2)` is the intersection of the set of values that both have
-  type`Type1` and have type `Type2`.
+- `T.any(Type1, Type2)` is the set of values that either have type `Type1` or
+  have type `Type2`.
+- `T.all(Type1, Type2)` is the set of values that both have type `Type1` and
+  have type `Type2`.
 
 An example to make things more concrete:
 

--- a/website/docs/intersection-types.md
+++ b/website/docs/intersection-types.md
@@ -29,7 +29,7 @@ As the names indicate, union types and intersection types can be understood by
 analogy to the related operations on sets. Given `Type1` and `Type2`:
 
 - `T.any(Type1, Type2)` is the union of the set of values in both types:
-  values that are either of `Type1`, or of type `Type2`.
+  values that are either of `Type1`, or of `Type2`.
 - `T.all(Type1, Type2)` is the intersection of the set of values in both types:
   values that of `Type1` **and** of `Type2`.
 

--- a/website/docs/intersection-types.md
+++ b/website/docs/intersection-types.md
@@ -28,8 +28,8 @@ for intersection types:
 As the names indicate, union types and intersection types can be understood by
 analogy to the related operations on sets. Given `Type1` and `Type2`:
 
-- `T.any(Type1, Type2)` is the union of the set of values in both types:
-  values that are either of `Type1`, or of `Type2`.
+- `T.any(Type1, Type2)` is the union of the set of values in both types: values
+  that are either of `Type1`, or of `Type2`.
 - `T.all(Type1, Type2)` is the intersection of the set of values in both types:
   values that of `Type1` **and** of `Type2`.
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

It currently ~says:

> the union of the set of values that have X or Y

To me, this reads like:

> the union of (set of values that have X or Y)

I believe the intention is:

> the union of (set of values that have X) or (set of values that have Y)

I tried to wordsmith this a bit more to make it a bit clearer to me, hope it helps?