### PR TITLE
Improve error message for variance mismatch with parent

### DIFF
--- a/core/Polarity.h
+++ b/core/Polarity.h
@@ -25,7 +25,7 @@ public:
             case Polarity::Positive:
                 return ":out";
             case Polarity::Neutral:
-                return ":invariant";
+                return "invariant";
             case Polarity::Negative:
                 return ":in";
         }
@@ -47,7 +47,7 @@ public:
             case core::Variance::CoVariant:
                 return ":out";
             case core::Variance::Invariant:
-                return ":invariant";
+                return "invariant";
             case core::Variance::ContraVariant:
                 return ":in";
         }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -82,7 +82,11 @@ bool resolveTypeMember(core::GlobalState &gs, core::ClassOrModuleRef parent, cor
     if (!sym.data(gs)->derivesFrom(gs, core::Symbols::Class()) && myVariance != parentVariance &&
         myVariance != core::Variance::Invariant) {
         if (auto e = gs.beginError(myTypeMember.data(gs)->loc(), core::errors::Resolver::ParentVarianceMismatch)) {
-            e.setHeader("Type variance mismatch with parent `{}`", parent.show(gs));
+            e.setHeader("Type variance mismatch for `{}` with parent `{}`. Child `{}` should be `{}` or invariant, but "
+                        "it is `{}`",
+                        name.show(gs), parent.show(gs), sym.show(gs), core::Polarities::showVariance(parentVariance),
+                        core::Polarities::showVariance(myVariance));
+            e.addErrorLine(parentTypeMember.data(gs)->loc(), "Parent `{}` declared here", parent.show(gs));
         }
         return true;
     }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -82,10 +82,11 @@ bool resolveTypeMember(core::GlobalState &gs, core::ClassOrModuleRef parent, cor
     if (!sym.data(gs)->derivesFrom(gs, core::Symbols::Class()) && myVariance != parentVariance &&
         myVariance != core::Variance::Invariant) {
         if (auto e = gs.beginError(myTypeMember.data(gs)->loc(), core::errors::Resolver::ParentVarianceMismatch)) {
-            e.setHeader("Type variance mismatch for `{}` with parent `{}`. Child `{}` should be `{}` or invariant, but "
+            auto orInvariant = parentVariance == core::Variance::Invariant ? "" : " or invariant";
+            e.setHeader("Type variance mismatch for `{}` with parent `{}`. Child `{}` should be `{}`{}, but "
                         "it is `{}`",
                         name.show(gs), parent.show(gs), sym.show(gs), core::Polarities::showVariance(parentVariance),
-                        core::Polarities::showVariance(myVariance));
+                        orInvariant, core::Polarities::showVariance(myVariance));
             e.addErrorLine(parentTypeMember.data(gs)->loc(), "Parent `{}` declared here", parent.show(gs));
         }
         return true;

--- a/test/cli/variance_mismatch/test.out
+++ b/test/cli/variance_mismatch/test.out
@@ -1,0 +1,7 @@
+test/cli/variance_mismatch/test.rb:11: Type variance mismatch for `Elem` with parent `Parent`. Child `Child` should be `:out` or invariant, but it is `:in` https://srb.help/5015
+    11 |  Elem = type_member(:in)
+          ^^^^^^^^^^^^^^^^^^^^^^^
+    test/cli/variance_mismatch/test.rb:5: Parent `Parent` declared here
+     5 |  Elem = type_member(:out)
+          ^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/variance_mismatch/test.rb
+++ b/test/cli/variance_mismatch/test.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+module Parent
+  extend T::Generic
+  Elem = type_member(:out)
+end
+
+module Child
+  extend T::Generic
+  include Parent
+  Elem = type_member(:in)
+end

--- a/test/cli/variance_mismatch/test.sh
+++ b/test/cli/variance_mismatch/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+main/sorbet --silence-dev-message test/cli/variance_mismatch/test.rb 2>&1

--- a/test/testdata/resolver/type_member_parent_missing.rb
+++ b/test/testdata/resolver/type_member_parent_missing.rb
@@ -11,7 +11,7 @@
 # ^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each`
     Elem = type_member(:out)
   # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Classes can only have invariant type members
-  # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Type variance mismatch for `Elem` with parent `Foo1`. Child `Bar1` should be `invariant`, but it is
+  # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Type variance mismatch for `Elem` with parent `Foo1`. Child `Bar1` should be `invariant`, but it is `:out`
     #      ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(Bar1)`
   end
 

--- a/test/testdata/resolver/type_member_parent_missing.rb
+++ b/test/testdata/resolver/type_member_parent_missing.rb
@@ -11,7 +11,7 @@
 # ^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each`
     Elem = type_member(:out)
   # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Classes can only have invariant type members
-  # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Type variance mismatch with parent `Foo1`
+  # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Type variance mismatch for `Elem` with parent `Foo1`. Child `Bar1` should be `:invariant` or invariant, but it is `:out`
     #      ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(Bar1)`
   end
 

--- a/test/testdata/resolver/type_member_parent_missing.rb
+++ b/test/testdata/resolver/type_member_parent_missing.rb
@@ -11,7 +11,7 @@
 # ^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each`
     Elem = type_member(:out)
   # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Classes can only have invariant type members
-  # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Type variance mismatch for `Elem` with parent `Foo1`. Child `Bar1` should be `:invariant` or invariant, but it is `:out`
+  # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Type variance mismatch for `Elem` with parent `Foo1`. Child `Bar1` should be `invariant`, but it is
     #      ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(Bar1)`
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Closes #5678
- [x] Should show what the variance in the child and parent is
- [x] Should attempt to explain (briefly) why this is not allowed
- [x] Should show the location of the matching type member in the parent

<img width="1030" alt="Screen Shot 2022-09-19 at 9 12 57 AM" src="https://user-images.githubusercontent.com/38566184/191025339-ee6bb3e6-72bf-4271-987f-6de57261d604.png">

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added automated test.
