### PR TITLE
Define all found classes first

### DIFF
--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -206,9 +206,8 @@ struct FoundField {
 CheckSize(FoundField, 20, 4);
 
 class FoundDefinitions final {
-    // Contains references to items in _klasses, _staticFields, and _typeMembers.
-    // Used to determine the order in which symbols are defined in SymbolDefiner.
-    // (All non-deletable definitions are defined before all deletable definitions)
+    // Contains references to items in _staticFields and _typeMembers.
+    // Used so there is a consistent definition & redefinition ordering.
     std::vector<FoundDefinitionRef> _nonDeletableDefinitions;
     // Contains references to classes in general. Separate from `FoundClass` because we sometimes need to define class
     // Symbols for classes that are referenced from but not present in the given file.

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -228,12 +228,12 @@ class FoundDefinitions final {
 
     FoundDefinitionRef addDefinition(FoundDefinitionRef ref) {
         DEBUG_ONLY(switch (ref.kind()) {
-            case FoundDefinitionRef::Kind::Class:
             case FoundDefinitionRef::Kind::StaticField:
             case FoundDefinitionRef::Kind::TypeMember:
-            case FoundDefinitionRef::Kind::Field:
                 break;
+            case FoundDefinitionRef::Kind::Class:
             case FoundDefinitionRef::Kind::Method:
+            case FoundDefinitionRef::Kind::Field:
             case FoundDefinitionRef::Kind::ClassRef:
             case FoundDefinitionRef::Kind::Empty:
             case FoundDefinitionRef::Kind::Symbol:
@@ -252,7 +252,7 @@ public:
     FoundDefinitionRef addClass(FoundClass &&klass) {
         const uint32_t idx = _klasses.size();
         _klasses.emplace_back(std::move(klass));
-        return addDefinition(FoundDefinitionRef(FoundDefinitionRef::Kind::Class, idx));
+        return FoundDefinitionRef(FoundDefinitionRef::Kind::Class, idx);
     }
 
     FoundDefinitionRef addClassRef(FoundClassRef &&klassRef) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -697,7 +697,7 @@ private:
         if (auto e = ctx.beginError(errorLoc, core::errors::Namer::ConstantKindRedefinition)) {
             auto prevSymbolKind = prettySymbolKind(ctx, prevSymbol.kind());
             if (prevSymbol.kind() == Kind::ClassOrModule &&
-                prevSymbol.asClassOrModuleRef().data(ctx)->isClassModuleSet()) {
+                !prevSymbol.asClassOrModuleRef().data(ctx)->isUndeclared()) {
                 prevSymbolKind = prevSymbol.asClassOrModuleRef().showKind(ctx);
             }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1370,34 +1370,6 @@ private:
         return sym;
     }
 
-    void defineNonDeletableSingle(core::MutableContext ctx, core::FoundDefinitionRef ref) {
-        switch (ref.kind()) {
-            case core::FoundDefinitionRef::Kind::Class: {
-                const auto &klass = ref.klass(foundDefs);
-                ENFORCE(state.definedClasses.size() == ref.idx());
-                state.definedClasses.emplace_back(insertClass(ctx.withOwner(getOwnerSymbol(klass.owner)), klass));
-                break;
-            }
-            case core::FoundDefinitionRef::Kind::StaticField: {
-                const auto &staticField = ref.staticField(foundDefs);
-                insertStaticField(ctx.withOwner(getOwnerSymbol(staticField.owner)), staticField);
-                break;
-            }
-            case core::FoundDefinitionRef::Kind::TypeMember: {
-                const auto &typeMember = ref.typeMember(foundDefs);
-                insertTypeMember(ctx.withOwner(getOwnerSymbol(typeMember.owner)), typeMember);
-                break;
-            }
-            case core::FoundDefinitionRef::Kind::Empty:
-            case core::FoundDefinitionRef::Kind::ClassRef:
-            case core::FoundDefinitionRef::Kind::Method:
-            case core::FoundDefinitionRef::Kind::Field:
-            case core::FoundDefinitionRef::Kind::Symbol:
-                ENFORCE(false, "Unexpected definition ref {}", core::FoundDefinitionRef::kindToString(ref.kind()));
-                break;
-        }
-    }
-
     void deleteMethodViaFullNameHash(core::MutableContext ctx, const core::FoundMethodHash &oldDefHash) {
         auto ownerRef = core::FoundDefinitionRef(core::FoundDefinitionRef::Kind::Class, oldDefHash.owner.idx);
         ENFORCE(oldDefHash.nameHash.isDefined(), "Can't delete rename if old hash is not defined");
@@ -1522,8 +1494,31 @@ public:
         state.definedClasses.reserve(foundDefs.klasses().size());
         state.definedMethods.reserve(foundDefs.methods().size());
 
+        for (const auto &klass : foundDefs.klasses()) {
+            state.definedClasses.emplace_back(insertClass(ctx.withOwner(getOwnerSymbol(klass.owner)), klass));
+        }
+
         for (auto ref : foundDefs.nonDeletableDefinitions()) {
-            defineNonDeletableSingle(ctx, ref);
+            switch (ref.kind()) {
+                case core::FoundDefinitionRef::Kind::StaticField: {
+                    const auto &staticField = ref.staticField(foundDefs);
+                    insertStaticField(ctx.withOwner(getOwnerSymbol(staticField.owner)), staticField);
+                    break;
+                }
+                case core::FoundDefinitionRef::Kind::TypeMember: {
+                    const auto &typeMember = ref.typeMember(foundDefs);
+                    insertTypeMember(ctx.withOwner(getOwnerSymbol(typeMember.owner)), typeMember);
+                    break;
+                }
+                case core::FoundDefinitionRef::Kind::Class:
+                case core::FoundDefinitionRef::Kind::Empty:
+                case core::FoundDefinitionRef::Kind::ClassRef:
+                case core::FoundDefinitionRef::Kind::Method:
+                case core::FoundDefinitionRef::Kind::Field:
+                case core::FoundDefinitionRef::Kind::Symbol:
+                    ENFORCE(false, "Unexpected definition ref {}", core::FoundDefinitionRef::kindToString(ref.kind()));
+                    break;
+            }
         }
     }
 
@@ -1533,6 +1528,10 @@ public:
     }
 
     void enterNewDefinitions(core::MutableContext ctx) {
+        // TODO(jez) After everything but classes is handled on the fast path, I think we can go
+        // back to having a single list of (non-class) definitions with a switch statement, like how
+        // namer used to work.
+
         // We have to defer defining "deletable" symbols until this (second) phase of incremental
         // namer so that we don't delete and immediately re-enter a symbol (possibly keeping it
         // alive, if it had multiple locs at the time of deletion) before SymbolDefiner has had a

--- a/test/cli/incremental-resolver/test.out
+++ b/test/cli/incremental-resolver/test.out
@@ -25,60 +25,64 @@ test/cli/incremental-resolver/expect-failures/abstract_impl.rb:126: Implementati
             ^^^^^^^^^^^^^
 Errors: 3
 ----- test/cli/incremental-resolver/expect-failures/constant_override.rb ---------------------
-test/cli/incremental-resolver/expect-failures/constant_override.rb:3: Redefining constant `B` as a class or module https://srb.help/4022
+test/cli/incremental-resolver/expect-failures/constant_override.rb:2: Cannot initialize the module `B` by constant assignment https://srb.help/4022
+     2 |B = e
+        ^^^^^
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:3: Previously defined as a module here
      3 |module B
-     4 |  extend T::Sig
+        ^^^^^^^^
+  Note:
+    Sorbet does not allow treating constant assignments as class or module definitions,
+    even if the initializer computes a `Module` object at runtime. See the docs for more.
+
+test/cli/incremental-resolver/expect-failures/constant_override.rb:5: Constant `B` is not a class or type alias https://srb.help/5004
      5 |  sig { returns(T.all(B,T)) }
-     6 |  def foo; T.unsafe(nil); end
-     7 |end
-    test/cli/incremental-resolver/expect-failures/constant_override.rb:2: Previously defined as a static field
+                              ^
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:2: If you are trying to define a type alias, you should use `T.type_alias` here
      2 |B = e
         ^
+
+test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Cannot initialize the module `B` by constant assignment https://srb.help/4022
+     110 |B = e
+          ^^^^^
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:111: Previously defined as a module here
+     111 |module B
+          ^^^^^^^^
   Note:
     Sorbet does not allow treating constant assignments as class or module definitions,
-    even if the initializer computes a value of type `Module`. See the docs for more.
+    even if the initializer computes a `Module` object at runtime. See the docs for more.
 
-
-test/cli/incremental-resolver/expect-failures/constant_override.rb:111: Redefining constant `B` as a class or module https://srb.help/4022
-     111 |module B
-     112 |  extend T::Sig
+test/cli/incremental-resolver/expect-failures/constant_override.rb:113: Constant `B` is not a class or type alias https://srb.help/5004
      113 |  sig { returns(T.all(B,T)) }
-     114 |  def foo; T.unsafe(nil); end
-     115 |end
-    test/cli/incremental-resolver/expect-failures/constant_override.rb:13: Previously defined as a static field
+                                ^
+    test/cli/incremental-resolver/expect-failures/constant_override.rb:13: If you are trying to define a type alias, you should use `T.type_alias` here
     13 |
     14 |
-  Note:
-    Sorbet does not allow treating constant assignments as class or module definitions,
-    even if the initializer computes a value of type `Module`. See the docs for more.
-
 
 test/cli/incremental-resolver/expect-failures/constant_override.rb:110: Method `e` does not exist on `T.class_of(<root>)` https://srb.help/7003
      110 |B = e
               ^
-Errors: 3
+Errors: 5
 ----- test/cli/incremental-resolver/expect-failures/constant_redefinition.rb ---------------------
-test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:4: Redefining constant `A` as a static field https://srb.help/4022
+test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:4: Cannot initialize the class `A` by constant assignment https://srb.help/4022
      4 |  A = nil
           ^^^^^^^
-    test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:3: Previously defined as a class or module
+    test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:3: Previously defined as a class here
      3 |  class A; end
           ^^^^^^^
   Note:
     Sorbet does not allow treating constant assignments as class or module definitions,
-    even if the initializer computes a value of type `Module`. See the docs for more.
+    even if the initializer computes a `Module` object at runtime. See the docs for more.
 
-
-test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:59: Redefining constant `A` as a static field https://srb.help/4022
+test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:59: Cannot initialize the class `A` by constant assignment https://srb.help/4022
     59 |  A = nil
           ^^^^^^^
-    test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:58: Previously defined as a class or module
+    test/cli/incremental-resolver/expect-failures/constant_redefinition.rb:58: Previously defined as a class here
     58 |  class A; end
           ^^^^^^^
   Note:
     Sorbet does not allow treating constant assignments as class or module definitions,
-    even if the initializer computes a value of type `Module`. See the docs for more.
-
+    even if the initializer computes a `Module` object at runtime. See the docs for more.
 Errors: 2
 ----- test/cli/incremental-resolver/expect-failures/multiple_sigs.rb ---------------------
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Unused type annotation. No method def before next annotation https://srb.help/5040

--- a/test/testdata/namer/all_constant_redefinitions.rb
+++ b/test/testdata/namer/all_constant_redefinitions.rb
@@ -1,0 +1,30 @@
+# typed: strict
+# disable-fast-path: true
+
+module Wrapper
+  extend T::Generic
+
+  class A; end
+  A = 1 # error: Redefining constant `A` as a static field
+  A = type_member # error: Redefining constant `A` as a type member or type template
+
+  B = 1
+  class B; end # error: Redefining constant `B` as a class or module
+  B = type_member # error: Redefining constant `B` as a type member or type template
+
+  C = 1
+  C = type_member # error: Redefining constant `C` as a type member or type template
+  class C; end # error: Redefining constant `C` as a class or module
+
+  class D; end
+  D = type_member # error: Redefining constant `D` as a type member or type template
+  D = 1 # error: Redefining constant `D` as a static field
+
+  E = type_member
+  class E; end  # error: Redefining constant `E` as a class or module
+  E = 1 # error: Redefining constant `E` as a static field
+
+  F = type_member
+  F = 1 # error: Redefining constant `F` as a static field
+  class F; end # error: Redefining constant `F` as a class or module
+end

--- a/test/testdata/namer/all_constant_redefinitions.rb
+++ b/test/testdata/namer/all_constant_redefinitions.rb
@@ -1,30 +1,29 @@
 # typed: strict
-# disable-fast-path: true
 
 module Wrapper
   extend T::Generic
 
   class A; end
-  A = 1 # error: Redefining constant `A` as a static field
+  A = 1 # error: Cannot initialize the class `A` by constant assignment
   A = type_member # error: Redefining constant `A` as a type member or type template
 
-  B = 1
-  class B; end # error: Redefining constant `B` as a class or module
+  B = 1 # error: Cannot initialize the class `B` by constant assignment
+  class B; end
   B = type_member # error: Redefining constant `B` as a type member or type template
 
-  C = 1
+  C = 1 # error: Cannot initialize the class `C` by constant assignment
   C = type_member # error: Redefining constant `C` as a type member or type template
-  class C; end # error: Redefining constant `C` as a class or module
+  class C; end
 
   class D; end
   D = type_member # error: Redefining constant `D` as a type member or type template
   D = 1 # error: Redefining constant `D` as a static field
 
-  E = type_member
-  class E; end  # error: Redefining constant `E` as a class or module
+  E = type_member # error: Redefining constant `E` as a type member or type template
+  class E; end
   E = 1 # error: Redefining constant `E` as a static field
 
-  F = type_member
+  F = type_member # error: Redefining constant `F` as a type member or type template
   F = 1 # error: Redefining constant `F` as a static field
-  class F; end # error: Redefining constant `F` as a class or module
+  class F; end
 end

--- a/test/testdata/namer/class_and_alias.rb
+++ b/test/testdata/namer/class_and_alias.rb
@@ -1,8 +1,8 @@
 # typed: true
-A = 91
-class A # error: Redefining constant `A` as a class or module
+A = 91 # error: Cannot initialize the class `A` by constant assignment
+class A
 end
 
 class B
 end
-B = 91 # error: Redefining constant `B` as a static field
+B = 91 # error: Cannot initialize the class `B` by constant assignment

--- a/test/testdata/namer/class_and_alias.rb.flatten-tree.exp
+++ b/test/testdata/namer/class_and_alias.rb.flatten-tree.exp
@@ -19,7 +19,7 @@ begin
       end
     end
   end
-  class ::A<<C A>> < (::<todo sym>)
+  class ::A<A$1> < (::<todo sym>)
     def self.<static-init>(<blk>)
       <emptyTree>
     end

--- a/test/testdata/namer/class_and_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/class_and_alias.rb.symbol-table-raw.exp
@@ -2,11 +2,11 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=2:1 end=8:7}
       argument <blk><block> @ Loc {file=test/testdata/namer/class_and_alias.rb start=??? end=???}
-  class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=3:8}
-  static-field <M <C <U A>> $1> -> Integer @ Loc {file=test/testdata/namer/class_and_alias.rb start=2:1 end=2:2}
-  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=3:8}
-    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=3:8}
-    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=4:4}
+  static-field <C <U A>> -> Integer @ Loc {file=test/testdata/namer/class_and_alias.rb start=2:1 end=2:2}
+  class <M <C <U A>> $1> < <C <U Object>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=3:8}
+  class <M <S <C <U A>> $1> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:7 end=3:8}
+    type-member(+) <M <S <C <U A>> $1> $1>::<C <U <AttachedClass>>> -> LambdaParam(<M <S <C <U A>> $1> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:7 end=3:8}
+    method <M <S <C <U A>> $1> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/class_and_alias.rb start=3:1 end=4:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/class_and_alias.rb start=??? end=???}
   static-field <C <U B>> -> Integer @ Loc {file=test/testdata/namer/class_and_alias.rb start=8:1 end=8:2}
   class <M <C <U B>> $1> < <C <U Object>> () @ Loc {file=test/testdata/namer/class_and_alias.rb start=6:1 end=6:8}

--- a/test/testdata/namer/constant_redefinition/class_then_constant.rb
+++ b/test/testdata/namer/constant_redefinition/class_then_constant.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 class R; end
-R = 5 # error: Redefining constant `R` as a static field
+R = 5 # error: Cannot initialize the class `R` by constant assignment
 
 # this should not resolve as a class, so this will be an error
 x = R.new # error: Method `new` does not exist on `Integer`

--- a/test/testdata/namer/constant_redefinition/class_then_constant_then_reopen.rb
+++ b/test/testdata/namer/constant_redefinition/class_then_constant_then_reopen.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 class R; end
-R = 5 # error: Redefining constant `R` as a static field
+R = 5 # error: Cannot initialize the class `R` by constant assignment
 class R; end
 # even though we've reopened the class here, the constant R still
 # "wins", because the first definition of the class is what counts

--- a/test/testdata/namer/constant_redefinition/constant_then_class.rb
+++ b/test/testdata/namer/constant_redefinition/constant_then_class.rb
@@ -1,9 +1,9 @@
 # typed: true
 
-R = 5
-class R; end # error: Redefining constant `R` as a class or module
+R = 5 # error: Cannot initialize the class `R` by constant assignment
+class R; end
 
-# this should resolve as a class, so this would not be an error
-x = R.new
+# The static field always mangles the class definition, so this is not allowed
+x = R.new # error: Method `new` does not exist on `Integer`
 # this should not resolve as the constant, so this will be an error
-puts R + 1 # error: Method `+` does not exist on `T.class_of(R)`
+puts R + 1

--- a/test/testdata/namer/constant_redefinition/constant_then_module.rb
+++ b/test/testdata/namer/constant_redefinition/constant_then_module.rb
@@ -1,9 +1,9 @@
 # typed: true
 
-R = 5
-module R; def self.x; end; end # error: Redefining constant `R` as a class or module
+R = 5 # error: Cannot initialize the module `R` by constant assignment
+module R; def self.x; end; end
 
 # this should resolve as a class, so this would not be an error
-x = R.x
+x = R.x # error: Method `x` does not exist on `Integer`
 # this should not resolve as the constant, so this will be an error
-puts R + 1 # error: Method `+` does not exist on `T.class_of(R)`
+puts R + 1

--- a/test/testdata/namer/constant_redefinition/module_then_constant.rb
+++ b/test/testdata/namer/constant_redefinition/module_then_constant.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 module R; def self.x; end; end
-R = 5 # error: Redefining constant `R` as a static field
+R = 5 # error: Cannot initialize the module `R` by constant assignment
 
 # this should not resolve as a class, so this will be an error
 x = R.x # error: Method `x` does not exist on `Integer`

--- a/test/testdata/namer/constant_redefinition/module_then_constant_then_reopen.rb
+++ b/test/testdata/namer/constant_redefinition/module_then_constant_then_reopen.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 module R; def self.x; end; end
-R = 5 # error: Redefining constant `R` as a static field
+R = 5 # error: Cannot initialize the module `R` by constant assignment
 module R; end
 # even though we've reopened the class here, the constant R still
 # "wins", because the first definition of the class is what counts

--- a/test/testdata/namer/constant_redefinition/nested_module_then_constant.rb
+++ b/test/testdata/namer/constant_redefinition/nested_module_then_constant.rb
@@ -4,4 +4,4 @@ module A::B::C
   def foo; end
 end
 
-A::B = 1 # error: Redefining constant `B` as a static field
+A::B = 1 # error: Cannot initialize the class or module `B` by constant assignment

--- a/test/testdata/namer/constant_redefinition/nested_module_then_nonexistent_name.rb
+++ b/test/testdata/namer/constant_redefinition/nested_module_then_nonexistent_name.rb
@@ -5,5 +5,5 @@ module A::B::C
 end
 
   A::B = A::D
-# ^^^^^^^^^^^ error: Redefining constant `B` as a static field
+# ^^^^^^^^^^^ error: Cannot initialize the class or module `B` by constant assignment
        # ^^^^ error: Unable to resolve constant `D`

--- a/test/testdata/namer/constants.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/constants.rb.symbol-table-raw.exp
@@ -6,8 +6,8 @@ class <C <U <root>>> < <C <U Object>> ()
     module <C <U A>>::<C <U B>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/constants.rb start=5:3 end=5:11}
       static-field <C <U A>>::<C <U B>>::<C <U C>> -> Integer @ Loc {file=test/testdata/namer/constants.rb start=3:3 end=3:7}
       static-field <C <U A>>::<C <U B>>::<C <U D>> -> Integer @ Loc {file=test/testdata/namer/constants.rb start=8:5 end=8:6}
-    class <C <U A>>::<S <C <U B>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/constants.rb start=3:3 end=3:4}
-      type-member(+) <C <U A>>::<S <C <U B>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U A>>::<S <C <U B>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A::B) @ Loc {file=test/testdata/namer/constants.rb start=3:3 end=3:4}
+    class <C <U A>>::<S <C <U B>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/constants.rb start=5:10 end=5:11}
+      type-member(+) <C <U A>>::<S <C <U B>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U A>>::<S <C <U B>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A::B) @ Loc {file=test/testdata/namer/constants.rb start=5:10 end=5:11}
       method <C <U A>>::<S <C <U B>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/constants.rb start=5:3 end=9:6}
         argument <blk><block> @ Loc {file=test/testdata/namer/constants.rb start=??? end=???}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/constants.rb start=2:8 end=2:9}

--- a/test/testdata/namer/fuzz_class_in_field.rb
+++ b/test/testdata/namer/fuzz_class_in_field.rb
@@ -1,7 +1,6 @@
 # typed: true
-module D 
-  D=1
-  class D::D; end # error: Definition of `D` is ambiguous
-      # ^^^^ error: Can't nest `D` under `D::D` because `D::D` is not a class or module
-end
+module D
+  D=1 # error: Cannot initialize the class or module `D` by constant assignment
+  class D::D; end
 
+end

--- a/test/testdata/namer/fuzz_class_in_field.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/fuzz_class_in_field.rb.symbol-table-raw.exp
@@ -1,0 +1,19 @@
+class <C <U <root>>> < <C <U Object>> ()
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:1 end=6:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=??? end=???}
+  module <C <U D>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:1 end=2:9}
+    module <C <U D>>::<C <U D>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
+      class <C <U D>>::<C <U D>>::<C <U D>> < <C <U Object>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:3 end=4:13}
+      class <C <U D>>::<C <U D>>::<S <C <U D>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
+        type-member(+) <C <U D>>::<C <U D>>::<S <C <U D>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U D>>::<C <U D>>::<S <C <U D>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D::D::D) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
+        method <C <U D>>::<C <U D>>::<S <C <U D>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:3 end=4:18}
+          argument <blk><block> @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=??? end=???}
+    static-field <C <U D>>::<M <C <U D>> $1> -> Integer @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=3:3 end=3:4}
+    class <C <U D>>::<S <C <U D>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
+      type-member(+) <C <U D>>::<S <C <U D>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U D>>::<S <C <U D>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D::D) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
+  class <S <C <U D>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:8 end=2:9}
+    type-member(+) <S <C <U D>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U D>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:8 end=2:9}
+    method <S <C <U D>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:1 end=6:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=??? end=???}
+

--- a/test/testdata/namer/fuzz_class_in_field.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/fuzz_class_in_field.rb.symbol-table-raw.exp
@@ -3,15 +3,15 @@ class <C <U <root>>> < <C <U Object>> ()
     method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:1 end=6:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=??? end=???}
   module <C <U D>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:1 end=2:9}
-    module <C <U D>>::<C <U D>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
-      class <C <U D>>::<C <U D>>::<C <U D>> < <C <U Object>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:3 end=4:13}
-      class <C <U D>>::<C <U D>>::<S <C <U D>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
-        type-member(+) <C <U D>>::<C <U D>>::<S <C <U D>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U D>>::<C <U D>>::<S <C <U D>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D::D::D) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
-        method <C <U D>>::<C <U D>>::<S <C <U D>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:3 end=4:18}
+    static-field <C <U D>>::<C <U D>> -> Integer @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=3:3 end=3:4}
+    module <C <U D>>::<M <C <U D>> $1> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:10}
+      class <C <U D>>::<M <C <U D>> $1>::<C <U D>> < <C <U Object>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:3 end=4:13}
+      class <C <U D>>::<M <C <U D>> $1>::<S <C <U D>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
+        type-member(+) <C <U D>>::<M <C <U D>> $1>::<S <C <U D>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U D>>::<M <C <U D>> $1>::<S <C <U D>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D::D::D) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
+        method <C <U D>>::<M <C <U D>> $1>::<S <C <U D>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:3 end=4:18}
           argument <blk><block> @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=??? end=???}
-    static-field <C <U D>>::<M <C <U D>> $1> -> Integer @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=3:3 end=3:4}
-    class <C <U D>>::<S <C <U D>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
-      type-member(+) <C <U D>>::<S <C <U D>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U D>>::<S <C <U D>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D::D) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:13}
+    class <C <U D>>::<M <S <C <U D>> $1> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:10}
+      type-member(+) <C <U D>>::<M <S <C <U D>> $1> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U D>>::<M <S <C <U D>> $1> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D::D) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=4:9 end=4:10}
   class <S <C <U D>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:8 end=2:9}
     type-member(+) <S <C <U D>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U D>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:8 end=2:9}
     method <S <C <U D>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/fuzz_class_in_field.rb start=2:1 end=6:4}

--- a/test/testdata/namer/fuzz_shared_singletons.rb
+++ b/test/testdata/namer/fuzz_shared_singletons.rb
@@ -1,4 +1,4 @@
 # typed: false
-A=class A; end # error: Redefining constant `A` as a static field
+A=class A; end # error: Cannot initialize the class `A` by constant assignment
 
 class A; end

--- a/test/testdata/namer/nested_static_field.rb
+++ b/test/testdata/namer/nested_static_field.rb
@@ -1,11 +1,11 @@
 # typed: false
 class A
-  B = T.unsafe(nil)
-  class B::C; end # error: Can't nest `C` under `A::B` because `A::B` is not a class or module
+  B = T.unsafe(nil) # error: Cannot initialize the class or module `B` by constant assignment
+  class B::C; end
 
   E = T.unsafe(nil)
   E::F = T.unsafe(nil) # error: Can't nest `F` under `A::E` because `A::E` is not a class or module
 
-  B::C
+  B::C # error: Unable to resolve constant `C`
   E::F
 end

--- a/test/testdata/namer/redefines_module_as_static_field.rb
+++ b/test/testdata/namer/redefines_module_as_static_field.rb
@@ -33,7 +33,7 @@ end
   T::AbstractUtils::Methods::Modes = T::Private::Methods::Modes # error: Can't nest `Modes` under `T::AbstractUtils::Methods`
   T::AbstractUtils::Methods::CallValidation::Modes = T::Private::Methods::Modes # error: Can't nest `CallValidation` under `T::AbstractUtils::Methods`
   T::AbstractUtils::Methods::CallValidation = T::Private::Methods::CallValidation 
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Redefining constant `CallValidation` as a static field
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Cannot initialize the class or module `CallValidation` by constant assignment
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Can't nest `CallValidation` under `T::AbstractUtils::Methods`
   # Defines a property on what was just previously a field.
   T::AbstractUtils::Methods::CallValidation::CallValidation = T::Private::Methods::CallValidation

--- a/test/testdata/namer/type_member_redefined_as_class.rb
+++ b/test/testdata/namer/type_member_redefined_as_class.rb
@@ -2,7 +2,7 @@
 
 module Wrapper
   extend T::Generic
-  C = 1
+  C = 1 # error: Cannot initialize the class `C` by constant assignment
   C = type_member # error: Redefining constant `C` as a type member or type template
-  class C; end # error: Redefining constant `C` as a class or module
+  class C; end
 end

--- a/test/testdata/resolver/fuzz_infinite_type.rb
+++ b/test/testdata/resolver/fuzz_infinite_type.rb
@@ -1,4 +1,4 @@
 # typed: false
   T = T.type_alias
-# ^^^^^^^^^^^^^^^^ error: Redefining constant `T` as a static field
+# ^^^^^^^^^^^^^^^^ error: Cannot initialize the module `T` by constant assignment
     # ^^^^^^^^^^^^ error: No block given to `T.type_alias`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This unblocks moving edits that change static fields and type members onto the
fast path.

### Commit summary

- **pre-work: Record the behavior of this new test on master** (006b505f9)

  Show master behavior and then show this branch behavior.

- **pre-work: Add master snapshot for fuzz_class_in_field test** (ce64fe83b)


- **Define all found classes first** (5a05b9a16)

  ... then define static fields and type members after that.

- **Make error reflect that classes always come first** (2d6c80ba9)


- **Show behavior of new test** (09506e9c5)


- **Update test expectations** (2afba2acd)

  Most of these are just wording changes of existing error messages, but a
  handful of tests (like `nested_static_field.rb`) actually change
  meaning. I think that the change is clear (maybe more clear than before)
  and only present in files that had errors previously, so it's fine.

  While in `nested_static_field.rb` the error feels out of order,
  overwhelmingly I think this error is going to be hit when two separate
  files combine to have the buggy code, so the confusion of
  seemingly-out-of-order execution will likely not be that common in
  practice.

- **Update a snapshot test** (be2465ab0)

  The behavior in the class_and_alias.rb file is showing what happens when
  an assignment like `X = 1` comes before or after a definition like
  `class Y; end`.

  Before, the behavior was that the first definition was always mangled.
  Now the behavior is that the class or module definition is always
  mangled.

- **Fix some fuzz_class_in_field tests** (3cda6b61d)

  The symbol table change looks bad, but when you realize that it's just
  two changes:

  - the `static-field` moves below the `module` declaration
  - the module declaration gets mangled

  This new behavior should be fine, because there's still a typed-false
  error somewhere, and the behavior is the same on the slow and fast path.

- **Update a cli test** (0b860997f)





### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.