### PR TITLE
Better error when the LHS of an `&&` is always true

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1098,6 +1098,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 auto rhs = node2TreeImpl(dctx, std::move(and_->right));
                 if (isa_reference(lhs)) {
                     auto cond = MK::cpRef(lhs);
+                    // TODO(jez) How to handle this case?
                     auto iff = MK::If(loc, std::move(cond), std::move(rhs), std::move(lhs));
                     result = std::move(iff);
                 } else {
@@ -1125,8 +1126,10 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     } else {
                         thenp = std::move(rhs);
                     }
+                    auto lhsLoc = lhs.loc();
                     auto temp = MK::Assign(loc, andAndTemp, std::move(lhs));
-                    auto iff = MK::If(loc, MK::Local(loc, andAndTemp), std::move(thenp), MK::Local(loc, andAndTemp));
+                    auto iff =
+                        MK::If(loc, MK::Local(lhsLoc, andAndTemp), std::move(thenp), MK::Local(lhsLoc, andAndTemp));
                     auto wrapped = MK::InsSeq1(loc, std::move(temp), std::move(iff));
                     result = std::move(wrapped);
                 }

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -175,6 +175,10 @@ bool LSPIndexer::canTakeFastPathInternal(
         }
     }
 
+    {
+        // TODO(jez)
+    }
+
     logger.debug("Taking fast path");
     return true;
 }

--- a/test/cli/and-and-always-truthy/test.out
+++ b/test/cli/and-and-always-truthy/test.out
@@ -1,0 +1,22 @@
+test/cli/and-and-always-truthy/test.rb:11: This code is unreachable https://srb.help/7006
+    11 |  if always_true && T.unsafe(true)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    test/cli/and-and-always-truthy/test.rb:11: This condition was always `truthy` (`TrueClass`)
+    11 |  if always_true && T.unsafe(true)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `TrueClass` originating from:
+    test/cli/and-and-always-truthy/test.rb:11:
+    11 |  if always_true && T.unsafe(true)
+             ^^^^^^^^^^^
+
+test/cli/and-and-always-truthy/test.rb:17: This code is unreachable https://srb.help/7006
+    17 |  if always_false && T.unsafe(true)
+                             ^^^^^^^^^^^^^^
+    test/cli/and-and-always-truthy/test.rb:17: This condition was always `falsy` (`FalseClass`)
+    17 |  if always_false && T.unsafe(true)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `FalseClass` originating from:
+    test/cli/and-and-always-truthy/test.rb:17:
+    17 |  if always_false && T.unsafe(true)
+             ^^^^^^^^^^^^
+Errors: 2

--- a/test/cli/and-and-always-truthy/test.out
+++ b/test/cli/and-and-always-truthy/test.out
@@ -1,9 +1,9 @@
-test/cli/and-and-always-truthy/test.rb:11: This code is unreachable https://srb.help/7006
+test/cli/and-and-always-truthy/test.rb:11: Left side of `&&` condition was always `truthy` https://srb.help/7006
     11 |  if always_true && T.unsafe(true)
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             ^^^^^^^^^^^
     test/cli/and-and-always-truthy/test.rb:11: This condition was always `truthy` (`TrueClass`)
     11 |  if always_true && T.unsafe(true)
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             ^^^^^^^^^^^
   Got `TrueClass` originating from:
     test/cli/and-and-always-truthy/test.rb:11:
     11 |  if always_true && T.unsafe(true)
@@ -14,7 +14,7 @@ test/cli/and-and-always-truthy/test.rb:17: This code is unreachable https://srb.
                              ^^^^^^^^^^^^^^
     test/cli/and-and-always-truthy/test.rb:17: This condition was always `falsy` (`FalseClass`)
     17 |  if always_false && T.unsafe(true)
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             ^^^^^^^^^^^^
   Got `FalseClass` originating from:
     test/cli/and-and-always-truthy/test.rb:17:
     17 |  if always_false && T.unsafe(true)

--- a/test/cli/and-and-always-truthy/test.rb
+++ b/test/cli/and-and-always-truthy/test.rb
@@ -1,0 +1,19 @@
+# typed: true
+extend T::Sig
+
+sig {returns(TrueClass)}
+def always_true; true; end
+
+sig {returns(FalseClass)}
+def always_false; false; end
+
+def example1
+  if always_true && T.unsafe(true)
+    puts 'here'
+  end
+end
+
+def example2
+  if always_false && T.unsafe(true)
+  end
+end

--- a/test/cli/and-and-always-truthy/test.sh
+++ b/test/cli/and-and-always-truthy/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+main/sorbet --silence-dev-message test/cli/and-and-always-truthy/test.rb 2>&1

--- a/test/cli/autocorrect_and_and/test.out
+++ b/test/cli/autocorrect_and_and/test.out
@@ -9,9 +9,6 @@ autocorrect_and_and.rb:12: Call to method `even?` after `&&` assumes result type
     autocorrect_and_and.rb:12:
     12 |    if a.foo && a.foo.even?
                ^^^^^
-    autocorrect_and_and.rb:12:
-    12 |    if a.foo && a.foo.even?
-               ^^^^^^^^^^^^^^^^^^^^
   Note:
     Sorbet never assumes that a method called twice returns the same result both times.
     Either factor out a variable or use `&.`
@@ -34,9 +31,6 @@ autocorrect_and_and.rb:17: Call to method `even?` after `&&` assumes result type
     autocorrect_and_and.rb:16:
     16 |    if a.foo &&
                ^^^^^
-    autocorrect_and_and.rb:16:
-    16 |    if a.foo &&
-    17 |        a.foo.even?
   Note:
     Sorbet never assumes that a method called twice returns the same result both times.
     Either factor out a variable or use `&.`
@@ -59,9 +53,6 @@ autocorrect_and_and.rb:22: Call to method `even?` after `&&` assumes result type
     autocorrect_and_and.rb:21:
     21 |    if foo &&
                ^^^
-    autocorrect_and_and.rb:21:
-    21 |    if foo &&
-    22 |        foo.even?
   Note:
     Sorbet never assumes that a method called twice returns the same result both times.
     Either factor out a variable or use `&.`
@@ -96,9 +87,6 @@ autocorrect_and_and.rb:36: Call to method `even?` after `&&` assumes result type
     autocorrect_and_and.rb:35:
     35 |    if a.foo && a.foo.
                ^^^^^
-    autocorrect_and_and.rb:35:
-    35 |    if a.foo && a.foo.
-    36 |        even?
   Note:
     Sorbet never assumes that a method called twice returns the same result both times.
     Either factor out a variable or use `&.`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #6138


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.