### PR TITLE
Avoid excess allocations in `T::Types::Enum#name`

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/enum.rb
@@ -29,7 +29,7 @@ module T::Types
 
     # overrides Base
     def name
-      "T.deprecated_enum([#{@values.map(&:inspect).join(', ')}])"
+      @name ||= "T.deprecated_enum([#{@values.map(&:inspect).join(', ')}])"
     end
 
     # overrides Base


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This method is showing up alarmingly high in object allocation profiles
on Stripe's codebase. May as well try caching the string to see if this
helps.

These type objects should not be getting mutated after initialization so
this should be fine.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.