### PR TITLE
clean up `bind_call` benchmarks

### DIFF
--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -130,21 +130,18 @@ module SorbetBenchmarks
         arg_plus_kwargs(:bar, x: 1)
       end
 
-      time_block(".bind(example).call") do
-        Object.instance_method(:class).bind(example).call
+      time_block("direct call Object#class") do
+        example.class
+      end
+
+      class_method = Object.instance_method(:class)
+      time_block(".bind(example).call Object#class") do
+        class_method.bind(example).call
       end
 
       if T::Configuration::AT_LEAST_RUBY_2_7
-        time_block(".bind_call(example)") do
-          Object.instance_method(:class).bind_call(example)
-        end
-
-        time_block("if AT_LEAST_RUBY_2_7; .bind_call(example); end") do
-          if T::Configuration::AT_LEAST_RUBY_2_7
-            Object.instance_method(:class).bind_call(example)
-          else
-            raise "must be run on 2.7"
-          end
+        time_block(".bind_call(example) Object#class") do
+          class_method.bind_call(example)
         end
       else
         puts 'skipping UnboundMethod#bind_call tests (re-run on Ruby 2.7+)'


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

* Add a benchmark for direct calls to `Object#class` for comparison purposes
* Hoist the access for `Object.instance_method(:class)` out of the actual timed benchmark
* remove duplicate 2.7-oriented `bind_call` benchmark

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
