### PR TITLE
serialize `NameRef` in `NamedLiteralType` in a better way

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -402,7 +402,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
             switch (c.literalKind) {
                 case NamedLiteralType::LiteralTypeKind::Symbol:
                 case NamedLiteralType::LiteralTypeKind::String:
-                    p.putS8(c.unsafeAsName().rawId());
+                    p.putU4(c.unsafeAsName().rawId());
                     break;
             }
             break;
@@ -496,12 +496,12 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             return OrType::make_shared(unpickleType(p, gs), unpickleType(p, gs));
         case TypePtr::Tag::NamedLiteralType: {
             auto kind = (core::NamedLiteralType::LiteralTypeKind)p.getU1();
-            auto value = p.getS8();
+            auto name = unpickleNameRef(p, *gs);
             switch (kind) {
                 case NamedLiteralType::LiteralTypeKind::String:
-                    return make_type<NamedLiteralType>(Symbols::String(), NameRef::fromRawUnchecked(value));
+                    return make_type<NamedLiteralType>(Symbols::String(), name);
                 case NamedLiteralType::LiteralTypeKind::Symbol:
-                    return make_type<NamedLiteralType>(Symbols::Symbol(), NameRef::fromRawUnchecked(value));
+                    return make_type<NamedLiteralType>(Symbols::Symbol(), name);
             }
             Exception::notImplemented();
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -496,7 +496,7 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             return OrType::make_shared(unpickleType(p, gs), unpickleType(p, gs));
         case TypePtr::Tag::NamedLiteralType: {
             auto kind = (core::NamedLiteralType::LiteralTypeKind)p.getU1();
-            auto name = unpickleNameRef(p, *gs);
+            auto name = NameRef::fromRawUnchecked(p.getU4());
             switch (kind) {
                 case NamedLiteralType::LiteralTypeKind::String:
                     return make_type<NamedLiteralType>(Symbols::String(), name);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Using an `s8` here is unnecessary overhead, as we know that the `NameRef` will only ever be a `u4`.  The `u4` (de)serialization path is also much better optimized, so this should be a slight win in performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
