### PR TITLE
Symbolize type_member assignments (and other fixes)

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2012,6 +2012,11 @@ public:
             return ast::MK::EmptyTree();
         }
 
+        // Simulates how squashNames in handleAssignment also creates a ConstantLit
+        // (simpler than squashNames, because type members are not allowed to use any sort of
+        // `A::B = type_member` syntax)
+        asgn.lhs = ast::make_expression<ast::ConstantLit>(asgn.lhs.loc(), sym, move(asgn.lhs));
+
         if (send->hasPosArgs() || send->hasKwArgs() || send->block() != nullptr) {
             if (send->numPosArgs() > 1) {
                 if (auto e = ctx.beginError(send->loc, core::errors::Namer::InvalidTypeDefinition)) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -584,8 +584,6 @@ public:
         } else {
             switch (send->fun.rawId()) {
                 case core::Names::typeTemplate().rawId():
-                    handleTypeMemberDefinition(ctx, send, asgn, lhs);
-                    break;
                 case core::Names::typeMember().rawId():
                     handleTypeMemberDefinition(ctx, send, asgn, lhs);
                     break;
@@ -2128,23 +2126,19 @@ public:
         auto *send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send == nullptr) {
             tree = handleAssignment(ctx, std::move(tree));
-            return;
-        }
-
-        if (!send->recv.isSelfReference()) {
+        } else if (!send->recv.isSelfReference()) {
             tree = handleAssignment(ctx, std::move(tree));
-            return;
-        }
-
-        switch (send->fun.rawId()) {
-            case core::Names::typeTemplate().rawId():
-            case core::Names::typeMember().rawId(): {
-                tree = handleTypeMemberDefinition(ctx, std::move(tree));
-                return;
-            }
-            default: {
-                tree = handleAssignment(ctx, std::move(tree));
-                return;
+        } else {
+            switch (send->fun.rawId()) {
+                case core::Names::typeTemplate().rawId():
+                case core::Names::typeMember().rawId(): {
+                    tree = handleTypeMemberDefinition(ctx, std::move(tree));
+                    break;
+                }
+                default: {
+                    tree = handleAssignment(ctx, std::move(tree));
+                    break;
+                }
             }
         }
     }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -581,6 +581,8 @@ public:
             fillAssign(ctx, asgn);
         } else if (!send->recv.isSelfReference()) {
             handleAssignment(ctx, asgn);
+        } else if (!ast::isa_tree<ast::EmptyTree>(lhs->scope)) {
+            handleAssignment(ctx, asgn);
         } else {
             switch (send->fun.rawId()) {
                 case core::Names::typeTemplate().rawId():
@@ -2127,6 +2129,8 @@ public:
         if (send == nullptr) {
             tree = handleAssignment(ctx, std::move(tree));
         } else if (!send->recv.isSelfReference()) {
+            tree = handleAssignment(ctx, std::move(tree));
+        } else if (!ast::isa_tree<ast::EmptyTree>(lhs->scope)) {
             tree = handleAssignment(ctx, std::move(tree));
         } else {
             switch (send->fun.rawId()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3000,8 +3000,13 @@ public:
                 return;
             }
 
-            ENFORCE(send->fun == core::Names::typeAlias() || send->fun == core::Names::typeMember() ||
-                    send->fun == core::Names::typeTemplate());
+            if ((sym.isTypeAlias(ctx) && send->fun != core::Names::typeAlias()) ||
+                (sym.isTypeMember() && send->fun != core::Names::typeMember() &&
+                 send->fun != core::Names::typeTemplate())) {
+                // This is a reassignment of a constant that was declared as a type member or a type alias.
+                // The redefinition error is reported elsewhere.
+                return;
+            }
 
             auto owner = sym.owner(ctx).asClassOrModuleRef();
 

--- a/test/testdata/infer/bad_child_class.rb
+++ b/test/testdata/infer/bad_child_class.rb
@@ -6,7 +6,7 @@
 class PreChild <Parent # error: Type `K` declared by parent `Parent` must be re-declared in `PreChild`
   extend T::Generic
   ::V = type_member
-# ^^^ error: Unable to resolve constant `V`
+
 end
 
 class Parent

--- a/test/testdata/infer/bad_child_class.rb.symbol-table.exp
+++ b/test/testdata/infer/bad_child_class.rb.symbol-table.exp
@@ -10,11 +10,11 @@ class ::<root> < ::Object ()
     type-member(+) ::<Class:Parent>::<AttachedClass> -> T.attached_class (of Parent) @ test/testdata/infer/bad_child_class.rb:12
     method ::<Class:Parent>#<static-init> (<blk>) @ test/testdata/infer/bad_child_class.rb:12
       argument <blk><block> @ Loc {file=test/testdata/infer/bad_child_class.rb start=??? end=???}
-  class ::PreChild[V] < ::Parent () @ test/testdata/infer/bad_child_class.rb:6
+  class ::PreChild < ::Parent () @ test/testdata/infer/bad_child_class.rb:6
     type-member(=) ::PreChild::K -> PreChild::K @ test/testdata/infer/bad_child_class.rb:6
-    type-member(=) ::PreChild::V -> PreChild::V @ test/testdata/infer/bad_child_class.rb:8
   class ::<Class:PreChild>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/infer/bad_child_class.rb:6
     type-member(+) ::<Class:PreChild>::<AttachedClass> -> T.attached_class (of PreChild) @ test/testdata/infer/bad_child_class.rb:6
     method ::<Class:PreChild>#<static-init> (<blk>) @ test/testdata/infer/bad_child_class.rb:6
       argument <blk><block> @ Loc {file=test/testdata/infer/bad_child_class.rb start=??? end=???}
+  static-field ::V @ test/testdata/infer/bad_child_class.rb:8
 

--- a/test/testdata/infer/bad_child_class.rb.symbol-table.exp
+++ b/test/testdata/infer/bad_child_class.rb.symbol-table.exp
@@ -1,0 +1,20 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/infer/bad_child_class.rb:6
+      argument <blk><block> @ Loc {file=test/testdata/infer/bad_child_class.rb start=??? end=???}
+  class ::Parent[K] < ::Object () @ test/testdata/infer/bad_child_class.rb:12
+    type-member(=) ::Parent::K -> Parent::K @ test/testdata/infer/bad_child_class.rb:15
+    method ::Parent#foo (<blk>) -> Parent::K @ test/testdata/infer/bad_child_class.rb:17
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/bad_child_class.rb start=??? end=???}
+  class ::<Class:Parent>[<AttachedClass>] < ::<Class:Object> (Generic, Helpers, Sig) @ test/testdata/infer/bad_child_class.rb:12
+    type-member(+) ::<Class:Parent>::<AttachedClass> -> T.attached_class (of Parent) @ test/testdata/infer/bad_child_class.rb:12
+    method ::<Class:Parent>#<static-init> (<blk>) @ test/testdata/infer/bad_child_class.rb:12
+      argument <blk><block> @ Loc {file=test/testdata/infer/bad_child_class.rb start=??? end=???}
+  class ::PreChild[V] < ::Parent () @ test/testdata/infer/bad_child_class.rb:6
+    type-member(=) ::PreChild::K -> PreChild::K @ test/testdata/infer/bad_child_class.rb:6
+    type-member(=) ::PreChild::V -> PreChild::V @ test/testdata/infer/bad_child_class.rb:8
+  class ::<Class:PreChild>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/infer/bad_child_class.rb:6
+    type-member(+) ::<Class:PreChild>::<AttachedClass> -> T.attached_class (of PreChild) @ test/testdata/infer/bad_child_class.rb:6
+    method ::<Class:PreChild>#<static-init> (<blk>) @ test/testdata/infer/bad_child_class.rb:6
+      argument <blk><block> @ Loc {file=test/testdata/infer/bad_child_class.rb start=??? end=???}
+

--- a/test/testdata/namer/top_level_type_member_alias.rb
+++ b/test/testdata/namer/top_level_type_member_alias.rb
@@ -1,0 +1,19 @@
+# typed: strict
+
+# These snippets just need to not crash Sorbet
+
+A = type_member
+#   ^^^^^^^^^^^ error: `type_member` cannot be used at the top-level
+A = T.type_alias {Integer}
+
+::B = type_member
+#     ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(<root>)`
+::B = T.type_alias {Integer}
+
+C = T.type_alias {Integer}
+C = type_member
+#   ^^^^^^^^^^^ error: `type_member` cannot be used at the top-level
+
+::D = T.type_alias {Integer}
+::D = type_member
+#     ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(<root>)`

--- a/test/testdata/namer/type_member_cbase.rb
+++ b/test/testdata/namer/type_member_cbase.rb
@@ -1,0 +1,13 @@
+# typed: strict
+
+class A
+  extend T::Generic
+
+  ::X = type_member
+  #     ^^^^^^^^^^^ error: Expected `Integer` but found `T::Types::TypeMember` for field
+  Y = type_member
+end
+
+class B
+  ::X = T.let(1, Integer)
+end

--- a/test/testdata/namer/type_member_redefined_as_class.rb
+++ b/test/testdata/namer/type_member_redefined_as_class.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Wrapper
+  extend T::Generic
+  C = 1
+  C = type_member # error: Redefining constant `C` as a type member or type template
+  class C; end # error: Redefining constant `C` as a class or module
+end

--- a/test/testdata/namer/type_member_redefs__1.rb
+++ b/test/testdata/namer/type_member_redefs__1.rb
@@ -8,7 +8,7 @@ end
 
 class B
   extend T::Generic
-  R = type_member # error: Expected `Integer` but found `T::Types::TypeMember` for field
+  R = type_member
   R = 1 # error: Redefining constant `R` as a static field
 end
 

--- a/test/testdata/namer/type_member_with_scope.rb
+++ b/test/testdata/namer/type_member_with_scope.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+# https://github.com/sorbet/sorbet/issues/6416
+
+class Example
+  extend T::Generic
+
+  ::OnRootScope = type_member
+
+  module Namespace; end
+  Namespace::Inside = type_member
+end

--- a/test/testdata/resolver/type_member_alias_redef.rb
+++ b/test/testdata/resolver/type_member_alias_redef.rb
@@ -1,0 +1,34 @@
+# typed: true
+
+class TypeAliasWithPuts
+  X = puts
+  #   ^^^^ error: Expected `Runtime object representing type: Integer` but found `NilClass` for field
+  X = T.type_alias {Integer}
+end
+
+class TypeMemberWithPuts
+  extend T::Generic
+
+  X = puts
+  X = type_member # error: Redefining constant `X` as a type member or type template
+end
+
+# This used to crash because we would skip entering type members for any
+# constants with an explicit scope, which would make the `::X` resolve to the
+# `static-field-type-alias ::X` symbol.
+#
+# (Without the `::X`, one of them gets mangled but namer records the mangled
+# and non-mangled names in the tree eagerly, triggering different code paths
+# later in resolver.)
+
+class TypeMemberWithTypeAlias
+  extend T::Generic
+  ::X = type_member
+  ::X = T.type_alias {Integer}
+end
+
+class TypeAliasWithTypeMember
+  extend T::Generic
+  ::Y = T.type_alias {Integer}
+  ::Y = type_member
+end

--- a/test/testdata/resolver/type_member_alias_redef.rb
+++ b/test/testdata/resolver/type_member_alias_redef.rb
@@ -24,6 +24,7 @@ end
 class TypeMemberWithTypeAlias
   extend T::Generic
   ::X = type_member
+  #     ^^^^^^^^^^^ error: Expected `Runtime object representing type: Integer` but found `T::Types::TypeMember` for field
   ::X = T.type_alias {Integer}
 end
 
@@ -31,4 +32,5 @@ class TypeAliasWithTypeMember
   extend T::Generic
   ::Y = T.type_alias {Integer}
   ::Y = type_member
+  #     ^^^^^^^^^^^ error: Expected `Runtime object representing type: Integer` but found `T::Types::TypeMember` for field
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were previously not converting `UnresolvedConstantLit` nodes to
`ConstantLit` nodes in the LHS of a `type_member` assignment.

This was being masked by `builder_walk.cc` calling
`unresolvedIdent2Local` to effectively do the constant resolution lazily in
CFG builder. However, that constant resolution didn't take into account
mangle renames, which meant that sometimes `X = type_member` would resolve
to a `class ::Wrapper::X` symbol if the `type_member` symbol had been
redefined later in the file.

This incorrect resolution caused an ENFORCE failure in
`builder_entry.cc` that asserted that the `aliases` list only contains 
static fields and type members (in the buggy version, it also could contain
class-or-module symbols).

### Commit summary

~~The first two commits are pre-work.~~

~~The third commit is the real change, and the last commit is a test that
previously crashed.~~

**Update**: in the process of reading the test code that failed from the first version of the PR, I discovered a bunch of other bugs in similar parts of the code. This PR now fixes all of those. I tried splitting the work into separate PRs, but the tests I was writing just kept hitting different ENFORCE failures if I tried to land pieces separately.

I have tried making it mostly easy to review by commit nonetheless if that helps.

- **pre-work: Just take one argument** (7dd940bfe)

  The others we can derive from the one.

- **pre-work: Move this snippet outside the `if`** (b2a6a105f)

  It doesn't actually depend on any of the `type_member`'s args.

  It was written where it was because also it wasn't previously required
  except inside that block, but that will change in the next commit.

- **Symbolize type_member assignments** (6fb96adb3)

  We were previously not converting `UnresolvedConstantLit` nodes to
  `ConstantLit` nodes in the LHS of a `type_member` assignment.

  This was being masked by `builder_walk.cc` calling
  `unresolvedIdent2Local` to effectively do the constant resolution lazily
  in CFG builder. However, that constant resolution didn't take into
  account mangle renames, which meant that sometimes `X = type_member`
  would resolve to a `class ::Wrapper::X` symbol if the `type_member`
  symbol had been redefined later in the file.

  This incorrect resolution caused an ENFORCE failure in
  `builder_entry.cc` that asserted that the `aliases` list only contains
  static fields and type members (in the buggy version, it also could
  contain class-or-module symbols).

- **Add a test** (881252d82)


- **Remove an error** (565ef8731)

  This error is spurious. It only used to appear because of how we decided
  to recover from the namer redefinition error.

- **Remove ENFORCE, because it wasn't true** (ec0285fc1)


- **Make findSymbols and symbolizeTrees symmetric** (f1ea33558)

  These two `postTransformAssign` methods are nearly identical (the only
  difference is that there is some extra code to handle instance variables
  in the `findSymbols` case--namer doesn't need to deal with instance
  variables in `symbolizeTrees`, so it's absent there).

  This is pre-work for the next commit.

- **pre-work: Add extra handling for weird scopes with `type_member`** (f2fc6ee50)


- **Add snapshot showing master behavior** (c4d9daabc)


- **Show new behavior** (12a2a635f)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.