### PR TITLE
don't construct unnecessary strings during autoloader generation

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -198,7 +198,7 @@ core::NameRef DefTree::name() const {
     return qname.name();
 }
 
-string DefTree::renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalState &gs, const AutoloaderConfig &alCfg) const {
+void DefTree::renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalState &gs, const AutoloaderConfig &alCfg) const {
     core::FileRef definingFileRef = definingFile();
 
     fmt::format_to(std::back_inserter(buf), "{}\n", alCfg.preamble);
@@ -244,7 +244,6 @@ string DefTree::renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalSta
         fmt::format_to(std::back_inserter(buf), "\n{}.for_autoload({}, \"{}\"{})\n", alCfg.registryModule, fullName,
                        alCfg.normalizePath(gs, definingFileRef), casgnArg);
     }
-    return to_string(buf);
 }
 
 void DefTree::requireStatements(const core::GlobalState &gs, const AutoloaderConfig &alCfg,
@@ -562,8 +561,8 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
                     ++n;
                     auto &task = tasks[idx];
                     fmt::memory_buffer buf;
-                    auto src = task.node.renderAutoloadSrc(buf, gs, alCfg);
-                    bool rewritten = FileOps::writeIfDifferent(task.filePath, src);
+                    task.node.renderAutoloadSrc(buf, gs, alCfg);
+                    bool rewritten = FileOps::writeIfDifferent(task.filePath, string_view{&buf.data()[0], buf.size()});
 
                     // Initial read should be cheap, read outside mutex
                     if (rewritten && !modificationState.modified) {

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -556,11 +556,12 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
             {
                 Timer timeit(gs.tracer(), "autogenWriteAutoloadsWorker");
                 int idx = 0;
+                fmt::memory_buffer buf;
 
                 for (auto result = inputq->try_pop(idx); !result.done(); result = inputq->try_pop(idx)) {
                     ++n;
                     auto &task = tasks[idx];
-                    fmt::memory_buffer buf;
+                    buf.clear();
                     task.node.renderAutoloadSrc(buf, gs, alCfg);
                     bool rewritten = FileOps::writeIfDifferent(task.filePath, string_view{&buf.data()[0], buf.size()});
 

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -198,8 +198,7 @@ core::NameRef DefTree::name() const {
     return qname.name();
 }
 
-string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderConfig &alCfg) const {
-    fmt::memory_buffer buf;
+string DefTree::renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalState &gs, const AutoloaderConfig &alCfg) const {
     core::FileRef definingFileRef = definingFile();
 
     fmt::format_to(std::back_inserter(buf), "{}\n", alCfg.preamble);
@@ -562,7 +561,8 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
                 for (auto result = inputq->try_pop(idx); !result.done(); result = inputq->try_pop(idx)) {
                     ++n;
                     auto &task = tasks[idx];
-                    auto src = task.node.renderAutoloadSrc(gs, alCfg);
+                    fmt::memory_buffer buf;
+                    auto src = task.node.renderAutoloadSrc(buf, gs, alCfg);
                     bool rewritten = FileOps::writeIfDifferent(task.filePath, src);
 
                     // Initial read should be cheap, read outside mutex

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -198,7 +198,8 @@ core::NameRef DefTree::name() const {
     return qname.name();
 }
 
-void DefTree::renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalState &gs, const AutoloaderConfig &alCfg) const {
+void DefTree::renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalState &gs,
+                                const AutoloaderConfig &alCfg) const {
     core::FileRef definingFileRef = definingFile();
 
     fmt::format_to(std::back_inserter(buf), "{}\n", alCfg.preamble);

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -96,7 +96,7 @@ public:
     std::string show(const core::GlobalState &gs, int level = 0) const; // Render the entire tree
     std::string fullName(const core::GlobalState &) const;
 
-    std::string renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalState &gs, const AutoloaderConfig &) const;
+    void renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalState &gs, const AutoloaderConfig &) const;
     bool mustRender(const core::GlobalState &gs, std::string_view filePath) const;
 
     DefTree() = default;

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -96,7 +96,7 @@ public:
     std::string show(const core::GlobalState &gs, int level = 0) const; // Render the entire tree
     std::string fullName(const core::GlobalState &) const;
 
-    std::string renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderConfig &) const;
+    std::string renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalState &gs, const AutoloaderConfig &) const;
     bool mustRender(const core::GlobalState &gs, std::string_view filePath) const;
 
     DefTree() = default;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We can generate `string_view` directly out of `fmt::memory_buffer`, which is all we need for writing the relevant files.

While we're here, let's also re-use a single buffer throughout the life of the worker thread.

(Full disclosure: this PR initially failed with an ASAN error in a non-autogen-related CLI test...retrying the tests worked. :ghost:)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
