### PR TITLE
Ignore formatting requests on __package.rb files

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -231,7 +231,7 @@ bool isPackageRBIPath(string_view path) {
     return absl::EndsWith(path, ".package.rbi");
 }
 
-bool isPackagePath(string_view path) {
+bool File::isPackagePath(string_view path) {
     auto pos = path.rfind("/");
     if (pos != string_view::npos) {
         path = path.substr(pos + 1);

--- a/core/Files.h
+++ b/core/Files.h
@@ -49,6 +49,8 @@ public:
     bool isStdlib() const;
     bool isPackageRBI() const;
 
+    static bool isPackagePath(std::string_view path);
+
     bool isPackage() const;
     void setIsPackage(bool isPackage);
 

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -1,8 +1,8 @@
 #include "main/lsp/requests/document_formatting.h"
-#include "absl/strings/match.h"
 #include "common/FileOps.h"
 #include "common/Subprocess.h"
 #include "common/common.h"
+#include "core/Files.h"
 #include "main/lsp/LSPLoop.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
@@ -83,7 +83,7 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
 
     // Don't format `__package.rb` files, since currently formatting them
     // can potentially break some pay-server tooling
-    if (!sourceView.empty() && !absl::EndsWith(path, "__package.rb")) {
+    if (!sourceView.empty() && !core::File::isPackagePath(path)) {
         auto originalLineCount = findLineBreaks(sourceView).size() - 1;
         auto processResponse = sorbet::Subprocess::spawn(config.opts.rubyfmtPath, vector<string>(), sourceView);
 

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/requests/document_formatting.h"
+#include "absl/strings/match.h"
 #include "common/FileOps.h"
 #include "common/Subprocess.h"
 #include "common/common.h"
@@ -80,7 +81,9 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
         sourceView = sorbet::FileOps::read(path);
     }
 
-    if (!sourceView.empty()) {
+    // Don't format `__package.rb` files, since currently formatting them
+    // can potentially break some pay-server tooling
+    if (!sourceView.empty() && !absl::EndsWith(path, "__package.rb")) {
         auto originalLineCount = findLineBreaks(sourceView).size() - 1;
         auto processResponse = sorbet::Subprocess::spawn(config.opts.rubyfmtPath, vector<string>(), sourceView);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Tooling for `__package.rb` files assumes some pretty specific rules that aren't quite the same as what `rubyfmt` enforces (e.g. sometimes `rubyfmt` will add parentheses to `import` and `export` calls, but our tools don't handle this). The easiest way around this is just to ignore requests for formatting those files. Other internal scripts also ignore package files explicitly, and I don't think `rubyfmt` should try and guess whether or not something is a package based on the file contents.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I manually tested this internally in VSCode.
