### PR TITLE
Fix broken link to /docs/nilable-types

### DIFF
--- a/website/docs/from-typescript.md
+++ b/website/docs/from-typescript.md
@@ -176,7 +176,7 @@ def f(x); ...; end</code></pre>
       <td>
         Ruby has only <code>nil</code>, while JavaScript has both
         <code>null</code> and <code>undefined</code>. See <a
-        href="/docs/nilable">Nilable Types</a> for more.
+        href="/docs/nilable-types">Nilable Types</a> for more.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The [TypeScript ↔ Sorbet Reference doc](https://sorbet.org/docs/from-typescript) has a broken link.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I've manually verified the URL of the [Nilable Types doc](https://sorbet.org/docs/nilable-types). I believe code review should be enough additional verification for this.
