### PR TITLE
fix problems with un-overlapped ranges for document symbols

### DIFF
--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -27,12 +27,12 @@ struct SymbolFileLocs {
     core::Loc declLoc;
 };
 
-class DefinitionLocSaver {
+class SymbolFileLocSaver {
 public:
     core::FileRef fref;
     UnorderedMap<core::SymbolRef, SymbolFileLocs> &mapping;
 
-    DefinitionLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, SymbolFileLocs> &mapping)
+    SymbolFileLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, SymbolFileLocs> &mapping)
         : fref(fref), mapping(mapping) {}
 
     void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &expr) {
@@ -243,7 +243,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
         candidates.end());
 
     UnorderedMap<core::SymbolRef, SymbolFileLocs> defMapping;
-    DefinitionLocSaver saver{fref, defMapping};
+    SymbolFileLocSaver saver{fref, defMapping};
     core::Context ctx{gs, core::Symbols::root(), fref};
     auto resolved = typechecker.getResolved({fref});
     ast::TreeWalk::apply(ctx, saver, resolved[0].tree);

--- a/test/testdata/lsp/dropped_document_symbols__0.rb
+++ b/test/testdata/lsp/dropped_document_symbols__0.rb
@@ -1,6 +1,13 @@
-# typed: true
+# typed: strict
 
+class PublicOuterface
+end
+
+# Move the declaration down so locs change for `Bottom` between this file
+# and the other files in this testcase.
 module Top::Upper::Lower::Bottom
   class Private::Basement::Primus
+  end
+  class PublicInterface
   end
 end

--- a/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
@@ -19,11 +19,11 @@
             },
             "selectionRange": {
                 "start": {
-                    "line": 7,
+                    "line": 2,
                     "character": 0
                 },
                 "end": {
-                    "line": 7,
+                    "line": 2,
                     "character": 32
                 }
             },

--- a/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
@@ -19,11 +19,11 @@
             },
             "selectionRange": {
                 "start": {
-                    "line": 2,
+                    "line": 7,
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
+                    "line": 7,
                     "character": 32
                 }
             },
@@ -34,21 +34,21 @@
                     "kind": 2,
                     "range": {
                         "start": {
-                            "line": 3,
+                            "line": 8,
                             "character": 8
                         },
                         "end": {
-                            "line": 3,
+                            "line": 8,
                             "character": 15
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 3,
+                            "line": 8,
                             "character": 8
                         },
                         "end": {
-                            "line": 3,
+                            "line": 8,
                             "character": 15
                         }
                     },
@@ -59,21 +59,21 @@
                             "kind": 2,
                             "range": {
                                 "start": {
-                                    "line": 3,
+                                    "line": 8,
                                     "character": 8
                                 },
                                 "end": {
-                                    "line": 3,
+                                    "line": 8,
                                     "character": 25
                                 }
                             },
                             "selectionRange": {
                                 "start": {
-                                    "line": 3,
+                                    "line": 8,
                                     "character": 8
                                 },
                                 "end": {
-                                    "line": 3,
+                                    "line": 8,
                                     "character": 25
                                 }
                             },

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
@@ -69,12 +69,12 @@
                             },
                             "selectionRange": {
                                 "start": {
-                                    "line": 3,
-                                    "character": 2
+                                    "line": 2,
+                                    "character": 0
                                 },
                                 "end": {
-                                    "line": 3,
-                                    "character": 14
+                                    "line": 2,
+                                    "character": 24
                                 }
                             },
                             "children": [

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__2.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__2.rb.document-symbols.exp
@@ -19,12 +19,12 @@
             },
             "selectionRange": {
                 "start": {
-                    "line": 3,
-                    "character": 2
+                    "line": 2,
+                    "character": 0
                 },
                 "end": {
-                    "line": 3,
-                    "character": 14
+                    "line": 2,
+                    "character": 17
                 }
             },
             "children": [


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#6158 introduced some extra checking for invariants that VSCode enforces; these invariants were responsible for a number of files in Stripe's codebase not displaying symbols, as the returned JSON LSP messages from Sorbet would throw exceptions during deserialization.

This problem was introduced (I believe) in #6123.  With that PR, we could select a loc in the current file for the `range` of a document symbol, but we would continue to use Sorbet's view of the loc for the `selectionRange`...except that Sorbet's canonical symbol for the document symbol might not be in the same file as the one we're currently generating document symbols for.  Which means that the ranges we generate for the document symbol have no relation and therefore run afoul of VSCode's checking.

The approach taken here is to record both the `loc` and `declLoc` for class and method symbols so that we can ensure that `range` and `selectionRange` for the document symbol are always referring to locs that are associated with the same file.  We could derive what offset would be associated with `declLoc` from the symbol table instead, but this approach seemed better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Also tested the reported files from Stripe's codebase and confirmed that they now generate symbols.