### PR TITLE
only look up the entry in `childMap` once per iteration

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -328,8 +328,9 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
 
             for (const auto &[parentName, children] : *el.subclasses) {
                 if (!parentName.empty()) {
-                    childMap[parentName].entries.insert(children.entries.begin(), children.entries.end());
-                    childMap[parentName].classKind = children.classKind;
+                    auto &childEntry = childMap[parentName];
+                    childEntry.entries.insert(children.entries.begin(), children.entries.end());
+                    childEntry.classKind = children.classKind;
                 }
             }
         }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less work is less work.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
