### PR TITLE
Allow `requires_ancestor` block to return a `T.class_of` object

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -317,25 +317,6 @@ public:
         return Hash(loc, std::move(keys), std::move(values));
     }
 
-    static bool isT(ExpressionPtr &expr) {
-        auto *tMod = ast::cast_tree<ast::ConstantLit>(expr);
-        return tMod && tMod->symbol == core::Symbols::T();
-    }
-
-    static bool isTClassOf(ExpressionPtr &expr) {
-        auto *send = ast::cast_tree<ast::Send>(expr);
-
-        if(send == nullptr) {
-            return false;
-        }
-
-        if(!isT(send->recv))  {
-            return false;
-        }
-
-        return send->fun == core::Names::classOf();
-    }
-
 private:
     static ExpressionPtr Params(core::LocOffsets loc, ExpressionPtr recv, Send::ARGS_store args) {
         ENFORCE(args.size() % 2 == 0, "Sig params must be arg name/type pairs");

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -317,6 +317,25 @@ public:
         return Hash(loc, std::move(keys), std::move(values));
     }
 
+    static bool isT(ExpressionPtr &expr) {
+        auto *tMod = ast::cast_tree<ast::ConstantLit>(expr);
+        return tMod && tMod->symbol == core::Symbols::T();
+    }
+
+    static bool isTClassOf(ExpressionPtr &expr) {
+        auto *send = ast::cast_tree<ast::Send>(expr);
+
+        if(send == nullptr) {
+            return false;
+        }
+
+        if(!isT(send->recv))  {
+            return false;
+        }
+
+        return send->fun == core::Names::classOf();
+    }
+
 private:
     static ExpressionPtr Params(core::LocOffsets loc, ExpressionPtr recv, Send::ARGS_store args) {
         ENFORCE(args.size() % 2 == 0, "Sig params must be arg name/type pairs");

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -758,7 +758,7 @@ void validateUnsatisfiableRequiredAncestors(core::Context ctx, const core::Class
             requiredClasses.emplace_back(ancst);
         }
 
-        if (ancst.symbol.data(ctx)->typeArity(ctx) > 0) {
+        if (ancst.symbol.data(ctx)->typeArity(ctx) > 0 && !ancst.symbol.data(ctx)->isSingletonClass(ctx)) {
             if (auto e = ctx.state.beginError(data->loc(), core::errors::Resolver::UnsatisfiableRequiredAncestor)) {
                 e.setHeader("`{}` can't require generic ancestor `{}` (unsupported)", sym.show(ctx),
                             ancst.symbol.show(ctx));

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -286,7 +286,7 @@ module T::Helpers
   # given type of module.
   #
   # For more information, see https://sorbet.org/docs/requires-ancestor
-  sig { params(block: T.proc.returns(Module)).void }
+  sig { params(block: T.proc.void).void }
   def requires_ancestor(&block); end
 end
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1913,13 +1913,8 @@ class ResolveTypeMembersAndFieldsWalk {
 
     void extendClassOfDepth(ast::Send &send) {
         if (trackDependencies_) {
-            classOfDepth_.emplace_back(isT(send.recv) && send.fun == core::Names::classOf());
+            classOfDepth_.emplace_back(ast::MK::isT(send.recv) && send.fun == core::Names::classOf());
         }
-    }
-
-    static bool isT(const ast::ExpressionPtr &expr) {
-        auto *tMod = ast::cast_tree<ast::ConstantLit>(expr);
-        return tMod && tMod->symbol == core::Symbols::T();
     }
 
     static bool isTodo(const core::TypePtr &type) {
@@ -2742,7 +2737,7 @@ public:
 
         if (send.fun == core::Names::typeAlias()) {
             // don't track dependencies if this is some other method named `type_alias`
-            if (!isT(send.recv)) {
+            if (!ast::MK::isT(send.recv)) {
                 extendClassOfDepth(send);
                 return;
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1175,8 +1175,7 @@ private:
             ENFORCE(send);
 
             if(send->numPosArgs() == 1) {
-                auto arg = send->getPosArg(0).deepCopy();
-                if(auto *argClass = ast::cast_tree<ast::ConstantLit>(arg)) {
+                if(auto *argClass = ast::cast_tree<ast::ConstantLit>(send->getPosArg(0))) {
                     if(argClass != nullptr && argClass->symbol.exists() && argClass->symbol.isClassOrModule()) {
                         if constexpr (isMutableStateType) {
                             symbol = argClass->symbol.asClassOrModuleRef().data(gs)->singletonClass(gs);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -101,11 +101,11 @@ bool isT(ast::ExpressionPtr &expr) {
 bool isTClassOf(ast::ExpressionPtr &expr) {
     auto *send = ast::cast_tree<ast::Send>(expr);
 
-    if(send == nullptr) {
+    if (send == nullptr) {
         return false;
     }
 
-    if(!isT(send->recv))  {
+    if (!isT(send->recv)) {
         return false;
     }
 
@@ -1165,18 +1165,18 @@ private:
         auto blockLoc = core::Loc(todo.file, block->body.loc());
         core::ClassOrModuleRef symbol = core::Symbols::StubModule();
 
-        if(auto *constant = ast::cast_tree<ast::ConstantLit>(block->body)) {
-            if(constant->symbol.exists() && constant->symbol.isClassOrModule()) {
+        if (auto *constant = ast::cast_tree<ast::ConstantLit>(block->body)) {
+            if (constant->symbol.exists() && constant->symbol.isClassOrModule()) {
                 symbol = constant->symbol.asClassOrModuleRef();
             }
-        } else if(isTClassOf(block->body)) {
+        } else if (isTClassOf(block->body)) {
             send = ast::cast_tree<ast::Send>(block->body);
 
             ENFORCE(send);
 
-            if(send->numPosArgs() == 1) {
-                if(auto *argClass = ast::cast_tree<ast::ConstantLit>(send->getPosArg(0))) {
-                    if(argClass->symbol.exists() && argClass->symbol.isClassOrModule()) {
+            if (send->numPosArgs() == 1) {
+                if (auto *argClass = ast::cast_tree<ast::ConstantLit>(send->getPosArg(0))) {
+                    if (argClass->symbol.exists() && argClass->symbol.isClassOrModule()) {
                         if constexpr (isMutableStateType) {
                             symbol = argClass->symbol.asClassOrModuleRef().data(gs)->singletonClass(gs);
                         }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1166,7 +1166,7 @@ private:
         core::ClassOrModuleRef symbol = core::Symbols::StubModule();
 
         if(auto *constant = ast::cast_tree<ast::ConstantLit>(block->body)) {
-            if(constant != nullptr && constant->symbol.exists() && constant->symbol.isClassOrModule()) {
+            if(constant->symbol.exists() && constant->symbol.isClassOrModule()) {
                 symbol = constant->symbol.asClassOrModuleRef();
             }
         } else if(isTClassOf(block->body)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1177,6 +1177,14 @@ private:
             if (send->numPosArgs() == 1) {
                 if (auto *argClass = ast::cast_tree<ast::ConstantLit>(send->getPosArg(0))) {
                     if (argClass->symbol.exists() && argClass->symbol.isClassOrModule()) {
+                        if (argClass->symbol == owner) {
+                            if (auto e = gs.beginError(blockLoc, core::errors::Resolver::InvalidRequiredAncestor)) {
+                                e.setHeader("Must not pass yourself to `{}` inside of `requires_ancestor`",
+                                            send->fun.show(gs));
+                            }
+                            return;
+                        }
+
                         if constexpr (isMutableStateType) {
                             symbol = argClass->symbol.asClassOrModuleRef().data(gs)->singletonClass(gs);
                         }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1176,7 +1176,7 @@ private:
 
             if(send->numPosArgs() == 1) {
                 if(auto *argClass = ast::cast_tree<ast::ConstantLit>(send->getPosArg(0))) {
-                    if(argClass != nullptr && argClass->symbol.exists() && argClass->symbol.isClassOrModule()) {
+                    if(argClass->symbol.exists() && argClass->symbol.isClassOrModule()) {
                         if constexpr (isMutableStateType) {
                             symbol = argClass->symbol.asClassOrModuleRef().data(gs)->singletonClass(gs);
                         }

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -18,6 +18,10 @@ module Helper3
   requires_ancestor { NotFound }
   #                   ^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
   #                   ^^^^^^^^ error: Unable to resolve constant `NotFound`
+
+  requires_ancestor { T.class_of(NotFound) }
+  #                   ^^^^^^^^^^^^^^^^^^^^ error: Argument to `class_of` must be statically resolvable to a class or a module
+  #                              ^^^^^^^^ error: Unable to resolve constant `NotFound`
 end
 
 class Helper4
@@ -37,7 +41,8 @@ module Helper5
   requires_ancestor { "Object" }
   #                   ^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
 
-  requires_ancestor { T.class_of(Object) }
+  requires_ancestor { Object.superclass }
+  #                   ^^^^^^^^^^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
 end
 
 module Helper6
@@ -45,6 +50,9 @@ module Helper6
 
   requires_ancestor { Helper6 }
   #                   ^^^^^^^ error: Must not pass yourself to `requires_ancestor`
+
+  requires_ancestor { T.class_of(Helper6) }
+  #                   ^^^^^^^^^^^^^^^^^^^ error: Must not pass yourself to `class_of` inside of `requires_ancestor`
 end
 
 module Helper7

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -34,11 +34,10 @@ end
 module Helper5
   extend T::Helpers
 
-  requires_ancestor { "Object" } # error: Expected `Module` but found `String("Object")` for block result type
+  requires_ancestor { "Object" }
   #                   ^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
 
-  requires_ancestor { T.class_of(Object) } # error: Expected `Module` but found `Runtime object representing type: T.class_of(Object)` for block result type
-  #                   ^^^^^^^^^^^^^^^^^^ error: Argument to `requires_ancestor` must be statically resolvable to a class or a module
+  requires_ancestor { T.class_of(Object) }
 end
 
 module Helper6

--- a/test/testdata/resolver/requires_ancestor_singleton_class.rb
+++ b/test/testdata/resolver/requires_ancestor_singleton_class.rb
@@ -1,0 +1,33 @@
+# typed: true
+# enable-experimental-requires-ancestor: true
+
+module Helper
+  extend T::Helpers
+
+  requires_ancestor { T.class_of(Foo) }
+
+  def helper
+    foo
+  end
+end
+
+class Foo
+  class << self
+    include Helper
+
+    def foo; end
+
+    def foo2
+      helper
+    end
+  end
+end
+
+class Bar
+  class << self
+# ^^^^^ error: `T.class_of(Bar)` must inherit `T.class_of(Foo)` (required by `Helper`)
+    include Helper
+
+    def bar; end
+  end
+end

--- a/website/docs/requires-ancestor.md
+++ b/website/docs/requires-ancestor.md
@@ -157,3 +157,25 @@ class MyBrokenTest < Test::TestBase # error: `MyBrokenTest` must include `Test::
   include MyTestHelper
 end
 ```
+
+`requires_ancestor` can also be used to require a singleton class as an ancestor:
+
+```
+module MyHelper
+  extend T::Helpers
+
+  requires_ancestor { T.class_of(MyBaseClass) }
+
+  def helper
+    my_singleton_method
+  end
+end
+
+class MyBaseClass
+  class << self
+    include MyHelper
+
+    def my_singleton_method; end
+  end
+end
+```

--- a/website/docs/requires-ancestor.md
+++ b/website/docs/requires-ancestor.md
@@ -158,7 +158,8 @@ class MyBrokenTest < Test::TestBase # error: `MyBrokenTest` must include `Test::
 end
 ```
 
-`requires_ancestor` can also be used to require a singleton class as an ancestor:
+`requires_ancestor` can also be used to require a singleton class as an
+ancestor:
 
 ```
 module MyHelper


### PR DESCRIPTION
Closes #4835.

This PR allows users to return `T.class_of` objects from the block of `requires_ancestor`. Using this functionality, users can now verify inheritance from a singleton class, rather than just a class or module, which is a feature that has been widely requested (see #4835).

### Motivation
Currently, `requires_ancestor` will not work if you try to return a singleton class/`T.class_of` object from its block argument. This prevents users from ensuring inheritance from a singleton class, which is useful in cases like this:

```
module MyHelper
  extend T::Helpers

  requires_ancestor { T.class_of(MyBaseClass) }

  def helper
    my_singleton_method
  end
end

class MyBaseClass
  class << self
    include MyHelper

    def my_singleton_method; end
  end
end
```

### Test plan
Automated tests have been added and updated to reflect this change.