### PR TITLE
Fix type member of `RDoc::Markup::Document` to `T.untyped`

### DIFF
--- a/rbi/stdlib/rdoc.rbi
+++ b/rbi/stdlib/rdoc.rbi
@@ -4401,7 +4401,7 @@ end
 class RDoc::Markup::Document
   include(::Enumerable)
 
-  Elem = type_member(:out)
+  Elem = type_member(:out) {{fixed: T.untyped}}
 
   # Creates a new
   # [`Document`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/Document.html)


### PR DESCRIPTION
The `parts` that can be stored in `RDoc::Markup::Document` seem to be anything that can be converted to string, thus there is no harm in fixing the type member to `T.untyped`.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
If we don't fix this type variable, signatures that reference `RDoc::Markup::Document` get a "Malformed type declaration. Generic class without type arguments `RDoc::Markup::Document` (fix available)" error

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No new tests.
