### PR TITLE
Auto-cast `Class.new(Parent)` to `T.class_of(Parent)`

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -373,6 +373,10 @@ public:
         return Send2(loc, T(loc), core::Names::bind(), loc, std::move(value), std::move(type));
     }
 
+    static ExpressionPtr Cast(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
+        return Send2(loc, T(loc), core::Names::cast(), loc, std::move(value), std::move(type));
+    }
+
     static ExpressionPtr ClassOf(core::LocOffsets loc, ExpressionPtr value) {
         return Send1(loc, T(loc), core::Names::classOf(), loc, std::move(value));
     }

--- a/rewriter/ClassNew.h
+++ b/rewriter/ClassNew.h
@@ -27,7 +27,7 @@ namespace sorbet::rewriter {
  *
  * Are rewritten into
  *
- *   c = Class.new(Parent)
+ *   c = Class.new(Parent) do
  *     T.bind(self, T.class_of(Parent))
  *     ...
  *   end
@@ -40,7 +40,7 @@ namespace sorbet::rewriter {
  *
  * Are rewritten into
  *
- *   Class.new(Parent)
+ *   Class.new(Parent) do
  *     T.bind(self, T.class_of(Parent))
  *     ...
  *   end

--- a/rewriter/ClassNew.h
+++ b/rewriter/ClassNew.h
@@ -27,10 +27,10 @@ namespace sorbet::rewriter {
  *
  * Are rewritten into
  *
- *   c = Class.new(Parent) do
+ *   c = T.cast(Class.new(Parent) do
  *     T.bind(self, T.class_of(Parent))
  *     ...
- *   end
+ *   end, T.class_of(Parent))
  *
  * And sends such as
  *
@@ -40,15 +40,15 @@ namespace sorbet::rewriter {
  *
  * Are rewritten into
  *
- *   Class.new(Parent) do
+ *   T.cast(Class.new(Parent) do
  *     T.bind(self, T.class_of(Parent))
  *     ...
- *   end
+ *   end, T.class_of(Parent))
  */
 class ClassNew final {
 public:
     static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Assign *asgn);
-    static bool run(core::MutableContext ctx, ast::Send *send);
+    static ast::ExpressionPtr run(core::MutableContext ctx, ast::Send *send);
 
     ClassNew() = delete;
 };

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -172,7 +172,8 @@ public:
     void postTransformSend(core::MutableContext ctx, ast::ExpressionPtr &tree) {
         auto *send = ast::cast_tree<ast::Send>(tree);
 
-        if (ClassNew::run(ctx, send)) {
+        if (auto expr = ClassNew::run(ctx, send)) {
+            tree = std::move(expr);
             return;
         }
 

--- a/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
@@ -85,13 +85,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  c2 = <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
-    begin
-      ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
-      <emptyTree>::<C T>.reveal_type(<self>)
-      <self>.foo()
-    end
-  end
+  c2 = ::T.cast(<emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
+      begin
+        ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+        <emptyTree>::<C T>.reveal_type(<self>)
+        <self>.foo()
+      end
+    end, ::T.class_of(<emptyTree>::<C Foo>))
 
   <emptyTree>::<C Class>.new() do ||
     begin
@@ -100,31 +100,31 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
-    begin
-      ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
-      <emptyTree>::<C T>.reveal_type(<self>)
-      <self>.foo()
-    end
-  end
+  ::T.cast(<emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
+      begin
+        ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+        <emptyTree>::<C T>.reveal_type(<self>)
+        <self>.foo()
+      end
+    end, ::T.class_of(<emptyTree>::<C Foo>))
 
   class <emptyTree>::<C Bar><<C <todo sym>>> < (::<todo sym>)
     def bar<<todo method>>(&<blk>)
-      <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
-        begin
-          ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
-          <emptyTree>::<C T>.reveal_type(<self>)
-        end
-      end
+      ::T.cast(<emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
+          begin
+            ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+            <emptyTree>::<C T>.reveal_type(<self>)
+          end
+        end, ::T.class_of(<emptyTree>::<C Foo>))
     end
 
     def self.bar<<todo method>>(&<blk>)
-      <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
-        begin
-          ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
-          <emptyTree>::<C T>.reveal_type(<self>)
-        end
-      end
+      ::T.cast(<emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
+          begin
+            ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+            <emptyTree>::<C T>.reveal_type(<self>)
+          end
+        end, ::T.class_of(<emptyTree>::<C Foo>))
     end
 
     <runtime method definition of bar>

--- a/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
@@ -19,10 +19,15 @@ method ::<Class:A>#make {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
-    <cfgAlias>$4: T.class_of(Class) = alias <C Class>
-    <cfgAlias>$6: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$4: T.class_of(Class).new(<cfgAlias>$6: T.class_of(A))
-    <selfRestore>$8: T.class_of(A) = <self>
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <cfgAlias>$8: T.class_of(T) = alias <C T>
+    <cfgAlias>$10: T.class_of(A) = alias <C A>
+    <statTemp>$6: Runtime object representing type: T.class_of(A) = <cfgAlias>$8: T.class_of(T).class_of(<cfgAlias>$10: T.class_of(A))
+    <statTemp>$3: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$6: Runtime object representing type: T.class_of(A))
+    <cfgAlias>$13: T.class_of(Class) = alias <C Class>
+    <cfgAlias>$15: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$16: Sorbet::Private::Static::Void = <cfgAlias>$13: T.class_of(Class).new(<cfgAlias>$15: T.class_of(A))
+    <selfRestore>$17: T.class_of(A) = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -33,31 +38,32 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=3](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
-    cls: Class = Solve<<block-pre-call-temp>$7, new>
-    <returnMethodTemp>$2: Class = cls
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Class
+bb3[rubyRegionId=0, firstDead=4](<block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: T.class_of(A)):
+    <castTemp>$11: Class = Solve<<block-pre-call-temp>$16, new>
+    cls: T.class_of(A) = cast(<castTemp>$11: Class, T.class_of(A));
+    <returnMethodTemp>$2: T.class_of(A) = cls
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.class_of(A)
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(A), <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: T.class_of(A)):
     # outerLoops: 1
     <self>: T.class_of(A) = loadSelf(new)
-    <cfgAlias>$14: T.class_of(Sorbet::Private::Static) = alias <C Static>
-    <cfgAlias>$17: T.class_of(T) = alias <C T>
-    <cfgAlias>$19: T.class_of(A) = alias <C A>
-    <statTemp>$15: Runtime object representing type: T.class_of(A) = <cfgAlias>$17: T.class_of(T).class_of(<cfgAlias>$19: T.class_of(A))
-    <statTemp>$12: Sorbet::Private::Static::Void = <cfgAlias>$14: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$15: Runtime object representing type: T.class_of(A))
-    <castTemp>$20: T.class_of(A) = <self>
-    <self>: T.class_of(A) = cast(<castTemp>$20: T.class_of(A), T.class_of(A));
-    <blockReturnTemp>$21: T.noreturn = blockreturn<new> <blockReturnTemp>$10: NilClass
+    <cfgAlias>$23: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <cfgAlias>$26: T.class_of(T) = alias <C T>
+    <cfgAlias>$28: T.class_of(A) = alias <C A>
+    <statTemp>$24: Runtime object representing type: T.class_of(A) = <cfgAlias>$26: T.class_of(T).class_of(<cfgAlias>$28: T.class_of(A))
+    <statTemp>$21: Sorbet::Private::Static::Void = <cfgAlias>$23: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$24: Runtime object representing type: T.class_of(A))
+    <castTemp>$29: T.class_of(A) = <self>
+    <self>: T.class_of(A) = cast(<castTemp>$29: T.class_of(A), T.class_of(A));
+    <blockReturnTemp>$30: T.noreturn = blockreturn<new> <blockReturnTemp>$19: NilClass
     <unconditional> -> bb2
 
 }

--- a/test/testdata/rewriter/class_new_strict.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.flatten-tree.exp
@@ -11,19 +11,27 @@ begin
   end
   class ::A<<C A>> < (::<todo sym>)
     def self.make(<blk>)
-      cls = ::Class.new(::A) do ||
-        begin
+      cls = begin
+        ::Sorbet::Private::Static.keep_for_typechecking(::T.class_of(::A))
+        T.cast(::Class.new(::A) do ||
           begin
-            ::Sorbet::Private::Static.keep_for_typechecking(::T.class_of(::A))
-            T.<synthetic bind>(<self>, AppliedType {
-              klass = <S <C <U A>> $1>
-              targs = [
-                <C <U <AttachedClass>>> = A
-              ]
-            })
+            begin
+              ::Sorbet::Private::Static.keep_for_typechecking(::T.class_of(::A))
+              T.<synthetic bind>(<self>, AppliedType {
+                klass = <S <C <U A>> $1>
+                targs = [
+                  <C <U <AttachedClass>>> = A
+                ]
+              })
+            end
+            <emptyTree>
           end
-          <emptyTree>
-        end
+        end, AppliedType {
+          klass = <S <C <U A>> $1>
+          targs = [
+            <C <U <AttachedClass>>> = A
+          ]
+        })
       end
     end
 

--- a/test/testdata/rewriter/class_new_strict.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.rewrite-tree.exp
@@ -5,12 +5,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.make<<todo method>>(&<blk>)
-      cls = <emptyTree>::<C Class>.new(<emptyTree>::<C A>) do ||
-        begin
-          ::T.bind(<self>, ::T.class_of(<emptyTree>::<C A>))
-          <emptyTree>
-        end
-      end
+      cls = ::T.cast(<emptyTree>::<C Class>.new(<emptyTree>::<C A>) do ||
+          begin
+            ::T.bind(<self>, ::T.class_of(<emptyTree>::<C A>))
+            <emptyTree>
+          end
+        end, ::T.class_of(<emptyTree>::<C A>))
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)


### PR DESCRIPTION
### Motivation

Change the `ClassNew` rewriter to auto-cast the result of `Class.new(Parent)` into a `T.class_of(Parent)`.

Right now, the associated type to `Class.new(Parent)` is always `Class`:

```rb
x = Class.new(Parent)
T.reveal_type(x) # => Class
```

This is problematic when trying to call things defined in `Parent`:

```rb
class Parent
  def foo; end
end

Class.new(Parent).new.foo # error: Method foo does not exist on Object
```

To be able to call `foo`, one has to manually cast the result:

```rb
T.cast(Class.new(Parent), T.class_of(Parent)).new.foo # ok
```

We can be a bit smarter and always rewrite `Class.new(<ConstantLiteral>)` to use a cast so this works out of the box:

```rb
x = Class.new(Parent)
T.reveal_type(x) # => T.class_of(Parent)
x.new.foo # ok
```

Since it's rewritten as this:

```rb
x = T.cast(Class.new(Parent), T.class_of(Parent))
T.reveal_type(x) # => T.class_of(Parent)
x.new.foo # ok
```

### Test plan

See included automated tests.

cc. @egiurleo