### PR TITLE
set `opts.inputFileNames` directly when possible

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -703,9 +703,13 @@ void addFilesFromDir(Options &opts, string_view dir, shared_ptr<spdlog::logger> 
         logger->error("Path `{}` is not a directory", dir);
         throw EarlyReturnWithCode(1);
     }
-    opts.inputFileNames.reserve(opts.inputFileNames.size() + containedFiles.size());
-    opts.inputFileNames.insert(opts.inputFileNames.end(), std::make_move_iterator(containedFiles.begin()),
-                               std::make_move_iterator(containedFiles.end()));
+    if (opts.inputFileNames.size() == 0) {
+        opts.inputFileNames = move(containedFiles);
+    } else {
+        opts.inputFileNames.reserve(opts.inputFileNames.size() + containedFiles.size());
+        opts.inputFileNames.insert(opts.inputFileNames.end(), std::make_move_iterator(containedFiles.begin()),
+                                   std::make_move_iterator(containedFiles.end()));
+    }
 }
 
 void readOptions(Options &opts,


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The common case is for Sorbet to be only used with a single input directory, so the common case here is that `opts.inputFileNames` is originally empty and we're adding all the files we just found to it.

In that case, we can re-use the vector we just allocated, rather than shuffling a bunch of memory around.  This saves about 5% of time reading files after #6530 lands on Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
