### PR TITLE
ensure that `ASAN_SYMBOLIZER_PATH` is available for CLI tests

### DIFF
--- a/test/cli/BUILD
+++ b/test/cli/BUILD
@@ -1,4 +1,8 @@
+load("//tools:clang.bzl", "clang_tool")  # todo: this should be decoupled and use the library toolchain, not the compiler one
+
 load(":cli_test.bzl", "cli_tests")
+
+clang_tool("llvm-symbolizer")
 
 cli_tests(
     "cli",

--- a/test/cli/BUILD
+++ b/test/cli/BUILD
@@ -1,5 +1,4 @@
 load("//tools:clang.bzl", "clang_tool")  # todo: this should be decoupled and use the library toolchain, not the compiler one
-
 load(":cli_test.bzl", "cli_tests")
 
 clang_tool("llvm-symbolizer")

--- a/test/cli/cli_test.bzl
+++ b/test/cli/cli_test.bzl
@@ -71,6 +71,7 @@ def _cli_test(name, script, tags = []):
             script_path,
             ":run_{}".format(name),
             output,
+            "//test/cli:llvm-symbolizer",
         ],
         size = "medium",
         tags = tags,

--- a/test/cli/test_one.sh
+++ b/test/cli/test_one.sh
@@ -2,6 +2,8 @@
 script="$1"
 expect="$2"
 
+export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_12_0_0/bin/llvm-symbolizer
+
 if ! diff "$expect" -u <("$script"); then
   cat <<EOF
 ================================================================================


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

We seem to be having some intermittent ASAN failures in one particular CLI test.  Ensure that we actually get reasonable symbols in CI, and make life more pleasant for anybody running into ASAN failures in CLI tests in the future.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
