### PR TITLE
Remove unused `Names::invariant`

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -191,7 +191,6 @@ NameDef names[] = {
     {"typeTemplate", "type_template"},
     {"covariant", "out"},
     {"contravariant", "in"},
-    {"invariant", "<invariant>"},
     {"fixed"},
     {"lower"},
     {"upper"},

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1303,8 +1303,6 @@ private:
                 variance = core::Variance::CoVariant;
             } else if (foundVariance == core::Names::contravariant()) {
                 variance = core::Variance::ContraVariant;
-            } else if (foundVariance == core::Names::invariant()) {
-                variance = core::Variance::Invariant;
             } else {
                 if (auto e = ctx.beginError(typeMember.litLoc, core::errors::Namer::InvalidTypeDefinition)) {
                     e.setHeader("Invalid variance kind, only `{}` and `{}` are supported",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This said that it was valid to write

    Elem = type_member(:'<invariant>')

but I don't think that was ever intentional and I don't think anyone
does it (it's certainly not documented that way).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests changed because it's unused.