### PR TITLE
fix "follow cursor" setting in VSCode's outline window with symbols not appearing in the file

### DIFF
--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -139,8 +139,8 @@ symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef, co
     if (owner.exists() && owner.isClassOrModule() && owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()) {
         prefix = "self.";
     }
-    auto result =
-        make_unique<DocumentSymbol>(prefix + symRef.name(gs).show(gs), kind, move(info->range), move(info->selectionRange));
+    auto result = make_unique<DocumentSymbol>(prefix + symRef.name(gs).show(gs), kind, move(info->range),
+                                              move(info->selectionRange));
 
     // Previous versions of VSCode have a bug that requires this non-optional field to be present.
     // This previously tried to include the method signature but due to issues where large signatures were not readable

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -57,11 +57,11 @@ public:
 std::unique_ptr<DocumentSymbol>
 symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef, core::FileRef filter,
                          const UnorderedMap<core::SymbolRef, SymbolFileLocs> &defMapping,
-                         const UnorderedSet<core::SymbolRef> &forced);
+                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced);
 
 void symbolRef2DocumentSymbolWalkMembers(const core::GlobalState &gs, core::SymbolRef sym, core::FileRef filter,
                                          const UnorderedMap<core::SymbolRef, SymbolFileLocs> &defMapping,
-                                         const UnorderedSet<core::SymbolRef> &forced,
+                                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced,
                                          vector<unique_ptr<DocumentSymbol>> &out) {
     if (!sym.isClassOrModule()) {
         return;
@@ -115,7 +115,7 @@ std::optional<RangeInfo> rangesForSymbol(const core::GlobalState &gs, core::Symb
 std::unique_ptr<DocumentSymbol>
 symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef, core::FileRef filter,
                          const UnorderedMap<core::SymbolRef, SymbolFileLocs> &defMapping,
-                         const UnorderedSet<core::SymbolRef> &forced) {
+                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced) {
     if (!symRef.exists()) {
         return nullptr;
     }
@@ -228,7 +228,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
 
     // We may wind up in a situation where we have something like:
     //
-    // A::B::C::D::E
+    // module A::B; class C::D::E; ...; end; end
     //
     // B and E are candidates, but neither C nor D have locs in the current
     // file.  We'll eliminate E from candidacy, but then when we go to get
@@ -236,9 +236,23 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
     // we won't walk C's children.  Which means we'll never walk D's children
     // and therefore E won't appear in the list of document symbols.
     //
-    // So we need to ensure that both C and D are displayed; this set records
-    // symbols that appear in an ownership chain between two candidates.
-    UnorderedSet<core::SymbolRef> forced;
+    // So we need to ensure that both C and D are represented in the document
+    // symbols for the file.  But this raises a separate issue: what ranges do
+    // we assign to the symbols for C and D?  Giving them ranges representing
+    // their actual definitions is not correct, because their locs appear in an
+    // entirely different file.  Giving them null ranges seems reasonable, but
+    // that solution breaks cursor following in VSCode.
+    //
+    // As a sort of hacky compromise, we will give them ranges corresponding to
+    // the nearest owner that appears in the file.  For C and D above, that
+    // would be B.  (It would probably be more technically correct to give C and
+    // D ranges corresponding to E, but this is complicated to do with our setup
+    // here.).
+    //
+    // This map's keys record symbols that appear in an ownership chain between two
+    // candidates; the corresponding values are the closest ancestor that appears
+    // in this file.
+    UnorderedMap<core::SymbolRef, core::SymbolRef> forced;
     for (auto ref : candidates) {
         auto owner = ref.owner(gs);
         while (owner != core::Symbols::root()) {
@@ -246,7 +260,13 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
                 deduplicatedCandidates.erase(ref);
                 auto forcedOwner = ref.owner(gs);
                 while (forcedOwner != owner) {
-                    forced.insert(forcedOwner);
+                    // We could record `owner` here, but `owner` itself may
+                    // eventually wind up in `forced`, which implies that the
+                    // value for `forcedOwner` should really be something
+                    // further up the ownership chain.  We'll fixup the values
+                    // later once we're sure of where all the original candidates
+                    // go.
+                    forced[forcedOwner] = core::Symbols::noSymbol();
                     forcedOwner = forcedOwner.owner(gs);
                 }
                 break;
@@ -255,6 +275,19 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
             owner = owner.owner(gs);
         }
     }
+
+    for (auto &slot : forced) {
+        ENFORCE(!deduplicatedCandidates.contains(slot.first));
+        auto owner = slot.first.owner(gs);
+        while (!deduplicatedCandidates.contains(owner)) {
+            ENFORCE(owner != core::Symbols::root());
+            ENFORCE(owner.exists());
+            owner = owner.owner(gs);
+        }
+        ENFORCE(owner.exists());
+        slot.second = owner;
+    }
+
     candidates.erase(
         std::remove_if(candidates.begin(), candidates.end(),
                        [&deduplicatedCandidates](const auto ref) { return !deduplicatedCandidates.contains(ref); }),

--- a/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
@@ -34,22 +34,22 @@
                     "kind": 2,
                     "range": {
                         "start": {
-                            "line": 8,
-                            "character": 8
+                            "line": 2,
+                            "character": 0
                         },
                         "end": {
-                            "line": 8,
-                            "character": 15
+                            "line": 7,
+                            "character": 3
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 8,
-                            "character": 8
+                            "line": 2,
+                            "character": 0
                         },
                         "end": {
-                            "line": 8,
-                            "character": 15
+                            "line": 2,
+                            "character": 32
                         }
                     },
                     "children": [
@@ -59,22 +59,22 @@
                             "kind": 2,
                             "range": {
                                 "start": {
-                                    "line": 8,
-                                    "character": 8
+                                    "line": 2,
+                                    "character": 0
                                 },
                                 "end": {
-                                    "line": 8,
-                                    "character": 25
+                                    "line": 7,
+                                    "character": 3
                                 }
                             },
                             "selectionRange": {
                                 "start": {
-                                    "line": 8,
-                                    "character": 8
+                                    "line": 2,
+                                    "character": 0
                                 },
                                 "end": {
-                                    "line": 8,
-                                    "character": 25
+                                    "line": 2,
+                                    "character": 32
                                 }
                             },
                             "children": [

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
@@ -34,22 +34,22 @@
                     "kind": 2,
                     "range": {
                         "start": {
-                            "line": 3,
-                            "character": 2
+                            "line": 2,
+                            "character": 0
                         },
                         "end": {
-                            "line": 3,
-                            "character": 14
+                            "line": 2,
+                            "character": 10
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 3,
-                            "character": 2
+                            "line": 2,
+                            "character": 0
                         },
                         "end": {
-                            "line": 3,
-                            "character": 14
+                            "line": 2,
+                            "character": 10
                         }
                     },
                     "children": [


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#6158 ensured that symbols that don't appear in the document, but do appear in the ownership chain of symbols that *do* appear in the document, are correctly traversed during the computation of document symbols.

Unfortunately, the ranges we send for those symbols reflect Sorbet's canonical location for the symbols, which don't appear in the file for which we are computing document symbols.   Which is just nonsense, but it also winds up breaking various bits of VSCode outlines that update based on the cursor position and its relationship to document symbols.

This PR proposes assigning symbols along an ownership chain that don't appear in the document a location based on the nearest ancestor symbol that does appear in the document.  This is technically a little weird, but it is easier to implement than the (slightly more correct?) nearest descendant symbol that does appear in the document.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Verified that this unbreaks cursor following on the example file I have on Stripe's codebase + light testing on other relevant files.  I did find files on which this doesn't fix cursor following issues that were present before; presumably there are still more cases to fix.