### PR TITLE
Don't insert `T.let` into the middle of a method def's params

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -114,23 +114,13 @@ bool sendRecvIsT(ast::Send &s) {
     }
 }
 
-bool isAnyStaticInit(const core::GlobalState &gs, core::NameRef name) {
-    if (name == core::Names::staticInit()) {
-        return true;
-    } else if (name.kind() != core::NameKind::UNIQUE) {
-        return false;
-    } else {
-        return name.dataUnique(gs)->original == core::Names::staticInit();
-    }
-}
-
 InstructionPtr maybeMakeTypeParameterAlias(CFGContext &cctx, ast::Send &s) {
     const auto &ctx = cctx.ctx;
     auto method = cctx.inWhat.symbol;
     if (!method.data(ctx)->flags.isGenericMethod) {
         // Using staticInit as a crude proxy for "is inside a `sig` block"
         // This means we do not report as many errors as we should (but cheaply guards against false positives)
-        if (!isAnyStaticInit(ctx, method.data(ctx)->name)) {
+        if (!method.data(ctx)->name.isAnyStaticInitName(ctx)) {
             if (auto e = ctx.beginError(s.loc, core::errors::CFG::UnknownTypeParameter)) {
                 e.setHeader("Method `{}` does not declare any type parameters", method.show(ctx));
                 e.addErrorLine(method.data(ctx)->loc(), "`{}` defined here", method.show(ctx));

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -186,6 +186,10 @@ public:
 
     bool isValidConstantName(const GlobalState &gs) const;
 
+    // Returns true if the name is `<static-init>` (class-level static init) or `<static-init>$...`
+    // (file-level static init).
+    bool isAnyStaticInitName(const GlobalState &gs) const;
+
     // All the names that Environment::updateKnowledge treats as special for the purposes of
     // updating control flow-sensitive type knowledge.
     //

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -239,6 +239,16 @@ bool NameRef::isValidConstantName(const GlobalState &gs) const {
     }
 }
 
+bool NameRef::isAnyStaticInitName(const GlobalState &gs) const {
+    if (*this == core::Names::staticInit()) {
+        return true;
+    } else if (this->kind() != core::NameKind::UNIQUE) {
+        return false;
+    } else {
+        return this->dataUnique(gs)->original == core::Names::staticInit();
+    }
+}
+
 bool NameRef::isUpdateKnowledgeName() const {
     switch (this->rawId()) {
         case Names::bang().rawId():

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1664,7 +1664,8 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                     // sometimes a variable has a given type because of a constant outside this method
                                     ctx.locAt(inWhat.loc).contains(cur.origins[0]) &&
                                     // don't attempt to insert a `T.let` into the method params list
-                                    !inWhat.symbol.data(ctx)->loc().contains(cur.origins[0])) {
+                                    (inWhat.symbol.data(ctx)->name.isAnyStaticInitName(ctx) ||
+                                     !inWhat.symbol.data(ctx)->loc().contains(cur.origins[0]))) {
                                     auto suggest =
                                         core::Types::any(ctx, dropConstructor(ctx, tp.origins[0], tp.type), cur.type);
                                     auto replacement = suggest.show(ctx, core::ShowOptions().withShowForRBI());

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1662,10 +1662,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
 
                                 if (cur.origins.size() == 1 && cur.origins[0].exists() &&
                                     // sometimes a variable has a given type because of a constant outside this method
-                                    ctx.locAt(inWhat.loc).contains(cur.origins[0])) {
-                                    // NOTE(nelhage): We assume that if there is a single definition location, that
-                                    // corresponds to an initial assignment. This is not necessarily correct if the
-                                    // variable came from some other source (e.g. a function argument)
+                                    ctx.locAt(inWhat.loc).contains(cur.origins[0]) &&
+                                    // don't attempt to insert a `T.let` into the method params list
+                                    !inWhat.symbol.data(ctx)->loc().contains(cur.origins[0])) {
                                     auto suggest =
                                         core::Types::any(ctx, dropConstructor(ctx, tp.origins[0], tp.type), cur.type);
                                     auto replacement = suggest.show(ctx, core::ShowOptions().withShowForRBI());

--- a/test/testdata/infer/autocorrect_decl_loc.rb
+++ b/test/testdata/infer/autocorrect_decl_loc.rb
@@ -1,0 +1,20 @@
+# typed: true
+extend T::Sig
+
+sig {params(klass: Class).void}
+def bad_arg(klass)
+  loop do
+    klass = klass.superclass
+    #       ^^^^^^^^^^^^^^^^ error: Changing the type of a variable in a loop is not permitted
+  end
+end
+
+sig {params(klass: Class).void}
+def multiline_bad_arg(
+  klass
+)
+  loop do
+    klass = klass.superclass
+    #       ^^^^^^^^^^^^^^^^ error: Changing the type of a variable in a loop is not permitted
+  end
+end

--- a/test/testdata/infer/autocorrect_decl_loc.rb.autocorrects.exp
+++ b/test/testdata/infer/autocorrect_decl_loc.rb.autocorrects.exp
@@ -3,7 +3,7 @@
 extend T::Sig
 
 sig {params(klass: Class).void}
-def bad_arg(T.let(klass, T.nilable(Class)))
+def bad_arg(klass)
   loop do
     klass = klass.superclass
     #       ^^^^^^^^^^^^^^^^ error: Changing the type of a variable in a loop is not permitted
@@ -12,7 +12,7 @@ end
 
 sig {params(klass: Class).void}
 def multiline_bad_arg(
-  T.let(klass, T.nilable(Class))
+  klass
 )
   loop do
     klass = klass.superclass

--- a/test/testdata/infer/autocorrect_decl_loc.rb.autocorrects.exp
+++ b/test/testdata/infer/autocorrect_decl_loc.rb.autocorrects.exp
@@ -1,0 +1,22 @@
+# -- test/testdata/infer/autocorrect_decl_loc.rb --
+# typed: true
+extend T::Sig
+
+sig {params(klass: Class).void}
+def bad_arg(T.let(klass, T.nilable(Class)))
+  loop do
+    klass = klass.superclass
+    #       ^^^^^^^^^^^^^^^^ error: Changing the type of a variable in a loop is not permitted
+  end
+end
+
+sig {params(klass: Class).void}
+def multiline_bad_arg(
+  T.let(klass, T.nilable(Class))
+)
+  loop do
+    klass = klass.superclass
+    #       ^^^^^^^^^^^^^^^^ error: Changing the type of a variable in a loop is not permitted
+  end
+end
+# ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #3190


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.