### PR TITLE
Passing no --autogen-autoloader-pbal-namespaces flag registers all "strictly compatible" packages for PBAL by default

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -39,10 +39,10 @@ bool AutoloaderConfig::sameFileCollapsable(const vector<core::NameRef> &module) 
 }
 
 bool AutoloaderConfig::registeredForPBAL(const vector<core::NameRef> &pkgParts) const {
-    return absl::c_any_of(pbalNamespaces, [&pkgParts](auto &pbalNamespace) {
-        return pbalNamespace.size() <= pkgParts.size() &&
-               std::equal(pbalNamespace.begin(), pbalNamespace.end(), pkgParts.begin());
-    });
+    return pbalNamespaces.empty() || (absl::c_any_of(pbalNamespaces, [&pkgParts](auto &pbalNamespace) {
+               return pbalNamespace.size() <= pkgParts.size() &&
+                      std::equal(pbalNamespace.begin(), pbalNamespace.end(), pkgParts.begin());
+           }));
 }
 
 string_view AutoloaderConfig::normalizePath(const core::GlobalState &gs, core::FileRef file) const {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
As part of migrating Stripe to path-based autoloading with Zeitwerk, we can now "GA" this feature. Meaning that we don't need a special flag that specifies allowlisted namespaces, in order to control turning off generating autoloader shims for paths that are strict. We do it across the board when the flag is empty.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing CLI tests for autogen. Tested on Stripe codebase.
