### PR TITLE
Handle methods that dispatch to intrinsics on fast path

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1118,8 +1118,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                             // Have to use zero-width locs here so that these auto-generated things
                             // don't show up in e.g. completion requests.
                             rhsSend->insertPosArg(0, std::move(rhsSend->recv));
-                            rhsSend->insertPosArg(1, MK::Local(loc.copyWithZeroLength(), andAndTemp));
-                            rhsSend->insertPosArg(2, MK::Symbol(rhsSend->funLoc.copyWithZeroLength(), rhsSend->fun));
+                            rhsSend->insertPosArg(1, MK::Symbol(rhsSend->funLoc.copyWithZeroLength(), rhsSend->fun));
+                            rhsSend->insertPosArg(2, MK::Local(loc.copyWithZeroLength(), andAndTemp));
                             rhsSend->recv = MK::Magic(loc.copyWithZeroLength());
                             rhsSend->fun = core::Names::checkAndAnd();
                             thenp = std::move(rhs);

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -124,7 +124,7 @@ public:
             // We're lucky because all of these methods have the symbol they dispatch to as the
             // positional arg at index 1.
             auto name = unwrapLiteralToName(send.getPosArg(1));
-            ENFORCE(name.exists());
+            ENFORCE(name.exists(), "Name should exist because this arg should be a Literal");
             [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
         }
 

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -98,8 +98,9 @@ public:
     void preTransformSend(core::MutableContext ctx, ExpressionPtr &original) {
         auto &send = cast_tree_nonnull<Send>(original);
         if (send.fun == core::Names::aliasMethod()) {
-            // This is basically a MethodDef in disguise, so we have to do similar logic to record
-            // the names that the MethodDef case would.
+            // `alias_method :foo :bar` is very similar to `def foo; self.bar(); end`, so in
+            // addition to handling the `alias_method` fun, we also want to look at the two
+            // possibly-Symbol-literal arguments and call substituteSymbolName on them as well.
 
             // Discards the new name. We only care to do this for the side effect of recording the entry in
             // acc.symbols in the NameSubstitution. When the tree traversal actually visits the arg
@@ -116,9 +117,19 @@ public:
                     [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
                 }
             }
+        } else if (send.fun == core::Names::callWithSplat() || send.fun == core::Names::callWithBlock() ||
+                   send.fun == core::Names::callWithSplatAndBlock() || send.fun == core::Names::checkAndAnd()) {
+            ENFORCE(send.numPosArgs() > 2, "These are special desugar methods, should have at least two args");
+
+            // We're lucky because all of these methods have the symbol they dispatch to as the
+            // positional arg at index 1.
+            auto name = unwrapLiteralToName(send.getPosArg(1));
+            ENFORCE(name.exists());
+            [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
         }
 
         send.fun = subst.substituteSymbolName(send.fun);
+        // TODO(jez) Also use the intrinsic methods to record other symbol names.
     }
 
     void postTransformLiteral(core::MutableContext ctx, ExpressionPtr &tree) {

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -129,7 +129,14 @@ public:
         }
 
         send.fun = subst.substituteSymbolName(send.fun);
-        // TODO(jez) Also use the intrinsic methods to record other symbol names.
+
+        // Some intrinsic method dispatch to other methods. Defensively assume that any method that
+        // shares a name with an intrinsic might be an intrinsic method.
+        for (const auto &[source, targets] : core::intrinsicMethodsDispatchMap()) {
+            for (const auto target : targets) {
+                [[maybe_unused]] auto _substituted = subst.substituteSymbolName(target);
+            }
+        }
     }
 
     void postTransformLiteral(core::MutableContext ctx, ExpressionPtr &tree) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -698,11 +698,11 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::attachedClass())
                  .repeatedUntypedArg(Names::arg0())
                  .buildWithResultUntyped();
-    // Synthesize <Magic>.<check-and-and>(arg0: T.untyped, arg1: T.untyped, arg2: Symbol, arg: *T.untyped) => T.untyped
+    // Synthesize <Magic>.<check-and-and>(arg0: T.untyped, arg1: Symbol, arg2: T.untyped, arg: *T.untyped) => T.untyped
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::checkAndAnd())
                  .untypedArg(Names::arg0())
-                 .untypedArg(Names::arg1())
-                 .typedArg(Names::arg2(), core::Types::Symbol())
+                 .typedArg(Names::arg1(), core::Types::Symbol())
+                 .untypedArg(Names::arg2())
                  .repeatedUntypedArg(Names::arg())
                  .buildWithResultUntyped();
     // Synthesize <Magic>.<nil-for-safe-navigation>(recv: T.untyped) => NilClass

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2641,6 +2641,10 @@ bool Method::hasIntrinsic() const {
     return this->intrinsicOffset != INVALID_INTRINSIC_OFFSET;
 }
 
+vector<NameRef> IntrinsicMethod::dispatchesTo() const {
+    return {};
+}
+
 const IntrinsicMethod *Method::getIntrinsic() const {
     if (this->intrinsicOffset == INVALID_INTRINSIC_OFFSET) {
         return nullptr;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -29,6 +29,18 @@ class SerializerImpl;
 }
 class IntrinsicMethod {
 public:
+    // A list of method names that this intrinsic dispatches to.
+    // Used to ensure that calls involving intrinsics are correctly typechecked on the fast path.
+    //
+    // If your intrinsic does not dispatch to another method, the default implementation returns an
+    // empty vector, so you can elide an implementation.
+    //
+    // If your intrinsic cannot declare the list of methods it might dispatch to (like
+    // `<call-with-splat>`, etc.), you will have to edit Substitute.cc.
+    virtual std::vector<NameRef> dispatchesTo() const {
+        return {};
+    }
+
     virtual void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const = 0;
 };
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -37,9 +37,7 @@ public:
     //
     // If your intrinsic cannot declare the list of methods it might dispatch to (like
     // `<call-with-splat>`, etc.), you will have to edit Substitute.cc.
-    virtual std::vector<NameRef> dispatchesTo() const {
-        return {};
-    }
+    virtual std::vector<NameRef> dispatchesTo() const;
 
     virtual void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const = 0;
 };

--- a/core/Types.h
+++ b/core/Types.h
@@ -183,6 +183,8 @@ struct Intrinsic {
     const IntrinsicMethod *impl;
 };
 absl::Span<const Intrinsic> intrinsicMethods();
+using IntrinsicMethodsDispatchMap = UnorderedMap<NameRef, const std::vector<NameRef>>;
+const IntrinsicMethodsDispatchMap &intrinsicMethodsDispatchMap();
 
 template <class To> bool isa_type(const TypePtr &what) {
     return what != nullptr && what.tag() == TypePtr::TypeToTag<To>::value;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2002,6 +2002,10 @@ public:
 
 class Class_new : public IntrinsicMethod {
 public:
+    vector<NameRef> dispatchesTo() const override {
+        return {core::Names::initialize()};
+    }
+
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         auto mustExist = true;
         ClassOrModuleRef self = unwrapSymbol(gs, args.thisType, mustExist);
@@ -2355,6 +2359,8 @@ private:
     }
 
 public:
+    // NOTE: Since this method dispatches to one of its Symbol-literal arguments, it has special
+    // handling in Substitute.cc to account for fast path updates.
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // args[0] is the receiver
         // args[1] is the method
@@ -2457,11 +2463,10 @@ private:
             }
         }
 
-        NameRef to_proc = core::Names::toProc();
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
         InlinedVector<LocOffsets, 2> sendArgLocs;
         CallLocs sendLocs{file, callLoc, receiverLoc, funLoc, sendArgLocs};
-        DispatchArgs innerArgs{to_proc,
+        DispatchArgs innerArgs{core::Names::toProc(),
                                sendLocs,
                                0,
                                sendArgs,
@@ -2595,6 +2600,14 @@ private:
     }
 
 public:
+    vector<NameRef> dispatchesTo() const override {
+        // This is in addition to the custom handling that we do in Substitute.cc for the dispatch
+        // to the Symbol literal arg.
+        return {core::Names::toProc()};
+    }
+
+    // NOTE: Since this method dispatches to one of its Symbol-literal arguments, it has special
+    // handling in Substitute.cc to account for fast path updates.
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // args[0] is the receiver
         // args[1] is the method
@@ -2672,6 +2685,14 @@ public:
 
 class Magic_callWithSplatAndBlock : public IntrinsicMethod {
 public:
+    vector<NameRef> dispatchesTo() const override {
+        // This is in addition to the custom handling that we do in Substitute.cc for the dispatch
+        // to the Symbol literal arg.
+        return {core::Names::toProc()};
+    }
+
+    // NOTE: Since this method dispatches to one of its Symbol-literal arguments, it has special
+    // handling in Substitute.cc to account for fast path updates.
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // args[0] is the receiver
         // args[1] is the method
@@ -2837,6 +2858,10 @@ public:
  */
 class Magic_selfNew : public IntrinsicMethod {
 public:
+    vector<NameRef> dispatchesTo() const override {
+        return {core::Names::new_()};
+    }
+
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // args[0] is the Class to create an instance of
         // args[1..] are the arguments to the constructor
@@ -2925,6 +2950,8 @@ public:
 
 class Magic_checkAndAnd : public IntrinsicMethod {
 public:
+    // NOTE: Since this method dispatches to one of its Symbol-literal arguments, it has special
+    // handling in Substitute.cc to account for fast path updates.
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // <Magic>.<check-and-and> is created when desugaring for the purpose of adding a more
         // specific error message when using `&&`. The normal error is something like "Method not
@@ -3064,6 +3091,10 @@ public:
 
 class Magic_splat : public IntrinsicMethod {
 public:
+    vector<NameRef> dispatchesTo() const override {
+        return {core::Names::toA()};
+    }
+
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         ENFORCE(args.args.size() == 1);
 
@@ -3474,6 +3505,10 @@ class Shape_to_hash : public IntrinsicMethod {
 // `<Magic>.<to-hash-dup>(x)` and `<Magic>.<to-hash-nodup>(x) both behave like `x.to_hash`
 class Magic_toHash : public IntrinsicMethod {
 public:
+    vector<NameRef> dispatchesTo() const override {
+        return {core::Names::toHash()};
+    }
+
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         ENFORCE(args.args.size() == 1);
 
@@ -3504,6 +3539,10 @@ public:
 // intrinsic that look like `a = <Magic>.<merge-hash>(a, b)`, so the fact that `merge!` won't update the type of the
 // receiver isn't a problem here.
 class Magic_mergeHash : public IntrinsicMethod {
+    vector<NameRef> dispatchesTo() const override {
+        return {core::Names::merge()};
+    }
+
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         ENFORCE(args.args.size() == 2);
 
@@ -3538,6 +3577,10 @@ class Magic_mergeHash : public IntrinsicMethod {
 //
 // See the note on Magic_mergeHash for why this doesn't dispatch to `merge!`.
 class Magic_mergeHashValues : public IntrinsicMethod {
+    vector<NameRef> dispatchesTo() const override {
+        return {core::Names::merge()};
+    }
+
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // Argument format is
         // 0 - the hash to merge values into
@@ -3682,6 +3725,10 @@ class Array_flatten : public IntrinsicMethod {
     }
 
 public:
+    vector<NameRef> dispatchesTo() const override {
+        return {core::Names::toAry()};
+    }
+
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // Unwrap the array one time to get the element type (we'll rewrap it down at the bottom)
         TypePtr element;
@@ -3771,6 +3818,10 @@ public:
 
 class Array_plus : public IntrinsicMethod {
 public:
+    vector<NameRef> dispatchesTo() const override {
+        return {core::Names::concat()};
+    }
+
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         if (args.suppressErrors || res.main.errors.empty() || args.numPosArgs != 1) {
             return;
@@ -3896,6 +3947,10 @@ public:
 
 class Enumerable_toH : public IntrinsicMethod {
 public:
+    vector<NameRef> dispatchesTo() const override {
+        return {core::Names::enumerableToH()};
+    }
+
     // Forward Enumerable.to_h to RubyType.enumerable_to_h[self]
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // Exit early when this is the case that's handled by the enumerable.rbi sig

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2959,8 +2959,8 @@ public:
         // special wording (especially for first-time Sorbet users).
         //
         // args[0] is recv
-        // args[1] is the && tmp var
-        // args[2] is the method name
+        // args[1] is the method name
+        // args[2] is the && tmp var
         // args[3...] are the args
 
         ENFORCE(args.args.size() >= 3, "Desugar should have created call to <check-and-and> with exactly 3 args");
@@ -2969,12 +2969,12 @@ public:
         }
 
         auto selfTy = *args.args[0];
-        auto selfTyAndAnd = *args.args[1];
+        auto selfTyAndAnd = *args.args[2];
 
-        if (!isa_type<NamedLiteralType>(args.args[2]->type)) {
+        if (!isa_type<NamedLiteralType>(args.args[1]->type)) {
             return;
         }
-        auto lit = cast_type_nonnull<NamedLiteralType>(args.args[2]->type);
+        auto lit = cast_type_nonnull<NamedLiteralType>(args.args[1]->type);
         if (!lit.derivesFrom(gs, Symbols::Symbol())) {
             return;
         }
@@ -3060,7 +3060,7 @@ public:
                                     auto funLoc = core::Loc(args.locs.file, args.locs.fun);
                                     if (funLoc.exists() && !funLoc.empty() &&
                                         funLoc.adjustLen(gs, -1, 1).source(gs) == ".") {
-                                        auto andAndLoc = args.locs.args[1];
+                                        auto andAndLoc = args.locs.args[2];
                                         newErr.addAutocorrect(AutocorrectSuggestion{
                                             "Refactor to use `&.`",
                                             {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1130,7 +1130,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 const bool isDesugarTripleEqSend = send.fun == core::Names::tripleEq() && send.funLoc.empty();
                 if (lspQueryMatch && !isDesugarTripleEqSend) {
                     auto fun = send.fun;
-                    if (fun == core::Names::checkAndAnd() && core::isa_type<core::NamedLiteralType>(args[2]->type)) {
+                    if (fun == core::Names::checkAndAnd() && core::isa_type<core::NamedLiteralType>(args[1]->type)) {
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[2]->type);
                         if (lit.derivesFrom(ctx, core::Symbols::Symbol())) {
                             fun = lit.asName();

--- a/test/testdata/lsp/fast_path/call_with_block__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/call_with_block__1.1.rbupdate
@@ -1,0 +1,11 @@
+# typed: strict
+# assert-fast-path: call_with_block__1.rb,call_with_block__2.rb
+
+class A
+  extend T::Sig
+
+  sig {params(blk: T.proc.params(arg0: String).returns(Integer)).void}
+  def self.takes_blk(&blk)
+    yield ''
+  end
+end

--- a/test/testdata/lsp/fast_path/call_with_block__1.rb
+++ b/test/testdata/lsp/fast_path/call_with_block__1.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+class A
+  extend T::Sig
+
+  sig {params(blk: T.proc.params(arg0: Integer).returns(String)).void}
+  def self.takes_blk(&blk)
+    yield '' # error: Expected `Integer` but found `String("")` for argument `arg0`
+  end
+end

--- a/test/testdata/lsp/fast_path/call_with_block__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/call_with_block__2.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: strict
+# exclude-from-file-update: true
+
+int_to_str = T.let(->(x) {x.to_s}, T.proc.params(arg0: Integer).returns(String))
+str_to_int = T.let(->(x) {x.to_s}, T.proc.params(arg0: String).returns(Integer))
+
+A.takes_blk(&int_to_str) # error: Expected `T.proc.params(arg0: String).returns(Integer)` but found `T.proc.params(arg0: Integer).returns(String)` for block argument
+A.takes_blk(&str_to_int)

--- a/test/testdata/lsp/fast_path/call_with_block__2.rb
+++ b/test/testdata/lsp/fast_path/call_with_block__2.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# spacer for exclude from file update
+
+int_to_str = T.let(->(x) {x.to_s}, T.proc.params(arg0: Integer).returns(String))
+str_to_int = T.let(->(x) {x.to_s}, T.proc.params(arg0: String).returns(Integer))
+
+A.takes_blk(&int_to_str)
+A.takes_blk(&str_to_int) # error: Expected `T.proc.params(arg0: Integer).returns(String)` but found `T.proc.params(arg0: String).returns(Integer)` for block argument

--- a/test/testdata/lsp/fast_path/call_with_splat__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/call_with_splat__1.1.rbupdate
@@ -1,0 +1,23 @@
+# typed: strict
+# assert-fast-path: call_with_splat__1.rb,call_with_splat__2.rb
+
+class A
+  extend T::Sig
+
+  sig {returns(String)}
+  def fooo
+    ''
+  end
+
+  sig do
+    type_parameters(:U)
+      .params(blk: T.proc.params(arg0: A).returns(T.type_parameter(:U)))
+      .returns(T.type_parameter(:U))
+  end
+  def self.example(&blk)
+    yield A.new
+  end
+
+  sig {params(x: String, y: Integer).void}
+  def self.takes_int_and_string(x, y); end
+end

--- a/test/testdata/lsp/fast_path/call_with_splat__1.rb
+++ b/test/testdata/lsp/fast_path/call_with_splat__1.rb
@@ -1,0 +1,22 @@
+# typed: strict
+
+class A
+  extend T::Sig
+
+  sig {returns(String)}
+  def foo
+    ''
+  end
+
+  sig do
+    type_parameters(:U)
+      .params(blk: T.proc.params(arg0: A).returns(T.type_parameter(:U)))
+      .returns(T.type_parameter(:U))
+  end
+  def self.example(&blk)
+    yield A.new
+  end
+
+  sig {params(x: Integer, y: String).void}
+  def self.takes_int_and_string(x, y); end
+end

--- a/test/testdata/lsp/fast_path/call_with_splat__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/call_with_splat__2.1.rbupdate
@@ -1,0 +1,21 @@
+# typed: strict
+# exclude-from-file-update: true
+
+res = A.example(&:foo) # error: Method `foo` does not exist on `A`
+T.reveal_type(res) # error: `T.untyped`
+res = A.example(&:fooo)
+T.reveal_type(res) # error: `String`
+
+int_str = [1, '']
+str_int = ['', 1]
+int_str_false = [1, '', false]
+  A.takes_int_and_string(*int_str)
+# ^ error: Expected `String` but found `Integer(1)` for argument `x`
+# ^ error: Expected `Integer` but found `String("")` for argument `y`
+  A.takes_int_and_string(*str_int)
+# spacer
+# spacer
+  A.takes_int_and_string(*int_str_false)
+# ^ error: Expected `String` but found `Integer(1)` for argument `x`
+# ^ error: Expected `Integer` but found `String("")` for argument `y`
+# ^ error: Too many arguments provided

--- a/test/testdata/lsp/fast_path/call_with_splat__2.rb
+++ b/test/testdata/lsp/fast_path/call_with_splat__2.rb
@@ -1,0 +1,21 @@
+# typed: strict
+# spacer for exclude from file update
+
+res = A.example(&:foo)
+T.reveal_type(res) # error: `String`
+res = A.example(&:fooo) # error: Method `fooo` does not exist on `A`
+T.reveal_type(res) # error: `T.untyped`
+
+int_str = [1, '']
+str_int = ['', 1]
+int_str_false = [1, '', false]
+  A.takes_int_and_string(*int_str)
+# spacer
+# spacer
+  A.takes_int_and_string(*str_int)
+# ^ error: Expected `Integer` but found `String("")` for argument `x`
+# ^ error: Expected `String` but found `Integer(1)` for argument `y`
+  A.takes_int_and_string(*int_str_false)
+# ^ error: Too many arguments provided
+# spacer
+# spacer

--- a/test/testdata/lsp/fast_path/initialize_new__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/initialize_new__1.1.rbupdate
@@ -1,0 +1,14 @@
+# typed: true
+# assert-fast-path: initialize_new__1.rb,initialize_new__2.rb,initialize_new__3.rb
+
+class A
+  extend T::Sig
+
+  sig {params(x: String).void}
+  def initialize(x)
+    T.reveal_type(x) # error: `String`
+  end
+end
+
+A.new(0) # error: Expected `String` but found `Integer(0)`
+A.new('')

--- a/test/testdata/lsp/fast_path/initialize_new__1.rb
+++ b/test/testdata/lsp/fast_path/initialize_new__1.rb
@@ -1,0 +1,14 @@
+# typed: true
+# spacer for assert-fast-path
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  def initialize(x)
+    T.reveal_type(x) # error: `Integer`
+  end
+end
+
+A.new(0)
+A.new('') # error: Expected `Integer` but found `String("")`

--- a/test/testdata/lsp/fast_path/initialize_new__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/initialize_new__2.1.rbupdate
@@ -1,0 +1,5 @@
+# typed: true
+# exclude-from-file-update: true
+
+A.new(0) # error: Expected `String` but found `Integer(0)`
+A.new('')

--- a/test/testdata/lsp/fast_path/initialize_new__2.rb
+++ b/test/testdata/lsp/fast_path/initialize_new__2.rb
@@ -1,0 +1,5 @@
+# typed: true
+# spacer for exclude from file update
+
+A.new(0)
+A.new('') # error: Expected `Integer` but found `String("")`

--- a/test/testdata/lsp/fast_path/initialize_new__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/initialize_new__3.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# exclude-from-file-update: true
+
+class A
+  sig {void}
+  def self.example
+    new(0) # error: Expected `String` but found `Integer(0)`
+    new('')
+  end
+end

--- a/test/testdata/lsp/fast_path/initialize_new__3.rb
+++ b/test/testdata/lsp/fast_path/initialize_new__3.rb
@@ -1,0 +1,10 @@
+# typed: true
+# spacer for exclude from file update
+
+class A
+  sig {void}
+  def self.example
+    new(0)
+    new('') # error: Expected `Integer` but found `String("")`
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Some of our intrinsics dispatch to other methods. Given that we currently use names not symbols to list the downstream files that might need to be retypechecked, it means we have to also record usages of these dispatched-to names as well.

This mostly affects stale errors that could have been occurring around usages of `<call-with-*>` helpers. It could also have affected `initialize`/`new`, but in a large enough codebase and with the changes we made to compute the "max files on fast path" in canTakeFastPath instead of in runFastPath, it was unlikely to still have much effect there (of course, it would matter in small codebases with fewer than 100 files).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.