### PR TITLE
Don't retypecheck payload files on incremental fast path

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -334,6 +334,12 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                     continue; // See note above about --stripe-packages.
                 }
 
+                if (oldFile->isPayload()) {
+                    // Don't retypecheck files in the payload via incremental namer, as that might
+                    // cause well-known symbols to get deleted and assigned a new SymbolRef ID.
+                    continue;
+                }
+
                 ENFORCE(oldFile->getFileHash() != nullptr);
                 const auto &oldHash = *oldFile->getFileHash();
                 vector<core::ShortNameHash> intersection;

--- a/test/testdata/lsp/fast_path/each.1.rbupdate
+++ b/test/testdata/lsp/fast_path/each.1.rbupdate
@@ -1,0 +1,30 @@
+# typed: true
+# assert-slow-path: false
+
+class A
+  extend T::Sig
+  extend T::Generic
+  include Enumerable
+
+  Elem = type_member {{fixed: String}}
+
+  sig do
+    override.
+    params(
+        blk: T.proc.params(arg0: Elem).returns(BasicObject),
+    )
+    .returns(T.untyped)
+  end
+  def each(&blk)
+    yield ''
+  end
+
+  sig {params(xs: T::Array[Integer]).void}
+  def example(xs)
+    xs.each do |x|
+      T.reveal_type(x) # error: `Integer`
+      x.even?
+    end
+  end
+end
+

--- a/test/testdata/lsp/fast_path/each.1.rbupdate
+++ b/test/testdata/lsp/fast_path/each.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: false
+# assert-fast-path: each.rb
 
 # This test at one point failed because we make use of the Array#[] intrinsic
 # in one of the steps to load the types of block arguments

--- a/test/testdata/lsp/fast_path/each.1.rbupdate
+++ b/test/testdata/lsp/fast_path/each.1.rbupdate
@@ -1,6 +1,9 @@
 # typed: true
 # assert-slow-path: false
 
+# This test at one point failed because we make use of the Array#[] intrinsic
+# in one of the steps to load the types of block arguments
+
 class A
   extend T::Sig
   extend T::Generic

--- a/test/testdata/lsp/fast_path/each.rb
+++ b/test/testdata/lsp/fast_path/each.rb
@@ -1,0 +1,29 @@
+# typed: true
+
+class A
+  extend T::Sig
+  extend T::Generic
+  include Enumerable
+
+  Elem = type_member {{fixed: String}}
+
+  sig do
+    override.
+    params(
+        blk: T.proc.params(arg0: Elem).void,
+    )
+    .returns(T.untyped)
+  end
+  def each(&blk) # error: Block parameter `blk` of type `T.proc.params(arg0: A::Elem).void` not compatible with type of abstract method `Enumerable#each`
+    yield ''
+  end
+
+  sig {params(xs: T::Array[Integer]).void}
+  def example(xs)
+    xs.each do |x|
+      T.reveal_type(x) # error: `Integer`
+      x.even?
+    end
+  end
+end
+

--- a/test/testdata/lsp/fast_path/each.rb
+++ b/test/testdata/lsp/fast_path/each.rb
@@ -1,5 +1,8 @@
 # typed: true
 
+# This test at one point failed because we make use of the Array#[] intrinsic
+# in one of the steps to load the types of block arguments
+
 class A
   extend T::Sig
   extend T::Generic

--- a/test/testdata/lsp/fast_path/intrinsics.1.rbupdate
+++ b/test/testdata/lsp/fast_path/intrinsics.1.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# assert-fast-path: intrinsics.rb
+
+def sample(x); end
+def ===(x); end
+def [](x); end
+def proc(x); end
+
+T.reveal_type([1, 2, 3].sample) # error: `Integer`
+T.reveal_type(Integer.===(0)) # error: `TrueClass`
+T.reveal_type(Integer.===('')) # error: `FalseClass`
+T.reveal_type(T::Array[T.proc.params(x: Integer).void].new) # error: `T::Array[T.proc.params(arg0: Integer).void]`

--- a/test/testdata/lsp/fast_path/intrinsics.rb
+++ b/test/testdata/lsp/fast_path/intrinsics.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+def sample; end
+def ===; end
+def []; end
+def proc; end
+
+T.reveal_type([1, 2, 3].sample) # error: `Integer`
+T.reveal_type(Integer.===(0)) # error: `TrueClass`
+T.reveal_type(Integer.===('')) # error: `FalseClass`
+T.reveal_type(T::Array[T.proc.params(x: Integer).void].new) # error: `T::Array[T.proc.params(arg0: Integer).void]`

--- a/test/testdata/packager/package_payload_fast_path/a.1.rbupdate
+++ b/test/testdata/packager/package_payload_fast_path/a.1.rbupdate
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # typed: strict
-# assert-fast-path: a.rb,https://github.com/sorbet/sorbet/tree/master/rbi/core/thread.rbi,https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/bundler.rbi,https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/erb.rbi,https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/irb.rbi,https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/rdoc.rbi,https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/rubygems.rbi,https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/webrick.rbi
+# assert-fast-path: a.rb
 
 # Various things in the standard library mention `run`, so we currently type check them on the fast path.
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Re-typechecking the payload files on the incremental fast path has the potential to do two things, both of which are bad:

- delete methods associated with well-known SymbolRef IDs
- delete methods which have had intrinsics registered for them

There are possibly multiple ways to solve this, but I have chosen the one which is "don't re-run incremental namer on payload files"

I think this should be fine, because it is essentially already what the slowpath will do (that is, the slow path is able to correctly type check *new* files without needing to be fed the list of payload files in `pipeline::resolve` or `pipeline::typecheck`).

### Alternatives considered

In the case that this approach *does* happen to bite us, some approaches which I tried and punted on, but which we may wish to reconsider:

- run incremental namer on payload files, but (1) never delete well-known (synthetic) symbols or symbols that have intrinsics associated with them
  - I tried this, but there was some subtlety around how overloads were handled which meant that it didn't work. luckily we had tests that failed when i went with this approach.
- run incremental namer on payload files. after it has deleted what it needs to delete (possibly including well-known symbols or symbols with intrinsics), re-run `GlobalState::initEmpty`
  - I did not try this, because I noticed that there were at least a few places in `initEmpty` where it was not idempotent (for example, `files.emplace_back()` to create the `core::File` with ID `0`. Also all the `synthesizeClass` do the same, but with `classAndModules.emplace_back()`). We could probably get `initEmpty` to be idempotent, but ENFORCE'ing that it remains idempotent going forward seems tricky (or maybe not? maybe it would suffice to just run `DEBUG_ONLY(initEmpty())` immediately after the first call, and see that it doesn't add anything or something).

In any case, I think that the approach above of skipping payload files should actually be fine.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.