### PR TITLE
Fix crash with bad format string in parser error

### DIFF
--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -63,7 +63,7 @@ void explainError(core::GlobalState &gs, core::FileRef file, core::ErrorBuilder 
                 if (lCurlyPos != string::npos && rCurlyPos != string::npos) {
                     replacement[lCurlyPos] = '(';
                     replacement[rCurlyPos] = ')';
-                    e.replaceWith("Replace the curly braces with parens", loc, replacement);
+                    e.replaceWith("Replace the curly braces with parens", loc, "{}", replacement);
                 }
             }
             break;

--- a/test/testdata/parser/crash_block_pass_suggestion.rb
+++ b/test/testdata/parser/crash_block_pass_suggestion.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  def example
+    example{&:"{}"}
+    #      ^^^^^^^^ error: block pass should not be enclosed in curly braces
+  end
+end

--- a/test/testdata/parser/crash_block_pass_suggestion.rb.autocorrects.exp
+++ b/test/testdata/parser/crash_block_pass_suggestion.rb.autocorrects.exp
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  def example
+    example(&:"{}")
+    #      ^^^^^^^^ error: block pass should not be enclosed in curly braces
+  end
+end

--- a/test/testdata/parser/crash_block_pass_suggestion.rb.autocorrects.exp
+++ b/test/testdata/parser/crash_block_pass_suggestion.rb.autocorrects.exp
@@ -1,3 +1,4 @@
+# -- test/testdata/parser/crash_block_pass_suggestion.rb --
 # typed: true
 
 class A
@@ -6,3 +7,4 @@ class A
     #      ^^^^^^^^ error: block pass should not be enclosed in curly braces
   end
 end
+# ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Noticed in our production logs that somehow people were hitting this :say-what:

I don't even want to know what kind of code they were writing but it should
nonetheless be fixed now.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.