### PR TITLE
Skip already-added files in fast path decision

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -366,6 +366,9 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     vector<ast::ParsedFile> updatedIndexed;
     for (auto &f : allFiles) {
         // TODO(jvilk): We don't need to re-index files that didn't change.
+        // (`updates` has already-indexed trees, but they've been indexed with initialGS, not the
+        // `*gs` that we'll be typechecking with. We could do an ast::Substitute here if we had
+        // access to `initialGS`, but that's owned by the indexer thread, not this thread.)
         auto t = pipeline::indexOne(config->opts, *gs, f);
         updatedIndexed.emplace_back(ast::ParsedFile{t.tree.deepCopy(), t.file});
         updates.updatedFinalGSFileIndexes.push_back(move(t));

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -236,7 +236,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
 
     Timer timeit(config->logger, "fast_path");
     UnorderedSet<core::FileRef> changedFiles;
-    vector<core::FileRef> extraFiles;
+    vector<core::FileRef> allFiles;
     vector<core::ShortNameHash> changedSymbolNameHashes;
     UnorderedMap<core::FileRef, core::FoundMethodHashes> oldFoundMethodHashesForFiles;
     // Replace error queue with one that is owned by this thread.
@@ -347,16 +347,12 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                     continue;
                 }
 
-                extraFiles.emplace_back(ref);
+                allFiles.emplace_back(ref);
             }
         }
-        config->logger->debug("Added {} files that were not part of the edit to the update set", extraFiles.size());
+        config->logger->debug("Added {} files that were not part of the edit to the update set", allFiles.size());
     }
-    vector<core::FileRef> allFiles;
     for (auto f : changedFiles) {
-        allFiles.emplace_back(f);
-    }
-    for (auto f : extraFiles) {
         allFiles.emplace_back(f);
     }
     fast_sort(allFiles);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This _should_ make the list of files free of duplicates by construction.

It also makes it easier for us to have the `gs->getFiles()` loop short
circuit once it adds too many files (deferring to a future change
because that might come after we move this logic from LSPTypechecker.cc
to LSPIndexer.cc).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.