### PR TITLE
Add error for non-`Proc`-typed block argument

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -113,6 +113,7 @@ public:
     static TypePtr rangeOfUntyped();
     static TypePtr hashOfUntyped();
     static TypePtr procClass();
+    static TypePtr nilableProcClass();
     static TypePtr classClass();
     static TypePtr declBuilderForProcsSingletonClass();
     static TypePtr falsyTypes();
@@ -669,6 +670,7 @@ private:
      * constructor, so the friend declaration doesn't work), we provide the
      * `make_shared` helper here.
      */
+    friend TypePtr Types::nilableProcClass();
     friend TypePtr Types::falsyTypes();
     friend TypePtr Types::Boolean();
     friend class NameSubstitution;

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -105,6 +105,11 @@ TypePtr Types::procClass() {
     return make_type<ClassType>(Symbols::Proc());
 }
 
+TypePtr Types::nilableProcClass() {
+    static auto res = OrType::make_shared(nilClass(), procClass());
+    return res;
+}
+
 TypePtr Types::classClass() {
     return make_type<ClassType>(Symbols::Class());
 }

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -246,7 +246,7 @@ module Kernel
   sig do
     params(
         symbol: T.any(Symbol, String),
-        blk: BasicObject
+        blk: T.untyped
     )
     .returns(Symbol)
   end
@@ -398,7 +398,7 @@ module Kernel
     params(
         method: Symbol,
         args: BasicObject,
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(T::Enumerator[T.untyped])
   end
@@ -612,7 +612,7 @@ module Kernel
     params(
         arg0: T.any(String, Symbol),
         arg1: BasicObject,
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(T.untyped)
   end
@@ -672,7 +672,7 @@ module Kernel
     params(
         method: Symbol,
         args: BasicObject,
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(T::Enumerator[T.untyped])
   end
@@ -1838,7 +1838,7 @@ module Kernel
   # [`Proc.new`](https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-c-new).
   sig do
     params(
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(Proc)
   end
@@ -1850,7 +1850,7 @@ module Kernel
   # objects check the number of parameters passed when called.
   sig do
     params(
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(Proc)
   end

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -425,7 +425,7 @@ class Module < Object
   sig do
     params(
         args: BasicObject,
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(T.untyped)
   end
@@ -802,7 +802,7 @@ class Module < Object
   sig do
     params(
         arg0: T.any(Symbol, String),
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(Symbol)
   end
@@ -1221,7 +1221,7 @@ class Module < Object
   sig do
     params(
         args: BasicObject,
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(T.untyped)
   end

--- a/rbi/core/proc.rbi
+++ b/rbi/core/proc.rbi
@@ -459,7 +459,7 @@ class Proc < Object
   # [`Proc#lambda?`](https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-i-lambda-3F).
   sig do
     params(
-        arg0: BasicObject,
+        arg0: T.untyped,
         blk: T.untyped,
     )
     .returns(T.untyped)

--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -587,7 +587,7 @@ class String < Object
   sig {returns(T::Array[Integer])}
   sig do
     params(
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(T::Array[Integer])
   end
@@ -1774,7 +1774,7 @@ class String < Object
   sig do
     params(
         arg0: T.any(Regexp, String),
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(T::Array[T.any(String, T::Array[String])])
   end

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -314,7 +314,7 @@ module URI
     params(
         str: String,
         schemes: T::Array[T.untyped],
-        blk: BasicObject,
+        blk: T.untyped,
     )
     .returns(T::Array[String])
   end

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3454,7 +3454,7 @@ private:
                             "    `{}` objects, but even those methods must return `{}` objects.",
                             "to_proc", "&blk", "Proc", "Proc");
 
-                        e.replaceWith("Convert block to `T.nilable(Proc)`", spec->typeLoc, "T.nilable(Proc)");
+                        e.replaceWith("Change block type to `T.nilable(Proc)`", spec->typeLoc, "T.nilable(Proc)");
                     }
                     arg.type = core::Types::untypedUntracked();
                 }

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -415,8 +415,8 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                         }
                         auto resultAndBind = move(maybeResultAndBind.value());
 
-                        sig.argTypes.emplace_back(
-                            ParsedSig::ArgSpec{ctx.locAt(key.loc()), name, resultAndBind.type, resultAndBind.rebind});
+                        sig.argTypes.emplace_back(ParsedSig::ArgSpec{ctx.locAt(key.loc()), name, ctx.locAt(value.loc()),
+                                                                     resultAndBind.type, resultAndBind.rebind});
                     }
                 }
                 break;

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -416,7 +416,7 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                         auto resultAndBind = move(maybeResultAndBind.value());
 
                         sig.argTypes.emplace_back(ParsedSig::ArgSpec{ctx.locAt(key.loc()), name, ctx.locAt(value.loc()),
-                                                                     resultAndBind.type, resultAndBind.rebind});
+                                                                     resultAndBind.rebind, resultAndBind.type});
                     }
                 }
                 break;

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -13,8 +13,8 @@ struct ParsedSig {
         core::Loc nameLoc;
         core::NameRef name;
         core::Loc typeLoc;
-        core::TypePtr type;
         core::ClassOrModuleRef rebind;
+        core::TypePtr type;
     };
     core::ClassOrModuleRef bind;
     std::vector<ArgSpec> argTypes;

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -10,8 +10,9 @@ namespace sorbet::resolver {
 
 struct ParsedSig {
     struct ArgSpec {
-        core::Loc loc;
+        core::Loc nameLoc;
         core::NameRef name;
+        core::Loc typeLoc;
         core::TypePtr type;
         core::ClassOrModuleRef rebind;
     };

--- a/test/testdata/infer/blockpass.rb
+++ b/test/testdata/infer/blockpass.rb
@@ -1,0 +1,29 @@
+# typed: true
+extend T::Sig
+
+class A
+  extend T::Sig
+
+  sig {returns(A)}
+  def to_proc
+    # The Ruby VM raises an exception when the result of calling `to_proc` for
+    # a blockpass does not produce a `Proc` object.
+    self
+  end
+
+  sig {void}
+  def call
+  end
+end
+
+sig {params(blk: A).void}
+#           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
+def takes_a_as_block(&blk)
+end
+
+[].each(&A.new) # error: Expected `T.proc.params(arg0: T.untyped).returns(BasicObject)` but found `A` for block argument
+
+# The above error about block argument type sets the block type to `T.untyped`,
+# which means neither of these are errors.
+takes_a_as_block(&A.new)
+takes_a_as_block(&(->(){}))

--- a/test/testdata/infer/crash_yield_load_params.rb
+++ b/test/testdata/infer/crash_yield_load_params.rb
@@ -3,12 +3,14 @@
 module Left
   extend T::Sig
   sig {params(blk: BasicObject).returns(NilClass)}
+  #           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
   def foo(&blk); end
 end
 
 module Up
   extend T::Sig
   sig {params(blk: BasicObject).returns(NilClass)}
+  #           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
   def foo(&blk); end
 end
 

--- a/test/testdata/infer/crash_yield_load_params.rb.autocorrects.exp
+++ b/test/testdata/infer/crash_yield_load_params.rb.autocorrects.exp
@@ -3,14 +3,14 @@
 
 module Left
   extend T::Sig
-  sig {params(blk: BasicObject).returns(NilClass)}
+  sig {params(blk: T.nilable(Proc)).returns(NilClass)}
   #           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
   def foo(&blk); end
 end
 
 module Up
   extend T::Sig
-  sig {params(blk: BasicObject).returns(NilClass)}
+  sig {params(blk: T.nilable(Proc)).returns(NilClass)}
   #           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
   def foo(&blk); end
 end

--- a/test/testdata/infer/crash_yield_load_params.rb.autocorrects.exp
+++ b/test/testdata/infer/crash_yield_load_params.rb.autocorrects.exp
@@ -1,0 +1,29 @@
+# -- test/testdata/infer/crash_yield_load_params.rb --
+# typed: true
+
+module Left
+  extend T::Sig
+  sig {params(blk: BasicObject).returns(NilClass)}
+  #           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
+  def foo(&blk); end
+end
+
+module Up
+  extend T::Sig
+  sig {params(blk: BasicObject).returns(NilClass)}
+  #           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
+  def foo(&blk); end
+end
+
+class Main
+  extend T::Sig
+
+  sig {params(x: T.all(Left, Up)).void}
+  def foo(x)
+    res = x.foo do |y|
+      T.reveal_type(y) # error: `T.untyped`
+    end
+    res = T.reveal_type(res) # error: `NilClass`
+  end
+end
+# ------------------------------

--- a/test/testdata/infer/get_call_arguments_nullptr.rb
+++ b/test/testdata/infer/get_call_arguments_nullptr.rb
@@ -8,6 +8,7 @@ class CallTakesBlock
 end
 
 sig {params(blk: CallTakesBlock).void}
+#           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
 def example(&blk)
   yield 42
 end

--- a/test/testdata/infer/get_call_arguments_nullptr.rb.autocorrects.exp
+++ b/test/testdata/infer/get_call_arguments_nullptr.rb.autocorrects.exp
@@ -1,0 +1,20 @@
+# -- test/testdata/infer/get_call_arguments_nullptr.rb --
+# typed: true
+extend T::Sig
+
+class CallTakesBlock
+  def call(x)
+    p x
+  end
+end
+
+sig {params(blk: CallTakesBlock).void}
+#           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
+def example(&blk)
+  yield 42
+end
+
+example do |x|
+  T.reveal_type(x) # error: `T.untyped`
+end
+# ------------------------------

--- a/test/testdata/infer/get_call_arguments_nullptr.rb.autocorrects.exp
+++ b/test/testdata/infer/get_call_arguments_nullptr.rb.autocorrects.exp
@@ -8,7 +8,7 @@ class CallTakesBlock
   end
 end
 
-sig {params(blk: CallTakesBlock).void}
+sig {params(blk: T.nilable(Proc)).void}
 #           ^^^ error: Block argument type must be either `Proc` or a `T.proc` type (and possibly nilable)
 def example(&blk)
   yield 42

--- a/test/testdata/namer/yield.rb.cfg-text.exp
+++ b/test/testdata/namer/yield.rb.cfg-text.exp
@@ -158,8 +158,8 @@ bb3[rubyRegionId=0, firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Stat
 bb5[rubyRegionId=1, firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     # outerLoops: 1
     <self>: Main = loadSelf(lambda)
-    <blk>$7: T.untyped = load_yield_params(lambda)
-    x$1: T.untyped = yield_load_arg(0, <blk>$7: T.untyped)
+    <blk>$7: T::Array[T.untyped] = load_yield_params(lambda)
+    x$1: T.untyped = yield_load_arg(0, <blk>$7: T::Array[T.untyped])
     <statTemp>$9: NilClass = <self>: Main.puts(x$1: T.untyped)
     <blockReturnTemp>$8: Integer(3) = 3
     <blockReturnTemp>$12: T.noreturn = blockreturn<lambda> <blockReturnTemp>$8: Integer(3)

--- a/test/testdata/namer/yield.rb.cfg-text.exp
+++ b/test/testdata/namer/yield.rb.cfg-text.exp
@@ -158,8 +158,8 @@ bb3[rubyRegionId=0, firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Stat
 bb5[rubyRegionId=1, firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     # outerLoops: 1
     <self>: Main = loadSelf(lambda)
-    <blk>$7: T::Array[T.untyped] = load_yield_params(lambda)
-    x$1: T.untyped = yield_load_arg(0, <blk>$7: T::Array[T.untyped])
+    <blk>$7: T.untyped = load_yield_params(lambda)
+    x$1: T.untyped = yield_load_arg(0, <blk>$7: T.untyped)
     <statTemp>$9: NilClass = <self>: Main.puts(x$1: T.untyped)
     <blockReturnTemp>$8: Integer(3) = 3
     <blockReturnTemp>$12: T.noreturn = blockreturn<lambda> <blockReturnTemp>$8: Integer(3)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #6483

The Ruby VM does not allow this.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.