### PR TITLE
Re-enable "fast path preempts slow path" for beta

### DIFF
--- a/core/ErrorCollector.h
+++ b/core/ErrorCollector.h
@@ -12,6 +12,9 @@ private:
 public:
     ErrorCollector() = default;
     ~ErrorCollector() = default;
+    bool wouldFlushErrors(core::FileRef file) override {
+        return true;
+    }
     void flushErrors(spdlog::logger &logger, const core::GlobalState &gs, core::FileRef file,
                      std::vector<std::unique_ptr<core::ErrorQueueMessage>> errors) override;
     std::vector<std::unique_ptr<core::Error>> drainErrors();

--- a/core/ErrorCollector.h
+++ b/core/ErrorCollector.h
@@ -12,7 +12,7 @@ private:
 public:
     ErrorCollector() = default;
     ~ErrorCollector() = default;
-    bool wouldFlushErrors(core::FileRef file) override {
+    bool wouldFlushErrors(core::FileRef file) const override {
         return true;
     }
     void flushErrors(spdlog::logger &logger, const core::GlobalState &gs, core::FileRef file,

--- a/core/ErrorFlusher.h
+++ b/core/ErrorFlusher.h
@@ -10,7 +10,7 @@ namespace core {
 
 class ErrorFlusher {
 public:
-    virtual bool wouldFlushErrors(core::FileRef file) = 0;
+    virtual bool wouldFlushErrors(core::FileRef file) const = 0;
 
     virtual void flushErrors(spdlog::logger &logger, const GlobalState &gs, core::FileRef file,
                              std::vector<std::unique_ptr<ErrorQueueMessage>> errors) = 0;

--- a/core/ErrorFlusher.h
+++ b/core/ErrorFlusher.h
@@ -10,6 +10,8 @@ namespace core {
 
 class ErrorFlusher {
 public:
+    virtual bool wouldFlushErrors(core::FileRef file) = 0;
+
     virtual void flushErrors(spdlog::logger &logger, const GlobalState &gs, core::FileRef file,
                              std::vector<std::unique_ptr<ErrorQueueMessage>> errors) = 0;
     virtual ~ErrorFlusher() = default;

--- a/core/ErrorFlusherStdout.h
+++ b/core/ErrorFlusherStdout.h
@@ -19,7 +19,7 @@ public:
 
     // wouldFlushErrors is only ever false in LSP mode, where a later edit can produce newer
     // errors, making it not useful to report errors for the given file.
-    bool wouldFlushErrors(core::FileRef file) override {
+    bool wouldFlushErrors(core::FileRef file) const override {
         return true;
     }
     void flushErrors(spdlog::logger &logger, const GlobalState &gs, core::FileRef file,

--- a/core/ErrorFlusherStdout.h
+++ b/core/ErrorFlusherStdout.h
@@ -17,6 +17,11 @@ public:
     ErrorFlusherStdout() = default;
     ~ErrorFlusherStdout() = default;
 
+    // wouldFlushErrors is only ever false in LSP mode, where a later edit can produce newer
+    // errors, making it not useful to report errors for the given file.
+    bool wouldFlushErrors(core::FileRef file) override {
+        return true;
+    }
     void flushErrors(spdlog::logger &logger, const GlobalState &gs, core::FileRef file,
                      std::vector<std::unique_ptr<ErrorQueueMessage>> errors) override;
     void flushErrorCount(spdlog::logger &logger, int count);

--- a/core/ErrorQueue.cc
+++ b/core/ErrorQueue.cc
@@ -22,6 +22,11 @@ void ErrorQueue::flushAllErrors(const GlobalState &gs) {
     }
 }
 
+bool ErrorQueue::wouldFlushErrorsForFile(FileRef file) {
+    checkOwned();
+    return errorFlusher->wouldFlushErrors(file);
+}
+
 void ErrorQueue::flushErrorsForFile(const GlobalState &gs, FileRef file) {
     checkOwned();
 

--- a/core/ErrorQueue.cc
+++ b/core/ErrorQueue.cc
@@ -22,9 +22,11 @@ void ErrorQueue::flushAllErrors(const GlobalState &gs) {
     }
 }
 
-bool ErrorQueue::wouldFlushErrorsForFile(FileRef file) {
-    checkOwned();
-    return errorFlusher->wouldFlushErrors(file);
+bool ErrorQueue::wouldFlushErrorsForFile(FileRef file) const {
+    // Must be able to to call this from multiple threads.
+    // No checkedOwned call, and instead explicitly only use `const &` here.
+    const auto &flusher = *errorFlusher;
+    return flusher.wouldFlushErrors(file);
 }
 
 void ErrorQueue::flushErrorsForFile(const GlobalState &gs, FileRef file) {

--- a/core/ErrorQueue.h
+++ b/core/ErrorQueue.h
@@ -38,6 +38,7 @@ public:
 
     void flushAllErrors(const GlobalState &gs);
     void flushErrorsForFile(const GlobalState &gs, FileRef file);
+    bool wouldFlushErrorsForFile(FileRef file);
 
     /** Checks if the queue is empty. Is approximate if there are any concurrent dequeue/enqueue operations */
     bool queueIsEmptyApprox() const;

--- a/core/ErrorQueue.h
+++ b/core/ErrorQueue.h
@@ -38,7 +38,7 @@ public:
 
     void flushAllErrors(const GlobalState &gs);
     void flushErrorsForFile(const GlobalState &gs, FileRef file);
-    bool wouldFlushErrorsForFile(FileRef file);
+    bool wouldFlushErrorsForFile(FileRef file) const;
 
     /** Checks if the queue is empty. Is approximate if there are any concurrent dequeue/enqueue operations */
     bool queueIsEmptyApprox() const;

--- a/core/NullFlusher.h
+++ b/core/NullFlusher.h
@@ -10,7 +10,7 @@ public:
     NullFlusher() = default;
     ~NullFlusher() = default;
 
-    bool wouldFlushErrors(core::FileRef file) override {
+    bool wouldFlushErrors(core::FileRef file) const override {
         return true;
     }
     void flushErrors(spdlog::logger &logger, const core::GlobalState &gs, core::FileRef file,

--- a/core/NullFlusher.h
+++ b/core/NullFlusher.h
@@ -10,6 +10,9 @@ public:
     NullFlusher() = default;
     ~NullFlusher() = default;
 
+    bool wouldFlushErrors(core::FileRef file) override {
+        return true;
+    }
     void flushErrors(spdlog::logger &logger, const core::GlobalState &gs, core::FileRef file,
                      std::vector<std::unique_ptr<core::ErrorQueueMessage>> errors) override;
 };

--- a/main/lsp/ErrorFlusherLSP.cc
+++ b/main/lsp/ErrorFlusherLSP.cc
@@ -5,7 +5,7 @@ namespace sorbet::realmain::lsp {
 ErrorFlusherLSP::ErrorFlusherLSP(const uint32_t epoch, shared_ptr<ErrorReporter> errorReporter)
     : epoch(epoch), errorReporter(errorReporter){};
 
-bool ErrorFlusherLSP::wouldFlushErrors(core::FileRef file) {
+bool ErrorFlusherLSP::wouldFlushErrors(core::FileRef file) const {
     return errorReporter->wouldReportForFile(epoch, file);
 }
 

--- a/main/lsp/ErrorFlusherLSP.cc
+++ b/main/lsp/ErrorFlusherLSP.cc
@@ -5,6 +5,10 @@ namespace sorbet::realmain::lsp {
 ErrorFlusherLSP::ErrorFlusherLSP(const uint32_t epoch, shared_ptr<ErrorReporter> errorReporter)
     : epoch(epoch), errorReporter(errorReporter){};
 
+bool ErrorFlusherLSP::wouldFlushErrors(core::FileRef file) {
+    return errorReporter->wouldReportForFile(epoch, file);
+}
+
 void ErrorFlusherLSP::flushErrors(spdlog::logger &logger, const core::GlobalState &gs, core::FileRef file,
                                   vector<unique_ptr<core::ErrorQueueMessage>> errors) {
     vector<std::unique_ptr<core::Error>> errorsAccumulated;

--- a/main/lsp/ErrorFlusherLSP.h
+++ b/main/lsp/ErrorFlusherLSP.h
@@ -15,7 +15,7 @@ public:
     ErrorFlusherLSP(const uint32_t epoch, std::shared_ptr<ErrorReporter> errorReporter);
     ~ErrorFlusherLSP() = default;
 
-    bool wouldFlushErrors(core::FileRef file) override;
+    bool wouldFlushErrors(core::FileRef file) const override;
 
     void flushErrors(spdlog::logger &logger, const core::GlobalState &gs, core::FileRef file,
                      std::vector<std::unique_ptr<core::ErrorQueueMessage>> errors) override;

--- a/main/lsp/ErrorFlusherLSP.h
+++ b/main/lsp/ErrorFlusherLSP.h
@@ -15,6 +15,8 @@ public:
     ErrorFlusherLSP(const uint32_t epoch, std::shared_ptr<ErrorReporter> errorReporter);
     ~ErrorFlusherLSP() = default;
 
+    bool wouldFlushErrors(core::FileRef file) override;
+
     void flushErrors(spdlog::logger &logger, const core::GlobalState &gs, core::FileRef file,
                      std::vector<std::unique_ptr<core::ErrorQueueMessage>> errors) override;
 };

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -201,7 +201,7 @@ bool ErrorReporter::wouldReportForFile(uint32_t epoch, core::FileRef file) {
 
 ErrorStatus &ErrorReporter::getFileErrorStatus(core::FileRef file) {
     if (file.id() >= fileErrorStatuses.size()) {
-        fileErrorStatuses.resize(file.id() + 1, ErrorStatus{0, false});
+        fileErrorStatuses.resize(file.id() + 1, ErrorStatus{0, 0});
     }
     return fileErrorStatuses[file.id()];
 };

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -78,7 +78,6 @@ void ErrorReporter::pushDiagnostics(uint32_t epoch, core::FileRef file, const ve
                                     const core::GlobalState &gs) {
     ENFORCE(file.exists());
 
-    ErrorStatus &fileErrorStatus = getFileErrorStatus(file);
     if (!wouldReportForFile(epoch, file)) {
         // Internal errors should always crash Sorbet in tests. Most of the time though, ENFORCE
         // failures and Exception::raise translate into user-visible errors with `beginError`.
@@ -86,6 +85,8 @@ void ErrorReporter::pushDiagnostics(uint32_t epoch, core::FileRef file, const ve
         assertNoCritical(errors);
         return;
     }
+
+    ErrorStatus &fileErrorStatus = getFileErrorStatus(file);
 
     // Update clientErrorCount
     if (fileErrorStatus.lastReportedEpoch >= this->lastFullTypecheckEpoch) {
@@ -194,9 +195,15 @@ void ErrorReporter::pushDiagnostics(uint32_t epoch, core::FileRef file, const ve
         make_unique<NotificationMessage>("2.0", LSPMethod::TextDocumentPublishDiagnostics, move(params))));
 };
 
-bool ErrorReporter::wouldReportForFile(uint32_t epoch, core::FileRef file) {
-    const auto &fileErrorStatus = getFileErrorStatus(file);
-    return fileErrorStatus.lastReportedEpoch <= epoch;
+bool ErrorReporter::wouldReportForFile(uint32_t epoch, core::FileRef file) const {
+    if (file.id() >= fileErrorStatuses.size()) {
+        // No entry in fileErrorStatuses yet means we have never reported for this file, so we will
+        // certainly report any errors when requested.
+        return true;
+    } else {
+        const auto &fileErrorStatus = fileErrorStatuses[file.id()];
+        return fileErrorStatus.lastReportedEpoch < epoch;
+    }
 }
 
 ErrorStatus &ErrorReporter::getFileErrorStatus(core::FileRef file) {

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -202,7 +202,7 @@ bool ErrorReporter::wouldReportForFile(uint32_t epoch, core::FileRef file) const
         return true;
     } else {
         const auto &fileErrorStatus = fileErrorStatuses[file.id()];
-        return fileErrorStatus.lastReportedEpoch < epoch;
+        return fileErrorStatus.lastReportedEpoch <= epoch;
     }
 }
 

--- a/main/lsp/ErrorReporter.h
+++ b/main/lsp/ErrorReporter.h
@@ -55,7 +55,7 @@ public:
      * When this happens, it means we can short circuit, because the file has already been
      * typechecked by a followup edit.
      */
-    bool wouldReportForFile(uint32_t epoch, core::FileRef file);
+    bool wouldReportForFile(uint32_t epoch, core::FileRef file) const;
 
     void beginEpoch(uint32_t epoch, bool isIncremental, std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
     void endEpoch(uint32_t epoch, bool committed = true);

--- a/main/lsp/ErrorReporter.h
+++ b/main/lsp/ErrorReporter.h
@@ -42,6 +42,21 @@ public:
     void pushDiagnostics(uint32_t epoch, core::FileRef file, const std::vector<std::unique_ptr<core::Error>> &errors,
                          const core::GlobalState &gs);
 
+    /**
+     * Checks whether, given the ErrorStatus for the file, diagnostics would even be reported for
+     * this file.
+     *
+     * Sometimes the lastReportedEpoch can be greater than the file's epoch. The file's epoch is a
+     * function of which edit last changed the source contents of the file, while the
+     * lastReportedEpoch is a function of which edit last triggered a fast or slow path which caused
+     * the file to be typechecked, whether as a part of the edit or included by way of looking for
+     * downstream files.
+     *
+     * When this happens, it means we can short circuit, because the file has already been
+     * typechecked by a followup edit.
+     */
+    bool wouldReportForFile(uint32_t epoch, core::FileRef file);
+
     void beginEpoch(uint32_t epoch, bool isIncremental, std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
     void endEpoch(uint32_t epoch, bool committed = true);
     uint32_t lastDiagnosticEpochForFile(core::FileRef file);

--- a/main/lsp/QueryCollector.h
+++ b/main/lsp/QueryCollector.h
@@ -14,7 +14,7 @@ public:
     ~QueryCollector() = default;
 
     // Can never skip, because we need to run for the sake of reporting query responses
-    bool wouldFlushErrors(core::FileRef file) override {
+    bool wouldFlushErrors(core::FileRef file) const override {
         return true;
     }
     void flushErrors(spdlog::logger &logger, const core::GlobalState &gs, core::FileRef file,

--- a/main/lsp/QueryCollector.h
+++ b/main/lsp/QueryCollector.h
@@ -13,6 +13,10 @@ public:
     QueryCollector() = default;
     ~QueryCollector() = default;
 
+    // Can never skip, because we need to run for the sake of reporting query responses
+    bool wouldFlushErrors(core::FileRef file) override {
+        return true;
+    }
     void flushErrors(spdlog::logger &logger, const core::GlobalState &gs, core::FileRef file,
                      std::vector<std::unique_ptr<core::ErrorQueueMessage>> errors) override;
 

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -144,11 +144,7 @@ bool SorbetWorkspaceEditTask::canTakeFastPath(const LSPIndexer &index) const {
 }
 
 bool SorbetWorkspaceEditTask::canPreempt(const LSPIndexer &index) const {
-    if (config.opts.lspExperimentalFastPathEnabled) {
-        return false;
-    } else {
-        return canTakeFastPath(index);
-    }
+    return canTakeFastPath(index);
 }
 
 bool SorbetWorkspaceEditTask::needsMultithreading(const LSPIndexer &index) const {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1146,7 +1146,7 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const 
                             // typechecking!
                             // TODO(jvilk): epoch is unlikely to overflow, but it is theoretically possible.
                             const bool fileWasChanged = preemptionManager && job.file.data(gs).epoch > epoch;
-                            if (!isCanceled && !fileWasChanged) {
+                            if (!isCanceled && !fileWasChanged && gs.errorQueue->wouldFlushErrorsForFile(job.file)) {
                                 core::FileRef file = job.file;
                                 try {
                                     core::Context ctx(gs, core::Symbols::root(), file);

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -464,7 +464,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPath") {
     sendAsync(*changeFile("foo.rb",
                           "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef "
                           "bar\nbaz\nend\nsig{returns(Float)}\ndef baz\n'not a float'\nend\nend\n",
-                          2, false, 0));
+                          2, false, 1));
     sendAsync(*changeFile(
         "bar.rb", "# typed: true\nclass Bar\nextend T::Sig\nsig{returns(String)}\ndef branch\n1\nend\nend\n", 3));
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
@@ -509,7 +509,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathThat
     sendAsync(*changeFile("foo.rb",
                           "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef "
                           "bar\n'hello'\nend\nend\n",
-                          2, false, 0));
+                          2, false, 1));
     sendAsync(*changeFile(
         "bar.rb", "# typed: true\nclass Bar\nextend T::Sig\nsig{returns(String)}\ndef str\nFoo.new.bar\nend\nend\n",
         3));
@@ -537,7 +537,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathThat
     //                      /* assertUniqueStartTimes */ false);
 }
 
-TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathAndThenCancelBoth" * doctest::skip()) {
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathAndThenCancelBoth") {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;
     assertDiagnostics(
@@ -615,7 +615,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathAndB
                           "# typed: true\n"
                           "class Foo\n"
                           "extend(T::Sig",
-                          2, false, 0));
+                          2, false, 1));
 
     // Wait for typechecking to begin to avoid races.
     {
@@ -691,7 +691,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathWithFastPathThatR
                          /* assertUniqueStartTimes */ false);
 }
 
-TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathEvenIfAddsFile" * doctest::skip()) {
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathEvenIfAddsFile") {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;
     assertDiagnostics(
@@ -838,8 +838,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanceledRequestsDontReportLatencyM
                          /* assertUniqueStartTimes */ false);
 }
 
-TEST_CASE_FIXTURE(MultithreadedProtocolTest,
-                  "ErrorIntroducedInSlowPathPreemptionByFastPathClearedByNewSlowPath" * doctest::skip()) {
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "ErrorIntroducedInSlowPathPreemptionByFastPathClearedByNewSlowPath") {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;
     assertDiagnostics(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We temporarily disabled letting fast path edits preempt slow path edits because
I misunderstood how preemptions worked.

If a fast path preempts a slow path, the slow path still runs (full,
non-incremental) resolver on the old file contents, then the fast path
edited-file gets incremental resolver run on it, then the slow path resumes.

What can sometimes actually happen as a result of this is that the fast path
actually runs inference on a file before the slow path gets a chance to type
check it! When that happens, the GlobalState will have been mutated to delete
certain symbols, but the old version of the AST on the slow path will still
mention symbol ref IDs that only existed in the old GlobalState, and don't exist
anymore.

This sort of "oh whoops, the new GlobalState actually has things that cause the
old slow path ASTs to seemingly discover type errors" was always a problem,
which was solved by simply only flushing errors for the last version of the
file.

That was fine when the worst thing that could happen was that "eh, maybe we
spend too much time computing errors that will be ignored" but in the fast path
methods beta, typechecking a file that should not be typechecked anymore
actually manifests in crashes, because symbols don't actually exist that used
to.

This PR fixes that by allowing the error reporter to indicate whether it would
have skipped reporting the errors.

It might be more apt to start calling `wouldReportErrors` something more
obviously load bearing, like "was already typechecked on newer epoch" so I'm
open to suggestions.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We did manage to write a multithreaded_protocol_test_corpus.cc test for this
earlier. It passes now, which is nice.

I will still want to do a fair bit of manual testing to make sure that this does
in fact fix the problems with crashes, as while I don't _think_ this involves
contended access to shared mutable state (and instead accesses only immutable
state), of the recent changes I've made it's the closest to come to that.