### PR TITLE
validate document symbols as vscode does during tests

### DIFF
--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -131,6 +131,20 @@ unique_ptr<Range> Range::copy() const {
     return make_unique<Range>(start->copy(), end->copy());
 }
 
+// cf. https://github.com/microsoft/vscode/blob/21f7df634a8ac45d1198cb414fe90366f782bcee/src/vs/workbench/api/common/extHostTypes.ts#L312-L327
+bool Range::contains(const Range &b) const {
+    return contains(*b.start) && contains(*b.end);
+}
+
+bool Range::contains(const Position &p) const {
+    int startCmp = p.cmp(*this->start);
+    if (startCmp < 0) {
+        return false;
+    }
+    int endCmp = this->end->cmp(p);
+    return endCmp >= 0;
+}
+
 int Location::cmp(const Location &b) const {
     const int uriCmp = uri.compare(b.uri);
     if (uriCmp != 0) {

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -131,7 +131,8 @@ unique_ptr<Range> Range::copy() const {
     return make_unique<Range>(start->copy(), end->copy());
 }
 
-// cf. https://github.com/microsoft/vscode/blob/21f7df634a8ac45d1198cb414fe90366f782bcee/src/vs/workbench/api/common/extHostTypes.ts#L312-L327
+// cf.
+// https://github.com/microsoft/vscode/blob/21f7df634a8ac45d1198cb414fe90366f782bcee/src/vs/workbench/api/common/extHostTypes.ts#L312-L327
 bool Range::contains(const Range &b) const {
     return contains(*b.start) && contains(*b.end);
 }

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -114,6 +114,8 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        "std::optional<core::Loc> toLoc(const core::GlobalState &gs, core::FileRef file) const;",
                        "int cmp(const Range &b) const;",
                        "std::unique_ptr<Range> copy() const;",
+                       "bool contains(const Range &b) const;",
+                       "bool contains(const Position &b) const;",
                    });
 
     auto Location = makeObject("Location",

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -75,6 +75,7 @@ string documentSymbolsToString(const variant<JSONNullObject, vector<unique_ptr<D
     }
 }
 
+// cf. https://github.com/microsoft/vscode/blob/21f7df634a8ac45d1198cb414fe90366f782bcee/src/vs/workbench/api/common/extHostTypes.ts#L1224-L1232
 void validateDocumentSymbol(unique_ptr<DocumentSymbol> &sym) {
     REQUIRE(!sym->name.empty());
     REQUIRE(sym->range != nullptr);
@@ -83,6 +84,8 @@ void validateDocumentSymbol(unique_ptr<DocumentSymbol> &sym) {
     REQUIRE(sym->range->end != nullptr);
     REQUIRE(sym->selectionRange->start != nullptr);
     REQUIRE(sym->selectionRange->end != nullptr);
+
+    REQUIRE(sym->range->contains(*sym->selectionRange));
 
     if (sym->children.has_value()) {
         for (auto &child : *sym->children) {

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -75,7 +75,8 @@ string documentSymbolsToString(const variant<JSONNullObject, vector<unique_ptr<D
     }
 }
 
-// cf. https://github.com/microsoft/vscode/blob/21f7df634a8ac45d1198cb414fe90366f782bcee/src/vs/workbench/api/common/extHostTypes.ts#L1224-L1232
+// cf.
+// https://github.com/microsoft/vscode/blob/21f7df634a8ac45d1198cb414fe90366f782bcee/src/vs/workbench/api/common/extHostTypes.ts#L1224-L1232
 void validateDocumentSymbol(unique_ptr<DocumentSymbol> &sym) {
     REQUIRE(!sym->name.empty());
     REQUIRE(sym->range != nullptr);

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -75,6 +75,22 @@ string documentSymbolsToString(const variant<JSONNullObject, vector<unique_ptr<D
     }
 }
 
+void validateDocumentSymbol(unique_ptr<DocumentSymbol> &sym) {
+    REQUIRE(!sym->name.empty());
+    REQUIRE(sym->range != nullptr);
+    REQUIRE(sym->selectionRange != nullptr);
+    REQUIRE(sym->range->start != nullptr);
+    REQUIRE(sym->range->end != nullptr);
+    REQUIRE(sym->selectionRange->start != nullptr);
+    REQUIRE(sym->selectionRange->end != nullptr);
+
+    if (sym->children.has_value()) {
+        for (auto &child : *sym->children) {
+            validateDocumentSymbol(child);
+        }
+    }
+}
+
 optional<unique_ptr<CodeAction>> resolveCodeAction(LSPWrapper &lspWrapper, int &nextId,
                                                    unique_ptr<CodeAction> codeAction) {
     const auto &config = lspWrapper.config().getClientConfig();
@@ -406,6 +422,13 @@ void testDocumentSymbols(LSPWrapper &lspWrapper, Expectations &test, int &nextId
     // Simple string comparison, just like other *.exp files.
     CHECK_EQ_DIFF(documentSymbolsToString(expectedSymbolResponse), documentSymbolsToString(receivedSymbolResponse),
                   "Mismatch on: " + expectedSymbolsPath);
+
+    // VSCode validates document symbols, so we should too.
+    if (auto *syms = get_if<vector<unique_ptr<DocumentSymbol>>>(&receivedSymbolResponse)) {
+        for (auto &sym : *syms) {
+            validateDocumentSymbol(sym);
+        }
+    }
 }
 
 void testDocumentFormatting(LSPWrapper &lspWrapper, Expectations &test, int &nextId, string_view uri,


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

VSCode verifies constraints on the document symbols it receives and throws if the symbols don't conform.  We should at least perform the same verification in our own internal tests.

Several Stripes have reported issues where particular files don't display document symbols.  I have verified that at least one of these files returns document symbols that do not pass this validation check.  A future PR will address that issue.

(For completeness, I don't think we should throw on the Sorbet LSP side; getting a bug report that document symbols don't display for a file should be enough to diagnose the problem, and crashing Sorbet here would be needlessly annoying to the user.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
