### PR TITLE
Make runtime type check `attr_accessor` writers

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -204,6 +204,34 @@ module T::Private::Methods
     @modules_with_final[mod.singleton_class.object_id]
   end
 
+  private_class_method def self.attr_accessor_reader?(method_name)
+    # If the method name ends with a "=", it's definitely not an attr_accessor reader
+    return false if method_name[-1] == "="
+
+    # If it was "attr_accessor" that triggered this, we should be 3 frames away from it:
+    # 3. `attr_accessor`
+    # 2. method_added hook
+    # 1. `_on_method_added`
+    # 0. `attr_accessor_reader?`
+    caller_frame = caller_locations(3, 1).first
+    return false unless caller_frame
+
+    caller_label = caller_frame.label
+    return false unless caller_label
+
+    caller_label.to_s == "attr_accessor"
+  end
+
+  private_class_method def self.declare_writer_sig_from_reader(method_name, current_declaration)
+    writer_decl = current_declaration.dup
+    # The block for the reader runs the block for the writer,
+    # but also adds the writer param with the same type as the return type.
+    writer_decl.blk = lambda do
+      instance_exec(&current_declaration.blk).params(**{method_name.to_sym => decl.returns})
+    end
+    T::Private::DeclState.current.active_declaration = writer_decl
+  end
+
   # Only public because it needs to get called below inside the replace_method blocks below.
   def self._on_method_added(hook_mod, method_name, is_singleton_method: false)
     if T::Private::DeclState.current.skip_on_method_added
@@ -228,6 +256,8 @@ module T::Private::Methods
       return
     end
     T::Private::DeclState.current.reset!
+
+    declare_writer_sig_from_reader(method_name, current_declaration) if attr_accessor_reader?(method_name)
 
     if method_name == :method_added || method_name == :singleton_method_added
       raise(

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -58,12 +58,14 @@ class T::Private::Methods::Signature
     @defined_raw = defined_raw
 
     declared_param_names = raw_arg_types.keys
-    # If sig params are declared but there is a single parameter with a missing name
+    # If sig params are declared and there is a single parameter with a missing name
     # **and** the method ends with a "=", assume it is a writer method generated
-    # by attr_writer or attr_accessor
-    writer_method = declared_param_names != [nil] && parameters == [[:req]] && method_name[-1] == "="
-    # For writer methods, map the single parameter to the method name without the "=" at the end
-    parameters = [[:req, method_name[0...-1].to_sym]] if writer_method
+    # by attr_writer or attr_accessor.
+    # We fix up the parameter name in that case to be the method name without the "=".
+    if declared_param_names != [nil] && parameters == [[:req]] && method_name[-1] == "="
+      parameters = [[:req, method_name[0...-1].to_sym]]
+    end
+
     param_names = parameters.map {|_, name| name}
     missing_names = param_names - declared_param_names
     extra_names = declared_param_names - param_names

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -21,19 +21,37 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
       extend T::Helpers
       sig {params(foo: String).returns(String)}
       attr_writer :foo
-      sig {params(bar: Integer).returns(Integer)}
+      sig {returns(Integer)}
       attr_accessor :bar
     end
 
+    # Verify that attr_writer works on the happy path
     assert_equal("foo", klass.new.foo = "foo")
+
+    # Verify that attr_writer does type checking
     err = assert_raises(TypeError) do
       klass.new.foo = 42
     end
     assert_match(/Expected type String, got type Integer/, err.message)
-    assert_equal(42, klass.new.bar = 42)
-    # TODO: This should also raise a type error, but currently doesn't because
-    # the sig only affects the reader part of the attr_accessor, not the writer.
-    assert_equal("foo", klass.new.bar = "foo")
+
+    # Verify that the reader and writer for attr_accessor work on the happy path
+    obj = klass.new
+    assert_equal(42, obj.bar = 42)
+    assert_equal(42, obj.bar)
+
+    # Verify that the writer for attr_accessor does type checking
+    err = assert_raises(TypeError) do
+      klass.new.bar = "bar"
+    end
+    assert_match(/Expected type Integer, got type String/, err.message)
+
+    # Verify that the reader for attr_accessor does type checking
+    obj = klass.new
+    obj.instance_variable_set(:@bar, "bar")
+    err = assert_raises(TypeError) do
+      obj.bar
+    end
+    assert_match(/Expected type Integer, got type String/, err.message)
   end
 
   it 'handles module_function on including class' do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Sorbet runtime has never checked the writer for `attr_accessor` defined methods since that is the only case where a single signature needs to be matched up to two methods.

This PR adds an exception for the reader method of an `attr_accessor` triggered method added handling. For those cases, after we clear the current declaration, we create a new writer declaration with the correct params and make it the current declaration. That makes sure that the next method added handling, which should be for the writer method, can find and process a correct declaration.

Credit to @XrXr for giving me the original idea to check the `caller_location` label to see if we are in an `attr_accessor` call or not.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes: https://github.com/sorbet/sorbet/issues/5685

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Extended existing automated tests, and removed a `TODO`.
