### PR TITLE
don't generate autoloader source twice

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -561,7 +561,7 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
                     ++n;
                     auto &task = tasks[idx];
                     auto src = task.node.renderAutoloadSrc(gs, alCfg);
-                    bool rewritten = FileOps::writeIfDifferent(task.filePath, task.node.renderAutoloadSrc(gs, alCfg));
+                    bool rewritten = FileOps::writeIfDifferent(task.filePath, src);
 
                     // Initial read should be cheap, read outside mutex
                     if (rewritten && !modificationState.modified) {


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less work is less work, even when we're doing things in parallel.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
