### PR TITLE
don't allocate strings in `GlobalState::findFileByPath`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2187,7 +2187,7 @@ void GlobalState::replaceFile(FileRef whatFile, const shared_ptr<File> &withWhat
 }
 
 FileRef GlobalState::findFileByPath(string_view path) const {
-    auto fnd = fileRefByPath.find(string(path));
+    auto fnd = fileRefByPath.find(path);
     if (fnd != fileRefByPath.end()) {
         return fnd->second;
     }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This code gets run moderately often in LSP and there's no reason to allocate here; `fileRefByPath` can handle `string_view` for lookups.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
