### PR TITLE
Set RDoc::Task parent to Rake::Tasklib

### DIFF
--- a/rbi/gems/rake.rbi
+++ b/rbi/gems/rake.rbi
@@ -1,0 +1,9 @@
+# typed: __STDLIB_INTERNAL
+
+# The RDoc RBI from the stdlib references Rake::TaskLib, so we need to have the module and class defined. The actual
+# contents of the class can be generated automatically with Tapioca
+
+module Rake
+  class TaskLib
+  end
+end

--- a/rbi/stdlib/rdoc.rbi
+++ b/rbi/stdlib/rdoc.rbi
@@ -9336,7 +9336,7 @@ end
 # ```
 #
 # This will create the tasks `:rdoc`, `:rdoc:clean` and `:rdoc:force`.
-class RDoc::Task
+class RDoc::Task < Rake::TaskLib
   # Whether to run the rdoc process as an external shell (default is false)
   def external; end
 


### PR DESCRIPTION
Set the parent of `RDoc::Task` to `Rake::Tasklib` and define `Rake::Tasklib` in a new `rake.rbi`.

I propose leaving the `rake.rbi` basically empty, since Tapioca can generate the types for it. We just need `Rake::Tasklib` to be defined within Sorbet's payload to use it as a parent class.

### Motivation

When Tapioca generates types for RDoc, it uses the [parent defined in Ruby](https://github.com/ruby/ruby/blob/26135312f61014967ef223dd16ad6577ebd9c5d8/lib/rdoc/task.rb#L96), which conflicts with Sorbet's stdlib payload and results in `Parent re-defined from Object to Rake::Tasklib` issues.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Just RBI changes.