### PR TITLE
eliminate the `spd` namespace alias

### DIFF
--- a/ast/desugar/test/desugar_test.cc
+++ b/ast/desugar/test/desugar_test.cc
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-auto logger = spd::stderr_color_mt("desugar_test");
+auto logger = spdlog::stderr_color_mt("desugar_test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
 TEST_CASE("SimpleDesugar") { // NOLINT

--- a/ast/desugar/test/desugar_test.cc
+++ b/ast/desugar/test/desugar_test.cc
@@ -17,7 +17,6 @@
 
 using namespace std;
 
-namespace spd = spdlog;
 auto logger = spd::stderr_color_mt("desugar_test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 

--- a/common/concurrency/WorkerPool.h
+++ b/common/concurrency/WorkerPool.h
@@ -13,7 +13,7 @@ public:
         return 20ms;
     }
     using Task = std::function<void()>;
-    static std::unique_ptr<WorkerPool> create(int size, spd::logger &logger);
+    static std::unique_ptr<WorkerPool> create(int size, spdlog::logger &logger);
     virtual void multiplexJob(std::string_view taskName, Task t) = 0;
     virtual ~WorkerPool() = 0;
     virtual int size() = 0;

--- a/common/concurrency/WorkerPool.h
+++ b/common/concurrency/WorkerPool.h
@@ -3,7 +3,6 @@
 
 #include "common/common.h"
 #include "spdlog/spdlog.h"
-namespace spd = spdlog;
 namespace sorbet {
 class WorkerPool {
 public:

--- a/common/concurrency/WorkerPoolImpl.cc
+++ b/common/concurrency/WorkerPoolImpl.cc
@@ -4,7 +4,7 @@
 
 using namespace std;
 namespace sorbet {
-unique_ptr<WorkerPool> WorkerPool::create(int size, spd::logger &logger) {
+unique_ptr<WorkerPool> WorkerPool::create(int size, spdlog::logger &logger) {
     return make_unique<WorkerPoolImpl>(size, logger);
 }
 
@@ -12,7 +12,7 @@ WorkerPool::~WorkerPool() {
     // see https://eli.thegreenplace.net/2010/11/13/pure-virtual-destructors-in-c
 }
 
-WorkerPoolImpl::WorkerPoolImpl(int size, spd::logger &logger) : _size(size), logger(logger) {
+WorkerPoolImpl::WorkerPoolImpl(int size, spdlog::logger &logger) : _size(size), logger(logger) {
     logger.trace("Creating {} worker threads", _size);
     if (sorbet::emscripten_build) {
         ENFORCE(size == 0);

--- a/common/concurrency/WorkerPoolImpl.h
+++ b/common/concurrency/WorkerPoolImpl.h
@@ -7,7 +7,6 @@
 #include "spdlog/spdlog.h"
 #include <memory>
 #include <vector>
-namespace spd = spdlog;
 namespace sorbet {
 class WorkerPoolImpl : public WorkerPool {
     int _size;

--- a/common/concurrency/WorkerPoolImpl.h
+++ b/common/concurrency/WorkerPoolImpl.h
@@ -80,12 +80,12 @@ class WorkerPoolImpl : public WorkerPool {
     // ORDER IS IMPORTANT. threads must be killed before Queues.
     std::vector<std::unique_ptr<Queue>> threadQueues;
     std::vector<std::unique_ptr<Joinable>> threads;
-    spd::logger &logger;
+    spdlog::logger &logger;
 
     void multiplexJob_(Task_ t);
 
 public:
-    WorkerPoolImpl(int size, spd::logger &logger);
+    WorkerPoolImpl(int size, spdlog::logger &logger);
     ~WorkerPoolImpl();
 
     void multiplexJob(std::string_view taskName, Task t) override;

--- a/core/serialize/test/serialize_test.cc
+++ b/core/serialize/test/serialize_test.cc
@@ -7,7 +7,6 @@
 
 using namespace std;
 
-namespace spd = spdlog;
 namespace sorbet::core::serialize {
 
 auto logger = spd::stderr_color_mt("serialize_test");

--- a/core/serialize/test/serialize_test.cc
+++ b/core/serialize/test/serialize_test.cc
@@ -9,7 +9,7 @@ using namespace std;
 
 namespace sorbet::core::serialize {
 
-auto logger = spd::stderr_color_mt("serialize_test");
+auto logger = spdlog::stderr_color_mt("serialize_test");
 
 TEST_CASE("U4") { // NOLINT
     Pickler p;

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -11,7 +11,6 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
 
-namespace spd = spdlog;
 using namespace std;
 
 namespace sorbet::core {

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -14,7 +14,7 @@
 using namespace std;
 
 namespace sorbet::core {
-auto logger = spd::stderr_color_mt("parse");
+auto logger = spdlog::stderr_color_mt("parse");
 auto errorCollector = make_shared<core::ErrorCollector>();
 auto errorQueue = make_shared<ErrorQueue>(*logger, *logger, errorCollector);
 

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -19,7 +19,6 @@
 #include <fstream>
 #include <memory>
 
-namespace spd = spdlog;
 using namespace std;
 
 namespace sorbet::infer::test {

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -23,7 +23,7 @@ using namespace std;
 
 namespace sorbet::infer::test {
 
-auto logger = spd::stderr_color_mt("infer_test");
+auto logger = spdlog::stderr_color_mt("infer_test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
 void processSource(core::GlobalState &cb, string str) {

--- a/main/autogen/test/constant_hash_test.cc
+++ b/main/autogen/test/constant_hash_test.cc
@@ -10,7 +10,6 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
 
-namespace spd = spdlog;
 using namespace std;
 
 namespace sorbet {

--- a/main/autogen/test/constant_hash_test.cc
+++ b/main/autogen/test/constant_hash_test.cc
@@ -13,7 +13,7 @@
 using namespace std;
 
 namespace sorbet {
-auto logger = spd::stderr_color_mt("parser_test");
+auto logger = spdlog::stderr_color_mt("parser_test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
 struct Helper {

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -106,7 +106,7 @@ CounterState mergeCounters(CounterState counters) {
     return getAndClearThreadCounters();
 }
 
-void tagNewRequest(spd::logger &logger, LSPMessage &msg) {
+void tagNewRequest(spdlog::logger &logger, LSPMessage &msg) {
     msg.latencyTimer = make_unique<Timer>(logger, "task_latency",
                                           initializer_list<int>{50, 100, 250, 500, 1000, 1500, 2000, 2500, 5000, 10000,
                                                                 15000, 20000, 25000, 30000, 35000, 40000});

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -23,7 +23,6 @@
 #include "sorbet_version/sorbet_version.h"
 
 using namespace std;
-namespace spd = spdlog;
 
 namespace sorbet::realmain::lsp {
 

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -36,9 +36,9 @@ options::Options makeOptions(string_view rootPath) {
     return opts;
 }
 
-auto nullSink = make_shared<spd::sinks::null_sink_mt>();
-auto logger = make_shared<spd::logger>("console", nullSink);
-auto typeErrorsConsole = make_shared<spd::logger>("typeDiagnostics", nullSink);
+auto nullSink = make_shared<spdlog::sinks::null_sink_mt>();
+auto logger = make_shared<spdlog::logger>("console", nullSink);
+auto typeErrorsConsole = make_shared<spdlog::logger>("typeDiagnostics", nullSink);
 auto nullOpts = makeOptions("");
 auto workers = WorkerPool::create(0, *logger);
 

--- a/main/lsp/test/lsp_test.cc
+++ b/main/lsp/test/lsp_test.cc
@@ -3,7 +3,6 @@
 
 #include "main/lsp/LSPLoop.h"
 
-namespace spd = spdlog;
 using namespace std;
 
 namespace sorbet::realmain::lsp::test {

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -34,15 +34,15 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
 
 pair<unique_ptr<core::GlobalState>, unique_ptr<KeyValueStore>>
 createGlobalStateAndOtherObjects(string_view rootPath, options::Options &options, int numWorkerThreads,
-                                 shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> &stderrColorSinkOut,
-                                 shared_ptr<spd::logger> &loggerOut, shared_ptr<spd::logger> &typeErrorsConsoleOut) {
+                                 shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> &stderrColorSinkOut,
+                                 shared_ptr<spdlog::logger> &loggerOut, shared_ptr<spdlog::logger> &typeErrorsConsoleOut) {
     options.rawInputDirNames.emplace_back(rootPath);
     options.threads = numWorkerThreads;
 
     // All of this stuff is ignored by LSP, but we need it to construct ErrorQueue/GlobalState.
-    stderrColorSinkOut = make_shared<spd::sinks::ansicolor_stderr_sink_mt>();
-    loggerOut = make_shared<spd::logger>("console", stderrColorSinkOut);
-    typeErrorsConsoleOut = make_shared<spd::logger>("typeDiagnostics", stderrColorSinkOut);
+    stderrColorSinkOut = make_shared<spdlog::sinks::ansicolor_stderr_sink_mt>();
+    loggerOut = make_shared<spdlog::logger>("console", stderrColorSinkOut);
+    typeErrorsConsoleOut = make_shared<spdlog::logger>("typeDiagnostics", stderrColorSinkOut);
     typeErrorsConsoleOut->set_pattern("%v");
     auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*typeErrorsConsoleOut, *loggerOut));
 
@@ -81,9 +81,9 @@ void MultiThreadedLSPWrapper::send(const std::string &json) {
 }
 
 LSPWrapper::LSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> opts,
-                       std::shared_ptr<spd::logger> logger,
-                       shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                       shared_ptr<spd::logger> typeErrorsConsole, unique_ptr<KeyValueStore> kvstore,
+                       std::shared_ptr<spdlog::logger> logger,
+                       shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
+                       shared_ptr<spdlog::logger> typeErrorsConsole, unique_ptr<KeyValueStore> kvstore,
                        bool disableFastPath)
     : logger(logger), workers(WorkerPool::create(opts->threads, *logger)), stderrColorSink(move(stderrColorSink)),
       typeErrorsConsole(move(typeErrorsConsole)), output(make_shared<LSPOutputToVector>()),
@@ -93,17 +93,17 @@ LSPWrapper::LSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Opt
 LSPWrapper::~LSPWrapper() = default;
 
 SingleThreadedLSPWrapper::SingleThreadedLSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> opts,
-                                                   shared_ptr<spd::logger> logger,
-                                                   shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                                                   shared_ptr<spd::logger> typeErrorsConsole,
+                                                   shared_ptr<spdlog::logger> logger,
+                                                   shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
+                                                   shared_ptr<spdlog::logger> typeErrorsConsole,
                                                    unique_ptr<KeyValueStore> kvstore, bool disableFastPath)
     : LSPWrapper(move(gs), move(opts), move(logger), move(stderrColorSink), move(typeErrorsConsole), move(kvstore),
                  disableFastPath) {}
 
 MultiThreadedLSPWrapper::MultiThreadedLSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> opts,
-                                                 shared_ptr<spd::logger> logger,
-                                                 shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                                                 shared_ptr<spd::logger> typeErrorsConsole,
+                                                 shared_ptr<spdlog::logger> logger,
+                                                 shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
+                                                 shared_ptr<spdlog::logger> typeErrorsConsole,
                                                  unique_ptr<KeyValueStore> kvstore, bool disableFastPath)
     : LSPWrapper(move(gs), move(opts), move(logger), move(stderrColorSink), move(typeErrorsConsole), move(kvstore),
                  disableFastPath),
@@ -131,9 +131,9 @@ SingleThreadedLSPWrapper::createWithGlobalState(unique_ptr<core::GlobalState> gs
 
 unique_ptr<SingleThreadedLSPWrapper>
 SingleThreadedLSPWrapper::create(string_view rootPath, shared_ptr<options::Options> options, bool disableFastPath) {
-    shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink;
-    shared_ptr<spd::logger> logger;
-    shared_ptr<spd::logger> typeErrorsConsole;
+    shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink;
+    shared_ptr<spdlog::logger> logger;
+    shared_ptr<spdlog::logger> typeErrorsConsole;
     auto pair = createGlobalStateAndOtherObjects(rootPath, *options, 0, stderrColorSink, logger, typeErrorsConsole);
     // See comment in `SingleThreadedLSPWrapper::createWithGlobalState`
     auto wrapper = new SingleThreadedLSPWrapper(move(pair.first), move(options), move(logger), move(stderrColorSink),
@@ -144,9 +144,9 @@ SingleThreadedLSPWrapper::create(string_view rootPath, shared_ptr<options::Optio
 unique_ptr<MultiThreadedLSPWrapper> MultiThreadedLSPWrapper::create(string_view rootPath,
                                                                     shared_ptr<options::Options> options,
                                                                     int numWorkerThreads, bool disableFastPath) {
-    shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink;
-    shared_ptr<spd::logger> logger;
-    shared_ptr<spd::logger> typeErrorsConsole;
+    shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink;
+    shared_ptr<spdlog::logger> logger;
+    shared_ptr<spdlog::logger> typeErrorsConsole;
     auto pair = createGlobalStateAndOtherObjects(rootPath, *options, numWorkerThreads, stderrColorSink, logger,
                                                  typeErrorsConsole);
     // See comment in `SingleThreadedLSPWrapper::createWithGlobalState`

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -35,7 +35,8 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
 pair<unique_ptr<core::GlobalState>, unique_ptr<KeyValueStore>>
 createGlobalStateAndOtherObjects(string_view rootPath, options::Options &options, int numWorkerThreads,
                                  shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> &stderrColorSinkOut,
-                                 shared_ptr<spdlog::logger> &loggerOut, shared_ptr<spdlog::logger> &typeErrorsConsoleOut) {
+                                 shared_ptr<spdlog::logger> &loggerOut,
+                                 shared_ptr<spdlog::logger> &typeErrorsConsoleOut) {
     options.rawInputDirNames.emplace_back(rootPath);
     options.threads = numWorkerThreads;
 

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -9,7 +9,6 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include <string_view>
 
-
 namespace sorbet {
 class WorkerPool;
 class KeyValueStore;

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -24,13 +24,13 @@ class LSPConfiguration;
 
 class LSPWrapper {
     // Bugfix: WorkerPool destructor assumes that logger is alive when it runs, so keep around logger until it finishes.
-    const std::shared_ptr<spd::logger> logger;
+    const std::shared_ptr<spdlog::logger> logger;
     /**
      * Sorbet assumes we 'own' the following three objects; keep them alive to avoid memory errors.
      */
     const std::unique_ptr<WorkerPool> workers;
-    const std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink;
-    const std::shared_ptr<spd::logger> typeErrorsConsole;
+    const std::shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink;
+    const std::shared_ptr<spdlog::logger> typeErrorsConsole;
 
 protected:
     const std::shared_ptr<LSPOutputToVector> output;
@@ -40,9 +40,9 @@ protected:
 
     /** Raw constructor. Note: Constructor is unwieldy so we can make class fields `const`. */
     LSPWrapper(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> opts,
-               std::shared_ptr<spd::logger> logger,
-               std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-               std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
+               std::shared_ptr<spdlog::logger> logger,
+               std::shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
+               std::shared_ptr<spdlog::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
                bool disableFastPath);
 
 public:
@@ -88,9 +88,9 @@ public:
 class SingleThreadedLSPWrapper final : public LSPWrapper {
     /** Raw constructor. Note: Constructor is unwieldy so we can make class fields `const`. */
     SingleThreadedLSPWrapper(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> opts,
-                             std::shared_ptr<spd::logger> logger,
-                             std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                             std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
+                             std::shared_ptr<spdlog::logger> logger,
+                             std::shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
+                             std::shared_ptr<spdlog::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
                              bool disableFastPath);
 
 public:
@@ -129,9 +129,9 @@ class MultiThreadedLSPWrapper final : public LSPWrapper {
 
     /** Raw constructor. Note: Constructor is unwieldy so we can make class fields `const`. */
     MultiThreadedLSPWrapper(std::unique_ptr<core::GlobalState> gs, std::shared_ptr<options::Options> opts,
-                            std::shared_ptr<spd::logger> logger,
-                            std::shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
-                            std::shared_ptr<spd::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
+                            std::shared_ptr<spdlog::logger> logger,
+                            std::shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink,
+                            std::shared_ptr<spdlog::logger> typeErrorsConsole, std::unique_ptr<KeyValueStore> kvstore,
                             bool disableFastPath);
 
 public:

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -9,7 +9,6 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include <string_view>
 
-namespace spd = spdlog;
 
 namespace sorbet {
 class WorkerPool;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -47,7 +47,6 @@
 #include <csignal>
 #include <poll.h>
 
-
 using namespace std;
 
 namespace sorbet::realmain {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -47,7 +47,6 @@
 #include <csignal>
 #include <poll.h>
 
-namespace spd = spdlog;
 
 using namespace std;
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -51,18 +51,18 @@
 using namespace std;
 
 namespace sorbet::realmain {
-shared_ptr<spd::logger> logger;
+shared_ptr<spdlog::logger> logger;
 int returnCode;
 
-shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> make_stderrColorSink() {
-    auto color_sink = make_shared<spd::sinks::ansicolor_stderr_sink_mt>();
-    color_sink->set_color(spd::level::info, color_sink->white);
-    color_sink->set_color(spd::level::debug, color_sink->magenta);
-    color_sink->set_level(spd::level::info);
+shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> make_stderrColorSink() {
+    auto color_sink = make_shared<spdlog::sinks::ansicolor_stderr_sink_mt>();
+    color_sink->set_color(spdlog::level::info, color_sink->white);
+    color_sink->set_color(spdlog::level::debug, color_sink->magenta);
+    color_sink->set_level(spdlog::level::info);
     return color_sink;
 }
 
-shared_ptr<spd::sinks::ansicolor_stderr_sink_mt> stderrColorSink = make_stderrColorSink();
+shared_ptr<spdlog::sinks::ansicolor_stderr_sink_mt> stderrColorSink = make_stderrColorSink();
 
 /*
  * Workaround https://bugzilla.mindrot.org/show_bug.cgi?id=2863 ; We are
@@ -344,7 +344,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
 
 // Returns `true` if the constant hash information provided tells us
 // we can exit `autogen` early, and `false` otherwise.
-bool autogenCanExitEarly(shared_ptr<spd::logger> &logger, const options::AutogenConstCacheConfig &cfg) {
+bool autogenCanExitEarly(shared_ptr<spdlog::logger> &logger, const options::AutogenConstCacheConfig &cfg) {
     Timer timeit(logger, "autogenCanExitEarly");
 
     if (cfg.cacheFile.empty()) {
@@ -378,12 +378,12 @@ int realmain(int argc, char *argv[]) {
     initializeSymbolizer(argv[0]);
 #endif
     returnCode = 0;
-    logger = make_shared<spd::logger>("console", stderrColorSink);
-    logger->set_level(spd::level::trace); // pass through everything, let the sinks decide
+    logger = make_shared<spdlog::logger>("console", stderrColorSink);
+    logger->set_level(spdlog::level::trace); // pass through everything, let the sinks decide
     logger->set_pattern("%v");
     fatalLogger = logger;
 
-    auto typeErrorsConsole = make_shared<spd::logger>("typeDiagnostics", stderrColorSink);
+    auto typeErrorsConsole = make_shared<spdlog::logger>("typeDiagnostics", stderrColorSink);
     typeErrorsConsole->set_pattern("%v");
 
 #ifndef SORBET_REALMAIN_MIN
@@ -419,25 +419,25 @@ int realmain(int argc, char *argv[]) {
         auto fileSink =
             make_shared<spdlog::sinks::rotating_file_sink_mt>(opts.debugLogFile, ((size_t)1) * 1024 * 1024 * 1024, 3);
         if (opts.logLevel >= 2) {
-            fileSink->set_level(spd::level::trace);
+            fileSink->set_level(spdlog::level::trace);
         } else {
-            fileSink->set_level(spd::level::debug);
+            fileSink->set_level(spdlog::level::debug);
         }
         { // replace console & fatal loggers
-            vector<spd::sink_ptr> sinks{stderrColorSink, fileSink};
-            auto combinedLogger = make_shared<spd::logger>("consoleAndFile", begin(sinks), end(sinks));
+            vector<spdlog::sink_ptr> sinks{stderrColorSink, fileSink};
+            auto combinedLogger = make_shared<spdlog::logger>("consoleAndFile", begin(sinks), end(sinks));
             combinedLogger->flush_on(spdlog::level::err);
-            combinedLogger->set_level(spd::level::trace); // pass through everything, let the sinks decide
+            combinedLogger->set_level(spdlog::level::trace); // pass through everything, let the sinks decide
 
-            spd::register_logger(combinedLogger);
+            spdlog::register_logger(combinedLogger);
             fatalLogger = combinedLogger;
             logger = combinedLogger;
         }
         { // replace type error logger
-            vector<spd::sink_ptr> sinks{stderrColorSink, fileSink};
-            auto combinedLogger = make_shared<spd::logger>("typeDiagnosticsAndFile", begin(sinks), end(sinks));
-            spd::register_logger(combinedLogger);
-            combinedLogger->set_level(spd::level::trace); // pass through everything, let the sinks decide
+            vector<spdlog::sink_ptr> sinks{stderrColorSink, fileSink};
+            auto combinedLogger = make_shared<spdlog::logger>("typeDiagnosticsAndFile", begin(sinks), end(sinks));
+            spdlog::register_logger(combinedLogger);
+            combinedLogger->set_level(spdlog::level::trace); // pass through everything, let the sinks decide
             typeErrorsConsole = combinedLogger;
         }
     }
@@ -445,15 +445,15 @@ int realmain(int argc, char *argv[]) {
 
     switch (opts.logLevel) {
         case 0:
-            stderrColorSink->set_level(spd::level::info);
+            stderrColorSink->set_level(spdlog::level::info);
             break;
         case 1:
-            stderrColorSink->set_level(spd::level::debug);
+            stderrColorSink->set_level(spdlog::level::debug);
             logger->set_pattern("[T%t][%Y-%m-%dT%T.%f] %v");
             logger->debug("Debug logging enabled");
             break;
         default:
-            stderrColorSink->set_level(spd::level::trace);
+            stderrColorSink->set_level(spdlog::level::trace);
             logger->set_pattern("[T%t][%Y-%m-%dT%T.%f] %v");
             logger->trace("Trace logging enabled");
             break;

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -20,7 +20,7 @@ using namespace std;
 namespace sorbet::namer::test {
 
 namespace {
-auto logger = spd::stderr_color_mt("namer_test");
+auto logger = spdlog::stderr_color_mt("namer_test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
 static string_view testClass_str = "Test"sv;

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -14,7 +14,6 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
 
-namespace spd = spdlog;
 
 using namespace std;
 

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -14,7 +14,6 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
 
-
 using namespace std;
 
 namespace sorbet::namer::test {

--- a/parser/test/parser_test.cc
+++ b/parser/test/parser_test.cc
@@ -14,7 +14,6 @@
 #include <string>
 #include <vector>
 
-namespace spd = spdlog;
 using namespace std;
 
 auto logger = spd::stderr_color_mt("parser_test");

--- a/parser/test/parser_test.cc
+++ b/parser/test/parser_test.cc
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-auto logger = spd::stderr_color_mt("parser_test");
+auto logger = spdlog::stderr_color_mt("parser_test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
 TEST_CASE("SimpleParse") { // NOLINT

--- a/test/error-check-test.cc
+++ b/test/error-check-test.cc
@@ -14,7 +14,6 @@
 
 using namespace std;
 
-
 auto logger = spdlog::stderr_color_mt("error-check-test");
 auto errorCollector = make_shared<sorbet::core::ErrorCollector>();
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger, errorCollector);

--- a/test/error-check-test.cc
+++ b/test/error-check-test.cc
@@ -15,7 +15,7 @@
 using namespace std;
 
 
-auto logger = spd::stderr_color_mt("error-check-test");
+auto logger = spdlog::stderr_color_mt("error-check-test");
 auto errorCollector = make_shared<sorbet::core::ErrorCollector>();
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger, errorCollector);
 

--- a/test/error-check-test.cc
+++ b/test/error-check-test.cc
@@ -14,7 +14,6 @@
 
 using namespace std;
 
-namespace spd = spdlog;
 
 auto logger = spd::stderr_color_mt("error-check-test");
 auto errorCollector = make_shared<sorbet::core::ErrorCollector>();

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -25,7 +25,7 @@ unique_ptr<const realmain::options::Options> opts =
 unique_ptr<const OwnedKeyValueStore> kvstore;
 
 unique_ptr<core::GlobalState> buildInitialGlobalState() {
-    typeErrorsConsole->set_level(spd::level::critical);
+    typeErrorsConsole->set_level(spdlog::level::critical);
 
     unique_ptr<core::GlobalState> gs =
         make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*typeErrorsConsole, *logger));
@@ -37,7 +37,7 @@ unique_ptr<core::GlobalState> buildInitialGlobalState() {
 }
 
 extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv) {
-    logger->set_level(spd::level::critical);
+    logger->set_level(spdlog::level::critical);
     fatalLogger = logger;
     // Huh, I wish we could use cxxopts, but libfuzzer & cxxopts choke on each other argument formats
     // thus we do it manually

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -8,7 +8,6 @@
 
 using namespace std;
 using namespace sorbet;
-namespace spd = spdlog;
 
 auto logger = spdlog::stdout_logger_mt("console");
 auto typeErrorsConsole = spdlog::stdout_logger_mt("typeErrorsConsole");

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -19,7 +19,7 @@
 using namespace std;
 
 
-auto logger = spd::stderr_color_mt("hello-test");
+auto logger = spdlog::stderr_color_mt("hello-test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
 namespace sorbet {
@@ -152,7 +152,7 @@ TEST_CASE("CountTrees") {
 }
 
 TEST_CASE("CloneSubstitutePayload") {
-    auto logger = spd::stderr_color_mt("ClonePayload");
+    auto logger = spdlog::stderr_color_mt("ClonePayload");
     auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
     sorbet::core::GlobalState gs(errorQueue);

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -18,12 +18,10 @@
 
 using namespace std;
 
-
 auto logger = spdlog::stderr_color_mt("hello-test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
 namespace sorbet {
-
 
 TEST_CASE("GetGreet") {
     CHECK_EQ("Hello Bazel", "Hello Bazel");

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -18,14 +18,12 @@
 
 using namespace std;
 
-namespace spd = spdlog;
 
 auto logger = spd::stderr_color_mt("hello-test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
 namespace sorbet {
 
-namespace spd = spdlog;
 
 TEST_CASE("GetGreet") {
     CHECK_EQ("Hello Bazel", "Hello Bazel");

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -14,7 +14,6 @@
 #include "test/helpers/position_assertions.h"
 
 namespace sorbet::test {
-namespace spd = spdlog;
 using namespace std;
 
 string singleTest;

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -79,7 +79,7 @@ TEST_CASE("WhitequarkParserTest") {
         }
     }
 
-    auto logger = spd::stderr_color_mt("fixtures: " + inputPath);
+    auto logger = spdlog::stderr_color_mt("fixtures: " + inputPath);
     auto errorCollector = make_shared<core::ErrorCollector>();
     auto errorQueue = make_shared<core::ErrorQueue>(*logger, *logger, errorCollector);
     core::GlobalState gs(errorQueue);

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -47,7 +47,6 @@
 #include <vector>
 
 namespace sorbet::test {
-namespace spd = spdlog;
 using namespace std;
 
 string singleTest;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -53,7 +53,6 @@
 #include <vector>
 
 namespace sorbet::test {
-namespace spd = spdlog;
 using namespace std;
 
 string singleTest;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -190,7 +190,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         }
     }
 
-    auto logger = spd::stderr_color_mt("fixtures: " + inputPath);
+    auto logger = spdlog::stderr_color_mt("fixtures: " + inputPath);
     auto errorCollector = make_shared<core::ErrorCollector>();
     auto errorQueue = make_shared<core::ErrorQueue>(*logger, *logger, errorCollector);
     auto gs = make_unique<core::GlobalState>(errorQueue);

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -16,7 +16,6 @@
 
 using namespace std;
 
-namespace spd = spdlog;
 auto logger = spd::stderr_color_mt("pkg-autocorrects-test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-auto logger = spd::stderr_color_mt("pkg-autocorrects-test");
+auto logger = spdlog::stderr_color_mt("pkg-autocorrects-test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
 string examplePackage = "class Opus::ExamplePackage < PackageSpec\nend\n";

--- a/third_party/licenses/licenses.h
+++ b/third_party/licenses/licenses.h
@@ -1,7 +1,7 @@
-#include<vector>
-#include<string_view>
-#include<utility>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 namespace sorbet::third_party::licenses {
- std::vector<std::pair<std::string_view, std::string_view>> all();
+std::vector<std::pair<std::string_view, std::string_view>> all();
 };

--- a/third_party/licenses/tools/generate_licenses.cc
+++ b/third_party/licenses/tools/generate_licenses.cc
@@ -1,5 +1,5 @@
-#include "common/common.h"
 #include "common/FileOps.h"
+#include "common/common.h"
 #include <algorithm>
 #include <fstream>
 #include <iostream>
@@ -20,7 +20,7 @@ string sourceName2funcName(string sourceName) {
 }
 
 string sourceName2DepName(string sourceName) {
-    return (string) absl::StripPrefix(sourceName, ".txt");
+    return (string)absl::StripPrefix(sourceName, ".txt");
 }
 
 void emitlicenses(vector<string> sourceFileNames, ostream &out) {
@@ -33,8 +33,8 @@ void emitlicenses(vector<string> sourceFileNames, ostream &out) {
     out << "vector<pair<string_view, string_view> > all() {" << '\n';
     out << "  vector<pair<string_view, string_view> > result;" << '\n';
     for (auto &file : sourceFileNames) {
-        out << "  result.emplace_back(make_pair<string_view, string_view>(\"" + absl::CEscape(sourceName2DepName(file)) + "\"sv, " +
-                   sourceName2funcName(file) + "()));"
+        out << "  result.emplace_back(make_pair<string_view, string_view>(\"" +
+                   absl::CEscape(sourceName2DepName(file)) + "\"sv, " + sourceName2funcName(file) + "()));"
             << '\n';
     }
     out << "  return result;" << '\n';

--- a/third_party/progressbar/progressbar/progressbar.h
+++ b/third_party/progressbar/progressbar/progressbar.h
@@ -1,22 +1,22 @@
 /**
-* \file
-* \author Trevor Fountain
-* \author Johannes Buchner
-* \author Erik Garrison
-* \date 2010-2014
-* \copyright BSD 3-Clause
-*
-* progressbar -- a C class (by convention) for displaying progress
-* on the command line (to stderr).
-*/
+ * \file
+ * \author Trevor Fountain
+ * \author Johannes Buchner
+ * \author Erik Garrison
+ * \date 2010-2014
+ * \copyright BSD 3-Clause
+ *
+ * progressbar -- a C class (by convention) for displaying progress
+ * on the command line (to stderr).
+ */
 
 #ifndef PROGRESSBAR_H
 #define PROGRESSBAR_H
 
-#include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,26 +25,25 @@ extern "C" {
 /**
  * Progressbar data structure (do not modify or create directly)
  */
-typedef struct _progressbar_t
-{
-  /// maximum value
-  unsigned long max;
-  /// current value
-  unsigned long value;
+typedef struct _progressbar_t {
+    /// maximum value
+    unsigned long max;
+    /// current value
+    unsigned long value;
 
-  /// time progressbar was started
-  time_t start;
+    /// time progressbar was started
+    time_t start;
 
-  /// label
-  const char *label;
+    /// label
+    const char *label;
 
-  /// characters for the beginning, filling and end of the
-  /// progressbar. E.g. |###    | has |#|
-  struct {
-    char begin;
-    char fill;
-    char end;
-  } format;
+    /// characters for the beginning, filling and end of the
+    /// progressbar. E.g. |###    | has |#|
+    struct {
+        char begin;
+        char fill;
+        char end;
+    } format;
 } progressbar;
 
 /// Create a new progressbar with the specified label and number of steps.

--- a/third_party/progressbar/progressbar/statusbar.h
+++ b/third_party/progressbar/progressbar/statusbar.h
@@ -1,22 +1,22 @@
 /**
-* \file
-* \author Trevor Fountain
-* \author Johannes Buchner
-* \author Erik Garrison
-* \date 2010-2014
-* \copyright BSD 3-Clause
-*
-* statusbar -- a C class (by convention) for displaying indefinite progress
-* on the command line (to stderr).
-*/
+ * \file
+ * \author Trevor Fountain
+ * \author Johannes Buchner
+ * \author Erik Garrison
+ * \date 2010-2014
+ * \copyright BSD 3-Clause
+ *
+ * statusbar -- a C class (by convention) for displaying indefinite progress
+ * on the command line (to stderr).
+ */
 
 #ifndef STATUSBAR_H
 #define STATUSBAR_H
 
-#include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,14 +25,13 @@ extern "C" {
 /**
  * Statusbar data structure (do not modify or create directly)
  */
-typedef struct _statusbar_t
-{
+typedef struct _statusbar_t {
     unsigned int start_time;
     const char *label;
     int format_index;
     int format_length;
-  char *format;
-  int last_printed;
+    char *format;
+    int last_printed;
 } statusbar;
 
 /// Create a new statusbar with the specified label and format string


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Just use the original (and more greppable?) `spdlog`; saving three characters is not worth it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
