### PR TITLE
don't copy `AutogenResult::Serialized` in workers

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -263,7 +263,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
                         }
                     }
 
-                    out.prints.emplace_back(make_pair(idx, serialized));
+                    out.prints.emplace_back(idx, move(serialized));
                 }
             }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Copying these strings can get rather large in aggregate across all of autogen.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
