### PR TITLE
delete vestiges of `Sorbet::Private::Static.keep_for_typechecking`

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -414,12 +414,6 @@ public:
                      std::move(arg));
     }
 
-    static ExpressionPtr KeepForTypechecking(ExpressionPtr arg) {
-        auto loc = core::LocOffsets::none();
-        return Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::keepForTypechecking(),
-                     loc, std::move(arg));
-    }
-
     static ExpressionPtr ZSuper(core::LocOffsets loc) {
         Send::Flags flags;
         flags.isPrivateOk = true;

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -56,7 +56,7 @@ public:
                         "Emitting intrinsic that should have been deleted!");
     }
     virtual InlinedVector<core::NameRef, 2> applicableMethods(CompilerState &cs) const override {
-        return {core::Names::keepForIde(), core::Names::keepForTypechecking()};
+        return {core::Names::keepForIde()};
     }
 } ShouldNeverSeeIntrinsic;
 

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -380,7 +380,6 @@ NameDef names[] = {
     {"args"},
     {"Elem", "Elem", true},
     {"keepForIde", "keep_for_ide"},
-    {"keepForTypechecking", "keep_for_typechecking"},
     {"keepDef", "keep_def"},
     {"keepSelfDef", "keep_self_def"},
     {"keepForCfg", "<keep-for-cfg>"},

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -149,7 +149,6 @@ class LLVMSemanticExtension : public SemanticExtension {
                 if (auto *send = cfg::cast_instruction<cfg::Send>(binding.value)) {
                     switch (send->fun.rawId()) {
                         case core::Names::keepForIde().rawId():
-                        case core::Names::keepForTypechecking().rawId():
                             // TODO: figure out why we can't delete this.
                             // case core::Names::keepForCfg().rawId():
                             refsToDelete.emplace(binding.bind.variable);

--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -21,15 +21,6 @@ module Sorbet::Private::Static
   end
 
   sig do
-    params(
-        expr: T.untyped,
-    )
-    .void
-  end
-  def self.keep_for_typechecking(expr)
-  end
-
-  sig do
     type_parameters(:U)
       .params(this: T.untyped, fun: T.all(T.type_parameter(:U), Symbol), kind: Symbol)
       .returns(T.type_parameter(:U))


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These probably ought to have been removed as part of #5823.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
