### PR TITLE
make filesystem-accessing `FileOps` functions take `const string &`

### DIFF
--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -16,33 +16,34 @@ public:
         std::optional<std::string> output = std::nullopt;
     };
 
-    static bool exists(std::string_view filename);
+    static bool exists(const std::string &filename);
     static bool isFile(std::string_view path, std::string_view ignorePattern, const int pos);
     static bool isFolder(std::string_view path, std::string_view ignorePattern, const int pos);
-    static std::string read(std::string_view filename);
-    static void write(std::string_view filename, const std::vector<uint8_t> &data);
-    static void append(std::string_view filename, std::string_view text);
-    static void write(std::string_view filename, std::string_view text);
-    static bool writeIfDifferent(std::string_view filename, std::string_view text);
-    static bool dirExists(std::string_view path);
-    static void createDir(std::string_view path);
+    static std::string read(const std::string &filename);
+    static void write(const std::string &filename, const std::vector<uint8_t> &data);
+    static void append(const std::string &filename, std::string_view text);
+    static void write(const std::string &filename, std::string_view text);
+    static bool writeIfDifferent(const std::string &filename, std::string_view text);
+    static bool dirExists(const std::string &path);
+    static void createDir(const std::string &path);
 
     // This differs from createDir, as it will not raise an exception if the directory already exists. Returns true when
     // the directory was created, and false if it already existed.
     //
     // NOTE: This does not create parent directories if they exist.
-    static bool ensureDir(std::string_view path);
+    static bool ensureDir(const std::string &path);
 
     // NOTE: this is a minimal wrapper around rmdir, and as such will raise an exception if the directory is not empty
     // when it's removed.
-    static void removeDir(std::string_view path);
+    static void removeDir(const std::string &path);
 
     // NOTE: this is a minimal wrapper around rmdir, and will return false if the directory is not empty
     // when it's removed. For any other errno, it will throw an exception. This exists as an convenience function to
     // prevent the caller from needing to try/catch removeDir.
-    static bool removeEmptyDir(std::string_view path);
+    static bool removeEmptyDir(const std::string &path);
 
-    static void removeFile(std::string_view path);
+    static void removeFile(const std::string &path);
+
     /**
      * Returns a list of all files in the given directory. Returns paths that include the path to directory.
      * Throws FileNotFoundException if path does not exist, and FileNotDirException if path is not a directory.

--- a/common/FileSystem.cc
+++ b/common/FileSystem.cc
@@ -4,11 +4,11 @@
 namespace sorbet {
 using namespace std;
 
-string OSFileSystem::readFile(string_view path) const {
+string OSFileSystem::readFile(const string &path) const {
     return FileOps::read(path);
 }
 
-void OSFileSystem::writeFile(string_view filename, string_view text) {
+void OSFileSystem::writeFile(const string &filename, string_view text) {
     return FileOps::write(filename, text);
 }
 

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -16,10 +16,10 @@ public:
     virtual ~FileSystem() = default;
 
     /** Read the file at the given path. Throws a `FileNotFoundException` if not found. */
-    virtual std::string readFile(std::string_view path) const = 0;
+    virtual std::string readFile(const std::string &path) const = 0;
 
     /** Writes the specified data to the given file. */
-    virtual void writeFile(std::string_view filename, std::string_view text) = 0;
+    virtual void writeFile(const std::string &filename, std::string_view text) = 0;
 
     /**
      * Returns a list of all files in the given directory. Returns paths that include the path to directory.
@@ -43,8 +43,8 @@ class OSFileSystem final : public FileSystem {
 public:
     OSFileSystem() = default;
 
-    std::string readFile(std::string_view path) const override;
-    void writeFile(std::string_view filename, std::string_view text) override;
+    std::string readFile(const std::string &path) const override;
+    void writeFile(const std::string &filename, std::string_view text) override;
     std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
                                             bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const override;

--- a/common/common.cc
+++ b/common/common.cc
@@ -31,11 +31,11 @@ shared_ptr<spdlog::logger> sorbet::fatalLogger = makeFatalLogger();
 
 bool sorbet::FileOps::exists(const string &filename) {
     struct stat buffer;
-    return (stat((string(filename)).c_str(), &buffer) == 0);
+    return (stat(filename.c_str(), &buffer) == 0);
 }
 
 string sorbet::FileOps::read(const string &filename) {
-    FILE *fp = std::fopen((string(filename)).c_str(), "rb");
+    FILE *fp = std::fopen(filename.c_str(), "rb");
     if (fp) {
         fseek(fp, 0, SEEK_END);
         auto sz = ftell(fp);
@@ -53,7 +53,7 @@ string sorbet::FileOps::read(const string &filename) {
 }
 
 void sorbet::FileOps::write(const string &filename, const vector<uint8_t> &data) {
-    FILE *fp = std::fopen(string(filename).c_str(), "wb");
+    FILE *fp = std::fopen(filename.c_str(), "wb");
     if (fp) {
         fwrite(data.data(), sizeof(uint8_t), data.size(), fp);
         fclose(fp);
@@ -64,18 +64,18 @@ void sorbet::FileOps::write(const string &filename, const vector<uint8_t> &data)
 
 bool sorbet::FileOps::dirExists(const string &path) {
     struct stat buffer;
-    return stat((string(path)).c_str(), &buffer) == 0 && S_ISDIR(buffer.st_mode);
+    return stat(path.c_str(), &buffer) == 0 && S_ISDIR(buffer.st_mode);
 }
 
 void sorbet::FileOps::createDir(const string &path) {
-    auto err = mkdir(string(path).c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    auto err = mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     if (err) {
         throw sorbet::CreateDirException(fmt::format("Error in createDir('{}'): {}", path, errno));
     }
 }
 
 bool sorbet::FileOps::ensureDir(const string &path) {
-    auto err = mkdir(string(path).c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    auto err = mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     if (err) {
         if (errno == EEXIST) {
             return false;
@@ -88,14 +88,14 @@ bool sorbet::FileOps::ensureDir(const string &path) {
 }
 
 void sorbet::FileOps::removeDir(const string &path) {
-    auto err = rmdir(string(path).c_str());
+    auto err = rmdir(path.c_str());
     if (err) {
         throw sorbet::CreateDirException(fmt::format("Error in removeDir('{}'): {}", path, errno));
     }
 }
 
 bool sorbet::FileOps::removeEmptyDir(const string &path) {
-    auto err = rmdir(string(path).c_str());
+    auto err = rmdir(path.c_str());
     if (err) {
         if (errno == ENOTEMPTY) {
             return false;
@@ -107,14 +107,14 @@ bool sorbet::FileOps::removeEmptyDir(const string &path) {
 }
 
 void sorbet::FileOps::removeFile(const string &path) {
-    auto err = remove(string(path).c_str());
+    auto err = remove(path.c_str());
     if (err) {
         throw sorbet::RemoveFileException(fmt::format("Error in removeFile('{}'): {}", path, errno));
     }
 }
 
 void sorbet::FileOps::write(const string &filename, string_view text) {
-    FILE *fp = std::fopen(string(filename).c_str(), "w");
+    FILE *fp = std::fopen(filename.c_str(), "w");
     if (fp) {
         fwrite(text.data(), sizeof(char), text.size(), fp);
         fclose(fp);
@@ -132,7 +132,7 @@ bool sorbet::FileOps::writeIfDifferent(const string &filename, string_view text)
 }
 
 void sorbet::FileOps::append(const string &filename, string_view text) {
-    FILE *fp = std::fopen(string(filename).c_str(), "a");
+    FILE *fp = std::fopen(filename.c_str(), "a");
     if (fp) {
         fwrite(text.data(), sizeof(char), text.size(), fp);
         fclose(fp);

--- a/common/common.cc
+++ b/common/common.cc
@@ -29,12 +29,12 @@ shared_ptr<spdlog::logger> makeFatalLogger() {
 } // namespace
 shared_ptr<spdlog::logger> sorbet::fatalLogger = makeFatalLogger();
 
-bool sorbet::FileOps::exists(string_view filename) {
+bool sorbet::FileOps::exists(const string &filename) {
     struct stat buffer;
     return (stat((string(filename)).c_str(), &buffer) == 0);
 }
 
-string sorbet::FileOps::read(string_view filename) {
+string sorbet::FileOps::read(const string &filename) {
     FILE *fp = std::fopen((string(filename)).c_str(), "rb");
     if (fp) {
         fseek(fp, 0, SEEK_END);
@@ -52,7 +52,7 @@ string sorbet::FileOps::read(string_view filename) {
     throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}`", filename));
 }
 
-void sorbet::FileOps::write(string_view filename, const vector<uint8_t> &data) {
+void sorbet::FileOps::write(const string &filename, const vector<uint8_t> &data) {
     FILE *fp = std::fopen(string(filename).c_str(), "wb");
     if (fp) {
         fwrite(data.data(), sizeof(uint8_t), data.size(), fp);
@@ -62,19 +62,19 @@ void sorbet::FileOps::write(string_view filename, const vector<uint8_t> &data) {
     throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}` for writing", filename));
 }
 
-bool sorbet::FileOps::dirExists(string_view path) {
+bool sorbet::FileOps::dirExists(const string &path) {
     struct stat buffer;
     return stat((string(path)).c_str(), &buffer) == 0 && S_ISDIR(buffer.st_mode);
 }
 
-void sorbet::FileOps::createDir(string_view path) {
+void sorbet::FileOps::createDir(const string &path) {
     auto err = mkdir(string(path).c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     if (err) {
         throw sorbet::CreateDirException(fmt::format("Error in createDir('{}'): {}", path, errno));
     }
 }
 
-bool sorbet::FileOps::ensureDir(string_view path) {
+bool sorbet::FileOps::ensureDir(const string &path) {
     auto err = mkdir(string(path).c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     if (err) {
         if (errno == EEXIST) {
@@ -87,14 +87,14 @@ bool sorbet::FileOps::ensureDir(string_view path) {
     return true;
 }
 
-void sorbet::FileOps::removeDir(string_view path) {
+void sorbet::FileOps::removeDir(const string &path) {
     auto err = rmdir(string(path).c_str());
     if (err) {
         throw sorbet::CreateDirException(fmt::format("Error in removeDir('{}'): {}", path, errno));
     }
 }
 
-bool sorbet::FileOps::removeEmptyDir(string_view path) {
+bool sorbet::FileOps::removeEmptyDir(const string &path) {
     auto err = rmdir(string(path).c_str());
     if (err) {
         if (errno == ENOTEMPTY) {
@@ -106,14 +106,14 @@ bool sorbet::FileOps::removeEmptyDir(string_view path) {
     return true;
 }
 
-void sorbet::FileOps::removeFile(string_view path) {
+void sorbet::FileOps::removeFile(const string &path) {
     auto err = remove(string(path).c_str());
     if (err) {
         throw sorbet::RemoveFileException(fmt::format("Error in removeFile('{}'): {}", path, errno));
     }
 }
 
-void sorbet::FileOps::write(string_view filename, string_view text) {
+void sorbet::FileOps::write(const string &filename, string_view text) {
     FILE *fp = std::fopen(string(filename).c_str(), "w");
     if (fp) {
         fwrite(text.data(), sizeof(char), text.size(), fp);
@@ -123,7 +123,7 @@ void sorbet::FileOps::write(string_view filename, string_view text) {
     throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}` for writing", filename));
 }
 
-bool sorbet::FileOps::writeIfDifferent(string_view filename, string_view text) {
+bool sorbet::FileOps::writeIfDifferent(const string &filename, string_view text) {
     if (!exists(filename) || text != read(filename)) {
         write(filename, text);
         return true;
@@ -131,7 +131,7 @@ bool sorbet::FileOps::writeIfDifferent(string_view filename, string_view text) {
     return false;
 }
 
-void sorbet::FileOps::append(string_view filename, string_view text) {
+void sorbet::FileOps::append(const string &filename, string_view text) {
     FILE *fp = std::fopen(string(filename).c_str(), "a");
     if (fp) {
         fwrite(text.data(), sizeof(char), text.size(), fp);

--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -36,7 +36,7 @@ void endLine(rapidjson::StringBuffer &result, rapidjson::Writer<rapidjson::Strin
 
 // Super rudimentary support for outputing trace files in Google's Trace Event Format
 // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
-bool Tracing::storeTraces(const CounterState &counters, string_view fileName) {
+bool Tracing::storeTraces(const CounterState &counters, const string &fileName) {
     rapidjson::StringBuffer result;
     rapidjson::Writer<rapidjson::StringBuffer> writer(result);
 

--- a/common/web_tracer_framework/tracing.h
+++ b/common/web_tracer_framework/tracing.h
@@ -8,7 +8,7 @@ class Tracing {
 public:
     Tracing() = delete;
 
-    static bool storeTraces(const CounterState &counters, std::string_view fileName);
+    static bool storeTraces(const CounterState &counters, const std::string &fileName);
 };
 } // namespace sorbet::web_tracer_framework
 

--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -47,7 +47,7 @@ UnorderedMap<FileRef, string> AutocorrectSuggestion::apply(const GlobalState &gs
         for (auto &edit : autocorrect.edits) {
             auto file = edit.loc.file();
             if (!sources.count(file)) {
-                sources[file] = fs.readFile(file.data(gs).path());
+                sources[file] = fs.readFile(string(file.data(gs).path()));
             }
         }
     }

--- a/core/ErrorFlusherStdout.cc
+++ b/core/ErrorFlusherStdout.cc
@@ -59,7 +59,7 @@ void ErrorFlusherStdout::flushErrorCount(spdlog::logger &logger, int count) {
 void ErrorFlusherStdout::flushAutocorrects(const GlobalState &gs, FileSystem &fs) {
     auto toWrite = AutocorrectSuggestion::apply(gs, fs, this->autocorrects);
     for (auto &[file, contents] : toWrite) {
-        fs.writeFile(file.data(gs).path(), contents);
+        fs.writeFile(string(file.data(gs).path()), contents);
     }
     autocorrects.clear();
 }

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -534,7 +534,7 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
             int curDirPos = filePath.find_last_of('/');
             while (curDirPos > 0) {
                 const auto curDir = filePath.substr(0, curDirPos);
-                if (curDir == path || !FileOps::removeEmptyDir(curDir)) {
+                if (curDir == path || !FileOps::removeEmptyDir(string(curDir))) {
                     break;
                 }
 

--- a/main/autogen/cache.cc
+++ b/main/autogen/cache.cc
@@ -13,7 +13,7 @@ namespace sorbet::autogen {
 
 const size_t MAX_SKIP_AMOUNT = 100;
 
-bool AutogenCache::canSkipAutogen(core::GlobalState &gs, string_view cachePath, const vector<string> &changedFiles) {
+bool AutogenCache::canSkipAutogen(core::GlobalState &gs, const string &cachePath, const vector<string> &changedFiles) {
     // this is here as an escape valve: if a _bunch_ of files change
     // all at once, then don't let us skip at all. This should pretty
     // rarely be the case: the autogen runner should only pass us a

--- a/main/autogen/cache.h
+++ b/main/autogen/cache.h
@@ -14,7 +14,7 @@ public:
     // This returns `true` when we have evidence that the set of changes in the changedFiles _definitely won't_ affect
     // the output of autogen. This means we can always be conservative: it's okay if this returns `false` in places
     // where it could return `true`, because that'll be correct but slower.
-    static bool canSkipAutogen(core::GlobalState &gs, std::string_view cachePath,
+    static bool canSkipAutogen(core::GlobalState &gs, const std::string &cachePath,
                                const std::vector<std::string> &changedFiles);
 
     static AutogenCache unpackForFiles(std::string_view path, const UnorderedSet<std::string> &changedFiles);

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -12,7 +12,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 namespace {
-string readFile(string_view path, const FileSystem &fs) {
+string readFile(const string &path, const FileSystem &fs) {
     try {
         return fs.readFile(path);
     } catch (FileNotFoundException e) {

--- a/main/options/ConfigParser.cc
+++ b/main/options/ConfigParser.cc
@@ -32,7 +32,7 @@ bool isComment(string_view line) {
 void ConfigParser::readArgsFromFile(std::shared_ptr<spdlog::logger> logger, string_view filename,
                                     std::vector<std::string> &stringArgs) {
     try {
-        string argsP = FileOps::read(filename);
+        string argsP = FileOps::read(string(filename));
         string_view argsPView = argsP;
         if (!argsPView.empty() && argsPView.back() == '\n') {
             argsPView = argsPView.substr(0, argsPView.size() - 1);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -403,8 +403,7 @@ ast::ExpressionPtr readFileWithStrictnessOverrides(core::GlobalState &gs, core::
 
     {
         core::UnfreezeFileTable unfreezeFiles(gs);
-        auto fileObj =
-            make_shared<core::File>(move(fileName), move(src), core::File::Type::Normal);
+        auto fileObj = make_shared<core::File>(move(fileName), move(src), core::File::Type::Normal);
         // Returns nullptr if tree is not in cache.
         ast = fetchTreeFromCache(gs, file, *fileObj, kvstore);
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1219,7 +1219,7 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, vector
     return written;
 }
 
-vector<ast::ParsedFile> autogenWriteCacheFile(const core::GlobalState &gs, string_view cachePath,
+vector<ast::ParsedFile> autogenWriteCacheFile(const core::GlobalState &gs, const string &cachePath,
                                               vector<ast::ParsedFile> what, WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
     Timer timeit(gs.tracer(), "autogenWriteCacheFile");

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -386,8 +386,8 @@ ast::ExpressionPtr readFileWithStrictnessOverrides(core::GlobalState &gs, core::
     if (file.dataAllowingUnsafe(gs).sourceType != core::File::Type::NotYetRead) {
         return ast;
     }
-    auto fileName = file.dataAllowingUnsafe(gs).path();
-    Timer timeit(gs.tracer(), "readFileWithStrictnessOverrides", {{"file", string(fileName)}});
+    string fileName{file.dataAllowingUnsafe(gs).path()};
+    Timer timeit(gs.tracer(), "readFileWithStrictnessOverrides", {{"file", fileName}});
     string src;
     bool fileFound = true;
     try {
@@ -404,7 +404,7 @@ ast::ExpressionPtr readFileWithStrictnessOverrides(core::GlobalState &gs, core::
     {
         core::UnfreezeFileTable unfreezeFiles(gs);
         auto fileObj =
-            make_shared<core::File>(string(fileName.begin(), fileName.end()), move(src), core::File::Type::Normal);
+            make_shared<core::File>(move(fileName), move(src), core::File::Type::Normal);
         // Returns nullptr if tree is not in cache.
         ast = fetchTreeFromCache(gs, file, *fileObj, kvstore);
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -43,7 +43,7 @@ incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
                                  WorkerPool &workers, core::FoundDefHashes *foundHashes);
 
-std::vector<ast::ParsedFile> autogenWriteCacheFile(const core::GlobalState &gs, const std::string_view cachePath,
+std::vector<ast::ParsedFile> autogenWriteCacheFile(const core::GlobalState &gs, const std::string &cachePath,
                                                    std::vector<ast::ParsedFile> what, WorkerPool &workers);
 
 // Note: `cancelable` and `preemption task manager` are only applicable to LSP.

--- a/test/helpers/MockFileSystem.cc
+++ b/test/helpers/MockFileSystem.cc
@@ -19,7 +19,7 @@ void MockFileSystem::writeFiles(const vector<pair<string, string>> &initialFiles
     }
 }
 
-string MockFileSystem::readFile(string_view path) const {
+string MockFileSystem::readFile(const string &path) const {
     auto file = contents.find(makeAbsolute(rootPath, path));
     if (file == contents.end()) {
         throw sorbet::FileNotFoundException(fmt::format("Cannot find file `{}`", path));
@@ -28,7 +28,7 @@ string MockFileSystem::readFile(string_view path) const {
     }
 }
 
-void MockFileSystem::writeFile(string_view filename, string_view text) {
+void MockFileSystem::writeFile(const string &filename, string_view text) {
     contents[makeAbsolute(rootPath, filename)] = text;
 }
 

--- a/test/helpers/MockFileSystem.h
+++ b/test/helpers/MockFileSystem.h
@@ -14,8 +14,8 @@ private:
 public:
     MockFileSystem(std::string_view rootPath);
     void writeFiles(const std::vector<std::pair<std::string, std::string>> &files);
-    std::string readFile(std::string_view path) const override;
-    void writeFile(std::string_view filename, std::string_view text) override;
+    std::string readFile(const std::string &path) const override;
+    void writeFile(const std::string &filename, std::string_view text) override;
     void deleteFile(std::string_view filename);
     std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
                                             bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -81,7 +81,7 @@ unique_ptr<LSPMessage> ProtocolTest::closeFile(string_view path) {
     // File is closed, so update contents from mock FS.
     try {
         sourceFileContents[string(path)] =
-            make_shared<core::File>(string(path), string(fs->readFile(path)), core::File::Type::Normal);
+            make_shared<core::File>(string(path), fs->readFile(string(path)), core::File::Type::Normal);
     } catch (FileNotFoundException e) {
         auto it = sourceFileContents.find(path);
         if (it != sourceFileContents.end()) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Most of these functions take `string_view`, but we need to pass null-terminated strings to the underlying OS functions and therefore need to allocate a `string`.  But in the common case, the caller already *had* a `string`, so we wind up allocating a `string` inside these functions for no good reason.  This is probably not a big deal, but less work is less work, and we avoid weird cases like repeatedly allocating strings in e.g. `FileOps::writeIfDifferent`.

In cases where the caller had a `string_view` (which is not that many), I think allocating the string at the callsite is a good thing, or at least not a bad one.  (Actually, for a lot of these, `core::File::path()` should be returning a `const string &`, and that would fix some awkwardness in places.  Next PR!)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
