### PR TITLE
don't let `state-enter`/`state-leave` get logged as "Unknown response"

### DIFF
--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -95,8 +95,12 @@ void WatchmanProcess::start() {
                     // Gracefully handle deserialization errors, since they could be our fault.
                     logger->error("Unable to deserialize Watchman request: {}\nOriginal request:\n{}", e.what(), line);
                 }
+            } else if (d.HasMember("state-enter")) {
+                // Deliberately keep these from "Unknown response" logging.
+            } else if (d.HasMember("state-leave")) {
+                // Deliberately keep these from "Unknown response" logging.
             } else if (!d.HasMember("subscribe")) {
-                // Not a subscription response, or a file update.
+                // Something we don't understand yet.
                 logger->debug("Unknown Watchman response:\n{}", line);
             }
         }

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -96,9 +96,15 @@ void WatchmanProcess::start() {
                     logger->error("Unable to deserialize Watchman request: {}\nOriginal request:\n{}", e.what(), line);
                 }
             } else if (d.HasMember("state-enter")) {
-                // Deliberately keep these from "Unknown response" logging.
+                // We know that these are messages from "state-enter" commands, but we are
+                // deliberately not doing anything with them.  See
+                // https://facebook.github.io/watchman/docs/cmd/state-enter.html
+                // for more information.
             } else if (d.HasMember("state-leave")) {
-                // Deliberately keep these from "Unknown response" logging.
+                // We know that these are messages from "state-leave" commands, but we are
+                // deliberately not doing anything with them.  See
+                // https://facebook.github.io/watchman/docs/cmd/state-leave.html
+                // for more information.
             } else if (!d.HasMember("subscribe")) {
                 // Something we don't understand yet.
                 logger->debug("Unknown Watchman response:\n{}", line);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less log clutter, and we intend to start doing things with `state-enter`/`state-leave` at some point anyway.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
