### PR TITLE
Remove TODO(jez) by adding test case

### DIFF
--- a/test/testdata/lsp/fast_path/private_overloads__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/private_overloads__1.1.rbupdate
@@ -1,0 +1,20 @@
+# typed: __STDLIB_INTERNAL
+# exclude-from-file-update: true
+
+class PrivateOverloads
+  extend T::Sig
+
+  sig {returns(NilClass)}
+  sig {params(x: Integer).returns(Integer)}
+  private def foo(x=nil); end
+end
+
+po1 = PrivateOverloads.new.foo # error: Non-private call to private method
+T.reveal_type(po1) # error: Revealed type: `NilClass`
+
+
+# Must be at least one `hover` in this file to trigger the
+# LSPTypechecker::retypecheck codepath (fast path with no edit)
+
+po2 = PrivateOverloads.new.foo(0) # error: Non-private call to private method
+T.reveal_type(po2) # error: Revealed type: `Integer`

--- a/test/testdata/lsp/fast_path/private_overloads__1.rb
+++ b/test/testdata/lsp/fast_path/private_overloads__1.rb
@@ -1,0 +1,20 @@
+# typed: __STDLIB_INTERNAL
+# spacer for exclude-from-file-update
+
+class PrivateOverloads
+  extend T::Sig
+
+  sig {returns(NilClass)}
+  sig {params(x: Integer).returns(Integer)}
+  private def foo(x=nil); end
+end
+
+po1 = PrivateOverloads.new.foo # error: Non-private call to private method
+T.reveal_type(po1) # error: Revealed type: `NilClass`
+#             ^ hover: NilClass
+
+# Must be at least one `hover` in this file to trigger the
+# LSPTypechecker::retypecheck codepath (fast path with no edit)
+
+po2 = PrivateOverloads.new.foo(0) # error: Non-private call to private method
+T.reveal_type(po2) # error: Revealed type: `Integer`

--- a/test/testdata/lsp/fast_path/private_overloads__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/private_overloads__2.1.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+# assert-fast-path: private_overloads__2.rb
+
+def example
+  PrivateOverloads.new.foo # error: Non-private call to private method
+end

--- a/test/testdata/lsp/fast_path/private_overloads__2.rb
+++ b/test/testdata/lsp/fast_path/private_overloads__2.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+def example
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If we attempt to delete the mentioned block of code (like the comment
suggested might be possible), this is what the symbol table looks like
when we re-run the fast path but don't run the incremental namer:

    contents before Namer::run
        method <C <U PrivateOverloads>>#<O <U foo> $1> : private (x, <blk>) -> Integer @ Loc {file=/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/foo.rb start=7:3 end=7:44}
        method <C <U PrivateOverloads>>#<U foo> : private (<blk>) -> NilClass @ Loc {file=/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/foo.rb start=8:11 end=8:25}
        method <C <U PrivateOverloads>>#<V <U foo> $1> : private (x, <blk>) @ Loc {file=/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/foo.rb start=8:11 end=8:25}

    contents after Namer::run, before Resolver::runIncremental
        method <C <U PrivateOverloads>>#<O <U foo> $1> : private (x, <blk>) -> Integer @ Loc {file=/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/foo.rb start=7:3 end=7:44}
        method <C <U PrivateOverloads>>#<U foo> : private (<blk>) -> NilClass @ Loc {file=/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/foo.rb start=8:11 end=8:25}
        method <C <U PrivateOverloads>>#<V <U foo> $1> (x, <blk>) @ Loc {file=/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/foo.rb start=8:11 end=8:25}

    contents after Resolver::runIncremental
        method <C <U PrivateOverloads>>#<O <U foo> $1> (x, <blk>) -> Integer @ Loc {file=/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/foo.rb start=7:3 end=7:44}
        method <C <U PrivateOverloads>>#<U foo> (<blk>) -> NilClass @ Loc {file=/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/foo.rb start=8:11 end=8:25}
        method <C <U PrivateOverloads>>#<V <U foo> $1> (x, <blk>) @ Loc {file=/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/foo.rb start=8:11 end=8:25}

What that means is that simply answering a hover or definition request
would mutate the visibility of a method, absent any actual file changes.

In fact, with just the tests that exist as of #6422, we could have
deleted the mentioned block of code and the suite would have passed, but
the lingering bug would have been added.

I've verified that when based on the changes in #6422 AND after deleting
that block of code, the test case included in this PR fails. So this
test should prevent someone from unknowingly deleting that block in the
future (or guide them if they attempt to implement the suggestion in the
comment).

(I don't happen to think that doing that refactor is particularly urgent
right now, because the hack works ~well enough.)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.