### PR TITLE
website: Don't use logo as ogImage

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -165,8 +165,8 @@ const siteConfig = {
 
   // Open Graph and Twitter card images.
   // (these images can't be SVGs)
-  ogImage: 'img/sorbet-logo-card@2x.png',
-  twitterImage: 'img/sorbet-logo-card@2x.png',
+  // ogImage: 'img/sorbet-logo-card@2x.png',
+  // twitterImage: 'img/sorbet-logo-card@2x.png',
 
   // Show documentation's last contributor's name.
   // enableUpdateBy: true,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

og:image and twitter image are meant to be used with a large,
descriptive image. They both fall back to your favicon / touch icon
image when no og:image is present.

We made a similar change to <https://sorbet.run> the other day:

<https://github.com/sorbet/sorbet.run/commit/8616ee52>



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a