### PR TITLE
fix placement for instance variables defined in toplevel methods

### DIFF
--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -119,20 +119,23 @@ using FoundMethodHashes = std::vector<FoundMethodHash>;
 struct FoundFieldHash {
     struct {
         // The owner of this field.
-        uint32_t idx : 30;
+        uint32_t idx : 29;
         // Whether the field was defined on instances of the class or on the singleton class.
         bool onSingletonClass : 1;
         // Whether the field was a class or instance variable.
         // TODO(froydnj) we should just subsume class variables into the more
         // general static fields, since that's how we represent them internally.
         bool isInstanceVariable : 1;
+        // Whether the definition of the field comes from inside a method.
+        bool fromWithinMethod : 1;
     } owner;
 
     // Hash of this field's name.
     const FullNameHash nameHash;
 
-    FoundFieldHash(uint32_t ownerIdx, bool onSingletonClass, bool isInstanceVariable, FullNameHash nameHash)
-        : owner({ownerIdx, onSingletonClass, isInstanceVariable}), nameHash(nameHash) {
+    FoundFieldHash(uint32_t ownerIdx, bool onSingletonClass, bool isInstanceVariable, bool fromWithinMethod,
+                   FullNameHash nameHash)
+        : owner({ownerIdx, onSingletonClass, isInstanceVariable, fromWithinMethod}), nameHash(nameHash) {
         sanityCheck();
     }
 

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -196,6 +196,7 @@ struct FoundField {
     };
     Kind kind;
     bool onSingletonClass;
+    bool fromWithinMethod;
     FoundDefinitionRef owner;
     core::LocOffsets loc;
     core::NameRef name;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -278,6 +278,7 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
         p.putU4(ffh.owner.idx);
         p.putU1(ffh.owner.onSingletonClass);
         p.putU1(ffh.owner.isInstanceVariable);
+        p.putU1(ffh.owner.fromWithinMethod);
         p.putU4(ffh.nameHash._hashValue);
     }
 }
@@ -342,9 +343,11 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
         auto ownerIdx = p.getU4();
         auto onSingletonClass = p.getU1();
         auto isInstanceVariable = p.getU1();
+        auto fromWithinMethod = p.getU1();
         FullNameHash fullNameHash;
         fullNameHash._hashValue = p.getU4();
-        ret.foundHashes.fieldHashes.emplace_back(ownerIdx, onSingletonClass, isInstanceVariable, fullNameHash);
+        ret.foundHashes.fieldHashes.emplace_back(ownerIdx, onSingletonClass, isInstanceVariable, fromWithinMethod,
+                                                 fullNameHash);
     }
     return make_unique<const FileHash>(move(ret));
 }

--- a/test/testdata/namer/toplevel_attr_writer.rb
+++ b/test/testdata/namer/toplevel_attr_writer.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+extend T::Sig
+
+sig {returns(T.untyped)}
+attr_writer :foo # error: Malformed `sig`. Type not specified for argument `foo`

--- a/test/testdata/namer/toplevel_attr_writer.rb.symbol-table.exp
+++ b/test/testdata/namer/toplevel_attr_writer.rb.symbol-table.exp
@@ -1,0 +1,10 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> (Sig)
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/namer/toplevel_attr_writer.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/namer/toplevel_attr_writer.rb start=??? end=???}
+  class ::Object < ::BasicObject (Kernel) @ https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED
+    field ::Object#@foo -> T.untyped @ test/testdata/namer/toplevel_attr_writer.rb:6
+    method ::Object#foo= : private (foo, <blk>) -> T.untyped @ test/testdata/namer/toplevel_attr_writer.rb:6
+      argument foo<> -> T.untyped @ Loc {file=test/testdata/namer/toplevel_attr_writer.rb start=6:14 end=6:17}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/toplevel_attr_writer.rb start=??? end=???}
+


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #6376.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  The testcase was generated at `f6135c7b09532ea2dbb4df17da37f1b39e78303a^`
