### PR TITLE
Revert "Make runtime type check `attr_accessor` writers (#6426)"

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -58,14 +58,12 @@ class T::Private::Methods::Signature
     @defined_raw = defined_raw
 
     declared_param_names = raw_arg_types.keys
-    # If sig params are declared and there is a single parameter with a missing name
+    # If sig params are declared but there is a single parameter with a missing name
     # **and** the method ends with a "=", assume it is a writer method generated
-    # by attr_writer or attr_accessor.
-    # We fix up the parameter name in that case to be the method name without the "=".
-    if declared_param_names != [nil] && parameters == [[:req]] && method_name[-1] == "="
-      parameters = [[:req, method_name[0...-1].to_sym]]
-    end
-
+    # by attr_writer or attr_accessor
+    writer_method = declared_param_names != [nil] && parameters == [[:req]] && method_name[-1] == "="
+    # For writer methods, map the single parameter to the method name without the "=" at the end
+    parameters = [[:req, method_name[0...-1].to_sym]] if writer_method
     param_names = parameters.map {|_, name| name}
     missing_names = param_names - declared_param_names
     extra_names = declared_param_names - param_names

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -21,37 +21,19 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
       extend T::Helpers
       sig {params(foo: String).returns(String)}
       attr_writer :foo
-      sig {returns(Integer)}
+      sig {params(bar: Integer).returns(Integer)}
       attr_accessor :bar
     end
 
-    # Verify that attr_writer works on the happy path
     assert_equal("foo", klass.new.foo = "foo")
-
-    # Verify that attr_writer does type checking
     err = assert_raises(TypeError) do
       klass.new.foo = 42
     end
     assert_match(/Expected type String, got type Integer/, err.message)
-
-    # Verify that the reader and writer for attr_accessor work on the happy path
-    obj = klass.new
-    assert_equal(42, obj.bar = 42)
-    assert_equal(42, obj.bar)
-
-    # Verify that the writer for attr_accessor does type checking
-    err = assert_raises(TypeError) do
-      klass.new.bar = "bar"
-    end
-    assert_match(/Expected type Integer, got type String/, err.message)
-
-    # Verify that the reader for attr_accessor does type checking
-    obj = klass.new
-    obj.instance_variable_set(:@bar, "bar")
-    err = assert_raises(TypeError) do
-      obj.bar
-    end
-    assert_match(/Expected type Integer, got type String/, err.message)
+    assert_equal(42, klass.new.bar = 42)
+    # TODO: This should also raise a type error, but currently doesn't because
+    # the sig only affects the reader part of the attr_accessor, not the writer.
+    assert_equal("foo", klass.new.bar = "foo")
   end
 
   it 'handles module_function on including class' do


### PR DESCRIPTION
This reverts commit b1a7f2cf522dddefa7d56120af49212f90a11612.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are two causes. Cause 1, discussed on Slack:

> Ufuk Kayserilioglu I’m having some problems landing your `attr_accessor` change on Stripe’s codebase. In my initial testing, I thought there were no problems, and then when I went to deploy certain services, I saw crashes at code load time.
>
> It turns out that if there is another gem or another part of the codebase that adds a `method_added` hook, it shows up in the backtrace, which throws off the “the attr_accessor call will be exactly 3 frames above us” computation
>
> ```
> vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.10483/lib/types/private/methods/_methods.rb:216:in `attr_accessor_reader?'
> vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.10483/lib/types/private/methods/_methods.rb:265:in `_on_method_added'
> vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.10483/lib/types/private/methods/_methods.rb:554:in `method_added'
> vendor/bundle/ruby/2.7.0/gems/blankslate-2.1.2.4/lib/blankslate.rb:80:in `method_added'
> manage/framework/erb_context.rb:12:in `attr_accessor'
> manage/framework/erb_context.rb:12:in `<class:ErbContext>'
> manage/framework/erb_context.rb:8:in `<module:Framework>'
> manage/framework/erb_context.rb:7:in `<compiled>'
> primus/lib/require.rb:854:in `require'
> ```
>
> not sure what the best way is to fix this is going to be. I can work around it for the time being, but I would love if you could lend some eyes as well.

Cause 2:

> i tried again with the upgrade (after fixing the override problems) and we’re seeing substantially increased memory, causing problems in our CI environment.
>
> It’s unclear but my guess is that this is a side effect of adding `sig`’s to thousands of `attr_accessor` calls.
>
> There are some other changes that we need to make to sorbet-runtime, that this attr_accessor change is blocking. While we work on a change to make it work in the presence of weird call stack depths and to give me time to figure out how to deal with the memory increase, I’m going to revert the attr_accessor PR to make way for the other changes that need to be made. We can re-measure the memory problems before landing whatever fixes we would make to the call stack depth problem.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a