### PR TITLE
move document symbols enablement into beta

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -764,7 +764,7 @@ void readOptions(Options &opts,
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
         opts.lspAllBetaFeaturesEnabled = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();
         opts.lspDocumentSymbolEnabled =
-            enableAllLSPFeatures || raw["enable-experimental-lsp-document-symbol"].as<bool>();
+            opts.lspAllBetaFeaturesEnabled || raw["enable-experimental-lsp-document-symbol"].as<bool>();
         opts.lspDocumentHighlightEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-highlight"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

People keep asking for this feature at Stripe, and we keep having them to enable experimental features to do it.  We've had a small number of people testing this for a while and our internal logs show that it's stable enough.

Ergo, let's roll it out to a wider audience by making it a beta feature (enabled by default on all Stripe developer machines).

Note that this is not changing the name of the option, which is somewhat unfortunate, but if this beta test shows that document symbols is as stable as we think it is, we can make document symbols stable in Sorbet by default, deprecate the option, and eventually remove it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
