### PR TITLE
Do not remove empty directories before writing autoloads

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -529,17 +529,19 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
         for (const auto &file : existingFilesSet) {
             FileOps::removeFile(file);
 
+            // TODO (aadi-stripe, 12/7/2022): Investigate whether dangling autoloads are an actual problem that needs
+            // to be mitigated here.
             // Remove all empty directories along path. This prevents zeitwerk from setting up dangling autoloads.
-            std::string_view filePath = file;
-            int curDirPos = filePath.find_last_of('/');
-            while (curDirPos > 0) {
-                const auto curDir = filePath.substr(0, curDirPos);
-                if (curDir == path || !FileOps::removeEmptyDir(string(curDir))) {
-                    break;
-                }
+            /* std::string_view filePath = file; */
+            /* int curDirPos = filePath.find_last_of('/'); */
+            /* while (curDirPos > 0) { */
+            /*     const auto curDir = filePath.substr(0, curDirPos); */
+            /*     if (curDir == path || !FileOps::removeEmptyDir(string(curDir))) { */
+            /*         break; */
+            /*     } */
 
-                curDirPos = filePath.find_last_of('/', curDirPos - 1);
-            }
+            /*     curDirPos = filePath.find_last_of('/', curDirPos - 1); */
+            /* } */
         }
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Comments out the logic in `autoloader.cc` that removes empty directories in addition to clearing out files we don't plan to write as part of the autogen run.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This is causing issues where files cannot be written to subsequently because their directories have been deleted.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on Stripe codebase.
