### PR TITLE
add support for ruby 3-style array values for method modifiers

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -239,14 +239,21 @@ public:
 
     void addMethodModifiers(core::Context ctx, core::NameRef modifierName,
                             absl::Span<const ast::ExpressionPtr> sendArgs) {
-        for (auto &arg : sendArgs) {
-            if (auto *array = ast::cast_tree<ast::Array>(arg)) {
+        if (sendArgs.empty()) {
+            return;
+        }
+
+        if (sendArgs.size() == 1) {
+            if (auto *array = ast::cast_tree<ast::Array>(sendArgs[0])) {
                 for (auto &e : array->elems) {
                     addMethodModifier(ctx, modifierName, e);
                 }
-            } else {
-                addMethodModifier(ctx, modifierName, arg);
+                return;
             }
+        }
+
+        for (auto &arg : sendArgs) {
+            addMethodModifier(ctx, modifierName, arg);
         }
     }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -237,6 +237,12 @@ public:
         ownerStack.pop_back();
     }
 
+    void addMethodModifiers(core::Context ctx, core::NameRef modifierName, absl::Span<const ast::ExpressionPtr> sendArgs) {
+        for (auto &arg : sendArgs) {
+            addMethodModifier(ctx, modifierName, arg);
+        }
+    }
+
     void postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &original = ast::cast_tree_nonnull<ast::Send>(tree);
         auto ownerIsMethod = getOwnerRaw().kind() == core::FoundDefinitionRef::Kind::Method;
@@ -246,9 +252,7 @@ public:
                 if (ownerIsMethod) {
                     break;
                 }
-                for (auto &arg : original.posArgs()) {
-                    addMethodModifier(ctx, original.fun, arg);
-                }
+                addMethodModifiers(ctx, original.fun, original.posArgs());
                 break;
             }
             case core::Names::packagePrivate().rawId():
@@ -269,9 +273,7 @@ public:
                         core::NameRef::noName(),
                     }};
                 } else {
-                    for (auto &arg : original.posArgs()) {
-                        addMethodModifier(ctx, original.fun, arg);
-                    }
+                    addMethodModifiers(ctx, original.fun, original.posArgs());
                 }
                 break;
             case core::Names::privateConstant().rawId(): {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -239,7 +239,13 @@ public:
 
     void addMethodModifiers(core::Context ctx, core::NameRef modifierName, absl::Span<const ast::ExpressionPtr> sendArgs) {
         for (auto &arg : sendArgs) {
-            addMethodModifier(ctx, modifierName, arg);
+            if (auto *array = ast::cast_tree<ast::Array>(arg)) {
+                for (auto &e : array->elems) {
+                    addMethodModifier(ctx, modifierName, e);
+                }
+            } else {
+                addMethodModifier(ctx, modifierName, arg);
+            }
         }
     }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -237,7 +237,8 @@ public:
         ownerStack.pop_back();
     }
 
-    void addMethodModifiers(core::Context ctx, core::NameRef modifierName, absl::Span<const ast::ExpressionPtr> sendArgs) {
+    void addMethodModifiers(core::Context ctx, core::NameRef modifierName,
+                            absl::Span<const ast::ExpressionPtr> sendArgs) {
         for (auto &arg : sendArgs) {
             if (auto *array = ast::cast_tree<ast::Array>(arg)) {
                 for (auto &e : array->elems) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

cc @gustavodegeus

#6352 adds support for typing `private_class_method([:foo])`, which is newly supported in Ruby 3.  We also need corresponding changes to namer to recognize this new syntax.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

There are no tests added here; I will follow up after #6352 lands with tests.  I have confirmed locally that the testcase I suggested there correctly emits the expected errors with #6352 applied on top of this branch.