### PR TITLE
use C++17 fold expressions for `typecase`

### DIFF
--- a/common/typecase.h
+++ b/common/typecase.h
@@ -57,9 +57,7 @@ GENERATE_HAS_MEMBER(tag)
 template <typename Base, typename... Subclasses> void typecase(Base *base, Subclasses &&...funcs) {
     static_assert(HAS_MEMBER_tag<Base>() != true,
                   "For tagged pointers, please call typecase on a reference to the object not a pointer.");
-    bool done = false;
-
-    bool UNUSED(dummy[sizeof...(Subclasses)]) = {(done = done || typecaseHelper<Base>(base, funcs))...};
+    bool done = (false || ... || typecaseHelper<Base>(base, funcs));
 
     if (!done) {
         if (!base) {
@@ -86,9 +84,7 @@ template <typename Base, typename FUNC> bool typecaseHelper(Base &base, FUNC &&f
 template <typename Base, typename... Subclasses> void typecase(Base &base, Subclasses &&...funcs) {
     static_assert(HAS_MEMBER_tag<Base>() == true,
                   "typecase used on reference type without .tag()! Did you mean to use it on a pointer type?");
-    bool done = false;
-
-    bool UNUSED(dummy[sizeof...(Subclasses)]) = {(done = done || typecaseHelper<Base>(base, funcs))...};
+    bool done = (false || ... || typecaseHelper<Base>(base, funcs));
 
     if (!done) {
         if (!base) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More C++.  Less clutter in the code.  Maybe slightly faster compilation of this oversized macro-like function.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

AFAICT, bazel thinks that test output is cached when adding this change on top of master, which I believe means that the generated assembly is identical.
