### PR TITLE
provide an escape hatch for github release archive builds

### DIFF
--- a/tools/buildstamp/get_workspace_status
+++ b/tools/buildstamp/get_workspace_status
@@ -14,6 +14,17 @@ set -e
 # If the script exits with non-zero code, it's considered as a failure
 # and the output will be discarded.
 
+# Provide an escape hatch for people building from github release tarballs,
+# but in non-Sorbet git repositories, to get somewhat more accurate version
+# information.
+if [ -f .github/SORBET_ARCHIVE_SHA ]; then
+    git_rev=$(head -n 1 .github/SORBET_ARCHIVE_SHA)
+    echo "STABLE_BUILD_SCM_REVISION ${git_rev}"
+    echo "STABLE_BUILD_SCM_COMMIT_COUNT 0"
+    echo "STABLE_BUILD_SCM_CLEAN 0"
+    exit 0
+fi
+    
 if ! git rev-parse --git-dir >&/dev/null; then
     echo "STABLE_BUILD_SCM_REVISION nongit"
     echo "STABLE_BUILD_SCM_COMMIT_COUNT 0"


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stripe's Sorbet build process builds Sorbet inside a git checkout of Stripe's monorepo.  The Sorbet directory is obtained from a Github release tarball, rather than a checkout from Sorbet's repository; there is no `.git` directory in the release tarball.  Which means that the `get_workspace_status` script picks up git information from the monorepo, which means that the information displayed in e.g. `sorbet --version` or LSP logs is based on Stripe's monorepo, rather than Sorbet's repository.

This makes figuring out exactly what version of Sorbet is running via a log or similar an elliptical exercise.

In the build process, we could move the Sorbet directory outside of a git checkout entirely, but then we wouldn't get any useful information in e.g. `sorbet --version`.

The compromise proposed here is that the build process creates a `.github/SORBET_ARCHIVE_SHA` file (name open to bikeshedding) with the git revision for the archive, and then `get_workspace_status` can read that file to at least be able to display the Sorbet SHA from which the release was built.  I looked for ways to have the Github release process automatically insert such things into the tarball, but did not see anything obvious (and I'm sure that enabling projects to customize the tarball generation process would be subject to limitations anyway, and it's probably simpler to just not permit customization).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I have verified that a Sorbet built from within a monorepo checkout, but with this patch applied first, has the expected version information present.  I have not yet modified the necessary build scripts on Stripe's side, but I don't expect that process to uncover any problems.