### PR TITLE
ensure that `llvm-symbolizer` is available for at least exp tests

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -1,6 +1,7 @@
 load("//tools:clang.bzl", "clang_tool")  # todo: this should be decoupled and use the library toolchain, not the compiler one
 
 clang_tool("llvm-diff")  # depended on by compiler_tests
+
 clang_tool("llvm-symbolizer")
 
 cc_binary(

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,3 +1,8 @@
+load("//tools:clang.bzl", "clang_tool")  # todo: this should be decoupled and use the library toolchain, not the compiler one
+
+clang_tool("llvm-diff")  # depended on by compiler_tests
+clang_tool("llvm-symbolizer")
+
 cc_binary(
     name = "pipeline_test_runner",
     testonly = 1,
@@ -278,9 +283,6 @@ test_suite(
 )
 
 load(":compiler_tests.bzl", "compiler_tests")
-load("//tools:clang.bzl", "clang_tool")  # todo: this should be decoupled and use the library toolchain, not the compiler one
-
-clang_tool("llvm-diff")  # depended on by compiler_tests
 
 compiler_tests(
     "compiler",

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -13,7 +13,7 @@ def dropExtension(p):
     return p.partition(".")[0]
 
 _TEST_SCRIPT = """#!/usr/bin/env bash
-set -x
+export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_12_0_0/bin/llvm-symbolizer
 exec {runner} --single_test="{test}"
 """
 
@@ -27,6 +27,7 @@ def _exp_test_impl(ctx):
     )
 
     runfiles = ctx.runfiles(files = ctx.files.runner + ctx.files.test + ctx.files.data)
+    runfiles = runfiles.merge(ctx.attr._llvm_symbolizer[DefaultInfo].default_runfiles)
 
     return [DefaultInfo(runfiles = runfiles)]
 
@@ -44,6 +45,9 @@ exp_test = rule(
             executable = True,
             cfg = "target",
             allow_files = True,
+        ),
+        "_llvm_symbolizer": attr.label(
+            default = "//test:llvm-symbolizer",
         ),
     },
 )


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It is zero fun to be faced with ASAN errors in CI (or locally!) that are an inscrutable mess of addresses.

There is probably a more bazel-y way to do this; this version cargo-cults from the existing support that we have for `llvm-diff`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I should probably verify that this actually works in CI, but it does symbolize things for me locally.
