### PR TITLE
[docs/overview] Fix "sigil not found" error in example code that runs in `sorbet.run`

### DIFF
--- a/website/docs/overview.md
+++ b/website/docs/overview.md
@@ -44,7 +44,7 @@ def main
 end
 ```
 
-<a href="https://sorbet.run/#class%20A%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bparams(x%3A%20Integer).returns(String)%7D%0A%20%20def%20bar(x)%0A%20%20%20%20x.to_s%0A%20%20end%0Aend%0A%0Adef%20main%0A%20%20A.new.barr(91)%20%20%20%23%20error%3A%20Typo!%0A%20%20A.new.bar(%2291%22)%20%20%23%20error%3A%20Type%20mismatch!%0Aend">
+<a href="https://sorbet.run/#%23%20typed%3A%20true%0Arequire%20'sorbet-runtime'%0A%0Aclass%20A%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bparams%28x%3A%20Integer%29.returns%28String%29%7D%0A%20%20def%20bar%28x%29%0A%20%20%20%20x.to_s%0A%20%20end%0Aend%0A%0Adef%20main%0A%20%20A.new.barr%2891%29%20%20%20%23%20error%3A%20Typo!%0A%20%20A.new.bar%28%2291%22%29%20%20%23%20error%3A%20Type%20mismatch!%0Aend">
   → View on sorbet.run
 </a>
 


### PR DESCRIPTION
The example code that's shown in `sorbet.run` is outdated. The sigil `# typed: true` and `require 'sorbet-runtime'` are missing.

## Motivation

Fix "sigil not found" error in the example code in `sorbet.run`

```
To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false`
```

## Test plan

- Open the new link
- The "sigil not found" error is not shown in the code editor.

[Before](https://sorbet.run/#class%20A%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bparams%28x%3A%20Integer%29.returns%28String%29%7D%0A%20%20def%20bar%28x%29%0A%20%20%20%20x.to_s%0A%20%20end%0Aend%0A%0Adef%20main%0A%20%20A.new.barr%2891%29%20%20%20%23%20error%3A%20Typo!%0A%20%20A.new.bar%28%2291%22%29%20%20%23%20error%3A%20Type%20mismatch!%0Aend) | [After](https://sorbet.run/#%23%20typed%3A%20true%0Arequire%20'sorbet-runtime'%0A%0Aclass%20A%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Bparams%28x%3A%20Integer%29.returns%28String%29%7D%0A%20%20def%20bar%28x%29%0A%20%20%20%20x.to_s%0A%20%20end%0Aend%0A%0Adef%20main%0A%20%20A.new.barr%2891%29%20%20%20%23%20error%3A%20Typo!%0A%20%20A.new.bar%28%2291%22%29%20%20%23%20error%3A%20Type%20mismatch!%0Aend)
---|---
![image](https://user-images.githubusercontent.com/3720424/193434196-45f629fd-8c7b-4278-962e-3b6443c2156f.png) | ![image](https://user-images.githubusercontent.com/3720424/193434199-346880ff-abaf-4bfc-9018-0ece71da200f.png)
