### PR TITLE
Restructure the Field hashing code

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2302,9 +2302,9 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
                        sym.name == Names::requiredAncestorsLin())
                     : true;
             if (needMethodShapeHash) {
-                uint32_t symhash = sym.methodShapeHash(*this);
-                hierarchyHash = mix(hierarchyHash, symhash);
-                methodHash = mix(methodHash, symhash);
+                uint32_t methodShapeHash = sym.methodShapeHash(*this);
+                hierarchyHash = mix(hierarchyHash, methodShapeHash);
+                methodHash = mix(methodHash, methodShapeHash);
             }
 
             counter++;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2320,6 +2320,11 @@ uint32_t Method::hash(const GlobalState &gs) const {
     return result;
 }
 
+bool Field::isClassAlias() const {
+    ENFORCE(this->flags.isStaticField, "should never ask whether instance variable is a class alias");
+    return isa_type<AliasType>(resultType);
+}
+
 uint32_t Field::hash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
     result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
@@ -2364,7 +2369,7 @@ uint32_t Field::fieldShapeHash(const GlobalState &gs) const {
         // this and the corresponding code in GlobalState, but one step at a time.
         !this->flags.isField &&
         // Only normal static fields are ok (no type aliases, no class aliases/type templates).
-        (!this->flags.isStaticFieldTypeAlias && !isa_type<AliasType>(this->resultType));
+        (!this->flags.isStaticFieldTypeAlias && !this->isClassAlias());
 
     if (!canSkipType) {
         result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -241,6 +241,8 @@ public:
     const InlinedVector<Loc, 2> &locs() const;
     void addLoc(const core::GlobalState &gs, core::Loc loc);
 
+    bool isClassAlias() const;
+
     uint32_t hash(const GlobalState &gs) const;
     uint32_t fieldShapeHash(const GlobalState &gs) const;
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -218,8 +218,7 @@ private:
                 // static fields to find the field on the singleton class.
                 auto lookup = scope->scope.asClassOrModuleRef().data(ctx)->findMemberNoDealias(ctx, name);
                 if (lookup.isStaticField(ctx)) {
-                    const auto &resultType = lookup.asFieldRef().data(ctx)->resultType;
-                    if (core::isa_type<core::AliasType>(resultType)) {
+                    if (lookup.asFieldRef().data(ctx)->isClassAlias()) {
                         auto dealiased = lookup.dealias(ctx);
                         if (dealiased.isTypeMember() &&
                             dealiased.asTypeMemberRef().data(ctx)->owner ==

--- a/test/testdata/lsp/fast_path/ivar.1.rbupdate
+++ b/test/testdata/lsp/fast_path/ivar.1.rbupdate
@@ -1,0 +1,16 @@
+# typed: true
+# assert-slow-path: true
+
+class A
+  extend T::Sig
+
+  sig {void}
+  def initialize
+    @x = T.let(0, String) # error: Argument does not have asserted type `String`
+  end
+
+  sig {void}
+  def example
+    T.reveal_type(@x) # error: `String`
+  end
+end

--- a/test/testdata/lsp/fast_path/ivar.rb
+++ b/test/testdata/lsp/fast_path/ivar.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {void}
+  def initialize
+    @x = T.let(0, Integer)
+  end
+
+  sig {void}
+  def example
+    T.reveal_type(@x) # error: `Integer`
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


Before, the `fieldShapeHash` function was doing double duty:

- If it was a "normal" static field, it would behave like a proper
  "shape hash" function and ignore the result type.
- If it was a "special" static field or a field, it would actually
  behave like `Field::hash` instead of like a "shape hash".

That implementation was confusing. Structuring the code this way makes
the code more parallel to the method hashing code.

There was also a slight bug that I fixed in this commit:

- Previously, we would _always_ use the `symhash` instead of the
  `staticFieldShapeHash` to mix into `fieldHash`. Luckily, `fieldHash`
  is only used for our metrics, to say when the reason that we took the
  slow path was because a field changed.
- If we took the slow path (say, because a class or module changed),
  *and* also in the same edit a static field's type changed, it would
  previously look like we took the slow path because both a
  ClassOrModule symbol and a Field symbol changed, when in fact we only
  took the slow path because of the change in the former.

The invariant here is that the `<specific>Hash` should always be mixed
with the same thing that the `hierarchyHash` is mixed with.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Should be a no-op, except for one fix for the metrics.