### PR TITLE
Fix crash in getCallArguments

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1532,6 +1532,10 @@ TypePtr getMethodArguments(const GlobalState &gs, ClassOrModuleRef klass, NameRe
         if (arg.flags.isBlock) {
             continue;
         }
+        if (arg.type == nullptr) {
+            args.emplace_back(core::Types::untyped(gs, method));
+            continue;
+        }
         args.emplace_back(Types::resultTypeAsSeenFrom(gs, arg.type, data->owner, klass, targs));
     }
     return make_type<TupleType>(move(args));

--- a/test/testdata/infer/get_call_arguments_nullptr.rb
+++ b/test/testdata/infer/get_call_arguments_nullptr.rb
@@ -1,0 +1,17 @@
+# typed: true
+extend T::Sig
+
+class CallTakesBlock
+  def call(x)
+    p x
+  end
+end
+
+sig {params(blk: CallTakesBlock).void}
+def example(&blk)
+  yield 42
+end
+
+example do |x|
+  T.reveal_type(x) # error: `T.untyped`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #6475

This is causing a handful of background crashes on Stripe's codebase
every day.

Separately, this pattern seems like it should be banned outright--I've
opened a ticket to handle that separately:

<https://github.com/sorbet/sorbet/issues/6483>


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.