### PR TITLE
add a document symbols test dealing with rewritten minitest bits

### DIFF
--- a/test/testdata/lsp/document_symbols_minitest.rb
+++ b/test/testdata/lsp/document_symbols_minitest.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+class Test
+  # placeholder for initialize
+  before do
+    nil
+  end
+
+  describe 'with this block' do
+    before do
+      nil
+    end
+
+    it 'runs one test' do
+    end
+
+    it 'runs another test' do
+    end
+  end
+end

--- a/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
@@ -1,0 +1,165 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "Test",
+            "detail": "",
+            "kind": 5,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 19,
+                    "character": 3
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 10
+                }
+            },
+            "children": [
+                {
+                    "name": "<describe 'with this block'>",
+                    "detail": "",
+                    "kind": 5,
+                    "range": {
+                        "start": {
+                            "line": 8,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 18,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 8,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 18,
+                            "character": 5
+                        }
+                    },
+                    "children": [
+                        {
+                            "name": "<it 'runs another test'>",
+                            "detail": "",
+                            "kind": 6,
+                            "range": {
+                                "start": {
+                                    "line": 16,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "character": 7
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 16,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "character": 7
+                                }
+                            },
+                            "children": []
+                        },
+                        {
+                            "name": "<it 'runs one test'>",
+                            "detail": "",
+                            "kind": 6,
+                            "range": {
+                                "start": {
+                                    "line": 13,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "character": 7
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 13,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "character": 7
+                                }
+                            },
+                            "children": []
+                        },
+                        {
+                            "name": "initialize",
+                            "detail": "",
+                            "kind": 9,
+                            "range": {
+                                "start": {
+                                    "line": 9,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "character": 7
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 9,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "character": 7
+                                }
+                            },
+                            "children": []
+                        }
+                    ]
+                },
+                {
+                    "name": "initialize",
+                    "detail": "",
+                    "kind": 9,
+                    "range": {
+                        "start": {
+                            "line": 4,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 4,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 5
+                        }
+                    },
+                    "children": []
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

An unexpected but mostly pleasant side effect of the way we rewrite bits of minitest is that we get the individual tests to show up in document symbols.  We should have a test for that.

(There has also been a feature request to change how document symbols interprets minitest bits, and a PR for that will be easier to review if we already have a minitest-related document symbols test.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
