### PR TITLE
Adding a default to a keyword arg takes fast path

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2322,6 +2322,7 @@ uint32_t Method::hash(const GlobalState &gs) const {
     result = mix(result, this->flags.serialize());
     result = mix(result, this->owner.id());
     result = mix(result, this->rebind.id());
+    result = mix(result, this->methodArityHash(gs)._hashValue);
     for (const auto &arg : arguments) {
         // If an argument's resultType changes, then the sig has changed.
         auto type = arg.type;
@@ -2329,7 +2330,6 @@ uint32_t Method::hash(const GlobalState &gs) const {
             type = Types::untypedUntracked();
         }
         result = mix(result, type.hash(gs));
-        result = mix(result, _hash(arg.name.shortName(gs)));
     }
     for (const auto &e : typeArguments()) {
         if (e.exists()) {

--- a/test/testdata/lsp/fast_path/keyword_args__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/keyword_args__1.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-fast-path: keyword_args__1.rb,keyword_args__2.rb
+
+module A
+  extend T::Sig
+
+  sig {params(a: String, b: T.nilable(String)).void}
+  def self.some_method(a, b:)
+  end
+end

--- a/test/testdata/lsp/fast_path/keyword_args__1.2.rbupdate
+++ b/test/testdata/lsp/fast_path/keyword_args__1.2.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-fast-path: keyword_args__1.rb,keyword_args__2.rb
+
+module A
+  extend T::Sig
+
+  sig {params(a: String, b: T.nilable(String)).void}
+  def self.some_method(a, b: nil)
+  end
+end

--- a/test/testdata/lsp/fast_path/keyword_args__1.rb
+++ b/test/testdata/lsp/fast_path/keyword_args__1.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module A
+  extend T::Sig
+
+  sig {params(a: String).void}
+  def self.some_method(a)
+  end
+end

--- a/test/testdata/lsp/fast_path/keyword_args__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/keyword_args__2.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# exclude-from-file-update: true
+
+module B
+  extend T::Sig
+
+  def some_other_method
+    A.some_method("") # error: Missing required keyword argument `b` for method `A.some_method`
+  end
+end

--- a/test/testdata/lsp/fast_path/keyword_args__2.2.rbupdate
+++ b/test/testdata/lsp/fast_path/keyword_args__2.2.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# exclude-from-file-update: true
+
+module B
+  extend T::Sig
+
+  def some_other_method
+    A.some_method("")
+  end
+end

--- a/test/testdata/lsp/fast_path/keyword_args__2.rb
+++ b/test/testdata/lsp/fast_path/keyword_args__2.rb
@@ -1,0 +1,10 @@
+# typed: true
+# spacer for exclude-from-file-update
+
+module B
+  extend T::Sig
+
+  def some_other_method
+    A.some_method("")
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`Method::hash` also needs to include information about the arity of the method. Ironically, `methodShapeHash` already includes information about the arity of a method this way, so in the olden days when non-type changes to methods couldn't take the fast path we would correctly detect changes in arity as a non-type change to the method.





### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

With this extra information in the hash, the failing test passes.

cc @jvilk-stripe who was kind enough to report the test case.