### PR TITLE
be smarter about adding nodes for IDE when symbolizing classes

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1551,13 +1551,14 @@ public:
             }
         }
         auto loc = klass.declLoc;
-        ast::InsSeq::STATS_store ideSeqs;
+        ast::InsSeq::STATS_store retSeqs;
+        retSeqs.emplace_back(std::move(tree));
         if (ast::isa_tree<ast::ConstantLit>(klass.name)) {
-            ideSeqs.emplace_back(ast::MK::KeepForIDE(loc.copyWithZeroLength(), klass.name.deepCopy()));
+            retSeqs.emplace_back(ast::MK::KeepForIDE(loc.copyWithZeroLength(), klass.name.deepCopy()));
         }
         if (klass.kind == ast::ClassDef::Kind::Class && !klass.ancestors.empty() &&
             shouldLeaveAncestorForIDE(klass.ancestors.front())) {
-            ideSeqs.emplace_back(ast::MK::KeepForIDE(loc.copyWithZeroLength(), klass.ancestors.front().deepCopy()));
+            retSeqs.emplace_back(ast::MK::KeepForIDE(loc.copyWithZeroLength(), klass.ancestors.front().deepCopy()));
         }
 
         if (klass.symbol != core::Symbols::root() && !ctx.file.data(ctx).isRBI() &&
@@ -1567,11 +1568,6 @@ public:
             locs.emplace_back(ctx.locAt(klass.declLoc));
         }
 
-        ast::InsSeq::STATS_store retSeqs;
-        retSeqs.emplace_back(std::move(tree));
-        for (auto &stat : ideSeqs) {
-            retSeqs.emplace_back(std::move(stat));
-        }
         tree = ast::MK::InsSeq(loc, std::move(retSeqs), ast::MK::EmptyTree());
     }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stop doing work we don't need to do.  We could probably be even smarter and only add these when `--lsp` hasn't been passed, but I'm not sure that's worth it.

Also, this combined with #6274 speeds things up enough that adding #6265 into the mix becomes ~performance-neutral with respect to current master.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
