### PR TITLE
Fix ruby3-keyword-args in LSP

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1964,6 +1964,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->censorForSnapshotTests = this->censorForSnapshotTests;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
+    result->ruby3KeywordArgs = this->ruby3KeywordArgs;
     result->lspExperimentalFastPathEnabled = this->lspExperimentalFastPathEnabled;
 
     if (keepId) {
@@ -2060,6 +2061,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->lspExperimentalFastPathEnabled = this->lspExperimentalFastPathEnabled;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
+    result->ruby3KeywordArgs = this->ruby3KeywordArgs;
     result->kvstoreUuid = this->kvstoreUuid;
     result->errorUrlBase = this->errorUrlBase;
     result->suppressedErrorClasses = this->suppressedErrorClasses;

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -89,6 +89,7 @@ core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<cor
                                           const realmain::options::Options &hashingOpts) {
     lgs = core::GlobalState::makeEmptyGlobalStateForHashing(logger);
     lgs->requiresAncestorEnabled = hashingOpts.requiresAncestorEnabled;
+    lgs->ruby3KeywordArgs = hashingOpts.ruby3KeywordArgs;
     lgs->lspExperimentalFastPathEnabled = hashingOpts.lspExperimentalFastPathEnabled;
     {
         core::UnfreezeFileTable fileTableAccess(*lgs);

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -25,6 +25,7 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
     }
 
     gs.requiresAncestorEnabled = options.requiresAncestorEnabled;
+    gs.ruby3KeywordArgs = options.ruby3KeywordArgs;
     gs.lspExperimentalFastPathEnabled = options.lspExperimentalFastPathEnabled;
 
     // Ensure LSP is enabled.

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -41,6 +41,7 @@ const UnorderedMap<
         {"disable-stress-incremental", BooleanPropertyAssertion::make},
         {"enable-packager", BooleanPropertyAssertion::make},
         {"enable-experimental-requires-ancestor", BooleanPropertyAssertion::make},
+        {"experimental-ruby3-keyword-args", BooleanPropertyAssertion::make},
         {"enable-suggest-unsafe", BooleanPropertyAssertion::make},
         {"selective-apply-code-action", StringPropertyAssertions::make},
         {"use-code-action-resolve", BooleanPropertyAssertion::make},

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -21,7 +21,7 @@ namespace {
 
 // Matches '    #    ^^^^^ label: dafhdsjfkhdsljkfh*&#&*%'
 // and '    # label: foobar'.
-const regex rangeAssertionRegex("(#[ ]*)(\\^*)[ ]*([a-zA-Z-]+): (.*)$");
+const regex rangeAssertionRegex("(#[ ]*)(\\^*)[ ]*([a-zA-Z0-9-]+): (.*)$");
 
 const regex whitespaceRegex("^[ ]*$");
 

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -552,6 +552,8 @@ TEST_CASE("LSPTest") {
         shared_ptr<realmain::options::Options> opts = make_shared<realmain::options::Options>();
         opts->noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
         opts->requiresAncestorEnabled =
+            BooleanPropertyAssertion::getValue("experimental-ruby3-keyword-args", assertions).value_or(false);
+        opts->requiresAncestorEnabled =
             BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
         opts->stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
         if (opts->stripePackages) {

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -551,7 +551,7 @@ TEST_CASE("LSPTest") {
     {
         shared_ptr<realmain::options::Options> opts = make_shared<realmain::options::Options>();
         opts->noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
-        opts->requiresAncestorEnabled =
+        opts->ruby3KeywordArgs =
             BooleanPropertyAssertion::getValue("experimental-ruby3-keyword-args", assertions).value_or(false);
         opts->requiresAncestorEnabled =
             BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -245,6 +245,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     gs->requiresAncestorEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
+    gs->ruby3KeywordArgs =
+        BooleanPropertyAssertion::getValue("experimental-ruby3-keyword-args", assertions).value_or(false);
 
     if (BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false)) {
         gs->initEmpty();

--- a/test/testdata/infer/ruby3_keyword_args.rb
+++ b/test/testdata/infer/ruby3_keyword_args.rb
@@ -1,0 +1,13 @@
+# typed: true
+# experimental-ruby3-keyword-args: true
+
+extend T::Sig
+
+sig {params(x: Integer, y: Integer).void}
+def takes_kwargs(x, y:)
+end
+
+arghash = {y: 42}
+takes_kwargs(99, arghash) # error: Keyword argument hash without `**` is deprecated
+
+takes_kwargs(99, **arghash)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #6427

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Automated test and also I manually tested that it works via LSP in my Vim setup.