### PR TITLE
make fields always owned by classes in namer

### DIFF
--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -195,6 +195,7 @@ struct FoundField {
         InstanceVariable,
     };
     Kind kind;
+    bool onSingletonClass;
     FoundDefinitionRef owner;
     core::LocOffsets loc;
     core::NameRef name;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -523,11 +523,8 @@ public:
         core::FoundField found;
         found.kind = uid->kind == ast::UnresolvedIdent::Kind::Instance ? core::FoundField::Kind::InstanceVariable
                                                                        : core::FoundField::Kind::ClassVariable;
-        auto onSingletonClass = found.kind == core::FoundField::Kind::InstanceVariable;
         auto [owner, isSelfMethod] = getOwnerSkippingMethods();
-        if (isSelfMethod.has_value()) {
-            onSingletonClass = isSelfMethod.value();
-        }
+        auto onSingletonClass = isSelfMethod.value_or(found.kind == core::FoundField::Kind::InstanceVariable);
         found.onSingletonClass = onSingletonClass;
         found.owner = owner;
         found.loc = uid->loc;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -239,9 +239,13 @@ public:
 
     void postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &original = ast::cast_tree_nonnull<ast::Send>(tree);
+        auto ownerIsMethod = getOwnerRaw().kind() == core::FoundDefinitionRef::Kind::Method;
 
         switch (original.fun.rawId()) {
             case core::Names::privateClassMethod().rawId(): {
+                if (ownerIsMethod) {
+                    break;
+                }
                 for (auto &arg : original.posArgs()) {
                     addMethodModifier(ctx, original.fun, arg);
                 }
@@ -252,6 +256,9 @@ public:
             case core::Names::private_().rawId():
             case core::Names::protected_().rawId():
             case core::Names::public_().rawId():
+                if (ownerIsMethod) {
+                    break;
+                }
                 if (!original.hasPosArgs()) {
                     ENFORCE(!methodVisiStack.empty());
                     methodVisiStack.back() = optional<core::FoundModifier>{core::FoundModifier{
@@ -268,6 +275,9 @@ public:
                 }
                 break;
             case core::Names::privateConstant().rawId(): {
+                if (ownerIsMethod) {
+                    break;
+                }
                 for (auto &arg : original.posArgs()) {
                     addConstantModifier(ctx, original.fun, arg);
                 }
@@ -297,6 +307,9 @@ public:
                 break;
             }
             case core::Names::aliasMethod().rawId(): {
+                if (ownerIsMethod) {
+                    break;
+                }
                 addMethodAlias(ctx, original);
                 break;
             }

--- a/test/testdata/infer/private_inside_method.rb
+++ b/test/testdata/infer/private_inside_method.rb
@@ -6,7 +6,7 @@ class A
 end
 
 # Sorbet needs a static view of the world. We assume that once a method is
-# defined, that's it's visibility always.
+# defined, that's its visibility always.
 
 # no runtime error
 A.foo

--- a/test/testdata/infer/private_inside_method.rb
+++ b/test/testdata/infer/private_inside_method.rb
@@ -6,12 +6,12 @@ class A
 end
 
 # Sorbet needs a static view of the world. We assume that once a method is
-# defined, that's its visibility always.
+# defined, that's it's visibility always.
 
-# no runtime error, but static error because we saw `private :foo`
-A.foo # error: Non-private call to private method `foo`
+# no runtime error
+A.foo
 
 A.bar
 
-# runtime error (private call), static error because we saw `private :foo`
-A.foo # error: Non-private call to private method `foo`
+# runtime error (private call)
+A.foo

--- a/test/testdata/rewriter/flatten_module_private_class_method.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/flatten_module_private_class_method.rb.symbol-table-raw.exp
@@ -7,7 +7,7 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:8 end=3:9}
     method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=3:1 end=8:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
-    method <S <C <U A>> $1>#<U bar> : private (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=5:26 end=5:38}
+    method <S <C <U A>> $1>#<U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=5:26 end=5:38}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
     method <S <C <U A>> $1>#<U thing> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=4:3 end=4:17}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
@@ -16,7 +16,7 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U B>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U B>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=B) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=10:7 end=10:8}
     method <S <C <U B>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=10:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
-    method <S <C <U B>> $1>#<U bar> : private (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=12:26 end=12:38}
+    method <S <C <U B>> $1>#<U bar> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=12:26 end=12:38}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}
     method <S <C <U B>> $1>#<U thing> (<blk>) @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=11:3 end=11:17}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/flatten_module_private_class_method.rb start=??? end=???}


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a followup to #6265.  Playing around with the necessary changes for #6278 indicate that we really do want fields to be owned by classes.  Otherwise, we have a sort of chicken-and-egg scenario for fields on the fast path:

1. Fields are owned by methods
2. We are going to delete (some) methods followed by re-defining (some) methods.
3. Therefore we have to delete and define fields prior to doing the same with methods.
4. But when we go to delete fields, we don't have enough information to figure out who the method "owner" is: we only have indices into a table of (not-yet defined!) methods, and worse, those indices are into a table that doesn't actually exist.

Making fields owned by classes works much better, as we can be assured the necessary class(es) are still around when we go to delete fields.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
