### PR TITLE
use `textDocContents` directly for lsp test initialization

### DIFF
--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -641,8 +641,7 @@ TEST_CASE("LSPTest") {
             vector<unique_ptr<LSPMessage>> updates;
             for (auto &filename : filenames) {
                 auto textDocContents = test.sourceFileContents[filename]->source();
-                updates.push_back(
-                    makeChange(testFileUris[filename], string(textDocContents.begin(), textDocContents.end()), 2 + i));
+                updates.push_back(makeChange(testFileUris[filename], textDocContents, 2 + i));
             }
             auto responses = getLSPResponsesFor(*lspWrapper, move(updates));
             updateDiagnostics(config, testFileUris, responses, diagnostics);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't need to allocate a separate string here when `makeChange` already takes a `string_view`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
