### PR TITLE
Don't track blame if method doesn't exist

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -51,7 +51,7 @@ TypePtr Types::untypedUntracked() {
 }
 
 TypePtr Types::untyped(const sorbet::core::GlobalState &gs, sorbet::core::SymbolRef blame) {
-    if (sorbet::debug_mode) {
+    if (sorbet::debug_mode && blame.exists()) {
         return make_type<BlamedUntyped>(blame);
     } else {
         return untypedUntracked();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #4818

There are some places where we might have untyped because a method
didn't exist, like this:

    # typed: strict
    module DatabaseInit
      class CreateUsers
        def do
          existing_roles = Set.new(rows.map { |row| row['rolname'] })
        end
      end
    end

In this example, the `rows` method does not exist, which means that when
we set the resultType for the blockResultType and blockPreType, we were
previously setting it to a symbol that didn't exist.

I thought about fixing the one-off problems with blocks in
environment.cc, but then I realized that it seemed like basically any
place where the method didn't exist, the behavior would be to simply
create an untracked untyped at that call site. So I figured I'd just
push that logic into the implementation of `Types::untyped`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We do not have tests for `--suggest-typed` because the option is not available
in all build configurations.