### PR TITLE
Cache files to typecheck on a fast path

### DIFF
--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -69,6 +69,8 @@ public:
     fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPConfiguration &config,
                              const std::vector<std::shared_ptr<core::File>> &updatedFiles);
 
+    std::optional<FastPathFilesToTypecheckResult> cachedFastPathFilesToTypecheck = std::nullopt;
+
     // Overload because sometimes we have to look up the old file's hash in GlobalState (when
     // running on the typechecker thread), and sometimes we have to look it up in evictedFiles (when
     // running on the indexer thread).

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -51,13 +51,13 @@ class LSPIndexer final {
      * Determines if the given edit can take the fast path relative to the most recently committed edit.
      * It compares the file hashes in the files in `edit` to those in `evictedFiles` and `initialGS` (in that order).
      */
-    PathType getTypecheckingPath(const LSPFileUpdates &edit,
+    PathType getTypecheckingPath(LSPFileUpdates &edit,
                                  const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
     /**
      * INVARIANT: `changedFiles` must have hashes computed.
      */
     PathType
-    getTypecheckingPathInternal(const std::vector<std::shared_ptr<core::File>> &changedFiles,
+    getTypecheckingPathInternal(LSPFileUpdates &edit, const std::vector<std::shared_ptr<core::File>> &changedFiles,
                                 const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
 
 public:
@@ -68,7 +68,8 @@ public:
     /**
      * Determines if the given files can take the fast path relative to the latest committed edit.
      */
-    PathType getTypecheckingPath(const std::vector<std::shared_ptr<core::File>> &changedFiles) const;
+    PathType getTypecheckingPath(LSPFileUpdates &edit,
+                                 const std::vector<std::shared_ptr<core::File>> &changedFiles) const;
 
     /**
      * Computes state hashes for the given set of files. Is a no-op if the provided files all have hashes.

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -220,7 +220,14 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     Timer timeit(config->logger, "fast_path");
     // Replace error queue with one that is owned by this thread.
     gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
-    auto result = updates.fastPathFilesToTypecheck(*gs, *config);
+
+    LSPFileUpdates::FastPathFilesToTypecheckResult result;
+    if (updates.cachedFastPathFilesToTypecheck.has_value()) {
+        result = updates.cachedFastPathFilesToTypecheck.value();
+    } else {
+        result = updates.fastPathFilesToTypecheck(*gs, *config);
+    }
+
     config->logger->debug("Added {} files that were not part of the edit to the update set", result.extraFiles.size());
     UnorderedMap<core::FileRef, core::FoundDefHashes> oldFoundHashesForFiles;
     auto toTypecheck = move(result.extraFiles);

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -137,7 +137,7 @@ PathType SorbetWorkspaceEditTask::getTypecheckingPath(const LSPIndexer &index) c
         return updates->typecheckingPath;
     }
     if (!cachedFastPathDecisionValid) {
-        cachedFastPathDecision = index.getTypecheckingPath(params->updates);
+        cachedFastPathDecision = index.getTypecheckingPath(*updates, params->updates);
         cachedFastPathDecisionValid = true;
     }
     return cachedFastPathDecision;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The change caches the result of the `LSPFileUpdates::fastPathFilesToTypecheck` call, which we compute in process of making the typechecking path decision. 
That data is used later in the incremental resolver on the fast path (and in future in the incremental slow path)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The `fastPathFilesToTypecheck` can be an expensive method to call. So having less calls will decrease latency of the fast path requests

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
