### PR TITLE
don't allocate strings in `PrinterConfig::flush`

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -98,7 +98,7 @@ void PrinterConfig::flush() {
         return;
     }
     absl::MutexLock lck(&state->mutex);
-    FileOps::write(outputPath, to_string(state->buf));
+    FileOps::write(outputPath, string_view(state->buf.data(), state->buf.size()));
 };
 
 string PrinterConfig::flushToString() {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's no good reason to construct a `string` here when we can just construct a `string_view` instead.

(I checked and there doesn't seem to be a `to_string_view` in `fmt`; the only one I could find is in an internal namespace.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
