### PR TITLE
use `absl::c_any_of` to clarify document symbols code

### DIFF
--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -168,11 +168,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
                 continue;
             }
 
-            for (auto definitionLocation : ref.locs(gs)) {
-                if (definitionLocation.file() != fref) {
-                    continue;
-                }
-
+            if (absl::c_any_of(ref.locs(gs), [&fref](const auto &loc) { return loc.file() == fref; })) {
                 candidates.emplace_back(ref);
             }
         }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's sort of obvious from this loop that we're only adding `ref` once to `candidates`, but you need to know something about how Sorbet manages locs to determine that.  Make the check more straightforward so it's clear we only add the ref once.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
