### PR TITLE
Never suggest `# typed: ignore`

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -118,6 +118,11 @@ core::StrictLevel levelMinusOne(core::StrictLevel level) {
 core::StrictLevel levelToRecommendation(core::StrictLevel level) {
     switch (level) {
         case core::StrictLevel::Ignore:
+            // We don't suggest `# typed: ignore` because it is too common for some probem in a
+            // generated RBI file to cause a problem that actually does need to be fixed, and not by
+            // ignoring the RBI file. Ignoring the file has bad consequences, like introducing more
+            // errors in other files, causing those files to be ignored, etc.
+            return core::StrictLevel::False;
         case core::StrictLevel::False:
         case core::StrictLevel::True:
         case core::StrictLevel::Strict:

--- a/test/cli/suggest-typed-true/test.out
+++ b/test/cli/suggest-typed-true/test.out
@@ -23,15 +23,15 @@ suggest-typed-true.rb:1: You could add `# typed: true` https://srb.help/7022
         ^
 Errors: 1
 -------------------------
-suggest-typed-ignore.rb:1: You could add `# typed: ignore` https://srb.help/7022
+suggest-typed-ignore.rb:1: You could add `# typed: false` https://srb.help/7022
      1 |Foo
         ^
   Autocorrect: Done
-    suggest-typed-ignore.rb:1: Inserted `# typed: ignore`
+    suggest-typed-ignore.rb:1: Inserted `# typed: false`
      1 |Foo
         ^
 Errors: 1
-# typed: ignore
+# typed: false
 Foo
 No errors! Great job.
 -------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We shouldn't suggest `# typed: ignore` because it is too common for some
problem in a generated RBI file to cause a problem that actually does
need to be fixed, and not by ignoring the RBI file. Ignoring the file
has bad consequences, like introducing more errors in other files,
causing those files to be ignored, etc.

This causes a huge number of problems and the user is never told when it
has happened. This problem especially confuses people attempting to
adopt Sorbet for the first time, and they have no clue that it's
happening.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We might have a test for this; we'll find out soon enough.