### PR TITLE
Set URI::File parent class as URI::Generic

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -2354,5 +2354,5 @@ end
 
 # The "file" [`URI`](https://docs.ruby-lang.org/en/2.7.0/URI.html) is defined by
 # RFC8089.
-class URI::File
+class URI::File < URI::Generic
 end


### PR DESCRIPTION
Set the parent class of `URI::File` to `URI::Generic`.

### Motivation

This matches the implementation in [Ruby](https://github.com/ruby/ruby/blob/5883bc7c0791de2ce5e8b22175aef07705f0c618/lib/uri/file.rb#L10). The lack of the parent sometimes causes trouble erroring with `Parent class re-defined from Object to URI::Generic`.

### Test plan

Just an RBI change.