### PR TITLE
use separate stats for fields and static fields

### DIFF
--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -150,9 +150,9 @@ struct LocalSymbolTableHashes {
     uint32_t typeMemberHash = HASH_STATE_NOT_COMPUTED;
     // A fingerprint for the fields contained in the file.
     uint32_t fieldHash = HASH_STATE_NOT_COMPUTED;
-    // A fingerprint for the non-alias static fields contained in the file.
+    // A fingerprint for the non-class alias static fields contained in the file.
     uint32_t staticFieldHash = HASH_STATE_NOT_COMPUTED;
-    // A fingerprint for the type and class alias static fields contained in the file.
+    // A fingerprint for the class alias static fields contained in the file.
     uint32_t classAliasHash = HASH_STATE_NOT_COMPUTED;
     // A fingerprint for the methods contained in the file.
     uint32_t methodHash = HASH_STATE_NOT_COMPUTED;

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -149,9 +149,11 @@ struct LocalSymbolTableHashes {
     // A fingerprint for the type member symbols contained in the file.
     uint32_t typeMemberHash = HASH_STATE_NOT_COMPUTED;
     // A fingerprint for the fields contained in the file.
-    // TODO(froydnj) would maybe be interesting to split this out into separate
-    // field/static field hashes, or even finer subdivisions on static fields.
     uint32_t fieldHash = HASH_STATE_NOT_COMPUTED;
+    // A fingerprint for the non-alias static fields contained in the file.
+    uint32_t staticFieldHash = HASH_STATE_NOT_COMPUTED;
+    // A fingerprint for the type and class alias static fields contained in the file.
+    uint32_t staticFieldAliasHash = HASH_STATE_NOT_COMPUTED;
     // A fingerprint for the methods contained in the file.
     uint32_t methodHash = HASH_STATE_NOT_COMPUTED;
 
@@ -185,6 +187,8 @@ struct LocalSymbolTableHashes {
         ret.typeArgumentHash = HASH_STATE_INVALID_PARSE;
         ret.typeMemberHash = HASH_STATE_INVALID_PARSE;
         ret.fieldHash = HASH_STATE_INVALID_PARSE;
+        ret.staticFieldHash = HASH_STATE_INVALID_PARSE;
+        ret.staticFieldAliasHash = HASH_STATE_INVALID_PARSE;
         ret.methodHash = HASH_STATE_INVALID_PARSE;
         return ret;
     }
@@ -196,12 +200,16 @@ struct LocalSymbolTableHashes {
                 ENFORCE(typeArgumentHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(typeMemberHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(fieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(staticFieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(staticFieldAliasHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(methodHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
             } else {
                 ENFORCE(classModuleHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(typeArgumentHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(typeMemberHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(fieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(staticFieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(staticFieldAliasHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(methodHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
             });
         return hierarchyHash == HASH_STATE_INVALID_PARSE;

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -153,7 +153,7 @@ struct LocalSymbolTableHashes {
     // A fingerprint for the non-alias static fields contained in the file.
     uint32_t staticFieldHash = HASH_STATE_NOT_COMPUTED;
     // A fingerprint for the type and class alias static fields contained in the file.
-    uint32_t staticFieldAliasHash = HASH_STATE_NOT_COMPUTED;
+    uint32_t classAliasHash = HASH_STATE_NOT_COMPUTED;
     // A fingerprint for the methods contained in the file.
     uint32_t methodHash = HASH_STATE_NOT_COMPUTED;
 
@@ -188,7 +188,7 @@ struct LocalSymbolTableHashes {
         ret.typeMemberHash = HASH_STATE_INVALID_PARSE;
         ret.fieldHash = HASH_STATE_INVALID_PARSE;
         ret.staticFieldHash = HASH_STATE_INVALID_PARSE;
-        ret.staticFieldAliasHash = HASH_STATE_INVALID_PARSE;
+        ret.classAliasHash = HASH_STATE_INVALID_PARSE;
         ret.methodHash = HASH_STATE_INVALID_PARSE;
         return ret;
     }
@@ -201,7 +201,7 @@ struct LocalSymbolTableHashes {
                 ENFORCE(typeMemberHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(fieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(staticFieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(staticFieldAliasHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(classAliasHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(methodHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
             } else {
                 ENFORCE(classModuleHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
@@ -209,7 +209,7 @@ struct LocalSymbolTableHashes {
                 ENFORCE(typeMemberHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(fieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(staticFieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(staticFieldAliasHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(classAliasHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(methodHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
             });
         return hierarchyHash == HASH_STATE_INVALID_PARSE;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2233,6 +2233,8 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     uint32_t typeArgumentHash = 0;
     uint32_t typeMemberHash = 0;
     uint32_t fieldHash = 0;
+    uint32_t staticFieldHash = 0;
+    uint32_t staticFieldAliasHash = 0;
     uint32_t methodHash = 0;
     UnorderedMap<WithoutUniqueNameHash, uint32_t> methodHashesMap;
     UnorderedMap<WithoutUniqueNameHash, uint32_t> staticFieldHashesMap;
@@ -2284,7 +2286,10 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
             target = mix(target, symhash);
             uint32_t staticFieldShapeHash = field.fieldShapeHash(*this);
             hierarchyHash = mix(hierarchyHash, staticFieldShapeHash);
-            fieldHash = mix(fieldHash, staticFieldShapeHash);
+            staticFieldHash = mix(fieldHash, staticFieldShapeHash);
+        } else if (field.flags.isStaticField) {
+            hierarchyHash = mix(hierarchyHash, symhash);
+            staticFieldAliasHash = mix(staticFieldAliasHash, symhash);
         } else {
             hierarchyHash = mix(hierarchyHash, symhash);
             fieldHash = mix(fieldHash, symhash);
@@ -2336,6 +2341,8 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     result->typeArgumentHash = LocalSymbolTableHashes::patchHash(typeArgumentHash);
     result->typeMemberHash = LocalSymbolTableHashes::patchHash(typeMemberHash);
     result->fieldHash = LocalSymbolTableHashes::patchHash(fieldHash);
+    result->staticFieldHash = LocalSymbolTableHashes::patchHash(staticFieldHash);
+    result->staticFieldAliasHash = LocalSymbolTableHashes::patchHash(staticFieldAliasHash);
     result->methodHash = LocalSymbolTableHashes::patchHash(methodHash);
     return result;
 }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2234,7 +2234,7 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     uint32_t typeMemberHash = 0;
     uint32_t fieldHash = 0;
     uint32_t staticFieldHash = 0;
-    uint32_t staticFieldAliasHash = 0;
+    uint32_t classAliasHash = 0;
     uint32_t methodHash = 0;
     UnorderedMap<WithoutUniqueNameHash, uint32_t> methodHashesMap;
     UnorderedMap<WithoutUniqueNameHash, uint32_t> staticFieldHashesMap;
@@ -2289,7 +2289,7 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
             staticFieldHash = mix(fieldHash, staticFieldShapeHash);
         } else if (field.flags.isStaticField) {
             hierarchyHash = mix(hierarchyHash, symhash);
-            staticFieldAliasHash = mix(staticFieldAliasHash, symhash);
+            classAliasHash = mix(classAliasHash, symhash);
         } else {
             hierarchyHash = mix(hierarchyHash, symhash);
             fieldHash = mix(fieldHash, symhash);
@@ -2342,7 +2342,7 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     result->typeMemberHash = LocalSymbolTableHashes::patchHash(typeMemberHash);
     result->fieldHash = LocalSymbolTableHashes::patchHash(fieldHash);
     result->staticFieldHash = LocalSymbolTableHashes::patchHash(staticFieldHash);
-    result->staticFieldAliasHash = LocalSymbolTableHashes::patchHash(staticFieldAliasHash);
+    result->classAliasHash = LocalSymbolTableHashes::patchHash(classAliasHash);
     result->methodHash = LocalSymbolTableHashes::patchHash(methodHash);
     return result;
 }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -245,7 +245,7 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
     p.putU4(fh->localSymbolTableHashes.typeMemberHash);
     p.putU4(fh->localSymbolTableHashes.fieldHash);
     p.putU4(fh->localSymbolTableHashes.staticFieldHash);
-    p.putU4(fh->localSymbolTableHashes.staticFieldAliasHash);
+    p.putU4(fh->localSymbolTableHashes.classAliasHash);
     p.putU4(fh->localSymbolTableHashes.methodHash);
     p.putU4(fh->localSymbolTableHashes.methodHashes.size());
     for (const auto &[key, value] : fh->localSymbolTableHashes.methodHashes) {
@@ -283,7 +283,7 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
     ret.localSymbolTableHashes.typeMemberHash = p.getU4();
     ret.localSymbolTableHashes.fieldHash = p.getU4();
     ret.localSymbolTableHashes.staticFieldHash = p.getU4();
-    ret.localSymbolTableHashes.staticFieldAliasHash = p.getU4();
+    ret.localSymbolTableHashes.classAliasHash = p.getU4();
     ret.localSymbolTableHashes.methodHash = p.getU4();
     auto methodHashSize = p.getU4();
     ret.localSymbolTableHashes.methodHashes.reserve(methodHashSize);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -240,6 +240,13 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
     }
     p.putU1(1);
     p.putU4(fh->localSymbolTableHashes.hierarchyHash);
+    p.putU4(fh->localSymbolTableHashes.classModuleHash);
+    p.putU4(fh->localSymbolTableHashes.typeArgumentHash);
+    p.putU4(fh->localSymbolTableHashes.typeMemberHash);
+    p.putU4(fh->localSymbolTableHashes.fieldHash);
+    p.putU4(fh->localSymbolTableHashes.staticFieldHash);
+    p.putU4(fh->localSymbolTableHashes.staticFieldAliasHash);
+    p.putU4(fh->localSymbolTableHashes.methodHash);
     p.putU4(fh->localSymbolTableHashes.methodHashes.size());
     for (const auto &[key, value] : fh->localSymbolTableHashes.methodHashes) {
         p.putU4(key._hashValue);
@@ -271,6 +278,13 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
     FileHash ret;
 
     ret.localSymbolTableHashes.hierarchyHash = p.getU4();
+    ret.localSymbolTableHashes.classModuleHash = p.getU4();
+    ret.localSymbolTableHashes.typeArgumentHash = p.getU4();
+    ret.localSymbolTableHashes.typeMemberHash = p.getU4();
+    ret.localSymbolTableHashes.fieldHash = p.getU4();
+    ret.localSymbolTableHashes.staticFieldHash = p.getU4();
+    ret.localSymbolTableHashes.staticFieldAliasHash = p.getU4();
+    ret.localSymbolTableHashes.methodHash = p.getU4();
     auto methodHashSize = p.getU4();
     ret.localSymbolTableHashes.methodHashes.reserve(methodHashSize);
     for (int it = 0; it < methodHashSize; it++) {

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -140,12 +140,12 @@ bool LSPIndexer::canTakeFastPathInternal(
                 newHash.localSymbolTableHashes.fieldHash != oldHash.localSymbolTableHashes.fieldHash;
             const bool staticFieldsDiffer =
                 newHash.localSymbolTableHashes.staticFieldHash != oldHash.localSymbolTableHashes.staticFieldHash;
-            const bool staticFieldAliasesDiffer = newHash.localSymbolTableHashes.staticFieldAliasHash !=
-                                                  oldHash.localSymbolTableHashes.staticFieldAliasHash;
+            const bool classAliasesDiffer =
+                newHash.localSymbolTableHashes.classAliasHash != oldHash.localSymbolTableHashes.classAliasHash;
             const bool methodsDiffer =
                 newHash.localSymbolTableHashes.methodHash != oldHash.localSymbolTableHashes.methodHash;
             const uint32_t differCount = int(classesDiffer) + int(typeArgumentsDiffer) + int(typeMembersDiffer) +
-                                         int(fieldsDiffer) + int(staticFieldsDiffer) + int(staticFieldAliasesDiffer) +
+                                         int(fieldsDiffer) + int(staticFieldsDiffer) + int(classAliasesDiffer) +
                                          int(methodsDiffer);
             if (classesDiffer) {
                 prodCategoryCounterInc("lsp.slow_path_changed_def", "classmodule");
@@ -162,8 +162,8 @@ bool LSPIndexer::canTakeFastPathInternal(
             if (staticFieldsDiffer) {
                 prodCategoryCounterInc("lsp.slow_path_changed_def", "staticfield");
             }
-            if (staticFieldAliasesDiffer) {
-                prodCategoryCounterInc("lsp.slow_path_changed_def", "staticfieldalias");
+            if (classAliasesDiffer) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "classalias");
             }
             if (methodsDiffer) {
                 prodCategoryCounterInc("lsp.slow_path_changed_def", "method");
@@ -179,8 +179,8 @@ bool LSPIndexer::canTakeFastPathInternal(
                     prodCategoryCounterInc("lsp.slow_path_changed_def", "onlyicvars");
                 } else if (staticFieldsDiffer) {
                     prodCategoryCounterInc("lsp.slow_path_changed_def", "onlystaticfields");
-                } else if (staticFieldAliasesDiffer) {
-                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlystaticfieldaliases");
+                } else if (classAliasesDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlyclassaliases");
                 } else {
                     ENFORCE(methodsDiffer);
                     prodCategoryCounterInc("lsp.slow_path_changed_def", "onlymethods");

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -138,10 +138,15 @@ bool LSPIndexer::canTakeFastPathInternal(
                 newHash.localSymbolTableHashes.typeMemberHash != oldHash.localSymbolTableHashes.typeMemberHash;
             const bool fieldsDiffer =
                 newHash.localSymbolTableHashes.fieldHash != oldHash.localSymbolTableHashes.fieldHash;
+            const bool staticFieldsDiffer =
+                newHash.localSymbolTableHashes.staticFieldHash != oldHash.localSymbolTableHashes.staticFieldHash;
+            const bool staticFieldAliasesDiffer = newHash.localSymbolTableHashes.staticFieldAliasHash !=
+                                                  oldHash.localSymbolTableHashes.staticFieldAliasHash;
             const bool methodsDiffer =
                 newHash.localSymbolTableHashes.methodHash != oldHash.localSymbolTableHashes.methodHash;
             const uint32_t differCount = int(classesDiffer) + int(typeArgumentsDiffer) + int(typeMembersDiffer) +
-                                         int(fieldsDiffer) + int(methodsDiffer);
+                                         int(fieldsDiffer) + int(staticFieldsDiffer) + int(staticFieldAliasesDiffer) +
+                                         int(methodsDiffer);
             if (classesDiffer) {
                 prodCategoryCounterInc("lsp.slow_path_changed_def", "classmodule");
             }
@@ -152,7 +157,13 @@ bool LSPIndexer::canTakeFastPathInternal(
                 prodCategoryCounterInc("lsp.slow_path_changed_def", "typemember");
             }
             if (fieldsDiffer) {
-                prodCategoryCounterInc("lsp.slow_path_changed_def", "field");
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "icvar");
+            }
+            if (staticFieldsDiffer) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "staticfield");
+            }
+            if (staticFieldAliasesDiffer) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "staticfieldalias");
             }
             if (methodsDiffer) {
                 prodCategoryCounterInc("lsp.slow_path_changed_def", "method");
@@ -165,7 +176,11 @@ bool LSPIndexer::canTakeFastPathInternal(
                 } else if (typeMembersDiffer) {
                     prodCategoryCounterInc("lsp.slow_path_changed_def", "onlytypemembers");
                 } else if (fieldsDiffer) {
-                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlyfields");
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlyicvars");
+                } else if (staticFieldsDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlystaticfields");
+                } else if (staticFieldAliasesDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlystaticfieldaliases");
                 } else {
                     ENFORCE(methodsDiffer);
                     prodCategoryCounterInc("lsp.slow_path_changed_def", "onlymethods");


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change could have been done when the original code was landed, but it wasn't.

Also in passing fixes a possible oversight where we weren't serializing all the `LocalSymbolTableHashes` state.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
