### PR TITLE
remove unused parameter from `DefTree::mustRender`

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -465,10 +465,10 @@ struct ModificationState {
 void populateAutoloadTasksAndCreateDirectories(const core::GlobalState &gs, vector<RenderAutoloadTask> &tasks,
                                                const AutoloaderConfig &alCfg, string_view path, const DefTree &node) {
     string name = node.root() ? "root" : node.name().show(gs);
-    string filePath = join(path, fmt::format("{}.rb", name));
 
-    if (node.mustRender(gs, filePath)) {
-        tasks.emplace_back(RenderAutoloadTask{filePath, node});
+    if (node.mustRender(gs)) {
+        string filePath = join(path, fmt::format("{}.rb", name));
+        tasks.emplace_back(RenderAutoloadTask{move(filePath), node});
     }
 
     // Generate autoloads for child nodes if they exist and pkgName is not present (since the latter indicates
@@ -495,7 +495,7 @@ core::FileRef DefTree::definingFile() const {
     return definingFileRef;
 }
 
-bool DefTree::mustRender(const core::GlobalState &gs, std::string_view filePath) const {
+bool DefTree::mustRender(const core::GlobalState &gs) const {
     // Either the node has a behavior-defining file, or has a package name
     if (definingFile().exists() || pkgName.exists()) {
         return true;

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -97,7 +97,7 @@ public:
     std::string fullName(const core::GlobalState &) const;
 
     void renderAutoloadSrc(fmt::memory_buffer &buf, const core::GlobalState &gs, const AutoloaderConfig &) const;
-    bool mustRender(const core::GlobalState &gs, std::string_view filePath) const;
+    bool mustRender(const core::GlobalState &gs) const;
 
     DefTree() = default;
     DefTree(const DefTree &) = delete;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This also enables us to avoid a small amount of work if the node doesn't need to be rendered, as we don't need to construct the file path for it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
