### PR TITLE
Put the constant kind in the redefinition error

### DIFF
--- a/core/errors/namer.h
+++ b/core/errors/namer.h
@@ -24,6 +24,7 @@ constexpr ErrorClass RootTypeMember{4016, StrictLevel::False};
 constexpr ErrorClass MultipleBehaviorDefs{4019, StrictLevel::False};
 // constexpr ErrorClass YAMLSyntaxError{4020, StrictLevel::False};
 constexpr ErrorClass OldTypeMemberSyntax{4021, StrictLevel::False};
+constexpr ErrorClass ConstantKindRedefinition{4022, StrictLevel::False};
 } // namespace sorbet::core::errors::Namer
 
 #endif

--- a/gems/sorbet/lib/hidden-definition-finder.rb
+++ b/gems/sorbet/lib/hidden-definition-finder.rb
@@ -141,6 +141,8 @@ class Sorbet::Private::HiddenMethodFinder
         # Redefining constant is needed because we serialize things both as
         # aliases and in-class constants.
         '--suppress-error-code=4012',
+        # At one point we split 4012 into 4012/4022
+        '--suppress-error-code=4022',
         # Invalid nesting is ok because we don't generate all the intermediate
         # namespaces for aliases
         '--suppress-error-code=4015',

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1175,7 +1175,10 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
             },
             [&](cfg::Alias &a) {
                 core::SymbolRef symbol = a.what.dealias(ctx);
-                if (symbol.isClassOrModule()) {
+                if (symbol == core::Symbols::StubModule()) {
+                    tp.origins.emplace_back(ctx.locAt(bind.loc));
+                    tp.type = core::Types::untyped(ctx, a.what);
+                } else if (symbol.isClassOrModule()) {
                     auto singletonClass = symbol.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx);
                     ENFORCE(singletonClass.exists(), "Every class should have a singleton class by now.");
                     tp.type = singletonClass.data(ctx)->externalType();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -525,7 +525,7 @@ class SymbolDefiner {
             case core::FoundDefinitionRef::Kind::ClassRef: {
                 auto &klassRef = ref.klassRef(foundDefs);
                 auto newOwner = squashNames(ctx, klassRef.owner, owner);
-                return getOrDefineSymbol(ctx.withOwner(newOwner), klassRef.name, klassRef.loc);
+                return getOrDefineClassSymbol(ctx.withOwner(newOwner), klassRef.name, klassRef.loc);
             }
             default:
                 Exception::raise("Invalid name reference");
@@ -567,8 +567,8 @@ class SymbolDefiner {
         emitRedefinedConstantError(ctx, errorLoc, symbol.show(ctx), renamedSymbol.loc(ctx));
     }
 
-    core::ClassOrModuleRef ensureIsClass(core::MutableContext ctx, core::SymbolRef scope, core::NameRef name,
-                                         core::LocOffsets loc) {
+    core::ClassOrModuleRef ensureScopeIsClass(core::MutableContext ctx, core::SymbolRef scope, core::NameRef name,
+                                              core::LocOffsets loc) {
         // Common case: Everything is fine, user is trying to define a symbol on a class or module.
         if (scope.isClassOrModule()) {
             // Check if original symbol was mangled away. If so, complain.
@@ -607,16 +607,16 @@ class SymbolDefiner {
     }
 
     // Gets the symbol with the given name, or defines it as a class if it does not exist.
-    core::SymbolRef getOrDefineSymbol(core::MutableContext ctx, core::NameRef name, core::LocOffsets loc) {
+    core::ClassOrModuleRef getOrDefineClassSymbol(core::MutableContext ctx, core::NameRef name, core::LocOffsets loc) {
         if (name == core::Names::singleton()) {
             return ctx.owner.enclosingClass(ctx).data(ctx)->singletonClass(ctx);
         }
 
-        auto scope = ensureIsClass(ctx, ctx.owner, name, loc);
-        core::SymbolRef existing = scope.data(ctx)->findMember(ctx, name);
+        auto scope = ensureScopeIsClass(ctx, ctx.owner, name, loc);
+        auto existing = ctx.state.lookupClassSymbol(scope, name);
         if (!existing.exists()) {
             existing = ctx.state.enterClassSymbol(ctx.locAt(loc), scope, name);
-            existing.asClassOrModuleRef().data(ctx)->singletonClass(ctx); // force singleton class into existance
+            existing.data(ctx)->singletonClass(ctx); // force singleton class into existance
         }
 
         return existing;
@@ -1052,8 +1052,8 @@ class SymbolDefiner {
     core::FieldRef insertStaticField(core::MutableContext ctx, const core::FoundStaticField &staticField) {
         ENFORCE(ctx.owner.isClassOrModule());
 
-        auto scope = ensureIsClass(ctx, squashNames(ctx, staticField.klass, contextClass(ctx, ctx.owner)),
-                                   staticField.name, staticField.asgnLoc);
+        auto scope = ensureScopeIsClass(ctx, squashNames(ctx, staticField.klass, contextClass(ctx, ctx.owner)),
+                                        staticField.name, staticField.asgnLoc);
         auto sym = ctx.state.lookupStaticFieldSymbol(scope, staticField.name);
         auto currSym = ctx.state.lookupSymbol(scope, staticField.name);
         if (!sym.exists() && currSym.exists()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1095,8 +1095,7 @@ class SymbolDefiner {
             ENFORCE(currSym.exists());
             auto renamedSym = ctx.state.findRenamedSymbol(scope, sym);
             if (renamedSym.exists()) {
-                emitRedefinedConstantError(ctx, staticField.asgnLoc, renamedSym.name(ctx),
-                                           core::SymbolRef::Kind::FieldOrStaticField, renamedSym);
+                emitRedefinedConstantError(ctx, staticField.asgnLoc, sym, renamedSym);
             }
         }
         auto name = sym.exists() ? sym.data(ctx)->name : staticField.name;
@@ -1164,7 +1163,7 @@ class SymbolDefiner {
             // same error
             auto oldSym = ctx.state.findRenamedSymbol(onSymbol, existingTypeMember);
             if (oldSym.exists()) {
-                emitRedefinedConstantError(ctx, typeMember.nameLoc, oldSym, existingTypeMember);
+                emitRedefinedConstantError(ctx, typeMember.nameLoc, existingTypeMember, oldSym);
             }
             // if we have more than one type member with the same name, then we have messed up somewhere
             if (::sorbet::debug_mode) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -607,16 +607,16 @@ class SymbolDefiner {
     }
 
     // Gets the symbol with the given name, or defines it as a class if it does not exist.
-    core::ClassOrModuleRef getOrDefineClassSymbol(core::MutableContext ctx, core::NameRef name, core::LocOffsets loc) {
+    core::SymbolRef getOrDefineClassSymbol(core::MutableContext ctx, core::NameRef name, core::LocOffsets loc) {
         if (name == core::Names::singleton()) {
             return ctx.owner.enclosingClass(ctx).data(ctx)->singletonClass(ctx);
         }
 
         auto scope = ensureScopeIsClass(ctx, ctx.owner, name, loc);
-        auto existing = ctx.state.lookupClassSymbol(scope, name);
+        core::SymbolRef existing = scope.data(ctx)->findMemberNoDealias(ctx, name);
         if (!existing.exists()) {
             existing = ctx.state.enterClassSymbol(ctx.locAt(loc), scope, name);
-            existing.data(ctx)->singletonClass(ctx); // force singleton class into existance
+            existing.asClassOrModuleRef().data(ctx)->singletonClass(ctx); // force singleton class into existance
         }
 
         return existing;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -671,7 +671,7 @@ private:
         bool alreadyReported = false;
         job.out->resolutionScopes = make_unique<ast::ConstantLit::ResolutionScopes>();
         if (auto *id = ast::cast_tree<ast::ConstantLit>(original.scope)) {
-            auto originalScope = id->symbol.dealias(ctx);
+            auto originalScope = id->symbol;
             if (originalScope == core::Symbols::StubModule()) {
                 // If we were trying to resolve some literal like C::D but `C` itself was already stubbed,
                 // no need to also report that `D` is missing.
@@ -1754,8 +1754,6 @@ public:
                 return compareLocOffsets(lhs.ancestor->loc, rhs.ancestor->loc);
             });
         }
-
-        // Note that this is missing alias stubbing, thus resolveJob needs to be able to handle missing aliases.
 
         {
             Timer timeit(gs.tracer(), "resolver.resolve_constants.errors");

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1779,17 +1779,12 @@ public:
                 }
             }
 
-            if (singlePackageRbiGeneration) {
-                if constexpr (isMutableStateType) {
-                    for (auto &job : todoClassAliases) {
-                        core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                        for (auto &item : job.items) {
-                            resolveClassAliasJob(ctx, item);
-                        }
+            if constexpr (isMutableStateType) {
+                for (auto &job : todoClassAliases) {
+                    core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                    for (auto &item : job.items) {
+                        resolveClassAliasJob(ctx, item);
                     }
-
-                } else {
-                    ENFORCE(false, "Was not expecting non-mutating resolver and single package RBI generation");
                 }
             }
 

--- a/test/cli/incremental-resolver/test.out
+++ b/test/cli/incremental-resolver/test.out
@@ -25,44 +25,60 @@ test/cli/incremental-resolver/expect-failures/abstract_impl.rb:126: Implementati
             ^^^^^^^^^^^^^
 Errors: 3
 ----- test/cli/incremental-resolver/expect-failures/constant_override.rb ---------------------
-test/cli/incremental-resolver/expect-failures/constant_override.rb:3: Redefining constant `B` https://srb.help/4012
+test/cli/incremental-resolver/expect-failures/constant_override.rb:3: Redefining constant `B` as a class or module https://srb.help/4022
      3 |module B
      4 |  extend T::Sig
      5 |  sig { returns(T.all(B,T)) }
      6 |  def foo; T.unsafe(nil); end
      7 |end
-    test/cli/incremental-resolver/expect-failures/constant_override.rb:2: Previous definition
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:2: Previously defined as a static field
      2 |B = e
         ^
+  Note:
+    Sorbet does not allow treating constant assignments as class or module definitions,
+even if the initializer computes a value of type `Module`. See the docs for more.
 
-test/cli/incremental-resolver/expect-failures/constant_override.rb:111: Redefining constant `B` https://srb.help/4012
+
+test/cli/incremental-resolver/expect-failures/constant_override.rb:111: Redefining constant `B` as a class or module https://srb.help/4022
      111 |module B
      112 |  extend T::Sig
      113 |  sig { returns(T.all(B,T)) }
      114 |  def foo; T.unsafe(nil); end
      115 |end
-    test/cli/incremental-resolver/expect-failures/constant_override.rb:13: Previous definition
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:13: Previously defined as a static field
     13 |
     14 |
+  Note:
+    Sorbet does not allow treating constant assignments as class or module definitions,
+even if the initializer computes a value of type `Module`. See the docs for more.
+
 
 test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Method `e` does not exist on `T.class_of(<root>)` https://srb.help/7003
      110 |B = e
               ^
 Errors: 3
 ----- test/cli/incremental-resolver/expect-failures/constant_redefinition.rb ---------------------
-test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:4: Redefining constant `A` https://srb.help/4012
+test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:4: Redefining constant `A` as a static field https://srb.help/4022
      4 |  A = nil
           ^^^^^^^
-    test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:3: Previous definition
+    test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:3: Previously defined as a class or module
      3 |  class A; end
           ^^^^^^^
+  Note:
+    Sorbet does not allow treating constant assignments as class or module definitions,
+even if the initializer computes a value of type `Module`. See the docs for more.
 
-test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:59: Redefining constant `A` https://srb.help/4012
+
+test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:59: Redefining constant `A` as a static field https://srb.help/4022
     59 |  A = nil
           ^^^^^^^
-    test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:58: Previous definition
+    test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:58: Previously defined as a class or module
     58 |  class A; end
           ^^^^^^^
+  Note:
+    Sorbet does not allow treating constant assignments as class or module definitions,
+even if the initializer computes a value of type `Module`. See the docs for more.
+
 Errors: 2
 ----- test/cli/incremental-resolver/expect-failures/multiple_sigs.rb ---------------------
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Unused type annotation. No method def before next annotation https://srb.help/5040

--- a/test/testdata/namer/class_and_alias.rb
+++ b/test/testdata/namer/class_and_alias.rb
@@ -1,8 +1,8 @@
 # typed: true
 A = 91
-class A # error: Redefining constant `A`
+class A # error: Redefining constant `A` as a class or module
 end
 
 class B
 end
-B = 91 # error: Redefining constant `B`
+B = 91 # error: Redefining constant `B` as a static field

--- a/test/testdata/namer/constant_redefinition/class_then_constant.rb
+++ b/test/testdata/namer/constant_redefinition/class_then_constant.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 class R; end
-R = 5 # error: Redefining constant `R`
+R = 5 # error: Redefining constant `R` as a static field
 
 # this should not resolve as a class, so this will be an error
 x = R.new # error: Method `new` does not exist on `Integer`

--- a/test/testdata/namer/constant_redefinition/class_then_constant_then_reopen.rb
+++ b/test/testdata/namer/constant_redefinition/class_then_constant_then_reopen.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 class R; end
-R = 5 # error: Redefining constant `R`
+R = 5 # error: Redefining constant `R` as a static field
 class R; end
 # even though we've reopened the class here, the constant R still
 # "wins", because the first definition of the class is what counts

--- a/test/testdata/namer/constant_redefinition/constant_then_class.rb
+++ b/test/testdata/namer/constant_redefinition/constant_then_class.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 R = 5
-class R; end # error: Redefining constant `R`
+class R; end # error: Redefining constant `R` as a class or module
 
 # this should resolve as a class, so this would not be an error
 x = R.new

--- a/test/testdata/namer/constant_redefinition/constant_then_module.rb
+++ b/test/testdata/namer/constant_redefinition/constant_then_module.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 R = 5
-module R; def self.x; end; end # error: Redefining constant `R`
+module R; def self.x; end; end # error: Redefining constant `R` as a class or module
 
 # this should resolve as a class, so this would not be an error
 x = R.x

--- a/test/testdata/namer/constant_redefinition/module_then_constant.rb
+++ b/test/testdata/namer/constant_redefinition/module_then_constant.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 module R; def self.x; end; end
-R = 5 # error: Redefining constant `R`
+R = 5 # error: Redefining constant `R` as a static field
 
 # this should not resolve as a class, so this will be an error
 x = R.x # error: Method `x` does not exist on `Integer`

--- a/test/testdata/namer/constant_redefinition/module_then_constant_then_reopen.rb
+++ b/test/testdata/namer/constant_redefinition/module_then_constant_then_reopen.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 module R; def self.x; end; end
-R = 5 # error: Redefining constant `R`
+R = 5 # error: Redefining constant `R` as a static field
 module R; end
 # even though we've reopened the class here, the constant R still
 # "wins", because the first definition of the class is what counts

--- a/test/testdata/namer/constant_redefinition/nested_module_then_constant.rb
+++ b/test/testdata/namer/constant_redefinition/nested_module_then_constant.rb
@@ -4,4 +4,4 @@ module A::B::C
   def foo; end
 end
 
-A::B = 1 # error: Redefining constant `B`
+A::B = 1 # error: Redefining constant `B` as a static field

--- a/test/testdata/namer/constant_redefinition/nested_module_then_nonexistent_name.rb
+++ b/test/testdata/namer/constant_redefinition/nested_module_then_nonexistent_name.rb
@@ -5,5 +5,5 @@ module A::B::C
 end
 
   A::B = A::D
-# ^^^^^^^^^^^ error: Redefining constant `B`
+# ^^^^^^^^^^^ error: Redefining constant `B` as a static field
        # ^^^^ error: Unable to resolve constant `D`

--- a/test/testdata/namer/fuzz_shared_singletons.rb
+++ b/test/testdata/namer/fuzz_shared_singletons.rb
@@ -1,4 +1,4 @@
 # typed: false
-A=class A; end # error: Redefining constant
+A=class A; end # error: Redefining constant `A` as a static field
 
 class A; end

--- a/test/testdata/namer/fuzz_type_template_overwrite.rb
+++ b/test/testdata/namer/fuzz_type_template_overwrite.rb
@@ -2,5 +2,5 @@
 # disable-fast-path: true
 class A
   B = 1
-  B = type_template # error: Redefining constant
+  B = type_template # error: Redefining constant `B` as a type member or type template
 end

--- a/test/testdata/namer/redefines_module_as_static_field.rb
+++ b/test/testdata/namer/redefines_module_as_static_field.rb
@@ -33,7 +33,7 @@ end
   T::AbstractUtils::Methods::Modes = T::Private::Methods::Modes # error: Can't nest `Modes` under `T::AbstractUtils::Methods`
   T::AbstractUtils::Methods::CallValidation::Modes = T::Private::Methods::Modes # error: Can't nest `CallValidation` under `T::AbstractUtils::Methods`
   T::AbstractUtils::Methods::CallValidation = T::Private::Methods::CallValidation 
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Redefining constant `CallValidation`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Redefining constant `CallValidation` as a static field
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Can't nest `CallValidation` under `T::AbstractUtils::Methods`
   # Defines a property on what was just previously a field.
   T::AbstractUtils::Methods::CallValidation::CallValidation = T::Private::Methods::CallValidation

--- a/test/testdata/namer/type_member_redefs__1.rb
+++ b/test/testdata/namer/type_member_redefs__1.rb
@@ -9,13 +9,13 @@ end
 class B
   extend T::Generic
   R = type_member # error: Expected `Integer` but found `T::Types::TypeMember` for field
-  R = 1 # error: Redefining constant `R`
+  R = 1 # error: Redefining constant `R` as a static field
 end
 
 class C
   extend T::Generic
   R = 1
-  R = type_member # error: Redefining constant `C::R`
+  R = type_member # error: Redefining constant `C::R` as a type member or type template
 end
 
 class D

--- a/test/testdata/namer/type_member_redefs__1.rb
+++ b/test/testdata/namer/type_member_redefs__1.rb
@@ -15,7 +15,7 @@ end
 class C
   extend T::Generic
   R = 1
-  R = type_member # error: Redefining constant `C::R` as a type member or type template
+  R = type_member # error: Redefining constant `R` as a type member or type template
 end
 
 class D

--- a/test/testdata/resolver/fuzz_infinite_type.rb
+++ b/test/testdata/resolver/fuzz_infinite_type.rb
@@ -1,5 +1,5 @@
 # typed: false
 # disable-fast-path: true
   T = T.type_alias
-# ^^^^^^^^^^^^^^^^ error: Redefining constant `T`
+# ^^^^^^^^^^^^^^^^ error: Redefining constant `T` as a static field
     # ^^^^^^^^^^^^ error: No block given to `T.type_alias`

--- a/test/testdata/resolver/redefining_static_fields.rb
+++ b/test/testdata/resolver/redefining_static_fields.rb
@@ -9,6 +9,6 @@ Alias = Integer
 Alias = String
 
 BadAlias = 1 + 1
-#          ^^^^^ error: Expected `T.class_of(Sorbet::Private::Static::StubModule)` but found `Integer` for field
+
 BadAlias = DoesNotExist
 #          ^^^^^^^^^^^^ error: Unable to resolve constant `DoesNotExist`

--- a/test/testdata/resolver/redefining_static_fields.rb
+++ b/test/testdata/resolver/redefining_static_fields.rb
@@ -9,7 +9,6 @@ Alias = Integer
 Alias = String
 
 BadAlias = 1 + 1
-#          ^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+#          ^^^^^ error: Expected `T.class_of(Sorbet::Private::Static::StubModule)` but found `Integer` for field
 BadAlias = DoesNotExist
 #          ^^^^^^^^^^^^ error: Unable to resolve constant `DoesNotExist`
-#          ^^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`

--- a/test/testdata/resolver/redefining_static_fields.rb
+++ b/test/testdata/resolver/redefining_static_fields.rb
@@ -1,0 +1,15 @@
+# typed: strict
+
+# No error (by analogy with how we handle sig'd method redefinitions?)
+X = T.let(0, Integer)
+X = T.let('', String)
+
+Alias = Integer
+#       ^^^^^^^ error: Expected `T.class_of(String)` but found `T.class_of(Integer)` for field
+Alias = String
+
+BadAlias = 1 + 1
+#          ^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+BadAlias = DoesNotExist
+#          ^^^^^^^^^^^^ error: Unable to resolve constant `DoesNotExist`
+#          ^^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`

--- a/test/testdata/resolver/redefining_static_fields.rb.symbol-table.exp
+++ b/test/testdata/resolver/redefining_static_fields.rb.symbol-table.exp
@@ -3,6 +3,6 @@ class ::<root> < ::Object ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/redefining_static_fields.rb:4
       argument <blk><block> @ Loc {file=test/testdata/resolver/redefining_static_fields.rb start=??? end=???}
   static-field ::Alias -> <Alias: ::String > @ test/testdata/resolver/redefining_static_fields.rb:7
-  static-field ::BadAlias @ test/testdata/resolver/redefining_static_fields.rb:11
+  static-field ::BadAlias -> <Alias: ::Sorbet::Private::Static::StubModule > @ test/testdata/resolver/redefining_static_fields.rb:11
   static-field ::X -> String @ test/testdata/resolver/redefining_static_fields.rb:4
 

--- a/test/testdata/resolver/redefining_static_fields.rb.symbol-table.exp
+++ b/test/testdata/resolver/redefining_static_fields.rb.symbol-table.exp
@@ -1,0 +1,8 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/redefining_static_fields.rb:4
+      argument <blk><block> @ Loc {file=test/testdata/resolver/redefining_static_fields.rb start=??? end=???}
+  static-field ::Alias -> <Alias: ::String > @ test/testdata/resolver/redefining_static_fields.rb:7
+  static-field ::BadAlias @ test/testdata/resolver/redefining_static_fields.rb:11
+  static-field ::X -> String @ test/testdata/resolver/redefining_static_fields.rb:4
+

--- a/test/testdata/resolver/stub_missing_class_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/stub_missing_class_alias.rb.symbol-table-raw.exp
@@ -5,7 +5,7 @@ class <C <U <root>>> < <C <U Object>> ()
   module <C <U O>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=4:7 end=4:8}
     class <C <U O>>::<C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=4:1 end=4:11}
       static-field <C <U O>>::<C <U B>>::<C <U Doc1>> -> Integer @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=9:3 end=9:7}
-      static-field <C <U O>>::<C <U B>>::<C <U Document>> @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=8:3 end=8:11}
+      static-field <C <U O>>::<C <U B>>::<C <U Document>> -> AliasType { symbol = <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U StubModule>> } @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=8:3 end=8:11}
       class <C <U O>>::<C <U B>>::<C <U J>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=5:3 end=5:10}
       class <C <U O>>::<C <U B>>::<S <C <U J>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=5:9 end=5:10}
         type-member(+) <C <U O>>::<C <U B>>::<S <C <U J>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U O>>::<C <U B>>::<S <C <U J>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=O::B::J) @ Loc {file=test/testdata/resolver/stub_missing_class_alias.rb start=5:9 end=5:10}

--- a/test/testdata/resolver/unresolved_via_alias.rb
+++ b/test/testdata/resolver/unresolved_via_alias.rb
@@ -6,4 +6,5 @@ end
 AliasToA = A
 
 sig {returns(AliasToA::B)}
+#            ^^^^^^^^^^^ error: Unable to resolve constant `B`
 def example; end

--- a/test/testdata/resolver/unresolved_via_alias.rb
+++ b/test/testdata/resolver/unresolved_via_alias.rb
@@ -1,0 +1,9 @@
+# typed: true
+extend T::Sig
+
+class A
+end
+AliasToA = A
+
+sig {returns(AliasToA::B)}
+def example; end

--- a/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
+++ b/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
@@ -1,0 +1,14 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> (Sig)
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/unresolved_via_alias.rb:2
+      argument <blk><block> @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
+  class ::A < ::Object () @ test/testdata/resolver/unresolved_via_alias.rb:4
+  class ::<Class:A>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/unresolved_via_alias.rb:4
+    type-member(+) ::<Class:A>::<AttachedClass> -> T.attached_class (of A) @ test/testdata/resolver/unresolved_via_alias.rb:4
+    method ::<Class:A>#<static-init> (<blk>) @ test/testdata/resolver/unresolved_via_alias.rb:4
+      argument <blk><block> @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
+  static-field ::AliasToA -> <Alias: ::A > @ test/testdata/resolver/unresolved_via_alias.rb:6
+  class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED
+    method ::Object#example : private (<blk>) -> A::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:9
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
+

--- a/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
+++ b/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
@@ -9,6 +9,6 @@ class ::<root> < ::Object ()
       argument <blk><block> @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
   static-field ::AliasToA -> <Alias: ::A > @ test/testdata/resolver/unresolved_via_alias.rb:6
   class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED
-    method ::Object#example : private (<blk>) -> A::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:9
+    method ::Object#example : private (<blk>) -> AliasToA::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:9
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
 

--- a/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
+++ b/test/testdata/resolver/unresolved_via_alias.rb.symbol-table.exp
@@ -9,6 +9,6 @@ class ::<root> < ::Object ()
       argument <blk><block> @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
   static-field ::AliasToA -> <Alias: ::A > @ test/testdata/resolver/unresolved_via_alias.rb:6
   class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED
-    method ::Object#example : private (<blk>) -> AliasToA::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:9
+    method ::Object#example : private (<blk>) -> AliasToA::B (unresolved) @ test/testdata/resolver/unresolved_via_alias.rb:10
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/unresolved_via_alias.rb start=??? end=???}
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I am planning on making some changes to the order of entering various kinds of
constants in namer. It will be useful to see capture the existing behavior
explicitly to see how it changes.

Also, this error message should be more clear, and the error code can now
contain specific docs.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.