### PR TITLE
use a non-initializing allocator for (de)serialization buffers

### DIFF
--- a/core/serialize/pickler.h
+++ b/core/serialize/pickler.h
@@ -17,10 +17,30 @@ public:
     Pickler() = default;
 };
 
+// Allocator adaptor that interposes construct() calls to
+// convert value initialization into default initialization.
+template <typename T, typename A = std::allocator<T>> class default_init_allocator : public A {
+    typedef std::allocator_traits<A> a_t;
+
+public:
+    template <typename U> struct rebind {
+        using other = default_init_allocator<U, typename a_t::template rebind_alloc<U>>;
+    };
+
+    using A::A;
+
+    template <typename U> void construct(U *ptr) noexcept(std::is_nothrow_default_constructible<U>::value) {
+        ::new (static_cast<void *>(ptr)) U;
+    }
+    template <typename U, typename... Args> void construct(U *ptr, Args &&...args) {
+        a_t::construct(static_cast<A &>(*this), ptr, std::forward<Args>(args)...);
+    }
+};
+
 class UnPickler {
     int pos;
     uint8_t zeroCounter = 0;
-    std::vector<uint8_t> data;
+    std::vector<uint8_t, default_init_allocator<uint8_t>> data;
 
 public:
     uint32_t getU4();


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fewer dead writes to memory during deserialization, which should theoretically be faster.

(The same principle can be applied to the serialization buffers, but that is a more invasive change.  At the moment this is more of a gut check.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
