### PR TITLE
force output of children on the ownership chain in document symbols

### DIFF
--- a/test/testdata/lsp/dropped_document_symbols__0.rb
+++ b/test/testdata/lsp/dropped_document_symbols__0.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module Top::Upper::Lower::Bottom
+  class Private::Basement::Primus
+  end
+end

--- a/test/testdata/lsp/dropped_document_symbols__1.rb
+++ b/test/testdata/lsp/dropped_document_symbols__1.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+module Top::Upper::Lower::Bottom
+  class Private::Basement::Actual
+    def interesting_function; end
+    def boring_function; end
+  end
+end

--- a/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
@@ -1,0 +1,33 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "Bottom",
+            "detail": "",
+            "kind": 2,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 7,
+                    "character": 3
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 32
+                }
+            },
+            "children": []
+        }
+    ]
+}

--- a/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
@@ -27,7 +27,141 @@
                     "character": 32
                 }
             },
-            "children": []
+            "children": [
+                {
+                    "name": "Private",
+                    "detail": "",
+                    "kind": 2,
+                    "range": {
+                        "start": {
+                            "line": 3,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 15
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 3,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 15
+                        }
+                    },
+                    "children": [
+                        {
+                            "name": "Basement",
+                            "detail": "",
+                            "kind": 2,
+                            "range": {
+                                "start": {
+                                    "line": 3,
+                                    "character": 8
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "character": 25
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 3,
+                                    "character": 8
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "character": 25
+                                }
+                            },
+                            "children": [
+                                {
+                                    "name": "Actual",
+                                    "detail": "",
+                                    "kind": 5,
+                                    "range": {
+                                        "start": {
+                                            "line": 3,
+                                            "character": 2
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "character": 5
+                                        }
+                                    },
+                                    "selectionRange": {
+                                        "start": {
+                                            "line": 3,
+                                            "character": 2
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "character": 33
+                                        }
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "boring_function",
+                                            "detail": "",
+                                            "kind": 6,
+                                            "range": {
+                                                "start": {
+                                                    "line": 5,
+                                                    "character": 4
+                                                },
+                                                "end": {
+                                                    "line": 5,
+                                                    "character": 28
+                                                }
+                                            },
+                                            "selectionRange": {
+                                                "start": {
+                                                    "line": 5,
+                                                    "character": 4
+                                                },
+                                                "end": {
+                                                    "line": 5,
+                                                    "character": 23
+                                                }
+                                            },
+                                            "children": []
+                                        },
+                                        {
+                                            "name": "interesting_function",
+                                            "detail": "",
+                                            "kind": 6,
+                                            "range": {
+                                                "start": {
+                                                    "line": 4,
+                                                    "character": 4
+                                                },
+                                                "end": {
+                                                    "line": 4,
+                                                    "character": 33
+                                                }
+                                            },
+                                            "selectionRange": {
+                                                "start": {
+                                                    "line": 4,
+                                                    "character": 4
+                                                },
+                                                "end": {
+                                                    "line": 4,
+                                                    "character": 28
+                                                }
+                                            },
+                                            "children": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/test/testdata/lsp/dropped_document_symbols__2.rb
+++ b/test/testdata/lsp/dropped_document_symbols__2.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module Top::Upper::Lower::Bottom
+  class Private::Basement::Imaginary
+  end
+end

--- a/test/testdata/lsp/dropped_document_symbols__3.rb
+++ b/test/testdata/lsp/dropped_document_symbols__3.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module Top::Upper::Lower::Bottom
+  class Private::Basement::Ordinary
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This came up via a Stripe tester.  Ideally the commit history + the associated comment explains what's going wrong.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I think the checks that we already have for children appearing in the relevant file will prevent an explosion of symbols here: e.g. for the `A::B::C::D::E` example given in the comments, we'll avoid outputting any children of `B`, `C`, or `D` that don't appear in the current file already.

* [ ] Double check that this fixes the issue on the relevant file