### PR TITLE
add a test for the symbol table with fields having non-existent types

### DIFF
--- a/test/testdata/resolver/field_nonexistent_type.rb
+++ b/test/testdata/resolver/field_nonexistent_type.rb
@@ -1,0 +1,34 @@
+# typed: strict
+
+class A
+  extend T::Sig
+
+  @@foo = T.let(nil, T.nilable(Foo))
+  #                            ^^^ error: Unable to resolve constant
+  @@bar = T.let(Bar.new, Bar)
+  #             ^^^ error: Unable to resolve constant
+  #                      ^^^ error: Unable to resolve constant
+  @@baz = T.let(Baz1.new, T.any(Baz1, Baz2))
+  #             ^^^^ error: Unable to resolve constant
+  #                             ^^^^ error: Unable to resolve constant
+  #                                   ^^^^ error: Unable to resolve constant
+  @@biz = T.let(nil, T.nilable(T.type_parameter(:U)))
+  #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve declared type
+  #                                             ^^ error: Unspecified type parameter
+  sig {void}
+  def initialize
+    @foo = T.let(nil, T.nilable(Foo))
+    #                           ^^^ error: Unable to resolve constant
+    @bar = T.let(Bar.new, Bar)
+    #            ^^^ error: Unable to resolve constant
+    #                     ^^^ error: Unable to resolve constant
+    @baz = T.let(Baz1.new, T.any(Baz1, Baz2))
+    #            ^^^^ error: Unable to resolve constant
+    #                            ^^^^ error: Unable to resolve constant
+    #                                  ^^^^ error: Unable to resolve constant
+    @biz = T.let(nil, T.nilable(T.type_parameter(:U)))
+    #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve declared type
+    #                           ^^^^^^^^^^^^^^^^^^^^ error: Method `A#initialize` does not declare any type parameters
+    #                                            ^^ error: Unspecified type parameter
+  end
+end

--- a/test/testdata/resolver/field_nonexistent_type.rb.symbol-table.exp
+++ b/test/testdata/resolver/field_nonexistent_type.rb.symbol-table.exp
@@ -1,0 +1,20 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/field_nonexistent_type.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/field_nonexistent_type.rb start=??? end=???}
+  class ::A < ::Object () @ test/testdata/resolver/field_nonexistent_type.rb:3
+    static-field ::A::@@bar -> A::Bar (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:8
+    static-field ::A::@@baz -> A::Baz1 (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:11
+    static-field ::A::@@biz -> T.untyped @ test/testdata/resolver/field_nonexistent_type.rb:15
+    static-field ::A::@@foo -> A::Foo (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:6
+    field ::A#@bar -> A::Bar (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:22
+    field ::A#@baz -> A::Baz1 (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:25
+    field ::A#@biz -> T.untyped @ test/testdata/resolver/field_nonexistent_type.rb:29
+    field ::A#@foo -> A::Foo (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:20
+    method ::A#initialize (<blk>) -> Sorbet::Private::Static::Void @ test/testdata/resolver/field_nonexistent_type.rb:19
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/field_nonexistent_type.rb start=??? end=???}
+  class ::<Class:A>[<AttachedClass>] < ::<Class:Object> (Sig) @ test/testdata/resolver/field_nonexistent_type.rb:3
+    type-member(+) ::<Class:A>::<AttachedClass> -> T.attached_class (of A) @ test/testdata/resolver/field_nonexistent_type.rb:3
+    method ::<Class:A>#<static-init> (<blk>) @ test/testdata/resolver/field_nonexistent_type.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/field_nonexistent_type.rb start=??? end=???}
+


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't have many tests for what the symbol table looks like for fields with declared types that couldn't be resolved.

Before this PR:

```
froydnj@pyro:~/src/sorbet$ rg 'field.*unresolved'
test/testdata/lsp/fast_path/static_field_unresolved.1.rbupdate
2:# assert-fast-path: static_field_unresolved.rb
```

After this PR:

```
froydnj@pyro:~/src/sorbet$ rg 'field.*unresolved'
test/testdata/lsp/fast_path/static_field_unresolved.1.rbupdate
2:# assert-fast-path: static_field_unresolved.rb

test/testdata/resolver/field_nonexistent_type.rb.symbol-table.exp
6:    static-field ::A::@@bar -> A::Bar (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:7
7:    static-field ::A::@@baz -> A::Baz1 (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:8
9:    static-field ::A::@@foo -> A::Foo (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:6
10:    field ::A#@bar -> A::Bar (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:14
11:    field ::A#@baz -> A::Baz1 (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:15
13:    field ::A#@foo -> A::Foo (unresolved) @ test/testdata/resolver/field_nonexistent_type.rb:13
```

This sort of test seems like a good thing to have before we start moving around where fields are possibly resolved.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
