### PR TITLE
Change "Typechecking in foreground..." threshold

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -235,7 +235,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
 
     config->logger->debug("Running fast path over num_files={}", toTypecheck.size());
     unique_ptr<ShowOperation> op;
-    if (toTypecheck.size() > 100) {
+    if (toTypecheck.size() > config->opts.lspMaxFilesOnFastPath / 2) {
         op = make_unique<ShowOperation>(*config, ShowOperation::Kind::FastPath);
     }
     ENFORCE(gs->errorQueue->isEmpty());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After the changes in #6166, it was impossible to have the "Typechecking in
foreground..." message show up if `lspMaxFilesOnFastPath` was `100` because then
`runFastPath` would never have been reached. This drops down the threshold just
in case.

Technically we don't _have_ to gate this on any arbitrary number and could
instead unconditionally show it, except that maybe we don't want it to blink
on-and-off rapidly while someone is typing.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.