### PR TITLE
Fix return type for IO#read without a length

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -2038,12 +2038,19 @@ class IO < Object
   # [`sysread`](https://docs.ruby-lang.org/en/2.7.0/IO.html#method-i-sysread).
   sig do
     params(
+        length: NilClass,
+        outbuf: String,
+    )
+    .returns(String)
+  end
+  sig do
+    params(
         length: Integer,
         outbuf: String,
     )
     .returns(T.nilable(String))
   end
-  def read(length=T.unsafe(nil), outbuf=T.unsafe(nil)); end
+  def read(length=nil, outbuf=T.unsafe(nil)); end
 
   # Reads at most *maxlen* bytes from *ios* using the read(2) system call after
   # O\_NONBLOCK is set for the underlying file descriptor.

--- a/test/testdata/rbi/io.rb
+++ b/test/testdata/rbi/io.rb
@@ -25,3 +25,9 @@ def test_io_gets(io)
   io.gets(nil)
   io.gets(nil, 1)
 end
+
+sig {params(io: IO).void}
+def test_io_read_return(io)
+  T.assert_type!(io.read(1), T.nilable(String))
+  T.assert_type!(io.read, String)
+end


### PR DESCRIPTION
From the docs:
> If length is omitted or is nil, it reads until EOF and the encoding conversion is applied, if applicable. A string is returned even if EOF is encountered before any data is read.