### PR TITLE
delete comments about `handleAbstractMethod`

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3826,14 +3826,12 @@ public:
                 }
             }
         }
-        // handleAbstractMethod called elsewhere
     }
     static void resolveSignatureJob(core::MutableContext ctx, ResolveSignatureJob &job) {
         prodCounterInc("types.sig.count");
         auto &mdef = *job.mdef;
         bool isOverloaded = false;
         fillInInfoFromSig(ctx, mdef.symbol, job.loc, job.sig, isOverloaded, mdef);
-        // handleAbstractMethod called elsewhere
     }
 
     static void handleAbstractMethod(core::Context ctx, ast::MethodDef &mdef) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Review comments on these were not enthusiastic, and coming back to them after some time, I was briefly confused by them anyway.  So let's just delete them.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
