### PR TITLE
Skip checking block type in sorbet-runtime when possible

### DIFF
--- a/gems/sorbet-runtime/.rubocop.yml
+++ b/gems/sorbet-runtime/.rubocop.yml
@@ -39,7 +39,22 @@ Lint/UnusedMethodArgument:
 Lint/UselessMethodDefinition:
   Enabled: false
 
+# Ratcheting these down is kind of outside the purview of a linter
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/BlockNesting:
+  Enabled: false
 Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/PerceivedComplexity:
   Enabled: false
 
 # This can be bad for performance

--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -99,6 +99,27 @@ module SorbetBenchmarks
         integer_param(1)
       end
 
+      my_proc = proc {}
+      time_block("sig {params(x: Integer, blk: T.proc.void)} -- block literal") do
+        integer_param_and_block(0) {}
+        integer_param_and_block(0) {}
+      end
+
+      time_block("sig {params(x: Integer, blk: T.proc.void)} -- block pass") do
+        integer_param_and_block(0, &my_proc)
+        integer_param_and_block(0, &my_proc)
+      end
+
+      time_block("sig {params(x: Integer, blk: T.nilable(T.proc.void))} -- block literal") do
+        integer_param_and_nilable_block(0) {}
+        integer_param_and_nilable_block(0) {}
+      end
+
+      time_block("sig {params(x: Integer, blk: T.nilable(T.proc.void))} -- block pass") do
+        integer_param_and_nilable_block(0, &my_proc)
+        integer_param_and_nilable_block(0, &my_proc)
+      end
+
       time_block("T.let(..., T.nilable(Integer))") do
         T.let(nil, T.nilable(Integer))
         T.let(1, T.nilable(Integer))
@@ -160,6 +181,12 @@ module SorbetBenchmarks
 
     sig {params(x: Integer).void}
     def self.integer_param(x); end
+
+    sig {params(x: Integer, blk: T.proc.void).void}
+    def self.integer_param_and_block(x, &blk); end
+
+    sig {params(x: Integer, blk: T.nilable(T.proc.void)).void}
+    def self.integer_param_and_nilable_block(x, &blk); end
 
     sig {params(x: T.nilable(Integer)).void}
     def self.nilable_integer_param(x); end

--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -136,15 +136,18 @@ module SorbetBenchmarks
 
       time_block("direct call Object#class") do
         example.class
+        example.class
       end
 
       class_method = Object.instance_method(:class)
       time_block(".bind(example).call Object#class") do
         class_method.bind(example).call
+        class_method.bind(example).call
       end
 
       if T::Configuration::AT_LEAST_RUBY_2_7
         time_block(".bind_call(example) Object#class") do
+          class_method.bind_call(example)
           class_method.bind_call(example)
         end
       else

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -125,19 +125,10 @@ module T::Private::Methods::CallValidation
       end
     end
 
-    if method_sig.block_type
-      message = method_sig.block_type.error_message_for_obj(blk)
-      if message
-        CallValidation.report_error(
-          method_sig,
-          message,
-          'Block parameter',
-          method_sig.block_name,
-          method_sig.block_type,
-          blk
-        )
-      end
-    end
+    # The Ruby VM already checks that the `&blk` arg is a `Proc` type.
+    # https://github.com/ruby/ruby/blob/v2_7_6/vm_args.c#L1150-L1154
+    # And `T.proc` types don't (can't) do any runtime arg checking, so doing any
+    # runtime check against the `method_sig.block_type` here is redundant.
 
     # The following line breaks are intentional to show nice pry message
 

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -59,8 +59,9 @@ module T::Private::Methods::CallValidation
 
   def self.create_validator_method(mod, original_method, method_sig, original_visibility)
     has_fixed_arity = method_sig.kwarg_types.empty? && !method_sig.has_rest && !method_sig.has_keyrest &&
-      original_method.parameters.all? {|(kind, _name)| kind == :req}
-    ok_for_fast_path = has_fixed_arity && !method_sig.bind && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
+      original_method.parameters.all? {|(kind, _name)| kind == :req || kind == :block}
+    can_skip_block_type = method_sig.block_type.nil? || method_sig.block_type.valid?(nil)
+    ok_for_fast_path = has_fixed_arity && can_skip_block_type && !method_sig.bind && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
 
     all_args_are_simple = ok_for_fast_path && method_sig.arg_types.all? {|_name, type| type.is_a?(T::Types::Simple)}
     simple_method = all_args_are_simple && method_sig.return_type.is_a?(T::Types::Simple)
@@ -76,7 +77,7 @@ module T::Private::Methods::CallValidation
           create_validator_procedure_medium(mod, original_method, method_sig, original_visibility)
         elsif ok_for_fast_path
           create_validator_method_medium(mod, original_method, method_sig, original_visibility)
-        elsif method_sig.block_type.nil? || method_sig.block_type.valid?(nil)
+        elsif can_skip_block_type
           # The Ruby VM already validates that any block passed to a method
           # must be either `nil` or a `Proc` object, so there's no need to also
           # have sorbet-runtime check that.

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -76,11 +76,98 @@ module T::Private::Methods::CallValidation
           create_validator_procedure_medium(mod, original_method, method_sig, original_visibility)
         elsif ok_for_fast_path
           create_validator_method_medium(mod, original_method, method_sig, original_visibility)
+        elsif method_sig.block_type.nil? || method_sig.block_type.valid?(nil)
+          # The Ruby VM already validates that any block passed to a method
+          # must be either `nil` or a `Proc` object, so there's no need to also
+          # have sorbet-runtime check that.
+          create_validator_slow_skip_block_type(mod, original_method, method_sig, original_visibility)
         else
           create_validator_slow(mod, original_method, method_sig, original_visibility)
         end
       end
       mod.send(original_visibility, method_sig.method_name)
+    end
+  end
+
+  def self.create_validator_slow_skip_block_type(mod, original_method, method_sig, original_visibility)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      CallValidation.validate_call_skip_block_type(self, original_method, method_sig, args, blk)
+    end
+  end
+
+  def self.validate_call_skip_block_type(instance, original_method, method_sig, args, blk)
+    # This method is called for every `sig`. It's critical to keep it fast and
+    # reduce number of allocations that happen here.
+
+    if method_sig.bind
+      message = method_sig.bind.error_message_for_obj(instance)
+      if message
+        CallValidation.report_error(
+          method_sig,
+          message,
+          'Bind',
+          nil,
+          method_sig.bind,
+          instance
+        )
+      end
+    end
+
+    # NOTE: We don't bother validating for missing or extra kwargs;
+    # the method call itself will take care of that.
+    method_sig.each_args_value_type(args) do |name, arg, type|
+      message = type.error_message_for_obj(arg)
+      if message
+        CallValidation.report_error(
+          method_sig,
+          message,
+          'Parameter',
+          name,
+          type,
+          arg,
+          caller_offset: 2
+        )
+      end
+    end
+
+    # The original method definition allows passing `nil` for the `&blk`
+    # argument, so we do not have to do any method_sig.block_type type checks
+    # of our own.
+
+    # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+    # PRY note:
+    # this code is sig validation code.
+    # Please issue `finish` to step out of it
+
+    return_value = T::Configuration::AT_LEAST_RUBY_2_7 ? original_method.bind_call(instance, *args, &blk) : original_method.bind(instance).call(*args, &blk)
+
+    # The only type that is allowed to change the return value is `.void`.
+    # It ignores what you returned and changes it to be a private singleton.
+    if method_sig.return_type.is_a?(T::Private::Types::Void)
+      T::Private::Types::Void::VOID
+    else
+      message = method_sig.return_type.error_message_for_obj(return_value)
+      if message
+        CallValidation.report_error(
+          method_sig,
+          message,
+          'Return value',
+          nil,
+          method_sig.return_type,
+          return_value,
+        )
+      end
+      return_value
     end
   end
 
@@ -125,10 +212,30 @@ module T::Private::Methods::CallValidation
       end
     end
 
-    # The Ruby VM already checks that the `&blk` arg is a `Proc` type.
+    # The Ruby VM already checks that `&blk` is either a `Proc` type or `nil`:
     # https://github.com/ruby/ruby/blob/v2_7_6/vm_args.c#L1150-L1154
-    # And `T.proc` types don't (can't) do any runtime arg checking, so doing any
-    # runtime check against the `method_sig.block_type` here is redundant.
+    # And `T.proc` types don't (can't) do any runtime arg checking, so we can
+    # save work by simply checking that `blk` is non-nil (if the method allows
+    # `nil` for the block, it would not have used this validate_call path).
+    unless blk
+      # Have to use `&.` here, because it's technically a public API that
+      # people can _always_ call `validate_call` to validate any signature
+      # (i.e., the faster validators are merely optimizations).
+      # In practice, this only affects the first call to the method (before the
+      # optimized validators have a chance to replace the initial, slow
+      # wrapper).
+      message = method_sig.block_type&.error_message_for_obj(blk)
+      if message
+        CallValidation.report_error(
+          method_sig,
+          message,
+          'Block parameter',
+          method_sig.block_name,
+          method_sig.block_type,
+          blk
+        )
+      end
+    end
 
     # The following line breaks are intentional to show nice pry message
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Runtime performance

### Benchmarks

I've collected these before fixing the aforementioned problems with `nil`, so
it's possible that these benchmarks will get slower after that.

Only the **bolded** things should get sped up from this change—other changes are included to showcase how noisy the measurements usually are. Speedups are reported as percentage speedups vs "Before" (so negative percents are slowdowns—some things slow down by small percentages due to noise in measurement).

| Benchmark (all times in ns)                                        | Before | w/o `nil` checks | % faster | w/ `nil` checks | % faster |
| ---                                                                | ---:   | ---:             | ---:     | ---:            | ---:     |
| Vanilla Ruby method call                                           | 15     | 15               | 0%       | 15              | 0%       |
| Vanilla Ruby is_a?                                                 | 25     | 24               | 4%       | 26              | -4%      |
| T::Types::Simple#valid?                                            | 37     | 37               | 0%       | 38              | -3%      |
| T.nilable(Integer).valid?                                          | 49     | 49               | 0%       | 51              | -4%      |
| T.any(Integer, Float, T::Boolean).valid?                           | 182    | 180              | 1%       | 180             | 1%       |
| T.let(..., Integer)                                                | 289    | 288              | 0%       | 294             | -2%      |
| sig {params(...).void}                                             | 198    | 210              | -6%      | 198             | 0%       |
| **sig {params(..., blk: T.proc.void)} -- `{}`**                    | 997    | 808              | 23%      | 807             | 24%      |
| **sig {params(..., blk: T.proc.void)} -- `&blk`**                  | 849    | 663              | 28%      | 657             | 29%      |
| **sig {params(..., blk: T.nilable(T.proc.void))} -- `{}`**         | 1044   | 780              | 34%      | 754             | 38%      |
| **sig {params(..., blk: T.nilable(T.proc.void))} -- `&blk`**       | 937    | 660              | 42%      | 651             | 44%      |
| T.let(..., T.nilable(Integer))                                     | 733    | 737              | -1%      | 741             | -1%      |
| sig {params(x: T.nilable(Integer)).void}                           | 223    | 224              | 0%       | 221             | 1%       |
| T.let(..., Example)                                                | 294    | 292              | 1%       | 297             | -1%      |
| sig {params(x: Example).void}                                      | 191    | 192              | -1%      | 189             | 1%       |
| T.let(..., T.nilable(Example))                                     | 736    | 723              | 2%       | 739             | 0%       |
| sig {params(x: T.nilable(Example)).void}                           | 223    | 225              | -1%      | 223             | 0%       |
| sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs) | 1413   | 1412             | 0%       | 1389            | 2%       |
| direct call Object#class                                           | 27     | 29               | -7%      | 28              | -4%      |
| .bind(example).call Object#class                                   | 182    | 188              | -3%      | 182             | 0%       |
| .bind_call(example) Object#class                                   | 102    | 106              | -4%      | 101             | 1%       |

**Update**

I pushed a change to make the optimization also combine with the existing fast path optimizations (because those validators already skip the block type checking, so when the method mentions a `&blk` parameter but there is no need to check the block type, we can still take the fast path validators). As expected, the fast path validators are quite fast.

| Benchmark (all times in ns)                                        | w/ `nil` and take fast path if possible | % faster |
| --- | ---: | ---: |
| sig {params(...).void}                                 | 206 | -4%  |
| sig {params(..., blk: T.proc.void)} -- {}              | 819 | 22%  |
| sig {params(..., blk: T.proc.void)} -- &blk            | 689 | 23%  |
| sig {params(..., blk: T.nilable(T.proc.void))} -- {}   | 309 | 238% |
| sig {params(..., blk: T.nilable(T.proc.void))} -- &blk | 236 | 298% |

This makes passing a `{}` block within 50% of no block, and passing a `&blk` block within 15% of no block.

### Analysis

Oddly, the "without `nil` checks" times are actually **faster** than the initial implementation that did not check and report a sorbet-runtiem error for `nil`. I take that to mean that there is likely, there is no additional performance gained by skipping the `nil` checking when possible, but I figure we may as well keep the separate code paths, because it also means that there's not a penalty to doing so.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

- - - 

**old, outdated initial description**

Leaving this as work-in-progress, because the one thing that the VM doesn't do
that Sorbet does do currently is check whether a block was required.

One approach would be to only skip this check for methods whose block is typed
as `T.nilable(...)`, and simply leave the old behavior otherwise.

Another approach would be to do something like the `create_validator_fast`
methods that skips checking block types for **all** methods (not just those that
have a certain arity) depending on whether they take a block or not.
