### PR TITLE
Improve error messages of "params" syntax

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -42,16 +42,16 @@ module T::Private::Methods
         some_or_only = params.any? ? "some" : "only"
         raise BuilderError.new(<<~MSG)
           'params' was called with #{some_or_only} positional arguments, but it needs to be called with keyword arguments.
-          the keyword arguments' keys must match the name and order of your method's parameters.
+          The keyword arguments' keys must match the name and order of the method's parameters.
         MSG
       end
 
       if params.empty?
         raise BuilderError.new(<<~MSG)
           'params' was called without any arguments, but it needs to be called with keyword arguments.
-          the keyword arguments' keys must match the name and order of your method's parameters.
+          The keyword arguments' keys must match the name and order of the method's parameters.
 
-          If your method has no parameters, then you should omit 'params' entirely.
+          Omit 'params' entirely for methods with no parameters.
         MSG
       end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -32,15 +32,29 @@ module T::Private::Methods
       )
     end
 
-    def params(**params)
+    def params(*unused_positional_params, **params)
       check_live!
       if !decl.params.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't call .params twice")
       end
 
-      if params.empty?
-        raise BuilderError.new("params expects keyword arguments")
+      if unused_positional_params.any?
+        some_or_only = params.any? ? "some" : "only"
+        raise BuilderError.new(<<~MSG)
+          'params' was called with #{some_or_only} positional arguments, but it needs to be called with keyword arguments.
+          the keyword arguments' keys must match the name and order of your method's parameters.
+        MSG
       end
+
+      if params.empty?
+        raise BuilderError.new(<<~MSG)
+          'params' was called without any arguments, but it needs to be called with keyword arguments.
+          the keyword arguments' keys must match the name and order of your method's parameters.
+
+          If your method has no parameters, then you should omit 'params' entirely.
+        MSG
+      end
+
       decl.params = params
 
       self

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -41,7 +41,7 @@ module Opus::Types::Test
       end
       assert_includes(ex.message, <<~MSG.chomp)
         'params' was called with some positional arguments, but it needs to be called with keyword arguments.
-        the keyword arguments' keys must match the name and order of your method's parameters.
+        The keyword arguments' keys must match the name and order of the method's parameters.
       MSG
     end
 
@@ -55,7 +55,7 @@ module Opus::Types::Test
       end
       assert_includes(ex.message, <<~MSG.chomp)
         'params' was called with only positional arguments, but it needs to be called with keyword arguments.
-        the keyword arguments' keys must match the name and order of your method's parameters.
+        The keyword arguments' keys must match the name and order of the method's parameters.
       MSG
     end
 
@@ -69,7 +69,7 @@ module Opus::Types::Test
       end
       assert_includes(ex.message, <<~MSG.chomp)
         'params' was called without any arguments, but it needs to be called with keyword arguments.
-        the keyword arguments' keys must match the name and order of your method's parameters.
+        The keyword arguments' keys must match the name and order of the method's parameters.
 
         If your method has no parameters, then you should omit 'params' entirely.
       MSG

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -31,6 +31,20 @@ module Opus::Types::Test
       assert_equal(true, builder.decl.finalized)
     end
 
+    it 'requires params not have any positional args' do
+      ex = assert_raises do
+        Class.new do
+          extend T::Sig
+          sig {params(Integer, s: String).void}
+          def self.foo(s); end; foo
+        end
+      end
+      assert_includes(ex.message, <<~MSG.chomp)
+        'params' was called with some positional arguments, but it needs to be called with keyword arguments.
+        the keyword arguments' keys must match the name and order of your method's parameters.
+      MSG
+    end
+
     it 'requires params be keyword args' do
       ex = assert_raises do
         Class.new do
@@ -39,7 +53,10 @@ module Opus::Types::Test
           def self.foo; end; foo
         end
       end
-      assert_includes(ex.message, "wrong number of arguments (given 1, expected 0)")
+      assert_includes(ex.message, <<~MSG.chomp)
+        'params' was called with only positional arguments, but it needs to be called with keyword arguments.
+        the keyword arguments' keys must match the name and order of your method's parameters.
+      MSG
     end
 
     it 'requires params have an arg' do
@@ -50,7 +67,12 @@ module Opus::Types::Test
           def self.foo; end; foo
         end
       end
-      assert_includes(ex.message, "params expects keyword arguments")
+      assert_includes(ex.message, <<~MSG.chomp)
+        'params' was called without any arguments, but it needs to be called with keyword arguments.
+        the keyword arguments' keys must match the name and order of your method's parameters.
+
+        If your method has no parameters, then you should omit 'params' entirely.
+      MSG
     end
 
     describe 'modes' do

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -71,7 +71,7 @@ module Opus::Types::Test
         'params' was called without any arguments, but it needs to be called with keyword arguments.
         The keyword arguments' keys must match the name and order of the method's parameters.
 
-        If your method has no parameters, then you should omit 'params' entirely.
+        Omit 'params' entirely for methods with no parameters.
       MSG
     end
 

--- a/rbi/sorbet/builder.rbi
+++ b/rbi/sorbet/builder.rbi
@@ -21,8 +21,8 @@ class T::Private::Methods::DeclBuilder
   sig {params(claz: T.untyped).returns(T::Private::Methods::DeclBuilder)}
   def bind(claz); end
 
-  sig {params(params: T.untyped).returns(T::Private::Methods::DeclBuilder)}
-  def params(**params); end
+  sig {params(unused_positional_params: T.untyped, params: T.untyped).returns(T::Private::Methods::DeclBuilder)}
+  def params(*unused_positional_params, **params); end
 
   sig {params(type: T.untyped).returns(T::Private::Methods::DeclBuilder)}
   def returns(type); end


### PR DESCRIPTION
### Motivation

Despite having used Sorbet for a long while now, I still sometimes forget to provide keyword labels to my arguments to `params`. E.g.:

```ruby
sig { params(Integer).returns(String) } # Ooops, forgot "input:"
def foo(input: 123)
  input.to_s
end
```

The message isn't particularly helpful:

> ArgumentError: wrong number of arguments (given 1, expected 0)

More than once now, I misinterpreted this as an issue with one of the call sites in my own (non-sig) code.

### Test plan

See included automated tests.
