### PR TITLE
Don't be quite so eager to short circuit

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -199,9 +199,12 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
 
         result.extraFiles.emplace_back(ref);
 
-        if (result.changedFiles.size() + result.extraFiles.size() > config.opts.lspMaxFilesOnFastPath) {
+        if (result.changedFiles.size() + result.extraFiles.size() > (2 * config.opts.lspMaxFilesOnFastPath)) {
             // Short circuit, as a performance optimization.
             // (gs.getFiles() is usually 3-4 orders of magnitude larger than lspMaxFilesOnFastPath)
+            //
+            // The "2 * ..." is so that we can get a rough idea of whether there's an easy
+            // bang-for-buck bump we could make to the threshold by reading the logs.
             //
             // One of two things could be true:
             // - We're running on the indexer thread to decide canTakeFastPath, which only cares about how


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I went to look at the logs to see if most files that had too many files were off
by 1-2 or off by hundreds or thousands, and was greeted by `51 files > 50 files`
exclusively, repeated thousands of times.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test in prod