### PR TITLE
Remove call to `dealias` in namer

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -141,7 +141,7 @@ class SymbolFinder {
     }
 
     // Returns index to foundDefs containing the given name. Recursively inserts class refs for its owners.
-    core::FoundDefinitionRef squashNames(core::Context ctx, const ast::ExpressionPtr &node) {
+    core::FoundDefinitionRef squashNames(const ast::ExpressionPtr &node) {
         if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
             // Already defined. Insert a foundname so we can reference it.
             auto sym = id->symbol;
@@ -149,7 +149,7 @@ class SymbolFinder {
             return foundDefs->addSymbol(sym);
         } else if (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node)) {
             core::FoundClassRef found;
-            found.owner = squashNames(ctx, constLit->scope);
+            found.owner = squashNames(constLit->scope);
             found.name = constLit->cnst;
             found.loc = constLit->loc;
             return foundDefs->addClassRef(move(found));
@@ -185,7 +185,7 @@ public:
             found.klass = foundDefs->addClassRef(move(foundRef));
         } else {
             if (klass.symbol == core::Symbols::todo()) {
-                found.klass = squashNames(ctx, klass.name);
+                found.klass = squashNames(klass.name);
             } else {
                 // Desugar populates a top-level root() ClassDef.
                 // Nothing else should have been typeAlias by now.
@@ -464,7 +464,7 @@ public:
 
         core::FoundStaticField found;
         found.owner = getOwner();
-        found.scopeClass = squashNames(ctx, lhs.scope);
+        found.scopeClass = squashNames(lhs.scope);
         found.name = lhs.cnst;
         found.asgnLoc = asgn.loc;
         found.lhsLoc = lhs.loc;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -144,7 +144,7 @@ class SymbolFinder {
     core::FoundDefinitionRef squashNames(core::Context ctx, const ast::ExpressionPtr &node) {
         if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
             // Already defined. Insert a foundname so we can reference it.
-            auto sym = id->symbol.dealias(ctx);
+            auto sym = id->symbol;
             ENFORCE(sym.exists());
             return foundDefs->addSymbol(sym);
         } else if (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node)) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't allow constant aliases in class scopes anyways. Not sure why we're
trying to dealias here.

If I had to guess, this was a remant of some hacks we had way long ago to
support this pattern, which was common in Stripe's codebase:

```ruby
class Chalk::ODM::Model
end

M = Chalk::ODM::Model

class M::A
end
```

But this pattern is already rejected by Sorbet, and has been for as long as
I can remember, so likely when that change was finally made, someone forgot
to delete this `dealias` call.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests