### PR TITLE
Add signature to Dir.tmpdir

### DIFF
--- a/rbi/core/dir.rbi
+++ b/rbi/core/dir.rbi
@@ -400,6 +400,7 @@ class Dir < Object
   def self.rmdir(arg0); end
 
   # Returns the operating system's temporary file path.
+  sig {returns(String)}
   def self.tmpdir; end
 
   # Deletes the named directory. Raises a subclass of


### PR DESCRIPTION
### Motivation
The signature was missing, so people sometimes would write `Dir.tmpdir do |dir|` expecting the dir to be created and the block to be executed, which doesn't happen

### Test plan
Looking at the docs and implementation ([here](https://ruby-doc.org/stdlib-3.1.2/libdoc/tmpdir/rdoc/Dir.html)), I can see that this is never `nil`