### PR TITLE
avoid displaying an error when watchman exits for unknown reasons

### DIFF
--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -157,15 +157,15 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                     messageQueue.pendingRequests.push_back(move(msg));
                 }
             },
-            [&messageQueue, &messageQueueMutex, logger = logger, config = this->config](int watchmanExitCode,
-                                                                                        string const &msg) {
+            [&messageQueue, &messageQueueMutex, logger = logger,
+             config = this->config](int watchmanExitCode, const optional<string> &msg) -> void {
                 {
                     absl::MutexLock lck(&messageQueueMutex);
                     if (!messageQueue.terminate) {
                         messageQueue.terminate = true;
                         messageQueue.errorCode = watchmanExitCode;
-                        if (watchmanExitCode != 0) {
-                            auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
+                        if (watchmanExitCode != 0 && msg.has_value()) {
+                            auto params = make_unique<ShowMessageParams>(MessageType::Error, msg.value());
                             config->output->write(make_unique<LSPMessage>(
                                 make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
                         }

--- a/main/lsp/watchman/WatchmanProcess.h
+++ b/main/lsp/watchman/WatchmanProcess.h
@@ -18,7 +18,7 @@ private:
     const std::string workSpace;
     const std::vector<std::string> extensions;
     const std::function<void(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>)> processUpdate;
-    const std::function<void(int, std::string const &)> processExit;
+    const std::function<void(int, const std::optional<std::string> &)> processExit;
     const std::unique_ptr<Joinable> thread;
     // Mutex that must be held before reading or writing stopped.
     absl::Mutex mutex;
@@ -30,7 +30,7 @@ private:
      */
     void start();
 
-    void exitWithCode(int code, std::string const &);
+    void exitWithCode(int code, const std::optional<std::string> &);
 
     bool isStopped();
 
@@ -42,7 +42,7 @@ public:
     WatchmanProcess(std::shared_ptr<spdlog::logger> logger, std::string_view watchmanPath, std::string_view workSpace,
                     std::vector<std::string> extensions,
                     std::function<void(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>)> processUpdate,
-                    std::function<void(int, std::string const &)> processExit);
+                    std::function<void(int, const std::optional<std::string> &)> processExit);
 
     ~WatchmanProcess();
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#3581 changed things so we always display some sort of notification in LSP mode for unusual things happening.  This is helpful for informing the user when, e.g. we can't fork watchman for some reason, but it's not so great for telling the user about random exits.  (We have tooling at Stripe that restarts all services on a remote machine; this restart results in watchman restarting, and then Sorbet tells the user that watchman exited, when they don't really care.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
