### PR TITLE
Add some explicit Exception::raise for some crashes

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -928,6 +928,15 @@ public:
         auto methodData = methodDef.symbol.data(ctx);
         auto ownerData = methodData->owner.data(ctx);
 
+        if (methodData->locs().empty()) {
+            Exception::raise("method has no locs! ctx.file=\"{}\" method=\"{}\"", ctx.file.data(ctx).path(),
+                             methodDef.symbol.show(ctx));
+        }
+        if (!methodData->loc().file().exists()) {
+            Exception::raise("file for method does not exist! ctx.file=\"{}\" method=\"{}\"", ctx.file.data(ctx).path(),
+                             methodDef.symbol.show(ctx));
+        }
+
         // Only perform this check if this isn't a module from the stdlib, and
         // if there are type members in the owning context.
         // NOTE: We're skipping variance checks on the stdlib right now, as


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We're seeing `nullptr` dereference segfaults around this code and I can't
tell why. I want to have explicit exceptions here, which should cause
the errors to show up in the logs better.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.