### PR TITLE
remove unused `FullyQualifiedName::toLiteral`

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -42,7 +42,6 @@ bool isTestNamespace(const core::GlobalState &gs, const core::NameRef ns) {
 struct FullyQualifiedName {
     vector<core::NameRef> parts;
     core::Loc loc;
-    ast::ExpressionPtr toLiteral(core::LocOffsets loc) const;
 
     FullyQualifiedName() = default;
     FullyQualifiedName(vector<core::NameRef> parts, core::Loc loc) : parts(parts), loc(loc) {}
@@ -460,18 +459,6 @@ bool isReferenceToPackageSpec(core::Context ctx, ast::ExpressionPtr &expr) {
 ast::ExpressionPtr name2Expr(core::NameRef name, ast::ExpressionPtr scope = ast::MK::EmptyTree(),
                              core::LocOffsets loc = core::LocOffsets::none()) {
     return ast::MK::UnresolvedConstant(loc, move(scope), name);
-}
-
-ast::ExpressionPtr FullyQualifiedName::toLiteral(core::LocOffsets loc) const {
-    ast::ExpressionPtr name = ast::MK::EmptyTree();
-    for (auto part : parts) {
-        name = name2Expr(part, move(name));
-    }
-    // Outer name should have the provided loc.
-    if (auto lit = ast::cast_tree<ast::UnresolvedConstantLit>(name)) {
-        name = ast::MK::UnresolvedConstant(loc, move(lit->scope), lit->cnst);
-    }
-    return name;
 }
 
 ast::ExpressionPtr prependName(ast::ExpressionPtr scope, core::NameRef prefix) {


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less dead code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
