### PR TITLE
Add type signatures for Tempfile

### DIFF
--- a/rbi/stdlib/tempfile.rbi
+++ b/rbi/stdlib/tempfile.rbi
@@ -123,9 +123,19 @@ class Tempfile
       tmpdir: T.nilable(String),
       mode: Integer,
       options: T.untyped,
-      blk: T.nilable(T.proc.params(arg0: File).returns(T.untyped)),
     )
-    .returns(T.untyped)
+    .returns(File)
+  end
+  sig do
+    type_parameters(:T)
+    .params(
+      basename: T.any(String, [String, String]),
+      tmpdir: T.nilable(String),
+      mode: Integer,
+      options: T.untyped,
+      blk: T.proc.params(arg0: File).returns(T.type_parameter(:T)),
+    )
+    .returns(T.type_parameter(:T))
   end
   def self.create(basename="", tmpdir=nil, mode: 0, **options, &blk); end
 
@@ -164,9 +174,19 @@ class Tempfile
       tmpdir: T.nilable(String),
       mode: Integer,
       options: T.untyped,
-      blk: T.nilable(T.proc.params(arg0: Tempfile).returns(T.untyped)),
     )
-    .returns(T.untyped)
+    .returns(Tempfile)
+  end
+  sig do
+    type_parameters(:T)
+    .params(
+      basename: T.any(String, [String, String]),
+      tmpdir: T.nilable(String),
+      mode: Integer,
+      options: T.untyped,
+      blk: T.nilable(T.proc.params(arg0: Tempfile).returns(T.type_parameter(:T))),
+    )
+    .returns(T.type_parameter(:T))
   end
   def self.open(basename='', tmpdir=nil, mode: 0, **options, &blk); end
 

--- a/test/testdata/rbi/tempfile.rb
+++ b/test/testdata/rbi/tempfile.rb
@@ -37,9 +37,15 @@ Tempfile.open('hello', '/tmp', encoding: 'ascii-8bit') do; end
 Tempfile.open('hello', '/tmp', mode: 0) do; end
 Tempfile.open('hello', '/tmp', mode: 0, encoding: 'ascii-8bit') do; end
 
-# can return any value from block
+# returns the correct type from block
 i = Tempfile.create('hello') { 1 }
-i + 1
+T.assert_type!(i, Integer)
 
 i = Tempfile.open('hello') { 1 }
-i + 1
+T.assert_type!(i, Integer)
+
+f = Tempfile.create('hello')
+T.assert_type!(f, File)
+
+tf = Tempfile.open('hello')
+T.assert_type!(tf, Tempfile)


### PR DESCRIPTION
Tempfile.create and Tempfile.open support optional blocks. We have added support for a type parameter for those blocks to indicate the return type of a probvided block.

Co-authored-by: Lisa Ugray <lisa.ugray@shopify.com>

### Motivation

Sorbet didn't know about the return types of blocks provided to `Tempfile.create` and `Tempfile.open`.


### Test plan

See additions to the `test/testdata/rbi/tempfile.rb` file.  Running sorbet against this file indicates that the new assertions pass.
