### PR TITLE
add `--watchman-pause-state-name` option

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -329,6 +329,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("watchman-path",
                                     "Path to watchman executable. Defaults to using `watchman` on your PATH.",
                                     cxxopts::value<string>()->default_value(empty.watchmanPath));
+    options.add_options("advanced")("watchman-pause-state-name",
+                                    "Name of watchman state that halts processing for its duration",
+                                    cxxopts::value<string>()->default_value(empty.watchmanPauseStateName));
+
     options.add_options("advanced")("enable-experimental-lsp-document-symbol",
                                     "Enable experimental LSP feature: Document Symbol");
     options.add_options("advanced")("enable-experimental-lsp-document-formatting-rubyfmt",
@@ -820,6 +824,12 @@ void readOptions(Options &opts,
         opts.runLSP = raw["lsp"].as<bool>();
         opts.disableWatchman = raw["disable-watchman"].as<bool>();
         opts.watchmanPath = raw["watchman-path"].as<string>();
+        opts.watchmanPauseStateName = raw["watchman-pause-state-name"].as<string>();
+        if (!opts.watchmanPauseStateName.empty() && !opts.disableWatchman) {
+            logger->error("watchman-pause-state-name must be used with watchman enabled");
+            throw EarlyReturnWithCode(1);
+        }
+
         // Certain features only need certain passes
         if (opts.print.isAutogen() && (opts.stopAfterPhase != Phase::NAMER)) {
             logger->error(

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -161,6 +161,7 @@ struct Options {
     bool runLSP = false;
     bool disableWatchman = false;
     std::string watchmanPath = "watchman";
+    std::string watchmanPauseStateName;
     bool stressIncrementalResolver = false;
     std::optional<int> sleepInSlowPathSeconds = std::nullopt;
     bool traceLexer = false;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

With several things in addition to Sorbet watching file changes via watchman, you can run into a situation where:

1. File changes occur
2. Sorbet starts typechecking (probably on the slow path)
3. Something else starts generating files
4. Sorbet notices more files have changed, restarts typechecking (probably still on the slow path)
5. Go to step 3 for several iterations

During this time, Sorbet and other automated processes are contending for CPU time and memory; it would probably be more effective if Sorbet held off until step 3 had finished (and therefore had a full view of the filesystem changes)

Hence, this option (which admittedly doesn't do much at the moment): the intent is that you can specify a Watchman state name that Sorbet will respond to:

1. When the state is entered, pause processing of new files and cancel in-progress typechecking operations
2. When the state is left, rescan for files and essentially re-initialize, without restarting

The actual functionality will be added in future PRs.  Bikeshedding on the name welcome.

I considered whether to allow multiple names and decided against it for now; we'll see how further experimentation goes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
