### PR TITLE
Fix Sorbet autogen mode after #6263

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -750,6 +750,7 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Namer::RedefinitionOfMethod.code);
             gs->suppressErrorClass(core::errors::Namer::InvalidClassOwner.code);
             gs->suppressErrorClass(core::errors::Namer::ModuleKindRedefinition.code);
+            gs->suppressErrorClass(core::errors::Namer::ConstantKindRedefinition.code);
             gs->suppressErrorClass(core::errors::Resolver::StubConstant.code);
             gs->suppressErrorClass(core::errors::Resolver::RecursiveTypeAlias.code);
 

--- a/test/cli/autogen-errors/autogen-errors.rb
+++ b/test/cli/autogen-errors/autogen-errors.rb
@@ -4,3 +4,17 @@ class Foo < Bar
 end
 class Bar < Foo
 end
+
+class Opus::Autogen::Proto::ProtobufGeneratedClass1
+end
+
+module Opus::Autogen::Proto
+  ProtobufGeneratedClass1 = T.unsafe(Class).new
+end
+
+module Opus::Autogen::Proto
+  ProtobufGeneratedClass2 = T.unsafe(Class).new
+end
+
+class Opus::Autogen::Proto::ProtobufGeneratedClass2
+end

--- a/test/cli/autogen-errors/test.out
+++ b/test/cli/autogen-errors/test.out
@@ -1,3 +1,25 @@
+test/cli/autogen-errors/autogen-errors.rb:12: Redefining constant `ProtobufGeneratedClass1` as a static field https://srb.help/4022
+    12 |  ProtobufGeneratedClass1 = T.unsafe(Class).new
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    test/cli/autogen-errors/autogen-errors.rb:8: Previously defined as a class or module
+     8 |class Opus::Autogen::Proto::ProtobufGeneratedClass1
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Sorbet does not allow treating constant assignments as class or module definitions,
+even if the initializer computes a value of type `Module`. See the docs for more.
+
+
+test/cli/autogen-errors/autogen-errors.rb:19: Redefining constant `ProtobufGeneratedClass2` as a class or module https://srb.help/4022
+    19 |class Opus::Autogen::Proto::ProtobufGeneratedClass2
+    20 |end
+    test/cli/autogen-errors/autogen-errors.rb:16: Previously defined as a static field
+    16 |  ProtobufGeneratedClass2 = T.unsafe(Class).new
+          ^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Sorbet does not allow treating constant assignments as class or module definitions,
+even if the initializer computes a value of type `Module`. See the docs for more.
+
+
 test/cli/autogen-errors/autogen-errors.rb:5: Circular dependency: `Bar` and `Foo` are declared as parents of each other https://srb.help/5011
      5 |class Bar < Foo
                     ^^^
@@ -7,4 +29,4 @@ test/cli/autogen-errors/autogen-errors.rb:5: Circular dependency: `Bar` and `Foo
     test/cli/autogen-errors/autogen-errors.rb:3: Other definition
      3 |class Foo < Bar
         ^^^^^^^^^^^^^^^
-Errors: 1
+Errors: 3

--- a/test/cli/autogen-errors/test.out
+++ b/test/cli/autogen-errors/test.out
@@ -1,25 +1,3 @@
-test/cli/autogen-errors/autogen-errors.rb:12: Redefining constant `ProtobufGeneratedClass1` as a static field https://srb.help/4022
-    12 |  ProtobufGeneratedClass1 = T.unsafe(Class).new
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test/cli/autogen-errors/autogen-errors.rb:8: Previously defined as a class or module
-     8 |class Opus::Autogen::Proto::ProtobufGeneratedClass1
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Sorbet does not allow treating constant assignments as class or module definitions,
-even if the initializer computes a value of type `Module`. See the docs for more.
-
-
-test/cli/autogen-errors/autogen-errors.rb:19: Redefining constant `ProtobufGeneratedClass2` as a class or module https://srb.help/4022
-    19 |class Opus::Autogen::Proto::ProtobufGeneratedClass2
-    20 |end
-    test/cli/autogen-errors/autogen-errors.rb:16: Previously defined as a static field
-    16 |  ProtobufGeneratedClass2 = T.unsafe(Class).new
-          ^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Sorbet does not allow treating constant assignments as class or module definitions,
-even if the initializer computes a value of type `Module`. See the docs for more.
-
-
 test/cli/autogen-errors/autogen-errors.rb:5: Circular dependency: `Bar` and `Foo` are declared as parents of each other https://srb.help/5011
      5 |class Bar < Foo
                     ^^^
@@ -29,4 +7,4 @@ test/cli/autogen-errors/autogen-errors.rb:5: Circular dependency: `Bar` and `Foo
     test/cli/autogen-errors/autogen-errors.rb:3: Other definition
      3 |class Foo < Bar
         ^^^^^^^^^^^^^^^
-Errors: 3
+Errors: 1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The changes in #6263 split out the 4012 error code into 4012 and 4022.

Sorbet autogen previously relied on (but did not have tests for) these errors
being silenced.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.