### PR TITLE
add a Ruby 3.1 build

### DIFF
--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -72,6 +72,14 @@ def register_ruby_dependencies():
         build_file = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD",
     )
 
+    http_archive(
+        name = "sorbet_ruby_3_1",
+        urls = _ruby_urls("3.1/ruby-3.1.2.tar.gz"),
+        sha256 = "61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e",
+        strip_prefix = "ruby-3.1.2",
+        build_file = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD",
+    )
+
 def _rubygems_urls(gem):
     """
     Produce a url list that works both with rubygems, and stripe's internal gem cache.


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More Ruby builds are more better.  This is currently stacked on top of #6378 so that I don't have to write snapshot tests, will rebase once that lands.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
