### PR TITLE
wip: Try making `Object#=~` return `T.noreturn`

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -627,11 +627,20 @@ module Kernel
   end
   def ===(other); end
 
+  # =~ is on Object is deprecated, and is almost always a mistake to use.
+  #
+  # Likely what you meant to do is call `=~` on `String` or `Symbol`--you can
+  # do so by first checking whether the type is correct first.
+  #
+  # This method has been deprecated in Ruby, and may be removed at some point
+  # in the future. In the mean time, we've assigned a sig of `T.noreturn` to
+  # this method, so that people don't try to use it incorrectly.
   sig do
     params(
         other: BasicObject,
     )
-    .returns(NilClass)
+      # .returns(NilClass)
+      .returns(T.noreturn)
   end
   def =~(other); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #707

(maybe)

The best solution would be to mark this method as not actually defined. Unfortunately, if someone ever tried to run missing method generation, it would just get defined in a different RBI, and that time be untyped.

Maybe keeping it as `returns(NilClass)` is best?


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.