### PR TITLE
lazily allocate strings when unpacking the autogen cache

### DIFF
--- a/main/autogen/cache.cc
+++ b/main/autogen/cache.cc
@@ -104,7 +104,7 @@ AutogenCache AutogenCache::unpackForFiles(string_view file_contents, const Unord
         if (mpack_reader_error(&reader) != mpack_ok) {
             break;
         }
-        auto key = string(key_buf, key_len);
+        string_view key{key_buf, key_len};
         mpack_done_str(&reader);
 
         // and the value should be an int

--- a/main/autogen/cache.h
+++ b/main/autogen/cache.h
@@ -19,7 +19,6 @@ public:
 
     static AutogenCache unpackForFiles(std::string_view path, const UnorderedSet<std::string> &changedFiles);
 
-    AutogenCache(UnorderedMap<std::string, unsigned int> constantHashMap) : _constantHashMap(constantHashMap){};
     AutogenCache() = default;
     AutogenCache(AutogenCache &&) = default;
     AutogenCache(const AutogenCache &) = delete;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's no reason to allocate a string here; the maps that we're using support heterogeneous lookup, and therefore we can avoid allocating a string for each entry in the cache.

Bonus deletion of a constructor that's unused.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
