### PR TITLE
move cast creation to rewriter

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -370,7 +370,8 @@ public:
     }
 
     static ExpressionPtr Bind(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
-        return Send2(loc, T(loc), core::Names::bind(), loc, std::move(value), std::move(type));
+        return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value),
+                                               core::Names::bind(), std::move(type));
     }
 
     static ExpressionPtr ClassOf(core::LocOffsets loc, ExpressionPtr value) {
@@ -378,11 +379,13 @@ public:
     }
 
     static ExpressionPtr Let(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
-        return Send2(loc, T(loc), core::Names::let(), loc, std::move(value), std::move(type));
+        return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value),
+                                               core::Names::let(), std::move(type));
     }
 
     static ExpressionPtr AssertType(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
-        return Send2(loc, T(loc), core::Names::assertType(), loc, std::move(value), std::move(type));
+        return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value),
+                                               core::Names::assertType(), std::move(type));
     }
 
     static ExpressionPtr Unsafe(core::LocOffsets loc, ExpressionPtr inner) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -369,9 +369,9 @@ public:
         return Constant(loc, core::Symbols::T());
     }
 
-    static ExpressionPtr Bind(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
+    static ExpressionPtr SyntheticBind(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
         return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value),
-                                               core::Names::bind(), std::move(type));
+                                               core::Names::syntheticBind(), std::move(type));
     }
 
     static ExpressionPtr ClassOf(core::LocOffsets loc, ExpressionPtr value) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -370,8 +370,8 @@ public:
     }
 
     static ExpressionPtr SyntheticBind(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
-        return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value),
-                                               core::Names::syntheticBind(), std::move(type));
+        return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value), core::Names::syntheticBind(),
+                                               std::move(type));
     }
 
     static ExpressionPtr ClassOf(core::LocOffsets loc, ExpressionPtr value) {
@@ -379,13 +379,13 @@ public:
     }
 
     static ExpressionPtr Let(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
-        return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value),
-                                               core::Names::let(), std::move(type));
+        return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value), core::Names::let(),
+                                               std::move(type));
     }
 
     static ExpressionPtr AssertType(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
-        return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value),
-                                               core::Names::assertType(), std::move(type));
+        return ast::make_expression<ast::Cast>(loc, core::Types::todo(), std::move(value), core::Names::assertType(),
+                                               std::move(type));
     }
 
     static ExpressionPtr Unsafe(core::LocOffsets loc, ExpressionPtr inner) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -931,6 +931,15 @@ struct PackageInfoFinder {
     unique_ptr<PackageInfoImpl> info = nullptr;
     vector<Export> exported;
 
+    void postTransformCast(ContextType ctx, ast::ExpressionPtr &tree) {
+        auto &cast = ast::cast_tree_nonnull<ast::Cast>(tree);
+        if (!ast::isa_tree<ast::Literal>(cast.typeExpr)) {
+            if (auto e = ctx.beginError(cast.typeExpr.loc(), core::errors::Packager::InvalidPackageExpression)) {
+                e.setHeader("Invalid expression in package: Arguments to functions must be literals");
+            }
+        }
+    }
+
     void postTransformSend(ContextType ctx, ast::ExpressionPtr &tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2840,29 +2840,7 @@ public:
                         return;
                     }
 
-                    ResolveCastItem item;
-                    item.file = ctx.file;
-                    item.owner = ctx.owner;
-                    item.inFieldAssign = this->inFieldAssign.back();
-
-                    auto expr = std::move(send.getPosArg(0));
-                    auto typeExpr = std::move(send.getPosArg(1));
-                    // We only do this for `bind` because `bind` doesn't participate in the same
-                    // sort of pinning decisions that the other casts do. Hiding pinning errors from
-                    // arbitrary synthetic lets and casts would push confusing behavior downstream.
-                    auto fun = (send.fun == core::Names::bind() && send.flags.isRewriterSynthesized)
-                                   ? core::Names::syntheticBind()
-                                   : send.fun;
-                    auto cast = ast::make_expression<ast::Cast>(send.loc, core::Types::todo(), std::move(expr), fun,
-                                                                std::move(typeExpr));
-                    item.cast = ast::cast_tree<ast::Cast>(cast);
-
-                    // We should be able to resolve simple casts immediately.
-                    if (!tryResolveSimpleClassCastItem(ctx.state, item)) {
-                        todoResolveCastItems_.emplace_back(move(item));
-                    }
-
-                    tree = std::move(cast);
+                    ENFORCE(false, "should have converted these to cast nodes");
                     return;
                 }
                 case core::Names::revealType().rawId():

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2797,6 +2797,17 @@ public:
         }
     }
 
+    void postTransformCast(core::Context ctx, ast::ExpressionPtr &tree) {
+        ResolveCastItem item;
+        item.file = ctx.file;
+        item.owner = ctx.owner;
+        item.cast = ast::cast_tree<ast::Cast>(tree);
+        item.inFieldAssign = this->inFieldAssign.back();
+        if (!tryResolveSimpleClassCastItem(ctx.withOwner(item.owner), item)) {
+            todoResolveCastItems_.emplace_back(move(item));
+        }
+    }
+
     void postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2803,7 +2803,7 @@ public:
         item.owner = ctx.owner;
         item.cast = ast::cast_tree<ast::Cast>(tree);
         item.inFieldAssign = this->inFieldAssign.back();
-        if (!tryResolveSimpleClassCastItem(ctx.withOwner(item.owner), item)) {
+        if (!tryResolveSimpleClassCastItem(ctx.state, item)) {
             todoResolveCastItems_.emplace_back(move(item));
         }
     }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -21,9 +21,9 @@ public:
     ast::ExpressionPtr createConstAssign(ast::Assign &asgn) {
         auto loc = asgn.loc;
         auto raiseUnimplemented = ast::MK::RaiseUnimplemented(loc);
-        if (auto send = ast::cast_tree<ast::Send>(asgn.rhs)) {
-            if (send->fun == core::Names::let() && send->numPosArgs() == 2) {
-                auto rhs = ast::MK::Let(loc, move(raiseUnimplemented), send->getPosArg(1).deepCopy());
+        if (auto cast = ast::cast_tree<ast::Cast>(asgn.rhs)) {
+            if (cast->cast == core::Names::let()) {
+                auto rhs = ast::MK::Let(loc, move(raiseUnimplemented), cast->typeExpr.deepCopy());
                 return ast::MK::Assign(asgn.loc, move(asgn.lhs), move(rhs));
             }
         }

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -146,10 +146,10 @@ vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *
     flags.isPrivateOk = true;
     auto singletonAsgn =
         ast::MK::Assign(stat.loc(), std::move(asgn->lhs),
-                        ast::make_expression<ast::Cast>(stat.loc(), core::Types::todo(),
-                                                        magicSelfNew->withNewBody(stat.loc(), classCnst.deepCopy(), core::Names::new_()),
-                                                        core::Names::uncheckedLet(),
-                                                        std::move(classCnst)));
+                        ast::make_expression<ast::Cast>(
+                            stat.loc(), core::Types::todo(),
+                            magicSelfNew->withNewBody(stat.loc(), classCnst.deepCopy(), core::Names::new_()),
+                            core::Names::uncheckedLet(), std::move(classCnst)));
     vector<ast::ExpressionPtr> result;
     result.emplace_back(std::move(classDef));
     result.emplace_back(std::move(singletonAsgn));

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -146,10 +146,10 @@ vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *
     flags.isPrivateOk = true;
     auto singletonAsgn =
         ast::MK::Assign(stat.loc(), std::move(asgn->lhs),
-                        ast::MK::Send2(stat.loc(), ast::MK::Constant(stat.loc(), core::Symbols::T()),
-                                       core::Names::uncheckedLet(), stat.loc().copyWithZeroLength(),
-                                       magicSelfNew->withNewBody(stat.loc(), classCnst.deepCopy(), core::Names::new_()),
-                                       std::move(classCnst)));
+                        ast::make_expression<ast::Cast>(stat.loc(), core::Types::todo(),
+                                                        magicSelfNew->withNewBody(stat.loc(), classCnst.deepCopy(), core::Names::new_()),
+                                                        core::Names::uncheckedLet(),
+                                                        std::move(classCnst)));
     vector<ast::ExpressionPtr> result;
     result.emplace_back(std::move(classDef));
     result.emplace_back(std::move(singletonAsgn));

--- a/rewriter/TypeAssertion.cc
+++ b/rewriter/TypeAssertion.cc
@@ -1,0 +1,48 @@
+#include "rewriter/TypeAssertion.h"
+#include "ast/Helpers.h"
+#include "ast/ast.h"
+#include "core/core.h"
+
+namespace sorbet::rewriter {
+
+namespace {
+bool isT(const ast::ExpressionPtr &expr) {
+    auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+    if (t == nullptr || t->cnst != core::Names::Constants::T()) {
+        return false;
+    }
+    return ast::MK::isRootScope(t->scope);
+}
+
+} // namespace
+
+ast::ExpressionPtr TypeAssertion::run(core::MutableContext ctx, ast::Send *send) {
+    if (!isT(send->recv)) {
+        return nullptr;
+    }
+
+    switch (send->fun.rawId()) {
+        case core::Names::let().rawId():
+        case core::Names::bind().rawId():
+        case core::Names::uncheckedLet().rawId():
+        case core::Names::assertType().rawId():
+        case core::Names::cast().rawId():
+            break;
+        default:
+            return nullptr;
+    }
+
+    if (send->numPosArgs() < 2) {
+        return nullptr;
+    }
+
+    // FIXME(froydnj): handle bind/syntheticBind
+    auto expr = std::move(send->getPosArg(0));
+    auto typeExpr = std::move(send->getPosArg(1));
+
+    return ast::make_expression<ast::Cast>(send->loc, core::Types::todo(), std::move(expr), send->fun,
+                                          std::move(typeExpr));
+}
+
+} // namespace sorbet::rewriter
+

--- a/rewriter/TypeAssertion.cc
+++ b/rewriter/TypeAssertion.cc
@@ -36,7 +36,6 @@ ast::ExpressionPtr TypeAssertion::run(core::MutableContext ctx, ast::Send *send)
         return nullptr;
     }
 
-    // FIXME(froydnj): handle bind/syntheticBind
     auto expr = std::move(send->getPosArg(0));
     auto typeExpr = std::move(send->getPosArg(1));
 

--- a/rewriter/TypeAssertion.cc
+++ b/rewriter/TypeAssertion.cc
@@ -41,8 +41,7 @@ ast::ExpressionPtr TypeAssertion::run(core::MutableContext ctx, ast::Send *send)
     auto typeExpr = std::move(send->getPosArg(1));
 
     return ast::make_expression<ast::Cast>(send->loc, core::Types::todo(), std::move(expr), send->fun,
-                                          std::move(typeExpr));
+                                           std::move(typeExpr));
 }
 
 } // namespace sorbet::rewriter
-

--- a/rewriter/TypeAssertion.h
+++ b/rewriter/TypeAssertion.h
@@ -1,0 +1,29 @@
+#ifndef SORBET_REWRITER_TYPE_ASSERTION_H
+#define SORBET_REWRITER_TYPE_ASSERTION_H
+
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * This class converts syntactic type assertions to ast::Cast nodes:
+ *
+ *    T.let(...)
+ *    T.cast(...)
+ *    T.bind(...)
+ *    T.uncheckedLet(...)
+ *    T.assertType(...)
+ *    T.cast(...)
+ *
+ * =>
+ *
+ */
+class TypeAssertion final {
+public:
+    static ast::ExpressionPtr run(core::MutableContext ctx, ast::Send *send);
+    TypeAssertion() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif /* SORBET_REWRITER_TYPE_ASSERTION_H */

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -29,6 +29,7 @@
 #include "rewriter/Struct.h"
 #include "rewriter/TEnum.h"
 #include "rewriter/TestCase.h"
+#include "rewriter/TypeAssertion.h"
 #include "rewriter/TypeMembers.h"
 
 using namespace std;
@@ -184,6 +185,10 @@ public:
         if (auto expr = SelfNew::run(ctx, send)) {
             tree = std::move(expr);
             return;
+        }
+
+        if (auto expr = TypeAssertion::run(ctx, send)) {
+            tree = std::move(expr);
         }
 
         if (SigRewriter::run(ctx, send)) {

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -189,6 +189,7 @@ public:
 
         if (auto expr = TypeAssertion::run(ctx, send)) {
             tree = std::move(expr);
+            return;
         }
 
         if (SigRewriter::run(ctx, send)) {

--- a/test/cli/autogen_print_rbi/test.out
+++ b/test/cli/autogen_print_rbi/test.out
@@ -109,13 +109,6 @@ requires: []
  is_defining_ref=0
 [ref id=2]
  scope=[FromRBI]
- name=[T]
- nesting=[[FromRBI]]
- resolved=[T]
- loc=test/cli/autogen_print_rbi/b.rbi:4
- is_defining_ref=0
-[ref id=3]
- scope=[FromRBI]
  name=[Integer]
  nesting=[[FromRBI]]
  resolved=[Integer]
@@ -123,9 +116,9 @@ requires: []
  is_defining_ref=0
 
 f3b9f8c31a343a60665c06f959a48dbdceef757c  autogen3.msgpack
-a20ed01b8a7646141440ba39b60b247bd13a4388  autogen4.msgpack
+2305b0d8f2c81fbb946e4f1dbec6230386925456  autogen4.msgpack
 
-39a40,80
+39a40,73
 > # ParsedFile: test/cli/autogen_print_rbi/b.rbi
 > requires: []
 > ## defs:
@@ -154,13 +147,6 @@ a20ed01b8a7646141440ba39b60b247bd13a4388  autogen4.msgpack
 >  loc=test/cli/autogen_print_rbi/b.rbi:4
 >  is_defining_ref=0
 > [ref id=2]
->  scope=[FromRBI]
->  name=[T]
->  nesting=[[FromRBI]]
->  resolved=[T]
->  loc=test/cli/autogen_print_rbi/b.rbi:4
->  is_defining_ref=0
-> [ref id=3]
 >  scope=[FromRBI]
 >  name=[Integer]
 >  nesting=[[FromRBI]]

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of self.static_method>
 
-    @hello = <emptyTree>::<C T>.let(nil, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+    @hello = <cast:let>(nil, <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
   end
 end
 # -- test/testdata/packager/invalid_package_control_flow/package_spec_additions.rb --

--- a/test/testdata/packager/shared_prefix/pass.package-tree.exp
+++ b/test/testdata/packager/shared_prefix/pass.package-tree.exp
@@ -7,7 +7,7 @@ end
 # -- test/testdata/packager/shared_prefix/bar/that/that.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C Project>::<C Bar>::<C That><<C <todo sym>>> < ()
-    <emptyTree>::<C Thing> = <emptyTree>::<C T>.let(:yeah, <emptyTree>::<C Symbol>)
+    <emptyTree>::<C Thing> = <cast:let>(:yeah, <todo sym>, <emptyTree>::<C Symbol>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/this/__package.rb --
@@ -19,7 +19,7 @@ end
 # -- test/testdata/packager/shared_prefix/bar/this/this.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C Project>::<C Bar>::<C This><<C <todo sym>>> < ()
-    <emptyTree>::<C Thing> = <emptyTree>::<C T>.let(:hey, <emptyTree>::<C Symbol>)
+    <emptyTree>::<C Thing> = <cast:let>(:hey, <todo sym>, <emptyTree>::<C Symbol>)
   end
 end
 # -- test/testdata/packager/shared_prefix/foo/__package.rb --

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def initialize<<todo method>>(value, &<blk>)
-      @value = <emptyTree>::<C T>.let(value, <emptyTree>::<C Integer>)
+      @value = <cast:let>(value, <todo sym>, <emptyTree>::<C Integer>)
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def initialize<<todo method>>(value, &<blk>)
-      @value = <emptyTree>::<C T>.let(value, <emptyTree>::<C Integer>)
+      @value = <cast:let>(value, <todo sym>, <emptyTree>::<C Integer>)
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)

--- a/test/testdata/rewriter/attr_multi.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_multi.rb.rewrite-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def a=<<todo method>>(a, &<blk>)
-      @a = ::T.let(a, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+      @a = <cast:let>(a, <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def b=<<todo method>>(b, &<blk>)
-      @b = ::T.let(b, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+      @b = <cast:let>(b, <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def c=<<todo method>>(c, &<blk>)
-      @c = ::T.let(c, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+      @c = <cast:let>(c, <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||

--- a/test/testdata/rewriter/attr_reader_method_kind.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_reader_method_kind.rb.rewrite-tree.exp
@@ -46,8 +46,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(using_t_struct_prop:, using_t_struct_const:, &<blk>)
       begin
-        @using_t_struct_prop = ::T.let(using_t_struct_prop, <emptyTree>::<C Integer>)
-        @using_t_struct_const = ::T.let(using_t_struct_const, <emptyTree>::<C Integer>)
+        @using_t_struct_prop = <cast:let>(using_t_struct_prop, <todo sym>, <emptyTree>::<C Integer>)
+        @using_t_struct_const = <cast:let>(using_t_struct_const, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/attr_reader_method_kind_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_reader_method_kind_compiled.rb.rewrite-tree.exp
@@ -46,8 +46,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(using_t_struct_prop:, using_t_struct_const:, &<blk>)
       begin
-        @using_t_struct_prop = ::T.let(using_t_struct_prop, <emptyTree>::<C Integer>)
-        @using_t_struct_const = ::T.let(using_t_struct_const, <emptyTree>::<C Integer>)
+        @using_t_struct_prop = <cast:let>(using_t_struct_prop, <todo sym>, <emptyTree>::<C Integer>)
+        @using_t_struct_const = <cast:let>(using_t_struct_const, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
@@ -80,14 +80,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   c1 = <emptyTree>::<C Class>.new() do ||
     begin
-      ::T.bind(<self>, ::Class)
+      <cast:<synthetic bind>>(<self>, <todo sym>, ::Class)
       <emptyTree>::<C T>.reveal_type(<self>)
     end
   end
 
   c2 = <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
     begin
-      ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+      <cast:<synthetic bind>>(<self>, <todo sym>, ::T.class_of(<emptyTree>::<C Foo>))
       <emptyTree>::<C T>.reveal_type(<self>)
       <self>.foo()
     end
@@ -95,14 +95,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <emptyTree>::<C Class>.new() do ||
     begin
-      ::T.bind(<self>, ::Class)
+      <cast:<synthetic bind>>(<self>, <todo sym>, ::Class)
       <emptyTree>::<C T>.reveal_type(<self>)
     end
   end
 
   <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
     begin
-      ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+      <cast:<synthetic bind>>(<self>, <todo sym>, ::T.class_of(<emptyTree>::<C Foo>))
       <emptyTree>::<C T>.reveal_type(<self>)
       <self>.foo()
     end
@@ -112,7 +112,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def bar<<todo method>>(&<blk>)
       <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
         begin
-          ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+          <cast:<synthetic bind>>(<self>, <todo sym>, ::T.class_of(<emptyTree>::<C Foo>))
           <emptyTree>::<C T>.reveal_type(<self>)
         end
       end
@@ -121,7 +121,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.bar<<todo method>>(&<blk>)
       <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
         begin
-          ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+          <cast:<synthetic bind>>(<self>, <todo sym>, ::T.class_of(<emptyTree>::<C Foo>))
           <emptyTree>::<C T>.reveal_type(<self>)
         end
       end

--- a/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
@@ -34,7 +34,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.include(<emptyTree>::<C M>)
   end
 
-  <emptyTree>::<C T>.let(<emptyTree>::<C C>.new(), <emptyTree>::<C M>)
+  <cast:let>(<emptyTree>::<C C>.new(), <todo sym>, <emptyTree>::<C M>)
 
   class <emptyTree>::<C D><<C <todo sym>>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -58,7 +58,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C E><<C <todo sym>>> < (<emptyTree>::<C Top>::<C Parent>)
   end
 
-  <emptyTree>::<C T>.let(<emptyTree>::<C E>.new(), <emptyTree>::<C Top>::<C Parent>)
+  <cast:let>(<emptyTree>::<C E>.new(), <todo sym>, <emptyTree>::<C Top>::<C Parent>)
 
   class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
     def self.foo<<todo method>>(&<blk>)

--- a/test/testdata/rewriter/class_new_strict.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.make<<todo method>>(&<blk>)
       cls = <emptyTree>::<C Class>.new(<emptyTree>::<C A>) do ||
         begin
-          ::T.bind(<self>, ::T.class_of(<emptyTree>::<C A>))
+          <cast:<synthetic bind>>(<self>, <todo sym>, ::T.class_of(<emptyTree>::<C A>))
           <emptyTree>
         end
       end

--- a/test/testdata/rewriter/command.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/command.rb.rewrite-tree.exp
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of call>
   end
 
-  <emptyTree>::<C T>.assert_type!(<emptyTree>::<C MyCommand>.call(7), <emptyTree>::<C String>)
+  <cast:assert_type!>(<emptyTree>::<C MyCommand>.call(7), <todo sym>, <emptyTree>::<C String>)
 
   class <emptyTree>::<C OtherCommand><<C <todo sym>>> < (::<root>::<C Opus>::<C Command>)
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of call>
   end
 
-  <emptyTree>::<C T>.assert_type!(<emptyTree>::<C OtherCommand>.call("8"), <emptyTree>::<C Integer>)
+  <cast:assert_type!>(<emptyTree>::<C OtherCommand>.call("8"), <todo sym>, <emptyTree>::<C Integer>)
 
   class <emptyTree>::<C NotACommand><<C <todo sym>>> < (<emptyTree>::<C Llamas>::<C Opus>::<C Command>)
     ::Sorbet::Private::Static.sig(<self>) do ||

--- a/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/default_args.rb.rewrite-tree.exp
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(x = "", &<blk>)
       begin
         @foo = "test"
-        @x = ::T.let(x, <emptyTree>::<C String>)
+        @x = <cast:let>(x, <todo sym>, <emptyTree>::<C String>)
       end
     end
 

--- a/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
@@ -190,9 +190,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C TestChild><<C <todo sym>>> < (<emptyTree>::<C TestDSLBuilder>)
     def test_instance_methods<<todo method>>(&<blk>)
       begin
-        <emptyTree>::<C T>.assert_type!(<self>.opt_string(), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
-        <emptyTree>::<C T>.assert_type!(<self>.opt_int_defaulted(), <emptyTree>::<C Integer>)
-        <emptyTree>::<C T>.assert_type!(<self>.req_string(), <emptyTree>::<C String>)
+        <cast:assert_type!>(<self>.opt_string(), <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+        <cast:assert_type!>(<self>.opt_int_defaulted(), <todo sym>, <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.req_string(), <todo sym>, <emptyTree>::<C String>)
         <self>.no_getter()
       end
     end
@@ -217,13 +217,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.class_of(<emptyTree>::<C Integer>)
 
-    <emptyTree>::<C T>.assert_type!(<self>.get_opt_string(), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+    <cast:assert_type!>(<self>.get_opt_string(), <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
 
-    <emptyTree>::<C T>.assert_type!(<self>.get_opt_string(), <emptyTree>::<C String>)
+    <cast:assert_type!>(<self>.get_opt_string(), <todo sym>, <emptyTree>::<C String>)
 
-    <emptyTree>::<C T>.assert_type!(<self>.get_opt_int_defaulted(), <emptyTree>::<C Integer>)
+    <cast:assert_type!>(<self>.get_opt_int_defaulted(), <todo sym>, <emptyTree>::<C Integer>)
 
-    <emptyTree>::<C T>.assert_type!(<self>.get_req_string(), <emptyTree>::<C String>)
+    <cast:assert_type!>(<self>.get_req_string(), <todo sym>, <emptyTree>::<C String>)
 
     <runtime method definition of test_instance_methods>
   end

--- a/test/testdata/rewriter/interface_wrapper.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/interface_wrapper.rb.rewrite-tree.exp
@@ -3,7 +3,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     begin
       s = <emptyTree>::<C SomeClass>.new()
       wrap = ::T.let(s, <emptyTree>::<C Interface>)
-      <emptyTree>::<C T>.assert_type!(wrap, <emptyTree>::<C Interface>)
+      <cast:assert_type!>(wrap, <todo sym>, <emptyTree>::<C Interface>)
       wrap.other_method()
       wrap.some_method()
       <emptyTree>::<C Other>.wrap_instance("hi", "there")

--- a/test/testdata/rewriter/interface_wrapper.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/interface_wrapper.rb.rewrite-tree.exp
@@ -2,7 +2,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   def testit<<todo method>>(&<blk>)
     begin
       s = <emptyTree>::<C SomeClass>.new()
-      wrap = ::T.let(s, <emptyTree>::<C Interface>)
+      wrap = <cast:let>(s, <todo sym>, <emptyTree>::<C Interface>)
       <cast:assert_type!>(wrap, <todo sym>, <emptyTree>::<C Interface>)
       wrap.other_method()
       wrap.some_method()

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def <it 'allows let-ed constants inside of IT'><<todo method>>(&<blk>)
-      ::Module.const_set(:C2, <emptyTree>::<C T>.let(10, <emptyTree>::<C Integer>))
+      ::Module.const_set(:C2, <cast:let>(10, <todo sym>, <emptyTree>::<C Integer>))
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -58,7 +58,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(&<blk>)
       begin
-        @foo = <emptyTree>::<C T>.let(3, <emptyTree>::<C Integer>)
+        @foo = <cast:let>(3, <todo sym>, <emptyTree>::<C Integer>)
         <self>.instance_helper()
       end
     end
@@ -80,7 +80,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def <it 'can read foo'><<todo method>>(&<blk>)
       begin
-        <emptyTree>::<C T>.assert_type!(@foo, <emptyTree>::<C Integer>)
+        <cast:assert_type!>(@foo, <todo sym>, <emptyTree>::<C Integer>)
         <self>.instance_helper()
       end
     end
@@ -109,7 +109,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     begin
-      <emptyTree>::<C C2> = ::T.let(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented"), <emptyTree>::<C Integer>)
+      <emptyTree>::<C C2> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       begin
         "allows let-ed constants inside of IT"
         <runtime method definition of <it 'allows let-ed constants inside of IT'>>
@@ -168,7 +168,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of self.random_method>
 
     <self>.random_method() do ||
-      @random_method_ivar = <emptyTree>::<C T>.let(3, <emptyTree>::<C Integer>)
+      @random_method_ivar = <cast:let>(3, <todo sym>, <emptyTree>::<C Integer>)
     end
 
     class <emptyTree>::<C <describe 'Object'>><<C <todo sym>>> < (<self>)

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -109,7 +109,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     begin
-      <emptyTree>::<C C2> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      <emptyTree>::<C C2> = <cast:let>(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented"), <todo sym>, <emptyTree>::<C Integer>)
       begin
         "allows let-ed constants inside of IT"
         <runtime method definition of <it 'allows let-ed constants inside of IT'>>

--- a/test/testdata/rewriter/minitest_strict_constants.rb
+++ b/test/testdata/rewriter/minitest_strict_constants.rb
@@ -1,0 +1,6 @@
+# typed: strict
+class MyTest
+  it "allows let-ed constants inside of IT" do
+    C2 = T.let(10, Integer)
+  end
+end

--- a/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
@@ -1,0 +1,19 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C MyTest><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'allows let-ed constants inside of IT'><<todo method>>(&<blk>)
+      ::Module.const_set(:C2, <cast:let>(10, <todo sym>, <emptyTree>::<C Integer>))
+    end
+
+    begin
+      <emptyTree>::<C C2> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      begin
+        "allows let-ed constants inside of IT"
+        <runtime method definition of <it 'allows let-ed constants inside of IT'>>
+      end
+    end
+  end
+end

--- a/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
@@ -9,7 +9,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     begin
-      <emptyTree>::<C C2> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      <emptyTree>::<C C2> = <cast:let>(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented"), <todo sym>, <emptyTree>::<C Integer>)
       begin
         "allows let-ed constants inside of IT"
         <runtime method definition of <it 'allows let-ed constants inside of IT'>>

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -430,7 +430,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <runtime method definition of <it 'succeeds with a constant list'>>
     end
 
-    <emptyTree>::<C ANOTHER_CONST_LIST> = <emptyTree>::<C T>.let([<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()], <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C Parent>))
+    <emptyTree>::<C ANOTHER_CONST_LIST> = <cast:let>([<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()], <todo sym>, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C Parent>))
 
     <self>.test_each(<emptyTree>::<C ANOTHER_CONST_LIST>) do |value|
       <runtime method definition of <it 'succeeds with a typed constant list'>>
@@ -492,7 +492,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <runtime method definition of <it 'succeeds with a constant list of tuples and destructuring'>>
     end
 
-    <emptyTree>::<C ANOTHER_CONST_LIST_TUPLE> = <emptyTree>::<C T>.let([[1, "a"], [2, "b"]], <emptyTree>::<C T>::<C Array>.[]([<emptyTree>::<C Integer>, <emptyTree>::<C String>]))
+    <emptyTree>::<C ANOTHER_CONST_LIST_TUPLE> = <cast:let>([[1, "a"], [2, "b"]], <todo sym>, <emptyTree>::<C T>::<C Array>.[]([<emptyTree>::<C Integer>, <emptyTree>::<C String>]))
 
     <self>.test_each(<emptyTree>::<C ANOTHER_CONST_LIST_TUPLE>) do |i, s|
       <runtime method definition of <it 'succeeds with a typed constant tuple list'>>

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1553,17 +1553,9 @@ ClassDef{
               kind = Local
               name = <U <blk>>
             } }]
-          rhs = Send{
-            flags = {}
-            recv = UnresolvedConstantLit{
-              cnst = <C <U T>>
-              scope = EmptyTree
-            }
-            fun = <U cast>
-            block = nullptr
-            pos_args = 2
-            args = [
-              Send{
+          rhs = Cast{
+              cast = <U cast>,
+              arg = Send{
                 flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U T>>
@@ -1576,7 +1568,8 @@ ClassDef{
                   Literal{ value = nil }
                 ]
               }
-              Send{
+              type = <todo sym>,
+              typeExpr = Send{
                 flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U T>>
@@ -1591,9 +1584,9 @@ ClassDef{
                     scope = EmptyTree
                   }
                 ]
-              }
-            ]
+              },
           }
+
         }
 
         Send{
@@ -1653,23 +1646,16 @@ ClassDef{
               kind = Local
               name = <U <blk>>
             } }]
-          rhs = Send{
-            flags = {}
-            recv = UnresolvedConstantLit{
-              cnst = <C <U T>>
-              scope = EmptyTree
-            }
-            fun = <U cast>
-            block = nullptr
-            pos_args = 2
-            args = [
-              Literal{ value = nil }
-              UnresolvedConstantLit{
+          rhs = Cast{
+              cast = <U cast>,
+              arg = Literal{ value = nil }
+              type = <todo sym>,
+              typeExpr = UnresolvedConstantLit{
                 cnst = <C <U String>>
                 scope = EmptyTree
-              }
-            ]
+              },
           }
+
         }
 
         Send{

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -92,7 +92,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo2<<todo method>>(&<blk>)
-      <emptyTree>::<C T>.cast(<emptyTree>::<C T>.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+      <cast:cast>(<emptyTree>::<C T>.unsafe(nil), <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -100,7 +100,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo2=<<todo method>>(arg0, &<blk>)
-      <emptyTree>::<C T>.cast(nil, <emptyTree>::<C String>)
+      <cast:cast>(nil, <todo sym>, <emptyTree>::<C String>)
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)

--- a/test/testdata/rewriter/prop_compiled.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop_compiled.rb.rewrite-tree-raw.exp
@@ -1620,17 +1620,9 @@ ClassDef{
               kind = Local
               name = <U <blk>>
             } }]
-          rhs = Send{
-            flags = {}
-            recv = UnresolvedConstantLit{
-              cnst = <C <U T>>
-              scope = EmptyTree
-            }
-            fun = <U cast>
-            block = nullptr
-            pos_args = 2
-            args = [
-              Send{
+          rhs = Cast{
+              cast = <U cast>,
+              arg = Send{
                 flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U T>>
@@ -1643,7 +1635,8 @@ ClassDef{
                   Literal{ value = nil }
                 ]
               }
-              Send{
+              type = <todo sym>,
+              typeExpr = Send{
                 flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U T>>
@@ -1658,9 +1651,9 @@ ClassDef{
                     scope = EmptyTree
                   }
                 ]
-              }
-            ]
+              },
           }
+
         }
 
         Send{
@@ -1720,23 +1713,16 @@ ClassDef{
               kind = Local
               name = <U <blk>>
             } }]
-          rhs = Send{
-            flags = {}
-            recv = UnresolvedConstantLit{
-              cnst = <C <U T>>
-              scope = EmptyTree
-            }
-            fun = <U cast>
-            block = nullptr
-            pos_args = 2
-            args = [
-              Literal{ value = nil }
-              UnresolvedConstantLit{
+          rhs = Cast{
+              cast = <U cast>,
+              arg = Literal{ value = nil }
+              type = <todo sym>,
+              typeExpr = UnresolvedConstantLit{
                 cnst = <C <U String>>
                 scope = EmptyTree
-              }
-            ]
+              },
           }
+
         }
 
         Send{

--- a/test/testdata/rewriter/prop_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_compiled.rb.rewrite-tree.exp
@@ -98,7 +98,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo2<<todo method>>(&<blk>)
-      <emptyTree>::<C T>.cast(<emptyTree>::<C T>.unsafe(nil), <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+      <cast:cast>(<emptyTree>::<C T>.unsafe(nil), <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -106,7 +106,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo2=<<todo method>>(arg0, &<blk>)
-      <emptyTree>::<C T>.cast(nil, <emptyTree>::<C String>)
+      <cast:cast>(nil, <todo sym>, <emptyTree>::<C String>)
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)

--- a/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_ok<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_ok(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_num_ok(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end
@@ -25,7 +25,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def missing<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_missing(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_missing(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_wrong_value<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_wrong_value(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_num_wrong_value(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end
@@ -55,7 +55,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_wrong_type<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_wrong_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_num_wrong_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end
@@ -90,7 +90,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_unknown_type<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_unknown_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_num_unknown_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end

--- a/test/testdata/rewriter/prop_computed_by_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_computed_by_compiled.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_ok<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_ok(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_num_ok(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end
@@ -25,7 +25,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def missing<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_missing(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_missing(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_wrong_value<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_wrong_value(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_num_wrong_value(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end
@@ -55,7 +55,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_wrong_type<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_wrong_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_num_wrong_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end
@@ -96,7 +96,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def num_unknown_type<<todo method>>(&<blk>)
       begin
-        ::T.assert_type!(<self>.class().compute_num_unknown_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <emptyTree>::<C Integer>)
+        <cast:assert_type!>(<self>.class().compute_num_unknown_type(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")), <todo sym>, <emptyTree>::<C Integer>)
         ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
       end
     end

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -464,7 +464,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(b:, &<blk>)
       begin
-        @b = ::T.let(b, <emptyTree>::<C String>)
+        @b = <cast:let>(b, <todo sym>, <emptyTree>::<C String>)
         nil
       end
     end

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C NotStruct><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C B> = <emptyTree>::<C T>.let(<emptyTree>::<C Foo>::<C Struct>.new(), <emptyTree>::<C Foo>::<C Struct>)
+    <emptyTree>::<C B> = <cast:let>(<emptyTree>::<C Foo>::<C Struct>.new(), <todo sym>, <emptyTree>::<C Foo>::<C Struct>)
 
     var = <emptyTree>::<C Struct>.new(:foo)
   end
@@ -117,7 +117,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def self.new<<todo method>>(foo = nil, bar = nil, &<blk>)
-        <emptyTree>::<C T>.cast(nil, <emptyTree>::<C A>)
+        <cast:cast>(nil, <todo sym>, <emptyTree>::<C A>)
       end
 
       <self>.extend(<emptyTree>::<C T>::<C Sig>)
@@ -375,16 +375,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def main<<todo method>>(&<blk>)
       begin
         a = <emptyTree>::<C Struct>.new(:foo)
-        <emptyTree>::<C T>.assert_type!(a, <emptyTree>::<C Struct>)
-        <emptyTree>::<C T>.assert_type!(a.new(), <emptyTree>::<C Struct>)
-        <emptyTree>::<C T>.assert_type!(a.new(2), <emptyTree>::<C Struct>)
-        <emptyTree>::<C T>.assert_type!(<emptyTree>::<C RealStruct>::<C A>.new(2, 3), <emptyTree>::<C RealStruct>::<C A>)
-        <emptyTree>::<C T>.assert_type!(<emptyTree>::<C RealStruct>::<C A>.new(2), <emptyTree>::<C RealStruct>::<C A>)
-        <emptyTree>::<C T>.assert_type!(<emptyTree>::<C RealStruct>::<C KeywordInit>.new(), <emptyTree>::<C RealStruct>::<C KeywordInit>)
-        <emptyTree>::<C T>.assert_type!(<emptyTree>::<C RealStruct>::<C KeywordInit>.new(:foo, 1), <emptyTree>::<C RealStruct>::<C KeywordInit>)
-        <emptyTree>::<C T>.assert_type!(<emptyTree>::<C RealStruct>::<C KeywordInit>.new(:foo, 2, :bar, 3), <emptyTree>::<C RealStruct>::<C KeywordInit>)
+        <cast:assert_type!>(a, <todo sym>, <emptyTree>::<C Struct>)
+        <cast:assert_type!>(a.new(), <todo sym>, <emptyTree>::<C Struct>)
+        <cast:assert_type!>(a.new(2), <todo sym>, <emptyTree>::<C Struct>)
+        <cast:assert_type!>(<emptyTree>::<C RealStruct>::<C A>.new(2, 3), <todo sym>, <emptyTree>::<C RealStruct>::<C A>)
+        <cast:assert_type!>(<emptyTree>::<C RealStruct>::<C A>.new(2), <todo sym>, <emptyTree>::<C RealStruct>::<C A>)
+        <cast:assert_type!>(<emptyTree>::<C RealStruct>::<C KeywordInit>.new(), <todo sym>, <emptyTree>::<C RealStruct>::<C KeywordInit>)
+        <cast:assert_type!>(<emptyTree>::<C RealStruct>::<C KeywordInit>.new(:foo, 1), <todo sym>, <emptyTree>::<C RealStruct>::<C KeywordInit>)
+        <cast:assert_type!>(<emptyTree>::<C RealStruct>::<C KeywordInit>.new(:foo, 2, :bar, 3), <todo sym>, <emptyTree>::<C RealStruct>::<C KeywordInit>)
         <emptyTree>::<C RealStruct>::<C KeywordInit>.new(1, 2)
-        <emptyTree>::<C T>.assert_type!(<emptyTree>::<C RealStructDesugar>::<C A>.new(2, 3), <emptyTree>::<C RealStructDesugar>::<C A>)
+        <cast:assert_type!>(<emptyTree>::<C RealStructDesugar>::<C A>.new(2, 3), <todo sym>, <emptyTree>::<C RealStructDesugar>::<C A>)
       end
     end
 

--- a/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.enums() do ||
       begin
         <emptyTree>::<C X> = ::<Magic>.<self-new>(<self>)
-        <emptyTree>::<C Y> = <emptyTree>::<C T>.let(::<Magic>.<self-new>(<self>), <self>)
+        <emptyTree>::<C Y> = <cast:let>(::<Magic>.<self-new>(<self>), <todo sym>, <self>)
       end
     end
   end
@@ -91,6 +91,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <emptyTree>::<C StaticField3> = 3
 
-    <emptyTree>::<C StaticField4> = <emptyTree>::<C T>.let(1, <emptyTree>::<C Integer>)
+    <emptyTree>::<C StaticField4> = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
   end
 end

--- a/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
@@ -10,13 +10,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         class <emptyTree>::<C X$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
         end
-        <emptyTree>::<C X> = ::T.<unchecked_let>(<emptyTree>::<C X$1>.new(), <emptyTree>::<C X$1>)
+        <emptyTree>::<C X> = <cast:<unchecked_let>>(<emptyTree>::<C X$1>.new(), <todo sym>, <emptyTree>::<C X$1>)
         class <emptyTree>::<C Y$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
         end
-        <emptyTree>::<C Y> = ::T.<unchecked_let>(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
+        <emptyTree>::<C Y> = <cast:<unchecked_let>>(<emptyTree>::<C Y$1>.new("y"), <todo sym>, <emptyTree>::<C Y$1>)
         class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C MyEnum>)
         end
-        <emptyTree>::<C Z> = ::T.<unchecked_let>(<emptyTree>::<C Z$1>.new(), <emptyTree>::<C Z$1>)
+        <emptyTree>::<C Z> = <cast:<unchecked_let>>(<emptyTree>::<C Z$1>.new(), <todo sym>, <emptyTree>::<C Z$1>)
         nil
       end
     end
@@ -46,13 +46,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         class <emptyTree>::<C X$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
         end
-        <emptyTree>::<C X> = ::T.<unchecked_let>(<emptyTree>::<C X$1>.new(), <emptyTree>::<C X$1>)
+        <emptyTree>::<C X> = <cast:<unchecked_let>>(<emptyTree>::<C X$1>.new(), <todo sym>, <emptyTree>::<C X$1>)
         class <emptyTree>::<C Y$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
         end
-        <emptyTree>::<C Y> = ::T.<unchecked_let>(<emptyTree>::<C Y$1>.new("y"), <emptyTree>::<C Y$1>)
+        <emptyTree>::<C Y> = <cast:<unchecked_let>>(<emptyTree>::<C Y$1>.new("y"), <todo sym>, <emptyTree>::<C Y$1>)
         class <emptyTree>::<C Z$1><<C <todo sym>>> < (<emptyTree>::<C EnumsDoEnum>)
         end
-        <emptyTree>::<C Z> = ::T.<unchecked_let>(<emptyTree>::<C Z$1>.new(), <emptyTree>::<C Z$1>)
+        <emptyTree>::<C Z> = <cast:<unchecked_let>>(<emptyTree>::<C Z$1>.new(), <todo sym>, <emptyTree>::<C Z$1>)
         nil
       end
     end
@@ -70,7 +70,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     class <emptyTree>::<C Before$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
     end
 
-    <emptyTree>::<C Before> = ::T.<unchecked_let>(<emptyTree>::<C Before$1>.new(), <emptyTree>::<C Before$1>)
+    <emptyTree>::<C Before> = <cast:<unchecked_let>>(<emptyTree>::<C Before$1>.new(), <todo sym>, <emptyTree>::<C Before$1>)
 
     <emptyTree>::<C StaticField1> = 1
 
@@ -78,7 +78,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         class <emptyTree>::<C Inside$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
         end
-        <emptyTree>::<C Inside> = ::T.<unchecked_let>(<emptyTree>::<C Inside$1>.new(), <emptyTree>::<C Inside$1>)
+        <emptyTree>::<C Inside> = <cast:<unchecked_let>>(<emptyTree>::<C Inside$1>.new(), <todo sym>, <emptyTree>::<C Inside$1>)
         <emptyTree>::<C StaticField2> = 2
         nil
       end
@@ -87,7 +87,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     class <emptyTree>::<C After$1><<C <todo sym>>> < (<emptyTree>::<C BadConsts>)
     end
 
-    <emptyTree>::<C After> = ::T.<unchecked_let>(<emptyTree>::<C After$1>.new(), <emptyTree>::<C After$1>)
+    <emptyTree>::<C After> = <cast:<unchecked_let>>(<emptyTree>::<C After$1>.new(), <todo sym>, <emptyTree>::<C After$1>)
 
     <emptyTree>::<C StaticField3> = 3
 

--- a/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo: = 3, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/default_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/default_compiled.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo: = 3, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo: = nil, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/nilable_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/nilable_compiled.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo: = nil, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo:, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/normal_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/normal_compiled.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo:, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo:, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C String>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C String>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/override_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/override_compiled.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo:, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C String>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C String>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
@@ -6,8 +6,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(bar:, foo: = 3, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        @bar = ::T.let(bar, <emptyTree>::<C Integer>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
+        @bar = <cast:let>(bar, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/param_order_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/param_order_compiled.rb.rewrite-tree.exp
@@ -6,8 +6,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(bar:, foo: = 3, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        @bar = ::T.let(bar, <emptyTree>::<C Integer>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
+        @bar = <cast:let>(bar, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo:, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/root_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/root_compiled.rb.rewrite-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo:, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
@@ -6,8 +6,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo:, bar: = false, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        @bar = ::T.let(bar, <emptyTree>::<C T>::<C Boolean>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
+        @bar = <cast:let>(bar, <todo sym>, <emptyTree>::<C T>::<C Boolean>)
         nil
       end
     end

--- a/test/testdata/rewriter/t_struct/some_default_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/some_default_compiled.rb.rewrite-tree.exp
@@ -6,8 +6,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(foo:, bar: = false, &<blk>)
       begin
-        @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        @bar = ::T.let(bar, <emptyTree>::<C T>::<C Boolean>)
+        @foo = <cast:let>(foo, <todo sym>, <emptyTree>::<C Integer>)
+        @bar = <cast:let>(bar, <todo sym>, <emptyTree>::<C T>::<C Boolean>)
         nil
       end
     end

--- a/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize<<todo method>>(&<blk>)
       begin
-        @a = <emptyTree>::<C T>.let(1, <emptyTree>::<C Integer>)
+        @a = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
         <self>.foo()
       end
     end
@@ -181,7 +181,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def initialize<<todo method>>(&<blk>)
-      @a = <emptyTree>::<C T>.let(1, <emptyTree>::<C Integer>)
+      @a = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change helps with putting changes to instance and class variables on the fast path, as after this PR, namer can clearly see where declarations of such variables occur, rather than having to re-implement the logic that resolver currently has.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
