### PR TITLE
use a non-initializing allocator for stable string storage buffers

### DIFF
--- a/common/StableStringStorage.h
+++ b/common/StableStringStorage.h
@@ -7,7 +7,28 @@
 
 namespace sorbet {
 
+// Allocator adaptor that interposes construct() calls to
+// convert value initialization into default initialization.
+template <typename T, typename A = std::allocator<T>> class default_init_allocator : public A {
+    typedef std::allocator_traits<A> a_t;
+
+public:
+    template <typename U> struct rebind {
+        using other = default_init_allocator<U, typename a_t::template rebind_alloc<U>>;
+    };
+
+    using A::A;
+
+    template <typename U> void construct(U *ptr) noexcept(std::is_nothrow_default_constructible<U>::value) {
+        ::new (static_cast<void *>(ptr)) U;
+    }
+    template <typename U, typename... Args> void construct(U *ptr, Args &&...args) {
+        a_t::construct(static_cast<A &>(*this), ptr, std::forward<Args>(args)...);
+    }
+};
+
 template <size_t PageSize = 4096> class StableStringStorage {
+    using Buffer = std::vector<char, default_init_allocator<char>>;
 public:
     StableStringStorage() = default;
 
@@ -24,7 +45,7 @@ public:
     std::string_view enterString(std::string_view str);
 
 private:
-    std::vector<std::shared_ptr<std::vector<char>>> strings;
+    std::vector<std::shared_ptr<Buffer>> strings;
     size_t currentPagePosition = PageSize + 1;
 };
 
@@ -42,7 +63,7 @@ StableStringStorage<PageSize> &StableStringStorage<PageSize>::operator=(const St
 template <size_t PageSize> std::string_view StableStringStorage<PageSize>::enterString(std::string_view str) {
     char *from = nullptr;
     if (str.size() > PageSize) {
-        auto &inserted = strings.emplace_back(std::make_unique<std::vector<char>>(str.size()));
+        auto &inserted = strings.emplace_back(std::make_unique<Buffer>(str.size()));
         from = inserted->data();
         if (strings.size() > 1) {
             // last page wasn't full, keep it in the end
@@ -53,12 +74,12 @@ template <size_t PageSize> std::string_view StableStringStorage<PageSize>::enter
         } else {
             // Insert a new empty page at the end to enforce the invariant that inserting a huge string will always
             // leave a page that can be written to at the end of the table.
-            strings.emplace_back(std::make_unique<std::vector<char>>(PageSize));
+            strings.emplace_back(std::make_unique<Buffer>(PageSize));
             currentPagePosition = 0;
         }
     } else {
         if (currentPagePosition + str.size() > PageSize) {
-            strings.emplace_back(std::make_unique<std::vector<char>>(PageSize));
+            strings.emplace_back(std::make_unique<Buffer>(PageSize));
             currentPagePosition = 0;
         }
         from = strings.back()->data() + currentPagePosition;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Same reason as #6129, but with a slightly large effect radius.

(Also may be worth exploring whether we should hold memory buffers directly, rather than indirecting through `vector` all the time.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
