### PR TITLE
Allow `abstract` methods in `# typed: strong` files

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -57,7 +57,8 @@ public:
 
     void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &m = ast::cast_tree_nonnull<ast::MethodDef>(tree);
-        if (ctx.file.data(ctx).strictLevel < core::StrictLevel::True || m.symbol.data(ctx)->flags.isOverloaded) {
+        if (ctx.file.data(ctx).strictLevel < core::StrictLevel::True || m.symbol.data(ctx)->flags.isOverloaded ||
+            (m.symbol.data(ctx)->flags.isAbstract && ctx.file.data(ctx).compiledLevel != core::CompiledLevel::True)) {
             return;
         }
         auto &print = opts.print;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3845,7 +3845,10 @@ public:
             }
 
             // Rewrite the empty body of the abstract method to forward all arguments to `super`, mirroring the
-            // behavior of the runtime.
+            // behavior of the runtime, but only in compiled files.
+            if (ctx.file.data(ctx).compiledLevel != core::CompiledLevel::True) {
+                return;
+            }
             ast::Send::ARGS_store args;
 
             auto argIdx = -1;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -63,7 +63,8 @@ public:
     void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &m = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
-        if (m.symbol.data(ctx)->flags.isOverloaded) {
+        if (m.symbol.data(ctx)->flags.isOverloaded ||
+            (m.symbol.data(ctx)->flags.isAbstract && ctx.file.data(ctx).compiledLevel != core::CompiledLevel::True)) {
             return;
         }
         auto cfg = cfg::CFGBuilder::buildFor(ctx.withOwner(m.symbol), m);

--- a/test/testdata/infer/generics/option.rb
+++ b/test/testdata/infer/generics/option.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 
 class Module
   include T::Sig


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

While writing certain generic abstractions, I wanted to ensure that
`T.untyped` never appeared in the implementation of any of my generic
classes.

The change as implemented forces the user to choose either `# compiled:
true`
or `# typed: strong` for a file containing an `abstract` method.

This might also contribute a slight performance improvement, by skipping
`CFG` construction and inference for abstract methods.

This comes at the cost of no longer type checking default arguments
against their provided types in abstract methods, but arguably this is
fine, as the default values for an abstract method's parameters are
never actually used at runtime.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.