### PR TITLE
do parallel maps with less work in the packager

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2,6 +2,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
+#include "absl/synchronization/blocking_counter.h"
 #include "ast/Helpers.h"
 #include "ast/treemap/treemap.h"
 #include "common/FileOps.h"
@@ -13,6 +14,7 @@
 #include "core/Unfreeze.h"
 #include "core/errors/packager.h"
 #include "core/packages/PackageInfo.h"
+#include <algorithm>
 #include <cctype>
 #include <sstream>
 #include <sys/stat.h>
@@ -1498,20 +1500,19 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
     {
         Timer timeit(gs.tracer(), "packager.rewritePackagesAndFiles");
 
-        auto resultq = make_shared<BlockingBoundedQueue<vector<ast::ParsedFile>>>(files.size());
-        auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(files.size());
-        for (auto &file : files) {
-            fileq->push(move(file), 1);
+        auto taskq = std::make_shared<ConcurrentBoundedQueue<size_t>>(files.size());
+        absl::BlockingCounter barrier(max(workers.size(), 1));
+
+        for (size_t i = 0; i < files.size(); ++i) {
+            taskq->push(i, 1);
         }
 
-        workers.multiplexJob("rewritePackagesAndFiles", [&gs, fileq, resultq]() {
+        workers.multiplexJob("rewritePackagesAndFiles", [&gs, &files, &barrier, taskq]() {
             Timer timeit(gs.tracer(), "packager.rewritePackagesAndFilesWorker");
-            vector<ast::ParsedFile> results;
-            uint32_t filesProcessed = 0;
-            ast::ParsedFile job;
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+            size_t idx;
+            for (auto result = taskq->try_pop(idx); !result.done(); result = taskq->try_pop(idx)) {
+                ast::ParsedFile &job = files[idx];
                 if (result.gotItem()) {
-                    filesProcessed++;
                     auto &file = job.file.data(gs);
                     core::Context ctx(gs, core::Symbols::root(), job.file);
 
@@ -1520,30 +1521,14 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
                     } else {
                         job = rewritePackagedFile(ctx, move(job));
                     }
-
-                    results.emplace_back(move(job));
                 }
             }
-            if (filesProcessed > 0) {
-                resultq->push(move(results), filesProcessed);
-            }
+
+            barrier.DecrementCount();
         });
-        files.clear();
 
-        {
-            vector<ast::ParsedFile> threadResult;
-            for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-                 !result.done();
-                 result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
-                if (result.gotItem()) {
-                    files.insert(files.end(), make_move_iterator(threadResult.begin()),
-                                 make_move_iterator(threadResult.end()));
-                }
-            }
-        }
+        barrier.Wait();
     }
-
-    fast_sort(files, [](const auto &a, const auto &b) -> bool { return a.file < b.file; });
 
     return files;
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The packager (both the actual packaging and the visibility checking pass(es)) are essentially parallel maps over the list of files we have.  This PR implements them in such a way to more closely reflect that, making the respective passes ~5% faster in the process.

It's worth noting that the same technique can be applied in other places for a small speedup, but this seemed like a good place to start.

It's also worth noting that I tried adding some `ENFORCE(absl::c_is_sorted(...));` scattered about.  I ran into testcase failures, because we have:

https://github.com/sorbet/sorbet/blob/567368a1dbc373991db5a44c869792610750b612/main/lsp/LSPTypechecker.cc#L412-L417

which does not provide sorted input to the resolving phase (packager/namer/resolver).  Upon reflection, I think not asserting sortedness is the right thing to do here: anything that cares about ordering (e.g. resolving signatures) will have to ensure sortedness beforehand; anything that doesn't care should not be providing stronger guarantees to downstream consumers.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
