### PR TITLE
RFC: Allow instance variable declaration inside `Minitest::Test#setup` method

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -543,6 +543,7 @@ NameDef names[] = {
     {"Autogen", "Autogen", true},
     {"Tokens", "Tokens", true},
     {"AccountModelMerchant", "AccountModelMerchant", true},
+    {"Minitest", "Minitest", true},
     {"Token", "Token", true},
 
     // used by the compiler

--- a/test/testdata/resolver/minitest.rb
+++ b/test/testdata/resolver/minitest.rb
@@ -1,0 +1,82 @@
+# typed: strict
+
+class Foo
+  extend T::Sig
+
+  sig { void }
+  def setup
+    @foo1 = T.let(5, Integer)
+#   ^^^^^ error: The instance variable `@foo1` must be declared inside `initialize` or declared nilable
+  end
+end
+
+module Minitest
+  class Test; end
+
+  class Foo
+    extend T::Sig
+
+    sig { void }
+    def setup
+      @foo2 = T.let(5, Integer)
+#     ^^^^^ error: The instance variable `@foo2` must be declared inside `initialize` or declared nilable
+    end
+  end
+end
+
+class Bar < Minitest::Foo
+  extend T::Sig
+
+  sig { void }
+  def setup
+    @foo3 = T.let(5, Integer)
+#   ^^^^^ error: The instance variable `@foo3` must be declared inside `initialize` or declared nilable
+  end
+end
+
+class BestCaseTestClass < Minitest::Test
+  extend T::Sig
+
+  sig { params(a: T.untyped, b: T.untyped).void }
+  def assert_equal(a, b); end
+
+  sig { void }
+  def initialize
+    @a = T.let(3, Integer)
+  end
+
+  sig { void }
+  def setup
+    @b = T.let(4, Integer)
+  end
+
+  test "it works" do
+    assert_equal 3, @a
+    assert_equal 4, @b
+  end
+end
+
+class SubclassOfMinitestTest < Minitest::Test
+end
+
+class SubSubclassOfMinitestTest < SubclassOfMinitestTest
+  extend T::Sig
+
+  sig { params(a: T.untyped, b: T.untyped).void }
+  def assert_equal(a, b); end
+
+  sig { void }
+  def initialize
+    @x = T.let(1, Integer)
+  end
+
+  sig { void }
+  def setup
+    @y = T.let(2, Integer)
+  end
+
+  test "it works" do
+    assert_equal 1, @x
+    assert_equal 2, @y
+  end
+end


### PR DESCRIPTION
This is a proof of concept from the Ruby Developer Experience Team at Shopify! Feedback welcome. (cc: @dirceu)

### Motivation

Currently, Sorbet doesn't allow non-nilable instance variables to be declared inside the `Minitest::Test#setup` method:

```
class Bar < Minitest::Test
  def setup
    @foo = T.let(42, Integer) # Error: The instance variable `@foo` must be declared inside `initialize` or declared `nilable`
  end
end
```

[[sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Minitest%0A%20%20class%20Test%0A%20%20%20%20def%20setup%3B%20end%0A%20%20end%0Aend%0A%0Aclass%20Bar%20%3C%20Minitest%3A%3ATest%0A%20%20def%20setup%0A%20%20%20%20%40foo%20%3D%20T.let%2842%2C%20Integer%29%0A%20%20end%0Aend)]

This forces us to use some workarounds that are not the right way to use Minitest:

https://github.com/Shopify/rbi-central/blob/main/gem/test/test_helper.rb#L142

## Implementation

We've attempted to solve this problem by modifying some behavior in the resolver, but we're not sure if there might be a better way to approach this issue. Feedback would be appreciated!

## Test Plan

See added tests.
