### PR TITLE
Remove all custom autoload_map and intermediate node generation in autoloader

### DIFF
--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -37,6 +37,11 @@ public:
     // when it's removed.
     static void removeDir(std::string_view path);
 
+    // NOTE: this is a minimal wrapper around rmdir, and will return false if the directory is not empty
+    // when it's removed. For any other errno, it will throw an exception. This exists as an convenience function to
+    // prevent the caller from needing to try/catch removeDir.
+    static bool removeEmptyDir(std::string_view path);
+
     static void removeFile(std::string_view path);
     /**
      * Returns a list of all files in the given directory. Returns paths that include the path to directory.

--- a/common/common.cc
+++ b/common/common.cc
@@ -94,6 +94,18 @@ void sorbet::FileOps::removeDir(string_view path) {
     }
 }
 
+bool sorbet::FileOps::removeEmptyDir(string_view path) {
+    auto err = rmdir(string(path).c_str());
+    if (err) {
+        if (errno == ENOTEMPTY) {
+            return false;
+        }
+        throw sorbet::CreateDirException(fmt::format("Error in removeEmptyDir('{}'): {}", path, errno));
+    }
+
+    return true;
+}
+
 void sorbet::FileOps::removeFile(string_view path) {
     auto err = remove(string(path).c_str());
     if (err) {

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -486,7 +486,7 @@ void populateAutoloadTasksAndCreateDirectories(const core::GlobalState &gs, vect
 }
 }; // namespace
 
-const core::FileRef DefTree::definingFile() const {
+core::FileRef DefTree::definingFile() const {
     core::FileRef definingFileRef;
 
     if (!namedDefs.empty() || (hasDef() && children.empty())) {
@@ -496,7 +496,7 @@ const core::FileRef DefTree::definingFile() const {
     return definingFileRef;
 }
 
-const bool DefTree::mustRender(const core::GlobalState &gs, std::string_view filePath) const {
+bool DefTree::mustRender(const core::GlobalState &gs, std::string_view filePath) const {
     // Either the node has a behavior-defining file, or has a package name
     if (definingFile().exists() || pkgName.exists()) {
         return true;

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -200,28 +200,24 @@ core::NameRef DefTree::name() const {
 
 string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderConfig &alCfg) const {
     fmt::memory_buffer buf;
+    core::FileRef definingFileRef = definingFile();
+
     fmt::format_to(std::back_inserter(buf), "{}\n", alCfg.preamble);
 
-    core::FileRef definingFile;
-    if (!namedDefs.empty()) {
-        definingFile = file();
-    } else if (children.empty() && hasDef()) {
-        definingFile = file();
-    }
-    if (definingFile.exists()) {
+    if (definingFileRef.exists()) {
         requireStatements(gs, alCfg, buf);
     }
 
     string fullName = "nil";
     string casgnArg;
     auto type = definitionType(gs);
+
     if (type == Definition::Type::Module || type == Definition::Type::Class) {
         fullName = root() ? alCfg.rootObject
                           : fmt::format("{}", fmt::map_join(qname.nameParts, "::", [&](const auto &nr) -> string {
                                             return nr.show(gs);
                                         }));
         if (!root()) {
-            fmt::format_to(std::back_inserter(buf), "{}.on_autoload('{}')\n", alCfg.registryModule, fullName);
             predeclare(gs, fullName, buf);
         }
 
@@ -235,17 +231,6 @@ string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderC
 
             fmt::format_to(std::back_inserter(buf), "\n{}.pbal_register_package({}, '{}')\n", alCfg.registryModule,
                            fullName, pathPrefix);
-        } else if (!children.empty()) {
-            fmt::format_to(std::back_inserter(buf), "\n{}.autoload_map({}, {{\n", alCfg.registryModule, fullName);
-            vector<pair<core::NameRef, string>> childNames;
-            std::transform(children.begin(), children.end(), back_inserter(childNames),
-                           [&gs](const auto &pair) { return make_pair(pair.first, pair.first.show(gs)); });
-            fast_sort(childNames, [](const auto &lhs, const auto &rhs) -> bool { return lhs.second < rhs.second; });
-            for (const auto &pair : childNames) {
-                fmt::format_to(std::back_inserter(buf), "  {}: \"{}/{}\",\n", pair.second, alCfg.rootDir,
-                               children.at(pair.first)->path(gs));
-            }
-            fmt::format_to(std::back_inserter(buf), "}})\n", fullName);
         }
     } else if (type == Definition::Type::Casgn || type == Definition::Type::Alias ||
                type == Definition::Type::TypeAlias) {
@@ -256,9 +241,9 @@ string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderC
                                qname.name().show(gs));
     }
 
-    if (definingFile.exists()) {
+    if (definingFileRef.exists()) {
         fmt::format_to(std::back_inserter(buf), "\n{}.for_autoload({}, \"{}\"{})\n", alCfg.registryModule, fullName,
-                       alCfg.normalizePath(gs, definingFile), casgnArg);
+                       alCfg.normalizePath(gs, definingFileRef), casgnArg);
     }
     return to_string(buf);
 }
@@ -482,7 +467,10 @@ void populateAutoloadTasksAndCreateDirectories(const core::GlobalState &gs, vect
                                                const AutoloaderConfig &alCfg, string_view path, const DefTree &node) {
     string name = node.root() ? "root" : node.name().show(gs);
     string filePath = join(path, fmt::format("{}.rb", name));
-    tasks.emplace_back(RenderAutoloadTask{filePath, node});
+
+    if (node.mustRender(gs, filePath)) {
+        tasks.emplace_back(RenderAutoloadTask{filePath, node});
+    }
 
     // Generate autoloads for child nodes if they exist and pkgName is not present (since the latter indicates
     // path-based autoloading for the package).
@@ -497,6 +485,30 @@ void populateAutoloadTasksAndCreateDirectories(const core::GlobalState &gs, vect
     }
 }
 }; // namespace
+
+const core::FileRef DefTree::definingFile() const {
+    core::FileRef definingFileRef;
+
+    if (!namedDefs.empty() || (hasDef() && children.empty())) {
+        definingFileRef = file();
+    }
+
+    return definingFileRef;
+}
+
+const bool DefTree::mustRender(const core::GlobalState &gs, std::string_view filePath) const {
+    // Either the node has a behavior-defining file, or has a package name
+    if (definingFile().exists() || pkgName.exists()) {
+        return true;
+    }
+
+    // The node is a class node (as opposed to a module)
+    if (definitionType(gs) == Definition::Type::Class) {
+        return true;
+    }
+
+    return false;
+}
 
 void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &workers, const AutoloaderConfig &alCfg,
                                     const std::string &path, const DefTree &root) {
@@ -536,6 +548,7 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
                 for (auto result = inputq->try_pop(idx); !result.done(); result = inputq->try_pop(idx)) {
                     ++n;
                     auto &task = tasks[idx];
+                    auto src = task.node.renderAutoloadSrc(gs, alCfg);
                     bool rewritten = FileOps::writeIfDifferent(task.filePath, task.node.renderAutoloadSrc(gs, alCfg));
 
                     // Initial read should be cheap, read outside mutex

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -528,6 +528,18 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
         }
         for (const auto &file : existingFilesSet) {
             FileOps::removeFile(file);
+
+            // Remove all empty directories along path. This prevents zeitwerk from setting up dangling autoloads.
+            std::string_view filePath = file;
+            int curDirPos = filePath.find_last_of('/');
+            while (curDirPos > 0) {
+                const auto curDir = filePath.substr(0, curDirPos);
+                if (curDir == path || !FileOps::removeEmptyDir(curDir)) {
+                    break;
+                }
+
+                curDirPos = filePath.find_last_of('/', curDirPos - 1);
+            }
         }
     }
 

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -97,7 +97,7 @@ public:
     std::string fullName(const core::GlobalState &) const;
 
     std::string renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderConfig &) const;
-    const bool mustRender(const core::GlobalState &gs, std::string_view filePath) const;
+    bool mustRender(const core::GlobalState &gs, std::string_view filePath) const;
 
     DefTree() = default;
     DefTree(const DefTree &) = delete;
@@ -107,7 +107,7 @@ public:
 
 private:
     core::FileRef file() const;
-    const core::FileRef definingFile() const;
+    core::FileRef definingFile() const;
     void predeclare(const core::GlobalState &gs, std::string_view fullName, fmt::memory_buffer &buf) const;
     void requireStatements(const core::GlobalState &gs, const AutoloaderConfig &, fmt::memory_buffer &buf) const;
     bool hasDifferentFile(core::FileRef) const;

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -97,6 +97,7 @@ public:
     std::string fullName(const core::GlobalState &) const;
 
     std::string renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderConfig &) const;
+    const bool mustRender(const core::GlobalState &gs, std::string_view filePath) const;
 
     DefTree() = default;
     DefTree(const DefTree &) = delete;
@@ -106,6 +107,7 @@ public:
 
 private:
     core::FileRef file() const;
+    const core::FileRef definingFile() const;
     void predeclare(const core::GlobalState &gs, std::string_view fullName, fmt::memory_buffer &buf) const;
     void requireStatements(const core::GlobalState &gs, const AutoloaderConfig &, fmt::memory_buffer &buf) const;
     bool hasDifferentFile(core::FileRef) const;

--- a/test/cli/autogen-autoloader/test.out
+++ b/test/cli/autogen-autoloader/test.out
@@ -1,35 +1,5 @@
 No errors! Great job.
 
---- output/Foo.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('Foo')
-
-module Foo
-end
-
-Opus::Require.autoload_map(Foo, {
-  Bar: "autoloader/Foo/Bar.rb",
-  Dabba: "autoloader/Foo/Dabba.rb",
-  Errors: "autoloader/Foo/Errors.rb",
-  TOP_LEVEL_CONST: "autoloader/Foo/TOP_LEVEL_CONST.rb",
-})
-
---- output/Foo/Bar.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('Foo::Bar')
-
-module Foo::Bar
-end
-
-Opus::Require.autoload_map(Foo::Bar, {
-  Jazz: "autoloader/Foo/Bar/Jazz.rb",
-  Quuz: "autoloader/Foo/Bar/Quuz.rb",
-})
-
 --- output/Foo/Bar/Jazz.rb
 # frozen_string_literal: true
 # typed: true
@@ -37,7 +7,6 @@ Opus::Require.autoload_map(Foo::Bar, {
 require 'in_class'
 require 'in_method'
 require 'my_gem'
-Opus::Require.on_autoload('Foo::Bar::Jazz')
 
 class Foo::Bar::Jazz < Foo::Bar::Quuz
 end
@@ -51,7 +20,6 @@ Opus::Require.for_autoload(Foo::Bar::Jazz, "test/cli/autogen-autoloader/example1
 require 'in_class'
 require 'in_method'
 require 'my_gem'
-Opus::Require.on_autoload('Foo::Bar::Quuz')
 
 class Foo::Bar::Quuz
 end
@@ -68,26 +36,10 @@ require 'my_gem'
 
 Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/example1.rb", [Foo, :Dabba])
 
---- output/Foo/Errors.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('Foo::Errors')
-
-module Foo::Errors
-end
-
-Opus::Require.autoload_map(Foo::Errors, {
-  BaseError: "autoloader/Foo/Errors/BaseError.rb",
-  MyError1: "autoloader/Foo/Errors/MyError1.rb",
-  MyError2: "autoloader/Foo/Errors/MyError2.rb",
-})
-
 --- output/Foo/Errors/BaseError.rb
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('Foo::Errors::BaseError')
 
 class Foo::Errors::BaseError < StandardError
 end
@@ -98,7 +50,6 @@ Opus::Require.for_autoload(Foo::Errors::BaseError, "test/cli/autogen-autoloader/
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('Foo::Errors::MyError1')
 
 class Foo::Errors::MyError1 < Foo::Errors::BaseError
 end
@@ -109,7 +60,6 @@ Opus::Require.for_autoload(Foo::Errors::MyError1, "test/cli/autogen-autoloader/e
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('Foo::Errors::MyError2')
 
 class Foo::Errors::MyError2 < Foo::Errors::BaseError
 end
@@ -126,40 +76,10 @@ require 'my_gem'
 
 Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/example1.rb", [Foo, :TOP_LEVEL_CONST])
 
---- output/Yabba.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('Yabba')
-
-module Yabba
-end
-
-Opus::Require.autoload_map(Yabba, {
-  Dabba: "autoloader/Yabba/Dabba.rb",
-})
-
---- output/Yabba/Dabba.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('Yabba::Dabba')
-
-module Yabba::Dabba
-end
-
-Opus::Require.autoload_map(Yabba::Dabba, {
-  Bar2: "autoloader/Yabba/Dabba/Bar2.rb",
-  Jazz: "autoloader/Yabba/Dabba/Jazz.rb",
-  NoBehavior: "autoloader/Yabba/Dabba/NoBehavior.rb",
-  Quuz: "autoloader/Yabba/Dabba/Quuz.rb",
-})
-
 --- output/Yabba/Dabba/Bar2.rb
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('Yabba::Dabba::Bar2')
 
 class Yabba::Dabba::Bar2
 end
@@ -170,20 +90,14 @@ Opus::Require.for_autoload(Yabba::Dabba::Bar2, "test/cli/autogen-autoloader/exam
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('Yabba::Dabba::Jazz')
 
 class Yabba::Dabba::Jazz
 end
-
-Opus::Require.autoload_map(Yabba::Dabba::Jazz, {
-  JazBaz: "autoloader/Yabba/Dabba/Jazz/JazBaz.rb",
-})
 
 --- output/Yabba/Dabba/Jazz/JazBaz.rb
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('Yabba::Dabba::Jazz::JazBaz')
 
 class Yabba::Dabba::Jazz::JazBaz
 end
@@ -194,7 +108,6 @@ Opus::Require.for_autoload(Yabba::Dabba::Jazz::JazBaz, "test/cli/autogen-autoloa
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('Yabba::Dabba::NoBehavior')
 
 class Yabba::Dabba::NoBehavior
 end
@@ -205,22 +118,11 @@ Opus::Require.for_autoload(Yabba::Dabba::NoBehavior, "test/cli/autogen-autoloade
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('Yabba::Dabba::Quuz')
 
 class Yabba::Dabba::Quuz < AWS::String
 end
 
 Opus::Require.for_autoload(Yabba::Dabba::Quuz, "test/cli/autogen-autoloader/example2.rb")
-
---- output/root.rb
-# frozen_string_literal: true
-# typed: true
-
-
-Opus::Require.autoload_map(Object, {
-  Foo: "autoloader/Foo.rb",
-  Yabba: "autoloader/Yabba.rb",
-})
 
 --- missing output directory
 --print=autogen-autoloader requires an output path to be specified
@@ -228,16 +130,9 @@ Opus::Require.autoload_map(Object, {
 --- in-place writes
 inplace-output
 inplace-output/Foo.rb
-inplace-output/root.rb
 
 --- strip-prefixes and root rename
 
-
-Primus::Require.autoload_map(Object, {
-  Foo: "my-autoloader/Foo.rb",
-})
-
-Primus::Require.on_autoload('Foo')
 
 module Foo
 end
@@ -247,12 +142,6 @@ Primus::Require.for_autoload(Foo, "autogen-autoloader/inplace.rb")
 --- with different root object
 No errors! Great job.
 
-
-Opus::Require.autoload_map(MyRootObject, {
-  Foo: "autoloader/Foo.rb",
-})
-
-Opus::Require.on_autoload('Foo')
 
 module Foo
 end

--- a/test/cli/autogen-autoloader/test.sh
+++ b/test/cli/autogen-autoloader/test.sh
@@ -55,7 +55,6 @@ main/sorbet --silence-dev-message --stop-after=namer \
   --autogen-registry-module "Primus::Require" \
   test/cli/autogen-autoloader/inplace.rb
 
-cat strip-output/root.rb
 cat strip-output/Foo.rb
 
 echo
@@ -67,5 +66,4 @@ main/sorbet --silence-dev-message --stop-after=namer -p autogen-autoloader:root-
   --autogen-root-object=MyRootObject \
   test/cli/autogen-autoloader/inplace.rb 2>&1
 
-cat root-object/root.rb
 cat root-object/Foo.rb

--- a/test/cli/autogen-pkg-autoloader/test.out
+++ b/test/cli/autogen-pkg-autoloader/test.out
@@ -1,50 +1,5 @@
 No errors! Great job.
 
---- output/RootPackage.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('RootPackage')
-
-module RootPackage
-end
-
-Opus::Require.autoload_map(RootPackage, {
-  Foo: "autoloader/RootPackage/Foo.rb",
-  Nested: "autoloader/RootPackage/Nested.rb",
-  Yabba: "autoloader/RootPackage/Yabba.rb",
-})
-
---- output/RootPackage/Foo.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('RootPackage::Foo')
-
-module RootPackage::Foo
-end
-
-Opus::Require.autoload_map(RootPackage::Foo, {
-  Bar: "autoloader/RootPackage/Foo/Bar.rb",
-  Dabba: "autoloader/RootPackage/Foo/Dabba.rb",
-  Errors: "autoloader/RootPackage/Foo/Errors.rb",
-  TOP_LEVEL_CONST: "autoloader/RootPackage/Foo/TOP_LEVEL_CONST.rb",
-})
-
---- output/RootPackage/Foo/Bar.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('RootPackage::Foo::Bar')
-
-module RootPackage::Foo::Bar
-end
-
-Opus::Require.autoload_map(RootPackage::Foo::Bar, {
-  Jazz: "autoloader/RootPackage/Foo/Bar/Jazz.rb",
-  Quuz: "autoloader/RootPackage/Foo/Bar/Quuz.rb",
-})
-
 --- output/RootPackage/Foo/Bar/Jazz.rb
 # frozen_string_literal: true
 # typed: true
@@ -52,7 +7,6 @@ Opus::Require.autoload_map(RootPackage::Foo::Bar, {
 require 'in_class'
 require 'in_method'
 require 'my_gem'
-Opus::Require.on_autoload('RootPackage::Foo::Bar::Jazz')
 
 class RootPackage::Foo::Bar::Jazz < RootPackage::Foo::Bar::Quuz
 end
@@ -66,7 +20,6 @@ Opus::Require.for_autoload(RootPackage::Foo::Bar::Jazz, "test/cli/autogen-pkg-au
 require 'in_class'
 require 'in_method'
 require 'my_gem'
-Opus::Require.on_autoload('RootPackage::Foo::Bar::Quuz')
 
 class RootPackage::Foo::Bar::Quuz
 end
@@ -83,26 +36,10 @@ require 'my_gem'
 
 Opus::Require.for_autoload(nil, "test/cli/autogen-pkg-autoloader/foo.rb", [RootPackage::Foo, :Dabba])
 
---- output/RootPackage/Foo/Errors.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('RootPackage::Foo::Errors')
-
-module RootPackage::Foo::Errors
-end
-
-Opus::Require.autoload_map(RootPackage::Foo::Errors, {
-  BaseError: "autoloader/RootPackage/Foo/Errors/BaseError.rb",
-  MyError1: "autoloader/RootPackage/Foo/Errors/MyError1.rb",
-  MyError2: "autoloader/RootPackage/Foo/Errors/MyError2.rb",
-})
-
 --- output/RootPackage/Foo/Errors/BaseError.rb
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('RootPackage::Foo::Errors::BaseError')
 
 class RootPackage::Foo::Errors::BaseError < StandardError
 end
@@ -113,7 +50,6 @@ Opus::Require.for_autoload(RootPackage::Foo::Errors::BaseError, "test/cli/autoge
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('RootPackage::Foo::Errors::MyError1')
 
 class RootPackage::Foo::Errors::MyError1 < RootPackage::Foo::Errors::BaseError
 end
@@ -124,7 +60,6 @@ Opus::Require.for_autoload(RootPackage::Foo::Errors::MyError1, "test/cli/autogen
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('RootPackage::Foo::Errors::MyError2')
 
 class RootPackage::Foo::Errors::MyError2 < RootPackage::Foo::Errors::BaseError
 end
@@ -145,7 +80,6 @@ Opus::Require.for_autoload(nil, "test/cli/autogen-pkg-autoloader/foo.rb", [RootP
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('RootPackage::Nested')
 
 module RootPackage::Nested
 end
@@ -154,40 +88,10 @@ Opus::Require.pbal_register_package(RootPackage::Nested, 'test/cli/autogen-pkg-a
 
 Opus::Require.for_autoload(RootPackage::Nested, "test/cli/autogen-pkg-autoloader/nested/nested.rb")
 
---- output/RootPackage/Yabba.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('RootPackage::Yabba')
-
-module RootPackage::Yabba
-end
-
-Opus::Require.autoload_map(RootPackage::Yabba, {
-  Dabba: "autoloader/RootPackage/Yabba/Dabba.rb",
-})
-
---- output/RootPackage/Yabba/Dabba.rb
-# frozen_string_literal: true
-# typed: true
-
-Opus::Require.on_autoload('RootPackage::Yabba::Dabba')
-
-module RootPackage::Yabba::Dabba
-end
-
-Opus::Require.autoload_map(RootPackage::Yabba::Dabba, {
-  Bar2: "autoloader/RootPackage/Yabba/Dabba/Bar2.rb",
-  Jazz: "autoloader/RootPackage/Yabba/Dabba/Jazz.rb",
-  NoBehavior: "autoloader/RootPackage/Yabba/Dabba/NoBehavior.rb",
-  Quuz: "autoloader/RootPackage/Yabba/Dabba/Quuz.rb",
-})
-
 --- output/RootPackage/Yabba/Dabba/Bar2.rb
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('RootPackage::Yabba::Dabba::Bar2')
 
 class RootPackage::Yabba::Dabba::Bar2
 end
@@ -198,20 +102,14 @@ Opus::Require.for_autoload(RootPackage::Yabba::Dabba::Bar2, "test/cli/autogen-pk
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('RootPackage::Yabba::Dabba::Jazz')
 
 class RootPackage::Yabba::Dabba::Jazz
 end
-
-Opus::Require.autoload_map(RootPackage::Yabba::Dabba::Jazz, {
-  JazBaz: "autoloader/RootPackage/Yabba/Dabba/Jazz/JazBaz.rb",
-})
 
 --- output/RootPackage/Yabba/Dabba/Jazz/JazBaz.rb
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('RootPackage::Yabba::Dabba::Jazz::JazBaz')
 
 class RootPackage::Yabba::Dabba::Jazz::JazBaz
 end
@@ -222,7 +120,6 @@ Opus::Require.for_autoload(RootPackage::Yabba::Dabba::Jazz::JazBaz, "test/cli/au
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('RootPackage::Yabba::Dabba::NoBehavior')
 
 class RootPackage::Yabba::Dabba::NoBehavior
 end
@@ -233,18 +130,8 @@ Opus::Require.for_autoload(RootPackage::Yabba::Dabba::NoBehavior, "test/cli/auto
 # frozen_string_literal: true
 # typed: true
 
-Opus::Require.on_autoload('RootPackage::Yabba::Dabba::Quuz')
 
 class RootPackage::Yabba::Dabba::Quuz < AWS::String
 end
 
 Opus::Require.for_autoload(RootPackage::Yabba::Dabba::Quuz, "test/cli/autogen-pkg-autoloader/bar.rb")
-
---- output/root.rb
-# frozen_string_literal: true
-# typed: true
-
-
-Opus::Require.autoload_map(Object, {
-  RootPackage: "autoloader/RootPackage.rb",
-})


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

As part of the ongoing migration of the Stripe codebase to use path-based autoloading with Zeitwerk, we update the autoloader shim generation logic to remove all "custom" autoloads.

Currently, the generation works as follows. Assume that there is a behavior-defining constant `Opus::Foo::Bar::Baz` which is defined in a file `lib/path/to/baz.rb`. Also assume that `Opus`, `Opus::Foo`, and `Opus::Foo::Bar` are pure namespace modules that don't define any behavior. Then, the following shim files will be produced:

* `Opus.rb` containing an `autoload_map` method call that maps `Opus::Foo` to `Opus/Foo.rb`
* `Opus/Foo.rb` containing an `autoload_map` method call that maps `Opus::Foo::Bar` to `Opus/Foo/Bar.rb`.
* `Opus/Foo/Bar.rb` containing an `autoload_map` method call that maps `Opus::Foo::Bar::Baz` to `Opus/Foo/Bar/Baz.rb`.
* `Opus/Foo/Bar/Baz.rb` which is the actual load-bearing shim that require-s `lib/path/to/baz.rb`.

If we use a Zeitwerk loader for autoloading code from these shim files, we don't need any `autoload_map` statements, since Zeitwerk does that for us implicitly.

We also don't require the presence of intermediate files for `Opus`, `Opus::Foo` or `Opus::Foo::Bar`; only the behavior-defining leaf node `Opus::Foo::Bar::Baz` needs a file to be generated at `Opus/Foo/Bar/Baz.rb`. This is because Zeitwerk lazily auto-vivifies modules based on the presence of directories at intermediate nodes -- it does not need intermediate files to be generated at these locations.

Thus, I'm making this change to the logic to remove all unnecessary generation. This will allow us to register these shim files with the Zeitwerk loader.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Making these changes has the following benefits:
* Allows us to more extensively leverage Zeitwerk at Stripe, moving us further forward in the migration.

* As we are currently in an in-between state with the migration, we have been working on ensuring interoperability between the two code-loading systems. Maintaining interoperability is a complex endeavor. We can simplify things by using Zeitwerk both for the source tree *and* these shims. We will not need any custom logic for interoperability, and the whole paradigm shifts from "shim-based vs path-based" to "path-based for shims vs path-based for source-tree". We will in effect switch to a 100% path-based world, with the only differentiating factor being where the paths are located.

* Removes a lot of unnecessary code generation. In the above example, we have reduced from 4 files for a single constant to 1 file. Extrapolating to the entire Stripe codebase, we are seeing that making this change removes ~40k shims. Note that there are two exceptional cases where intermediate files still need to be generated:
  - if the intermediate node is a class.
  - if the intermediate node is a module that defines behavior.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.