### PR TITLE
Add possibility to pass T::Structs as value for #with

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -105,7 +105,9 @@ module T::Props::Serializable
   end
 
   private def recursive_stringify_keys(obj)
-    if obj.is_a?(Hash)
+    if obj.is_a?(T::Struct)
+      new_obj = recursive_stringify_keys(obj.serialize)
+    elsif obj.is_a?(Hash)
       new_obj = obj.class.new
       obj.each do |k, v|
         new_obj[k.to_s] = recursive_stringify_keys(v)

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -513,6 +513,18 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal('foo', b.f2.foo)
       assert_equal(10, b.f2.bar)
     end
+
+    it 'with nested fields as model' do
+      a = WithModel2.new(f1: 'foo')
+      b = a.with(f2: WithModel1.new(foo: 'foo', bar: 10))
+
+      assert_equal('foo', a.f1)
+      assert_nil(a.f2)
+      assert_equal('foo', b.f1)
+      refute_nil(b.f2)
+      assert_equal('foo', b.f2.foo)
+      assert_equal(10, b.f2.bar)
+    end
   end
 
   class BooleanStruct < T::Struct


### PR DESCRIPTION
The solution is rather straightforward:

In `#recursive_stringify_keys` add another branch to check for wether the value is a `T::Struct`. In this case just call `serialize`.

### Motivation
Using the `#with` helper on T::Struct can be really useful especially when using immutable objects. Typical example is having an address or money type:

```ruby
class Money < T::Struct
  const :amount, Integer
  const :currency, String
end

class Order < T::Struct
  const :value, Money
end


o = Order.new(value: Money.new(amount: 100_00, currency: "USD"))
o.with(value: Money.new(amount: 200_00, currency: "USD"))
```

Not only is this not possible, the error message is also very cryptic:

```
/gems/ruby/3.1.0/gems/sorbet-runtime-0.5.10526/lib/types/props/serializable.rb:72:in `rescue in rescue in deserialize': Error in Order#__t_props_generated_deserialize: <Money amount=20000, currency="USD"> provided to from_hash (TypeError)
at line 8 in:
    found = 1
    val = hash["value"]
  @value = if val.nil?
    found -= 1 unless hash.key?("value")
    self.class.decorator.raise_nil_deserialize_error("value")
  else
    begin
    Money.from_hash(val)
  rescue NoMethodError => e
    raise_deserialization_error(
      :value,
      val,
      e,
    )
    val
  end
/gems/ruby/3.1.0/gems/sorbet-runtime-0.5.10526/lib/types/props/serializable.rb:70:in `rescue in deserialize': Error in Order#__t_props_generated_deserialize: <Money amount=20000, currency="USD"> provided to from_hash (ArgumentError)
at line 8 in:
    found = 1
    val = hash["value"]
  @value = if val.nil?
    found -= 1 unless hash.key?("value")
    self.class.decorator.raise_nil_deserialize_error("value")
  else
    begin
    Money.from_hash(val)
  rescue NoMethodError => e
    raise_deserialization_error(
      :value,
      val,
      e,
    )
    val
  end
/gems/ruby/3.1.0/gems/sorbet-runtime-0.5.10526/lib/types/props/serializable.rb:209:in `from_hash': <Money amount=20000, currency="USD"> provided to from_hash (ArgumentError)
```

For the user there is a workaround by just calling `#serialize` on the passed in value:

```ruby
o.with(value: Money.new(amount: 200_00, currency: "USD").serialize)
=> <Order value=<Money amount=20000, currency="USD">>
```


### Test plan

See included automated tests.
