### PR TITLE
add an informative message for document symbol range checking

### DIFF
--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -86,6 +86,8 @@ void validateDocumentSymbol(unique_ptr<DocumentSymbol> &sym) {
     REQUIRE(sym->selectionRange->start != nullptr);
     REQUIRE(sym->selectionRange->end != nullptr);
 
+    INFO(fmt::format("Checking range {} contains selectionRange {}", sym->range->toJSON(false),
+                     sym->selectionRange->toJSON(false)));
     REQUIRE(sym->range->contains(*sym->selectionRange));
 
     if (sym->children.has_value()) {


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I added this when debugging some issues with document symbols; this message points you right to where problems are occurring in the response message.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
