### PR TITLE
don't expose `MethodDef::args` directly to clients; only expose `Span`s

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -68,7 +68,7 @@ ExpressionPtr getDefaultValue(ExpressionPtr arg) {
 
 } // namespace
 
-vector<core::ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &args) {
+vector<core::ParsedArg> ArgParsing::parseArgs(absl::Span<const ExpressionPtr> args) {
     vector<core::ParsedArg> parsedArgs;
     for (auto &arg : args) {
         if (!ast::isa_reference(arg)) {

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -5,7 +5,7 @@
 namespace sorbet::ast {
 class ArgParsing {
 public:
-    static std::vector<core::ParsedArg> parseArgs(const ast::MethodDef::ARGS_store &args);
+    static std::vector<core::ParsedArg> parseArgs(absl::Span<const ExpressionPtr> args);
     static core::ArityHash hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args);
     // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
     static ExpressionPtr getDefault(const core::ParsedArg &parsedArg, ExpressionPtr arg);

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -9,6 +9,15 @@ namespace {
 
 ExpressionPtr deepCopy(const void *avoid, const ExpressionPtr &tree, bool root = false);
 
+template <class T> T deepCopySpan(const void *avoid, absl::Span<const ExpressionPtr> origin) {
+    T copy;
+    copy.reserve(origin.size());
+    for (const auto &memb : origin) {
+        copy.emplace_back(deepCopy(avoid, memb));
+    };
+    return copy;
+}
+
 template <class T> T deepCopyVec(const void *avoid, const T &origin) {
     T copy;
     copy.reserve(origin.size());
@@ -45,7 +54,8 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
         case Tag::MethodDef: {
             auto *exp = reinterpret_cast<const MethodDef *>(tree);
             return make_expression<MethodDef>(exp->loc, exp->declLoc, exp->symbol, exp->name,
-                                              deepCopyVec(avoid, exp->args), deepCopy(avoid, exp->rhs), exp->flags);
+                                              deepCopySpan<MethodDef::ARGS_store>(avoid, exp->args()),
+                                              deepCopy(avoid, exp->rhs), exp->flags);
         }
 
         case Tag::If: {

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -142,10 +142,10 @@ void Local::_sanityCheck() {
 
 void MethodDef::_sanityCheck() {
     ENFORCE(name.exists());
-    ENFORCE(!args.empty(), "Every method should have at least one arg (the block arg).\n");
-    ENFORCE(isa_tree<BlockArg>(args.back()) || isa_tree<Local>(args.back()),
+    ENFORCE(!args().empty(), "Every method should have at least one arg (the block arg).\n");
+    ENFORCE(isa_tree<BlockArg>(args().back()) || isa_tree<Local>(args().back()),
             "Last arg must be a block arg (or a local, if block args have already been removed).");
-    for (auto &node : args) {
+    for (auto &node : args()) {
         ENFORCE(node);
     }
     ENFORCE(rhs);

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -166,9 +166,10 @@ ClassDef::ClassDef(core::LocOffsets loc, core::LocOffsets declLoc, core::ClassOr
 
 MethodDef::MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::MethodRef symbol, core::NameRef name,
                      ARGS_store args, ExpressionPtr rhs, Flags flags)
-    : loc(loc), declLoc(declLoc), symbol(symbol), rhs(std::move(rhs)), args(std::move(args)), name(name), flags(flags) {
+    : loc(loc), declLoc(declLoc), symbol(symbol), rhs(std::move(rhs)), args_(std::move(args)), name(name),
+      flags(flags) {
     categoryCounterInc("trees", "methoddef");
-    histogramInc("trees.methodDef.args", this->args.size());
+    histogramInc("trees.methodDef.args", this->args_.size());
     _sanityCheck();
 }
 
@@ -534,7 +535,7 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
     fmt::format_to(std::back_inserter(buf), "(");
     bool first = true;
     if (this->symbol == core::Symbols::todoMethod()) {
-        for (auto &a : this->args) {
+        for (auto &a : this->args_) {
             if (!first) {
                 fmt::format_to(std::back_inserter(buf), ", ");
             }
@@ -579,7 +580,7 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::format_to(std::back_inserter(buf), "args = [");
     bool first = true;
     if (this->symbol == core::Symbols::todoMethod()) {
-        for (auto &a : this->args) {
+        for (auto &a : this->args_) {
             if (!first) {
                 fmt::format_to(std::back_inserter(buf), ", ");
             }
@@ -587,7 +588,7 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
             fmt::format_to(std::back_inserter(buf), "{}", a.showRaw(gs, tabs + 2));
         }
     } else {
-        for (auto &a : this->args) {
+        for (auto &a : this->args_) {
             if (!first) {
                 fmt::format_to(std::back_inserter(buf), ", ");
             }

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -389,7 +389,17 @@ public:
     ExpressionPtr rhs;
 
     using ARGS_store = InlinedVector<ExpressionPtr, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
-    ARGS_store args;
+
+private:
+    ARGS_store args_;
+
+public:
+    absl::Span<ExpressionPtr> args() {
+        return absl::MakeSpan(args_);
+    }
+    absl::Span<const ExpressionPtr> args() const {
+        return absl::MakeSpan(args_);
+    }
 
     core::NameRef name;
 

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -69,7 +69,7 @@ public:
     void preTransformMethodDef(core::MutableContext ctx, ExpressionPtr &tree) {
         auto &original = cast_tree_nonnull<MethodDef>(tree);
         original.name = subst.substituteSymbolName(original.name);
-        for (auto &arg : original.args) {
+        for (auto &arg : original.args()) {
             substArg(ctx, arg);
         }
     }

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -255,7 +255,7 @@ private:
     return_type mapMethodDef(arg_type v, CTX ctx) {
         CALL_PRE(MethodDef);
 
-        for (auto &arg : cast_tree_nonnull<MethodDef>(v).args) {
+        for (auto &arg : cast_tree_nonnull<MethodDef>(v).args()) {
             // Only OptionalArgs have subexpressions within them.
             if (auto *optArg = cast_tree<OptionalArg>(arg)) {
                 CALL_MAP(optArg->default_, ctx.withOwner(cast_tree_nonnull<MethodDef>(v).symbol));

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -42,7 +42,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         bool isAbstract = md.symbol.data(ctx)->flags.isAbstract;
         bool seenKeyword = false;
         int i = -1;
-        for (auto &argExpr : md.args) {
+        for (auto &argExpr : md.args()) {
             i++;
             auto *a = ast::MK::arg2Local(argExpr);
             auto local = res->enterLocal(a->localVariable);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1248,9 +1248,9 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             p.putU1(flags);
             p.putU4(c.name.rawId());
             p.putU4(c.symbol.id());
-            p.putU4(c.args.size());
+            p.putU4(c.args().size());
             pickle(p, c.rhs);
-            for (auto &a : c.args) {
+            for (auto &a : c.args()) {
                 pickle(p, a);
             }
             break;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -20,11 +20,11 @@ void DefLocSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &
 
         // Check if it matches against a specific argument. If it does, send that instead;
         // it's more specific.
-        const int numArgs = methodDef.args.size();
+        const int numArgs = methodDef.args().size();
 
         ENFORCE(numArgs == argTypes.size());
         for (int i = 0; i < numArgs; i++) {
-            auto &arg = methodDef.args[i];
+            auto &arg = methodDef.args()[i];
             auto &argType = argTypes[i];
             auto *localExp = ast::MK::arg2Local(arg);
             // localExp should never be null, but guard against the possibility.

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -50,7 +50,7 @@ void LocalVarFinder::preTransformMethodDef(core::Context ctx, ast::ExpressionPtr
     auto currentMethod = methodDef.symbol;
 
     if (currentMethod == this->targetMethod) {
-        auto parsedArgs = ast::ArgParsing::parseArgs(methodDef.args);
+        auto parsedArgs = ast::ArgParsing::parseArgs(methodDef.args());
         for (const auto &parsedArg : parsedArgs) {
             this->result_.emplace_back(parsedArg.local._name);
         }

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -55,7 +55,7 @@ void LocalVarSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     // Check args.
-    for (auto &arg : methodDef.args) {
+    for (auto &arg : methodDef.args()) {
         // nullptrs should never happen, but guard against it anyway.
         if (auto *localExp = ast::MK::arg2Local(arg)) {
             bool lspQueryMatch = ctx.state.lspQuery.matchesVar(methodDef.symbol, localExp->localVariable);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -201,7 +201,7 @@ public:
         foundMethod.loc = method.loc;
         foundMethod.declLoc = method.declLoc;
         foundMethod.flags = method.flags;
-        foundMethod.parsedArgs = ast::ArgParsing::parseArgs(method.args);
+        foundMethod.parsedArgs = ast::ArgParsing::parseArgs(method.args());
         foundMethod.arityHash = ast::ArgParsing::hashArgs(ctx, foundMethod.parsedArgs);
         foundDefs->addMethod(move(foundMethod));
 
@@ -1575,31 +1575,29 @@ public:
         tree = ast::MK::InsSeq(loc, std::move(retSeqs), ast::MK::EmptyTree());
     }
 
-    ast::MethodDef::ARGS_store fillInArgs(vector<core::ParsedArg> parsedArgs, ast::MethodDef::ARGS_store oldArgs) {
-        ast::MethodDef::ARGS_store args;
+    void fillInArgs(absl::Span<ast::ExpressionPtr> args, vector<core::ParsedArg> parsedArgs) {
+        ENFORCE(args.size() == parsedArgs.size());
         int i = -1;
         for (auto &arg : parsedArgs) {
             i++;
+            ENFORCE(i < args.size());
             auto localVariable = arg.local;
 
             if (arg.flags.isShadow) {
                 auto localExpr = ast::make_expression<ast::Local>(arg.loc, localVariable);
-                args.emplace_back(move(localExpr));
+                args[i] = move(localExpr);
             } else {
-                ENFORCE(i < oldArgs.size());
-                auto expr = arg2Symbol(i, move(arg), move(oldArgs[i]));
-                args.emplace_back(move(expr));
+                auto expr = arg2Symbol(i, move(arg), move(args[i]));
+                args[i] = move(expr);
             }
         }
-
-        return args;
     }
 
     void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
         auto owner = methodOwner(ctx, ctx.owner, method.flags.isSelfMethod);
-        auto parsedArgs = ast::ArgParsing::parseArgs(method.args);
+        auto parsedArgs = ast::ArgParsing::parseArgs(method.args());
         auto sym = ctx.state.lookupMethodSymbolWithHash(owner, method.name, ast::ArgParsing::hashArgs(ctx, parsedArgs));
         if (!sym.exists()) {
             ENFORCE(this->bestEffort);
@@ -1609,7 +1607,7 @@ public:
             return;
         }
         method.symbol = sym;
-        method.args = fillInArgs(move(parsedArgs), std::move(method.args));
+        fillInArgs(method.args(), move(parsedArgs));
     }
 
     void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
@@ -1620,8 +1618,8 @@ public:
             return;
         }
 
-        ENFORCE(method.args.size() == method.symbol.data(ctx)->arguments.size(), "{}: {} != {}",
-                method.name.showRaw(ctx), method.args.size(), method.symbol.data(ctx)->arguments.size());
+        ENFORCE(method.args().size() == method.symbol.data(ctx)->arguments.size(), "{}: {} != {}",
+                method.name.showRaw(ctx), method.args().size(), method.symbol.data(ctx)->arguments.size());
     }
 
     ast::ExpressionPtr handleAssignment(core::Context ctx, ast::ExpressionPtr tree) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3250,7 +3250,7 @@ private:
     static ast::Local const *getArgLocal(core::Context ctx, const core::ArgInfo &argSym, const ast::MethodDef &mdef,
                                          int pos, bool isOverloaded) {
         if (!isOverloaded) {
-            return ast::MK::arg2Local(mdef.args[pos]);
+            return ast::MK::arg2Local(mdef.args()[pos]);
         }
 
         // we cannot rely on method and symbol arguments being aligned, as method could have more arguments.
@@ -3260,7 +3260,7 @@ private:
                                              [&](const auto &arg) { return arg.name == internalNameToLookFor; });
         ENFORCE(originalArgIt != mdef.symbol.data(ctx)->arguments.end());
         auto realPos = originalArgIt - mdef.symbol.data(ctx)->arguments.begin();
-        return ast::MK::arg2Local(mdef.args[realPos]);
+        return ast::MK::arg2Local(mdef.args()[realPos]);
     }
 
     static bool usesArgumentForwardingSyntax(core::Context ctx, core::MethodData methodInfo, const ast::MethodDef &mdef,
@@ -3353,7 +3353,7 @@ private:
                                                             core::LocOffsets exprLoc, ParsedSig &sig, bool isOverloaded,
                                                             const ast::MethodDef &mdef) {
         ENFORCE(isOverloaded || mdef.symbol == method);
-        ENFORCE(isOverloaded || method.data(ctx)->arguments.size() == mdef.args.size());
+        ENFORCE(isOverloaded || method.data(ctx)->arguments.size() == mdef.args().size());
 
         if (!sig.seen.returns && !sig.seen.void_) {
             if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
@@ -3691,7 +3691,7 @@ private:
                             auto sig = parseSig(ctx, sigOwner, *lastSig, mdef);
                             vector<bool> argsToKeep;
                             if (isOverloaded) {
-                                for (auto &argTree : mdef.args) {
+                                for (auto &argTree : mdef.args()) {
                                     const auto local = ast::MK::arg2Local(argTree);
                                     auto treeArgName = local->localVariable._name;
                                     ENFORCE(local != nullptr);
@@ -3860,7 +3860,7 @@ public:
 
             auto argIdx = -1;
             auto numPosArgs = 0;
-            for (auto &arg : mdef.args) {
+            for (auto &arg : mdef.args()) {
                 ++argIdx;
 
                 const ast::Local *local = nullptr;

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -74,8 +74,8 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     }
 
     ast::MethodDef::ARGS_store newArgs;
-    newArgs.reserve(call->args.size());
-    for (auto &arg : call->args) {
+    newArgs.reserve(call->args().size());
+    for (auto &arg : call->args()) {
         newArgs.emplace_back(arg.deepCopy());
     }
 

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -186,7 +186,7 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::
     }
 
     UnorderedMap<core::NameRef, ArgKind> argKindMap;
-    for (const auto &arg : methodDef->args) {
+    for (const auto &arg : methodDef->args()) {
         const auto *restArg = ast::cast_tree<ast::RestArg>(arg);
         if (restArg == nullptr) {
             argKindMap[ast::MK::arg2Name(arg)] = ArgKind::Plain;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Pre-work for an eventual storing of arguments inline with `MethodDef` rather than in a separate vector.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
