### PR TITLE
Fix `InterfaceWrapper` for ruby 2.7/3 kwarg compatibility

### DIFF
--- a/gems/sorbet-runtime/lib/types/interface_wrapper.rb
+++ b/gems/sorbet-runtime/lib/types/interface_wrapper.rb
@@ -71,6 +71,10 @@ class T::InterfaceWrapper
         target_obj.send(method_name, *args, &blk)
       end
 
+      if singleton_class.respond_to?(:ruby2_keywords, true)
+        singleton_class.send(:ruby2_keywords, method_name)
+      end
+
       if target_obj.singleton_class.public_method_defined?(method_name)
         # no-op, it's already public
       elsif target_obj.singleton_class.protected_method_defined?(method_name)

--- a/gems/sorbet-runtime/test/types/interface_wrapper.rb
+++ b/gems/sorbet-runtime/test/types/interface_wrapper.rb
@@ -16,6 +16,10 @@ class Opus::Types::Test::InterfaceWrapperTest < Critic::Unit::UnitTest
     private def priv
       42
     end
+
+    def kwarg(x:)
+      x + 1
+    end
   end
 
   module Mixin2
@@ -128,6 +132,37 @@ class Opus::Types::Test::InterfaceWrapperTest < Critic::Unit::UnitTest
       assert_raises(RuntimeError) {T::InterfaceWrapper.wrap_instances([@obj, nil], Mixin)}
       assert_raises(RuntimeError) {T::InterfaceWrapper.wrap_instances([@obj, "foo"], Mixin)}
       assert_raises(RuntimeError) {T::InterfaceWrapper.wrap_instances([@obj, 5], Mixin)}
+    end
+  end
+
+  describe "argument forwarding" do
+    it "does not cause Ruby keyword argument warnings" do
+      # this test has a few different failure modes:
+      # - on 2.6 and below, we want to make sure we don't call the
+      #   `ruby2_keywords` helper method because it doesn't exist yet
+      # - on 2.7, we want to make sure we don't get warnings about
+      #   bad kwarg usage: to do this, we enable the relevant deprecation
+      #   warnings for the duration of the test and assert that the warn
+      #   method is never called
+      # - on 3 and above, simply calling a wrapped kwarg method is
+      #   sufficient to show that the behavior is correct: if we didn't
+      #   specify `ruby2_keywords`, then it would fail with a "wrong
+      #   number of arguments" error.
+
+      begin
+        if RUBY_VERSION.start_with?("2.7")
+          Warning[:deprecated] = true
+          replaced = T::Private::ClassUtils.replace_method(Warning, :warn) do |warning|
+            raise "Found kwarg warning: #{warning}"
+          end
+        end
+        @wrapper.kwarg(x: 5)
+      ensure
+        if RUBY_VERSION.start_with?("2.7")
+          replaced&.restore
+          Warning[:deprecated] = false
+        end
+      end
     end
   end
 end

--- a/gems/sorbet-runtime/test/types/interface_wrapper.rb
+++ b/gems/sorbet-runtime/test/types/interface_wrapper.rb
@@ -17,8 +17,8 @@ class Opus::Types::Test::InterfaceWrapperTest < Critic::Unit::UnitTest
       42
     end
 
-    def kwarg(x:)
-      x + 1
+    def kwarg(bar:)
+      bar + 1
     end
   end
 
@@ -149,19 +149,17 @@ class Opus::Types::Test::InterfaceWrapperTest < Critic::Unit::UnitTest
       #   specify `ruby2_keywords`, then it would fail with a "wrong
       #   number of arguments" error.
 
-      begin
-        if RUBY_VERSION.start_with?("2.7")
-          Warning[:deprecated] = true
-          replaced = T::Private::ClassUtils.replace_method(Warning, :warn) do |warning|
-            raise "Found kwarg warning: #{warning}"
-          end
+      if RUBY_VERSION.start_with?("2.7")
+        Warning[:deprecated] = true
+        replaced = T::Private::ClassUtils.replace_method(Warning, :warn) do |warning|
+          raise "Found kwarg warning: #{warning}"
         end
-        @wrapper.kwarg(x: 5)
-      ensure
-        if RUBY_VERSION.start_with?("2.7")
-          replaced&.restore
-          Warning[:deprecated] = false
-        end
+      end
+      @wrapper.kwarg(bar: 5)
+    ensure
+      if RUBY_VERSION.start_with?("2.7")
+        replaced&.restore
+        Warning[:deprecated] = false
       end
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This lets us keep using `InterfaceWrapper` even on Ruby 3+. (It'd be nice to get rid of it, but it's currently load-bearing, so this kicks the can on getting rid of it.)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a test and ran it (locally) with Ruby 2.6, 2.7, and 3.0 to verify that it correctly works on all of them.
