### PR TITLE
Some no-op / pre-work edits

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -75,7 +75,7 @@ string ExpressionPtr::nodeName() const {
 #undef NODE_NAME
 }
 
-string ExpressionPtr::showRaw(const core::GlobalState &gs, int tabs) {
+string ExpressionPtr::showRaw(const core::GlobalState &gs, int tabs) const {
     auto *ptr = get();
 
     ENFORCE(ptr != nullptr);
@@ -446,7 +446,7 @@ string ClassDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return fmt::to_string(buf);
 }
 
-string ClassDef::showRaw(const core::GlobalState &gs, int tabs) {
+string ClassDef::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -499,7 +499,7 @@ string InsSeq::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return fmt::to_string(buf);
 }
 
-string InsSeq::showRaw(const core::GlobalState &gs, int tabs) {
+string InsSeq::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -558,7 +558,7 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
     return fmt::to_string(buf);
 }
 
-string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
+string MethodDef::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -618,7 +618,7 @@ string If::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return fmt::to_string(buf);
 }
 
-string If::showRaw(const core::GlobalState &gs, int tabs) {
+string If::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
 
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
@@ -633,7 +633,7 @@ string If::showRaw(const core::GlobalState &gs, int tabs) {
     return fmt::to_string(buf);
 }
 
-string Assign::showRaw(const core::GlobalState &gs, int tabs) {
+string Assign::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
 
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
@@ -657,7 +657,7 @@ string While::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return fmt::to_string(buf);
 }
 
-string While::showRaw(const core::GlobalState &gs, int tabs) {
+string While::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
 
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
@@ -678,7 +678,7 @@ string UnresolvedConstantLit::toStringWithTabs(const core::GlobalState &gs, int 
     return fmt::format("{}::{}", this->scope.toStringWithTabs(gs, tabs), this->cnst.toString(gs));
 }
 
-string UnresolvedConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
+string UnresolvedConstantLit::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
 
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
@@ -698,7 +698,7 @@ string ConstantLit::toStringWithTabs(const core::GlobalState &gs, int tabs) cons
     return "Unresolved: " + this->original.toStringWithTabs(gs, tabs);
 }
 
-string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
+string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
 
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
@@ -725,11 +725,11 @@ string Local::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return this->localVariable.toString(gs);
 }
 
-string Local::nodeName() {
+string Local::nodeName() const {
     return "Local";
 }
 
-string Local::showRaw(const core::GlobalState &gs, int tabs) {
+string Local::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -743,7 +743,7 @@ string UnresolvedIdent::toStringWithTabs(const core::GlobalState &gs, int tabs) 
     return this->name.toString(gs);
 }
 
-string UnresolvedIdent::showRaw(const core::GlobalState &gs, int tabs) {
+string UnresolvedIdent::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -771,19 +771,19 @@ string UnresolvedIdent::showRaw(const core::GlobalState &gs, int tabs) {
     return fmt::to_string(buf);
 }
 
-string Return::showRaw(const core::GlobalState &gs, int tabs) {
+string Return::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{ expr = " + this->expr.showRaw(gs, tabs + 1) + " }";
 }
 
-string Next::showRaw(const core::GlobalState &gs, int tabs) {
+string Next::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{ expr = " + this->expr.showRaw(gs, tabs + 1) + " }";
 }
 
-string Break::showRaw(const core::GlobalState &gs, int tabs) {
+string Break::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{ expr = " + this->expr.showRaw(gs, tabs + 1) + " }";
 }
 
-string Retry::showRaw(const core::GlobalState &gs, int tabs) {
+string Retry::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{}";
 }
 
@@ -803,7 +803,7 @@ string Retry::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return "retry";
 }
 
-string Literal::showRaw(const core::GlobalState &gs, int tabs) {
+string Literal::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{ value = " + this->toStringWithTabs(gs, 0) + " }";
 }
 
@@ -851,7 +851,7 @@ string RescueCase::toStringWithTabs(const core::GlobalState &gs, int tabs) const
     return fmt::to_string(buf);
 }
 
-string RescueCase::showRaw(const core::GlobalState &gs, int tabs) {
+string RescueCase::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -896,7 +896,7 @@ string Rescue::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return fmt::to_string(buf);
 }
 
-string Rescue::showRaw(const core::GlobalState &gs, int tabs) {
+string Rescue::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -929,7 +929,7 @@ string Send::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return fmt::to_string(buf);
 }
 
-string Send::showRaw(const core::GlobalState &gs, int tabs) {
+string Send::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
 
@@ -978,7 +978,7 @@ std::string RuntimeMethodDefinition::toStringWithTabs(const core::GlobalState &g
     return fmt::format("<runtime method definition of {}{}>", prefix, this->name.toString(gs));
 }
 
-std::string RuntimeMethodDefinition::showRaw(const core::GlobalState &gs, int tabs) {
+std::string RuntimeMethodDefinition::showRaw(const core::GlobalState &gs, int tabs) const {
     return this->toStringWithTabs(gs, tabs);
 }
 
@@ -1114,7 +1114,7 @@ string Cast::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return fmt::to_string(buf);
 }
 
-string Cast::showRaw(const core::GlobalState &gs, int tabs) {
+string Cast::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 2);
@@ -1131,11 +1131,11 @@ string Cast::showRaw(const core::GlobalState &gs, int tabs) {
     return fmt::to_string(buf);
 }
 
-string ZSuperArgs::showRaw(const core::GlobalState &gs, int tabs) {
+string ZSuperArgs::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{ }";
 }
 
-string Hash::showRaw(const core::GlobalState &gs, int tabs) {
+string Hash::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -1162,7 +1162,7 @@ string Hash::showRaw(const core::GlobalState &gs, int tabs) {
     return fmt::to_string(buf);
 }
 
-string Array::showRaw(const core::GlobalState &gs, int tabs) {
+string Array::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -1223,7 +1223,7 @@ string Block::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return fmt::to_string(buf);
 }
 
-string Block::showRaw(const core::GlobalState &gs, int tabs) {
+string Block::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{} {{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -1266,66 +1266,66 @@ string BlockArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return "&" + this->expr.toStringWithTabs(gs, tabs);
 }
 
-string RescueCase::nodeName() {
+string RescueCase::nodeName() const {
     return "RescueCase";
 }
-string Rescue::nodeName() {
+string Rescue::nodeName() const {
     return "Rescue";
 }
-string Next::nodeName() {
+string Next::nodeName() const {
     return "Next";
 }
-string ClassDef::nodeName() {
+string ClassDef::nodeName() const {
     return "ClassDef";
 }
 
-string MethodDef::nodeName() {
+string MethodDef::nodeName() const {
     return "MethodDef";
 }
-string If::nodeName() {
+string If::nodeName() const {
     return "If";
 }
-string While::nodeName() {
+string While::nodeName() const {
     return "While";
 }
-string UnresolvedIdent::nodeName() {
+string UnresolvedIdent::nodeName() const {
     return "UnresolvedIdent";
 }
-string Return::nodeName() {
+string Return::nodeName() const {
     return "Return";
 }
-string Break::nodeName() {
+string Break::nodeName() const {
     return "Break";
 }
-string Retry::nodeName() {
+string Retry::nodeName() const {
     return "Retry";
 }
 
-string Assign::nodeName() {
+string Assign::nodeName() const {
     return "Assign";
 }
 
-string Send::nodeName() {
+string Send::nodeName() const {
     return "Send";
 }
 
-string Cast::nodeName() {
+string Cast::nodeName() const {
     return "Cast";
 }
 
-string ZSuperArgs::nodeName() {
+string ZSuperArgs::nodeName() const {
     return "ZSuperArgs";
 }
 
-string Hash::nodeName() {
+string Hash::nodeName() const {
     return "Hash";
 }
 
-string Array::nodeName() {
+string Array::nodeName() const {
     return "Array";
 }
 
-string Literal::nodeName() {
+string Literal::nodeName() const {
     return "Literal";
 }
 
@@ -1367,47 +1367,47 @@ bool Literal::isFalse(const core::GlobalState &gs) const {
     return value.derivesFrom(gs, core::Symbols::FalseClass());
 }
 
-string UnresolvedConstantLit::nodeName() {
+string UnresolvedConstantLit::nodeName() const {
     return "UnresolvedConstantLit";
 }
 
-string ConstantLit::nodeName() {
+string ConstantLit::nodeName() const {
     return "ConstantLit";
 }
 
-string Block::nodeName() {
+string Block::nodeName() const {
     return "Block";
 }
 
-string InsSeq::nodeName() {
+string InsSeq::nodeName() const {
     return "InsSeq";
 }
 
-string EmptyTree::nodeName() {
+string EmptyTree::nodeName() const {
     return "EmptyTree";
 }
 
-string EmptyTree::showRaw(const core::GlobalState &gs, int tabs) {
+string EmptyTree::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName();
 }
 
-string RestArg::showRaw(const core::GlobalState &gs, int tabs) {
+string RestArg::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{ expr = " + expr.showRaw(gs, tabs) + " }";
 }
 
-string RestArg::nodeName() {
+string RestArg::nodeName() const {
     return "RestArg";
 }
 
-string KeywordArg::showRaw(const core::GlobalState &gs, int tabs) {
+string KeywordArg::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{ expr = " + expr.showRaw(gs, tabs) + " }";
 }
 
-string KeywordArg::nodeName() {
+string KeywordArg::nodeName() const {
     return "KeywordArg";
 }
 
-string OptionalArg::showRaw(const core::GlobalState &gs, int tabs) {
+string OptionalArg::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
@@ -1422,27 +1422,27 @@ string OptionalArg::showRaw(const core::GlobalState &gs, int tabs) {
     return fmt::to_string(buf);
 }
 
-string OptionalArg::nodeName() {
+string OptionalArg::nodeName() const {
     return "OptionalArg";
 }
 
-string ShadowArg::showRaw(const core::GlobalState &gs, int tabs) {
+string ShadowArg::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{ expr = " + expr.showRaw(gs, tabs) + " }";
 }
 
-string BlockArg::showRaw(const core::GlobalState &gs, int tabs) {
+string BlockArg::showRaw(const core::GlobalState &gs, int tabs) const {
     return nodeName() + "{ expr = " + expr.showRaw(gs, tabs) + " }";
 }
 
-string ShadowArg::nodeName() {
+string ShadowArg::nodeName() const {
     return "ShadowArg";
 }
 
-string BlockArg::nodeName() {
+string BlockArg::nodeName() const {
     return "BlockArg";
 }
 
-string RuntimeMethodDefinition::nodeName() {
+string RuntimeMethodDefinition::nodeName() const {
     return "RuntimeMethodDefinition";
 }
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -220,7 +220,7 @@ public:
 
     std::string nodeName() const;
 
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
 
     bool isSelfReference() const;
 
@@ -373,8 +373,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -402,8 +402,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -422,8 +422,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -441,8 +441,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -459,8 +459,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -475,8 +475,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -493,8 +493,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -511,8 +511,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -537,8 +537,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -562,8 +562,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -580,8 +580,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -605,8 +605,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -623,8 +623,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -641,8 +641,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -660,8 +660,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -678,8 +678,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -696,8 +696,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -715,8 +715,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -798,8 +798,8 @@ public:
     void addKwArg(ExpressionPtr key, ExpressionPtr value);
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     // Add the given positional argument as the last positional argument.
     void addPosArg(ExpressionPtr ptr);
@@ -961,8 +961,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -983,8 +983,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -1004,8 +1004,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -1022,8 +1022,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
     bool isString() const;
     bool isSymbol() const;
     bool isNil(const core::GlobalState &gs) const;
@@ -1048,8 +1048,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -1072,8 +1072,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
     std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(
         const core::GlobalState &gs) const;
 
@@ -1091,8 +1091,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -1110,8 +1110,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
     void _sanityCheck();
 };
 CheckSize(Block, 40, 8);
@@ -1133,8 +1133,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -1153,8 +1153,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };
@@ -1169,8 +1169,8 @@ public:
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
-    std::string showRaw(const core::GlobalState &gs, int tabs = 0);
-    std::string nodeName();
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
 
     void _sanityCheck();
 };

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -721,15 +721,15 @@ private:
         emitRedefinedConstantError(ctx, errorLoc, symbol.name(ctx), symbol.kind(), prevSymbol);
     }
 
-    core::ClassOrModuleRef ensureScopeIsClass(core::MutableContext ctx, core::SymbolRef scope, core::NameRef name,
-                                              core::LocOffsets loc) {
+    core::ClassOrModuleRef ensureScopeIsClass(core::MutableContext ctx, core::SymbolRef scope,
+                                              core::NameRef nameForErrors, core::LocOffsets loc) {
         // Common case: Everything is fine, user is trying to define a symbol on a class or module.
         if (scope.isClassOrModule()) {
             // Check if original symbol was mangled away. If so, complain.
             auto renamedSymbol = ctx.state.findRenamedSymbol(scope.asClassOrModuleRef().data(ctx)->owner, scope);
             if (renamedSymbol.exists()) {
                 if (auto e = ctx.beginError(loc, core::errors::Namer::InvalidClassOwner)) {
-                    auto constLitName = name.show(ctx);
+                    auto constLitName = nameForErrors.show(ctx);
                     auto scopeName = scope.show(ctx);
                     e.setHeader("Can't nest `{}` under `{}` because `{}` is not a class or module", constLitName,
                                 scopeName, scopeName);
@@ -746,7 +746,7 @@ private:
         }
 
         if (auto e = ctx.beginError(loc, core::errors::Namer::InvalidClassOwner)) {
-            auto constLitName = name.show(ctx);
+            auto constLitName = nameForErrors.show(ctx);
             auto newOwnerName = scope.show(ctx);
             e.setHeader("Can't nest `{}` under `{}` because `{}` is not a class or module", constLitName, newOwnerName,
                         newOwnerName);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -721,8 +721,8 @@ private:
         emitRedefinedConstantError(ctx, errorLoc, symbol.name(ctx), symbol.kind(), prevSymbol);
     }
 
-    core::ClassOrModuleRef ensureIsClass(core::MutableContext ctx, core::SymbolRef scope, core::NameRef name,
-                                         core::LocOffsets loc) {
+    core::ClassOrModuleRef ensureScopeIsClass(core::MutableContext ctx, core::SymbolRef scope, core::NameRef name,
+                                              core::LocOffsets loc) {
         // Common case: Everything is fine, user is trying to define a symbol on a class or module.
         if (scope.isClassOrModule()) {
             // Check if original symbol was mangled away. If so, complain.
@@ -766,7 +766,7 @@ private:
             return ctx.owner.enclosingClass(ctx).data(ctx)->singletonClass(ctx);
         }
 
-        auto scope = ensureIsClass(ctx, ctx.owner, name, loc);
+        auto scope = ensureScopeIsClass(ctx, ctx.owner, name, loc);
         core::SymbolRef existing = scope.data(ctx)->findMember(ctx, name);
         if (!existing.exists()) {
             existing = ctx.state.enterClassSymbol(ctx.locAt(loc), scope, name);
@@ -1254,8 +1254,8 @@ private:
     core::FieldRef insertStaticField(core::MutableContext ctx, const core::FoundStaticField &staticField) {
         ENFORCE(ctx.owner.isClassOrModule());
 
-        auto scope = ensureIsClass(ctx, squashNames(ctx, staticField.scopeClass, contextClass(ctx, ctx.owner)),
-                                   staticField.name, staticField.asgnLoc);
+        auto scope = ensureScopeIsClass(ctx, squashNames(ctx, staticField.scopeClass, contextClass(ctx, ctx.owner)),
+                                        staticField.name, staticField.asgnLoc);
         auto sym = ctx.state.lookupStaticFieldSymbol(scope, staticField.name);
         auto currSym = ctx.state.lookupSymbol(scope, staticField.name);
         if (!sym.exists() && currSym.exists()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1347,13 +1347,14 @@ private:
             }
             sym = existingTypeMember;
         } else {
-            auto oldSym = onSymbol.data(ctx)->findMemberNoDealias(ctx, typeMember.name);
+            auto name = typeMember.name;
+            auto oldSym = onSymbol.data(ctx)->findMemberNoDealias(ctx, name);
             if (oldSym.exists()) {
                 emitRedefinedConstantError(ctx, typeMember.nameLoc, oldSym.name(ctx), core::SymbolRef::Kind::TypeMember,
                                            oldSym);
                 ctx.state.mangleRenameSymbol(oldSym, oldSym.name(ctx));
             }
-            sym = ctx.state.enterTypeMember(ctx.locAt(typeMember.asgnLoc), onSymbol, typeMember.name, variance);
+            sym = ctx.state.enterTypeMember(ctx.locAt(typeMember.asgnLoc), onSymbol, name, variance);
 
             // The todo bounds will be fixed by the resolver in ResolveTypeParamsWalk.
             auto todo = core::make_type<core::ClassType>(core::Symbols::todo());
@@ -1361,17 +1362,17 @@ private:
 
             if (isTypeTemplate) {
                 auto context = ctx.owner.enclosingClass(ctx);
-                oldSym = context.data(ctx)->findMemberNoDealias(ctx, typeMember.name);
+                oldSym = context.data(ctx)->findMemberNoDealias(ctx, name);
                 if (oldSym.exists() &&
                     !(oldSym.loc(ctx) == ctx.locAt(typeMember.asgnLoc) || oldSym.loc(ctx).isTombStoned(ctx))) {
-                    emitRedefinedConstantError(ctx, typeMember.nameLoc, typeMember.name,
-                                               core::SymbolRef::Kind::TypeMember, oldSym);
-                    ctx.state.mangleRenameSymbol(oldSym, typeMember.name);
+                    emitRedefinedConstantError(ctx, typeMember.nameLoc, name, core::SymbolRef::Kind::TypeMember,
+                                               oldSym);
+                    ctx.state.mangleRenameSymbol(oldSym, name);
                 }
                 // This static field with an AliasType is how we get `MyTypeTemplate` to resolve,
                 // because resolver does not usually look on the singleton class to resolve constant
                 // literals, but type_template's are only ever entered on the singleton class.
-                auto alias = ctx.state.enterStaticFieldSymbol(ctx.locAt(typeMember.asgnLoc), context, typeMember.name);
+                auto alias = ctx.state.enterStaticFieldSymbol(ctx.locAt(typeMember.asgnLoc), context, name);
                 alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
             }
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Pulling these edits out to make diffs smaller and stacked changes less likely to
conflict.


### Commit summary

- **pre-work: Factor `typeMember.name` to a variable** (b3294026d)


- **pre-work: ensureIsClass -> ensureScopeIsClass** (37b265078)


- **pre-work: name -> nameForErrors** (0b70e15ff)

  The thing we're ensuring is a class is the scope only, not the name of
  the constant itself. For example:

      class A::B::C
        X::Y::Z = 1
      end

  This leads to two calls to this method:

      ensureScopeIsClass(A::B, "C")
      ensureScopeIsClass(X::Y, "Z")

  Only `A::B` and `X::Y` are checked for being a class. In this case,
  `X::Y::Z` is not a class, and that's OK—the name passed to this method
  is only for error messages, so that we can say more about the cause of
  the error.

- **no-op: Add `const` to some tree methods** (0c8f54861)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a