### PR TITLE
Allow `sorbet.*` VS Code commands from anywhere

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -255,20 +255,16 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "sorbet.configure",
-          "when": "editorLangId == ruby"
+          "command": "sorbet.configure"
         },
         {
-          "command": "sorbet.disable",
-          "when": "editorLangId == ruby"
+          "command": "sorbet.disable"
         },
         {
-          "command": "sorbet.enable",
-          "when": "editorLangId == ruby"
+          "command": "sorbet.enable"
         },
         {
-          "command": "sorbet.restart",
-          "when": "editorLangId == ruby"
+          "command": "sorbet.restart"
         },
         {
           "command": "sorbet.showOutput",


### PR DESCRIPTION
cc @jeffjo-stripe

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, Sorbet required that you have a Ruby file actively opened,
for these commands to even appear in the command palette. As far as I
can tell, none of those commands depend on the currently open file to
function correctly.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested this change manually a few times to verify that I can still
configure and restart sorbet even when there is no Ruby file open.