### PR TITLE
Factor out `getFilesToTypecheck` helper

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -227,8 +227,6 @@ UnorderedSet<core::FileRef> getFilesToTypecheck() {
     UnorderedSet<core::FileRef> toTypecheck;
     vector<core::ShortNameHash> changedSymbolNameHashes;
     UnorderedMap<core::FileRef, core::FoundMethodHashes> oldFoundMethodHashesForFiles;
-    // Replace error queue with one that is owned by this thread.
-    gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
     {
         Timer timeit(config->logger, "compute_fast_path_file_set");
         {
@@ -366,6 +364,8 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     ENFORCE(updates.canTakeFastPath);
 
     Timer timeit(config->logger, "fast_path");
+    // Replace error queue with one that is owned by this thread.
+    gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
     auto toTypecheck = getFilesToTypecheck();
     vector<core::FileRef> sortedToTypecheck(toTypecheck.begin(), toTypecheck.end());
     fast_sort(sortedToTypecheck);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -235,7 +235,7 @@ struct FastPathFilesToTypecheckResult {
 };
 
 FastPathFilesToTypecheckResult getFilesToTypecheck(const core::GlobalState &gs, const LSPConfiguration &config,
-                                                   const vector<shared_ptr<core::File>> updatedFiles) {
+                                                   const vector<shared_ptr<core::File>> &updatedFiles) {
     FastPathFilesToTypecheckResult result;
     Timer timeit(config.logger, "compute_fast_path_file_set");
     vector<core::SymbolHash> changedMethodSymbolHashes;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -237,112 +237,103 @@ struct FastPathFilesToTypecheckResult {
 FastPathFilesToTypecheckResult getFilesToTypecheck(const core::GlobalState &gs, const LSPConfiguration &config,
                                                    const vector<shared_ptr<core::File>> updatedFiles) {
     FastPathFilesToTypecheckResult result;
-    {
-        Timer timeit(config.logger, "compute_fast_path_file_set");
-        {
-            vector<core::SymbolHash> changedMethodSymbolHashes;
-            vector<core::SymbolHash> changedFieldSymbolHashes;
-            auto idx = -1;
-            for (const auto &updatedFile : updatedFiles) {
-                idx++;
-                auto fref = gs.findFileByPath(updatedFile->path());
-                // We don't support new files on the fast path. This enforce failing indicates a bug in our fast/slow
-                // path logic in LSPPreprocessor.
-                ENFORCE(fref.exists());
-                ENFORCE(updatedFile->getFileHash() != nullptr);
-                if (config.opts.stripePackages && updatedFile->isPackage()) {
-                    // Only relevant in --stripe-packages mode. Package declarations do not have method
-                    // hashes. Instead we rely on recomputing packages if any __package.rb source
-                    // changes.
-                    continue;
-                }
-                if (fref.exists()) {
-                    // Update to existing file on fast path
-                    ENFORCE(fref.data(gs).getFileHash() != nullptr);
-                    const auto &oldSymbolHashes = fref.data(gs).getFileHash()->localSymbolTableHashes;
-                    const auto &newSymbolHashes = updatedFile->getFileHash()->localSymbolTableHashes;
-                    const auto &oldMethodHashes = oldSymbolHashes.methodHashes;
-                    const auto &newMethodHashes = newSymbolHashes.methodHashes;
+    Timer timeit(config.logger, "compute_fast_path_file_set");
+    vector<core::SymbolHash> changedMethodSymbolHashes;
+    vector<core::SymbolHash> changedFieldSymbolHashes;
+    auto idx = -1;
+    for (const auto &updatedFile : updatedFiles) {
+        idx++;
+        auto fref = gs.findFileByPath(updatedFile->path());
+        // We don't support new files on the fast path. This enforce failing indicates a bug in our fast/slow
+        // path logic in LSPPreprocessor.
+        ENFORCE(fref.exists());
+        ENFORCE(updatedFile->getFileHash() != nullptr);
+        if (config.opts.stripePackages && updatedFile->isPackage()) {
+            // Only relevant in --stripe-packages mode. Package declarations do not have method
+            // hashes. Instead we rely on recomputing packages if any __package.rb source
+            // changes.
+            continue;
+        }
+        if (fref.exists()) {
+            // Update to existing file on fast path
+            ENFORCE(fref.data(gs).getFileHash() != nullptr);
+            const auto &oldSymbolHashes = fref.data(gs).getFileHash()->localSymbolTableHashes;
+            const auto &newSymbolHashes = updatedFile->getFileHash()->localSymbolTableHashes;
+            const auto &oldMethodHashes = oldSymbolHashes.methodHashes;
+            const auto &newMethodHashes = newSymbolHashes.methodHashes;
 
-                    if (config.opts.lspExperimentalFastPathEnabled) {
-                        // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
-                        // This will insert two entries into `changedMethodHashes` for each changed method, but they
-                        // will get deduped later.
-                        absl::c_set_symmetric_difference(oldMethodHashes, newMethodHashes,
-                                                         std::back_inserter(changedMethodSymbolHashes));
-                    } else {
-                        // Both oldHash and newHash should have the same methods, since this is the fast path!
-                        ENFORCE(validateIdenticalFingerprints(oldMethodHashes, newMethodHashes),
-                                "definitionHash should have failed");
+            if (config.opts.lspExperimentalFastPathEnabled) {
+                // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
+                // This will insert two entries into `changedMethodHashes` for each changed method, but they
+                // will get deduped later.
+                absl::c_set_symmetric_difference(oldMethodHashes, newMethodHashes,
+                                                 std::back_inserter(changedMethodSymbolHashes));
+            } else {
+                // Both oldHash and newHash should have the same methods, since this is the fast path!
+                ENFORCE(validateIdenticalFingerprints(oldMethodHashes, newMethodHashes),
+                        "definitionHash should have failed");
 
-                        // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
-                        // This will insert two entries into `changedMethodHashes` for each changed method, but they
-                        // will get deduped later.
-                        absl::c_set_difference(oldMethodHashes, newMethodHashes,
-                                               std::back_inserter(changedMethodSymbolHashes));
-                    }
-
-                    const auto &oldFieldHashes = oldSymbolHashes.staticFieldHashes;
-                    const auto &newFieldHashes = newSymbolHashes.staticFieldHashes;
-
-                    ENFORCE(validateIdenticalFingerprints(oldFieldHashes, newFieldHashes),
-                            "definitionHash should have failed");
-
-                    absl::c_set_difference(oldFieldHashes, newFieldHashes,
-                                           std::back_inserter(changedFieldSymbolHashes));
-
-                    result.changedFiles.emplace(fref, idx);
-                }
+                // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
+                // This will insert two entries into `changedMethodHashes` for each changed method, but they
+                // will get deduped later.
+                absl::c_set_difference(oldMethodHashes, newMethodHashes, std::back_inserter(changedMethodSymbolHashes));
             }
 
-            result.changedSymbolNameHashes.reserve(changedMethodSymbolHashes.size() + changedFieldSymbolHashes.size());
-            absl::c_transform(changedMethodSymbolHashes, std::back_inserter(result.changedSymbolNameHashes),
-                              [](const auto &symhash) { return symhash.nameHash; });
-            absl::c_transform(changedFieldSymbolHashes, std::back_inserter(result.changedSymbolNameHashes),
-                              [](const auto &symhash) { return symhash.nameHash; });
-            core::ShortNameHash::sortAndDedupe(result.changedSymbolNameHashes);
+            const auto &oldFieldHashes = oldSymbolHashes.staticFieldHashes;
+            const auto &newFieldHashes = newSymbolHashes.staticFieldHashes;
+
+            ENFORCE(validateIdenticalFingerprints(oldFieldHashes, newFieldHashes), "definitionHash should have failed");
+
+            absl::c_set_difference(oldFieldHashes, newFieldHashes, std::back_inserter(changedFieldSymbolHashes));
+
+            result.changedFiles.emplace(fref, idx);
         }
+    }
 
-        if (!result.changedSymbolNameHashes.empty()) {
-            // ^ optimization--skip the loop over every file in the project (`gs.getFiles()`) if
-            // the set of changed symbols is empty (e.g., running a completion request inside a
-            // method body)
-            int i = -1;
-            for (auto &oldFile : gs.getFiles()) {
-                i++;
-                if (oldFile == nullptr) {
-                    continue;
-                }
+    result.changedSymbolNameHashes.reserve(changedMethodSymbolHashes.size() + changedFieldSymbolHashes.size());
+    absl::c_transform(changedMethodSymbolHashes, std::back_inserter(result.changedSymbolNameHashes),
+                      [](const auto &symhash) { return symhash.nameHash; });
+    absl::c_transform(changedFieldSymbolHashes, std::back_inserter(result.changedSymbolNameHashes),
+                      [](const auto &symhash) { return symhash.nameHash; });
+    core::ShortNameHash::sortAndDedupe(result.changedSymbolNameHashes);
 
-                auto ref = core::FileRef(i);
-                if (result.changedFiles.contains(ref)) {
-                    continue;
-                }
-
-                if (config.opts.stripePackages && oldFile->isPackage()) {
-                    continue; // See note above about --stripe-packages.
-                }
-
-                if (oldFile->isPayload()) {
-                    // Don't retypecheck files in the payload via incremental namer, as that might
-                    // cause well-known symbols to get deleted and assigned a new SymbolRef ID.
-                    continue;
-                }
-
-                ENFORCE(oldFile->getFileHash() != nullptr);
-                const auto &oldHash = *oldFile->getFileHash();
-                vector<core::ShortNameHash> intersection;
-                absl::c_set_intersection(result.changedSymbolNameHashes, oldHash.usages.nameHashes,
-                                         std::back_inserter(intersection));
-                if (intersection.empty()) {
-                    continue;
-                }
-
-                result.extraFiles.emplace_back(ref);
+    if (!result.changedSymbolNameHashes.empty()) {
+        // ^ optimization--skip the loop over every file in the project (`gs.getFiles()`) if
+        // the set of changed symbols is empty (e.g., running a completion request inside a
+        // method body)
+        int i = -1;
+        for (auto &oldFile : gs.getFiles()) {
+            i++;
+            if (oldFile == nullptr) {
+                continue;
             }
+
+            auto ref = core::FileRef(i);
+            if (result.changedFiles.contains(ref)) {
+                continue;
+            }
+
+            if (config.opts.stripePackages && oldFile->isPackage()) {
+                continue; // See note above about --stripe-packages.
+            }
+
+            if (oldFile->isPayload()) {
+                // Don't retypecheck files in the payload via incremental namer, as that might
+                // cause well-known symbols to get deleted and assigned a new SymbolRef ID.
+                continue;
+            }
+
+            ENFORCE(oldFile->getFileHash() != nullptr);
+            const auto &oldHash = *oldFile->getFileHash();
+            vector<core::ShortNameHash> intersection;
+            absl::c_set_intersection(result.changedSymbolNameHashes, oldHash.usages.nameHashes,
+                                     std::back_inserter(intersection));
+            if (intersection.empty()) {
+                continue;
+            }
+
+            result.extraFiles.emplace_back(ref);
         }
-        config.logger->debug("Added {} files that were not part of the edit to the update set",
-                             result.extraFiles.size());
     }
 
     return result;
@@ -367,6 +358,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     // Replace error queue with one that is owned by this thread.
     gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
     auto result = getFilesToTypecheck(*gs, *config, updates.updatedFiles);
+    config->logger->debug("Added {} files that were not part of the edit to the update set", result.extraFiles.size());
     UnorderedMap<core::FileRef, core::FoundMethodHashes> oldFoundMethodHashesForFiles;
     auto toTypecheck = move(result.extraFiles);
     for (auto [fref, idx] : result.changedFiles) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -224,7 +224,7 @@ bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
 namespace {
 
 struct FastPathFilesToTypecheckResult {
-    // size_t is an index into the updatedFiles vector
+    // size_t is an index into the LSPFileUpdates::updatedFiles vector
     UnorderedMap<core::FileRef, size_t> changedFiles;
 
     // The names of all symbols changed by this set of updates

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -362,9 +362,6 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     UnorderedMap<core::FileRef, core::FoundMethodHashes> oldFoundMethodHashesForFiles;
     auto toTypecheck = move(result.extraFiles);
     for (auto [fref, idx] : result.changedFiles) {
-        // TODO(jez) If you are seeing problems, on problem might be because this used to use only
-        // changedMethodSymbolHashes instead of changedSymbolNameHashes. I think this change should
-        // be safe but it's possible I'm wrong.
         if (config->opts.lspExperimentalFastPathEnabled && !result.changedSymbolNameHashes.empty()) {
             // Only set oldFoundMethodHashesForFiles if symbols actually changed
             // Means that no-op edits (and thus calls to LSPTypechecker::retypecheck) don't blow away


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a preliminary step to moving some logic from `LSPTypechecker.cc` to
`LSPIndexer.cc`, which will let us stop showing `Typechecking in foreground...`
for so many edits (especially when the fast path methods beta is enabled).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This should be a no-op change.

I will also be doing some light interactive testing on Stripe's codebase.