### PR TITLE
enumerating over a CSV should return rows

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -212,7 +212,7 @@ class CSV < Object
   include Enumerable
 
   extend T::Generic
-  Elem = type_member(:out) {{fixed: T::Array[T.nilable(String)]}}
+  Elem = type_member(:out) {{fixed: CSV::Row}}
 
   # The options used when no overrides are given by calling code. They are:
   #


### PR DESCRIPTION
I think, I can flesh this out

The particular issue a ran into was `map` on a `CSV` object wasnt allowing me to call `fields` on the row as that is a property of `CSV::Row` not `Array`

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
