### PR TITLE
Split apart VS Code extension crash reason

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/src/LanguageClient.ts
+++ b/vscode_extension/src/LanguageClient.ts
@@ -89,6 +89,7 @@ export default class SorbetLanguageClient implements ErrorHandler {
 
   // Contains the Sorbet process.
   private _sorbetProcess: ChildProcess | null = null;
+  private _sorbetProcessExitCode: number | null = null;
 
   // Tracks disposable subscriptions so we can clean them up when language client is disposed.
   private _subscriptions: { dispose: () => void }[] = [];
@@ -271,7 +272,15 @@ export default class SorbetLanguageClient implements ErrorHandler {
     this._sorbetProcess = spawn(command, args, {
       cwd: workspace.rootPath,
     });
-    const onExit = (err?: NodeJS.ErrnoException) => {
+    // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
+    // So, we need to handle both events. ¯\_(ツ)_/¯
+    this._sorbetProcess.on(
+      "exit",
+      (code: number | null, _signal: string | null) => {
+        this._sorbetProcessExitCode = code;
+      },
+    );
+    this._sorbetProcess.on("error", (err?: NodeJS.ErrnoException) => {
       if (
         err &&
         this._status === ServerStatus.INITIALIZING &&
@@ -287,11 +296,8 @@ export default class SorbetLanguageClient implements ErrorHandler {
         this._updateStatus(ServerStatus.ERROR);
       }
       this._sorbetProcess = null;
-    };
-    // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
-    // So, we need to handle both events. ¯\_(ツ)_/¯
-    this._sorbetProcess.on("exit", onExit);
-    this._sorbetProcess.on("error", onExit);
+      this._sorbetProcessExitCode = err?.errno ?? null;
+    });
     return Promise.resolve(this._sorbetProcess);
   }
 
@@ -306,7 +312,7 @@ export default class SorbetLanguageClient implements ErrorHandler {
   public error(): ErrorAction {
     if (this._status !== ServerStatus.ERROR) {
       this._updateStatus(ServerStatus.RESTARTING);
-      this._restart(RestartReason.CRASH);
+      this._restart(RestartReason.CRASH_LC_ERROR);
     }
     return ErrorAction.Shutdown;
   }
@@ -317,7 +323,15 @@ export default class SorbetLanguageClient implements ErrorHandler {
   public closed(): CloseAction {
     if (this._status !== ServerStatus.ERROR) {
       this._updateStatus(ServerStatus.RESTARTING);
-      this._restart(RestartReason.CRASH);
+      let reason = RestartReason.CRASH_LC_CLOSED;
+      if (this._sorbetProcessExitCode === 11) {
+        // 11 is EAGAIN
+        reason = RestartReason.WRAPPER_REFUSED_SPAWN;
+      } else if (this._sorbetProcessExitCode === 143) {
+        // 143 = 128 + 15 and 15 is TERM signal
+        reason = RestartReason.FORCIBLY_TERMINATED;
+      }
+      this._restart(reason);
     }
     return CloseAction.DoNotRestart;
   }

--- a/vscode_extension/src/SorbetStatusBarEntry.ts
+++ b/vscode_extension/src/SorbetStatusBarEntry.ts
@@ -59,7 +59,7 @@ export default class SorbetStatusBarEntry {
         this._sorbetExtensionConfig.setEnabled(false);
         break;
       case Action.RestartSorbet:
-        this._restartSorbet(RestartReason.CRASH);
+        this._restartSorbet(RestartReason.STATUS_BAR_BUTTON);
         break;
       default:
         // Nothing selected.
@@ -112,7 +112,7 @@ export default class SorbetStatusBarEntry {
     this._lastError = lastError;
     this._render();
     if (isError) {
-      this._restartSorbet(RestartReason.CRASH);
+      this._restartSorbet(RestartReason.CRASH_EXT_ERROR);
     }
   }
 

--- a/vscode_extension/src/types.ts
+++ b/vscode_extension/src/types.ts
@@ -9,8 +9,22 @@ export interface ShowOperationParams {
 
 // Reasons why Sorbet might be restarted.
 export enum RestartReason {
+  // Command manuallyinvoked from command palette
   COMMAND = "command",
-  CRASH = "crash",
+  // Manually invoked from the user clicking on "Restart Sorbet" in status bar popup
+  STATUS_BAR_BUTTON = "status_bar_button",
+  // For environments where a wrapper script protects the `sorbet` invocation,
+  // and fails to start it under certain circumstances (for example, an rsync
+  // client not running in the background, or a VPN not being connected).
+  WRAPPER_REFUSED_SPAWN = "wrapper_refused_spawn",
+  // For situations where `sorbet` died because it was sent the TERM signal
+  FORCIBLY_TERMINATED = "forcibly_terminated",
+  // LanguageClient closed callback
+  CRASH_LC_CLOSED = "crash_lc_closed",
+  // LanguageClient error callback
+  CRASH_LC_ERROR = "crash_lc_error",
+  // Extension (non-LanguageClient) error
+  CRASH_EXT_ERROR = "crash_ext_error",
   CONFIG_CHANGE = "config_change",
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We had a monolithic crash reason. Stripe's codebase sees 2 million such crash
events per day. I highly suspect that most of those are what I'm calling the new
`WRAPPER_REFUSED_SPAWN` bucket.

Importantly, we don't have any references to the old "crash" metric, and none of
our existing dashboards were looking at it. So we should be able to ignore all
`crash` metrics as being entirely from old clients (instead of having to filter
out "only up to date clients" or something).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on Stripe's codebase.

### TODO

- [x] Review comments
- [x] Send PR to Stripe's codebase for wrapper script
- [x] Double-check what happens if the new extension version runs somewhere with the old wrapper script.