### PR TITLE
move includes to `WorkerPoolImpl.cc` when possible

### DIFF
--- a/common/concurrency/WorkerPool.h
+++ b/common/concurrency/WorkerPool.h
@@ -1,7 +1,6 @@
 #ifndef SORBET_WORKERPOOL_H
 #define SORBET_WORKERPOOL_H
 
-#include "common/common.h"
 #include "spdlog/spdlog.h"
 namespace sorbet {
 class WorkerPool {

--- a/common/concurrency/WorkerPoolImpl.cc
+++ b/common/concurrency/WorkerPoolImpl.cc
@@ -1,5 +1,6 @@
 #include "common/concurrency/WorkerPoolImpl.h"
 #include "absl/strings/str_cat.h"
+#include "common/common.h"
 #include "common/concurrency/WorkerPool.h"
 
 using namespace std;

--- a/common/concurrency/WorkerPoolImpl.h
+++ b/common/concurrency/WorkerPoolImpl.h
@@ -1,7 +1,6 @@
 #ifndef SORBET_WORKERPOOL_IMPL_H
 #define SORBET_WORKERPOOL_IMPL_H
 #include "blockingconcurrentqueue.h"
-#include "common/common.h"
 #include "common/concurrency/WorkerPool.h"
 #include "common/os/os.h"
 #include "spdlog/spdlog.h"


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It is slightly cleaner to have `common.h` included where its bits are actually used; they're not used in the headers here.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
