### PR TITLE
add more logging for `SorbetException` in `main`

### DIFF
--- a/main/main.cc
+++ b/main/main.cc
@@ -7,6 +7,7 @@ int main(int argc, char *argv[]) {
     } catch (sorbet::EarlyReturnWithCode &c) {
         return c.returnCode;
     } catch (sorbet::SorbetException &e) {
+        fprintf(stderr, "caught %s: %s\n", typeid(e).name(), e.what());
         return 1;
     }
 };


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We're seeing some weird errors coming out of autogen at Stripe.  Some of the messages look like there are actually exceptions being thrown during the exception throwing process, which is scary, but we also have various exceptions deriving from `SorbetException` with informative error messages that don't appear to be printed anywhere.

This PR attempts to remediate this, so at least we get something out of catching the exception at the toplevel.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
