### PR TITLE
Desugar lazily initialized variable values into temporary statements

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1249,8 +1249,19 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     if ((recvIsIvarLhs || recvIsCvarLhs) && (tlet = asTLet(arg))) {
                         auto val = std::move(tlet->getPosArg(0));
                         tlet->getPosArg(0) = MK::cpRef(lhs);
+
+                        auto tempLocalName = dctx.freshNameUnique(core::Names::statTemp());
+                        auto tempLocal = MK::Local(loc, tempLocalName);
+                        auto value = MK::Assign(loc, MK::cpRef(tempLocal), std::move(val));
+
                         auto decl = MK::Assign(loc, MK::cpRef(lhs), std::move(arg));
-                        elsep = MK::InsSeq1(loc, std::move(decl), MK::Assign(loc, std::move(lhs), std::move(val)));
+                        auto assign = MK::Assign(loc, MK::cpRef(lhs), std::move(tempLocal));
+
+                        InsSeq::STATS_store stats;
+                        stats.emplace_back(std::move(value));
+                        stats.emplace_back(std::move(decl));
+
+                        elsep = MK::InsSeq(loc, std::move(stats), std::move(assign));
                     } else {
                         elsep = MK::Assign(loc, std::move(lhs), std::move(arg));
                     }

--- a/test/testdata/desugar/oror_classvar.rb.desugar-tree.exp
+++ b/test/testdata/desugar/oror_classvar.rb.desugar-tree.exp
@@ -10,8 +10,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @@supported_methods
     else
       begin
+        <statTemp>$2 = nil
         @@supported_methods = <emptyTree>::<C T>.let(@@supported_methods, <emptyTree>::<C T>.nilable(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
-        @@supported_methods = nil
+        @@supported_methods = <statTemp>$2
       end
     end
 

--- a/test/testdata/desugar/oror_ivar.rb.desugar-tree.exp
+++ b/test/testdata/desugar/oror_ivar.rb.desugar-tree.exp
@@ -20,8 +20,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           @supported_methods
         else
           begin
+            <statTemp>$2 = ["fast", "slow", "special"].uniq().freeze()
             @supported_methods = <emptyTree>::<C T>.let(@supported_methods, <emptyTree>::<C T>.nilable(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
-            @supported_methods = ["fast", "slow", "special"].uniq().freeze()
+            @supported_methods = <statTemp>$2
           end
         end
         <emptyTree>::<C T>.reveal_type(@supported_methods)
@@ -38,8 +39,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         @initialized_to_nilable
       else
         begin
+          <statTemp>$2 = nil
           @initialized_to_nilable = <emptyTree>::<C T>.let(@initialized_to_nilable, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
-          @initialized_to_nilable = nil
+          @initialized_to_nilable = <statTemp>$2
         end
       end
     end
@@ -53,8 +55,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         @lazy_boolean
       else
         begin
+          <statTemp>$2 = <self>.expensively_compute_boolean()
           @lazy_boolean = <emptyTree>::<C T>.let(@lazy_boolean, <emptyTree>::<C T>.nilable(<emptyTree>::<C T>::<C Boolean>))
-          @lazy_boolean = <self>.expensively_compute_boolean()
+          @lazy_boolean = <statTemp>$2
         end
       end
     end
@@ -81,8 +84,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           @accidentally_untyped
         else
           begin
+            <statTemp>$2 = <emptyTree>::<C T>.unsafe(nil)
             @accidentally_untyped = <emptyTree>::<C T>.let(@accidentally_untyped, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
-            @accidentally_untyped = <emptyTree>::<C T>.unsafe(nil)
+            @accidentally_untyped = <statTemp>$2
           end
         end
         <emptyTree>::<C T>.must(@accidentally_untyped)


### PR DESCRIPTION
Closes #6145

More context in the issue.

Change the desugar for lazily initialized variables from
```ruby
@ivar = T.let(@ivar, T.nilable(Integer))
@ivar = T.cast(123.0, Integer)
```
to
```ruby
<statTemp>$2 = T.cast(123.0, Integer)
@ivar = T.let(@ivar, T.nilable(Integer))
@ivar = <statTemp>$2
```

### Motivation

This change in how it's desugared allows people to narrow types with a `T.cast` before declaring the variable using `T.let` in `typed: strict` files.


### Test plan

Modified the existing tests - in particular the rewrite trees.