### PR TITLE
Add missing URI::Parser, URI::REGEXP

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -137,8 +137,10 @@ module URI
   HOST = T.let(T.unsafe(nil), Regexp)
   HTML5ASCIIINCOMPAT = T.let(T.unsafe(nil), String)
   OPAQUE = T.let(T.unsafe(nil), Regexp)
+  Parser = URI::RFC2396_Parser
   PORT = T.let(T.unsafe(nil), Regexp)
   QUERY = T.let(T.unsafe(nil), Regexp)
+  REGEXP = URI::RFC2396_REGEXP
   REGISTRY = T.let(T.unsafe(nil), Regexp)
   REL_PATH = T.let(T.unsafe(nil), Regexp)
   REL_URI = T.let(T.unsafe(nil), Regexp)

--- a/test/testdata/rbi/uri.rb
+++ b/test/testdata/rbi/uri.rb
@@ -8,3 +8,13 @@ def validate_http(uri_string)
   raise 'Must be an HTTP URI' unless uri.is_a?(URI::HTTP)
   uri
 end
+
+sig {returns(Class)}
+def uri_parser
+  URI::Parser
+end
+
+sig {returns(Module)}
+def uri_regexp
+  URI::REGEXP
+end


### PR DESCRIPTION
Ruby defines `URI::Parser` to alias `URI::RFC2396_Parser` (class). Likewise `URI::REGEXP` aliases `URI::RFC2396_REGEXP` (module). Sorbet doesn't appear to know these ([→ sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0AURI%3A%3AParser%0AURI%3A%3AREGEXP)).

I've had a stab at the rbi file, though pretty uncertain I'm anywhere near the correct way to go about defining these aliases (is reopening URI later in the file acceptable? is `T.let` needed for a simple alias?). I'm happy to implement feedback on this, and I marked this PR as draft for this reason.

### Motivation

My project uses URI::Parser but sorbet cannot resolve that constant.

### Test plan

I added these to test/testdata/rbi/uri.rb - here too I have low confidence in how correctly I am doing it, and can improve / fix per feedback. 