### PR TITLE
parallelize file discovery

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -32,6 +32,7 @@ cc_library(
         "//common/exception",
         "//common/os",
         "//sorbet_version",
+        "//common/concurrency",
         "//third_party/progressbar",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/common/BUILD
+++ b/common/BUILD
@@ -28,11 +28,11 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "//common/concurrency",
         "//common/enforce_no_timer",
         "//common/exception",
         "//common/os",
         "//sorbet_version",
-        "//common/concurrency",
         "//third_party/progressbar",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 namespace sorbet {
+class WorkerPool;
 
 class FileOps final {
 public:
@@ -49,7 +50,7 @@ public:
      * Throws FileNotFoundException if path does not exist, and FileNotDirException if path is not a directory.
      */
     static std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
-                                                   bool recursive,
+                                                   WorkerPool &workers, bool recursive,
                                                    const std::vector<std::string> &absoluteIgnorePatterns,
                                                    const std::vector<std::string> &relativeIgnorePatterns);
     /**

--- a/common/FileSystem.cc
+++ b/common/FileSystem.cc
@@ -1,6 +1,6 @@
-#include "common/concurrency/WorkerPool.h"
 #include "common/FileSystem.h"
 #include "common/FileOps.h"
+#include "common/concurrency/WorkerPool.h"
 
 namespace sorbet {
 using namespace std;
@@ -14,19 +14,20 @@ void OSFileSystem::writeFile(const string &filename, string_view text) {
 }
 
 vector<string> FileSystem::listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
-                              bool recursive,
-                              const std::vector<std::string> &absoluteIgnorePatterns,
-                              const std::vector<std::string> &relativeIgnorePatterns) const {
+                                          bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
+                                          const std::vector<std::string> &relativeIgnorePatterns) const {
     unique_ptr<WorkerPool> workerPool = WorkerPool::create(0, *spdlog::default_logger());
 
-    return this->listFilesInDir(path, extensions, *workerPool, recursive, absoluteIgnorePatterns, relativeIgnorePatterns);
+    return this->listFilesInDir(path, extensions, *workerPool, recursive, absoluteIgnorePatterns,
+                                relativeIgnorePatterns);
 }
 
 vector<string> OSFileSystem::listFilesInDir(string_view path, const UnorderedSet<std::string> &extensions,
-                                            WorkerPool &workerPool,
-                                            bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
+                                            WorkerPool &workerPool, bool recursive,
+                                            const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const {
-    return FileOps::listFilesInDir(path, extensions, workerPool, recursive, absoluteIgnorePatterns, relativeIgnorePatterns);
+    return FileOps::listFilesInDir(path, extensions, workerPool, recursive, absoluteIgnorePatterns,
+                                   relativeIgnorePatterns);
 }
 
 } // namespace sorbet

--- a/common/FileSystem.cc
+++ b/common/FileSystem.cc
@@ -1,3 +1,4 @@
+#include "common/concurrency/WorkerPool.h"
 #include "common/FileSystem.h"
 #include "common/FileOps.h"
 
@@ -12,10 +13,20 @@ void OSFileSystem::writeFile(const string &filename, string_view text) {
     return FileOps::write(filename, text);
 }
 
+vector<string> FileSystem::listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
+                              bool recursive,
+                              const std::vector<std::string> &absoluteIgnorePatterns,
+                              const std::vector<std::string> &relativeIgnorePatterns) const {
+    unique_ptr<WorkerPool> workerPool = WorkerPool::create(0, *spdlog::default_logger());
+
+    return this->listFilesInDir(path, extensions, *workerPool, recursive, absoluteIgnorePatterns, relativeIgnorePatterns);
+}
+
 vector<string> OSFileSystem::listFilesInDir(string_view path, const UnorderedSet<std::string> &extensions,
+                                            WorkerPool &workerPool,
                                             bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const {
-    return FileOps::listFilesInDir(path, extensions, recursive, absoluteIgnorePatterns, relativeIgnorePatterns);
+    return FileOps::listFilesInDir(path, extensions, workerPool, recursive, absoluteIgnorePatterns, relativeIgnorePatterns);
 }
 
 } // namespace sorbet

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -2,6 +2,8 @@
 #define COMMON_FILESYSTEM_H
 
 #include "common/common.h"
+#include "common/concurrency/WorkerPool.h"
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -31,9 +33,15 @@ public:
      * Throws FileNotFoundException if path does not exist, and FileNotDirException if path is not a directory.
      */
     virtual std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
+                                                    WorkerPool &workerPool,
                                                     bool recursive,
                                                     const std::vector<std::string> &absoluteIgnorePatterns,
                                                     const std::vector<std::string> &relativeIgnorePatterns) const = 0;
+
+    virtual std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
+                                                    bool recursive,
+                                                    const std::vector<std::string> &absoluteIgnorePatterns,
+                                                    const std::vector<std::string> &relativeIgnorePatterns) const;
 };
 
 /**
@@ -46,6 +54,7 @@ public:
     std::string readFile(const std::string &path) const override;
     void writeFile(const std::string &filename, std::string_view text) override;
     std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
+                                            WorkerPool &workerPool,
                                             bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const override;
 };

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -33,8 +33,7 @@ public:
      * Throws FileNotFoundException if path does not exist, and FileNotDirException if path is not a directory.
      */
     virtual std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
-                                                    WorkerPool &workerPool,
-                                                    bool recursive,
+                                                    WorkerPool &workerPool, bool recursive,
                                                     const std::vector<std::string> &absoluteIgnorePatterns,
                                                     const std::vector<std::string> &relativeIgnorePatterns) const = 0;
 
@@ -54,8 +53,8 @@ public:
     std::string readFile(const std::string &path) const override;
     void writeFile(const std::string &filename, std::string_view text) override;
     std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
-                                            WorkerPool &workerPool,
-                                            bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
+                                            WorkerPool &workerPool, bool recursive,
+                                            const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const override;
 };
 

--- a/common/common.cc
+++ b/common/common.cc
@@ -314,7 +314,8 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
     closedir(dir);
 }
 
-vector<string> sorbet::FileOps::listFilesInDir(string_view path, const UnorderedSet<string> &extensions, bool recursive,
+vector<string> sorbet::FileOps::listFilesInDir(string_view path, const UnorderedSet<string> &extensions,
+                                               WorkerPool &workerPool, bool recursive,
                                                const std::vector<std::string> &absoluteIgnorePatterns,
                                                const std::vector<std::string> &relativeIgnorePatterns) {
     vector<string> result;

--- a/common/common.cc
+++ b/common/common.cc
@@ -373,6 +373,10 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
             }
         } catch (sorbet::SorbetException &e) {
             resultq->push(e, 1);
+            pendingJobs += numWorkers;
+            for (auto i = 0; i < numWorkers; ++i) {
+                jobq->push(QuitToken{}, 1);
+            }
             return;
         }
 

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -520,7 +520,7 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
 
     if (FileOps::exists(path)) {
         // Clear out files that we do not plan to write.
-        vector<string> existingFiles = FileOps::listFilesInDir(path, {".rb"}, true, {}, {});
+        vector<string> existingFiles = FileOps::listFilesInDir(path, {".rb"}, workers, true, {}, {});
         UnorderedSet<string> existingFilesSet(make_move_iterator(existingFiles.begin()),
                                               make_move_iterator(existingFiles.end()));
         for (auto &task : tasks) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -4,9 +4,9 @@
 #include <cxxopts.hpp>
 
 #include "absl/strings/str_split.h"
-#include "common/concurrency/WorkerPool.h"
 #include "common/FileOps.h"
 #include "common/Timer.h"
+#include "common/concurrency/WorkerPool.h"
 #include "common/formatting.h"
 #include "common/sort.h"
 #include "core/Error.h"

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -4,6 +4,7 @@
 #include <cxxopts.hpp>
 
 #include "absl/strings/str_split.h"
+#include "common/concurrency/WorkerPool.h"
 #include "common/FileOps.h"
 #include "common/Timer.h"
 #include "common/formatting.h"
@@ -737,6 +738,9 @@ void readOptions(Options &opts,
             auto rawIgnorePatterns = raw["ignore"].as<vector<string>>();
             parseIgnorePatterns(rawIgnorePatterns, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
         }
+
+        int maxInputFileThreads = raw["max-threads"].as<int>();
+        auto workerPool = WorkerPool::create(maxInputFileThreads, logger);
 
         opts.pathPrefix = raw["remove-path-prefix"].as<string>();
         if (raw.count("files") > 0) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -689,13 +689,13 @@ bool extractAutoloaderConfig(cxxopts::ParseResult &raw, Options &opts, shared_pt
     return true;
 }
 
-void addFilesFromDir(Options &opts, string_view dir, shared_ptr<spdlog::logger> logger) {
+void addFilesFromDir(Options &opts, string_view dir, WorkerPool &workerPool, shared_ptr<spdlog::logger> logger) {
     auto fileNormalized = stripTrailingSlashes(dir);
     opts.rawInputDirNames.emplace_back(fileNormalized);
     // Expand directory into list of files.
     vector<string> containedFiles;
     try {
-        containedFiles = opts.fs->listFilesInDir(fileNormalized, opts.allowedExtensions, true,
+        containedFiles = opts.fs->listFilesInDir(fileNormalized, opts.allowedExtensions, workerPool, true,
                                                  opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
     } catch (sorbet::FileNotFoundException e) {
         logger->error(e.what());
@@ -740,7 +740,7 @@ void readOptions(Options &opts,
         }
 
         int maxInputFileThreads = raw["max-threads"].as<int>();
-        auto workerPool = WorkerPool::create(maxInputFileThreads, logger);
+        auto workerPool = WorkerPool::create(maxInputFileThreads, *logger);
 
         opts.pathPrefix = raw["remove-path-prefix"].as<string>();
         if (raw.count("files") > 0) {
@@ -748,7 +748,7 @@ void readOptions(Options &opts,
             struct stat s;
             for (auto &file : rawFiles) {
                 if (stat(file.c_str(), &s) == 0 && s.st_mode & S_IFDIR) {
-                    addFilesFromDir(opts, file, logger);
+                    addFilesFromDir(opts, file, *workerPool, logger);
                 } else {
                     opts.rawInputFileNames.push_back(file);
                     opts.inputFileNames.push_back(file);
@@ -766,7 +766,7 @@ void readOptions(Options &opts,
             auto rawDirs = raw["dir"].as<vector<string>>();
             for (auto &dir : rawDirs) {
                 // Since we don't stat here, we're unsure if the directory exists / is a directory.
-                addFilesFromDir(opts, dir, logger);
+                addFilesFromDir(opts, dir, *workerPool, logger);
             }
         }
 

--- a/test/helpers/MockFileSystem.cc
+++ b/test/helpers/MockFileSystem.cc
@@ -46,4 +46,11 @@ vector<string> MockFileSystem::listFilesInDir(string_view path, const UnorderedS
                                               const vector<string> &relativeIgnorePatterns) const {
     Exception::raise("Not implemented.");
 }
+
+vector<string> MockFileSystem::listFilesInDir(string_view path, const UnorderedSet<std::string> &extensions,
+                                              WorkerPool &workerPool, bool recursive,
+                                              const std::vector<std::string> &absoluteIgnorePatterns,
+                                              const std::vector<std::string> &relativeIgnorePatterns) const {
+    Exception::raise("Not implemented.");
+}
 } // namespace sorbet::test

--- a/test/helpers/MockFileSystem.h
+++ b/test/helpers/MockFileSystem.h
@@ -20,6 +20,10 @@ public:
     std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
                                             bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const override;
+    std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
+                                            WorkerPool &workerPool, bool recursive,
+                                            const std::vector<std::string> &absoluteIgnorePatterns,
+                                            const std::vector<std::string> &relativeIgnorePatterns) const override;
 };
 
 } // namespace sorbet::test

--- a/test/helpers/expectations.cc
+++ b/test/helpers/expectations.cc
@@ -4,6 +4,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
 #include "common/FileOps.h"
+#include "common/concurrency/WorkerPool.h"
 #include "common/sort.h"
 #include "dtl/dtl.hpp"
 #include "test/helpers/expectations.h"
@@ -104,8 +105,9 @@ bool addToExpectations(Expectations &exp, string_view filePath, bool isDirectory
 }
 
 vector<string> listTrimmedTestFilesInDir(string_view dir, bool recursive) {
+    unique_ptr<WorkerPool> workerPool = WorkerPool::create(0, *spdlog::default_logger());
     vector<string> names =
-        sorbet::FileOps::listFilesInDir(dir, {".rb", ".rbi", ".rbupdate", ".exp"}, recursive, {}, {});
+        sorbet::FileOps::listFilesInDir(dir, {".rb", ".rbi", ".rbupdate", ".exp"}, *workerPool, recursive, {}, {});
     const int prefixLen = dir.length() + 1;
     // Trim off the input directory from the name.
     transform(names.begin(), names.end(), names.begin(),

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -5,6 +5,7 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "common/FileOps.h"
+#include "common/concurrency/WorkerPool.h"
 #include "common/formatting.h"
 #include "common/sort.h"
 #include "main/lsp/LSPConfiguration.h"
@@ -1475,7 +1476,9 @@ void ApplyRenameAssertion::check(const UnorderedMap<std::string, std::shared_ptr
     UnorderedMap<string, string> actualEditedFiles;
     // map of all .rbedited files whose version equals `this->version`
     UnorderedMap<string, string> expectedEditedFiles;
-    for (auto filePath : FileOps::listFilesInDir(testDataPath, {".rb", ".rbi", ".rbedited"}, false, {}, {})) {
+    unique_ptr<WorkerPool> workerPool = WorkerPool::create(0, *spdlog::default_logger());
+    for (auto filePath :
+         FileOps::listFilesInDir(testDataPath, {".rb", ".rbi", ".rbedited"}, *workerPool, false, {}, {})) {
         auto extension = FileOps::getExtension(filePath);
         if (extension == "rbedited") {
             auto extensionIndex = filePath.rfind(".rbedited", filePath.length());


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Finding all the files with a serial recursive walk through the input directory takes a long time on Stripe's codebase.  This makes it significantly faster.

I did not test what this does on a machine with a single core; I did experiment at one point with making `appendFilesInDir` use an explicit stack and therefore be iterative rather than recursive.  There was no speedup in that case, but neither was there a slowdown.  I'd expect roughly the same thing to happen here, maybe with slightly higher overhead for the concurrent queue rather than a vector for holding the directories to scan.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested this on Stripe's codebase and verified that it was processing the same number and kind of files (e.g. number of `typed: strict`) as before; typecheck results were also identical (including introducing various errors), so I have some confidence that we're not finding completely different files.