### PR TITLE
Add a new autoloader_compatibility DSL to package-spec files

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -588,6 +588,11 @@ void GlobalState::initEmpty() {
     method = this->staticInitForClass(core::Symbols::root(), Loc::none());
     ENFORCE(method == Symbols::rootStaticInit());
 
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::autoloader_compatibility())
+                 .arg(Names::arg0())
+                 .build();
+    ENFORCE(method == Symbols::PackageSpec_autoloader_compatibility());
+
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ResolvedSig());
     ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSig());
     klass = Symbols::Sorbet_Private_Static_ResolvedSig().data(*this)->singletonClass(*this);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1007,6 +1007,10 @@ public:
         return MethodRef::fromRaw(12);
     }
 
+    static MethodRef PackageSpec_autoloader_compatibility() {
+        return MethodRef::fromRaw(13);
+    }
+
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
         return ClassOrModuleRef::fromRaw(86);
     }
@@ -1062,7 +1066,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 207;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 47;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 48;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 105;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -443,6 +443,7 @@ NameDef names[] = {
     {"test_import"},
     {"export_", "export"},
     {"restrict_to_service"},
+    {"autoloader_compatibility"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageSpecRegistry", "<PackageSpecRegistry>", true},
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -652,6 +652,7 @@ void parseIgnorePatterns(const vector<string> &rawIgnorePatterns, vector<string>
 }
 
 bool extractAutoloaderConfig(cxxopts::ParseResult &raw, Options &opts, shared_ptr<spdlog::logger> logger) {
+    Timer timeit(*logger, "extractAutoloaderConfig");
     AutoloaderConfig &cfg = opts.autoloaderConfig;
     if (raw.count("autogen-autoloader-exclude-require") > 0) {
         cfg.requireExcludes = raw["autogen-autoloader-exclude-require"].as<vector<string>>();
@@ -721,8 +722,10 @@ void readOptions(Options &opts,
         }
 
         if (raw.count("ignore") > 0) {
-            auto rawIgnorePatterns = raw["ignore"].as<vector<string>>();
-            parseIgnorePatterns(rawIgnorePatterns, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
+            {
+                auto rawIgnorePatterns = raw["ignore"].as<vector<string>>();
+                parseIgnorePatterns(rawIgnorePatterns, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
+            }
         }
 
         opts.pathPrefix = raw["remove-path-prefix"].as<string>();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1134,6 +1134,7 @@ struct PackageInfoFinder {
             case core::Names::test_import().rawId():
             case core::Names::export_().rawId():
             case core::Names::restrict_to_service().rawId():
+            case core::Names::autoloader_compatibility().rawId():
                 return true;
             default:
                 return false;

--- a/test/cli/package-special-allowed-dsls/foo/__package.rb
+++ b/test/cli/package-special-allowed-dsls/foo/__package.rb
@@ -3,4 +3,5 @@
 class Project::Foo < PackageSpec
   restrict_to_service Project::Foo
   restrict_to_service Project::Bar
+  autoloader_compatibility 'legacy'
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds a new DSL method called `autoloader_compatibility` to `__package.rb` files

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In the Stripe codebase, we are in the midst of a migration related to how we autoload code. In order to facilitate this migration, we need to add a new configuration to package files that is related to the compatibility of the code inside the package file with a given autoloader.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.