### PR TITLE
Fix infinite loop in type_member with self

### DIFF
--- a/test/testdata/resolver/type_member_block.rb
+++ b/test/testdata/resolver/type_member_block.rb
@@ -27,8 +27,8 @@ end
 
 module IBox5
   extend T::Generic
-  X = type_member(:out) {x = 1; p(x); {upper: Integer}}
-  #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Block given to `type_member` must contain a single `Hash` literal
+  X = type_member(:out) {x = 1; {upper: Integer}}
+  #                      ^^^^^^^^^^^^^^^^^^^^^^^ error: Block given to `type_member` must contain a single `Hash` literal
 end
 
 module IBox6

--- a/test/testdata/resolver/type_member_block.rb.autocorrects.exp
+++ b/test/testdata/resolver/type_member_block.rb.autocorrects.exp
@@ -28,8 +28,8 @@ end
 
 module IBox5
   extend T::Generic
-  X = type_member(:out) {x = 1; p(x); {upper: Integer}}
-  #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Block given to `type_member` must contain a single `Hash` literal
+  X = type_member(:out) {x = 1; {upper: Integer}}
+  #                      ^^^^^^^^^^^^^^^^^^^^^^^ error: Block given to `type_member` must contain a single `Hash` literal
 end
 
 module IBox6

--- a/test/testdata/resolver/type_member_cycle.rb
+++ b/test/testdata/resolver/type_member_cycle.rb
@@ -23,3 +23,9 @@ class B
 end
 
 T.reveal_type(B.new.test) # error: Revealed type: `T.untyped`
+
+class C
+  extend T::Generic
+
+  Elem = type_member {{upper: self}} # error: Type member `C::Elem` is involved in a cycle
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #3613

These two things should behave identically:

```ruby
class A
  extend T::Generic
  Elem1 = type_member {{upper: A}}
  Elem2 = type_member {{upper: self}}
end
```

We correctly report the error for `Elem1` by tracking a list of
dependencies which must have been resolved before we allow resolving the
`ResolveAssignItem` that will enter the bounds for the type member.

However, we were forgetting to add the dependencies when creating a job
that mentions `self` instead of a constant literal.

This manifested as an infinite loop when trying to use the upper bound
to do something recursive. The first place that happened was when
computing hashes for LSP, because LSP will hash the type members of a
class, which will hash their upper bounds, which will hash the class,
which will hash the type members of the class (which is a cycle).

(The fact that `self` is allowed here at all is maybe an accident of
history. I don't quite know why it behaves the way it does, but `self`
is basically allowed in any type syntax position where the syntactic
name of the enclosing class would also be allowed. It's a weird rule but
it's what we have.)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.