### PR TITLE
LSP - show references in package

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,57 @@ different version number, and also marked `default-arg-value`:
 This is due to the translation of defaults into the CFG: there is a synthetic conditional that chooses either to
 initialize the variable from the argument passed at the send, or to the default value when no value is present.
 
+Finding all references works differently in package specification (__package.rb) files. Consider the following:
+
+```ruby
+class Foo < PackageSpec
+  import Bar
+```
+
+Calling "find all references" on `Bar` in this file will return only references to `Bar` in the `Foo` package. LSP tests 
+have access to `import` and `importusage` assertions that you can use to test this functionality.
+
+```ruby
+class Foo < PackageSpec
+  import Bar
+  #      ^^^ import: bar
+```
+
+```ruby
+  class Foo::Baz
+    Bar.new
+ #  ^^^ importusage: bar
+  end
+```
+
+With these annotations, the LSP test will check if "find all references" on `Bar` in `import Bar` statement returns the `Bar.new` usage.
+
+Note that an `import` assertion is dissimilar to a `def` assertion, in that it is in fact a subclass of a `usage` assertion. 
+In this case, the `def` corresponding to an `import` is the PackageSpec declaration of the imported package. Calling "find all references"
+on a PackageSpec declaration will return all imports of the package.
+
+
+```ruby
+class Bar < PackageSpec
+  #   ^^^ def: bar
+  import Bar
+```
+
+```ruby
+class Foo < PackageSpec
+  import Bar
+  #      ^^^ import: bar
+```
+
+```ruby
+class Baz < PackageSpec
+  import Bar
+  #      ^^^ import: bar
+```
+
+With these annotations, the LSP test will check if "find all references" on `Bar` from the `class Bar < PackageSpec`
+declaration returns the declaration itself plus the imports.
+
 #### Testing "Go to Type Definition"
 
 This is somewhat similar to "Find Definition" above, but also slightly different

--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -104,7 +104,7 @@ LSPQueryResult LSPQuery::LSPQuery::bySymbolInFiles(const LSPConfiguration &confi
 }
 
 LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypecheckerInterface &typechecker,
-                                  core::SymbolRef symbol) {
+                                  core::SymbolRef symbol, core::NameRef pkgName) {
     Timer timeit(config.logger, "setupLSPQueryBySymbol");
     ENFORCE(symbol.exists());
     vector<core::FileRef> frefs;
@@ -118,10 +118,14 @@ LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypechecker
             continue;
         }
 
+        auto ref = core::FileRef(i);
+        if (pkgName.exists() && gs.packageDB().getPackageForFile(gs, ref).mangledName() != pkgName) {
+            continue;
+        }
+
         ENFORCE(file->getFileHash() != nullptr);
         const auto &hash = *file->getFileHash();
         const auto &usedSymbolNameHashes = hash.usages.nameHashes;
-        auto ref = core::FileRef(i);
 
         const bool fileIsValid = ref.exists() && ref.data(gs).sourceType == core::File::Type::Normal;
         if (fileIsValid && (absl::c_find(usedSymbolNameHashes, symShortNameHash) != usedSymbolNameHashes.end())) {

--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -119,7 +119,7 @@ LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypechecker
         }
 
         auto ref = core::FileRef(i);
-        if (pkgName.exists() && gs.packageDB().getPackageForFile(gs, ref).mangledName() != pkgName) {
+        if (pkgName.exists() && gs.packageDB().getPackageNameForFile(ref) != pkgName) {
             continue;
         }
 

--- a/main/lsp/LSPQuery.h
+++ b/main/lsp/LSPQuery.h
@@ -17,7 +17,7 @@ public:
     static LSPQueryResult bySymbolInFiles(const LSPConfiguration &config, LSPTypecheckerInterface &typechecker,
                                           core::SymbolRef symbol, std::vector<core::FileRef> frefs);
     static LSPQueryResult bySymbol(const LSPConfiguration &config, LSPTypecheckerInterface &typechecker,
-                                   core::SymbolRef symbol);
+                                   core::SymbolRef symbol, core::NameRef pkgName = core::NameRef::noName());
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -54,7 +54,7 @@ ResponseMessageStatus statusForResponse(const ResponseMessage &response) {
                     // textDocument/documentSymbol
                     return ResponseMessageStatus::Unknown;
                 } else if constexpr (is_same_v<T, variant<JSONNullObject, vector<unique_ptr<Location>>>>) {
-                    // textDocument/definition, textDocument/typeDefinition, textDocument/references, and
+                    // textDocument/definition, textDocument/typeDefinition, textDocument/references and
                     // textDocument/implementation
                     if (const auto *locationsPtr = get_if<vector<unique_ptr<Location>>>(&res)) {
                         return locationsPtr->empty() ? ResponseMessageStatus::EmptyResult
@@ -296,6 +296,17 @@ LSPTask::getReferencesToSymbol(LSPTypecheckerInterface &typechecker, core::Symbo
                                vector<unique_ptr<core::lsp::QueryResponse>> &&priorRefs) const {
     if (symbol.exists()) {
         auto run2 = LSPQuery::bySymbol(config, typechecker, symbol);
+        absl::c_move(run2.responses, back_inserter(priorRefs));
+    }
+    return move(priorRefs);
+}
+
+vector<unique_ptr<core::lsp::QueryResponse>>
+LSPTask::getReferencesInPackageToSymbol(LSPTypecheckerInterface &typechecker, core::NameRef packageName,
+                                        core::SymbolRef symbol,
+                                        vector<unique_ptr<core::lsp::QueryResponse>> &&priorRefs) const {
+    if (symbol.exists()) {
+        auto run2 = LSPQuery::bySymbol(config, typechecker, symbol, packageName);
         absl::c_move(run2.responses, back_inserter(priorRefs));
     }
     return move(priorRefs);

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -54,7 +54,7 @@ ResponseMessageStatus statusForResponse(const ResponseMessage &response) {
                     // textDocument/documentSymbol
                     return ResponseMessageStatus::Unknown;
                 } else if constexpr (is_same_v<T, variant<JSONNullObject, vector<unique_ptr<Location>>>>) {
-                    // textDocument/definition, textDocument/typeDefinition, textDocument/references and
+                    // textDocument/definition, textDocument/typeDefinition, textDocument/references, and
                     // textDocument/implementation
                     if (const auto *locationsPtr = get_if<vector<unique_ptr<Location>>>(&res)) {
                         return locationsPtr->empty() ? ResponseMessageStatus::EmptyResult
@@ -302,7 +302,7 @@ LSPTask::getReferencesToSymbol(LSPTypecheckerInterface &typechecker, core::Symbo
 }
 
 vector<unique_ptr<core::lsp::QueryResponse>>
-LSPTask::getReferencesInPackageToSymbol(LSPTypecheckerInterface &typechecker, core::NameRef packageName,
+LSPTask::getReferencesToSymbolInPackage(LSPTypecheckerInterface &typechecker, core::NameRef packageName,
                                         core::SymbolRef symbol,
                                         vector<unique_ptr<core::lsp::QueryResponse>> &&priorRefs) const {
     if (symbol.exists()) {

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -39,6 +39,12 @@ protected:
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
     getReferencesToSymbol(LSPTypecheckerInterface &typechecker, core::SymbolRef symbol,
                           std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
+
+    std::vector<std::unique_ptr<core::lsp::QueryResponse>>
+    getReferencesInPackageToSymbol(LSPTypecheckerInterface &typechecker, core::NameRef packageName,
+                                   core::SymbolRef symbol,
+                                   std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
+
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
     getReferencesToSymbolInFile(LSPTypecheckerInterface &typechecker, core::FileRef file, core::SymbolRef symbol,
                                 std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -41,7 +41,7 @@ protected:
                           std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
-    getReferencesInPackageToSymbol(LSPTypecheckerInterface &typechecker, core::NameRef packageName,
+    getReferencesToSymbolInPackage(LSPTypecheckerInterface &typechecker, core::NameRef packageName,
                                    core::SymbolRef symbol,
                                    std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -125,7 +125,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerInterface &
                     for (auto &symToCheck : symsToCheck) {
                         for (auto &location :
                              extractLocations(typechecker.state(),
-                                              getReferencesInPackageToSymbol(typechecker, packageName, symToCheck))) {
+                                              getReferencesToSymbolInPackage(typechecker, packageName, symToCheck))) {
                             locations.emplace_back(std::move(location));
                         }
                     }

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPQuery.h"
 #include "main/lsp/ShowOperation.h"
 #include "main/lsp/json_types.h"
+#include "packager/packager.h"
 
 using namespace std;
 
@@ -14,6 +15,51 @@ ReferencesTask::ReferencesTask(const LSPConfiguration &config, MessageId id, std
 
 bool ReferencesTask::needsMultithreading(const LSPIndexer &indexer) const {
     return true;
+}
+
+vector<core::SymbolRef> ReferencesTask::getSymsToCheckWithinPackage(const core::GlobalState &gs,
+                                                                    core::SymbolRef symInPackage,
+                                                                    core::NameRef packageName) {
+    std::vector<core::NameRef> fullName;
+
+    auto sym = symInPackage;
+    while (sym.exists() && sym != core::Symbols::PackageSpecRegistry() && sym != core::Symbols::root()) {
+        fullName.emplace_back(sym.name(gs));
+        sym = sym.owner(gs);
+    }
+    reverse(fullName.begin(), fullName.end());
+
+    vector<core::SymbolRef> result;
+    vector<core::SymbolRef> namespacesToCheck = {core::Symbols::root(),
+                                                 core::Symbols::root().data(gs)->findMember(gs, packager::TEST_NAME)};
+
+    for (auto &namespaceToCheck : namespacesToCheck) {
+        if (!namespaceToCheck.exists()) {
+            continue;
+        }
+
+        auto symFound = findSym(gs, fullName, namespaceToCheck);
+        // Do nothing if the symbol is not found or is from the same package -- i.e. for class ... < PackageSpec
+        // declarations
+        if (symFound.exists() && gs.packageDB().getPackageNameForFile(symFound.loc(gs).file()) != packageName) {
+            result.emplace_back(std::move(symFound));
+        }
+    }
+
+    return result;
+}
+
+core::SymbolRef ReferencesTask::findSym(const core::GlobalState &gs, const vector<core::NameRef> &fullName,
+                                        core::SymbolRef underNamespace) {
+    core::SymbolRef symToCheck = underNamespace;
+    for (auto &part : fullName) {
+        symToCheck = symToCheck.asClassOrModuleRef().data(gs)->findMember(gs, part);
+        if (!symToCheck.exists()) {
+            return symToCheck;
+        }
+    }
+
+    return symToCheck;
 }
 
 unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerInterface &typechecker) {
@@ -44,8 +90,58 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerInterface &
         // N.B.: Ignores literals.
         // If file is untyped, only supports find reference requests from constants and class definitions.
         if (auto constResp = resp->isConstant()) {
-            response->result =
-                extractLocations(typechecker.state(), getReferencesToSymbol(typechecker, constResp->symbol));
+            if (fref.data(gs).isPackage()) {
+                // Special handling for package files.
+                //
+                // Case 1. get-refs on a package declaration
+                //   class Foo < PackageSpec
+                //         ^^^
+                //   Returns all `import Foo` statements, globally
+                //
+                // Case 2. get-refs on an import statement
+                //
+                //  class Foo < PackageSpec
+                //    ...
+                //
+                //    import Bar
+                //          ^^^
+                //  Returns all usages of `Bar` or `Test::Bar` *within* the Foo package only.
+                //
+                // Case 3. get-refs on an export statement
+                //
+                //  class Foo < PackageSpec
+                //    ...
+                //
+                //    export Foo::A
+                //                ^
+                //  Returns all global usages of Foo::A
+
+                auto packageName = gs.packageDB().getPackageNameForFile(fref);
+                auto symsToCheck = getSymsToCheckWithinPackage(gs, constResp->symbol, packageName);
+
+                if (!symsToCheck.empty()) {
+                    std::vector<std::unique_ptr<Location>> locations;
+
+                    for (auto &symToCheck : symsToCheck) {
+                        for (auto &location :
+                             extractLocations(typechecker.state(),
+                                              getReferencesInPackageToSymbol(typechecker, packageName, symToCheck))) {
+                            locations.emplace_back(std::move(location));
+                        }
+                    }
+
+                    response->result = std::move(locations);
+                } else {
+                    // Fall back to normal case when we are not querying for an external symbol, e.g. class Foo <
+                    // PackageSpec declarations, or export statements.
+                    response->result =
+                        extractLocations(typechecker.state(), getReferencesToSymbol(typechecker, constResp->symbol));
+                }
+            } else {
+                // Normal handling for non-package files
+                response->result =
+                    extractLocations(typechecker.state(), getReferencesToSymbol(typechecker, constResp->symbol));
+            }
         } else if (auto fieldResp = resp->isField()) {
             // This could be a `prop` or `attr_*`, which have multiple associated symbols.
             response->result = extractLocations(

--- a/main/lsp/requests/references.h
+++ b/main/lsp/requests/references.h
@@ -7,6 +7,10 @@ namespace sorbet::realmain::lsp {
 class ReferenceParams;
 class ReferencesTask final : public LSPRequestTask {
     std::unique_ptr<ReferenceParams> params;
+    std::vector<core::SymbolRef> getSymsToCheckWithinPackage(const core::GlobalState &gs, core::SymbolRef symInPackage,
+                                                             core::NameRef packageName);
+    core::SymbolRef findSym(const core::GlobalState &gs, const std::vector<core::NameRef> &fullName,
+                            core::SymbolRef underNamespace);
 
 public:
     ReferencesTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<ReferenceParams> params);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -23,7 +23,6 @@ namespace sorbet::packager {
 namespace {
 
 constexpr string_view PACKAGE_FILE_NAME = "__package.rb"sv;
-constexpr core::NameRef TEST_NAME = core::Names::Constants::Test();
 
 bool isPrimaryTestNamespace(const core::NameRef ns) {
     return ns == TEST_NAME;

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -9,6 +9,8 @@ class WorkerPool;
 }
 
 namespace sorbet::packager {
+const core::NameRef TEST_NAME = core::Names::Constants::Test();
+
 /**
  * This pass transforms package files (`foo/__package.rb`) from
  *

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -32,6 +32,8 @@ const UnorderedMap<
         {"error", ErrorAssertion::make},
         {"error-with-dupes", ErrorAssertion::make},
         {"usage", UsageAssertion::make},
+        {"import", ImportAssertion::make},
+        {"importusage", ImportUsageAssertion::make},
         {"def", DefAssertion::make},
         {"type", TypeAssertion::make},
         {"type-def", TypeDefAssertion::make},
@@ -727,6 +729,35 @@ shared_ptr<UsageAssertion> UsageAssertion::make(string_view filename, unique_ptr
                           fmt::format("Unexpected usage assertion option: `{}`", option));
     }
     return make_shared<UsageAssertion>(filename, range, assertionLine, symbol, versions);
+}
+
+ImportAssertion::ImportAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine, string_view symbol,
+                                 vector<int> versions)
+    : UsageAssertion(filename, range, assertionLine, symbol, versions) {}
+
+shared_ptr<ImportAssertion> ImportAssertion::make(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                                  string_view assertionContents, string_view assertionType) {
+    auto [symbol, versions, option] = getSymbolVersionAndOption(assertionContents);
+    if (!option.empty()) {
+        ADD_FAIL_CHECK_AT(string(filename).c_str(), assertionLine + 1,
+                          fmt::format("Unexpected import assertion option: `{}`", option));
+    }
+    return make_shared<ImportAssertion>(filename, range, assertionLine, symbol, versions);
+}
+
+ImportUsageAssertion::ImportUsageAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                           string_view symbol, vector<int> versions)
+    : UsageAssertion(filename, range, assertionLine, symbol, versions) {}
+
+shared_ptr<ImportUsageAssertion> ImportUsageAssertion::make(string_view filename, unique_ptr<Range> &range,
+                                                            int assertionLine, string_view assertionContents,
+                                                            string_view assertionType) {
+    auto [symbol, versions, option] = getSymbolVersionAndOption(assertionContents);
+    if (!option.empty()) {
+        ADD_FAIL_CHECK_AT(string(filename).c_str(), assertionLine + 1,
+                          fmt::format("Unexpected importusage assertion option: `{}`", option));
+    }
+    return make_shared<ImportUsageAssertion>(filename, range, assertionLine, symbol, versions);
 }
 
 string UsageAssertion::toString() const {

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -115,7 +115,7 @@ public:
 };
 
 // # ^^^ usage: symbol
-class UsageAssertion final : public RangeAssertion {
+class UsageAssertion : public RangeAssertion {
 public:
     static std::shared_ptr<UsageAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
                                                 int assertionLine, std::string_view assertionContents,
@@ -138,6 +138,28 @@ public:
                    std::vector<int> versions);
 
     std::string toString() const override;
+};
+
+// # ^^^ import: symbol
+class ImportAssertion final : public UsageAssertion {
+public:
+    static std::shared_ptr<ImportAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                 int assertionLine, std::string_view assertionContents,
+                                                 std::string_view assertionType);
+
+    ImportAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                    std::string_view symbol, std::vector<int> versions);
+};
+
+// # ^^^ importusage: symbol
+class ImportUsageAssertion final : public UsageAssertion {
+public:
+    static std::shared_ptr<ImportUsageAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                      int assertionLine, std::string_view assertionContents,
+                                                      std::string_view assertionType);
+
+    ImportUsageAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                         std::string_view symbol, std::vector<int> versions);
 };
 
 // # some-property: foo

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -729,6 +729,19 @@ TEST_CASE("LSPTest") {
             // Shouldn't be possible to have an entry with 0 assertions, but explicitly check anyway.
             CHECK_GE(entryAssertions.size(), 1);
 
+            // Collect importUsageAssertions into a separate collection to handle them differently.
+            std::vector<shared_ptr<RangeAssertion>> importUsageAssertions;
+            entryAssertions.erase(std::remove_if(entryAssertions.begin(), entryAssertions.end(),
+                                                 [&](auto &assertion) -> bool {
+                                                     if (dynamic_pointer_cast<ImportUsageAssertion>(assertion)) {
+                                                         importUsageAssertions.emplace_back(assertion);
+                                                         return true;
+                                                     }
+
+                                                     return false;
+                                                 }),
+                                  entryAssertions.end());
+
             for (auto &assertion : entryAssertions) {
                 string_view symbol;
                 vector<int> versions;
@@ -768,20 +781,30 @@ TEST_CASE("LSPTest") {
                 }
 
                 auto queryLoc = assertion->getLocation(config);
+
                 // Check that a definition request at this location returns defs.
                 DefAssertion::check(test.sourceFileContents, *lspWrapper, nextId, *queryLoc, defs);
-                // Check that a reference request at this location returns entryAssertions.
-                UsageAssertion::check(test.sourceFileContents, *lspWrapper, nextId, symbol, *queryLoc, entryAssertions);
-                // Check that a highlight request at this location returns all of the entryAssertions for the same
-                // file as the request.
-                vector<shared_ptr<RangeAssertion>> filteredEntryAssertions;
-                for (auto &e : entryAssertions) {
-                    if (absl::StartsWith(e->getLocation(config)->uri, queryLoc->uri)) {
-                        filteredEntryAssertions.push_back(e);
+                if (dynamic_pointer_cast<ImportAssertion>(assertion)) {
+                    // For an ImportAssertion, check that a reference request at this location returns
+                    // importUsageAssertions.
+                    UsageAssertion::check(test.sourceFileContents, *lspWrapper, nextId, symbol, *queryLoc,
+                                          importUsageAssertions);
+                } else {
+                    // For a regular UsageAssertion, check that a reference request at this location returns
+                    // entryAssertions.
+                    UsageAssertion::check(test.sourceFileContents, *lspWrapper, nextId, symbol, *queryLoc,
+                                          entryAssertions);
+                    // Check that a highlight request at this location returns all of the entryAssertions for the same
+                    // file as the request.
+                    vector<shared_ptr<RangeAssertion>> filteredEntryAssertions;
+                    for (auto &e : entryAssertions) {
+                        if (absl::StartsWith(e->getLocation(config)->uri, queryLoc->uri)) {
+                            filteredEntryAssertions.push_back(e);
+                        }
                     }
+                    UsageAssertion::checkHighlights(test.sourceFileContents, *lspWrapper, nextId, symbol, *queryLoc,
+                                                    filteredEntryAssertions);
                 }
-                UsageAssertion::checkHighlights(test.sourceFileContents, *lspWrapper, nextId, symbol, *queryLoc,
-                                                filteredEntryAssertions);
             }
         }
 

--- a/test/testdata/packager/lsp_features/__package.rb
+++ b/test/testdata/packager/lsp_features/__package.rb
@@ -7,12 +7,12 @@ class Simpsons < PackageSpec
     # go-to-def on a reference to Bart within the package goes here, but go-to-def on Bart in `import Bart` goes to the
     # package.
     import Bart
-    #      ^^^^ usage: bartpkg
+    #      ^^^^ import: bartpkg
     #      ^^^^ hover: Bart package description
     #      ^    show-symbol: Bart
 
     test_import Krabappel
-    #           ^^^^^^^^^ usage: krabappel-pkg
+    #           ^^^^^^^^^ import: krabappel-pkg
     #           ^^^^^^^^^ hover: Bart's teacher
     #           ^         show-symbol: Krabappel
 

--- a/test/testdata/packager/lsp_features/family.rb
+++ b/test/testdata/packager/lsp_features/family.rb
@@ -17,11 +17,13 @@ module Simpsons
           #     ^^^^^^^^^^^ hover: String
           #     ^           show-symbol: Bart::CatchPhrase
         # ^^^^ usage: bartmod
+        # ^^^^ importusage: bartpkg
       end
 
       sig {returns(Bart::Character)}
       #                  ^^^^^^^^^ usage: character
       #            ^^^^ usage: bartmod
+      #            ^^^^ importusage: bartpkg
       def son
           Bart::Character.new
           #     ^^^^^^^^^ usage: character
@@ -30,9 +32,11 @@ module Simpsons
           #     ^^^^^^^^^ hover: Character class description
           #               ^^^ hover: Description of Character initialize
         # ^^^^ usage: bartmod
+        # ^^^^ importusage: bartpkg
           Bart::C # error: Unable to resolve constant `C`
           #      ^ completion: CatchPhrase, Character
         # ^^^^ usage: bartmod
+        # ^^^^ importusage: bartpkg
       end
   end
 
@@ -40,6 +44,7 @@ module Simpsons
 # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Test::Krabappel::Popquiz` in non-test file
 # ^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Krabappel::Popquiz` is defined in a test namespace
   #                ^^^^^^^ usage: popquiz
+# ^^^^^^^^^^^^^^^ importusage: krabappel-pkg
 
   class Private
     #   ^^^^^^^ def: s-private


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds functionality to LSP references method to show references within a package.

```
                // Case 1. get-refs on a package declaration
                //   class Foo < PackageSpec
                //         ^^^
                //   Returns all `import Foo` statements, globally
                //
                // Case 2. get-refs on an import statement
                //
                //  class Foo < PackageSpec
                //    ...
                //
                //    import Bar
                //          ^^^
                //  Returns all usages of `Bar` or `Test::Bar` *within* the Foo package only.
                //
                // Case 3. get-refs on an export statement
                //
                //  class Foo < PackageSpec
                //    ...
                //
                //    export Foo::A
                //                ^
                //  Returns all global usages of Foo::A
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://github.com/sorbet/sorbet/issues/6202

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested in Stripe codebase.
