### PR TITLE
LSP ErrorReporter: Do not report extraneous empty error lists to the client.

### DIFF
--- a/main/lsp/LSPOutput.cc
+++ b/main/lsp/LSPOutput.cc
@@ -69,6 +69,11 @@ vector<unique_ptr<LSPMessage>> LSPOutputToVector::getOutput() {
     return messages;
 }
 
+uint32_t LSPOutputToVector::size() {
+    absl::MutexLock lock(&mtx);
+    return output.size();
+}
+
 unique_ptr<LSPMessage> LSPOutputToVector::read(int timeoutMs) {
     absl::MutexLock lock(&mtx);
     mtx.AwaitWithTimeout(absl::Condition(

--- a/main/lsp/LSPOutput.h
+++ b/main/lsp/LSPOutput.h
@@ -70,6 +70,12 @@ public:
     std::vector<std::unique_ptr<LSPMessage>> getOutput();
 
     /**
+     * Counts the number of messages in the internal vector.
+     * Used in tests.
+     */
+    uint32_t size();
+
+    /**
      * Blocking read. Waits until the next message is available, or the given timeout occurs. If a timeout occurs, it
      * returns nullptr.
      */


### PR DESCRIPTION
LSP ErrorReporter: Do not report extraneous empty error lists to the client.

Sorbet only needs to send empty error lists to the client when it has previously sent errors for a file that now has no errors.

Before this change, when the client has `lspErrorCap` errors, the ErrorReporter would report an empty error list for
any file with errors that exceed the cap -- even if Sorbet had never sent errors for that file before.
This can freeze VS Code (DoS due to many messages) if you make a catastrophic typo that causes many files to error.

This PR changes `clientErrorCount` to count the errors _reported_ to the client (as it should), and not the total number of errors in the last epoch.
Similarly, `FileErrorStatus.errorCount` now tracks the errors _reported_ to the client, and not the errors in the last epoch.

Now, we can avoid sending unneeded empty lists when `errorCount == 0` from the last epoch and `errorsToReport == 0`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet was freezing VS Code at Stripe when it was run before some core code generation routines finished. The source of the freeze was Sorbet spamming empty error lists at VS Code for nearly every source file in our repository.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
