### PR TITLE
handle the return value of `getResolved` more carefully

### DIFF
--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -303,7 +303,9 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
     SymbolFileLocSaver saver{fref, defMapping};
     core::Context ctx{gs, core::Symbols::root(), fref};
     auto resolved = typechecker.getResolved({fref});
-    ast::TreeWalk::apply(ctx, saver, resolved[0].tree);
+    for (auto &f : resolved) {
+        ast::TreeWalk::apply(ctx, saver, f.tree);
+    }
 
     for (auto ref : candidates) {
         auto data = symbolRef2DocumentSymbol(gs, ref, fref, defMapping, forced);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There were some fairly common crashes in Stripe logs blaming to around this line.  Passing in N files to `getResolved` is not guaranteed to get N trees back.

I think the crashes might actually be taken care of by #6147, but this is more defensiveness and more consistent with how other parts of LSP use `getResolved`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
