### PR TITLE
delete no longer applicable comment on `resolveField`

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2057,7 +2057,6 @@ class ResolveTypeMembersAndFieldsWalk {
         return castType;
     }
 
-    // Attempts to resolve the type of the given field. Returns `false` if the cast is not yet resolved.
     static void resolveField(core::MutableContext ctx, ResolveFieldItem &job) {
         auto cast = job.cast;
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The second half of this comment is no longer applicable.  And once we don't need the second half, the first half is kind of redundant with the name of the function itself.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
