### PR TITLE
Rename AccountModelMerchantToken to AccountModelMerchant::Token

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -542,7 +542,8 @@ NameDef names[] = {
     {"Test", "Test", true},
     {"Autogen", "Autogen", true},
     {"Tokens", "Tokens", true},
-    {"AccountModelMerchantToken", "AccountModelMerchantToken", true},
+    {"AccountModelMerchant", "AccountModelMerchant", true},
+    {"Token", "Token", true},
 
     // used by the compiler
     {"returnValue", "<returnValue>"},

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -197,10 +197,10 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
                     send->loc,
                     ast::MK::UnresolvedConstant(
                         send->loc,
-                        ast::MK::UnresolvedConstant(
-                            send->loc,
-                            ast::MK::UnresolvedConstant(send->loc, ast::MK::EmptyTree(), core::Names::Constants::Opus()),
-                            core::Names::Constants::Autogen()),
+                        ast::MK::UnresolvedConstant(send->loc,
+                                                    ast::MK::UnresolvedConstant(send->loc, ast::MK::EmptyTree(),
+                                                                                core::Names::Constants::Opus()),
+                                                    core::Names::Constants::Autogen()),
                         core::Names::Constants::Tokens()),
                     core::Names::Constants::AccountModelMerchant()),
                 core::Names::Constants::Token());

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -197,10 +197,13 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
                     send->loc,
                     ast::MK::UnresolvedConstant(
                         send->loc,
-                        ast::MK::UnresolvedConstant(send->loc, ast::MK::EmptyTree(), core::Names::Constants::Opus()),
-                        core::Names::Constants::Autogen()),
-                    core::Names::Constants::Tokens()),
-                core::Names::Constants::AccountModelMerchantToken());
+                        ast::MK::UnresolvedConstant(
+                            send->loc,
+                            ast::MK::UnresolvedConstant(send->loc, ast::MK::EmptyTree(), core::Names::Constants::Opus()),
+                            core::Names::Constants::Autogen()),
+                        core::Names::Constants::Tokens()),
+                    core::Names::Constants::AccountModelMerchant()),
+                core::Names::Constants::Token());
             break;
 
         default:

--- a/test/testdata/rewriter/shard_by_merchant_prop.rb
+++ b/test/testdata/rewriter/shard_by_merchant_prop.rb
@@ -1,10 +1,10 @@
 # typed: true
 
-module Opus::Autogen::Tokens
+module Opus::Autogen::Tokens::AccountModelMerchant
   # This isn't exactly right; this would actually be more like a type alias to
   # a String, but we're using a class to make sure that the Prop.cc logic is
   # right.
-  class AccountModelMerchantToken; end
+  class Token; end
 end
 
 module ShardByMerchant
@@ -32,5 +32,5 @@ end
 T.reveal_type(MerchantPropModel.new.merchant) # error: Revealed type: `String`
 MerchantPropModel.new.merchant = "hi" # error: Method `merchant=` does not exist
 
-T.reveal_type(MerchantTokenPropModel.new.merchant) # error: Revealed type: `Opus::Autogen::Tokens::AccountModelMerchantToken`
+T.reveal_type(MerchantTokenPropModel.new.merchant) # error: Revealed type: `Opus::Autogen::Tokens::AccountModelMerchant::Token`
 MerchantTokenPropModel.new.merchant = nil # error: Method `merchant=` does not exist

--- a/test/testdata/rewriter/shard_by_merchant_prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/shard_by_merchant_prop.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Opus>::<C Autogen>::<C Tokens><<C <todo sym>>> < ()
-    class <emptyTree>::<C AccountModelMerchantToken><<C <todo sym>>> < (::<todo sym>)
+  module <emptyTree>::<C Opus>::<C Autogen>::<C Tokens>::<C AccountModelMerchant><<C <todo sym>>> < ()
+    class <emptyTree>::<C Token><<C <todo sym>>> < (::<todo sym>)
     end
   end
 
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C MerchantTokenPropModel><<C <todo sym>>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.returns(<emptyTree>::<C Opus>::<C Autogen>::<C Tokens>::<C AccountModelMerchantToken>)
+      <self>.returns(<emptyTree>::<C Opus>::<C Autogen>::<C Tokens>::<C AccountModelMerchant>::<C Token>)
     end
 
     def merchant<<todo method>>(&<blk>)

--- a/test/testdata/rewriter/shard_by_merchant_prop_compiled.rb
+++ b/test/testdata/rewriter/shard_by_merchant_prop_compiled.rb
@@ -1,11 +1,11 @@
 # compiled: true
 # typed: true
 
-module Opus::Autogen::Tokens
+module Opus::Autogen::Tokens::AccountModelMerchant
   # This isn't exactly right; this would actually be more like a type alias to
   # a String, but we're using a class to make sure that the Prop.cc logic is
   # right.
-  class AccountModelMerchantToken; end
+  class Token; end
 end
 
 module ShardByMerchant
@@ -33,5 +33,5 @@ end
 T.reveal_type(MerchantPropModel.new.merchant) # error: Revealed type: `String`
 MerchantPropModel.new.merchant = "hi" # error: Method `merchant=` does not exist
 
-T.reveal_type(MerchantTokenPropModel.new.merchant) # error: Revealed type: `Opus::Autogen::Tokens::AccountModelMerchantToken`
+T.reveal_type(MerchantTokenPropModel.new.merchant) # error: Revealed type: `Opus::Autogen::Tokens::AccountModelMerchant::Token`
 MerchantTokenPropModel.new.merchant = nil # error: Method `merchant=` does not exist

--- a/test/testdata/rewriter/shard_by_merchant_prop_compiled.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/shard_by_merchant_prop_compiled.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Opus>::<C Autogen>::<C Tokens><<C <todo sym>>> < ()
-    class <emptyTree>::<C AccountModelMerchantToken><<C <todo sym>>> < (::<todo sym>)
+  module <emptyTree>::<C Opus>::<C Autogen>::<C Tokens>::<C AccountModelMerchant><<C <todo sym>>> < ()
+    class <emptyTree>::<C Token><<C <todo sym>>> < (::<todo sym>)
     end
   end
 
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C MerchantTokenPropModel><<C <todo sym>>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.returns(<emptyTree>::<C Opus>::<C Autogen>::<C Tokens>::<C AccountModelMerchantToken>)
+      <self>.returns(<emptyTree>::<C Opus>::<C Autogen>::<C Tokens>::<C AccountModelMerchant>::<C Token>)
     end
 
     def merchant<<todo method>>(&<blk>)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This PR renames `AccountModelMerchantToken` to `AccountModelMerchant::Token` since that's the actual generated type.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Removing the need for the alias `AccountModelMerchantToken` to the actual generated type `AccountModelMerchant::Token`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
- Included tests
