### PR TITLE
use inline storage for `AppliedType`

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -82,8 +82,8 @@ bool TypeArgumentRef::operator!=(const TypeArgumentRef &rhs) const {
     return rhs._id != this->_id;
 }
 
-vector<TypePtr> ClassOrModule::selfTypeArgs(const GlobalState &gs) const {
-    vector<TypePtr> targs;
+InlinedVector<TypePtr, 1> ClassOrModule::selfTypeArgs(const GlobalState &gs) const {
+    InlinedVector<TypePtr, 1> targs;
     for (auto tm : typeMembers()) {
         auto tmData = tm.data(gs);
         if (tmData->flags.isFixed) {
@@ -128,7 +128,7 @@ TypePtr ClassOrModule::unsafeComputeExternalType(GlobalState &gs) {
     if (typeMembers().empty()) {
         resultType = make_type<ClassType>(ref);
     } else {
-        vector<TypePtr> targs;
+        InlinedVector<TypePtr, 1> targs;
         targs.reserve(typeMembers().size());
 
         // Special-case covariant stdlib generics to have their types

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -403,7 +403,7 @@ public:
 
     uint32_t hash(const GlobalState &gs) const;
 
-    std::vector<TypePtr> selfTypeArgs(const GlobalState &gs) const;
+    InlinedVector<TypePtr, 1> selfTypeArgs(const GlobalState &gs) const;
 
     // selfType and externalType return the type of an instance of this Symbol
     // if instantiated without specific type parameters, as seen from inside or

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -296,7 +296,7 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, const TypeConstraint &tc) c
 }
 
 TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                              const std::vector<TypePtr> &targs) const {
+                              absl::Span<const TypePtr> targs) const {
     switch (tag()) {
         case Tag::BlamedUntyped:
         case Tag::UnresolvedAppliedType:

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -278,7 +278,7 @@ public:
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+                         absl::Span<const TypePtr> targs) const;
 
     // If this TypePtr `is_proxy_type`, returns its underlying type.
     TypePtr underlying(const GlobalState &gs) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -125,14 +125,14 @@ public:
     enum class Combinator { OR, AND };
 
     static TypePtr resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, ClassOrModuleRef fromWhat,
-                                        ClassOrModuleRef inWhat, const std::vector<TypePtr> &targs);
+                                        ClassOrModuleRef inWhat, absl::Span<const TypePtr> args);
 
     static InlinedVector<TypeMemberRef, 4> alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
                                                              const std::vector<TypePtr> &targs, ClassOrModuleRef asIf);
     // Extract the return value type from a proc.
     static TypePtr getProcReturnType(const GlobalState &gs, const TypePtr &procType);
     static TypePtr instantiate(const GlobalState &gs, const TypePtr &what, absl::Span<const TypeMemberRef> params,
-                               const std::vector<TypePtr> &targs);
+                               absl::Span<const TypePtr> targs);
     /** Replace all type variables in `what` with their instantiations.
      * Requires that `tc` has already been solved.
      */
@@ -390,7 +390,7 @@ public:
     void _sanityCheck(const GlobalState &gs) const;
 
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+                         absl::Span<const TypePtr> targs) const;
 };
 CheckSize(LambdaParam, 24, 8);
 
@@ -651,7 +651,7 @@ public:
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+                         absl::Span<const TypePtr> targs) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
@@ -708,7 +708,7 @@ public:
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+                         absl::Span<const TypePtr> targs) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -754,7 +754,7 @@ public:
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+                         absl::Span<const TypePtr> targs) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr underlying(const GlobalState &gs) const;
@@ -787,7 +787,7 @@ public:
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+                         absl::Span<const TypePtr> targs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -816,7 +816,7 @@ public:
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+                         absl::Span<const TypePtr> targs) const;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -128,7 +128,7 @@ public:
                                         ClassOrModuleRef inWhat, absl::Span<const TypePtr> args);
 
     static InlinedVector<TypeMemberRef, 4> alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
-                                                             const std::vector<TypePtr> &targs, ClassOrModuleRef asIf);
+                                                             absl::Span<const TypePtr> targs, ClassOrModuleRef asIf);
     // Extract the return value type from a proc.
     static TypePtr getProcReturnType(const GlobalState &gs, const TypePtr &procType);
     static TypePtr instantiate(const GlobalState &gs, const TypePtr &what, absl::Span<const TypeMemberRef> params,

--- a/core/Types.h
+++ b/core/Types.h
@@ -802,8 +802,8 @@ CheckSize(TupleType, 32, 8);
 TYPE(AppliedType) final : public Refcounted {
 public:
     ClassOrModuleRef klass;
-    std::vector<TypePtr> targs;
-    AppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs);
+    InlinedVector<TypePtr, 1> targs;
+    AppliedType(ClassOrModuleRef klass, InlinedVector<TypePtr, 1> targs);
     AppliedType(const AppliedType &) = delete;
     AppliedType &operator=(const AppliedType &) = delete;
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -389,8 +389,8 @@ public:
 
     void _sanityCheck(const GlobalState &gs) const;
 
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         absl::Span<const TypePtr> targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
 };
 CheckSize(LambdaParam, 24, 8);
 
@@ -650,8 +650,8 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         absl::Span<const TypePtr> targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
@@ -707,8 +707,8 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         absl::Span<const TypePtr> targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -753,8 +753,8 @@ public:
     std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         absl::Span<const TypePtr> targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr underlying(const GlobalState &gs) const;
@@ -786,8 +786,8 @@ public:
     std::string showWithMoreInfo(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         absl::Span<const TypePtr> targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -815,8 +815,8 @@ public:
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         absl::Span<const TypePtr> targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -543,11 +543,11 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
         case TypePtr::Tag::AppliedType: {
             auto klass = ClassOrModuleRef::fromRaw(p.getU4());
             int sz = p.getU4();
-            vector<TypePtr> targs(sz);
+            InlinedVector<TypePtr, 1> targs(sz);
             for (auto &t : targs) {
                 t = unpickleType(p, gs);
             }
-            return make_type<AppliedType>(klass, move(targs));
+            return make_type<AppliedType>(klass, std::move(targs));
         }
         case TypePtr::Tag::TypeVar: {
             auto sym = TypeArgumentRef::fromRaw(p.getU4());

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -326,7 +326,8 @@ int getArity(const GlobalState &gs, MethodRef method) {
 // Guess overload. The way we guess is only arity based - we will return the overload that has the smallest number of
 // arguments that is >= args.size()
 MethodRef guessOverload(const GlobalState &gs, ClassOrModuleRef inClass, MethodRef primary, uint16_t numPosArgs,
-                        InlinedVector<const TypeAndOrigins *, 2> &args, absl::Span<const TypePtr> targs, bool hasBlock) {
+                        InlinedVector<const TypeAndOrigins *, 2> &args, absl::Span<const TypePtr> targs,
+                        bool hasBlock) {
     counterInc("calls.overloaded_invocations");
     ENFORCE(Context::permitOverloadDefinitions(gs, primary.data(gs)->loc().file(), primary),
             "overload not permitted here");
@@ -1512,7 +1513,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     return result;
 }
 
-TypePtr getMethodArguments(const GlobalState &gs, ClassOrModuleRef klass, NameRef name, absl::Span<const TypePtr> targs) {
+TypePtr getMethodArguments(const GlobalState &gs, ClassOrModuleRef klass, NameRef name,
+                           absl::Span<const TypePtr> targs) {
     MethodRef method = klass.data(gs)->findMethodTransitive(gs, name);
 
     if (!method.exists()) {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -299,7 +299,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         // now a1 <: a2
 
         InlinedVector<TypeMemberRef, 4> indexes = Types::alignBaseTypeArgs(gs, a1->klass, a1->targs, a2->klass);
-        vector<TypePtr> newTargs;
+        InlinedVector<TypePtr, 1> newTargs;
         newTargs.reserve(indexes.size());
         // code below inverts permutation of type params
         int j = 0;
@@ -340,7 +340,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         } else if (!changedFromT1) {
             return t1s;
         } else {
-            return make_type<AppliedType>(a2->klass, move(newTargs));
+            return make_type<AppliedType>(a2->klass, std::move(newTargs));
         }
     }
 
@@ -961,7 +961,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
         // code below inverts permutation of type params
 
-        vector<TypePtr> newTargs;
+        InlinedVector<TypePtr, 1> newTargs;
         newTargs.reserve(a1->klass.data(gs)->typeMembers().size());
         int j = 0;
         for (auto idx : a1->klass.data(gs)->typeMembers()) {
@@ -1000,7 +1000,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         } else if (absl::c_equal(a2->targs, newTargs) && a1->klass == a2->klass) {
             return ltr ? t1 : t2;
         } else {
-            return make_type<AppliedType>(a1->klass, move(newTargs));
+            return make_type<AppliedType>(a1->klass, std::move(newTargs));
         }
     }
     {

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -77,7 +77,7 @@ TypePtr TypeVar::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
 namespace {
 
 template <typename... MethodArgs>
-optional<vector<TypePtr>> instantiateElems(const vector<TypePtr> &elems, const MethodArgs &...methodArgs) {
+optional<vector<TypePtr>> instantiateElems(absl::Span<const TypePtr> elems, const MethodArgs &...methodArgs) {
     optional<vector<TypePtr>> newElems;
     int i = -1;
     for (auto &e : elems) {
@@ -109,7 +109,7 @@ optional<vector<TypePtr>> instantiateElems(const vector<TypePtr> &elems, const M
 // Matches the 4 used in the vector backing ClassOrModuleRef::typeMembers()
 using PolaritiesStore = InlinedVector<core::Polarity, 4>;
 
-optional<vector<TypePtr>> approximateElems(const vector<TypePtr> &elems, const GlobalState &gs,
+optional<vector<TypePtr>> approximateElems(absl::Span<const TypePtr> elems, const GlobalState &gs,
                                            const TypeConstraint &tc, PolaritiesStore &polarities) {
     optional<vector<TypePtr>> newElems;
     int i = -1;

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -10,7 +10,7 @@ using namespace std;
 namespace sorbet::core {
 
 TypePtr Types::instantiate(const GlobalState &gs, const TypePtr &what, absl::Span<const TypeMemberRef> params,
-                           const vector<TypePtr> &targs) {
+                           absl::Span<const TypePtr> targs) {
     ENFORCE(what != nullptr);
     auto t = what._instantiate(gs, params, targs);
     if (t) {
@@ -142,7 +142,7 @@ optional<vector<TypePtr>> approximateElems(absl::Span<const TypePtr> elems, cons
 } // anonymous namespace
 
 TypePtr TupleType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                                const vector<TypePtr> &targs) const {
+                                absl::Span<const TypePtr> targs) const {
     optional<vector<TypePtr>> newElems = instantiateElems(this->elems, gs, params, targs);
     if (!newElems) {
         return nullptr;
@@ -168,7 +168,7 @@ TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc,
 };
 
 TypePtr ShapeType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                                const vector<TypePtr> &targs) const {
+                                absl::Span<const TypePtr> targs) const {
     optional<vector<TypePtr>> newValues = instantiateElems(this->values, gs, params, targs);
     if (!newValues) {
         return nullptr;
@@ -194,7 +194,7 @@ TypePtr ShapeType::_approximate(const GlobalState &gs, const TypeConstraint &tc,
 }
 
 TypePtr OrType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                             const vector<TypePtr> &targs) const {
+                             absl::Span<const TypePtr> targs) const {
     auto left = this->left._instantiate(gs, params, targs);
     auto right = this->right._instantiate(gs, params, targs);
     if (left || right) {
@@ -240,7 +240,7 @@ TypePtr OrType::_approximate(const GlobalState &gs, const TypeConstraint &tc, co
 }
 
 TypePtr AndType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                              const vector<TypePtr> &targs) const {
+                              absl::Span<const TypePtr> targs) const {
     auto left = this->left._instantiate(gs, params, targs);
     auto right = this->right._instantiate(gs, params, targs);
     if (left || right) {
@@ -286,7 +286,7 @@ TypePtr AndType::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
 }
 
 TypePtr AppliedType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                                  const vector<TypePtr> &targs) const {
+                                  absl::Span<const TypePtr> targs) const {
     optional<vector<TypePtr>> newTargs = instantiateElems(this->targs, gs, params, targs);
     if (!newTargs) {
         return nullptr;
@@ -324,7 +324,7 @@ TypePtr AppliedType::_approximate(const GlobalState &gs, const TypeConstraint &t
 }
 
 TypePtr LambdaParam::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                                  const vector<TypePtr> &targs) const {
+                                  absl::Span<const TypePtr> targs) const {
     ENFORCE(params.size() == targs.size());
     for (auto &el : params) {
         if (el == this->definition) {

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -76,9 +76,9 @@ TypePtr TypeVar::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
 
 namespace {
 
-template <typename... MethodArgs>
-optional<vector<TypePtr>> instantiateElems(absl::Span<const TypePtr> elems, const MethodArgs &...methodArgs) {
-    optional<vector<TypePtr>> newElems;
+template <typename VectorType, typename... MethodArgs>
+optional<VectorType> instantiateElems(absl::Span<const TypePtr> elems, const MethodArgs &...methodArgs) {
+    optional<VectorType> newElems;
     int i = -1;
     for (auto &e : elems) {
         ++i;
@@ -109,9 +109,10 @@ optional<vector<TypePtr>> instantiateElems(absl::Span<const TypePtr> elems, cons
 // Matches the 4 used in the vector backing ClassOrModuleRef::typeMembers()
 using PolaritiesStore = InlinedVector<core::Polarity, 4>;
 
-optional<vector<TypePtr>> approximateElems(absl::Span<const TypePtr> elems, const GlobalState &gs,
+template <typename VectorType>
+optional<VectorType> approximateElems(absl::Span<const TypePtr> elems, const GlobalState &gs,
                                            const TypeConstraint &tc, PolaritiesStore &polarities) {
-    optional<vector<TypePtr>> newElems;
+    optional<VectorType> newElems;
     int i = -1;
     for (auto &e : elems) {
         ++i;
@@ -143,7 +144,7 @@ optional<vector<TypePtr>> approximateElems(absl::Span<const TypePtr> elems, cons
 
 TypePtr TupleType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                                 absl::Span<const TypePtr> targs) const {
-    optional<vector<TypePtr>> newElems = instantiateElems(this->elems, gs, params, targs);
+    optional<vector<TypePtr>> newElems = instantiateElems<vector<TypePtr>>(this->elems, gs, params, targs);
     if (!newElems) {
         return nullptr;
     }
@@ -151,7 +152,7 @@ TypePtr TupleType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemb
 }
 
 TypePtr TupleType::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newElems = instantiateElems(this->elems, gs, tc);
+    optional<vector<TypePtr>> newElems = instantiateElems<vector<TypePtr>>(this->elems, gs, tc);
     if (!newElems) {
         return nullptr;
     }
@@ -160,7 +161,7 @@ TypePtr TupleType::_instantiate(const GlobalState &gs, const TypeConstraint &tc)
 
 TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const {
     PolaritiesStore polarities(this->elems.size(), polarity);
-    optional<vector<TypePtr>> newElems = approximateElems(this->elems, gs, tc, polarities);
+    optional<vector<TypePtr>> newElems = approximateElems<vector<TypePtr>>(this->elems, gs, tc, polarities);
     if (!newElems) {
         return nullptr;
     }
@@ -169,7 +170,7 @@ TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc,
 
 TypePtr ShapeType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                                 absl::Span<const TypePtr> targs) const {
-    optional<vector<TypePtr>> newValues = instantiateElems(this->values, gs, params, targs);
+    optional<vector<TypePtr>> newValues = instantiateElems<vector<TypePtr>>(this->values, gs, params, targs);
     if (!newValues) {
         return nullptr;
     }
@@ -177,7 +178,7 @@ TypePtr ShapeType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemb
 }
 
 TypePtr ShapeType::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newValues = instantiateElems(this->values, gs, tc);
+    optional<vector<TypePtr>> newValues = instantiateElems<vector<TypePtr>>(this->values, gs, tc);
     if (!newValues) {
         return nullptr;
     }
@@ -186,7 +187,7 @@ TypePtr ShapeType::_instantiate(const GlobalState &gs, const TypeConstraint &tc)
 
 TypePtr ShapeType::_approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const {
     PolaritiesStore polarities(this->values.size(), polarity);
-    optional<vector<TypePtr>> newValues = approximateElems(this->values, gs, tc, polarities);
+    optional<vector<TypePtr>> newValues = approximateElems<vector<TypePtr>>(this->values, gs, tc, polarities);
     if (!newValues) {
         return nullptr;
     }
@@ -287,7 +288,7 @@ TypePtr AndType::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
 
 TypePtr AppliedType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                                   absl::Span<const TypePtr> targs) const {
-    optional<vector<TypePtr>> newTargs = instantiateElems(this->targs, gs, params, targs);
+    optional<vector<TypePtr>> newTargs = instantiateElems<vector<TypePtr>>(this->targs, gs, params, targs);
     if (!newTargs) {
         return nullptr;
     }
@@ -295,7 +296,7 @@ TypePtr AppliedType::_instantiate(const GlobalState &gs, absl::Span<const TypeMe
 }
 
 TypePtr AppliedType::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newTargs = instantiateElems(this->targs, gs, tc);
+    optional<vector<TypePtr>> newTargs = instantiateElems<vector<TypePtr>>(this->targs, gs, tc);
     if (!newTargs) {
         return nullptr;
     }
@@ -316,7 +317,7 @@ TypePtr AppliedType::_approximate(const GlobalState &gs, const TypeConstraint &t
         }
     }
 
-    optional<vector<TypePtr>> newTargs = approximateElems(this->targs, gs, tc, polarities);
+    optional<vector<TypePtr>> newTargs = approximateElems<vector<TypePtr>>(this->targs, gs, tc, polarities);
     if (!newTargs) {
         return nullptr;
     }

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -288,19 +288,19 @@ TypePtr AndType::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
 
 TypePtr AppliedType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                                   absl::Span<const TypePtr> targs) const {
-    optional<vector<TypePtr>> newTargs = instantiateElems<vector<TypePtr>>(this->targs, gs, params, targs);
+    auto newTargs = instantiateElems<InlinedVector<TypePtr, 1>>(this->targs, gs, params, targs);
     if (!newTargs) {
         return nullptr;
     }
-    return make_type<AppliedType>(this->klass, move(*newTargs));
+    return make_type<AppliedType>(this->klass, std::move(*newTargs));
 }
 
 TypePtr AppliedType::_instantiate(const GlobalState &gs, const TypeConstraint &tc) const {
-    optional<vector<TypePtr>> newTargs = instantiateElems<vector<TypePtr>>(this->targs, gs, tc);
+    auto newTargs = instantiateElems<InlinedVector<TypePtr, 1>>(this->targs, gs, tc);
     if (!newTargs) {
         return nullptr;
     }
-    return make_type<AppliedType>(this->klass, move(*newTargs));
+    return make_type<AppliedType>(this->klass, std::move(*newTargs));
 }
 
 TypePtr AppliedType::_approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const {
@@ -317,11 +317,11 @@ TypePtr AppliedType::_approximate(const GlobalState &gs, const TypeConstraint &t
         }
     }
 
-    optional<vector<TypePtr>> newTargs = approximateElems<vector<TypePtr>>(this->targs, gs, tc, polarities);
+    auto newTargs = approximateElems<InlinedVector<TypePtr, 1>>(this->targs, gs, tc, polarities);
     if (!newTargs) {
         return nullptr;
     }
-    return make_type<AppliedType>(this->klass, move(*newTargs));
+    return make_type<AppliedType>(this->klass, std::move(*newTargs));
 }
 
 TypePtr LambdaParam::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -110,8 +110,8 @@ optional<VectorType> instantiateElems(absl::Span<const TypePtr> elems, const Met
 using PolaritiesStore = InlinedVector<core::Polarity, 4>;
 
 template <typename VectorType>
-optional<VectorType> approximateElems(absl::Span<const TypePtr> elems, const GlobalState &gs,
-                                           const TypeConstraint &tc, PolaritiesStore &polarities) {
+optional<VectorType> approximateElems(absl::Span<const TypePtr> elems, const GlobalState &gs, const TypeConstraint &tc,
+                                      PolaritiesStore &polarities) {
     optional<VectorType> newElems;
     int i = -1;
     for (auto &e : elems) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -614,7 +614,7 @@ InlinedVector<TypeMemberRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, 
  * inWhat   - where the generic type is observed
  */
 TypePtr Types::resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, ClassOrModuleRef fromWhat,
-                                    ClassOrModuleRef inWhat, const vector<TypePtr> &targs) {
+                                    ClassOrModuleRef inWhat, absl::Span<const TypePtr> targs) {
     auto originalOwner = fromWhat;
 
     // TODO: the ENFORCE below should be above this conditional, but there is

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -575,7 +575,7 @@ void MetaType::_sanityCheck(const GlobalState &gs) const {
  * If some typeArgs are not present, return NoSymbol
  * */
 InlinedVector<TypeMemberRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
-                                                         const vector<TypePtr> &targs, ClassOrModuleRef asIf) {
+                                                         absl::Span<const TypePtr> targs, ClassOrModuleRef asIf) {
     ENFORCE(what == asIf || what.data(gs)->derivesFrom(gs, asIf) || asIf.data(gs)->derivesFrom(gs, what),
             "what={} asIf={}", what.data(gs)->name.showRaw(gs), asIf.data(gs)->name.showRaw(gs));
     InlinedVector<TypeMemberRef, 4> currentAlignment;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1189,9 +1189,9 @@ private:
 
             // T.noreturn here represents the zero-length list of subclasses of this sealed class.
             // We will use T.any to record subclasses when they're resolved.
-            vector<core::TypePtr> targs{core::Types::bottom()};
+            InlinedVector<core::TypePtr, 1> targs{core::Types::bottom()};
             sealedSubclasses.data(ctx)->resultType =
-                core::make_type<core::AppliedType>(core::Symbols::Set(), move(targs));
+                core::make_type<core::AppliedType>(core::Symbols::Set(), std::move(targs));
         }
         if (fun == core::Names::declareInterface() || fun == core::Names::declareAbstract()) {
             symbolData->flags.isAbstract = true;

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1066,7 +1066,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
                 }
             }
 
-            vector<core::TypePtr> targs;
+            InlinedVector<core::TypePtr, 1> targs;
 
             if (sig.returns == nullptr) {
                 if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
@@ -1091,7 +1091,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
             }
             auto sym = core::Symbols::Proc(arity);
 
-            result.type = core::make_type<core::AppliedType>(sym, move(targs));
+            result.type = core::make_type<core::AppliedType>(sym, std::move(targs));
             return result;
         }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

One argument for `AppliedType` is the common case, so we can save an allocation here.  This might also be beneficial in reducing allocations (e.g. the changes to `ClassOrModule::selfTypeArgs`).  It's possible that some of the `Span` changes might make things a little more efficient because we're not indirecting to grab args repeatedly, but that's speculation, and the compiler is generally smarter than I am.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
