### PR TITLE
Make synthetic, inheritance-tracking methods blame to classes

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2313,7 +2313,14 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
             if (needMethodShapeHash) {
                 uint32_t methodShapeHash = sym.methodShapeHash(*this);
                 hierarchyHash = mix(hierarchyHash, methodShapeHash);
-                methodHash = mix(methodHash, methodShapeHash);
+                if (this->lspExperimentalFastPathEnabled) {
+                    // With this feature enabled, the only three methods that trigger a method
+                    // change anymore all relate to inheritance. Let's blame this to a change to
+                    // class symbols, not to methods
+                    classModuleHash = mix(classModuleHash, methodShapeHash);
+                } else {
+                    methodHash = mix(methodHash, methodShapeHash);
+                }
             }
 
             counter++;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We currently only say that a method changed if it is one of three
special methods:

- `Names::unresolvedAncestors`
- `Names::requiredAncestors`
- `Names::requiredAncestorsLin`

If the hashes of any of these method symbols changes, it's not actually
a true change to a method. Instead, it's something class-or-module
related.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.