### PR TITLE
Don't format rbi files in document formatting requests

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -231,6 +231,10 @@ bool isPackageRBIPath(string_view path) {
     return absl::EndsWith(path, ".package.rbi");
 }
 
+bool File::isRBIPath(string_view path) {
+    return absl::EndsWith(path, ".rbi");
+}
+
 bool File::isPackagePath(string_view path) {
     auto pos = path.rfind("/");
     if (pos != string_view::npos) {
@@ -317,7 +321,7 @@ bool File::isPayload() const {
 }
 
 bool File::isRBI() const {
-    return absl::EndsWith(path(), ".rbi");
+    return File::isRBIPath(path());
 }
 
 bool File::isStdlib() const {

--- a/core/Files.h
+++ b/core/Files.h
@@ -49,6 +49,7 @@ public:
     bool isStdlib() const;
     bool isPackageRBI() const;
 
+    static bool isRBIPath(std::string_view path);
     static bool isPackagePath(std::string_view path);
 
     bool isPackage() const;

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -83,7 +83,7 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
 
     // Don't format `__package.rb` files, since currently formatting them
     // can potentially break some pay-server tooling
-    if (!sourceView.empty() && !core::File::isPackagePath(path)) {
+    if (!sourceView.empty() && !core::File::isPackagePath(path) && !core::File::isRBIPath(path)) {
         auto originalLineCount = findLineBreaks(sourceView).size() - 1;
         auto processResponse = sorbet::Subprocess::spawn(config.opts.rubyfmtPath, vector<string>(), sourceView);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`.rbi` files aren't intended to be formatted by `rubyfmt` (and `rubyfmt` skips them when it does the file traversal itself), but since this extension handles files by reading in to `stdin`, `rubyfmt` has no context on the file type and will format it anyways, so we should just skip them directly in the extension.

I originally attempted this purely using VSCode settings (e.g. just turn off the `editor.formatOnSave` setting for `.rbi` extensions) to avoid a network round trip, but I don't believe that's possible given the way VSCode handles file extensions[1], but I'm open to other ideas here.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I manually ran this change and confirmed it didn't modify an `rbi` file.

[1]: see [this open issue](https://github.com/microsoft/vscode/issues/35350)