### PR TITLE
Merge evicted files before running canTakeFastPath

### DIFF
--- a/common/Timer.cc
+++ b/common/Timer.cc
@@ -19,7 +19,12 @@ clockid_t clock_monotonic_coarse() {
 #endif
 }
 
-microseconds get_clock_threshold_coarse() {
+// Don't want to have to measure the resolution of the clock every time we ask for the time.
+const microseconds clock_threshold_coarse = Timer::get_clock_threshold_coarse();
+
+} // namespace
+
+microseconds Timer::get_clock_threshold_coarse() {
     timespec tp;
     clock_getres(clock_monotonic_coarse(), &tp);
     auto usec = 2 * (tp.tv_sec * 1'000'000L) + (tp.tv_nsec / 1'000L);
@@ -29,11 +34,6 @@ microseconds get_clock_threshold_coarse() {
         return {usec};
     }
 }
-
-// Don't want to have to measure the resolution of the clock every time we ask for the time.
-const microseconds clock_threshold_coarse = get_clock_threshold_coarse();
-
-} // namespace
 
 microseconds Timer::clock_gettime_coarse() {
     timespec tp;

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -53,7 +53,12 @@ public:
         Timer timer(log, name);
         std::this_thread::sleep_for(sleep_duration);
     }
+    static void timedSleep(const microseconds &sleep_duration, spdlog::logger &log, ConstExprStr name) {
+        Timer timer(log, name);
+        std::this_thread::sleep_for(std::chrono::microseconds{sleep_duration.usec});
+    }
 
+    static microseconds get_clock_threshold_coarse();
     static microseconds clock_gettime_coarse();
 
     void setEndTime();

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -321,10 +321,10 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPoo
         if (!update.canTakeFastPath && initialGS->epochManager->tryCancelSlowPath(update.epoch)) {
             // Cancelation succeeded! Merge the updates from the cancelled run into the current update.
             update.mergeOlder(pendingTypecheckUpdates);
-            // The two updates together could end up taking the fast path.
-            update.canTakeFastPath = canTakeFastPath(update, evictedFiles);
-            update.canceledSlowPath = true;
             mergeEvictedFiles(evictedFiles, newlyEvictedFiles);
+            // The two updates together could end up taking the fast path.
+            update.canTakeFastPath = canTakeFastPath(update, newlyEvictedFiles);
+            update.canceledSlowPath = true;
         }
     }
 

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -498,8 +498,8 @@ vector<unique_ptr<LSPMessage>> getLSPResponsesFor(LSPWrapper &wrapper, vector<un
         vector<unique_ptr<LSPMessage>> responses;
         while (true) {
             // In tests, wait a maximum of 20 seconds for a response. It seems like sanitized builds running locally
-            // take ~10 seconds.
-            auto msg = mtWrapper->read(20000);
+            // take ~10 seconds. Wait 5 minutes if running in the debugger
+            auto msg = mtWrapper->read(amIBeingDebugged() ? 300'000 : 20'000);
             if (!msg) {
                 // We should be guaranteed to receive the fence response, so if this happens something is seriously
                 // wrong.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This should fix a crash that I discovered from reading Stripe logs.

Some files might only be present in one of the two sets of files. In the
implementation of canTakeFastPath, we assume that if the evictedFiles
mapping is not empty, but that is not true unless we merge things
beforehand like this.

This bug should only be present when using `--enable-experimental-lsp-fast-path`.

This bug is new as of the changes I landed today in 5f0e79974.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I verified that the test added in this change failed before the fix and passes after it.

- - - - -

**old test plan**

I should probably be able to write a multithreaded protocol test for
this?

It would have to be for something like three edits:

1.  There is a slow path running
2.  There is a fast path after that (else we would have cancelled the
    running slow path)
3.  There is a slow path after that (else we would not get back to
    this call to mergeEvictedFiles)
    - merging edits (2) + (3) can take the fast path given that (1) is
      still running (else our fastPathFilesToTypecheck helper would
      not have been called)
    - edit (2) must mention a file that (3) didn't change

Having written that out, it sounds like the test could possibly be:

1.  Slow path edit in `foo.rb`
2.  Edit in method body in `bar.rb`
3.  Undo edit in `foo.rb`

- [x] @jez write this test