### PR TITLE
add lsp fast path tests for declaring instance/class variables at wrong scope

### DIFF
--- a/test/testdata/lsp/fast_path/class_ivar_at_method_scope.1.rbupdate
+++ b/test/testdata/lsp/fast_path/class_ivar_at_method_scope.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# assert-slow-path: true
+
+class A
+  def self.wherein_we_add_an_ivar
+    @var = T.let(0, Integer) # error: The singleton instance variable `@var` must be declared inside the class body or declared nilable
+    T.reveal_type(@var) # error: Revealed type: `Integer`
+  end
+end

--- a/test/testdata/lsp/fast_path/class_ivar_at_method_scope.rb
+++ b/test/testdata/lsp/fast_path/class_ivar_at_method_scope.rb
@@ -1,0 +1,7 @@
+# typed: true
+# assert-slow-path: true
+
+class A
+  def self.wherein_we_add_an_ivar
+  end
+end

--- a/test/testdata/lsp/fast_path/cvar_at_method_scope.1.rbupdate
+++ b/test/testdata/lsp/fast_path/cvar_at_method_scope.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# assert-slow-path: true
+
+class A
+  def self.wherein_we_add_a_cvar
+    @@var = T.let(0, Integer) # error: The class variable `@@var` must be declared at class scope
+    T.reveal_type(@@var) # error: Revealed type: `Integer`
+  end
+end

--- a/test/testdata/lsp/fast_path/cvar_at_method_scope.rb
+++ b/test/testdata/lsp/fast_path/cvar_at_method_scope.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+class A
+  def self.wherein_we_add_a_cvar
+  end
+end

--- a/test/testdata/lsp/fast_path/ivar_at_method_scope.1.rbupdate
+++ b/test/testdata/lsp/fast_path/ivar_at_method_scope.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-slow-path: true
+class A
+  def wherein_we_add_an_ivar
+    @var = T.let(0, Integer) # error: The instance variable `@var` must be declared inside `initialize` or declared nilable
+    T.reveal_type(@var) # error: Revealed type: `Integer`
+  end
+end

--- a/test/testdata/lsp/fast_path/ivar_at_method_scope.rb
+++ b/test/testdata/lsp/fast_path/ivar_at_method_scope.rb
@@ -1,0 +1,8 @@
+# typed: true
+# assert-slow-path: true
+
+class A
+  def wherein_we_add_an_ivar
+  end
+end
+


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Trying to add more tests that #6278 would exercise.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
