### PR TITLE
Force class alias jobs to always run

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1175,7 +1175,10 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
             },
             [&](cfg::Alias &a) {
                 core::SymbolRef symbol = a.what.dealias(ctx);
-                if (symbol.isClassOrModule()) {
+                if (symbol == core::Symbols::StubModule()) {
+                    tp.origins.emplace_back(ctx.locAt(bind.loc));
+                    tp.type = core::Types::untyped(ctx, a.what);
+                } else if (symbol.isClassOrModule()) {
                     auto singletonClass = symbol.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx);
                     ENFORCE(singletonClass.exists(), "Every class should have a singleton class by now.");
                     tp.type = singletonClass.data(ctx)->externalType();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -525,7 +525,7 @@ class SymbolDefiner {
             case core::FoundDefinitionRef::Kind::ClassRef: {
                 auto &klassRef = ref.klassRef(foundDefs);
                 auto newOwner = squashNames(ctx, klassRef.owner, owner);
-                return getOrDefineSymbol(ctx.withOwner(newOwner), klassRef.name, klassRef.loc);
+                return getOrDefineClassSymbol(ctx.withOwner(newOwner), klassRef.name, klassRef.loc);
             }
             default:
                 Exception::raise("Invalid name reference");
@@ -567,8 +567,8 @@ class SymbolDefiner {
         emitRedefinedConstantError(ctx, errorLoc, symbol.show(ctx), renamedSymbol.loc(ctx));
     }
 
-    core::ClassOrModuleRef ensureIsClass(core::MutableContext ctx, core::SymbolRef scope, core::NameRef name,
-                                         core::LocOffsets loc) {
+    core::ClassOrModuleRef ensureScopeIsClass(core::MutableContext ctx, core::SymbolRef scope, core::NameRef name,
+                                              core::LocOffsets loc) {
         // Common case: Everything is fine, user is trying to define a symbol on a class or module.
         if (scope.isClassOrModule()) {
             // Check if original symbol was mangled away. If so, complain.
@@ -607,16 +607,16 @@ class SymbolDefiner {
     }
 
     // Gets the symbol with the given name, or defines it as a class if it does not exist.
-    core::SymbolRef getOrDefineSymbol(core::MutableContext ctx, core::NameRef name, core::LocOffsets loc) {
+    core::ClassOrModuleRef getOrDefineClassSymbol(core::MutableContext ctx, core::NameRef name, core::LocOffsets loc) {
         if (name == core::Names::singleton()) {
             return ctx.owner.enclosingClass(ctx).data(ctx)->singletonClass(ctx);
         }
 
-        auto scope = ensureIsClass(ctx, ctx.owner, name, loc);
-        core::SymbolRef existing = scope.data(ctx)->findMember(ctx, name);
+        auto scope = ensureScopeIsClass(ctx, ctx.owner, name, loc);
+        auto existing = ctx.state.lookupClassSymbol(scope, name);
         if (!existing.exists()) {
             existing = ctx.state.enterClassSymbol(ctx.locAt(loc), scope, name);
-            existing.asClassOrModuleRef().data(ctx)->singletonClass(ctx); // force singleton class into existance
+            existing.data(ctx)->singletonClass(ctx); // force singleton class into existance
         }
 
         return existing;
@@ -1052,8 +1052,8 @@ class SymbolDefiner {
     core::FieldRef insertStaticField(core::MutableContext ctx, const core::FoundStaticField &staticField) {
         ENFORCE(ctx.owner.isClassOrModule());
 
-        auto scope = ensureIsClass(ctx, squashNames(ctx, staticField.klass, contextClass(ctx, ctx.owner)),
-                                   staticField.name, staticField.asgnLoc);
+        auto scope = ensureScopeIsClass(ctx, squashNames(ctx, staticField.klass, contextClass(ctx, ctx.owner)),
+                                        staticField.name, staticField.asgnLoc);
         auto sym = ctx.state.lookupStaticFieldSymbol(scope, staticField.name);
         auto currSym = ctx.state.lookupSymbol(scope, staticField.name);
         if (!sym.exists() && currSym.exists()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -607,16 +607,16 @@ class SymbolDefiner {
     }
 
     // Gets the symbol with the given name, or defines it as a class if it does not exist.
-    core::ClassOrModuleRef getOrDefineClassSymbol(core::MutableContext ctx, core::NameRef name, core::LocOffsets loc) {
+    core::SymbolRef getOrDefineClassSymbol(core::MutableContext ctx, core::NameRef name, core::LocOffsets loc) {
         if (name == core::Names::singleton()) {
             return ctx.owner.enclosingClass(ctx).data(ctx)->singletonClass(ctx);
         }
 
         auto scope = ensureScopeIsClass(ctx, ctx.owner, name, loc);
-        auto existing = ctx.state.lookupClassSymbol(scope, name);
+        core::SymbolRef existing = scope.data(ctx)->findMemberNoDealias(ctx, name);
         if (!existing.exists()) {
             existing = ctx.state.enterClassSymbol(ctx.locAt(loc), scope, name);
-            existing.data(ctx)->singletonClass(ctx); // force singleton class into existance
+            existing.asClassOrModuleRef().data(ctx)->singletonClass(ctx); // force singleton class into existance
         }
 
         return existing;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -671,7 +671,7 @@ private:
         bool alreadyReported = false;
         job.out->resolutionScopes = make_unique<ast::ConstantLit::ResolutionScopes>();
         if (auto *id = ast::cast_tree<ast::ConstantLit>(original.scope)) {
-            auto originalScope = id->symbol.dealias(ctx);
+            auto originalScope = id->symbol;
             if (originalScope == core::Symbols::StubModule()) {
                 // If we were trying to resolve some literal like C::D but `C` itself was already stubbed,
                 // no need to also report that `D` is missing.
@@ -1754,8 +1754,6 @@ public:
                 return compareLocOffsets(lhs.ancestor->loc, rhs.ancestor->loc);
             });
         }
-
-        // Note that this is missing alias stubbing, thus resolveJob needs to be able to handle missing aliases.
 
         {
             Timer timeit(gs.tracer(), "resolver.resolve_constants.errors");

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1779,17 +1779,12 @@ public:
                 }
             }
 
-            if (singlePackageRbiGeneration) {
-                if constexpr (isMutableStateType) {
-                    for (auto &job : todoClassAliases) {
-                        core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                        for (auto &item : job.items) {
-                            resolveClassAliasJob(ctx, item);
-                        }
+            if constexpr (isMutableStateType) {
+                for (auto &job : todoClassAliases) {
+                    core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                    for (auto &item : job.items) {
+                        resolveClassAliasJob(ctx, item);
                     }
-
-                } else {
-                    ENFORCE(false, "Was not expecting non-mutating resolver and single package RBI generation");
                 }
             }
 

--- a/test/testdata/resolver/redefining_static_fields.rb
+++ b/test/testdata/resolver/redefining_static_fields.rb
@@ -9,6 +9,6 @@ Alias = Integer
 Alias = String
 
 BadAlias = 1 + 1
-#          ^^^^^ error: Expected `T.class_of(Sorbet::Private::Static::StubModule)` but found `Integer` for field
+
 BadAlias = DoesNotExist
 #          ^^^^^^^^^^^^ error: Unable to resolve constant `DoesNotExist`

--- a/test/testdata/resolver/redefining_static_fields.rb
+++ b/test/testdata/resolver/redefining_static_fields.rb
@@ -9,7 +9,6 @@ Alias = Integer
 Alias = String
 
 BadAlias = 1 + 1
-#          ^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+#          ^^^^^ error: Expected `T.class_of(Sorbet::Private::Static::StubModule)` but found `Integer` for field
 BadAlias = DoesNotExist
 #          ^^^^^^^^^^^^ error: Unable to resolve constant `DoesNotExist`
-#          ^^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`

--- a/test/testdata/resolver/redefining_static_fields.rb
+++ b/test/testdata/resolver/redefining_static_fields.rb
@@ -1,0 +1,15 @@
+# typed: strict
+
+# No error (by analogy with how we handle sig'd method redefinitions?)
+X = T.let(0, Integer)
+X = T.let('', String)
+
+Alias = Integer
+#       ^^^^^^^ error: Expected `T.class_of(String)` but found `T.class_of(Integer)` for field
+Alias = String
+
+BadAlias = 1 + 1
+#          ^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+BadAlias = DoesNotExist
+#          ^^^^^^^^^^^^ error: Unable to resolve constant `DoesNotExist`
+#          ^^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`

--- a/test/testdata/resolver/redefining_static_fields.rb.symbol-table.exp
+++ b/test/testdata/resolver/redefining_static_fields.rb.symbol-table.exp
@@ -3,6 +3,6 @@ class ::<root> < ::Object ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/redefining_static_fields.rb:4
       argument <blk><block> @ Loc {file=test/testdata/resolver/redefining_static_fields.rb start=??? end=???}
   static-field ::Alias -> <Alias: ::String > @ test/testdata/resolver/redefining_static_fields.rb:7
-  static-field ::BadAlias @ test/testdata/resolver/redefining_static_fields.rb:11
+  static-field ::BadAlias -> <Alias: ::Sorbet::Private::Static::StubModule > @ test/testdata/resolver/redefining_static_fields.rb:11
   static-field ::X -> String @ test/testdata/resolver/redefining_static_fields.rb:4
 

--- a/test/testdata/resolver/redefining_static_fields.rb.symbol-table.exp
+++ b/test/testdata/resolver/redefining_static_fields.rb.symbol-table.exp
@@ -1,0 +1,8 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/redefining_static_fields.rb:4
+      argument <blk><block> @ Loc {file=test/testdata/resolver/redefining_static_fields.rb start=??? end=???}
+  static-field ::Alias -> <Alias: ::String > @ test/testdata/resolver/redefining_static_fields.rb:7
+  static-field ::BadAlias @ test/testdata/resolver/redefining_static_fields.rb:11
+  static-field ::X -> String @ test/testdata/resolver/redefining_static_fields.rb:4
+

--- a/test/testdata/resolver/stub_missing_class_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/stub_missing_class_alias.rb.symbol-table-raw.exp
@@ -5,7 +5,7 @@ class <C <U <root>>> < <C <U Object>> ()
   module <C <U O>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=4:7 end=4:8}
     class <C <U O>>::<C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=4:1 end=4:11}
       static-field <C <U O>>::<C <U B>>::<C <U Doc1>> -> Integer @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=9:3 end=9:7}
-      static-field <C <U O>>::<C <U B>>::<C <U Document>> @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=8:3 end=8:11}
+      static-field <C <U O>>::<C <U B>>::<C <U Document>> -> AliasType { symbol = <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U StubModule>> } @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=8:3 end=8:11}
       class <C <U O>>::<C <U B>>::<C <U J>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=5:3 end=5:10}
       class <C <U O>>::<C <U B>>::<S <C <U J>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=5:9 end=5:10}
         type-member(+) <C <U O>>::<C <U B>>::<S <C <U J>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U O>>::<C <U B>>::<S <C <U J>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=O::B::J) @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=5:9 end=5:10}

--- a/test/testdata/resolver/unresolved_via_alias.rb
+++ b/test/testdata/resolver/unresolved_via_alias.rb
@@ -6,4 +6,5 @@ end
 AliasToA = A
 
 sig {returns(AliasToA::B)}
+#            ^^^^^^^^^^^ error: Unable to resolve constant `B`
 def example; end

--- a/test/testdata/resolver/unresolved_via_alias.rb
+++ b/test/testdata/resolver/unresolved_via_alias.rb
@@ -1,0 +1,9 @@
+# typed: true
+extend T::Sig
+
+class A
+end
+AliasToA = A
+
+sig {returns(AliasToA::B)}
+def example; end

--- a/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
+++ b/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
@@ -1,0 +1,14 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> (Sig)
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/unresolved_via_alias.rb:2
+      argument <blk><block> @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
+  class ::A < ::Object () @ test/testdata/resolver/unresolved_via_alias.rb:4
+  class ::<Class:A>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/unresolved_via_alias.rb:4
+    type-member(+) ::<Class:A>::<AttachedClass> -> T.attached_class (of A) @ test/testdata/resolver/unresolved_via_alias.rb:4
+    method ::<Class:A>#<static-init> (<blk>) @ test/testdata/resolver/unresolved_via_alias.rb:4
+      argument <blk><block> @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
+  static-field ::AliasToA -> <Alias: ::A > @ test/testdata/resolver/unresolved_via_alias.rb:6
+  class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED
+    method ::Object#example : private (<blk>) -> A::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:9
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
+

--- a/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
+++ b/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
@@ -9,6 +9,6 @@ class ::<root> < ::Object ()
       argument <blk><block> @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
   static-field ::AliasToA -> <Alias: ::A > @ test/testdata/resolver/unresolved_via_alias.rb:6
   class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED
-    method ::Object#example : private (<blk>) -> A::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:9
+    method ::Object#example : private (<blk>) -> AliasToA::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:9
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
 

--- a/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
+++ b/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
@@ -9,6 +9,6 @@ class ::<root> < ::Object ()
       argument <blk><block> @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
   static-field ::AliasToA -> <Alias: ::A > @ test/testdata/resolver/unresolved_via_alias.rb:6
   class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED
-    method ::Object#example : private (<blk>) -> AliasToA::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:9
+    method ::Object#example : private (<blk>) -> AliasToA::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:10
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For some upcoming changes to make Sorbet more incremental, I want to be able to
at least see whether a static field is a class alias or not even in the hashing
code. When we run hashing, most of the time the class aliases do not exist,
because the alias target is defined in some other file but hashing code runs in
local global states that do not have all the classes defined.

To record the fact that something was a class alias, I want to makes sure that
its result type is at least `AliasType { symbol = StubModule }`, which can then
be used in `GlobalState::hash` to check whether some static field is a class
alias or not.

This PR should not have any real behavior changes other than some internal
representations that change.

### Commit summary

I recommend reviewing by commit; there are messages for most of the commits.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.