### PR TITLE
define toplevel instance and class variables on the correct scope

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1169,7 +1169,11 @@ class SymbolDefiner {
         // resolver checks a whole bunch of various error conditions here; we just want to
         // know where to define the field.
         ENFORCE(ctx.owner.isClassOrModule(), "Actual {}", ctx.owner.show(ctx));
-        auto scope = methodOwner(ctx, ctx.owner, field.onSingletonClass);
+        auto scope = ctx.owner.enclosingClass(ctx);
+        if (field.onSingletonClass) {
+            scope = scope.data(ctx)->lookupSingletonClass(ctx);
+        }
+        ENFORCE(scope.exists());
 
         auto existing = scope.data(ctx)->findMember(ctx, field.name);
         if (existing.exists() && existing.isFieldOrStaticField()) {

--- a/test/testdata/namer/toplevel_instance_variable.rb
+++ b/test/testdata/namer/toplevel_instance_variable.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+@a = T.let(1, T.nilable(Integer))
+
+@@b = T.let("", T.nilable(String))

--- a/test/testdata/namer/toplevel_instance_variable.rb.symbol-table.exp
+++ b/test/testdata/namer/toplevel_instance_variable.rb.symbol-table.exp
@@ -1,0 +1,7 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/namer/toplevel_instance_variable.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/namer/toplevel_instance_variable.rb start=??? end=???}
+    field ::<Class:<root>>#@a -> T.nilable(Integer) @ test/testdata/namer/toplevel_instance_variable.rb:3
+  static-field ::@@b -> T.nilable(String) @ test/testdata/namer/toplevel_instance_variable.rb:5
+


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes a debug enforce after #6278.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The included testcase was generated at the commit prior to #6278, which is where the crash was introduced.  It's not obvious to me that Sorbet is defining the variables in the "right" place for Ruby's runtime behavior, but at least we're not regressing things.