### PR TITLE
drop angle brackets on `describe` and `it` symbols in document symbols

### DIFF
--- a/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
@@ -29,7 +29,7 @@
             },
             "children": [
                 {
-                    "name": "<describe 'with this block'>",
+                    "name": "describe 'with this block'",
                     "detail": "",
                     "kind": 5,
                     "range": {
@@ -54,7 +54,7 @@
                     },
                     "children": [
                         {
-                            "name": "<it 'runs another test'>",
+                            "name": "it 'runs another test'",
                             "detail": "",
                             "kind": 6,
                             "range": {
@@ -80,7 +80,7 @@
                             "children": []
                         },
                         {
-                            "name": "<it 'runs one test'>",
+                            "name": "it 'runs one test'",
                             "detail": "",
                             "kind": 6,
                             "range": {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Feature request from Stripe.  This makes document symbols slightly cleaner for tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
