### PR TITLE
`Logger#add` and `Logger#log` have optional blocks

### DIFF
--- a/rbi/stdlib/logger.rbi
+++ b/rbi/stdlib/logger.rbi
@@ -514,7 +514,7 @@ class Logger
       severity: T.nilable(Integer),
       message: T.untyped,
       progname: T.untyped,
-      blk: T.proc.returns(T.untyped)
+      blk: T.nilable(T.proc.returns(T.untyped))
     ).returns(TrueClass)
   end
   def add(severity, message = nil, progname = nil, &blk); end
@@ -526,7 +526,7 @@ class Logger
       severity: T.nilable(Integer),
       message: T.untyped,
       progname: T.untyped,
-      blk: T.proc.returns(T.untyped)
+      blk: T.nilable(T.proc.returns(T.untyped))
     ).returns(TrueClass)
   end
   def log(severity, message = nil, progname = nil, &blk); end


### PR DESCRIPTION
See https://ruby-doc.org/stdlib-3.1.2/libdoc/logger/rdoc/Logger.html#method-i-add