### PR TITLE
make `T.let` faster for simple module types

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/casts.rb
+++ b/gems/sorbet-runtime/lib/types/private/casts.rb
@@ -5,7 +5,10 @@ module T::Private
   module Casts
     def self.cast(value, type, cast_method)
       begin
-        error = T::Utils.coerce(type).error_message_for_obj(value)
+        coerced_type = T::Utils::Private.coerce_and_check_module_types(type, value, true)
+        return value unless coerced_type
+
+        error = coerced_type.error_message_for_obj(value)
         return value unless error
 
         caller_loc = T.must(caller_locations(2..2)).first

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -9,7 +9,11 @@ module T::Utils
       elsif val.is_a?(T::Types::Base)
         val
       elsif val.is_a?(Module)
-        T::Types::Simple::Private::Pool.type_for_module(val)
+        if check_module_type && check_val.is_a?(val)
+          nil
+        else
+          T::Types::Simple::Private::Pool.type_for_module(val)
+        end
       elsif val.is_a?(::Array)
         T::Types::FixedArray.new(val)
       elsif val.is_a?(::Hash)

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -2,29 +2,35 @@
 # typed: true
 
 module T::Utils
+  module Private
+    def self.coerce_and_check_module_types(val, check_val, check_module_type)
+      if val.is_a?(T::Private::Types::TypeAlias)
+        val.aliased_type
+      elsif val.is_a?(T::Types::Base)
+        val
+      elsif val.is_a?(Module)
+        T::Types::Simple::Private::Pool.type_for_module(val)
+      elsif val.is_a?(::Array)
+        T::Types::FixedArray.new(val)
+      elsif val.is_a?(::Hash)
+        T::Types::FixedHash.new(val)
+      elsif val.is_a?(T::Private::Methods::DeclBuilder)
+        T::Private::Methods.finalize_proc(val.decl)
+      elsif val.is_a?(::T::Enum)
+        T::Types::TEnum.new(val)
+      elsif val.is_a?(::String)
+        raise "Invalid String literal for type constraint. Must be an #{T::Types::Base}, a " \
+              "class/module, or an array. Got a String with value `#{val}`."
+      else
+        raise "Invalid value for type constraint. Must be an #{T::Types::Base}, a " \
+              "class/module, or an array. Got a `#{val.class}`."
+      end
+    end
+  end
+
   # Used to convert from a type specification to a `T::Types::Base`.
   def self.coerce(val)
-    if val.is_a?(T::Private::Types::TypeAlias)
-      val.aliased_type
-    elsif val.is_a?(T::Types::Base)
-      val
-    elsif val.is_a?(Module)
-      T::Types::Simple::Private::Pool.type_for_module(val)
-    elsif val.is_a?(::Array)
-      T::Types::FixedArray.new(val)
-    elsif val.is_a?(::Hash)
-      T::Types::FixedHash.new(val)
-    elsif val.is_a?(T::Private::Methods::DeclBuilder)
-      T::Private::Methods.finalize_proc(val.decl)
-    elsif val.is_a?(::T::Enum)
-      T::Types::TEnum.new(val)
-    elsif val.is_a?(::String)
-      raise "Invalid String literal for type constraint. Must be an #{T::Types::Base}, a " \
-            "class/module, or an array. Got a String with value `#{val}`."
-    else
-      raise "Invalid value for type constraint. Must be an #{T::Types::Base}, a " \
-            "class/module, or an array. Got a `#{val.class}`."
-    end
+    Private.coerce_and_check_module_types(val, nil, false)
   end
 
   # Dynamically confirm that `value` is recursively a valid value of


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`T.let` with a simple `Module` type (`Integer`, `String`, etc.) is moderately common.  We can speed up this case by not fetching an entire `T::Types::Simple` structure from the cached pool, but instead check `is_a?` directly on such types for casts.

Benchmarks before (non-`let` benchmarks elided):

```
froydnj@pyro:~/src/sorbet/gems/sorbet-runtime$ env PATH=$PATH:/home/froydnj/ruby/bin /home/froydnj/ruby/bin/bundle exec rake bench:typecheck
T.let(..., Integer): 334.068 ns
T.let(..., T.nilable(Integer)): 834.552 ns
T.let(..., Example): 344.172 ns
T.let(..., T.nilable(Example)): 839.652 ns
```

Benchmarks after (nilable benchmarks not expected to change much and are within noise for these benchmarks):

```
T.let(..., Integer): 193.649 ns
T.let(..., T.nilable(Integer)): 825.172 ns
T.let(..., Example): 187.888 ns
T.let(..., T.nilable(Example)): 824.67 ns
```

Good for a 40%-ish speedup, which is nice.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
