### PR TITLE
🐛 Allow nil separator in IO.gets

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -1378,7 +1378,7 @@ class IO < Object
   # ```
   sig do
     params(
-        sep: String,
+        sep: T.nilable(String),
         limit: Integer,
     )
     .returns(T.nilable(String))

--- a/test/testdata/rbi/io.rb
+++ b/test/testdata/rbi/io.rb
@@ -15,3 +15,13 @@ def test_io_read_encoding(file_name)
   IO.read(file_name, encoding: 42)
   #                            ^^ error: Expected `T.any(String, Encoding)` but found `Integer(42)` for argument `encoding`
 end
+
+sig {params(io: IO).void}
+def test_io_gets(io)
+  io.gets('')
+  io.gets('', 1)
+  io.gets('\n')
+  io.gets('\n', 1)
+  io.gets(nil)
+  io.gets(nil, 1)
+end


### PR DESCRIPTION
Fixes #6360

### Motivation
Despite the documentation (and runtime!) saying that `nil` is acceptable for the `sep`:

https://github.com/sorbet/sorbet/blob/48877f8a29cebb32e0de2b975c92872d812738aa/rbi/core/io.rbi#L1334-L1338

The signature doesn't allow it:

https://github.com/sorbet/sorbet/blob/48877f8a29cebb32e0de2b975c92872d812738aa/rbi/core/io.rbi#L1379-L1386

### Test plan
- `bazel build //main:sorbet && bazel run //main:sorbet -- ~/stripe/sorbet/test/testdata/rbi/io.rb`
- Running against Stripe's codebase