### PR TITLE
Remove `insertField` from `defineNonDeletableSingle`

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1388,14 +1388,10 @@ private:
                 insertTypeMember(ctx.withOwner(getOwnerSymbol(typeMember.owner)), typeMember);
                 break;
             }
-            case core::FoundDefinitionRef::Kind::Field: {
-                const auto &field = ref.field(foundDefs);
-                insertField(ctx.withOwner(getOwnerSymbol(field.owner)), field);
-                break;
-            }
             case core::FoundDefinitionRef::Kind::Empty:
             case core::FoundDefinitionRef::Kind::ClassRef:
             case core::FoundDefinitionRef::Kind::Method:
+            case core::FoundDefinitionRef::Kind::Field:
             case core::FoundDefinitionRef::Kind::Symbol:
                 ENFORCE(false, "Unexpected definition ref {}", core::FoundDefinitionRef::kindToString(ref.kind()));
                 break;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was redundant with the `insertField` call in `enterNewDefinitions`
later in `SymbolDefiner`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests should cover this.