### PR TITLE
delete `FileReadException`

### DIFF
--- a/common/Exception.h
+++ b/common/Exception.h
@@ -26,11 +26,6 @@ public:
     FileNotDirException() : SorbetException("File is not a directory") {}
 };
 
-class FileReadException : SorbetException {
-public:
-    FileReadException(const std::string &message) : SorbetException(message) {}
-};
-
 class CreateDirException : SorbetException {
 public:
     CreateDirException(const std::string &message) : SorbetException(message) {}

--- a/main/lsp/LSPInput.h
+++ b/main/lsp/LSPInput.h
@@ -38,8 +38,6 @@ public:
 
 /**
  * Reads messages from a file descriptor (like stdin).
- *
- * Throws a FileReadException on error or EOF.
  */
 class LSPFDInput final : public LSPInput {
     // Contains unparsed strings containing a partial message read from file descriptor.
@@ -56,8 +54,6 @@ public:
 
 /**
  * Input is provided programmatically via the `write` method. Threadsafe.
- *
- * Throws a FileReadException when stream has been closed.
  */
 class LSPProgrammaticInput final : public LSPInput {
     absl::Mutex mtx;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This class is unused; `LSPInput` started using errors-via-return-values some time ago.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
