### PR TITLE
reuse state across multiple consecutive `SymbolDefiner` invocations

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -595,6 +595,7 @@ public:
         State(State &&) = default;
         State &operator=(State &&) = default;
     };
+
 private:
     State state;
     const core::FoundDefinitions &foundDefs;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Each run of `SymbolDefiner` (tens of thousands on Stripe's codebase) allocates a separate vector of defined classes and methods.  We can do better than this by wrapping those up into a `State` object that are re-used across run.

This shaves about ~1% off of symbol definition time during namer.  But more importantly, we have a bug with the LSP fast path where methods and fields moving across files + changes in their definitions can result in inconsistencies.  This framework gives us a way to address that, since we can potentially save state from individual `SymbolDefiner` runs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
