### PR TITLE
Add fast-path Union subclass for unions of two simple types, take 2

### DIFF
--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -167,6 +167,8 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
   Max: 1098
+  Exclude:
+    - 'test/types/types.rb'
 
 # Offense count: 38
 # Configuration parameters: IgnoredMethods.

--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -72,17 +72,21 @@ module SorbetBenchmarks
       end
 
       type = T::Utils.coerce(T.nilable(Integer))
-      time_block("T::Types::Union#valid?", iterations_in_block: 10) do
+      time_block("T.nilable(Integer).valid?", iterations_in_block: 5) do
         type.valid?(0)
         type.valid?(1)
         type.valid?(2)
         type.valid?(nil)
         type.valid?(false)
+      end
+
+      type = T::Utils.coerce(T.any(Integer, Float, T::Boolean))
+      time_block("T.any(Integer, Float, T::Boolean).valid?", iterations_in_block: 5) do
         type.valid?(0)
         type.valid?(1)
         type.valid?(2)
         type.valid?(nil)
-        type.valid?(false)
+        type.valid?('hi')
       end
 
       time_block("T.let(..., Integer)") do

--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -55,6 +55,7 @@ require_relative 'types/private/types/not_typed'
 require_relative 'types/private/types/void'
 require_relative 'types/private/types/string_holder'
 require_relative 'types/private/types/type_alias'
+require_relative 'types/private/types/simple_pair_union'
 
 require_relative 'types/types/type_variable'
 require_relative 'types/types/type_member'

--- a/gems/sorbet-runtime/lib/types/private/types/simple_pair_union.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/simple_pair_union.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+# Specialization of Union for the common case of the union of two simple types.
+#
+# This covers e.g. T.nilable(SomeModule), T.any(Integer, Float), and T::Boolean.
+class T::Private::Types::SimplePairUnion < T::Types::Union
+  class DuplicateType < RuntimeError; end
+
+  # @param type_a [T::Types::Simple]
+  # @param type_b [T::Types::Simple]
+  def initialize(type_a, type_b)
+    if type_a == type_b
+      raise DuplicateType.new("#{type_a} == #{type_b}")
+    end
+
+    @raw_a = type_a.raw_type
+    @raw_b = type_b.raw_type
+  end
+
+  # @override Union
+  def recursively_valid?(obj)
+    obj.is_a?(@raw_a) || obj.is_a?(@raw_b)
+  end
+
+  # @override Union
+  def valid?(obj)
+    obj.is_a?(@raw_a) || obj.is_a?(@raw_b)
+  end
+
+  # @override Union
+  def types
+    # We reconstruct the simple types rather than just storing them because
+    # (1) this is normally not a hot path and (2) we want to keep the instance
+    # variable count <= 3 so that we can fit in a 40 byte heap entry along
+    # with object headers.
+    @types ||= [
+      T::Types::Simple::Private::Pool.type_for_module(@raw_a),
+      T::Types::Simple::Private::Pool.type_for_module(@raw_b),
+    ]
+  end
+end

--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -163,8 +163,12 @@ module T::Types
     # Type equivalence, defined by serializing the type to a string (with
     # `#name`) and comparing the resulting strings for equality.
     def ==(other)
-      (T::Utils.resolve_alias(other).class == T::Utils.resolve_alias(self).class) &&
+      case other
+      when T::Types::Base
         other.name == self.name
+      else
+        false
+      end
     end
 
     alias_method :eql?, :==

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -52,7 +52,10 @@ module T::Types
     end
 
     def to_nilable
-      @nilable ||= T::Types::Union.new([self, T::Utils::Nilable::NIL_TYPE])
+      @nilable ||= T::Private::Types::SimplePairUnion.new(
+        self,
+        T::Utils::Nilable::NIL_TYPE,
+      )
     end
 
     module Private

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -231,6 +231,29 @@ module Opus::Types::Test
         assert_equal(x.hash, y.hash)
       end
 
+      it 'pools correctly for simple nilable types' do
+        x = T::Types::Union::Private::Pool.union_of_types(
+          T::Utils.coerce(String),
+          T::Utils.coerce(NilClass),
+        )
+        y = T::Types::Union::Private::Pool.union_of_types(
+          T::Utils.coerce(String),
+          T::Utils.coerce(NilClass),
+        )
+        assert_equal(x.object_id, y.object_id)
+        assert_equal(
+          T::Private::Types::SimplePairUnion,
+          x.class,
+        )
+      end
+
+      it 'uses fast path for T::Boolean' do
+        assert_equal(
+          T::Private::Types::SimplePairUnion,
+          T::Boolean.aliased_type.class,
+        )
+      end
+
       it 'deduplicates type, fast path' do
         assert_equal(
           'Integer',

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -231,6 +231,16 @@ module Opus::Types::Test
         assert_equal(x.hash, y.hash)
       end
 
+      it 'handles equality between simple pair and complex unions' do
+        x = T::Types::Union.new([String, NilClass])
+        y = T::Private::Types::SimplePairUnion.new(
+          T::Utils.coerce(String),
+          T::Utils.coerce(NilClass),
+        )
+        assert_equal(x, y)
+        assert_equal(x.hash, y.hash)
+      end
+
       it 'pools correctly for simple nilable types' do
         x = T::Types::Union::Private::Pool.union_of_types(
           T::Utils.coerce(String),

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -133,34 +133,84 @@ module Opus::Types::Test
     end
 
     describe "Union" do
-      before do
-        @type = T.nilable(Integer)
+      describe "with simple nilable type" do
+        before do
+          @type = T.nilable(Integer)
+        end
+
+        it "passes a validation with a non-nil value" do
+          msg = check_error_message_for_obj(@type, 1)
+          assert_nil(msg)
+        end
+
+        it "passes a validation with a nil value" do
+          msg = check_error_message_for_obj(@type, nil)
+          assert_nil(msg)
+        end
+
+        it "fails a validation with a different type" do
+          msg = check_error_message_for_obj(@type, "1")
+          assert_equal("Expected type T.nilable(Integer), got type String with value \"1\"", msg)
+        end
+
+        it 'valid? does not allocate' do
+          skip unless check_alloc_counts
+          allocs_when_valid = counting_allocations {@type.valid?(0)}
+          assert_equal(0, allocs_when_valid)
+
+          allocs_when_invalid = counting_allocations {@type.valid?(0.1)}
+          assert_equal(0, allocs_when_invalid)
+        end
+
+        it 'can hand back its underlying types' do
+          value = @type.types.map(&:raw_type)
+          assert_equal([Integer, NilClass], value)
+        end
       end
 
-      it "passes a validation with a non-nil value" do
-        msg = check_error_message_for_obj(@type, 1)
-        assert_nil(msg)
-      end
+      describe "with complex type" do
+        before do
+          @type = T.nilable(T.any(Integer, T::Boolean))
+        end
 
-      it "passes a validation with a nil value" do
-        msg = check_error_message_for_obj(@type, nil)
-        assert_nil(msg)
-      end
+        it "passes a validation with a non-nil value" do
+          msg = check_error_message_for_obj(@type, 1)
+          assert_nil(msg)
+        end
 
-      it "fails a validation with a different type" do
-        msg = check_error_message_for_obj(@type, "1")
-        assert_equal("Expected type T.nilable(Integer), got type String with value \"1\"", msg)
+        it "passes a validation with a nil value" do
+          msg = check_error_message_for_obj(@type, nil)
+          assert_nil(msg)
+        end
+
+        it "fails a validation with a different type" do
+          msg = check_error_message_for_obj(@type, "1")
+          assert_equal("Expected type T.nilable(T.any(Integer, T::Boolean)), got type String with value \"1\"", msg)
+        end
+
+        it 'valid? does not allocate' do
+          skip unless check_alloc_counts
+          allocs_when_valid = counting_allocations {@type.valid?(0)}
+          assert_equal(0, allocs_when_valid)
+
+          allocs_when_invalid = counting_allocations {@type.valid?(0.1)}
+          assert_equal(0, allocs_when_invalid)
+        end
+
+        it 'can hand back its underlying types' do
+          value = @type.types.map(&:raw_type)
+          assert_equal([Integer, TrueClass, FalseClass, NilClass], value)
+        end
       end
 
       it "simplifies a union containing another union" do
-        type = T.any(@type, T.nilable(String))
+        type = T.any(T.nilable(Integer), T.nilable(String))
         assert_equal("T.nilable(T.any(Integer, String))", type.name)
       end
 
-      it 'can hand back its underlying types' do
-        type = T.any(Integer, T::Boolean, NilClass)
-        value = type.types.map(&:raw_type)
-        assert_equal([Integer, TrueClass, FalseClass, NilClass], value)
+      it "simplifies doubly-nested union" do
+        type = T.any(T.nilable(T.any(Integer, Float)), String)
+        assert_equal("T.nilable(T.any(Float, Integer, String))", type.name)
       end
 
       it "does not crash on anonymous classes" do
@@ -173,15 +223,6 @@ module Opus::Types::Test
         assert_equal("T.any(Integer, String)", type.name)
       end
 
-      it 'valid? does not allocate' do
-        skip unless check_alloc_counts
-        allocs_when_valid = counting_allocations {@type.valid?(0)}
-        assert_equal(0, allocs_when_valid)
-
-        allocs_when_invalid = counting_allocations {@type.valid?(0.1)}
-        assert_equal(0, allocs_when_invalid)
-      end
-
       it 'uses structural, not reference, equality' do
         x = T::Types::Union.new([String, NilClass])
         y = T::Types::Union.new([String, NilClass])
@@ -190,16 +231,18 @@ module Opus::Types::Test
         assert_equal(x.hash, y.hash)
       end
 
-      it 'pools correctly for simple nilable types' do
-        x = T::Types::Union::Private::Pool.union_of_types(
-          T::Utils.coerce(String),
-          T::Utils.coerce(NilClass),
+      it 'deduplicates type, fast path' do
+        assert_equal(
+          'Integer',
+          T.any(Integer, Integer).name,
         )
-        y = T::Types::Union::Private::Pool.union_of_types(
-          T::Utils.coerce(String),
-          T::Utils.coerce(NilClass),
+      end
+
+      it 'deduplicates type, slow path' do
+        assert_equal(
+          'T.all(Opus::Types::Test::TypesTest::Mixin1, Opus::Types::Test::TypesTest::Mixin2)',
+          T.any(T.all(Mixin1, Mixin2), T.all(Mixin1, Mixin2)).name,
         )
-        assert_equal(x.object_id, y.object_id)
       end
     end
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a straight rebase of #4568; I don't think I can push to djudd's branch.  I have been working to get Stripe's codebase green, and assuming the last change or two lands, I think we could safely commit this.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
