### PR TITLE
fix `test/cli/bad-perm` output

### DIFF
--- a/test/cli/bad-perm/test.out
+++ b/test/cli/bad-perm/test.out
@@ -1,1 +1,1 @@
-Couldn't open directory `dir`
+Couldn't open directory `dir/no-read`

--- a/test/cli/bad-perm/test.out
+++ b/test/cli/bad-perm/test.out
@@ -1,1 +1,1 @@
-Couldn't open directory `dir/no-read`
+Couldn't open directory `dir`

--- a/test/cli/bad-perm/test.sh
+++ b/test/cli/bad-perm/test.sh
@@ -2,8 +2,7 @@
 
 dir=$(mktemp -d)
 echo "parse_fail +" > "$dir/file.rb"
-mkdir "$dir/no-read"
-chmod 000 "$dir/no-read"
+chmod 000 "$dir"
 cmd="main/sorbet --silence-dev-message $dir"
 if [ "$(id -u)" = 0 ]; then
     su -s /bin/bash nobody -c "$cmd" 2>&1 | sed "s,$dir,dir,"


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`master` builds are failing.  This PR should correct it, though I don't really understand why we passed CI to merge this and the change passed on my local machine before I pushed.

There's some weirdness where this test explicitly checks for executing as `root` and tries to switch to `nobody` for executing Sorbet...maybe that codepath is getting triggered on master in a way that it's not for PR builds (or vice versa)?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
