### PR TITLE
use a shallow walk for document symbols

### DIFF
--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -304,7 +304,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterfa
     core::Context ctx{gs, core::Symbols::root(), fref};
     auto resolved = typechecker.getResolved({fref});
     for (auto &f : resolved) {
-        ast::TreeWalk::apply(ctx, saver, f.tree);
+        ast::ShallowWalk::apply(ctx, saver, f.tree);
     }
 
     for (auto ref : candidates) {

--- a/test/testdata/lsp/document_symbols_nested_methods.rb
+++ b/test/testdata/lsp/document_symbols_nested_methods.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class Test
+  def self.a_func
+    def b_func
+      nil
+    end
+  end
+end

--- a/test/testdata/lsp/document_symbols_nested_methods.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_nested_methods.rb.document-symbols.exp
@@ -1,0 +1,86 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "Test",
+            "detail": "",
+            "kind": 5,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 8,
+                    "character": 3
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 10
+                }
+            },
+            "children": [
+                {
+                    "name": "b_func",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 4,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 7
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 4,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 4,
+                            "character": 14
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "self.a_func",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 7,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 3,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 17
+                        }
+                    },
+                    "children": []
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The walker here only cares about class defs and method defs, so we shouldn't need to descend into method defs themselves.  (We should be able to rely on rewriter-based flattening here, so nested method defs should not be a problem, but we are not relying on class flattening being done.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
