### PR TITLE
convert `FoundMethodHashes` into a `FoundHashes` structure

### DIFF
--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -103,7 +103,7 @@ string FoundMethodHash::toString() const {
                        owner.idx, owner.useSingletonClass, nameHash._hashValue, arityHash._hashValue);
 }
 
-FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages, FoundHashes &&foundHashes)
+FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages, FoundDefHashes &&foundHashes)
     : localSymbolTableHashes(move(localSymbolTableHashes)), usages(move(usages)), foundHashes(move(foundHashes)) {}
 
 } // namespace sorbet::core

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -103,9 +103,7 @@ string FoundMethodHash::toString() const {
                        owner.idx, owner.useSingletonClass, nameHash._hashValue, arityHash._hashValue);
 }
 
-FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages,
-                   FoundMethodHashes &&foundMethodHashes)
-    : localSymbolTableHashes(move(localSymbolTableHashes)), usages(move(usages)),
-      foundMethodHashes(move(foundMethodHashes)) {}
+FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages, FoundHashes &&foundHashes)
+    : localSymbolTableHashes(move(localSymbolTableHashes)), usages(move(usages)), foundHashes(move(foundHashes)) {}
 
 } // namespace sorbet::core

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -116,6 +116,10 @@ CheckSize(FoundMethodHash, 12, 4);
 
 using FoundMethodHashes = std::vector<FoundMethodHash>;
 
+struct FoundHashes {
+    FoundMethodHashes methodHashes;
+};
+
 // When a file is edited, we run index and resolve it using an local (empty) GlobalState.
 // We then hash the symbols defined in that local GlobalState, and use the result to quickly decide
 // whether "something" changed, or whether nothing changed (and thus we can take the fast path).
@@ -245,11 +249,10 @@ struct UsageHash {
 struct FileHash {
     LocalSymbolTableHashes localSymbolTableHashes;
     UsageHash usages;
-    FoundMethodHashes foundMethodHashes;
+    FoundHashes foundHashes;
 
     FileHash() = default;
-    FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages,
-             FoundMethodHashes &&foundMethodHashes);
+    FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages, FoundHashes &&foundHashes);
 };
 
 }; // namespace sorbet::core

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -116,7 +116,7 @@ CheckSize(FoundMethodHash, 12, 4);
 
 using FoundMethodHashes = std::vector<FoundMethodHash>;
 
-struct FoundHashes {
+struct FoundDefHashes {
     FoundMethodHashes methodHashes;
 };
 
@@ -249,10 +249,10 @@ struct UsageHash {
 struct FileHash {
     LocalSymbolTableHashes localSymbolTableHashes;
     UsageHash usages;
-    FoundHashes foundHashes;
+    FoundDefHashes foundHashes;
 
     FileHash() = default;
-    FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages, FoundHashes &&foundHashes);
+    FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages, FoundDefHashes &&foundHashes);
 };
 
 }; // namespace sorbet::core

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -261,8 +261,8 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
     for (const auto &e : fh->usages.nameHashes) {
         p.putU4(e._hashValue);
     }
-    p.putU4(fh->foundMethodHashes.size());
-    for (const auto &fdh : fh->foundMethodHashes) {
+    p.putU4(fh->foundHashes.methodHashes.size());
+    for (const auto &fdh : fh->foundHashes.methodHashes) {
         p.putU4(fdh.owner.idx);
         p.putU1(fdh.owner.useSingletonClass);
         p.putU4(fdh.nameHash._hashValue);
@@ -307,7 +307,7 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
         ret.usages.nameHashes.emplace_back(key);
     }
     auto foundMethodHashesSize = p.getU4();
-    ret.foundMethodHashes.reserve(foundMethodHashesSize);
+    ret.foundHashes.methodHashes.reserve(foundMethodHashesSize);
     for (int it = 0; it < foundMethodHashesSize; it++) {
         auto ownerIdx = p.getU4();
         auto useSingletonClass = p.getU1();
@@ -315,7 +315,7 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
         fullNameHash._hashValue = p.getU4();
         ArityHash arityHash;
         arityHash._hashValue = p.getU4();
-        ret.foundMethodHashes.emplace_back(ownerIdx, useSingletonClass, fullNameHash, arityHash);
+        ret.foundHashes.methodHashes.emplace_back(ownerIdx, useSingletonClass, fullNameHash, arityHash);
     }
     return make_unique<const FileHash>(move(ret));
 }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -69,7 +69,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
             logger.debug(view);
 
             return make_unique<core::FileHash>(core::LocalSymbolTableHashes::invalidParse(), move(usageHash),
-                                               core::FoundMethodHashes{});
+                                               core::FoundHashes{});
         }
     }
 
@@ -77,10 +77,10 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
     single.emplace_back(move(file));
 
     auto workers = WorkerPool::create(0, lgs->tracer());
-    core::FoundMethodHashes foundMethodHashes; // out parameter
-    realmain::pipeline::resolve(lgs, move(single), opts(), *workers, &foundMethodHashes);
+    core::FoundHashes foundHashes; // out parameter
+    realmain::pipeline::resolve(lgs, move(single), opts(), *workers, &foundHashes);
 
-    return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash), move(foundMethodHashes));
+    return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash), move(foundHashes));
 }
 
 // Note: lgs is an outparameter.

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -69,7 +69,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
             logger.debug(view);
 
             return make_unique<core::FileHash>(core::LocalSymbolTableHashes::invalidParse(), move(usageHash),
-                                               core::FoundHashes{});
+                                               core::FoundDefHashes{});
         }
     }
 
@@ -77,7 +77,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
     single.emplace_back(move(file));
 
     auto workers = WorkerPool::create(0, lgs->tracer());
-    core::FoundHashes foundHashes; // out parameter
+    core::FoundDefHashes foundHashes; // out parameter
     realmain::pipeline::resolve(lgs, move(single), opts(), *workers, &foundHashes);
 
     return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash), move(foundHashes));

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -41,7 +41,7 @@ void processSource(core::GlobalState &cb, string str) {
     vector<ast::ParsedFile> trees;
     trees.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    core::FoundHashes foundHashes; // compute this just for test coverage
+    core::FoundDefHashes foundHashes; // compute this just for test coverage
     trees = move(namer::Namer::run(cb, move(trees), *workers, &foundHashes).result());
     auto resolved = resolver::Resolver::run(cb, move(trees), *workers);
     for (auto &tree : resolved.result()) {

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -41,8 +41,8 @@ void processSource(core::GlobalState &cb, string str) {
     vector<ast::ParsedFile> trees;
     trees.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
-    trees = move(namer::Namer::run(cb, move(trees), *workers, &foundMethodHashes).result());
+    core::FoundHashes foundHashes; // compute this just for test coverage
+    trees = move(namer::Namer::run(cb, move(trees), *workers, &foundHashes).result());
     auto resolved = resolver::Resolver::run(cb, move(trees), *workers);
     for (auto &tree : resolved.result()) {
         sorbet::core::MutableContext ctx(cb, core::Symbols::root(), tree.file);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -216,7 +216,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     auto toTypecheck = move(result.extraFiles);
     for (auto [fref, idx] : result.changedFiles) {
         if (config->opts.lspExperimentalFastPathEnabled && !result.changedSymbolNameHashes.empty()) {
-            // Only set oldFoundHashesForFiles if symbols actually changed
+            // Only set oldFoundDefHashesForFiles if symbols actually changed
             // Means that no-op edits (and thus calls to LSPTypechecker::retypecheck) don't blow away
             // methods only to redefine them with different IDs.
 

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -418,7 +418,7 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }
 
-    // Only need to compute FoundHashes when running to compute a FileHash
+    // Only need to compute FoundDefHashes when running to compute a FileHash
     auto foundHashes = nullptr;
     rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers, foundHashes).result());
     if (rbiGS->hadCriticalError()) {

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -418,9 +418,9 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }
 
-    // Only need to compute FoundMethodHashes when running to compute a FileHash
-    auto foundMethodHashes = nullptr;
-    rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers, foundMethodHashes).result());
+    // Only need to compute FoundHashes when running to compute a FileHash
+    auto foundHashes = nullptr;
+    rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers, foundHashes).result());
     if (rbiGS->hadCriticalError()) {
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -846,7 +846,8 @@ ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, a
 }
 
 ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers, core::FoundDefHashes *foundHashes) {
+                                    const options::Options &opts, WorkerPool &workers,
+                                    core::FoundDefHashes *foundHashes) {
     try {
         // packager intentionally runs outside of rewriter so that its output does not get cached.
         what = package(*gs, move(what), opts, workers);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -761,7 +761,7 @@ ast::ParsedFilesOrCancelled nameBestEffortConst(const core::GlobalState &gs, vec
 }
 
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, vector<ast::ParsedFile> what, const options::Options &opts,
-                                 WorkerPool &workers, core::FoundHashes *foundHashes) {
+                                 WorkerPool &workers, core::FoundDefHashes *foundHashes) {
     Timer timeit(gs.tracer(), "name");
     core::UnfreezeNameTable nameTableAccess(gs);     // creates singletons and class names
     core::UnfreezeSymbolTable symbolTableAccess(gs); // enters symbols
@@ -846,7 +846,7 @@ ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, a
 }
 
 ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers, core::FoundHashes *foundHashes) {
+                                    const options::Options &opts, WorkerPool &workers, core::FoundDefHashes *foundHashes) {
     try {
         // packager intentionally runs outside of rewriter so that its output does not get cached.
         what = package(*gs, move(what), opts, workers);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -26,8 +26,7 @@ std::vector<ast::ParsedFile> package(core::GlobalState &gs, std::vector<ast::Par
                                      const options::Options &opts, WorkerPool &workers);
 
 ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers,
-                                    core::FoundMethodHashes *foundMethodHashes);
+                                    const options::Options &opts, WorkerPool &workers, core::FoundHashes *foundHashes);
 
 // If `foundMethodHashesForFiles` is non-nullopt, incrementalResolve invokes Namer in runIncremental mode.
 //
@@ -47,7 +46,7 @@ std::vector<ast::ParsedFile> incrementalResolveBestEffort(const core::GlobalStat
                                                           const options::Options &opts);
 
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
-                                 WorkerPool &workers, core::FoundMethodHashes *foundMethodHashes);
+                                 WorkerPool &workers, core::FoundHashes *foundHashes);
 
 ast::ParsedFilesOrCancelled nameBestEffortConst(const core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                                 WorkerPool &workers);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -26,7 +26,8 @@ std::vector<ast::ParsedFile> package(core::GlobalState &gs, std::vector<ast::Par
                                      const options::Options &opts, WorkerPool &workers);
 
 ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers, core::FoundDefHashes *foundHashes);
+                                    const options::Options &opts, WorkerPool &workers,
+                                    core::FoundDefHashes *foundHashes);
 
 // If `foundMethodHashesForFiles` is non-nullopt, incrementalResolve invokes Namer in runIncremental mode.
 //

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -26,7 +26,7 @@ std::vector<ast::ParsedFile> package(core::GlobalState &gs, std::vector<ast::Par
                                      const options::Options &opts, WorkerPool &workers);
 
 ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers, core::FoundHashes *foundHashes);
+                                    const options::Options &opts, WorkerPool &workers, core::FoundDefHashes *foundHashes);
 
 // If `foundMethodHashesForFiles` is non-nullopt, incrementalResolve invokes Namer in runIncremental mode.
 //
@@ -46,7 +46,7 @@ std::vector<ast::ParsedFile> incrementalResolveBestEffort(const core::GlobalStat
                                                           const options::Options &opts);
 
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
-                                 WorkerPool &workers, core::FoundHashes *foundHashes);
+                                 WorkerPool &workers, core::FoundDefHashes *foundHashes);
 
 ast::ParsedFilesOrCancelled nameBestEffortConst(const core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                                 WorkerPool &workers);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -770,9 +770,9 @@ int realmain(int argc, char *argv[]) {
             runAutogen(*gs, opts, autoloaderCfg, *workers, indexed);
 #endif
         } else {
-            // Only need to compute FoundMethodHashes when running to compute a FileHash
-            auto foundMethodHashes = nullptr;
-            indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers, foundMethodHashes).result());
+            // Only need to compute hashes when running to compute a FileHash
+            auto foundHashes = nullptr;
+            indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers, foundHashes).result());
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1304,7 +1304,7 @@ public:
         }
     }
 
-    void populateFoundHashes(core::Context ctx, core::FoundHashes &foundHashesOut) {
+    void populateFoundDefHashes(core::Context ctx, core::FoundDefHashes &foundHashesOut) {
         ENFORCE(foundHashesOut.methodHashes.empty());
         foundHashesOut.methodHashes.reserve(foundDefs.methods().size());
         for (const auto &method : foundDefs.methods()) {
@@ -1936,7 +1936,7 @@ vector<SymbolFinderResult> findSymbols(const core::GlobalState &gs, vector<ast::
 ast::ParsedFilesOrCancelled
 defineSymbols(core::GlobalState &gs, vector<SymbolFinderResult> allFoundDefinitions, WorkerPool &workers,
               UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
-              core::FoundHashes *foundHashesOut) {
+              core::FoundDefHashes *foundHashesOut) {
     Timer timeit(gs.tracer(), "naming.defineSymbols");
     vector<ast::ParsedFile> output;
     output.reserve(allFoundDefinitions.size());
@@ -1963,7 +1963,7 @@ defineSymbols(core::GlobalState &gs, vector<SymbolFinderResult> allFoundDefiniti
         output.emplace_back(move(fileFoundDefinitions.tree));
         symbolDefiner.run(ctx);
         if (foundHashesOut != nullptr) {
-            symbolDefiner.populateFoundHashes(ctx, *foundHashesOut);
+            symbolDefiner.populateFoundDefHashes(ctx, *foundHashesOut);
         }
     }
     prodCounterAdd("types.input.foundmethods.total", foundMethods);
@@ -2089,7 +2089,7 @@ ast::ParsedFilesOrCancelled Namer::symbolizeTreesBestEffort(const core::GlobalSt
 ast::ParsedFilesOrCancelled
 Namer::runInternal(core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers,
                    UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
-                   core::FoundHashes *foundHashesOut) {
+                   core::FoundDefHashes *foundHashesOut) {
     auto foundDefs = findSymbols(gs, move(trees), workers);
     if (gs.epochManager->wasTypecheckingCanceled()) {
         trees.reserve(foundDefs.size());
@@ -2112,7 +2112,7 @@ Namer::runInternal(core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerP
 }
 
 ast::ParsedFilesOrCancelled Namer::run(core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers,
-                                       core::FoundHashes *foundHashesOut) {
+                                       core::FoundDefHashes *foundHashesOut) {
     // In non-incremental namer, there are no old FoundMethodHashes; just defineSymbols like normal.
     auto oldFoundMethodHashesForFiles = UnorderedMap<core::FileRef, core::FoundMethodHashes>{};
     return runInternal(gs, move(trees), workers, std::move(oldFoundMethodHashesForFiles), foundHashesOut);

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -14,7 +14,7 @@ class Namer final {
     static ast::ParsedFilesOrCancelled
     runInternal(core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers,
                 UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
-                core::FoundMethodHashes *foundMethodHashesOut);
+                core::FoundHashes *foundHashesOut);
 
 public:
     static ast::ParsedFilesOrCancelled
@@ -26,7 +26,7 @@ public:
     // it found while running. (Thus, it's usually nullptr except when pipeline::resolve is called
     // for the purpose of computing a FileHash.)
     static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
-                                           WorkerPool &workers, core::FoundMethodHashes *foundMethodHashesOut);
+                                           WorkerPool &workers, core::FoundHashes *foundHashesOut);
 
     // Version of Namer that accepts the old FoundMethodHashes for each file to run Namer, which
     // it uses to figure out how to mutate the already-populated GlobalState into the right shape

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -20,7 +20,7 @@ public:
     static ast::ParsedFilesOrCancelled
     symbolizeTreesBestEffort(const core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers);
 
-    // Note: foundMethodHashes is an optional out parameter.
+    // Note: foundHashes is an optional out parameter.
     //
     // Setting it to a non-nullptr requests that Namer compute a fingerprint of the FoundDefinitions
     // it found while running. (Thus, it's usually nullptr except when pipeline::resolve is called

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -14,7 +14,7 @@ class Namer final {
     static ast::ParsedFilesOrCancelled
     runInternal(core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers,
                 UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
-                core::FoundHashes *foundHashesOut);
+                core::FoundDefHashes *foundHashesOut);
 
 public:
     static ast::ParsedFilesOrCancelled
@@ -26,7 +26,7 @@ public:
     // it found while running. (Thus, it's usually nullptr except when pipeline::resolve is called
     // for the purpose of computing a FileHash.)
     static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
-                                           WorkerPool &workers, core::FoundHashes *foundHashesOut);
+                                           WorkerPool &workers, core::FoundDefHashes *foundHashesOut);
 
     // Version of Namer that accepts the old FoundMethodHashes for each file to run Namer, which
     // it uses to figure out how to mutate the already-populated GlobalState into the right shape

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -47,8 +47,8 @@ vector<ast::ParsedFile> runNamer(core::GlobalState &gs, ast::ParsedFile tree) {
     vector<ast::ParsedFile> v;
     v.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
-    return move(namer::Namer::run(gs, move(v), *workers, &foundMethodHashes).result());
+    core::FoundHashes foundHashes; // compute this just for test coverage
+    return move(namer::Namer::run(gs, move(v), *workers, &foundHashes).result());
 }
 
 } // namespace

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -47,7 +47,7 @@ vector<ast::ParsedFile> runNamer(core::GlobalState &gs, ast::ParsedFile tree) {
     vector<ast::ParsedFile> v;
     v.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    core::FoundHashes foundHashes; // compute this just for test coverage
+    core::FoundDefHashes foundHashes; // compute this just for test coverage
     return move(namer::Namer::run(gs, move(v), *workers, &foundHashes).result());
 }
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -526,7 +526,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters symbols
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(tree));
-            core::FoundHashes foundHashes; // compute this just for test coverage
+            core::FoundDefHashes foundHashes; // compute this just for test coverage
             vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundHashes).result());
             namedTree = testSerialize(*gs, move(vTmp[0]));
         }
@@ -852,7 +852,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs);
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(tree));
-            core::FoundHashes foundHashes; // out param, compute this just for test coverage
+            core::FoundDefHashes foundHashes; // out param, compute this just for test coverage
             // The lsp_test_runner will turn every testdata test into a test of
             // Namer::runIncremental by way of creating a file update with leading whitespace.
             //

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -488,8 +488,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             {
                 core::UnfreezeNameTable nameTableAccess(*rbiGenGs);     // creates singletons and class names
                 core::UnfreezeSymbolTable symbolTableAccess(*rbiGenGs); // enters symbols
-                auto foundMethodHashes = nullptr;
-                trees = move(namer::Namer::run(*rbiGenGs, move(trees), *workers, foundMethodHashes).result());
+                auto foundHashes = nullptr;
+                trees = move(namer::Namer::run(*rbiGenGs, move(trees), *workers, foundHashes).result());
             }
 
             // Resolver
@@ -526,8 +526,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters symbols
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(tree));
-            core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
-            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundMethodHashes).result());
+            core::FoundHashes foundHashes; // compute this just for test coverage
+            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundHashes).result());
             namedTree = testSerialize(*gs, move(vTmp[0]));
         }
 
@@ -852,14 +852,14 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs);
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(tree));
-            core::FoundMethodHashes foundMethodHashes; // out param, compute this just for test coverage
+            core::FoundHashes foundHashes; // out param, compute this just for test coverage
             // The lsp_test_runner will turn every testdata test into a test of
             // Namer::runIncremental by way of creating a file update with leading whitespace.
             //
             // Here, to complement those tests, we just run Namer::run (not Namer::runIncremental)
             // to stress the codepath where Namer is not tasked with deleting anything when run for
             // the fast path.
-            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundMethodHashes).result());
+            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundHashes).result());
             tree = testSerialize(*gs, move(vTmp[0]));
 
             handler.addObserved(*gs, "name-tree", [&]() { return tree.tree.toString(*gs); });


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We currently compute hashes for found methods during file hashing, and we use those hashes to inform how to incrementally typecheck things in LSP mode.

We plan on adding support for incrementally typechecking when other entities are modified; rather than pass a bunch of params, let's just pass a single structure that will (one day) encompass all the things we want to pass, and then we can add a single structure member in one place, rather than outparams ten different places.

I did not modify the `FileRef` -> method hashes map in this patch, because I think it's a little easier to follow, but I'm happy to do that work as a followup.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
