### PR TITLE
convert maps of `FoundMethodHashes` into maps of `FoundDefHashes`

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -223,7 +223,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
 
 vector<ast::ParsedFile>
 incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
-                   optional<UnorderedMap<core::FileRef, core::FoundMethodHashes>> &&foundMethodHashesForFiles,
+                   optional<UnorderedMap<core::FileRef, core::FoundDefHashes>> &&foundHashesForFiles,
                    const options::Options &opts) {
     try {
 #ifndef SORBET_REALMAIN_MIN
@@ -238,9 +238,9 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
             core::UnfreezeNameTable nameTable(gs);
             auto emptyWorkers = WorkerPool::create(0, gs.tracer());
 
-            auto result = foundMethodHashesForFiles.has_value()
+            auto result = foundHashesForFiles.has_value()
                               ? sorbet::namer::Namer::runIncremental(
-                                    gs, move(what), std::move(foundMethodHashesForFiles.value()), *emptyWorkers)
+                                    gs, move(what), std::move(foundHashesForFiles.value()), *emptyWorkers)
                               : sorbet::namer::Namer::run(gs, move(what), *emptyWorkers, nullptr);
 
             // Cancellation cannot occur during incremental namer.

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -37,11 +37,11 @@ ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std:
 // that AST has already been resolved once before on the fast path
 std::vector<ast::ParsedFile>
 incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
-                   std::optional<UnorderedMap<core::FileRef, core::FoundMethodHashes>> &&foundMethodHashesForFiles,
+                   std::optional<UnorderedMap<core::FileRef, core::FoundDefHashes>> &&foundHashesForFiles,
                    const options::Options &opts);
 
 // This function only calls Namer::symbolizeTreesBestEffort, not Namer::defineSymbols, which means
-// there's no point in taking any FoundMethodHashes.
+// there's no point in taking any FoundDefHashes.
 std::vector<ast::ParsedFile> incrementalResolveBestEffort(const core::GlobalState &gs,
                                                           std::vector<ast::ParsedFile> what,
                                                           const options::Options &opts);

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -13,7 +13,7 @@ namespace sorbet::namer {
 class Namer final {
     static ast::ParsedFilesOrCancelled
     runInternal(core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers,
-                UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
+                UnorderedMap<core::FileRef, core::FoundDefHashes> &&oldFoundDefHashesForFiles,
                 core::FoundDefHashes *foundHashesOut);
 
 public:
@@ -28,18 +28,17 @@ public:
     static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
                                            WorkerPool &workers, core::FoundDefHashes *foundHashesOut);
 
-    // Version of Namer that accepts the old FoundMethodHashes for each file to run Namer, which
+    // Version of Namer that accepts the old FoundDefHashes for each file to run Namer, which
     // it uses to figure out how to mutate the already-populated GlobalState into the right shape
     // when considering that only the files in `trees` were edited.
     //
     // `trees` and `foundMethodHashesForFiles` should have the same number of elements, and
-    // `foundMethodHashesForFiles[i]` should be the `FoundMethodHashes` for `trees[i]`.
+    // `foundMethodHashesForFiles[i]` should be the `FoundDefHashes` for `trees[i]`.
     // (Done this way, instead of using something like a `std::pair`, to avoid intermediate
-    // allocations for phases that don't actually need to operate on the `FoundMethodHashes`.)
+    // allocations for phases that don't actually need to operate on the `FoundDefHashes`.)
     static ast::ParsedFilesOrCancelled
     runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
-                   UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
-                   WorkerPool &workers);
+                   UnorderedMap<core::FileRef, core::FoundDefHashes> &&oldFoundDefHashesForFiles, WorkerPool &workers);
 
     Namer() = delete;
 };

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -32,8 +32,8 @@ public:
     // it uses to figure out how to mutate the already-populated GlobalState into the right shape
     // when considering that only the files in `trees` were edited.
     //
-    // `trees` and `foundMethodHashesForFiles` should have the same number of elements, and
-    // `foundMethodHashesForFiles[i]` should be the `FoundDefHashes` for `trees[i]`.
+    // `trees` and `foundDef` should have the same number of elements, and
+    // `foundDefHashesForFiles[i]` should be the `FoundDefHashes` for `trees[i]`.
     // (Done this way, instead of using something like a `std::pair`, to avoid intermediate
     // allocations for phases that don't actually need to operate on the `FoundDefHashes`.)
     static ast::ParsedFilesOrCancelled


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is the other half of #6280.  I briefly toyed with having separate maps for methods, fields, etc., but I think rolling everything up into one map is the right way to go.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
