### PR TITLE
Bump rules_m4 to v0.2.1

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -274,8 +274,8 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "rules_m4",
-        urls = _github_public_urls("jmillikin/rules_m4/releases/download/v0.2/rules_m4-v0.2.tar.xz"),
-        sha256 = "c67fa9891bb19e9e6c1050003ba648d35383b8cb3c9572f397ad24040fb7f0eb",
+        urls = _github_public_urls("jmillikin/rules_m4/releases/download/v0.2.1/rules_m4-v0.2.1.tar.xz"),
+        sha256 = "f59f75ac8a315d7647a2d058d324a87ff9ebbc4bf5c7a61b08d58da119a7fb43",
     )
 
     http_archive(


### PR DESCRIPTION
### Motivation

The v0.2.1 release includes support for building m4 1.4.18 with new glibc versions,
and m4 1.4.18 is the default with Ubuntu 22.04 and newer.

See https://github.com/jmillikin/rules_m4/issues/9#issuecomment-1111730269

Without this patch, one runs into a build failure on Ubuntu 22.04

```
ERROR: /home/varun/.cache/bazel/_bazel_varun/5a191b72f0376a228bd40e26312540b5/external/m4_v1.4.18/gnulib/BUILD.bazel:192:11: Compiling gnulib/lib/c-stack.c [for host] failed: (Exit 1): clang failed: error executing command 
/home/varun/.cache/bazel/_bazel_varun/5a191b72f0376a228bd40e26312540b5/external/llvm_toolchain_12_0_0/bin/clang -U_FORTIFY_SOURCE -fstack-protector -fno-omit-frame-pointer -fcolor-diagnostics -Wall ... (remaining 34 argumen
ts skipped)                                                                                                    
external/m4_v1.4.18/gnulib/lib/c-stack.c:55:26: error: function-like macro 'sysconf' is not defined            
#elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384                                                                      
                         ^                                                                                     
/usr/include/x86_64-linux-gnu/bits/sigstksz.h:28:19: note: expanded from macro 'SIGSTKSZ'                      
# define SIGSTKSZ sysconf (_SC_SIGSTKSZ)                                                                       
                  ^                                                                                                                                                                                                            
external/m4_v1.4.18/gnulib/lib/c-stack.c:139:8: error: fields must have a constant size: 'variable length array in structure' extension will never be supported                       
  char buffer[SIGSTKSZ];                                                                                       
       ^                                                                                                       
2 errors generated.             
```

### Test plan

Build on Ubuntu 22.04 or newer. Old builds should continue to work.