### PR TITLE
Make the Elem of Reline::History only hold strings

### DIFF
--- a/rbi/stdlib/reline.rbi
+++ b/rbi/stdlib/reline.rbi
@@ -521,7 +521,7 @@ class Reline::History < Array
   def initialize(config); end
   def push(*val); end
   def to_s; end
-  Elem = type_member(:out)
+  Elem = type_member {{fixed: String}}
 end
 module Reline::Terminfo
   def self.curses_dl; end


### PR DESCRIPTION
We recently started having issues with the auto-generated RBI files for `Reline` from Tapioca: https://github.com/Shopify/tapioca/issues/1108

[sorbet.run link](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Foo%20%3C%20Array%0A%20%20extend%20T%3A%3AGeneric%0A%0A%20%20Elem%20%3D%20type_member%0Aend%0A%0Afoo%20%3D%20T.let%28T.unsafe%28nil%29%2C%20Reline%3A%3AHistory%5BT.untyped%5D%29%0Afoo2%20%3D%20T.let%28T.unsafe%28nil%29%2C%20Foo%5BT.untyped%5D%29%0Abar%20%3D%20T.let%28T.unsafe%28nil%29%2C%20T%3A%3AArray%5BT.untyped%5D%29%0Abaz%20%3D%20T.let%28T.unsafe%28nil%29%2C%20T%3A%3ARange%5BT.untyped%5D%29)

It turns out that `Reline::History` can only hold strings:
https://github.com/ruby/reline/blob/9ab5850444b49aff8e360a84eb1dfa425e96ced1/lib/reline/history.rb#L20-L23

```ruby
> Reline::HISTORY << :foo
TypeError: no implicit conversion of Symbol into String
from /Users/ufuk/.gem/ruby/3.1.1/gems/reline-0.3.1/lib/reline/history.rb:59:in `initialize'
> Reline::HISTORY << "foo"
=> ["foo"]
```

... so this PR is changing the `Elem` declaration to make that explicit.

### Motivation

Fix https://github.com/Shopify/tapioca/issues/1108

### Test plan

Following what was done on https://github.com/sorbet/sorbet/pull/6057, given these are type definitions it seems we don't need new tests?