### PR TITLE
Factor out errorFlusher argument to runSlowPath

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -121,7 +121,7 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
     {
         const bool isIncremental = false;
         ErrorEpoch epoch(*errorReporter, updates.epoch, isIncremental, {});
-        auto errorFlusher = make_shared<ErrorFlusherLSP>(epoch, errorReporter);
+        auto errorFlusher = make_shared<ErrorFlusherLSP>(updates.epoch, errorReporter);
         committed = runSlowPath(move(updates), workers, errorFlusher, /* cancelable */ false);
         epoch.committed = committed;
     }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -121,7 +121,8 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
     {
         const bool isIncremental = false;
         ErrorEpoch epoch(*errorReporter, updates.epoch, isIncremental, {});
-        committed = runSlowPath(move(updates), workers, /* cancelable */ false);
+        auto errorFlusher = make_shared<ErrorFlusherLSP>(epoch, errorReporter);
+        committed = runSlowPath(move(updates), workers, errorFlusher, /* cancelable */ false);
         epoch.committed = committed;
     }
     ENFORCE(committed);
@@ -178,13 +179,13 @@ bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
     {
         ErrorEpoch epoch(*errorReporter, updates.epoch, isFastPath, move(diagnosticLatencyTimers));
 
+        auto errorFlusher = make_shared<ErrorFlusherLSP>(updates.epoch, errorReporter);
         if (isFastPath) {
-            filesTypechecked =
-                runFastPath(updates, workers, make_shared<ErrorFlusherLSP>(updates.epoch, errorReporter));
+            filesTypechecked = runFastPath(updates, workers, errorFlusher);
             commitFileUpdates(updates, /* cancelable */ false);
             prodCategoryCounterInc("lsp.updates", "fastpath");
         } else {
-            committed = runSlowPath(move(updates), workers, /* cancelable */ true);
+            committed = runSlowPath(move(updates), workers, errorFlusher, /* cancelable */ true);
         }
         epoch.committed = committed;
     }
@@ -339,7 +340,8 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
     return !epochManager.wasTypecheckingCanceled();
 }
 
-bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bool cancelable) {
+bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
+                                 shared_ptr<core::ErrorFlusher> errorFlusher, bool cancelable) {
     ENFORCE(this_thread::get_id() == typecheckerThreadId,
             "runSlowPath can only be called from the typechecker thread.");
 
@@ -356,8 +358,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
     auto finalGS = move(updates.updatedGS.value());
     const uint32_t epoch = updates.epoch;
     // Replace error queue with one that is owned by this thread.
-    finalGS->errorQueue = make_shared<core::ErrorQueue>(finalGS->errorQueue->logger, finalGS->errorQueue->tracer,
-                                                        make_shared<ErrorFlusherLSP>(epoch, errorReporter));
+    finalGS->errorQueue =
+        make_shared<core::ErrorQueue>(finalGS->errorQueue->logger, finalGS->errorQueue->tracer, errorFlusher);
     auto &epochManager = *finalGS->epochManager;
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
     // cancelation feature is enabled.

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -62,7 +62,8 @@ class LSPTypechecker final {
 
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */
-    bool runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bool cancelable);
+    bool runSlowPath(LSPFileUpdates updates, WorkerPool &workers, std::shared_ptr<core::ErrorFlusher> errorFlusher,
+                     bool cancelable);
 
     /** Runs incremental typechecking on the provided updates. Returns the final list of files typechecked. */
     std::vector<core::FileRef> runFastPath(LSPFileUpdates &updates, WorkerPool &workers,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The `runFastPath` and some of the methods it calls take an explicit
`errorFlusher` argument, but `runSlowPath` doesn't. In a future change,
we're going to want to start calling those same APIs from `runSlowPath`.
So it's convenient to make these two methods have basically the same
signature.

This should be a no-op, because every instance of an errorFlusher used
in this file is always constructed in the same way with values that
would be the same at runtime to those that are used in this PR.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests
