### PR TITLE
add tests for disallowed static fields within methods

### DIFF
--- a/test/testdata/namer/class_alias_inside_method.rb
+++ b/test/testdata/namer/class_alias_inside_method.rb
@@ -1,0 +1,12 @@
+# typed: true
+module A
+  extend T::Sig
+
+  class C1; end
+
+  sig {params(x: C1).returns(NilClass)}
+  def f(x)
+    C2 = C1 # error: dynamic constant assignment
+    nil
+  end
+end

--- a/test/testdata/namer/class_alias_inside_method.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/class_alias_inside_method.rb.symbol-table-raw.exp
@@ -1,0 +1,18 @@
+class <C <U <root>>> < <C <U Object>> ()
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=2:1 end=12:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=??? end=???}
+  module <C <U A>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=2:1 end=2:9}
+    class <C <U A>>::<C <U C1>> < <C <U Object>> () @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=5:3 end=5:11}
+    class <C <U A>>::<S <C <U C1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=5:9 end=5:11}
+      type-member(+) <C <U A>>::<S <C <U C1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U A>>::<S <C <U C1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A::C1) @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=5:9 end=5:11}
+      method <C <U A>>::<S <C <U C1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=5:3 end=5:16}
+        argument <blk><block> @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=??? end=???}
+    method <C <U A>>#<U f> (x, <blk>) -> NilClass @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=8:3 end=8:11}
+      argument x<> -> A::C1 @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=7:15 end=7:16}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=??? end=???}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Sig>>) @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=2:8 end=2:9}
+    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=2:8 end=2:9}
+    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=2:1 end=12:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/class_alias_inside_method.rb start=??? end=???}
+

--- a/test/testdata/namer/type_alias_inside_method.rb
+++ b/test/testdata/namer/type_alias_inside_method.rb
@@ -1,0 +1,12 @@
+# typed: true
+module A
+  extend T::Sig
+
+  class C1; end
+
+  sig {params(x: C1).returns(NilClass)}
+  def f(x)
+    C2 = T.type_alias {C1} # error: dynamic constant assignment
+    nil
+  end
+end

--- a/test/testdata/namer/type_alias_inside_method.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/type_alias_inside_method.rb.symbol-table-raw.exp
@@ -1,0 +1,18 @@
+class <C <U <root>>> < <C <U Object>> ()
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=2:1 end=12:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=??? end=???}
+  module <C <U A>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=2:1 end=2:9}
+    class <C <U A>>::<C <U C1>> < <C <U Object>> () @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=5:3 end=5:11}
+    class <C <U A>>::<S <C <U C1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=5:9 end=5:11}
+      type-member(+) <C <U A>>::<S <C <U C1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U A>>::<S <C <U C1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A::C1) @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=5:9 end=5:11}
+      method <C <U A>>::<S <C <U C1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=5:3 end=5:16}
+        argument <blk><block> @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=??? end=???}
+    method <C <U A>>#<U f> (x, <blk>) -> NilClass @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=8:3 end=8:11}
+      argument x<> -> A::C1 @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=7:15 end=7:16}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=??? end=???}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Sig>>) @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=2:8 end=2:9}
+    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=2:8 end=2:9}
+    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=2:1 end=12:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/type_alias_inside_method.rb start=??? end=???}
+

--- a/test/testdata/namer/type_member_inside_method.rb
+++ b/test/testdata/namer/type_member_inside_method.rb
@@ -1,0 +1,13 @@
+# typed: true
+module A
+  extend T::Sig
+
+  class C1; end
+
+  sig {params(x: C1).returns(NilClass)}
+  def f(x)
+    C2 = type_member # error: dynamic constant assignment
+    #    ^^^^^^^^^^^ error: Method `type_member` does not exist on `A`
+    nil
+  end
+end

--- a/test/testdata/namer/type_member_inside_method.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/type_member_inside_method.rb.symbol-table-raw.exp
@@ -1,0 +1,18 @@
+class <C <U <root>>> < <C <U Object>> ()
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=2:1 end=13:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=??? end=???}
+  module <C <U A>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=2:1 end=2:9}
+    class <C <U A>>::<C <U C1>> < <C <U Object>> () @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=5:3 end=5:11}
+    class <C <U A>>::<S <C <U C1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=5:9 end=5:11}
+      type-member(+) <C <U A>>::<S <C <U C1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U A>>::<S <C <U C1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A::C1) @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=5:9 end=5:11}
+      method <C <U A>>::<S <C <U C1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=5:3 end=5:16}
+        argument <blk><block> @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=??? end=???}
+    method <C <U A>>#<U f> (x, <blk>) -> NilClass @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=8:3 end=8:11}
+      argument x<> -> A::C1 @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=7:15 end=7:16}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=??? end=???}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Sig>>) @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=2:8 end=2:9}
+    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=2:8 end=2:9}
+    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=2:1 end=13:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/type_member_inside_method.rb start=??? end=???}
+

--- a/test/testdata/namer/type_template_inside_method.rb
+++ b/test/testdata/namer/type_template_inside_method.rb
@@ -1,0 +1,13 @@
+# typed: true
+module A
+  extend T::Sig
+
+  class C1; end
+
+  sig {params(x: C1).returns(NilClass)}
+  def f(x)
+    C2 = type_template # error: dynamic constant assignment
+    #    ^^^^^^^^^^^^^ error: Method `type_template` does not exist on `A`
+    nil
+  end
+end

--- a/test/testdata/namer/type_template_inside_method.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/type_template_inside_method.rb.symbol-table-raw.exp
@@ -1,0 +1,18 @@
+class <C <U <root>>> < <C <U Object>> ()
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=2:1 end=13:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=??? end=???}
+  module <C <U A>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=2:1 end=2:9}
+    class <C <U A>>::<C <U C1>> < <C <U Object>> () @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=5:3 end=5:11}
+    class <C <U A>>::<S <C <U C1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=5:9 end=5:11}
+      type-member(+) <C <U A>>::<S <C <U C1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U A>>::<S <C <U C1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A::C1) @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=5:9 end=5:11}
+      method <C <U A>>::<S <C <U C1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=5:3 end=5:16}
+        argument <blk><block> @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=??? end=???}
+    method <C <U A>>#<U f> (x, <blk>) -> NilClass @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=8:3 end=8:11}
+      argument x<> -> A::C1 @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=7:15 end=7:16}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=??? end=???}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> (<C <U Sig>>) @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=2:8 end=2:9}
+    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=2:8 end=2:9}
+    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=2:1 end=13:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/type_template_inside_method.rb start=??? end=???}
+


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I don't think we have any tests for the contents of the symbol table when we have bad constants like this.  (Or maybe we do, but it's nice to have them all in one location now?)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  `C2` should not and does not appear in the exp files.
