### PR TITLE
Don't require abstract mangle renamed methods to be implemented

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -839,7 +839,15 @@ private:
         auto isAbstract = klass.data(gs)->flags.isAbstract;
         if (isAbstract) {
             for (auto [name, sym] : klass.data(gs)->members()) {
-                if (sym.exists() && sym.isMethod() && sym.asMethodRef().data(gs)->flags.isAbstract) {
+                if (!sym.exists() || !sym.isMethod()) {
+                    continue;
+                }
+                const auto &method = sym.asMethodRef().data(gs);
+                if (method->flags.isAbstract &&
+                    // Ignore mangle renames, because users shouldn't have to create *another*
+                    // mangle rename error in order to implement such an abstract method.
+                    !(method->name.kind() == core::NameKind::UNIQUE &&
+                      method->name.dataUnique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRename)) {
                     abstract.emplace_back(sym.asMethodRef());
                 }
             }

--- a/test/testdata/resolver/redefined_abstract.rb
+++ b/test/testdata/resolver/redefined_abstract.rb
@@ -1,0 +1,30 @@
+# typed: true
+
+module IFoo
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.void}
+  def foo; end
+
+  # This redefinition is an error, but since redefinition errors are only
+  # reported at `typed: true`, this situation might not have been reported to
+  # the user.
+  sig {abstract.params(x: Integer).void}
+  def foo(x); end
+# ^^^^^^^^^^ error: Method `IFoo#foo` redefined without matching argument count. Expected: `0`, got: `1`
+end
+
+  class FooGood
+# ^^^^^^^^^^^^^ error: Missing definition for abstract method `IFoo#foo`
+    include IFoo
+
+    def foo(x); end
+  end
+
+  class FooBad
+# ^^^^^^^^^^^^ error: Missing definition for abstract method `IFoo#foo`
+# ^^^^^^^^^^^^ error: Missing definition for abstract method `IFoo#foo`
+    include IFoo
+  end

--- a/test/testdata/resolver/redefined_abstract.rb
+++ b/test/testdata/resolver/redefined_abstract.rb
@@ -17,14 +17,12 @@ module IFoo
 end
 
   class FooGood
-# ^^^^^^^^^^^^^ error: Missing definition for abstract method `IFoo#foo`
     include IFoo
 
     def foo(x); end
   end
 
   class FooBad
-# ^^^^^^^^^^^^ error: Missing definition for abstract method `IFoo#foo`
 # ^^^^^^^^^^^^ error: Missing definition for abstract method `IFoo#foo`
     include IFoo
   end

--- a/test/testdata/resolver/redefined_abstract_false__1.rb
+++ b/test/testdata/resolver/redefined_abstract_false__1.rb
@@ -1,0 +1,14 @@
+# typed: false
+
+module IFoo
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.void}
+  def foo; end
+
+  # This redefinition is an error, but silenced at `# typed: false`
+  sig {abstract.params(x: Integer).void}
+  def foo(x); end
+end

--- a/test/testdata/resolver/redefined_abstract_false__2.rb
+++ b/test/testdata/resolver/redefined_abstract_false__2.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class FooGood
+  include IFoo
+
+  def foo(x); end
+end
+
+class FooBad # error: Missing definition for abstract method `IFoo#foo`
+  include IFoo
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's possible for a method to be improperly redefined but the error be silenced,
because the definition is in a `# typed: false` file.

This then made it ~impossible to implement the abstract class in a `# typed:
true` file.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.