### PR TITLE
Error when abstract class is initialized

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -77,6 +77,7 @@ constexpr ErrorClass MultipleStatementsInSig{5069, StrictLevel::False};
 constexpr ErrorClass NilableUntyped{5070, StrictLevel::False};
 constexpr ErrorClass BindNonBlockParameter{5071, StrictLevel::False};
 constexpr ErrorClass TypeMemberScopeMismatch{5072, StrictLevel::False};
+constexpr ErrorClass AbstractClassInstantiated{5073, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -963,6 +963,37 @@ public:
 
         validateOverriding(ctx, methodDef.symbol);
     }
+
+    void postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
+        auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
+        if (send.fun != core::Names::new_()) {
+            return;
+        }
+
+        auto *id = ast::cast_tree<ast::ConstantLit>(send.recv);
+        if (id == nullptr || !id->symbol.exists() || !id->symbol.isClassOrModule()) {
+            return;
+        }
+
+        auto symbol = id->symbol.asClassOrModuleRef().data(ctx);
+        if (!symbol->flags.isAbstract) {
+            return;
+        }
+
+        auto singletonClass = symbol->lookupSingletonClass(ctx.state);
+        if (!singletonClass.exists()) {
+            return;
+        }
+
+        auto method_new = singletonClass.data(ctx)->findMethodTransitive(ctx.state, core::Names::new_());
+        // If the .new method we find is owned by Class, that means
+        // there was no user defined .new method, which warrants an error.
+        if (method_new.data(ctx)->owner == core::Symbols::Class()) {
+            if (auto e = ctx.beginError(send.loc, core::errors::Resolver::AbstractClassInstantiated)) {
+                e.setHeader("Attempt to instantiate abstract class `{}`", id->symbol.show(ctx));
+            }
+        }
+    }
 };
 } // namespace
 
@@ -970,7 +1001,7 @@ ast::ParsedFile runOne(core::Context ctx, ast::ParsedFile tree) {
     Timer timeit(ctx.state.tracer(), "validateSymbols");
 
     ValidateWalk validate;
-    ast::ShallowWalk::apply(ctx, validate, tree.tree);
+    ast::TreeWalk::apply(ctx, validate, tree.tree);
     return tree;
 }
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -990,7 +990,9 @@ public:
         // there was no user defined .new method, which warrants an error.
         if (method_new.data(ctx)->owner == core::Symbols::Class()) {
             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::AbstractClassInstantiated)) {
-                e.setHeader("Attempt to instantiate abstract class `{}`", id->symbol.show(ctx));
+                auto symbolName = id->symbol.show(ctx);
+                e.setHeader("Attempt to instantiate abstract class `{}`", symbolName);
+                e.addErrorLine(id->symbol.loc(ctx), "`{}` defined here", symbolName);
             }
         }
     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3970,6 +3970,94 @@ public:
     }
 };
 
+class CheckAbstractClassInitialization {
+public:
+    struct CheckAbstractClassInitializationWalkResult {
+        vector<ast::ParsedFile> trees;
+    };
+
+    void postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
+        auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
+        if (send.fun != core::Names::new_()) {
+            return;
+        }
+
+        auto *id = ast::cast_tree<ast::ConstantLit>(send.recv);
+        if (id == nullptr || !id->symbol.exists() || !id->symbol.isClassOrModule()) {
+            return;
+        }
+
+        auto symbol = id->symbol.asClassOrModuleRef().data(ctx);
+        if (!symbol->flags.isAbstract) {
+            return;
+        }
+
+        auto singletonClass = symbol->lookupSingletonClass(ctx.state);
+        if (!singletonClass.exists()) {
+            return;
+        }
+
+        auto method_new = singletonClass.data(ctx)->findMethodTransitive(ctx.state, core::Names::new_());
+        // If the .new method we find is owned by Class, that means
+        // there was no user defined .new method, which warrants an error.
+        if (method_new.data(ctx)->owner == core::Symbols::Class()) {
+            if (auto e = ctx.beginError(send.loc, core::errors::Resolver::AbstractClassInstantiated)) {
+                e.setHeader("Attempt to instantiate abstract class `{}`", id->symbol.show(ctx));
+            }
+        }
+    }
+
+    template <typename StateType>
+    static vector<ast::ParsedFile> run(StateType &gs, vector<ast::ParsedFile> jobs, WorkerPool &workers) {
+        static_assert(is_same_v<remove_const_t<StateType>, core::GlobalState>);
+        Timer timeit(gs.tracer(), "resolver.check_abstract_class_initialization");
+
+        auto inputq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(jobs.size());
+        auto outputq = make_shared<
+            BlockingBoundedQueue<CheckAbstractClassInitialization::CheckAbstractClassInitializationWalkResult>>(
+            jobs.size());
+
+        for (auto &job : jobs) {
+            inputq->push(move(job), 1);
+        }
+
+        jobs.clear();
+
+        workers.multiplexJob("checkAbstractClassInitialization", [&gs, inputq, outputq]() -> void {
+            CheckAbstractClassInitialization walker;
+            CheckAbstractClassInitialization::CheckAbstractClassInitializationWalkResult output;
+
+            ast::ParsedFile current_job;
+            for (auto result = inputq->try_pop(current_job); !result.done(); result = inputq->try_pop(current_job)) {
+                if (result.gotItem()) {
+                    core::Context ctx(gs, core::Symbols::root(), current_job.file);
+                    ast::TreeWalk::apply(ctx, walker, current_job.tree);
+                    output.trees.emplace_back(move(current_job));
+                }
+            }
+
+            if (!output.trees.empty()) {
+                auto count = output.trees.size();
+                outputq->push(move(output), count);
+            }
+        });
+
+        {
+            CheckAbstractClassInitialization::CheckAbstractClassInitializationWalkResult threadResult;
+            for (auto result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
+                 !result.done();
+                 result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+                if (result.gotItem()) {
+                    jobs.insert(jobs.end(), make_move_iterator(threadResult.trees.begin()),
+                                make_move_iterator(threadResult.trees.end()));
+                }
+            }
+        }
+
+        return jobs;
+    }
+};
+
 vector<ast::ParsedFile> resolveSigs(core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
     Timer timeit(gs.tracer(), "resolver.sigs_vars_and_flatten");
     auto inputq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(trees.size());
@@ -4075,6 +4163,12 @@ ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::Par
     if (epochManager.wasTypecheckingCanceled()) {
         return ast::ParsedFilesOrCancelled::cancel(move(trees), workers);
     }
+
+    trees = CheckAbstractClassInitialization::run(gs, std::move(trees), workers);
+    if (epochManager.wasTypecheckingCanceled()) {
+        return ast::ParsedFilesOrCancelled::cancel(move(trees), workers);
+    }
+
     auto rtmafResult = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), workers);
     if (epochManager.wasTypecheckingCanceled()) {
         return ast::ParsedFilesOrCancelled::cancel(move(rtmafResult.trees), workers);

--- a/test/testdata/resolver/abstract_initialization.rb
+++ b/test/testdata/resolver/abstract_initialization.rb
@@ -1,0 +1,69 @@
+
+# typed: true
+
+class Abstract
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.void}
+  def foo; end
+end
+
+Abstract.new # error: Attempt to instantiate abstract class `Abstract`
+
+class SubclassOfAbstract < Abstract
+  def foo; end
+end
+
+SubclassOfAbstract.new
+
+class AbstractWithSingletonNew
+  extend T::Helpers
+  abstract!
+
+  def self.new; end
+end
+
+AbstractWithSingletonNew.new
+
+class SingletonNew
+  def self.new; end
+end
+
+class AbstractInheritedFromSingletonNew < SingletonNew
+  extend T::Helpers
+  abstract!
+end
+
+AbstractInheritedFromSingletonNew.new
+
+module ModuleNew
+  def new; end
+end
+
+class Bar
+  extend ModuleNew
+  extend T::Helpers
+  abstract!
+end
+
+Bar.new
+
+# Common Ruby pattern
+class A
+  extend T::Helpers
+  abstract!
+end
+
+class B < A; end
+
+sig{ params(a: T.class_of(A)).void }
+def takesA(a)
+  a.new
+end
+
+def assignsA
+  a = T.let(B, T.class_of(A))
+  a.new
+end

--- a/test/testdata/resolver/abstract_initialization.rb
+++ b/test/testdata/resolver/abstract_initialization.rb
@@ -50,20 +50,23 @@ end
 
 Bar.new
 
-# Common Ruby pattern
-class A
-  extend T::Helpers
-  abstract!
-end
+class CommonRubyPattern
+  extend T::Sig
 
-class B < A; end
+  class A
+    extend T::Helpers
+    abstract!
+  end
 
-sig{ params(a: T.class_of(A)).void }
-def takesA(a)
-  a.new
-end
+  class B < A; end
 
-def assignsA
-  a = T.let(B, T.class_of(A))
-  a.new
+  sig{ params(a: T.class_of(A)).void }
+  def takesA(a)
+    a.new
+  end
+
+  def assignsA
+    a = T.let(B, T.class_of(A))
+    a.new
+  end
 end

--- a/test/testdata/resolver/abstract_initialization.rb
+++ b/test/testdata/resolver/abstract_initialization.rb
@@ -1,4 +1,3 @@
-
 # typed: true
 
 class Abstract

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -2764,6 +2764,17 @@ end
 Abstract.new # error: Attempt to instantiate abstract class `Abstract`
 ```
 
+To fix this error, there are some options:
+
+- If the class which is marked `abstract!` does not actually have any `abstract`
+  methods, simply remove `abstract!` from the class definition to fix the error.
+- If the class _does_ have `abstract` methods, find some concrete subclass to
+  call `new` on instead. If the call to `new` is in a test file, you may wish to
+  make a new, test-only subclass of the abstract class. (Depending on the
+  specifics of the test, it may even be possible to simply define all the
+  abstract methods to simply `raise`, so that other aspects of the parent class
+  can be tested.)
+
 ## 6001
 
 Certain Ruby keywords like `break`, `next`, and `retry` can only be used inside

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -2746,6 +2746,24 @@ class MyClass < AbstractSerializable
 end
 ```
 
+## 5073
+
+Abstract classes cannot be instantiated by definition. See
+[Abstract Classes and Interfaces](abstract.md) for more information.
+
+```ruby
+class Abstract
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.void}
+  def foo; end
+end
+
+Abstract.new # error: Attempt to instantiate abstract class `Abstract`
+```
+
 ## 6001
 
 Certain Ruby keywords like `break`, `next`, and `retry` can only be used inside


### PR DESCRIPTION
This PR adds a new error `AbstractClassInstantiated` when an abstract class is initialized. 

Example: 

```ruby
class Abstract
  extend T::Sig
  extend T::Helpers
  abstract!

  sig {abstract.void}
  def foo; end
end

Abstract.new # error: Attempt to instantiate abstract class `Abstract`
```

### Motivation

Fixes: https://github.com/sorbet/sorbet/issues/4454

Previously, Alan implemented a version of this change (https://github.com/sorbet/sorbet/pull/2222) but did not cover the [common Ruby patterns pointed out in this comment](https://github.com/sorbet/sorbet/pull/2222#issuecomment-558753052): 

```ruby
class A;
  abstract!
end
class B < A
end

sig{params(a: T.class_of(A)).void}
def takesA(a)
  a.new
end

def assignsA
  a = T.let(B, T.class_of(A))
  a.new 
end
```

In this implementation, we check any abstract class that was initialized, if it is, we also check its singleton class's transitive methods to make sure that there isn't another `.new` defined.

### Test plan

See included automated tests - I believe the cases should have been covered.