### PR TITLE
Add intrinsic for `+` on empty tuples

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3326,8 +3326,14 @@ public:
         auto *tuple = cast_type<TupleType>(args.thisType);
         ENFORCE(tuple != nullptr);
 
-        res = dispatchCallProxyType(gs, args.thisType.underlying(gs), args);
-        if (tuple->elems.empty() && args.args.size() == 1) {
+        auto specialEmptyTupleCase = tuple->elems.empty() && args.args.size() == 1 &&
+                                     (isa_type<TupleType>(args.args[0]->type) ||
+                                      Types::isSubType(gs, Types::arrayOfUntyped(), args.args[0]->type));
+        auto underlying =
+            specialEmptyTupleCase ? core::Types::arrayOf(gs, core::Types::bottom()) : args.thisType.underlying(gs);
+
+        res = dispatchCallProxyType(gs, underlying, args);
+        if (specialEmptyTupleCase) {
             res.returnType = args.args[0]->type;
         }
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3320,6 +3320,19 @@ public:
     }
 } Tuple_concat;
 
+class Tuple_plus : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        auto *tuple = cast_type<TupleType>(args.thisType);
+        ENFORCE(tuple != nullptr);
+
+        res = dispatchCallProxyType(gs, args.thisType.underlying(gs), args);
+        if (tuple->elems.empty() && args.args.size() == 1) {
+            res.returnType = args.args[0]->type;
+        }
+    }
+} Tuple_plus;
+
 namespace {
 
 optional<Loc> locOfValueForKey(const GlobalState &gs, const Loc origin, const NameRef key, const TypePtr expectedType) {
@@ -4170,6 +4183,7 @@ const vector<Intrinsic> intrinsics{
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::sample(), &Tuple_sample},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::toA(), &Tuple_to_a},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::concat(), &Tuple_concat},
+    {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::plus(), &Tuple_plus},
 
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::squareBracketsEq(), &Shape_squareBracketsEq},
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::merge(), &Shape_merge},

--- a/test/testdata/infer/tuple_plus.rb
+++ b/test/testdata/infer/tuple_plus.rb
@@ -1,0 +1,27 @@
+# typed: true
+extend T::Sig
+
+def example1
+  xs = []
+  T.reveal_type(xs) # error: `[] (0-tuple)`
+  xs += [1]
+  T.reveal_type(xs) # error: `[Integer(1)] (1-tuple)`
+  xs += [2]
+  T.reveal_type(xs) # error: `T::Array[Integer]`
+end
+
+sig {params(ys: T::Array[Integer]).void}
+def example2(ys)
+  xs = []
+  T.reveal_type(xs) # error: `[] (0-tuple)`
+  xs += ys
+  T.reveal_type(xs) # error: `T::Array[Integer]`
+end
+
+sig {params(ys: T::Array[Integer]).void}
+def example3(ys)
+  xs = []
+  T.reveal_type(xs) # error: `[] (0-tuple)`
+  ys += xs
+  T.reveal_type(ys) # error: `T::Array[Integer]`
+end

--- a/test/testdata/infer/tuple_plus.rb
+++ b/test/testdata/infer/tuple_plus.rb
@@ -25,3 +25,23 @@ def example3(ys)
   ys += xs
   T.reveal_type(ys) # error: `T::Array[Integer]`
 end
+
+def example4
+  xs = []
+  xs += "asdf"
+  #     ^^^^^^ error: Expected `T::Enumerable[T.untyped]` but found `String("asdf")` for argument `arg0`
+  T.reveal_type(xs) # error: `T::Array[T.untyped]`
+end
+
+def example5
+  xs = []
+  xs += {}
+  T.reveal_type(xs) # error: `T::Array[T.untyped]`
+end
+
+sig {params(ys: T::Array[T.untyped]).void}
+def example6(ys)
+  xs = []
+  xs += ys
+  T.reveal_type(xs) # error: `T::Array[T.untyped]`
+end


### PR DESCRIPTION
Before, the revealed type for `xs` was `T::Array[T.untyped]` after the
`+=` assignment.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.