### PR TITLE
delete some dead forward definitions from `shared_ptr<core::Type>` days

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -16,7 +16,6 @@ namespace sorbet::core {
 class ClassOrModule;
 class GlobalState;
 struct LocalSymbolTableHashes;
-class Type;
 class MutableContext;
 class Context;
 class TypeAndOrigins;

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -9,7 +9,6 @@
 #include <memory>
 
 namespace sorbet::core {
-class Type;
 class TypeConstraint;
 struct DispatchResult;
 struct DispatchArgs;

--- a/core/Types.h
+++ b/core/Types.h
@@ -15,7 +15,6 @@
 #include <string>
 namespace sorbet::core {
 /** Dmitry: unlike in Dotty, those types are always dealiased. For now */
-class Type;
 class AppliedType;
 class IntrinsicMethod;
 class TypeConstraint;

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -13,7 +13,6 @@
 #include "core/Types.h"
 
 // improve debugging.
-template class std::shared_ptr<sorbet::core::Type>;
 template class std::shared_ptr<sorbet::core::TypeConstraint>;
 template class std::shared_ptr<sorbet::core::SendAndBlockLink>;
 template class std::vector<sorbet::core::Loc>;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -8,8 +8,6 @@
 #include "core/TypeErrorDiagnostics.h"
 #include <algorithm> // find, remove_if
 
-template struct std::pair<sorbet::core::LocalVariable, std::shared_ptr<sorbet::core::Type>>;
-
 using namespace std;
 
 namespace sorbet::infer {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Cleaner code.

(I deleted the forward definitions of `class Type`, and the compiler started complaining about the template definitions, so I feel extra-good about `class Type` not being a thing.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
