### PR TITLE
make `T::Private::Casts` methods take positional args only

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -130,7 +130,7 @@ module T
   def self.cast(value, type, checked: true)
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.cast")
+    Private::Casts.cast(value, type, "T.cast")
   end
 
   # Tells the typechecker to declare a variable of type `type`. Use
@@ -145,7 +145,7 @@ module T
   def self.let(value, type, checked: true)
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.let")
+    Private::Casts.cast(value, type, "T.let")
   end
 
   # Tells the type checker to treat `self` in the current block as `type`.
@@ -164,7 +164,7 @@ module T
   def self.bind(value, type, checked: true)
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.bind")
+    Private::Casts.cast(value, type, "T.bind")
   end
 
   # Tells the typechecker to ensure that `value` is of type `type` (if not, the typechecker will
@@ -174,7 +174,7 @@ module T
   def self.assert_type!(value, type, checked: true)
     return value unless checked
 
-    Private::Casts.cast(value, type, cast_method: "T.assert_type!")
+    Private::Casts.cast(value, type, "T.assert_type!")
   end
 
   # For the static type checker, strips all type information from a value

--- a/gems/sorbet-runtime/lib/types/private/casts.rb
+++ b/gems/sorbet-runtime/lib/types/private/casts.rb
@@ -3,7 +3,7 @@
 
 module T::Private
   module Casts
-    def self.cast(value, type, cast_method:)
+    def self.cast(value, type, cast_method)
       begin
         error = T::Utils.coerce(type).error_message_for_obj(value)
         return value unless error
@@ -22,7 +22,7 @@ module T::Private
     # there's a lot of shared logic with the above one, but factoring
     # it out like this makes it easier to hopefully one day delete
     # this one
-    def self.cast_recursive(value, type, cast_method:)
+    def self.cast_recursive(value, type, cast_method)
       begin
         error = T::Utils.coerce(type).error_message_for_obj_recursive(value)
         return value unless error

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -32,7 +32,7 @@ module T::Utils
   # in some cases this runtime check can be very expensive, especially
   # with large collections of objects.
   def self.check_type_recursive!(value, type)
-    T::Private::Casts.cast_recursive(value, type, cast_method: "T.check_type_recursive!")
+    T::Private::Casts.cast_recursive(value, type, "T.check_type_recursive!")
   end
 
   # Returns the set of all methods (public, protected, private) defined on a module or its


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The (MRI) Ruby VM features fast paths for methods written in Ruby if they only have required positional args and are only passed positional args.  There exist fast paths for methods with required positional + kwargs if there are no kwargs or all of the relevant kwargs are passed (as in calls to `T::Private::Casts.cast` currently), but the fast paths for only required positional args are, well, faster than the kwargs ones.

This is pretty minor, but it does make `T.let` performance with `bundle exec rake bench:typecheck` a couple percent faster.  (If we could figure out some way to not call `T::Utils.coerce` on every `T.let` call, that would be fantastic, but looking for micro-optimizations in the couch cushions here will have to do.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
