### PR TITLE
Fix fast path bug with removing `T.let` from static field

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2368,6 +2368,7 @@ uint32_t Field::fieldShapeHash(const GlobalState &gs) const {
     ENFORCE(!this->flags.isField && !this->flags.isStaticFieldTypeAlias && !this->isClassAlias());
     uint32_t result = _hash(name.shortName(gs));
 
+    result = mix(result, 1 + (this->resultType != nullptr));
     result = mix(result, this->flags.serialize());
     result = mix(result, this->owner.id());
     return result;

--- a/test/testdata/lsp/fast_path/static_field_type.3.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type.3.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-slow-path: true
+
+class A
+  def foo(x); end
+
+  X = 0 + 0
+end
+
+T.reveal_type(A::X) # error: `T.untyped`

--- a/test/testdata/lsp/fast_path/static_field_type.3.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type.3.rbupdate
@@ -1,10 +1,10 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: static_field_type.rb
 
 class A
   def foo(x); end
 
-  X = 0 + 0
+  X = 0 + 0 # error: Expected `String` but found `Integer` for field
 end
 
-T.reveal_type(A::X) # error: `T.untyped`
+T.reveal_type(A::X) # error: `String`

--- a/test/testdata/lsp/fast_path/static_field_type.3.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type.3.rbupdate
@@ -1,10 +1,10 @@
 # typed: true
-# assert-fast-path: static_field_type.rb
+# assert-slow-path: true
 
 class A
   def foo(x); end
 
-  X = 0 + 0 # error: Expected `String` but found `Integer` for field
+  X = 0 + 0
 end
 
-T.reveal_type(A::X) # error: `String`
+T.reveal_type(A::X) # error: `T.untyped`

--- a/test/testdata/lsp/fast_path/static_field_type.4.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type.4.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: static_field_type.rb
 
 class A
   def foo(x); end

--- a/test/testdata/lsp/fast_path/static_field_type.4.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type.4.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-slow-path: true
+
+class A
+  def foo(x); end
+
+  X = T.let(0 + 0, Float) # error: Argument does not have asserted type `Float`
+end
+
+T.reveal_type(A::X) # error: `Float`

--- a/test/testdata/lsp/fast_path/static_field_type.4.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type.4.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-fast-path: static_field_type.rb
+# assert-slow-path: true
 
 class A
   def foo(x); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes the bug in the test case.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.