### PR TITLE
add back `set -x` for pipeline test execution

### DIFF
--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -14,6 +14,7 @@ def dropExtension(p):
 
 _TEST_SCRIPT = """#!/usr/bin/env bash
 export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_12_0_0/bin/llvm-symbolizer
+set -x
 exec {runner} --single_test="{test}"
 """
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#6251 removed the `set -x` from this script, which was actually kind of handy for debugging.  This PR puts it back, and opts to put it after the `export`, so we don't get a bunch of noise about the bazel sandbox paths.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
