### PR TITLE
gracefully handle `nil` in `T::Types::Intersection#name`

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/intersection.rb
+++ b/gems/sorbet-runtime/lib/types/types/intersection.rb
@@ -20,7 +20,7 @@ module T::Types
 
     # overrides Base
     def name
-      "T.all(#{@types.map(&:name).sort.join(', ')})"
+      "T.all(#{@types.map(&:name).compact.sort.join(', ')})"
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1484,5 +1484,16 @@ module Opus::Types::Test
         assert_equal(:sym, GenericSingletonChild.foo(:sym))
       end
     end
+
+    describe "names" do
+      it 'can name T.any with runtime-created classes' do
+        klass = Class.new
+        name = T.any(klass, String).name
+        assert_equal(name, "T.any(String)")
+
+        name = T.any(String, klass).name
+        assert_equal(name, "T.any(String)")
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1494,6 +1494,15 @@ module Opus::Types::Test
         name = T.any(String, klass).name
         assert_equal(name, "T.any(String)")
       end
+
+      it 'can name T.all with runtime-created classes' do
+        klass = Class.new
+        name = T.all(klass, String).name
+        assert_equal(name, "T.all(String)")
+
+        name = T.all(String, klass).name
+        assert_equal(name, "T.all(String)")
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a gross corner case that showed up as a result of testing #4568 on Stripe's codebase.  Due to this change:

https://github.com/sorbet/sorbet/pull/4568/files#diff-e9f3c08a4fe9dd4e5c911a3cc84b06a1ef3639bf3c3d101ea26b59cb609c287fR164

We wind up calling `#name` when doing equality checking on types.  This shows up as a problem for intersection types, as sorting between strings and `nil` is not well-defined.  (This behavior is not normally a problem, but certain tests in Stripe's codebase use runtime-generated classes with `sorbet-runtime` types, and such classes don't have a name.)

Union types already handle this by dropping `nil`:

https://github.com/sorbet/sorbet/blob/58983475a4feb864551b8023b10f908bdb508b07/gems/sorbet-runtime/lib/types/types/union.rb#L39-L42

I think that is a reasonable thing to do here as well.  This does mean that the change in #4568 would cause `T.any(Class.new, String)` to compare equal to `T.any(String, Class.new)` (resp. for `T.all` with this change), which is admittedly a little weird.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
