### PR TITLE
Require block arg type in signature

### DIFF
--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -138,10 +138,10 @@ module T::Props::PrettyPrintable
 end
 
 module T::Props::PrettyPrintable::DecoratorMethods
-  def inspect_instance(instance, multiline: false, indent: '  ', &blk); end
-  def inspect_instance_components(instance, multiline:, indent:, &blk); end
-  def inspect_prop_value(instance, prop, multiline:, indent:, &blk); end
-  def join_props_with_pretty_values(pretty_kvs, multiline:, indent: '  ', &blk); end
+  def inspect_instance(instance, multiline: false, indent: '  '); end
+  def inspect_instance_components(instance, multiline:, indent:); end
+  def inspect_prop_value(instance, prop, multiline:, indent:); end
+  def join_props_with_pretty_values(pretty_kvs, multiline:, indent: '  '); end
   def self.method_added(name); end
   def self.singleton_method_added(name); end
   def valid_rule_key?(key); end

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -22,7 +22,7 @@ end
 
 module T::Props::ClassMethods
   sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
-  def const(name, cls_or_args, args={}, &blk); end
+  def const(name, cls_or_args, args={}); end
   sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
   def prop(name, cls, rules = nil); end
   def decorator; end

--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -1355,7 +1355,12 @@ class OpenSSL::ASN1::Constructive < OpenSSL::ASN1::ASN1Data
   #   puts asn1
   # end
   # ```
-  sig {returns(::T.untyped)}
+  sig do
+    params(
+      blk: T.nilable(T.proc.returns(::T.untyped)),
+    )
+    .returns(::T.untyped)
+  end
   def each(&blk); end
 
   sig do
@@ -2076,6 +2081,7 @@ module OpenSSL::Buffering
   sig do
     params(
       eol: ::T.untyped,
+      blk: T.nilable(T.proc.returns(::T.untyped)),
     )
     .returns(::T.untyped)
   end
@@ -3245,7 +3251,12 @@ class OpenSSL::Config
   #   # ...
   # end
   # ```
-  sig {returns(::T.untyped)}
+  sig do
+    params(
+      blk: T.nilable(T.proc.returns(::T.untyped)),
+    )
+    .returns(::T.untyped)
+  end
   def each(&blk); end
 
   # Gets the value of *key* from the given *section*

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3485,7 +3485,7 @@ private:
                     // Only error if we have any types
                     if (auto e = ctx.state.beginError(arg.loc, core::errors::Resolver::InvalidMethodSignature)) {
                         e.setHeader("Malformed `{}`. Type not specified for argument `{}`", "sig",
-                                    treeArgName.show(ctx));
+                                    arg.argumentName(ctx.state));
                         e.addErrorLine(ctx.locAt(exprLoc), "Signature");
                     }
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3429,7 +3429,7 @@ private:
             defParams.push_back(local);
 
             auto spec = absl::c_find_if(sig.argTypes, [&](const auto &spec) { return spec.name == treeArgName; });
-            bool isSyntheticBlkArg = arg.name == core::Names::blkArg();
+            bool isSyntheticBlkArg = arg.isSyntheticBlockArgument();
             bool isBlkArg = arg.flags.isBlock;
 
             if (spec != sig.argTypes.end()) {

--- a/test/testdata/infer/generics/option.rb
+++ b/test/testdata/infer/generics/option.rb
@@ -28,10 +28,10 @@ module Option
   def and_then(&blk); end
 
   sig {abstract.returns(Elem)}
-  def unwrap!(&blk); end
+  def unwrap!; end
 
   sig {abstract.params(msg: String).returns(Elem)}
-  def expect!(msg, &blk); end
+  def expect!(msg); end
 
   class Some < T::Struct
     extend T::Generic
@@ -67,12 +67,12 @@ module Option
     end
 
     sig {override.returns(Elem)}
-    def unwrap!(&blk)
+    def unwrap!
       T.reveal_type(self.val) # error: `Option::Some::Elem`
     end
 
     sig {override.params(msg: String).returns(Elem)}
-    def expect!(msg, &blk)
+    def expect!(msg)
       T.reveal_type(self.val) # error: `Option::Some::Elem`
     end
   end
@@ -103,12 +103,12 @@ module Option
     end
 
     sig {override.returns(T.noreturn)}
-    def unwrap!(&blk)
+    def unwrap!
       raise ArgumentError.new("Called Option#unwrap! on a None value")
     end
 
     sig {override.params(msg: String).returns(Elem)}
-    def expect!(msg, &blk)
+    def expect!(msg)
       raise ArgumentError.new(msg)
     end
   end

--- a/test/testdata/resolver/sig_arg_types.rb
+++ b/test/testdata/resolver/sig_arg_types.rb
@@ -23,4 +23,9 @@ class A
   sig {void}
   def test_block_type_not_specified(&blk); end
                                    # ^^^ error: Malformed `sig`. Type not specified for argument `blk`
+
+  sig {void}
+  def test_yield
+    yield
+  end
 end

--- a/test/testdata/resolver/sig_arg_types.rb
+++ b/test/testdata/resolver/sig_arg_types.rb
@@ -16,4 +16,11 @@ class A
   sig {void}
   def test_kwarg_type_not_specified(foo:); end
                                   # ^^^^ error: Malformed `sig`. Type not specified for argument `foo`
+
+  sig {params(blk: T.proc.void).void}
+  def test_block_type_specified(&blk); end
+
+  sig {void}
+  def test_block_type_not_specified(&blk); end
+                                   # ^^^ error: Malformed `sig`. Type not specified for argument `blk`
 end

--- a/test/testdata/resolver/sig_arg_types.rb
+++ b/test/testdata/resolver/sig_arg_types.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {params(foo: Integer).void}
+  def test_arg_type_specified(foo); end
+
+  sig {void}
+  def test_arg_type_not_specified(foo); end
+                                # ^^^ error: Malformed `sig`. Type not specified for argument `foo`
+
+  sig {params(foo: Integer).void}
+  def test_kwarg_type_specified(foo:); end
+
+  sig {void}
+  def test_kwarg_type_not_specified(foo:); end
+                                  # ^^^^ error: Malformed `sig`. Type not specified for argument `foo`
+end

--- a/test/testdata/resolver/sig_arg_types.rb
+++ b/test/testdata/resolver/sig_arg_types.rb
@@ -28,4 +28,12 @@ class A
   def test_yield
     yield
   end
+
+  sig {void}
+  def test_block_type_not_specified_later; end
+end
+
+class A
+  def test_block_type_not_specified_later(&my_custom_block_name); end
+                                         # ^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`. Type not specified for argument `my_custom_block_name`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR ensures explicit block arguments must be defined in the signature:

```rb
sig {void}
def foo(&blk); end
#        ^^^ error: Malformed `sig`. Type not specified for argument `blk`
```

The following will not produce an error:

```rb
sig {params(blk: T.proc.void).void}
def foo(&blk); end
```

Every method has a "synthetic" block argument if an explicit one isn't defined, for which an argument type **shouldn't** be required in the signature. We were previously determining if a block arg was synthetic or not based on its name reference. However, block arguments always have the name reference `<blk>` whether they are explicitly defined or synthetically added. This might not be intended, but is currently how it works:

https://github.com/sorbet/sorbet/blob/9adecfa7bffc4ffb6f72f806161709d6b97681af/namer/namer.cc#L801-L802

This PR swaps the name comparison for `isSyntheticBlockArgument`, which has a more robust way of determining if the block is synthetic or not, based on whether a `Loc` exists. Synthetic blocks use `Loc::none()`:

https://github.com/sorbet/sorbet/blob/9adecfa7bffc4ffb6f72f806161709d6b97681af/core/Symbols.cc#L2019-L2022

An alternative might be to change the namer so explicit block arguments are not named `<blk>`, but leaning on the `isSyntheticBlockArgument` seemed a smaller and simpler change.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5670. The motivation for the change is that all other arguments must have argument types if the signature is present, but block arguments are apparently ignored.

:wave: I picked this up as a "good first issue" as it seemed relatively straightforward to understand and limited in scope.

#### Notes

- The issue above mentions `typed: strict` but this change also applies in `typed: true` if a signature is defined, as it does for other argument types. Is this correct?
- The code was already in place for this to work, but the check for a "synthetic block" was apparently always returning true. Should we instead make that check work by changing `namer.cc`?
- I suspect this will produce errors in some codebases that previously didn't have them (as it did in some RBIs and tests here). Is that OK?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
