### PR TITLE
Add IRB::RelineInputMethod RBI definition

### DIFF
--- a/rbi/stdlib/irb.rbi
+++ b/rbi/stdlib/irb.rbi
@@ -1523,7 +1523,9 @@ end
 
 class IRB::OutputMethod::NotImplementedError < ::StandardError; end
 
-class IRB::ReidlineInputMethod < ::IRB::InputMethod
+class IRB::ReidlineInputMethod < ::IRB::RelineInputMethod; end
+
+class IRB::RelineInputMethod < ::IRB::InputMethod
   include(::Reline)
 
   # Creates a new input method object using


### PR DESCRIPTION
Updates IRB RBIs to make its latest version compatible with tapioca. 

Reflects this change https://github.com/ruby/irb/pull/409/files#diff-947d919ba6e7132eb9acbdb77bd1df88b074c4e21039b550054aa3ffaf4a425dR264


### Motivation
IRB renamed the constant in the above PR, changing its parent class. It now conflicts with the payload 


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
