### PR TITLE
consider `NilClass` props with a default `nil` as nilable

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -300,7 +300,9 @@ class T::Props::Decorator
     .checked(:never)
   end
   private def prop_nilable?(cls, rules)
-    T::Utils::Nilable.is_union_with_nilclass(cls) || (cls == T.untyped && rules.key?(:default) && rules[:default].nil?)
+    # NB: `prop` and `const` do not `T::Utils::coerce the type of the prop if it is a `Module`,
+    # hence the bare `NilClass` check.
+    T::Utils::Nilable.is_union_with_nilclass(cls) || ((cls == T.untyped || cls == NilClass) && rules.key?(:default) && rules[:default].nil?)
   end
 
   # checked(:never) - Rules hash is expensive to check

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -1346,7 +1346,9 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'round-trip serializes' do
       h = {'still_required_prop' => 5}
       x = ConstDefault.from_hash!(h)
+      assert_nil(x.required_at_some_point)
       x = x.with(still_required_prop: 6)
+      assert_nil(x.required_at_some_point)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -1337,6 +1337,19 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
   end
 
+  class ConstDefault < T::Struct
+    const :required_at_some_point, NilClass, default: nil
+    const :still_required_prop, Integer
+  end
+
+  describe 'const NilClass' do
+    it 'round-trip serializes' do
+      h = {'still_required_prop' => 5}
+      x = ConstDefault.from_hash!(h)
+      x = x.with(still_required_prop: 6)
+    end
+  end
+
   class MuckAboutWithPropInternals
     include T::Props::Serializable
     include T::Props::WeakConstructor


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Code has been written with `const :prop, T.nilable(NilClass)` to work around this omission.  Such props block #4568, and I think it's reasonable to disallow `T.nilable(NilClass)` in `type_syntax.cc` entirely.

But to get to this point, we have to have a reasonable path forward for `T.nilable(NilClass)` users, and this PR implements that.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
