### PR TITLE
Implement `Array#[](index, length)`  intrinsic for tuples

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3101,27 +3101,66 @@ public:
 class Tuple_squareBrackets : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto *tuple = cast_type<TupleType>(args.thisType);
-        ENFORCE(tuple);
-        TypePtr argType = nullptr;
-        if (args.args.size() == 1) {
-            argType = args.args.front()->type;
-        }
-        if (!isa_type<IntegerLiteralType>(argType)) {
+        if (args.args.empty() || args.args.size() > 2) {
             return;
         }
 
+        auto *tuple = cast_type<TupleType>(args.thisType);
+        ENFORCE(tuple);
+        auto tupleSize = tuple->elems.size();
+
+        auto argType = args.args.front()->type;
+        if (!isa_type<IntegerLiteralType>(argType)) {
+            // One day we might want to handle support for ranges,
+            // but it's tricky because we don't have literal types for ranges.
+            //
+            // We might honestly have better luck by desugaring literal ranges to an equivalent
+            // index+len call if supporting literal ranges isn't a good idea.
+            return;
+        }
         auto &lit = cast_type_nonnull<IntegerLiteralType>(argType);
 
         auto idx = lit.value;
         if (idx < 0) {
-            idx = tuple->elems.size() + idx;
+            idx = tupleSize + idx;
         }
-        if (idx >= tuple->elems.size()) {
+
+        if (args.args.size() == 1) {
+            if (idx >= tupleSize) {
+                res.returnType = Types::nilClass();
+            } else {
+                res.returnType = tuple->elems[idx];
+            }
+            return;
+        }
+
+        ENFORCE(args.args.size() == 2);
+
+        if (idx < 0 || idx > tupleSize) {
             res.returnType = Types::nilClass();
-        } else {
-            res.returnType = tuple->elems[idx];
+            return;
         }
+
+        const auto &lengthType = args.args[1]->type;
+        if (!isa_type<IntegerLiteralType>(lengthType)) {
+            return;
+        }
+        const auto &lengthLit = cast_type_nonnull<IntegerLiteralType>(lengthType);
+        auto length = lengthLit.value;
+        if (length < 0) {
+            res.returnType = Types::nilClass();
+            return;
+        }
+
+        if (tupleSize < length || tupleSize < idx + length) {
+            length = tupleSize - idx;
+        }
+
+        vector<TypePtr> newElems;
+        for (long i = 0; i < length; i++) {
+            newElems.emplace_back(tuple->elems[idx + i]);
+        }
+        res.returnType = make_type<TupleType>(move(newElems));
     }
 } Tuple_squareBrackets;
 

--- a/test/testdata/infer/tuples.rb
+++ b/test/testdata/infer/tuples.rb
@@ -12,6 +12,17 @@ x[i]
 
 T.assert_type!(x[i], T.any(NilClass, Integer, String, Symbol, Float))
 
+T.reveal_type(x[0, 0]) # error: `[] (0-tuple)`
+T.reveal_type(x[0, -1]) # error: `NilClass`
+T.reveal_type(x[-2, 1]) # error: `[Symbol(:what)] (1-tuple)`
+T.reveal_type(x[1, 10]) # error: `[String("hi"), Symbol(:what), Float(3.141593)] (3-tuple)`
+long_max = 9223372036854775807
+T.reveal_type(x[1, long_max]) # error: `[String("hi"), Symbol(:what), Float(3.141593)] (3-tuple)`
+T.reveal_type(x[-6, 1]) # error: `NilClass`
+T.reveal_type(x[1, 2]) # error: `[String("hi"), Symbol(:what)] (2-tuple)`
+
+T.reveal_type(x[1..2]) # error: `T.nilable(T::Array[T.any(Integer, String, Symbol, Float)])`
+
 T.assert_type!([1, 2].min, Integer)
 T.assert_type!([1, 2].max, Integer)
 T.assert_type!([1, 2].first, Integer)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Unblocks a better way to desugar `&:foo` blocks. (#6118)

Also intrinsically useful.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.