### PR TITLE
refactor `WatchmanProcess` to make it more extendable

### DIFF
--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -74,11 +74,13 @@ class LSPWatchmanProcess final : public watchman::WatchmanProcess {
     const std::shared_ptr<const LSPConfiguration> config;
 
 public:
-    LSPWatchmanProcess(std::shared_ptr<spdlog::logger> logger, std::string_view watchmanPath, std::string_view workSpace,
-                       std::vector<std::string> extensions, MessageQueueState &messageQueue, absl::Mutex &messageQueueMutex, absl::Notification &initializedNotification,
-                       std::shared_ptr<const LSPConfiguration> config) :
-        WatchmanProcess(std::move(logger), watchmanPath, workSpace, std::move(extensions)), messageQueue(messageQueue),
-            messageQueueMutex(messageQueueMutex), initializedNotification(initializedNotification), config(std::move(config)) {}
+    LSPWatchmanProcess(std::shared_ptr<spdlog::logger> logger, std::string_view watchmanPath,
+                       std::string_view workSpace, std::vector<std::string> extensions, MessageQueueState &messageQueue,
+                       absl::Mutex &messageQueueMutex, absl::Notification &initializedNotification,
+                       std::shared_ptr<const LSPConfiguration> config)
+        : WatchmanProcess(std::move(logger), watchmanPath, workSpace, std::move(extensions)),
+          messageQueue(messageQueue), messageQueueMutex(messageQueueMutex),
+          initializedNotification(initializedNotification), config(std::move(config)) {}
 
     virtual void processQueryResponse(std::unique_ptr<WatchmanQueryResponse> response) {
         auto notifMsg = make_unique<NotificationMessage>("2.0", LSPMethod::SorbetWatchmanFileChange, move(response));
@@ -94,19 +96,19 @@ public:
     }
 
     virtual void processExit(int watchmanExitCode, const std::optional<std::string> &msg) {
-                {
-                    absl::MutexLock lck(&messageQueueMutex);
-                    if (!messageQueue.terminate) {
-                        messageQueue.terminate = true;
-                        messageQueue.errorCode = watchmanExitCode;
-                        if (watchmanExitCode != 0 && msg.has_value()) {
-                            auto params = make_unique<ShowMessageParams>(MessageType::Error, msg.value());
-                            config->output->write(make_unique<LSPMessage>(
-                                make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
-                        }
-                    }
-                    logger->debug("Watchman terminating");
+        {
+            absl::MutexLock lck(&messageQueueMutex);
+            if (!messageQueue.terminate) {
+                messageQueue.terminate = true;
+                messageQueue.errorCode = watchmanExitCode;
+                if (watchmanExitCode != 0 && msg.has_value()) {
+                    auto params = make_unique<ShowMessageParams>(MessageType::Error, msg.value());
+                    config->output->write(make_unique<LSPMessage>(
+                        make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
                 }
+            }
+            logger->debug("Watchman terminating");
+        }
     }
 };
 } // namespace
@@ -183,9 +185,9 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
             throw EarlyReturnWithCode(1);
         }
 
-        watchmanProcess = make_unique<LSPWatchmanProcess>(
-            logger, opts.watchmanPath, opts.rawInputDirNames.at(0), vector<string>({"rb", "rbi"}),
-            messageQueue, messageQueueMutex, initializedNotification, this->config);
+        watchmanProcess = make_unique<LSPWatchmanProcess>(logger, opts.watchmanPath, opts.rawInputDirNames.at(0),
+                                                          vector<string>({"rb", "rbi"}), messageQueue,
+                                                          messageQueueMutex, initializedNotification, this->config);
     }
 
     auto readerThread =

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -13,7 +13,8 @@ namespace sorbet::realmain::lsp::watchman {
 WatchmanProcess::WatchmanProcess(shared_ptr<spdlog::logger> logger, string_view watchmanPath, string_view workSpace,
                                  vector<string> extensions)
     : logger(std::move(logger)), watchmanPath(string(watchmanPath)), workSpace(string(workSpace)),
-      extensions(std::move(extensions)), thread(runInAThread("watchmanReader", std::bind(&WatchmanProcess::start, this))) {}
+      extensions(std::move(extensions)),
+      thread(runInAThread("watchmanReader", std::bind(&WatchmanProcess::start, this))) {}
 
 WatchmanProcess::~WatchmanProcess() {
     exitWithCode(0, "");

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -11,12 +11,9 @@ using namespace std;
 namespace sorbet::realmain::lsp::watchman {
 
 WatchmanProcess::WatchmanProcess(shared_ptr<spdlog::logger> logger, string_view watchmanPath, string_view workSpace,
-                                 vector<string> extensions,
-                                 function<void(unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>)> processUpdate,
-                                 std::function<void(int, const std::optional<std::string> &)> processExit)
+                                 vector<string> extensions)
     : logger(std::move(logger)), watchmanPath(string(watchmanPath)), workSpace(string(workSpace)),
-      extensions(std::move(extensions)), processUpdate(std::move(processUpdate)), processExit(std::move(processExit)),
-      thread(runInAThread("watchmanReader", std::bind(&WatchmanProcess::start, this))) {}
+      extensions(std::move(extensions)), thread(runInAThread("watchmanReader", std::bind(&WatchmanProcess::start, this))) {}
 
 WatchmanProcess::~WatchmanProcess() {
     exitWithCode(0, "");
@@ -90,7 +87,7 @@ void WatchmanProcess::start() {
             } else if (d.HasMember("is_fresh_instance")) {
                 try {
                     auto queryResponse = sorbet::realmain::lsp::WatchmanQueryResponse::fromJSONValue(d);
-                    processUpdate(move(queryResponse));
+                    processQueryResponse(move(queryResponse));
                 } catch (sorbet::realmain::lsp::DeserializationError e) {
                     // Gracefully handle deserialization errors, since they could be our fault.
                     logger->error("Unable to deserialize Watchman request: {}\nOriginal request:\n{}", e.what(), line);

--- a/main/lsp/watchman/WatchmanProcess.h
+++ b/main/lsp/watchman/WatchmanProcess.h
@@ -12,13 +12,13 @@ class WatchmanQueryResponse;
 
 namespace sorbet::realmain::lsp::watchman {
 class WatchmanProcess {
-private:
+protected:
     std::shared_ptr<spdlog::logger> logger;
+
+private:
     const std::string watchmanPath;
     const std::string workSpace;
     const std::vector<std::string> extensions;
-    const std::function<void(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>)> processUpdate;
-    const std::function<void(int, const std::optional<std::string> &)> processExit;
     const std::unique_ptr<Joinable> thread;
     // Mutex that must be held before reading or writing stopped.
     absl::Mutex mutex;
@@ -34,17 +34,20 @@ private:
 
     bool isStopped();
 
+protected:
+    virtual void processQueryResponse(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>) = 0;
+
+    virtual void processExit(int core, const std::optional<std::string> &) = 0;
+
 public:
     /**
      * Immediately starts a Watchman subprocess and begins processing file updates in the provided
      * workspace folder. Passes file updates to `processUpdate` function.
      */
     WatchmanProcess(std::shared_ptr<spdlog::logger> logger, std::string_view watchmanPath, std::string_view workSpace,
-                    std::vector<std::string> extensions,
-                    std::function<void(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>)> processUpdate,
-                    std::function<void(int, const std::optional<std::string> &)> processExit);
+                    std::vector<std::string> extensions);
 
-    ~WatchmanProcess();
+    virtual ~WatchmanProcess();
 
     WatchmanProcess(const WatchmanProcess &&) = delete;
     WatchmanProcess(WatchmanProcess &) = delete;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We are eventually going to add support for the `state-enter` and `state-leave` watchman notifications.  With the current setup of `WatchmanProcess`, we'd need to add a member variable, constructor arg, and lambda for each notification.  The current style of passing in lambda functions is actually kind of elegant, but I don't think it's great to have to add extra stuff for each notification we might want to handle.

Hence, this PR, which refactors things to use a more standard technique: virtual functions.  The intent is that for `state-enter` / `state-leave` (and any future notifications we might add), we just add a virtual function for each one and update `WatchmanProcess` to call it.

This is...not great, in the sense that now we have two "`WatchmanProcess`" classes (the elegance of the former approach was that we only needed one), and we do need to pass weird things like the `messageQueue*` bits and `initializedNotification` around.

So, pluses and minuses, but I think the former outweighs the latter.  WDYT?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
