### PR TITLE
Add `class_eval` test

### DIFF
--- a/test/testdata/infer/class_eval.rb
+++ b/test/testdata/infer/class_eval.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+def foo
+  (class << self; self; end).class_eval # error: Method `class_eval` does not exist on `NilClass`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Follow up to #3794, adds a test to ensure error `Method class_eval does not exist on NilClass` is raised instead of crashing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
