### PR TITLE
Desugar step removes all method bodies for autogen

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -320,11 +320,14 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
 
     bool removeBody = dctx.ctx.state.autogenPrintingSubclassesOrAutoloaderOnly;
     ExpressionPtr desugaredBody;
-    if (!removeBody) {
+    if (removeBody) {
+        // For performance reasons, we remove method bodies in autogen when only generating
+        // autoloader files or subclass lists. In this configuration, passing method bodies
+        // is not required for correctness.
+        desugaredBody = MK::EmptyTree();
+    } else {
         desugaredBody = desugarBody(dctx2, loc, body, std::move(destructures));
         desugaredBody = validateRBIBody(dctx2, move(desugaredBody));
-    } else {
-        desugaredBody = MK::EmptyTree();
     }
 
     auto mdef = MK::Method(loc, declLoc, name, std::move(args), std::move(desugaredBody));

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1966,7 +1966,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->autocorrect = this->autocorrect;
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
-    result->autogenPrintingDepDB = this->autogenPrintingDepDB;
+    result->autogenPrintingSubclassesOrAutoloaderOnly = this->autogenPrintingSubclassesOrAutoloaderOnly;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
@@ -2063,7 +2063,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->autocorrect = this->autocorrect;
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
-    result->autogenPrintingDepDB = this->autogenPrintingDepDB;
+    result->autogenPrintingSubclassesOrAutoloaderOnly = this->autogenPrintingSubclassesOrAutoloaderOnly;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
     result->lspExperimentalFastPathEnabled = this->lspExperimentalFastPathEnabled;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1966,6 +1966,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->autocorrect = this->autocorrect;
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
+    result->autogenPrintingDepDB = this->autogenPrintingDepDB;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
@@ -2062,6 +2063,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->autocorrect = this->autocorrect;
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
+    result->autogenPrintingDepDB = this->autogenPrintingDepDB;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
     result->lspExperimentalFastPathEnabled = this->lspExperimentalFastPathEnabled;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -240,6 +240,7 @@ public:
     // Think very hard before looking at this value in namer / resolver!
     // (hint: probably you want to find an alternate solution)
     bool runningUnderAutogen = false;
+    bool autogenPrintingDepDB = false;
     bool censorForSnapshotTests = false;
 
     std::optional<int> sleepInSlowPathSeconds = std::nullopt;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -240,7 +240,7 @@ public:
     // Think very hard before looking at this value in namer / resolver!
     // (hint: probably you want to find an alternate solution)
     bool runningUnderAutogen = false;
-    bool autogenPrintingDepDB = false;
+    bool autogenPrintingSubclassesOrAutoloaderOnly = false;
     bool censorForSnapshotTests = false;
 
     std::optional<int> sleepInSlowPathSeconds = std::nullopt;

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -13,7 +13,16 @@ unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::log
     if (opts.cacheDir.empty()) {
         return nullptr;
     }
-    auto flavor = opts.lspExperimentalFastPathEnabled ? "experimentalfastpath" : "normalfastpath";
+
+    std::string flavor;
+    if (opts.print.isAutogen() && !opts.print.isAutogenPrintingDepDB()) {
+        flavor = "autogenemptymethodbodies";
+    } else if (opts.lspExperimentalFastPathEnabled) {
+        flavor = "experimentalfastpath";
+    } else {
+        flavor = "normalfastpath";
+    }
+
     return make_unique<OwnedKeyValueStore>(make_unique<KeyValueStore>(logger, sorbet_full_version_string, opts.cacheDir,
                                                                       move(flavor), opts.maxCacheSizeBytes));
 }

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -15,7 +15,7 @@ unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::log
     }
 
     std::string flavor;
-    if (opts.print.isAutogen() && !opts.print.isAutogenPrintingDepDB()) {
+    if (opts.print.isAutogenPrintingSubclassesOrAutoloaderOnly()) {
         flavor = "autogenemptymethodbodies";
     } else if (opts.lspExperimentalFastPathEnabled) {
         flavor = "experimentalfastpath";

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -154,6 +154,10 @@ vector<reference_wrapper<PrinterConfig>> Printers::printers() {
     });
 }
 
+bool Printers::isAutogenPrintingDepDB() const {
+    return Autogen.enabled || AutogenMsgPack.enabled;
+}
+
 bool Printers::isAutogen() const {
     return Autogen.enabled || AutogenMsgPack.enabled || AutogenSubclasses.enabled || AutogenAutoloader.enabled;
 }

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -154,12 +154,12 @@ vector<reference_wrapper<PrinterConfig>> Printers::printers() {
     });
 }
 
-bool Printers::isAutogenPrintingDepDB() const {
-    return Autogen.enabled || AutogenMsgPack.enabled;
-}
-
 bool Printers::isAutogen() const {
     return Autogen.enabled || AutogenMsgPack.enabled || AutogenSubclasses.enabled || AutogenAutoloader.enabled;
+}
+
+bool Printers::isAutogenPrintingSubclassesOrAutoloaderOnly() const {
+    return isAutogen() && !(Autogen.enabled || AutogenMsgPack.enabled);
 }
 
 struct StopAfterOptions {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -90,6 +90,7 @@ struct Printers {
 
     std::vector<std::reference_wrapper<PrinterConfig>> printers();
     bool isAutogen() const;
+    bool isAutogenPrintingDepDB() const;
 };
 
 enum class Phase {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -90,7 +90,7 @@ struct Printers {
 
     std::vector<std::reference_wrapper<PrinterConfig>> printers();
     bool isAutogen() const;
-    bool isAutogenPrintingDepDB() const;
+    bool isAutogenPrintingSubclassesOrAutoloaderOnly() const;
 };
 
 enum class Phase {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -497,8 +497,8 @@ int realmain(int argc, char *argv[]) {
     if (opts.print.isAutogen()) {
         gs->runningUnderAutogen = true;
     }
-    if (opts.print.isAutogenPrintingDepDB()) {
-        gs->autogenPrintingDepDB = true;
+    if (opts.print.isAutogenPrintingSubclassesOrAutoloaderOnly()) {
+        gs->autogenPrintingSubclassesOrAutoloaderOnly = true;
     }
     if (opts.censorForSnapshotTests) {
         gs->censorForSnapshotTests = true;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -498,6 +498,7 @@ int realmain(int argc, char *argv[]) {
         gs->runningUnderAutogen = true;
     }
     if (opts.print.isAutogenPrintingSubclassesOrAutoloaderOnly()) {
+        ENFORCE(gs->runningUnderAutogen);
         gs->autogenPrintingSubclassesOrAutoloaderOnly = true;
     }
     if (opts.censorForSnapshotTests) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -497,6 +497,9 @@ int realmain(int argc, char *argv[]) {
     if (opts.print.isAutogen()) {
         gs->runningUnderAutogen = true;
     }
+    if (opts.print.isAutogenPrintingDepDB()) {
+        gs->autogenPrintingDepDB = true;
+    }
     if (opts.censorForSnapshotTests) {
         gs->censorForSnapshotTests = true;
     }

--- a/test/cli/autogen-autoloader/example1.rb
+++ b/test/cli/autogen-autoloader/example1.rb
@@ -20,10 +20,6 @@ module Foo
       class JazBaz
         p 'x'
         require 'in_class'
-
-        def honk
-          require 'in_method'
-        end
       end
     end
   end

--- a/test/cli/autogen-autoloader/example1.rb
+++ b/test/cli/autogen-autoloader/example1.rb
@@ -20,6 +20,10 @@ module Foo
       class JazBaz
         p 'x'
         require 'in_class'
+
+        def honk
+          require 'in_method'
+        end
       end
     end
   end

--- a/test/cli/autogen-autoloader/test.out
+++ b/test/cli/autogen-autoloader/test.out
@@ -5,7 +5,6 @@ No errors! Great job.
 # typed: true
 
 require 'in_class'
-require 'in_method'
 require 'my_gem'
 
 class Foo::Bar::Jazz < Foo::Bar::Quuz
@@ -18,7 +17,6 @@ Opus::Require.for_autoload(Foo::Bar::Jazz, "test/cli/autogen-autoloader/example1
 # typed: true
 
 require 'in_class'
-require 'in_method'
 require 'my_gem'
 
 class Foo::Bar::Quuz
@@ -31,7 +29,6 @@ Opus::Require.for_autoload(Foo::Bar::Quuz, "test/cli/autogen-autoloader/example1
 # typed: true
 
 require 'in_class'
-require 'in_method'
 require 'my_gem'
 
 Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/example1.rb", [Foo, :Dabba])
@@ -71,7 +68,6 @@ Opus::Require.for_autoload(Foo::Errors::MyError2, "test/cli/autogen-autoloader/e
 # typed: true
 
 require 'in_class'
-require 'in_method'
 require 'my_gem'
 
 Opus::Require.for_autoload(nil, "test/cli/autogen-autoloader/example1.rb", [Foo, :TOP_LEVEL_CONST])

--- a/test/cli/autogen-pkg-autoloader/test.out
+++ b/test/cli/autogen-pkg-autoloader/test.out
@@ -5,7 +5,6 @@ No errors! Great job.
 # typed: true
 
 require 'in_class'
-require 'in_method'
 require 'my_gem'
 
 class RootPackage::Foo::Bar::Jazz < RootPackage::Foo::Bar::Quuz
@@ -18,7 +17,6 @@ Opus::Require.for_autoload(RootPackage::Foo::Bar::Jazz, "test/cli/autogen-pkg-au
 # typed: true
 
 require 'in_class'
-require 'in_method'
 require 'my_gem'
 
 class RootPackage::Foo::Bar::Quuz
@@ -31,7 +29,6 @@ Opus::Require.for_autoload(RootPackage::Foo::Bar::Quuz, "test/cli/autogen-pkg-au
 # typed: true
 
 require 'in_class'
-require 'in_method'
 require 'my_gem'
 
 Opus::Require.for_autoload(nil, "test/cli/autogen-pkg-autoloader/foo.rb", [RootPackage::Foo, :Dabba])
@@ -71,7 +68,6 @@ Opus::Require.for_autoload(RootPackage::Foo::Errors::MyError2, "test/cli/autogen
 # typed: true
 
 require 'in_class'
-require 'in_method'
 require 'my_gem'
 
 Opus::Require.for_autoload(nil, "test/cli/autogen-pkg-autoloader/foo.rb", [RootPackage::Foo, :TOP_LEVEL_CONST])


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

In the Stripe codebase, our core autogen pass (the one that does not print parsed file information into msgpack) only needs to know about definitions and ancestry information. It does not need to walk over methods at all. Given this, we can empty out all method bodies and achieve the same result with a decent speedup in our tooling.

Based on some (slightly noisy) measurements in my local environment, I saw a 1s-3s improvement in the Sorbet autogen run, amounting to a 6%-20% improvement.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.