### PR TITLE
Better log message when no metrics gathering

### DIFF
--- a/vscode_extension/src/veneur.ts
+++ b/vscode_extension/src/veneur.ts
@@ -82,7 +82,13 @@ async function initSorbetMetricsApi(outputChannel: OutputChannel) {
     },
     (reason) => {
       sorbetMetricsApi = NoOpApi.INSTANCE;
-      outputChannel.appendLine(`Sorbet metrics gathering disabled: ${reason}`);
+      const adjustedReason =
+        reason.message === "command 'sorbet.metrics.getExportedApi' not found"
+          ? "Define the 'sorbet.metrics.getExportedApi' command to enable metrics gathering"
+          : reason.message;
+      outputChannel.appendLine(
+        `Sorbet metrics gathering disabled: ${adjustedReason}`,
+      );
     },
   );
 }

--- a/website/docs/vscode.md
+++ b/website/docs/vscode.md
@@ -415,3 +415,35 @@ result.
 
 It is not possible to opt-out of these completion snippets. If you find that
 this is annoying, please let us know.
+
+## Reporting metrics
+
+> Sorbet does not require metrics gathering for full functionality. If you are
+> seeing a log line like "Sorbet metrics gathering disabled," Sorbet is working
+> as intended.
+
+It is possible to ask the Sorbet VS Code extension to collect and report usage
+metrics. This is predominantly useful if you maintain a large Ruby codebase that
+uses Sorbet, and want to gather metrics on things like daily users and editor
+responsiveness.
+
+To start gathering metrics, implement a
+[custom VS Code command](https://code.visualstudio.com/api/extension-guides/command#creating-new-commands)
+using the name `sorbet.metrics.getExportedApi`.
+
+The implementation of this command should simply return an object like this:
+
+```js
+{
+  metricsEmitter: ...
+}
+```
+
+The `metricsEmitter` value should conform to the [`MetricsEmitter` interface]
+declared in the Sorbet VS Code extension source code. Most likely, you will want
+to implement this interface by importing a StatsD client, connecting to an
+internal metrics reporting host, and forwarding requests from the
+`MetricEmitter` interface function calls to the StatsD client of your choice.
+
+[`metricsemitter` interface]:
+  https://github.com/sorbet/sorbet/blob/2b850340e9bccd689d6a976cddbbfecf533933ae/vscode_extension/src/veneur.ts#L11


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5736

Some users were seeing this message and thinking that something was
misconfigured because the message says "error". There is not actually a
problem--Sorbet works just fine without metrics gathering. The log line is
merely meant to show that it's possible to get the VS Code to report
metrics.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested this interactively.