### PR TITLE
copy less stuff when using `msgpack` in autogen

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -102,7 +102,7 @@ NamedDefinition NamedDefinition::fromDef(const core::GlobalState &gs, ParsedFile
 
     auto fullName = parsedFile.showQualifiedName(gs, def);
 
-    return {def.data(parsedFile), fullName, parentName, parsedFile.requireStatements, parsedFile.tree.file, pathDepth};
+    return {def.data(parsedFile), move(fullName), move(parentName), parsedFile.requireStatements, parsedFile.tree.file, pathDepth};
 }
 
 bool NamedDefinition::preferredTo(const core::GlobalState &gs, const NamedDefinition &lhs, const NamedDefinition &rhs) {

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -102,7 +102,8 @@ NamedDefinition NamedDefinition::fromDef(const core::GlobalState &gs, ParsedFile
 
     auto fullName = parsedFile.showQualifiedName(gs, def);
 
-    return {def.data(parsedFile), move(fullName), move(parentName), parsedFile.requireStatements, parsedFile.tree.file, pathDepth};
+    return {def.data(parsedFile),         move(fullName),       move(parentName),
+            parsedFile.requireStatements, parsedFile.tree.file, pathDepth};
 }
 
 bool NamedDefinition::preferredTo(const core::GlobalState &gs, const NamedDefinition &lhs, const NamedDefinition &rhs) {

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -68,8 +68,8 @@ struct NamedDefinition {
     NamedDefinition() = default;
     NamedDefinition(Definition def, QualifiedName qname, QualifiedName parentName,
                     std::vector<core::NameRef> requireStatements, core::FileRef fileRef, uint32_t pathDepth)
-        : def(def), qname(std::move(qname)), parentName(std::move(parentName)), requireStatements(std::move(requireStatements)),
-          fileRef(fileRef), pathDepth(pathDepth) {}
+        : def(def), qname(std::move(qname)), parentName(std::move(parentName)),
+          requireStatements(std::move(requireStatements)), fileRef(fileRef), pathDepth(pathDepth) {}
     NamedDefinition(const NamedDefinition &) = delete;
     NamedDefinition(NamedDefinition &&) = default;
     NamedDefinition &operator=(const NamedDefinition &) = delete;

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -68,7 +68,7 @@ struct NamedDefinition {
     NamedDefinition() = default;
     NamedDefinition(Definition def, QualifiedName qname, QualifiedName parentName,
                     std::vector<core::NameRef> requireStatements, core::FileRef fileRef, uint32_t pathDepth)
-        : def(def), qname(qname), parentName(parentName), requireStatements(std::move(requireStatements)),
+        : def(def), qname(std::move(qname)), parentName(std::move(parentName)), requireStatements(std::move(requireStatements)),
           fileRef(fileRef), pathDepth(pathDepth) {}
     NamedDefinition(const NamedDefinition &) = delete;
     NamedDefinition(NamedDefinition &&) = default;

--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -57,7 +57,7 @@ QualifiedName ParsedFile::showQualifiedName(const core::GlobalState &gs, Definit
     auto &ref = def.defining_ref.data(*this);
     auto nameParts = showFullName(gs, ref.scope);
     nameParts.insert(nameParts.end(), ref.name.nameParts.begin(), ref.name.nameParts.end());
-    return QualifiedName{nameParts};
+    return QualifiedName::fromFullName(move(nameParts));
 }
 
 // Pretty-print a `ParsedFile`, including all definitions and references and the pieces of metadata associated with them

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -187,29 +187,36 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
     mpack_start_array(&writer, symbols.size());
     for (auto sym : symbols) {
         ++i;
-        string str;
+        string_view str;
         if (i < numTypes) {
             switch ((Definition::Type)i) {
                 case Definition::Type::Module:
-                    str = "module";
+                    str = "module"sv;
                     break;
                 case Definition::Type::Class:
-                    str = "class";
+                    str = "class"sv;
                     break;
                 case Definition::Type::Casgn:
-                    str = "casgn";
+                    str = "casgn"sv;
                     break;
                 case Definition::Type::Alias:
-                    str = "alias";
+                    str = "alias"sv;
                     break;
                 case Definition::Type::TypeAlias:
-                    str = "typealias";
+                    str = "typealias"sv;
                     break;
-                default: // shouldn't happen
-                    str = sym.shortName(ctx);
+                default: {
+                    // shouldn't happen
+                    auto v = sym.shortName(ctx);
+                    static_assert(std::is_same_v<decltype(v), string_view>, "shortName doesn't return the right thing");
+                    str = v;
+                    break;
+                }
             }
         } else {
-            str = sym.shortName(ctx);
+            auto v = sym.shortName(ctx);
+            static_assert(std::is_same_v<decltype(v), string_view>, "shortName doesn't return the right thing");
+            str = v;
         }
 
         packString(str);

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -11,11 +11,12 @@ namespace sorbet::autogen {
 
 void MsgpackWriter::packName(core::NameRef nm) {
     uint32_t id;
-    auto it = symbolIds.find(nm);
-    if (it == symbolIds.end()) {
+    typename decltype(symbolIds)::value_type v{nm, 0};
+    auto [it, inserted] = symbolIds.insert(v);
+    if (inserted) {
         id = symbols.size();
         symbols.emplace_back(nm);
-        symbolIds[nm] = id;
+        it->second = id;
     } else {
         id = it->second;
     }

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -143,9 +143,9 @@ MsgpackWriter::MsgpackWriter(int version)
       symbols(typeCount.at(version)) {}
 
 string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg) {
-    char *data;
-    size_t size;
-    mpack_writer_init_growable(&writer, &data, &size);
+    char *body;
+    size_t bodySize;
+    mpack_writer_init_growable(&writer, &body, &bodySize);
     mpack_start_array(&writer, 6);
 
     mpack_write_true(&writer); // did_resolution
@@ -173,11 +173,11 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
     mpack_finish_array(&writer);
 
     mpack_writer_destroy(&writer);
-    auto body = string(data, size);
-    MPACK_FREE(data);
 
     // write header
-    mpack_writer_init_growable(&writer, &data, &size);
+    char *header;
+    size_t headerSize;
+    mpack_writer_init_growable(&writer, &header, &headerSize);
 
     mpack_start_map(&writer, 5);
 
@@ -235,12 +235,13 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
     }
     mpack_finish_array(&writer);
 
-    mpack_write_object_bytes(&writer, body.data(), body.size());
+    mpack_write_object_bytes(&writer, body, bodySize);
+    MPACK_FREE(body);
 
     mpack_writer_destroy(&writer);
 
-    auto ret = string(data, size);
-    MPACK_FREE(data);
+    auto ret = string(header, headerSize);
+    MPACK_FREE(header);
 
     return ret;
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

All these changes combined with some previous changes are good for ~5% improvement when generating packages (which relies on the msgpack files generated by autogen) on Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
