### PR TITLE
don't crash for non-existent args in the initializer rewriter

### DIFF
--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -53,7 +53,11 @@ void maybeAddLet(core::MutableContext ctx, ast::ExpressionPtr &expr,
     if (typeExpr != argTypeMap.end() && isCopyableType(*typeExpr->second)) {
         auto loc = rhs->loc;
         auto type = (*typeExpr->second).deepCopy();
-        switch (argKindMap.at(rhs->name)) {
+        auto it = argKindMap.find(rhs->name);
+        if (it == argKindMap.end()) {
+            return;
+        }
+        switch (it->second) {
             case ArgKind::Plain:
                 break;
             case ArgKind::RestArg: {

--- a/test/testdata/rewriter/initializer_local.rb
+++ b/test/testdata/rewriter/initializer_local.rb
@@ -1,0 +1,12 @@
+# typed: strict
+
+class A
+  extend T::Sig
+
+  sig {params(y: T.nilable(String)).void}
+  #           ^ error: Unknown argument name `y`
+  def initialize
+    y = 1
+    @y = y # error: The instance variable `@y` must be declared
+  end
+end

--- a/test/testdata/rewriter/initializer_no_arg_with_local.rb
+++ b/test/testdata/rewriter/initializer_no_arg_with_local.rb
@@ -1,0 +1,16 @@
+# typed: strict
+
+class A
+  extend T::Sig
+
+  # At one point, the parser would produce local variables inside the method,
+  # but no corresponding argument in the method definition.
+  sig {params(x: Integer, y: T.nilable(String)).void}
+  #                       ^ error: Unknown argument name `y`
+  def initialize(x, y=nil, )
+                # ^ error: unexpected token ","
+    @x = x
+    @y = y
+  # ^^ error: The instance variable `@y` must be declared
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #6383.

Arguably, this is a problem in the parser, and the `.at()` here is correct.  But I think it would be better to be tolerant of input shaped not quite like we expect.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
