### PR TITLE
wip: Crash in static init method locs

### DIFF
--- a/test/testdata/lsp/fast_path/static_init_method_locs.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_init_method_locs.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  if T.unsafe(nil)
+    x = 1
+  end
+  T.reveal_type(x)
+end

--- a/test/testdata/lsp/fast_path/static_init_method_locs.rb
+++ b/test/testdata/lsp/fast_path/static_init_method_locs.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+
+class A
+  if T.unsafe(nil)
+    x = 1
+  end
+  T.reveal_type(x)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The more test cases I find like this, the more I wonder if we should
have something akin to our lsp_test_runner fast path tests, but instead
of adding one `\n` for each character in the file and running the fast
path, start the file with that many `\n` characters and run a fast path
where we delete them all. (Unfortunately, I think this means running
another full slow path edit, and then another fast path edit after, for
each test, which could substantially slow down our tests. Maybe it's the
kind of thing that we do just once to find the problems, commit
individual tests where relevant, and then don't commit any changes to
the test harness? We could at least build it and see how much slower
things get.)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.