### PR TITLE
Fix crash in go_to_type_definition.cc

### DIFF
--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -30,6 +30,9 @@ void DefLocSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &
             // localExp should never be null, but guard against the possibility.
             if (localExp && lspQuery.matchesLoc(ctx.locAt(localExp->loc))) {
                 tp.type = argType.type;
+                if (tp.type == nullptr) {
+                    tp.type = core::Types::untyped(ctx, methodDef.symbol);
+                }
                 tp.origins.emplace_back(ctx.locAt(localExp->loc));
                 core::lsp::QueryResponse::pushQueryResponse(
                     ctx,

--- a/test/testdata/lsp/go_to_type_definition.rb
+++ b/test/testdata/lsp/go_to_type_definition.rb
@@ -48,4 +48,9 @@ class TestClass
   a_or_b_or_mn = T.let(A.new, T.any(A, B, T.all(M, N)))
   puts a_or_b_or_mn
   #    ^ type: ABMN
+
+  def example(x)
+    #         ^ type: (nothing)
+  end
 end
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In other locations where we push a `QueryResponse`, we check for `nullptr` and
default it to `T.untyped`.

We were not doing this for `IdentResponse` in method definitions.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See the commit history to see that the new test yielded a crash when run before
the fix in this PR.