### PR TITLE
Track name kind more accurately in fast path decision

### DIFF
--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -40,9 +40,9 @@ uint32_t hashFullNameRef(const GlobalState &gs, NameRef nm) {
 
 } // namespace
 
-ShortNameHash::ShortNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(_hash(nm.shortName(gs)))){};
+WithoutUniqueNameHash::WithoutUniqueNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(_hash(nm.shortName(gs)))){};
 
-void ShortNameHash::sortAndDedupe(std::vector<core::ShortNameHash> &hashes) {
+void WithoutUniqueNameHash::sortAndDedupe(std::vector<core::WithoutUniqueNameHash> &hashes) {
     fast_sort(hashes);
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
 }

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -40,7 +40,8 @@ uint32_t hashFullNameRef(const GlobalState &gs, NameRef nm) {
 
 } // namespace
 
-WithoutUniqueNameHash::WithoutUniqueNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(_hash(nm.shortName(gs)))){};
+WithoutUniqueNameHash::WithoutUniqueNameHash(const GlobalState &gs, NameRef nm)
+    : _hashValue(incZero(_hash(nm.shortName(gs)))){};
 
 void WithoutUniqueNameHash::sortAndDedupe(std::vector<core::WithoutUniqueNameHash> &hashes) {
     fast_sort(hashes);

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -13,6 +13,44 @@ uint32_t incZero(uint32_t a) {
     return a == 0 ? 1 : a;
 };
 
+// We ignore unique names because those are names created by Sorbet not written by the user. If a
+// symbol with a unique name changes (like an overload, or a T::Enum name, or a Singleton class), we
+// want to force the fast path to retypecheck any file that mentioned the original name in any way
+//
+// For example, `A#foo (overload.1)` changes, that means we should typecheck all files with `foo`,
+// because the that `foo` might end up dispatching to the unique name, despite not mentioning the
+// unique name directly.
+//
+// Similarly for constant names--changes to the the fake `MyEnum::X$1` symbols we create to model
+// `T::Enum` subclasses could affect a file that simply mentions a constant with the name `X` (but
+// not a file that mentions a method called `X()`, which is why we still include the name kind in
+// the hash for non-UNIQUE names).
+uint32_t hashNameRefWithoutUniques(const GlobalState &gs, NameRef nm) {
+    uint32_t result;
+    auto kind = nm.kind();
+
+    switch (kind) {
+        case NameKind::UTF8: {
+            result = _hash(nm.dataUtf8(gs)->utf8);
+            break;
+        }
+        case NameKind::CONSTANT: {
+            result = hashNameRefWithoutUniques(gs, nm.dataCnst(gs)->original);
+            break;
+        }
+        case NameKind::UNIQUE: {
+            result = hashNameRefWithoutUniques(gs, nm.dataUnique(gs)->original);
+            break;
+        }
+    }
+
+    if (kind != NameKind::UNIQUE) {
+        auto hashedKind = static_cast<underlying_type<NameKind>::type>(kind);
+        result = mix(result, hashedKind);
+    }
+    return result;
+}
+
 uint32_t hashFullNameRef(const GlobalState &gs, NameRef nm) {
     uint32_t result;
     auto kind = nm.kind();
@@ -41,7 +79,7 @@ uint32_t hashFullNameRef(const GlobalState &gs, NameRef nm) {
 } // namespace
 
 WithoutUniqueNameHash::WithoutUniqueNameHash(const GlobalState &gs, NameRef nm)
-    : _hashValue(incZero(_hash(nm.shortName(gs)))){};
+    : _hashValue(incZero(hashNameRefWithoutUniques(gs, nm))){};
 
 void WithoutUniqueNameHash::sortAndDedupe(std::vector<core::WithoutUniqueNameHash> &hashes) {
     fast_sort(hashes);

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -5,34 +5,34 @@
 namespace sorbet::core {
 class NameRef;
 class GlobalState;
-class ShortNameHash {
+class WithoutUniqueNameHash {
 public:
-    static void sortAndDedupe(std::vector<core::ShortNameHash> &hashes);
+    static void sortAndDedupe(std::vector<core::WithoutUniqueNameHash> &hashes);
 
-    ShortNameHash(const GlobalState &gs, NameRef nm);
+    WithoutUniqueNameHash(const GlobalState &gs, NameRef nm);
     inline bool isDefined() const {
         return _hashValue != 0;
     }
-    ShortNameHash(const ShortNameHash &nm) noexcept = default;
-    ShortNameHash() noexcept : _hashValue(0){};
-    inline bool operator==(const ShortNameHash &rhs) const noexcept {
+    WithoutUniqueNameHash(const WithoutUniqueNameHash &nm) noexcept = default;
+    WithoutUniqueNameHash() noexcept : _hashValue(0){};
+    inline bool operator==(const WithoutUniqueNameHash &rhs) const noexcept {
         ENFORCE(isDefined());
         ENFORCE(rhs.isDefined());
         return _hashValue == rhs._hashValue;
     }
 
-    inline bool operator!=(const ShortNameHash &rhs) const noexcept {
+    inline bool operator!=(const WithoutUniqueNameHash &rhs) const noexcept {
         return !(rhs == *this);
     }
 
-    inline bool operator<(const ShortNameHash &rhs) const noexcept {
+    inline bool operator<(const WithoutUniqueNameHash &rhs) const noexcept {
         return this->_hashValue < rhs._hashValue;
     }
 
     uint32_t _hashValue;
 };
 
-template <typename H> H AbslHashValue(H h, const ShortNameHash &m) {
+template <typename H> H AbslHashValue(H h, const WithoutUniqueNameHash &m) {
     return H::combine(std::move(h), m._hashValue);
 }
 
@@ -69,17 +69,18 @@ template <typename H> H AbslHashValue(H h, const FullNameHash &m) {
 
 struct SymbolHash {
     // The hash of the symbol's name. Note that symbols with the same name owned by different
-    // symbols map to the same ShortNameHash. This is fine, because our strategy for deciding which
+    // symbols map to the same WithoutUniqueNameHash. This is fine, because our strategy for deciding which
     // downstream files to retypecheck is "any file that mentions any method with this name,"
     // regardless of which method symbol(s) that call might dispatch to.
-    ShortNameHash nameHash;
+    WithoutUniqueNameHash nameHash;
     // The combined hash of all method symbols with the given nameHash. If this changes, it tells us
     // that at least one method symbol with the given name changed in some way, including type
     // information.
     uint32_t symbolHash;
 
     SymbolHash() noexcept = default;
-    SymbolHash(ShortNameHash nameHash, uint32_t symbolHash) noexcept : nameHash(nameHash), symbolHash(symbolHash) {}
+    SymbolHash(WithoutUniqueNameHash nameHash, uint32_t symbolHash) noexcept
+        : nameHash(nameHash), symbolHash(symbolHash) {}
 
     inline bool operator<(const SymbolHash &h) const noexcept {
         return this->nameHash < h.nameHash || (!(h.nameHash < this->nameHash) && this->symbolHash < h.symbolHash);
@@ -155,7 +156,7 @@ struct LocalSymbolTableHashes {
     // A fingerprint for the methods contained in the file.
     uint32_t methodHash = HASH_STATE_NOT_COMPUTED;
 
-    // Essentially a map from ShortNameHash -> uint32_t, where keys are names of methods and values are
+    // Essentially a map from WithoutUniqueNameHash -> uint32_t, where keys are names of methods and values are
     // Symbol hashes for all methods defined in the file with that name (on any owner).
     //
     // Stored as a vector instead of a map to optimize for set_difference and compact storage
@@ -224,7 +225,7 @@ struct LocalSymbolTableHashes {
 //
 // (Useful for _over_ approximating the set of files that might be affected.)
 struct UsageHash {
-    std::vector<core::ShortNameHash> nameHashes;
+    std::vector<core::WithoutUniqueNameHash> nameHashes;
 };
 
 // This is stored on the core::File object directly, which is then cached.

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -70,12 +70,11 @@ template <typename H> H AbslHashValue(H h, const FullNameHash &m) {
 struct SymbolHash {
     // The hash of the symbol's name. Note that symbols with the same name owned by different
     // symbols map to the same WithoutUniqueNameHash. This is fine, because our strategy for deciding which
-    // downstream files to retypecheck is "any file that mentions any method with this name,"
-    // regardless of which method symbol(s) that call might dispatch to.
+    // downstream files to retypecheck is "any file that mentions any symbol with this name,"
+    // regardless of which symbol(s) that name might refer to in that position.
     WithoutUniqueNameHash nameHash;
-    // The combined hash of all method symbols with the given nameHash. If this changes, it tells us
-    // that at least one method symbol with the given name changed in some way, including type
-    // information.
+    // The combined hash of all symbols with the given nameHash. If this changes, it tells us that at
+    // least one symbol with the given name changed in some way, ignoring nothing about the symbol.
     uint32_t symbolHash;
 
     SymbolHash() noexcept = default;

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -7,7 +7,6 @@ class NameRef;
 class GlobalState;
 class ShortNameHash {
 public:
-    /** Sorts an array of ShortNameHashes and removes duplicates. */
     static void sortAndDedupe(std::vector<core::ShortNameHash> &hashes);
 
     ShortNameHash(const GlobalState &gs, NameRef nm);
@@ -39,7 +38,6 @@ template <typename H> H AbslHashValue(H h, const ShortNameHash &m) {
 
 class FullNameHash {
 public:
-    /** Sorts an array of ShortNameHashes and removes duplicates. */
     static void sortAndDedupe(std::vector<core::FullNameHash> &hashes);
 
     FullNameHash(const GlobalState &gs, NameRef nm);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2234,8 +2234,8 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     uint32_t typeMemberHash = 0;
     uint32_t fieldHash = 0;
     uint32_t methodHash = 0;
-    UnorderedMap<ShortNameHash, uint32_t> methodHashesMap;
-    UnorderedMap<ShortNameHash, uint32_t> staticFieldHashesMap;
+    UnorderedMap<WithoutUniqueNameHash, uint32_t> methodHashesMap;
+    UnorderedMap<WithoutUniqueNameHash, uint32_t> staticFieldHashesMap;
     int counter = 0;
 
     for (const auto &sym : this->classAndModules) {
@@ -2280,7 +2280,7 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
         // No fields are ignored in hashing.
         uint32_t symhash = field.hash(*this);
         if (field.flags.isStaticField) {
-            auto &target = staticFieldHashesMap[ShortNameHash(*this, field.name)];
+            auto &target = staticFieldHashesMap[WithoutUniqueNameHash(*this, field.name)];
             target = mix(target, symhash);
         }
         hierarchyHash = mix(hierarchyHash, field.fieldShapeHash(*this));
@@ -2294,7 +2294,7 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     counter = 0;
     for (const auto &sym : this->methods) {
         if (!sym.ignoreInHashing(*this)) {
-            auto &target = methodHashesMap[ShortNameHash(*this, sym.name)];
+            auto &target = methodHashesMap[WithoutUniqueNameHash(*this, sym.name)];
             target = mix(target, sym.hash(*this));
             auto needMethodShapeHash =
                 this->lspExperimentalFastPathEnabled

--- a/core/NameSubstitution.cc
+++ b/core/NameSubstitution.cc
@@ -87,7 +87,7 @@ NameRef LazyNameSubstitution::defineName(NameRef from) {
 }
 
 core::UsageHash LazyNameSubstitution::getAllNames() {
-    core::ShortNameHash::sortAndDedupe(acc.nameHashes);
+    core::WithoutUniqueNameHash::sortAndDedupe(acc.nameHashes);
     return move(acc);
 }
 } // namespace sorbet::core

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -274,21 +274,21 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
     auto methodHashSize = p.getU4();
     ret.localSymbolTableHashes.methodHashes.reserve(methodHashSize);
     for (int it = 0; it < methodHashSize; it++) {
-        ShortNameHash key;
+        WithoutUniqueNameHash key;
         key._hashValue = p.getU4();
         ret.localSymbolTableHashes.methodHashes.emplace_back(key, p.getU4());
     }
     auto staticFieldHashSize = p.getU4();
     ret.localSymbolTableHashes.staticFieldHashes.reserve(staticFieldHashSize);
     for (int it = 0; it < staticFieldHashSize; it++) {
-        ShortNameHash key;
+        WithoutUniqueNameHash key;
         key._hashValue = p.getU4();
         ret.localSymbolTableHashes.staticFieldHashes.emplace_back(key, p.getU4());
     }
     auto constantsSize = p.getU4();
     ret.usages.nameHashes.reserve(constantsSize);
     for (int it = 0; it < constantsSize; it++) {
-        ShortNameHash key;
+        WithoutUniqueNameHash key;
         key._hashValue = p.getU4();
         ret.usages.nameHashes.emplace_back(key);
     }

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -157,7 +157,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
                       [](const auto &symhash) { return symhash.nameHash; });
     absl::c_transform(changedFieldSymbolHashes, std::back_inserter(result.changedSymbolNameHashes),
                       [](const auto &symhash) { return symhash.nameHash; });
-    core::ShortNameHash::sortAndDedupe(result.changedSymbolNameHashes);
+    core::WithoutUniqueNameHash::sortAndDedupe(result.changedSymbolNameHashes);
 
     if (result.changedSymbolNameHashes.empty()) {
         // Optimization--skip the loop over every file in the project (`gs.getFiles()`) if
@@ -190,7 +190,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
 
         ENFORCE(oldFile->getFileHash() != nullptr);
         const auto &oldHash = *oldFile->getFileHash();
-        vector<core::ShortNameHash> intersection;
+        vector<core::WithoutUniqueNameHash> intersection;
         absl::c_set_intersection(result.changedSymbolNameHashes, oldHash.usages.nameHashes,
                                  std::back_inserter(intersection));
         if (intersection.empty()) {

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -55,7 +55,7 @@ public:
         UnorderedMap<core::FileRef, size_t> changedFiles;
 
         // The names of all symbols changed by this set of updates
-        std::vector<core::ShortNameHash> changedSymbolNameHashes;
+        std::vector<core::WithoutUniqueNameHash> changedSymbolNameHashes;
 
         // Extra files that need to be typechecked because the file mentions the name of one of the changed symbols.
         std::vector<core::FileRef> extraFiles;

--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -109,7 +109,7 @@ LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypechecker
     ENFORCE(symbol.exists());
     vector<core::FileRef> frefs;
     const core::GlobalState &gs = typechecker.state();
-    const core::ShortNameHash symShortNameHash(gs, symbol.name(gs));
+    const core::WithoutUniqueNameHash symShortNameHash(gs, symbol.name(gs));
     // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.
     int i = -1;
     for (auto &file : typechecker.state().getFiles()) {

--- a/test/testdata/lsp/fast_path/name_kind__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/name_kind__1.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: strict
+# assert-fast-path: name_kind__1.rb,name_kind__3.rb
+
+class A
+  extend T::Sig
+
+  sig {returns(String)}
+  def Foo; 0; end
+  #        ^ error: Expected `String` but found `Integer(0)` for method result type
+end

--- a/test/testdata/lsp/fast_path/name_kind__1.rb
+++ b/test/testdata/lsp/fast_path/name_kind__1.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class A
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def Foo; 0; end
+end

--- a/test/testdata/lsp/fast_path/name_kind__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/name_kind__2.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: strict
+# exclude-from-file-update: true
+
+class Foo
+end
+
+T.reveal_type(Foo) # error: `T.class_of(Foo)`

--- a/test/testdata/lsp/fast_path/name_kind__2.rb
+++ b/test/testdata/lsp/fast_path/name_kind__2.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# spacer for exclude-from-file-update
+
+class Foo
+end
+
+T.reveal_type(Foo) # error: `T.class_of(Foo)`

--- a/test/testdata/lsp/fast_path/name_kind__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/name_kind__3.1.rbupdate
@@ -1,0 +1,5 @@
+# typed: strict
+# spacer for exclude-from-file-update
+
+x = A.new.Foo
+T.reveal_type(x) # error: `String`

--- a/test/testdata/lsp/fast_path/name_kind__3.rb
+++ b/test/testdata/lsp/fast_path/name_kind__3.rb
@@ -1,0 +1,5 @@
+# typed: strict
+# spacer for exclude-from-file-update
+
+x = A.new.Foo
+T.reveal_type(x) # error: `Integer`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This isn't _exactly_ a problem right now, because:

- it's uncommon for people to define methods with uppercase names
- especially uppercase names that share names with constants
- the worst thing that happens is that it appears as though we have to typecheck
  _extra_ files on the fast path, but otherwise doesn't interfere with whether
  we can take the fast path or not

But in #6206 I'm starting to work on having changes to `type_member`'s take the
fast path, which will start making constant names more common here.

So I'd like to just properly handle this.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Note that these changes apply independent of any already-landed or still-ongoing work to take the fast path more often.