### PR TITLE
Remove realpath from a test

### DIFF
--- a/test/cli/windows-line-endings/test.sh
+++ b/test/cli/windows-line-endings/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-file --brief test/cli/windows-line-endings/windows-line-endings.rb
+file --brief --dereference test/cli/windows-line-endings/windows-line-endings.rb
 
 main/sorbet --silence-dev-message test/cli/windows-line-endings/windows-line-endings.rb 2>&1

--- a/test/cli/windows-line-endings/test.sh
+++ b/test/cli/windows-line-endings/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-file --brief "$(realpath test/cli/windows-line-endings/windows-line-endings.rb)"
+file --brief test/cli/windows-line-endings/windows-line-endings.rb
 
 main/sorbet --silence-dev-message test/cli/windows-line-endings/windows-line-endings.rb 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't really need `realpath` in this test


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

A test failed because the new mac laptop didn't have realpath yet.

It seems not particularly useful to use realpath here.

Separately I've installed `realpath` on the laptop.