### PR TITLE
Also silence `private` method redefinition warning

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -83,7 +83,7 @@ module T::Props
         lazily_defined_methods[name] = blk
 
         cls = decorated_class
-        if cls.method_defined?(name)
+        if cls.method_defined?(name) || cls.private_method_defined?(name)
           # Ruby does not emit "method redefined" warnings for aliased methods
           # (more robust than undef_method that would create a small window in which the method doesn't exist)
           cls.send(:alias_method, name, name)


### PR DESCRIPTION
We use `alias_method` to silence warnings when redefining methods.

`method_defined?` only considers public and protected methods.

**Also checking `private_method_defined?` ensures we silence those warnings too.**

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#4695 silenced `public` and `protected` method redefinition warnings (probably intending to silence all such warnings). This simply extends this behavior to **`private`** methods for consistency. The same justifications that applied there also apply here.

I noticed this when running the test suite for [Shopify/ruby-lsp](https://github.com/Shopify/ruby-lsp), whose output included several lines of warnings due to this bug.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

#4695, which originally introduced silencing these warnings did not include tests, so I think it's reasonable to skip that here too.