### PR TITLE
move `args` closer to the point of use

### DIFF
--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -11,7 +11,6 @@ namespace sorbet::rewriter {
 ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
     auto send = ast::cast_tree<ast::Send>(orig);
     if (send) {
-        ast::Send::ARGS_store args;
         auto dupRecv = dupType(send->recv);
         if (!dupRecv) {
             return nullptr;
@@ -42,6 +41,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
             return ast::MK::Send(send->loc, std::move(dupRecv), send->fun, send->funLoc, 0, std::move(args));
         }
 
+        ast::Send::ARGS_store args;
         for (auto &arg : send->nonBlockArgs()) {
             auto dupArg = dupType(arg);
             if (!dupArg) {


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This also avoids some confusion with the block in between defining an `args` variable: did we mean to define a separate one, or not?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
