### PR TITLE
be more precise when rewriting `T.let`'d enums

### DIFF
--- a/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
@@ -110,10 +110,10 @@ bb5[rubyRegionId=1, firstDead=40](<self>: T.class_of(MyEnum), <block-pre-call-te
     <cfgAlias>$80: T.class_of(MyEnum::Z) = alias <C Z$1>
     <statTemp>$76: Sorbet::Private::Static::Void = <cfgAlias>$78: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$80: T.class_of(MyEnum::Z))
     <cfgAlias>$83: T.class_of(MyEnum::Z) = alias <C Z$1>
-    <castTemp>$81: MyEnum::Z = <cfgAlias>$83: T.class_of(MyEnum::Z).new(<self>: T.class_of(MyEnum))
+    <castTemp>$81: MyEnum::Z = <cfgAlias>$83: T.class_of(MyEnum::Z).new()
     <C Z>$75: MyEnum::Z = <castTemp>$81
     <blockReturnTemp>$16: NilClass = nil
-    <blockReturnTemp>$85: T.noreturn = blockreturn<enums> <blockReturnTemp>$16: NilClass
+    <blockReturnTemp>$84: T.noreturn = blockreturn<enums> <blockReturnTemp>$16: NilClass
     <unconditional> -> bb2
 
 }
@@ -297,10 +297,10 @@ bb5[rubyRegionId=1, firstDead=40](<self>: T.class_of(EnumsDoEnum), <block-pre-ca
     <cfgAlias>$80: T.class_of(EnumsDoEnum::Z) = alias <C Z$1>
     <statTemp>$76: Sorbet::Private::Static::Void = <cfgAlias>$78: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$80: T.class_of(EnumsDoEnum::Z))
     <cfgAlias>$83: T.class_of(EnumsDoEnum::Z) = alias <C Z$1>
-    <castTemp>$81: EnumsDoEnum::Z = <cfgAlias>$83: T.class_of(EnumsDoEnum::Z).new(<self>: T.class_of(EnumsDoEnum))
+    <castTemp>$81: EnumsDoEnum::Z = <cfgAlias>$83: T.class_of(EnumsDoEnum::Z).new()
     <C Z>$75: EnumsDoEnum::Z = <castTemp>$81
     <blockReturnTemp>$16: NilClass = nil
-    <blockReturnTemp>$85: T.noreturn = blockreturn<enums> <blockReturnTemp>$16: NilClass
+    <blockReturnTemp>$84: T.noreturn = blockreturn<enums> <blockReturnTemp>$16: NilClass
     <unconditional> -> bb2
 
 }

--- a/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C Y> = ::T.<unchecked_let>(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
         class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
         end
-        <emptyTree>::<C Z> = ::T.<unchecked_let>(<emptyTree>::<C Z$1>.new(<self>), <emptyTree>::<C Z$1>)
+        <emptyTree>::<C Z> = ::T.<unchecked_let>(<emptyTree>::<C Z$1>.new(), <emptyTree>::<C Z$1>)
         nil
       end
     end
@@ -52,7 +52,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C Y> = ::T.<unchecked_let>(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
         class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
         end
-        <emptyTree>::<C Z> = ::T.<unchecked_let>(<emptyTree>::<C Z$1>.new(<self>), <emptyTree>::<C Z$1>)
+        <emptyTree>::<C Z> = ::T.<unchecked_let>(<emptyTree>::<C Z$1>.new(), <emptyTree>::<C Z$1>)
         nil
       end
     end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Rewriting enums that are defined as `X = T.let(new, self)` or similar is a little sloppy: we use the `T.let` send as the basis for pulling out args for the rewritten enum initialization, rather than the inner `<Magic>.<self-new>` send.

This PR corrects that oversight.  It also makes it easier to deal with `Cast` AST nodes here, were one to encounter them in a future PR.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
