### PR TITLE
free found definitions in parallel in namer

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1354,7 +1354,7 @@ class SymbolDefiner {
                 break;
             }
             case core::FoundDefinitionRef::Kind::Field: {
-                const auto &field = ref.field(foundDefs);
+                const auto &field = ref.field(*foundDefs);
                 insertField(ctx.withOwner(getOwnerSymbol(field.owner)), field);
                 break;
             }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The code is kind of gross, but we can parallelize the freeing of all the found definitions during tree symbolificaton rather than doing it while we populate the global symbol table.

The proof-of-concept where we just leaked the found definitions took about 5% off the time required to populate the symbol table on Stripe's codebase, so ideally actually doing the work in parallel should realize approximately the same speedup.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
