### PR TITLE
Add fast path test that currently fails

### DIFF
--- a/test/testdata/lsp/fast_path/const_alias_to_namespace__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/const_alias_to_namespace__1.1.rbupdate
@@ -1,0 +1,13 @@
+# typed: true
+# assert-fast-path: const_alias_to_namespace__1.rb
+
+# This test currently shows incorrect behavior. As far as I can tell, this has
+# been incorrect for as long as Sorbet has had a fast path mode. The fact that
+# this bug is only appearing now means that maybe we can tolerate it a while
+# longer?
+#
+# In any case, we will want to fix this eventually.
+
+module Wrapper
+  Alias = Namespace2
+end

--- a/test/testdata/lsp/fast_path/const_alias_to_namespace__1.rb
+++ b/test/testdata/lsp/fast_path/const_alias_to_namespace__1.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+module Wrapper
+  Alias = Namespace1
+end

--- a/test/testdata/lsp/fast_path/const_alias_to_namespace__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/const_alias_to_namespace__2.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# exclude-from-file-update: true
+
+module Namespace1
+  X = 1
+end
+
+module Namespace2
+  X = ''
+end

--- a/test/testdata/lsp/fast_path/const_alias_to_namespace__2.rb
+++ b/test/testdata/lsp/fast_path/const_alias_to_namespace__2.rb
@@ -1,0 +1,10 @@
+# typed: true
+# spacer for exclude-from-file-update
+
+module Namespace1
+  X = 1
+end
+
+module Namespace2
+  X = ''
+end

--- a/test/testdata/lsp/fast_path/const_alias_to_namespace__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/const_alias_to_namespace__3.1.rbupdate
@@ -1,0 +1,4 @@
+# typed: true
+# exclude-from-file-update: true
+
+T.reveal_type(Wrapper::Alias::X) # error: `Integer`

--- a/test/testdata/lsp/fast_path/const_alias_to_namespace__3.rb
+++ b/test/testdata/lsp/fast_path/const_alias_to_namespace__3.rb
@@ -1,0 +1,4 @@
+# typed: true
+# spacer for exclude-from-file-update
+
+T.reveal_type(Wrapper::Alias::X) # error: `Integer`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I first noticed this bug while working on #6422.

This test currently shows incorrect behavior. As far as I can tell, this
has been incorrect for as long as Sorbet has had a fast path mode. The
fact that this bug is only appearing now means that maybe we can
tolerate it a while longer?

In any case, we will want to fix this eventually.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test case is written so that it passes, but it captures incorrect behavior.