### PR TITLE
make `FileNotFoundException` have an actual message

### DIFF
--- a/common/Exception.h
+++ b/common/Exception.h
@@ -16,7 +16,7 @@ public:
     SorbetException(const char *message) : logic_error(message) {}
 };
 
-class FileNotFoundException : SorbetException {
+class FileNotFoundException : public SorbetException {
 public:
     FileNotFoundException(const std::string &message) : SorbetException(message) {}
 };

--- a/common/Exception.h
+++ b/common/Exception.h
@@ -18,7 +18,7 @@ public:
 
 class FileNotFoundException : SorbetException {
 public:
-    FileNotFoundException() : SorbetException("File not found") {}
+    FileNotFoundException(const std::string &message) : SorbetException(message) {}
 };
 
 class FileNotDirException : SorbetException {

--- a/common/common.cc
+++ b/common/common.cc
@@ -45,11 +45,11 @@ string sorbet::FileOps::read(string_view filename) {
         fclose(fp);
         if (readBytes != contents.size()) {
             // Error reading file?
-            throw sorbet::FileNotFoundException();
+            throw sorbet::FileNotFoundException(fmt::format("Error reading file: `{}`: {}", filename, errno));
         }
         return contents;
     }
-    throw sorbet::FileNotFoundException();
+    throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}`", filename));
 }
 
 void sorbet::FileOps::write(string_view filename, const vector<uint8_t> &data) {
@@ -59,7 +59,7 @@ void sorbet::FileOps::write(string_view filename, const vector<uint8_t> &data) {
         fclose(fp);
         return;
     }
-    throw sorbet::FileNotFoundException();
+    throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}` for writing", filename));
 }
 
 bool sorbet::FileOps::dirExists(string_view path) {
@@ -108,7 +108,7 @@ void sorbet::FileOps::write(string_view filename, string_view text) {
         fclose(fp);
         return;
     }
-    throw sorbet::FileNotFoundException();
+    throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}` for writing", filename));
 }
 
 bool sorbet::FileOps::writeIfDifferent(string_view filename, string_view text) {
@@ -126,7 +126,7 @@ void sorbet::FileOps::append(string_view filename, string_view text) {
         fclose(fp);
         return;
     }
-    throw sorbet::FileNotFoundException();
+    throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}` for writing", filename));
 }
 
 string_view sorbet::FileOps::getFileName(string_view path) {
@@ -261,7 +261,7 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
                 throw sorbet::FileNotDirException();
             default:
                 // Mirrors other FileOps functions: Assume other errors are from FileNotFound.
-                throw sorbet::FileNotFoundException();
+                throw sorbet::FileNotFoundException(fmt::format("Couldn't open directory `{}`", path));
         }
     }
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -691,8 +691,8 @@ void addFilesFromDir(Options &opts, string_view dir, shared_ptr<spdlog::logger> 
     try {
         containedFiles = opts.fs->listFilesInDir(fileNormalized, opts.allowedExtensions, true,
                                                  opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
-    } catch (sorbet::FileNotFoundException) {
-        logger->error("Directory `{}` not found", dir);
+    } catch (sorbet::FileNotFoundException e) {
+        logger->error(e.what());
         throw EarlyReturnWithCode(1);
     } catch (sorbet::FileNotDirException) {
         logger->error("Path `{}` is not a directory", dir);

--- a/payload/binary/tools/gen_state_payload.cc
+++ b/payload/binary/tools/gen_state_payload.cc
@@ -11,7 +11,7 @@ using namespace std;
 int main(int argc, char **argv) {
     ifstream fin(argv[1], ios::binary);
     if (!fin.good()) {
-        throw sorbet::FileNotFoundException();
+        throw sorbet::FileNotFoundException(string(argv[1]));
     }
     vector<uint8_t> data;
 

--- a/test/cli/bad-perm/test.out
+++ b/test/cli/bad-perm/test.out
@@ -1,1 +1,1 @@
-Directory `dir` not found
+Couldn't open directory `dir`

--- a/test/cli/folder-input-not-found/test.out
+++ b/test/cli/folder-input-not-found/test.out
@@ -1,1 +1,1 @@
-Directory `test/cli/folder-input-not-found/files` not found
+Couldn't open directory `test/cli/folder-input-not-found/files`

--- a/test/helpers/MockFileSystem.cc
+++ b/test/helpers/MockFileSystem.cc
@@ -22,7 +22,7 @@ void MockFileSystem::writeFiles(const vector<pair<string, string>> &initialFiles
 string MockFileSystem::readFile(string_view path) const {
     auto file = contents.find(makeAbsolute(rootPath, path));
     if (file == contents.end()) {
-        throw sorbet::FileNotFoundException();
+        throw sorbet::FileNotFoundException(fmt::format("Cannot find file `{}`", path));
     } else {
         return file->second;
     }
@@ -35,7 +35,7 @@ void MockFileSystem::writeFile(string_view filename, string_view text) {
 void MockFileSystem::deleteFile(string_view filename) {
     auto file = contents.find(makeAbsolute(rootPath, filename));
     if (file == contents.end()) {
-        throw sorbet::FileNotFoundException();
+        throw sorbet::FileNotFoundException(fmt::format("Cannot find file `{}`", filename));
     } else {
         contents.erase(file);
     }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were having some issues at Stripe where we were getting a `FileNotFoundException` at:

https://github.com/sorbet/sorbet/blob/3776975aa2b22bdc537c150e24fd475e16c593f7/main/options/options.cc#L689-L696

...but it's not clear that catching a `FileNotFoundException` here necessarily implies that the original, top-level directory is the thing not found.

The way this PR chooses to fix the issue is to add a proper message to `FileNotFoundException`, which we can then propagate out to this particular location.

I considered making the "message" to `FileNotFoundException` just the filename, but it seemed better to have an actual message, since we can include a little bit more information about what exactly we were trying to do when we couldn't find the file.  Happy to discuss alternative approaches.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
