### PR TITLE
delete unused `blockRetrunTemp`

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -334,7 +334,6 @@ NameDef names[] = {
     {"classMethods", "class_methods"},
 
     {"blockTemp", "<block>"},
-    {"blockRetrunType", "<block-return-type>"},
     {"blockPreCallTemp", "<block-pre-call-temp>"},
     {"blockPassTemp", "<block-pass>"},
     {"forTemp"},


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Why fix a misspelling when you can just delete the code entirely?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
