### PR TITLE
don't unnecessarily load `ParsedArg`s during tree symbolification

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1428,7 +1428,7 @@ class TreeSymbolizer {
         return result.exists() ? make_optional<core::SymbolRef>(result) : nullopt;
     }
 
-    ast::ExpressionPtr arg2Symbol(int pos, core::ParsedArg parsedArg, ast::ExpressionPtr arg) {
+    ast::ExpressionPtr arg2Symbol(int pos, const core::ParsedArg &parsedArg, ast::ExpressionPtr arg) {
         ast::ExpressionPtr localExpr = ast::make_expression<ast::Local>(parsedArg.loc, parsedArg.local);
         if (parsedArg.flags.isDefault) {
             localExpr =
@@ -1623,7 +1623,7 @@ public:
                 args.emplace_back(move(localExpr));
             } else {
                 ENFORCE(i < oldArgs.size());
-                auto expr = arg2Symbol(i, move(arg), move(oldArgs[i]));
+                auto expr = arg2Symbol(i, arg, move(oldArgs[i]));
                 args.emplace_back(move(expr));
             }
         }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Minor runtime improvements.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
