### PR TITLE
Support allow-listing certain RBI files to declare behavior in autogen mode

### DIFF
--- a/main/autogen/autogen.h
+++ b/main/autogen/autogen.h
@@ -9,7 +9,8 @@ namespace sorbet::autogen {
 
 class Autogen final {
 public:
-    static ParsedFile generate(core::Context ctx, ast::ParsedFile tree, const CRCBuilder &crcBuilder);
+    static ParsedFile generate(core::Context ctx, ast::ParsedFile tree, const AutogenConfig &autogenCfg,
+                               const CRCBuilder &crcBuilder);
     Autogen() = delete;
 };
 

--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -169,9 +169,9 @@ vector<string> ParsedFile::listAllClasses(core::Context ctx) {
 }
 
 // Convert this parsedfile to a msgpack representation
-string ParsedFile::toMsgpack(core::Context ctx, int version) {
+string ParsedFile::toMsgpack(core::Context ctx, int version, const AutogenConfig &autogenCfg) {
     MsgpackWriter write(version);
-    return write.pack(ctx, *this);
+    return write.pack(ctx, *this, autogenCfg);
 }
 
 } // namespace sorbet::autogen

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -148,6 +148,10 @@ struct Reference {
     DefinitionRef parent_of;
 };
 
+struct AutogenConfig {
+    const std::vector<std::string> behaviorAllowedInRBIsPaths;
+};
+
 // A `ParsedFile` contains all the `Definition`s and `References` used in a particular file
 struct ParsedFile {
     friend class MsgpackWriter;
@@ -166,7 +170,7 @@ struct ParsedFile {
     std::vector<core::NameRef> requireStatements;
 
     std::string toString(const core::GlobalState &gs, int version) const;
-    std::string toMsgpack(core::Context ctx, int version);
+    std::string toMsgpack(core::Context ctx, int version, const AutogenConfig &autogenCfg);
     std::vector<core::NameRef> showFullName(const core::GlobalState &gs, DefinitionRef id) const;
     QualifiedName showQualifiedName(const core::GlobalState &gs, DefinitionRef id) const;
     std::vector<std::string> listAllClasses(core::Context ctx);

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -30,7 +30,7 @@ private:
     void packReferenceRef(ReferenceRef ref);
     void packDefinitionRef(DefinitionRef ref);
     void packRange(uint32_t begin, uint32_t end);
-    void packDefinition(core::Context ctx, ParsedFile &pf, Definition &def);
+    void packDefinition(core::Context ctx, ParsedFile &pf, Definition &def, const AutogenConfig &autogenCfg);
     void packReference(core::Context ctx, ParsedFile &pf, Reference &ref);
     static int assertValidVersion(int version) {
         if (version < AutogenVersion::MIN_VERSION || version > AutogenVersion::MAX_VERSION) {
@@ -43,7 +43,7 @@ private:
 public:
     MsgpackWriter(int version);
 
-    std::string pack(core::Context ctx, ParsedFile &pf);
+    std::string pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg);
 };
 
 } // namespace sorbet::autogen

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -442,6 +442,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("dev")("autogen-subclasses-ignore",
                                "Like --ignore, but it only affects `-p autogen-subclasses`.",
                                cxxopts::value<vector<string>>(), "string");
+    options.add_options("dev")("autogen-behavior-allowed-in-rbi-files-paths",
+                               "RBI files defined in these paths can be considered by autogen as behavior-defining.",
+                               cxxopts::value<vector<string>>(), "string");
     options.add_options("dev")("stop-after", to_string(all_stop_after),
                                cxxopts::value<string>()->default_value("inferencer"), "phase");
     options.add_options("dev")("no-stdlib", "Do not load included rbi files for stdlib");
@@ -844,6 +847,16 @@ void readOptions(Options &opts,
                     opts.autogenSubclassesRelativeIgnorePatterns.emplace_back(fmt::format("/{}", pNormalized));
                 }
             }
+        }
+
+        if (raw.count("autogen-behavior-allowed-in-rbi-files-paths") > 0) {
+            if (!opts.print.isAutogen() || opts.print.AutogenAutoloader.enabled) {
+                logger->error("autogen-behavior-allowed-in-rbi-files-paths can only be used with -p autogen or -p "
+                              "autogen-msgpack");
+                throw EarlyReturnWithCode(1);
+            }
+            opts.autogenBehaviorAllowedInRBIFilesPaths =
+                raw["autogen-behavior-allowed-in-rbi-files-paths"].as<vector<string>>();
         }
 
         extractAutogenConstCacheConfig(raw, opts.autogenConstantCacheConfig);

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -246,6 +246,8 @@ struct Options {
     std::vector<std::string> autogenSubclassesAbsoluteIgnorePatterns;
     // Ignore patterns that can occur anywhere in a file's path from an input folder.
     std::vector<std::string> autogenSubclassesRelativeIgnorePatterns;
+    // Allow RBI files to define behavior if they are in one of these paths.
+    std::vector<std::string> autogenBehaviorAllowedInRBIFilesPaths;
     AutogenConstCacheConfig autogenConstantCacheConfig;
 
     // List of directories not available editor-side. References to files in these directories should be sent via

--- a/test/cli/autogen_print_rbi/behavior_allowed.rbi
+++ b/test/cli/autogen_print_rbi/behavior_allowed.rbi
@@ -1,0 +1,7 @@
+# typed: strict
+
+class BehaviorRBI
+  sig {void}
+  def bar; end
+end
+

--- a/test/cli/autogen_print_rbi/test.out
+++ b/test/cli/autogen_print_rbi/test.out
@@ -114,11 +114,31 @@ requires: []
  resolved=[Integer]
  loc=test/cli/autogen_print_rbi/b.rbi:4
  is_defining_ref=0
+# ParsedFile: test/cli/autogen_print_rbi/behavior_allowed.rbi
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+[def id=1]
+ type=class
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[BehaviorRBI]
+## refs:
+[ref id=0]
+ scope=[]
+ name=[BehaviorRBI]
+ nesting=[]
+ resolved=[BehaviorRBI]
+ loc=test/cli/autogen_print_rbi/behavior_allowed.rbi:3
+ is_defining_ref=1
 
 f3b9f8c31a343a60665c06f959a48dbdceef757c  autogen3.msgpack
-2305b0d8f2c81fbb946e4f1dbec6230386925456  autogen4.msgpack
+bd4da471dd4868384af366a23bed507c32c6f98b  autogen4.msgpack
 
-39a40,73
+39a40,93
 > # ParsedFile: test/cli/autogen_print_rbi/b.rbi
 > requires: []
 > ## defs:
@@ -153,3 +173,23 @@ f3b9f8c31a343a60665c06f959a48dbdceef757c  autogen3.msgpack
 >  resolved=[Integer]
 >  loc=test/cli/autogen_print_rbi/b.rbi:4
 >  is_defining_ref=0
+> # ParsedFile: test/cli/autogen_print_rbi/behavior_allowed.rbi
+> requires: []
+> ## defs:
+> [def id=0]
+>  type=module
+>  defines_behavior=0
+>  is_empty=0
+> [def id=1]
+>  type=class
+>  defines_behavior=1
+>  is_empty=0
+>  defining_ref=[BehaviorRBI]
+> ## refs:
+> [ref id=0]
+>  scope=[]
+>  name=[BehaviorRBI]
+>  nesting=[]
+>  resolved=[BehaviorRBI]
+>  loc=test/cli/autogen_print_rbi/behavior_allowed.rbi:3
+>  is_defining_ref=1

--- a/test/cli/autogen_print_rbi/test.sh
+++ b/test/cli/autogen_print_rbi/test.sh
@@ -12,7 +12,7 @@ echo
 echo
 echo "Version 4:"
 main/sorbet --silence-dev-message --stop-after namer --autogen-version=4 \
-  -p autogen:autogen4.txt -p autogen-msgpack:autogen4.msgpack \
+  -p autogen:autogen4.txt -p autogen-msgpack:autogen4.msgpack --autogen-behavior-allowed-in-rbi-files-paths="test/cli/autogen_print_rbi/behavior_allowed.rbi" \
   test/cli/autogen_print_rbi/*.{rb,rbi}
 
 cat autogen4.txt

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -28,6 +28,7 @@
 #include "local_vars/local_vars.h"
 #include "main/autogen/autogen.h"
 #include "main/autogen/crc_builder.h"
+#include "main/autogen/data/definitions.h"
 #include "main/autogen/data/version.h"
 #include "main/minimize/minimize.h"
 #include "namer/namer.h"
@@ -551,7 +552,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 auto crcBuilder = autogen::CRCBuilder::create();
                 for (auto &tree : trees) {
                     core::Context ctx(*gs, core::Symbols::root(), tree.file);
-                    auto pf = autogen::Autogen::generate(ctx, move(tree), *crcBuilder);
+                    auto pf = autogen::Autogen::generate(ctx, move(tree), autogen::AutogenConfig{{}}, *crcBuilder);
                     tree = move(pf.tree);
                     payload << pf.toString(ctx, autogen::AutogenVersion::MAX_VERSION);
                 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds a command-line flag in autogen mode that supports listing certain RBI files as being able to define behavior.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In the Stripe codebase, we autogenerate Ruby files that represent protobuf message declarations, which often have definitions of the form:

```
module Foo
  Bar ||= ...
```

Since `||=` constant reassignments are not supported by Sorbet, autogen skips interpreting `Foo::Bar` as a definition. This breaks our tooling. In order to fix this issue, given that we also generate RBI files for protobuf declarations, we can allow autogen to interpret these RBI files as defining behavior -- so that we can capture the definition of `Foo::Bar` in the serialized static analysis results from autogen.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.
