### PR TITLE
Follow up to #6299 (Allow `requires_ancestor` to return `T.class_of` object)

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -758,7 +758,10 @@ void validateUnsatisfiableRequiredAncestors(core::Context ctx, const core::Class
             requiredClasses.emplace_back(ancst);
         }
 
-        if (ancst.symbol.data(ctx)->typeArity(ctx) > 0 && !ancst.symbol.data(ctx)->isSingletonClass(ctx)) {
+        auto isSingletonClass = ancst.symbol.data(ctx)->isSingletonClass(ctx);
+        auto typeArity = ancst.symbol.data(ctx)->typeArity(ctx);
+
+        if ((isSingletonClass && typeArity > 1) || (!isSingletonClass && typeArity > 0)) {
             if (auto e = ctx.state.beginError(data->loc(), core::errors::Resolver::UnsatisfiableRequiredAncestor)) {
                 e.setHeader("`{}` can't require generic ancestor `{}` (unsupported)", sym.show(ctx),
                             ancst.symbol.show(ctx));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1185,7 +1185,7 @@ private:
                         }
 
                         if constexpr (isMutableStateType) {
-                            symbol = argClass->symbol.asClassOrModuleRef().data(gs)->singletonClass(gs);
+                            symbol = argClass->symbol.asClassOrModuleRef().data(gs)->lookupSingletonClass(gs);
                         }
                     }
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1184,9 +1184,7 @@ private:
                             return;
                         }
 
-                        if constexpr (isMutableStateType) {
-                            symbol = argClass->symbol.asClassOrModuleRef().data(gs)->lookupSingletonClass(gs);
-                        }
+                        symbol = argClass->symbol.asClassOrModuleRef().data(gs)->lookupSingletonClass(gs);
                     }
                 }
             }

--- a/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
+++ b/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
@@ -57,3 +57,34 @@ module Test3
     end
   end
 end
+
+module Test4
+  class RA
+    extend T::Sig
+    extend T::Generic
+
+    Elem = type_template
+
+    sig {returns(T.nilable(Elem))}
+    def self.elem
+      @elem
+    end
+
+      sig { params(elem: T.nilable(Elem)).void }
+    def self.initialize(elem)
+      @elem = T.let(elem, T.nilable(Elem))
+    end
+  end
+
+  module M # error: `Test4::M` can't require generic ancestor `T.class_of(Test4::RA)` (unsupported)
+    extend T::Sig
+    extend T::Helpers
+
+    requires_ancestor { T.class_of(RA) }
+
+    sig { void }
+    def elem
+      self.elem
+    end
+  end
+end

--- a/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
+++ b/test/testdata/resolver/requires_ancestor_unsupported_generics.rb
@@ -26,3 +26,34 @@ module Test2
     requires_ancestor { RA }
   end
 end
+
+module Test3
+  class RA
+    class << self
+      extend T::Sig
+      extend T::Generic
+
+      Elem = type_member
+
+      sig {returns(T.nilable(Elem))}
+      attr_accessor :elem
+
+      sig { params(elem: T.nilable(Elem)).void }
+      def initialize(elem)
+        @elem = T.let(elem, T.nilable(Elem))
+      end
+    end
+  end
+
+  module M # error: `Test3::M` can't require generic ancestor `T.class_of(Test3::RA)` (unsupported)
+    extend T::Sig
+    extend T::Helpers
+
+    requires_ancestor { T.class_of(RA) }
+
+    sig { void }
+    def elem
+      self.elem
+    end
+  end
+end


### PR DESCRIPTION
This is a follow up to #6299 to address @jez's comments.


### Motivation
There were a couple of oversights in my previous PR that made it possible to require singleton classes as ancestors:
- I incorrectly used the `singletonClass` method instead of `lookupSingletonClass`
- I didn't account for the fact that generics are not allowed to be required ancestors, and singleton classes can be generics

### Test plan
I added an automated test based on [Jake's comment](https://github.com/sorbet/sorbet/pull/6299/files#r960131829).
