### PR TITLE
`Pathname.readlines` receives an optional chomp argument

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -1085,10 +1085,11 @@ class Pathname < Object
         sep: String,
         limit: Integer,
         open_args: Integer,
+        chomp: T::Boolean
     )
     .returns(T::Array[String])
   end
-  def readlines(sep=T.unsafe(nil), limit=T.unsafe(nil), open_args=T.unsafe(nil)); end
+  def readlines(sep=T.unsafe(nil), limit=T.unsafe(nil), open_args=T.unsafe(nil), chomp: false); end
 
   # Read symbolic link.
   #


### PR DESCRIPTION
See https://ruby-doc.org/stdlib-3.1.2/libdoc/pathname/rdoc/Pathname.html#readlines-method and https://ruby-doc.org/core-3.1.2/IO.html#method-c-readlines