### PR TITLE
Only call `toString` in the stdout flusher

### DIFF
--- a/core/ErrorFlusherStdout.cc
+++ b/core/ErrorFlusherStdout.cc
@@ -21,8 +21,8 @@ void ErrorFlusherStdout::flushErrors(spdlog::logger &logger, const GlobalState &
             if (out.size() != 0) {
                 fmt::format_to(std::back_inserter(out), "\n\n");
             }
-            ENFORCE(error->text.has_value());
-            fmt::format_to(std::back_inserter(out), "{}", error->text.value_or(""));
+            auto text = error->error->toString(gs);
+            fmt::format_to(std::back_inserter(out), "{}", text);
 
             for (auto &autocorrect : error->error->autocorrects) {
                 autocorrects.emplace_back(move(autocorrect));

--- a/core/ErrorQueue.cc
+++ b/core/ErrorQueue.cc
@@ -50,6 +50,7 @@ void ErrorQueue::pushError(const core::GlobalState &gs, unique_ptr<core::Error> 
     if (!error->isSilenced) {
         this->nonSilencedErrorCount.fetch_add(1);
         // Serializing errors is expensive, so we only serialize them if the error isn't silenced.
+        // TODO(jez) It looks like we compute the command-line error string even in LSP mode
         msg.text = error->toString(gs);
     }
     msg.error = move(error);

--- a/core/ErrorQueue.cc
+++ b/core/ErrorQueue.cc
@@ -49,9 +49,6 @@ void ErrorQueue::pushError(const core::GlobalState &gs, unique_ptr<core::Error> 
     msg.whatFile = error->loc.file();
     if (!error->isSilenced) {
         this->nonSilencedErrorCount.fetch_add(1);
-        // Serializing errors is expensive, so we only serialize them if the error isn't silenced.
-        // TODO(jez) It looks like we compute the command-line error string even in LSP mode
-        msg.text = error->toString(gs);
     }
     msg.error = move(error);
     this->queue.push(move(msg), 1);

--- a/core/ErrorQueueMessage.h
+++ b/core/ErrorQueueMessage.h
@@ -11,8 +11,6 @@ struct ErrorQueueMessage {
     enum class Kind { Error, Flush, QueryResponse };
     Kind kind;
     core::FileRef whatFile;
-    // The text of the error. Is a `nullopt` if the error is silenced.
-    std::optional<std::string> text;
     std::unique_ptr<Error> error;
     std::unique_ptr<lsp::QueryResponse> queryResponse;
 };


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, we were calling `toString` before pushing the the error message
into the queue, which mean that even flushers that did not using the
`toString` version of the error were eagerly computing it.

This might have a slight performance improvement? But probably not noticeable,
unless you're seeing tons and tons of errors in the IDE.

Incidentally, this will fix most of the crash logs we're seeing for `addLocLine`
by simply not exercising that code path. I still am curious to see if the logs I
just added are going to be enough to show me where the problem is, so I'll hold
off on merging this for the moment while I wait for those logs to show up.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.