### PR TITLE
add an lsp fast path test for swapping class order

### DIFF
--- a/test/testdata/lsp/fast_path/swap_class_order.1.rbupdate
+++ b/test/testdata/lsp/fast_path/swap_class_order.1.rbupdate
@@ -3,10 +3,10 @@
 
 module A
   class C
-    def bar; end
+    def method_on_c; end
   end
 
   class B
-    def foo; end
+    def method_on_b; end
   end
 end

--- a/test/testdata/lsp/fast_path/swap_class_order.1.rbupdate
+++ b/test/testdata/lsp/fast_path/swap_class_order.1.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# assert-slow-path: true
+
+module A
+  class C
+    def bar; end
+  end
+
+  class B
+    def foo; end
+  end
+end

--- a/test/testdata/lsp/fast_path/swap_class_order.rb
+++ b/test/testdata/lsp/fast_path/swap_class_order.rb
@@ -2,10 +2,10 @@
 
 module A
   class B
-    def foo; end
+    def method_on_b; end
   end
 
   class C
-    def bar; end
+    def method_on_c; end
   end
 end

--- a/test/testdata/lsp/fast_path/swap_class_order.rb
+++ b/test/testdata/lsp/fast_path/swap_class_order.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+module A
+  class B
+    def foo; end
+  end
+
+  class C
+    def bar; end
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is pretty dumb, but it is the sort of thing that one might expect should take the fast path (even if it doesn't), so we might as well have it as a test.  It took me a little time to write the test and understand why, anyway.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
