### PR TITLE
Add `base` parameter to `#to_i` and `#to_int`

### DIFF
--- a/rbi/core/integer.rbi
+++ b/rbi/core/integer.rbi
@@ -1129,8 +1129,8 @@ class Integer < Numeric
   # [`to_int`](https://docs.ruby-lang.org/en/2.7.0/Integer.html#method-i-to_int)
   # is an alias for
   # [`to_i`](https://docs.ruby-lang.org/en/2.7.0/Integer.html#method-i-to_i).
-  sig {returns(Integer)}
-  def to_i(); end
+  sig {params(base: Integer).returns(Integer)}
+  def to_i(base=10); end
 
   # Since `int` is already an
   # [`Integer`](https://docs.ruby-lang.org/en/2.7.0/Integer.html), returns
@@ -1139,8 +1139,8 @@ class Integer < Numeric
   # [`to_int`](https://docs.ruby-lang.org/en/2.7.0/Integer.html#method-i-to_int)
   # is an alias for
   # [`to_i`](https://docs.ruby-lang.org/en/2.7.0/Integer.html#method-i-to_i).
-  sig {returns(Integer)}
-  def to_int(); end
+  sig {params(base: Integer).returns(Integer)}
+  def to_int(base=10); end
 
   # Returns the value as a rational.
   #


### PR DESCRIPTION
Ruby's [`to_i`](https://ruby-doc.org/core-3.1.2/String.html#to_i-method) method takes an optional base parameter

### Motivation

The RBI defined in this repository is wrong, and should include the existence of this parameter.

### Test plan

I'm not sure if I need to write a test—at least, I could not find any prior art or documentation on whether it was necessary!