### PR TITLE
rearrange checks when coercing types

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -4,10 +4,12 @@
 module T::Utils
   module Private
     def self.coerce_and_check_module_types(val, check_val, check_module_type)
-      if val.is_a?(T::Private::Types::TypeAlias)
-        val.aliased_type
-      elsif val.is_a?(T::Types::Base)
-        val
+      if val.is_a?(T::Types::Base)
+        if val.is_a?(T::Private::Types::TypeAlias)
+          val.aliased_type
+        else
+          val
+        end
       elsif val.is_a?(Module)
         if check_module_type && check_val.is_a?(val)
           nil


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is not a particularly big deal in many cases, e.g. for `T.nilable(Foo)`, we perform just as many `is_a?` calls and the main cost is allocating the `T.nilable` type anyway.  But for simple module types (e.g. `Integer`), this removes an `is_a?` call and some branching logic, which makes `T.let(..., Integer)` benchmarks ~10-15% faster.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
