### PR TITLE
Stop testing sorbet-runtime against 2.6, start 3.1

### DIFF
--- a/.buildkite/build-sorbet-runtime.sh
+++ b/.buildkite/build-sorbet-runtime.sh
@@ -23,9 +23,12 @@ for runtime_version in "${runtime_versions[@]}"; do
 
   failed=
 
-  echo "+++ rubocop ($runtime_version)"
-  if ! rbenv exec bundle exec rake rubocop; then
-    failed=1
+  if [ "$runtime_version" = "2.7.2" ]; then
+    # Our Rubocop version doesn't understand Ruby 3.1 as a valid Ruby version
+    echo "+++ rubocop ($runtime_version)"
+    if ! rbenv exec bundle exec rake rubocop; then
+      failed=1
+    fi
   fi
 
   echo "+++ tests ($runtime_version)"

--- a/.buildkite/build-sorbet-runtime.sh
+++ b/.buildkite/build-sorbet-runtime.sh
@@ -7,7 +7,7 @@ pushd gems/sorbet-runtime
 echo "--- setup :ruby:"
 eval "$(rbenv init -)"
 
-runtime_versions=(2.6.3 2.7.2)
+runtime_versions=(2.7.2 3.1.2)
 
 for runtime_version in "${runtime_versions[@]}"; do
   rbenv install --skip-existing "$runtime_version"

--- a/.buildkite/build-sorbet-static-and-runtime.sh
+++ b/.buildkite/build-sorbet-static-and-runtime.sh
@@ -7,7 +7,7 @@ pushd gems/sorbet-static-and-runtime
 echo "--- setup :ruby:"
 eval "$(rbenv init -)"
 
-runtime_versions=(2.6.3 2.7.2)
+runtime_versions=(2.7.2 3.1.2)
 
 for runtime_version in "${runtime_versions[@]}"; do
   rbenv install --skip-existing "$runtime_version"

--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/sorbet/sorbet",
   }
 
-  s.required_ruby_version = ['>= 2.3.0']
+  s.required_ruby_version = ['>= 2.7.0']
 
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 1.7'

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -209,7 +209,7 @@ module Opus::Types::Test
             mod = Module.new do
               extend T::Sig
               sig do
-                params({x: Integer})
+                params(x: Integer)
                 .returns(String)
                 .checked(:always)
               end
@@ -225,7 +225,7 @@ module Opus::Types::Test
             mod = Module.new do
               extend T::Sig
               sig do
-                params({x: Integer})
+                params(x: Integer)
                 .returns(String)
                 .checked(:never)
               end
@@ -239,7 +239,7 @@ module Opus::Types::Test
             mod = Module.new do
               extend T::Sig
               sig do
-                params({x: Integer})
+                params(x: Integer)
                 .returns(String)
                 .checked(:compiled)
               end
@@ -253,7 +253,7 @@ module Opus::Types::Test
             Module.new do
               extend T::Sig
               sig do
-                params({x: Integer})
+                params(x: Integer)
                 .returns(String)
                 .checked(:tests)
               end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -60,6 +60,17 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     GC.stat[:total_allocated_objects] - before - 1 # Subtract one for the allocation by GC.stat itself
   end
 
+  private def assert_less_than(actual, expected, msg=nil)
+    unless msg
+      msg = "Expected #{actual} to be less than #{expected}"
+    end
+    assert(actual < expected, msg)
+  end
+
+  private def check_alloc_counts
+    @check_alloc_counts = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
+  end
+
   describe 'aliasing' do
     describe 'instance method' do
       it 'handles alias_method with runtime checking' do
@@ -83,7 +94,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations {obj.bar}
-        assert(allocs < 5)
+        assert_less_than(allocs, 5) if check_alloc_counts
       end
 
       it 'handles alias_method without runtime checking' do
@@ -102,7 +113,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = klass.new
         allocs = counting_allocations {obj.bar}
-        assert_equal(0, allocs)
+        assert_equal(0, allocs) if check_alloc_counts
       end
 
       it 'handles alias with runtime checking' do
@@ -126,7 +137,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations {obj.bar}
-        assert(allocs < 5)
+        assert_less_than(allocs, 5) if check_alloc_counts
       end
 
       it 'handles alias without runtime checking' do
@@ -145,7 +156,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = klass.new
         allocs = counting_allocations {obj.bar}
-        assert_equal(0, allocs)
+        assert_equal(0, allocs) if check_alloc_counts
       end
 
       it 'handles alias to superclass method with runtime checking' do
@@ -174,7 +185,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = subclass.new
         allocs = counting_allocations {obj.bar}
-        assert(allocs < 5)
+        assert_less_than(allocs, 5) if check_alloc_counts
       end
 
       it 'handles alias to superclass method without runtime checking' do
@@ -198,7 +209,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = subclass.new
         allocs = counting_allocations {obj.bar}
-        assert_equal(0, allocs)
+        assert_equal(0, allocs) if check_alloc_counts
       end
 
       it 'handles alias_method to included method with runtime checking' do
@@ -227,7 +238,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations {obj.bar}
-        assert(allocs < 5)
+        assert_less_than(allocs, 5) if check_alloc_counts
       end
 
       it 'handles alias_method to included method without runtime checking' do
@@ -251,7 +262,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = klass.new
         allocs = counting_allocations {obj.bar}
-        assert_equal(0, allocs)
+        assert_equal(0, allocs) if check_alloc_counts
       end
     end
 
@@ -278,7 +289,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations {klass.bar}
-        assert(allocs < 5)
+        assert_less_than(allocs, 5) if check_alloc_counts
       end
 
       it 'handles alias_method without runtime checking' do
@@ -299,7 +310,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         klass.bar # Need extra call since first one came before `foo` unwrap
         allocs = counting_allocations {klass.bar}
-        assert_equal(0, allocs)
+        assert_equal(0, allocs) if check_alloc_counts
       end
 
       it 'handles alias with runtime checking' do
@@ -324,7 +335,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations {klass.bar}
-        assert(allocs < 5)
+        assert_less_than(allocs, 5) if check_alloc_counts
       end
 
       it 'handles alias without runtime checking' do
@@ -345,7 +356,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         klass.bar # Need extra call since first one came before `foo` unwrap
         allocs = counting_allocations {klass.bar}
-        assert_equal(0, allocs)
+        assert_equal(0, allocs) if check_alloc_counts
       end
 
       it 'handles alias_method to superclass method with runtime checking' do
@@ -375,7 +386,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations {subclass.bar}
-        assert(allocs < 5)
+        assert_less_than(allocs, 5) if check_alloc_counts
       end
 
       it 'handles alias_method to superclass method without runtime checking' do
@@ -400,7 +411,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Shouldn't add overhead
         allocs = counting_allocations {subclass.bar}
-        assert_equal(0, allocs)
+        assert_equal(0, allocs) if check_alloc_counts
       end
 
       it 'handles alias_method to extended method with runtime checking' do
@@ -431,7 +442,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations {klass.bar}
-        assert(allocs < 5)
+        assert_less_than(allocs, 5) if check_alloc_counts
       end
 
       it 'handles alias_method to extended method without runtime checking' do
@@ -457,7 +468,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Shouldn't add overhead
         allocs = counting_allocations {klass.bar}
-        assert_equal(0, allocs)
+        assert_equal(0, allocs) if check_alloc_counts
       end
 
       it 'handles method reference without sig' do

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -60,13 +60,6 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     GC.stat[:total_allocated_objects] - before - 1 # Subtract one for the allocation by GC.stat itself
   end
 
-  private def assert_less_than(actual, expected, msg=nil)
-    unless msg
-      msg = "Expected #{actual} to be less than #{expected}"
-    end
-    assert(actual < expected, msg)
-  end
-
   private def check_alloc_counts
     @check_alloc_counts = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
   end
@@ -94,7 +87,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations {obj.bar}
-        assert_less_than(allocs, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5) if check_alloc_counts
       end
 
       it 'handles alias_method without runtime checking' do
@@ -137,7 +130,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations {obj.bar}
-        assert_less_than(allocs, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5) if check_alloc_counts
       end
 
       it 'handles alias without runtime checking' do
@@ -185,7 +178,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = subclass.new
         allocs = counting_allocations {obj.bar}
-        assert_less_than(allocs, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5) if check_alloc_counts
       end
 
       it 'handles alias to superclass method without runtime checking' do
@@ -238,7 +231,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations {obj.bar}
-        assert_less_than(allocs, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5) if check_alloc_counts
       end
 
       it 'handles alias_method to included method without runtime checking' do
@@ -289,7 +282,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations {klass.bar}
-        assert_less_than(allocs, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5) if check_alloc_counts
       end
 
       it 'handles alias_method without runtime checking' do
@@ -335,7 +328,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations {klass.bar}
-        assert_less_than(allocs, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5) if check_alloc_counts
       end
 
       it 'handles alias without runtime checking' do
@@ -386,7 +379,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations {subclass.bar}
-        assert_less_than(allocs, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5) if check_alloc_counts
       end
 
       it 'handles alias_method to superclass method without runtime checking' do
@@ -442,7 +435,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations {klass.bar}
-        assert_less_than(allocs, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5) if check_alloc_counts
       end
 
       it 'handles alias_method to extended method without runtime checking' do

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -369,7 +369,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
   end
 
   describe 'string value conversion assertions' do
-    ENUM_CONVERSION_MSG = 'Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead.'
+    ENUM_CONVERSION_MSG = /Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead./
     before do
       T::Configuration.expects(:soft_assert_handler).never
     end
@@ -378,14 +378,14 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
       ex = assert_raises(NoMethodError) do
         CardSuit::HEART.to_str
       end
-      assert_equal(ENUM_CONVERSION_MSG, ex.message)
+      assert_match(ENUM_CONVERSION_MSG, ex.message)
     end
 
     it 'raises an assertion if to_str is called (implicitly) and also returns the serialized value' do
       ex = assert_raises(NoMethodError) do
         'foo ' + CardSuit::HEART
       end
-      assert_equal(ENUM_CONVERSION_MSG, ex.message)
+      assert_match(ENUM_CONVERSION_MSG, ex.message)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -369,7 +369,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
   end
 
   describe 'string value conversion assertions' do
-    ENUM_CONVERSION_MSG = /Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead./
+    ENUM_CONVERSION_MSG = /Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead./.freeze
     before do
       T::Configuration.expects(:soft_assert_handler).never
     end

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -16,6 +16,10 @@ module Opus::Types::Test
       GC.stat[:total_allocated_objects] - before - 1 # Subtract one for the allocation by GC.stat itself
     end
 
+    private def check_alloc_counts
+      @check_alloc_counts = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
+    end
+
     # this checks that both the recursive and nonrecursive path should
     # have the same behavior
     private def check_error_message_for_obj(type, value)
@@ -66,6 +70,7 @@ module Opus::Types::Test
       end
 
       it 'valid? does not allocate' do
+        skip unless check_alloc_counts
         allocs_when_valid = counting_allocations {@type.valid?(0)}
         assert_equal(0, allocs_when_valid)
 
@@ -169,6 +174,7 @@ module Opus::Types::Test
       end
 
       it 'valid? does not allocate' do
+        skip unless check_alloc_counts
         allocs_when_valid = counting_allocations {@type.valid?(0)}
         assert_equal(0, allocs_when_valid)
 
@@ -243,6 +249,7 @@ module Opus::Types::Test
       end
 
       it 'valid? does not allocate' do
+        skip unless check_alloc_counts
         @klass.include(Mixin1)
         @klass.include(Mixin2)
 
@@ -280,6 +287,7 @@ module Opus::Types::Test
       end
 
       it 'valid? does not allocate' do
+        skip unless check_alloc_counts
         arr = ["foo", false]
         allocs_when_valid = counting_allocations {@type.valid?(arr)}
         assert_equal(0, allocs_when_valid)
@@ -331,6 +339,7 @@ module Opus::Types::Test
       end
 
       it 'valid? does not allocate' do
+        skip unless check_alloc_counts
         h = {a: 'foo', b: false, c: nil}
         allocs_when_valid = counting_allocations {@type.valid?(h)}
         assert_equal(0, allocs_when_valid)
@@ -477,6 +486,7 @@ module Opus::Types::Test
       end
 
       it 'valid? does not allocate' do
+        skip unless check_alloc_counts
         type = T::Array[Integer]
         valid = [1]
         invalid = {}
@@ -559,6 +569,7 @@ module Opus::Types::Test
       end
 
       it 'valid? does not allocate' do
+        skip unless check_alloc_counts
         type = T::Hash[String, Integer]
         valid = {'one' => 1}
         invalid = []

--- a/gems/sorbet-static-and-runtime/sorbet-static-and-runtime.gemspec
+++ b/gems/sorbet-static-and-runtime/sorbet-static-and-runtime.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'sorbet', '0.0.0'
   s.add_dependency 'sorbet-runtime', '0.0.0'
 
-  s.required_ruby_version = ['>= 2.3.0']
+  s.required_ruby_version = ['>= 2.7.0']
 end

--- a/gems/sorbet-static/sorbet-static.gemspec
+++ b/gems/sorbet-static/sorbet-static.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   # We include a pre-built binary (in libexec/), making us platform dependent.
   s.platform = Gem::Platform::CURRENT
 
-  s.required_ruby_version = ['>= 2.3.0']
+  s.required_ruby_version = ['>= 2.7.0']
 end

--- a/gems/sorbet/sorbet.gemspec
+++ b/gems/sorbet/sorbet.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'sorbet-static', '0.0.0'
 
-  s.required_ruby_version = ['>= 2.3.0']
+  s.required_ruby_version = ['>= 2.7.0']
 
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 1.7'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes this master build failure:

<https://buildkite.com/sorbet/sorbet/builds/24815#0183852a-577c-4355-b34d-f70b55dcf821/168-218>

which was in turn caused by this release:

https://github.com/deivid-rodriguez/pry-byebug/releases/tag/v3.10.0

Fixes #4265


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.