### PR TITLE
Prevent C/C++ Extension Pack recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
   ],
   "unwantedRecommendations": [
     // Microsoft C++ intellisense (doesn't work properly with Sorbet)
+    "ms-vscode.cpptools-extension-pack",
     "ms-vscode.cpptools"
   ]
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This commit ensures VS Code does not prompt to install [the C/C++ Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-extension-pack), as this includes [the C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) which apparently does not work properly with Sorbet's `compile_commands.json`, according to 5578533.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

:wave: I started setting up the project and when I opened a C++ file, VS Code prompted me to install the C/C++ Extension Pack, which is not recommended according to the [README](https://github.com/sorbet/sorbet/#:~:text=Microsoft%27s%20C/C%2B%2B%20extension):

> **Note: Microsoft's C/C++ extension does not work properly with Sorbet's `compile_commands.json`.**

<img src="https://user-images.githubusercontent.com/770763/198380458-d434d11f-f181-4796-bbe6-d4172518c9b0.png" width="400" /> <img src="https://user-images.githubusercontent.com/770763/198381080-cd55baeb-415e-48c3-8cac-0f7ab4ad2a44.png" width="400" />

Adding the extension pack to `unwantedRecommendations` prevents the above prompt from showing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This only changes the VS Code settings for the project.
