### PR TITLE
Make fast path fast again by regressing type member fixes

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -258,7 +258,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 if (pkgName.exists()) {
                     // Since even no-op (e.g. whitespace-only) edits will cause constants to be deleted
                     // and re-added, we have to add the __package.rb files to set of files to retypecheck
-                    // so that we can re-run PropagateVisibility to set export bits for any contants.
+                    // so that we can re-run PropagateVisibility to set export bits for any constants.
                     auto packageFref = gs->packageDB().getPackageInfo(pkgName).fullLoc().file();
                     if (result.changedFiles.find(packageFref) == result.changedFiles.end()) {
                         // Skip duplicates

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -218,7 +218,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     UnorderedMap<core::FileRef, core::FoundDefHashes> oldFoundHashesForFiles;
     auto toTypecheck = move(result.extraFiles);
     for (auto [fref, idx] : result.changedFiles) {
-        if (config->opts.lspExperimentalFastPathEnabled && !isNoopUpdateForRetypecheck) {
+        if (config->opts.lspExperimentalFastPathEnabled && !result.changedSymbolNameHashes.empty()) {
             // Only set oldFoundHashesForFiles if we're processing a real edit.
             //
             // This means that no-op edits (and thus calls to LSPTypechecker::retypecheck) don't
@@ -281,7 +281,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         updates.updatedFinalGSFileIndexes.push_back(move(t));
 
         // See earlier in the method for an explanation of the isNoopUpdateForRetypecheck check here.
-        if (config->opts.lspExperimentalFastPathEnabled && !isNoopUpdateForRetypecheck &&
+        if (config->opts.lspExperimentalFastPathEnabled && !result.changedSymbolNameHashes.empty() &&
             oldFoundHashesForFiles.find(f) == oldFoundHashesForFiles.end()) {
             // This is an extra file that we need to typecheck which was not part of the original
             // edited files, so whatever it happens to have in foundMethodHashes is still "old"

--- a/test/testdata/autogen/generator.rb
+++ b/test/testdata/autogen/generator.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 class Gener
   extend T::Sig
 

--- a/test/testdata/core/fuzz_bad_subtyping.rb
+++ b/test/testdata/core/fuzz_bad_subtyping.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 # Found by fuzzer: https://github.com/sorbet/sorbet/issues/1132
 module MyEnumerable
   extend T::Generic

--- a/test/testdata/infer/bad_child_class.rb
+++ b/test/testdata/infer/bad_child_class.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 
 # found by fuzzer: https://github.com/sorbet/sorbet/issues/1080
 

--- a/test/testdata/infer/generics/self_params.rb
+++ b/test/testdata/infer/generics/self_params.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 class Foo
   extend T::Generic
   extend T::Sig

--- a/test/testdata/infer/lub_between_self_params.rb
+++ b/test/testdata/infer/lub_between_self_params.rb
@@ -1,4 +1,5 @@
 # typed: true
+# disable-fast-path: true
          class QueryProfile < Hash
 #        ^^^^^^^^^^^^^^^^^^^^^^^^^ noerror Type `K` declared by parent `Hash` must be re-declared in `QueryProfile`
 #        ^^^^^^^^^^^^^^^^^^^^^^^^^ noerror Type `Elem` declared by parent `Hash` must be re-declared in `QueryProfile`

--- a/test/testdata/lsp/fast_path/type_member_redeclare_parent__1.rb
+++ b/test/testdata/lsp/fast_path/type_member_redeclare_parent__1.rb
@@ -1,5 +1,5 @@
 # typed: strict
-
+# disable-fast-path: true
 # This test currently exhbits this bug:
 # https://github.com/sorbet/sorbet/issues/5941
 # which we should fix at some point

--- a/test/testdata/lsp/fast_path/type_member_rename.rb
+++ b/test/testdata/lsp/fast_path/type_member_rename.rb
@@ -1,5 +1,5 @@
 # typed: strict
-
+# disable-fast-path: true
 class Parent
   extend T::Sig
   extend T::Generic

--- a/test/testdata/lsp/fast_path/type_template_rename.rb
+++ b/test/testdata/lsp/fast_path/type_template_rename.rb
@@ -1,5 +1,5 @@
 # typed: strict
-
+# disable-fast-path: true
 class Parent
   extend T::Sig
   extend T::Generic

--- a/test/testdata/namer/fuzz_type_template_overwrite.rb
+++ b/test/testdata/namer/fuzz_type_template_overwrite.rb
@@ -1,5 +1,5 @@
 # typed: false
-
+# disable-fast-path: true
 class A
   B = 1
   B = type_template # error: Redefining constant `B` as a type member or type template

--- a/test/testdata/resolver/bad_alias.rb
+++ b/test/testdata/resolver/bad_alias.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 class A
   extend T::Generic
   B = type_member

--- a/test/testdata/resolver/enumerable_strict.rb
+++ b/test/testdata/resolver/enumerable_strict.rb
@@ -1,5 +1,5 @@
 # typed: strict
-
+# disable-fast-path: true
 class A # error: Type `Elem` declared by parent `Enumerable` must be re-declared in `A`
   include Enumerable
   extend T::Sig

--- a/test/testdata/resolver/fuzz_alias_to_type_alias.rb
+++ b/test/testdata/resolver/fuzz_alias_to_type_alias.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 # from fuzzer: https://github.com/sorbet/sorbet/issues/1126
 A = T.type_alias {A} # error: Unable to resolve right hand side of type alias `A`
 C = A::B # error: Resolving constants through type aliases is not supported

--- a/test/testdata/resolver/fuzz_type_member_forget.rb
+++ b/test/testdata/resolver/fuzz_type_member_forget.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 class Parent
   extend T::Generic
   TParent = type_member

--- a/test/testdata/resolver/generic_enum.rb
+++ b/test/testdata/resolver/generic_enum.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 class MyEnum < T::Enum
   extend T::Generic
   Value = type_template {{fixed: String}} # error: All constants defined on an `T::Enum` must be unique instances of the enum

--- a/test/testdata/resolver/redefinition_of_subclass_type_member.rb
+++ b/test/testdata/resolver/redefinition_of_subclass_type_member.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 
 # This was a fuzzer-generated test file. The specific edge case that
 # it ended up uncovering was that `Foo` here has two type members, and

--- a/test/testdata/resolver/type_member_cycle.rb
+++ b/test/testdata/resolver/type_member_cycle.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 
 class A
   extend T::Sig

--- a/test/testdata/resolver/type_member_missing.rb
+++ b/test/testdata/resolver/type_member_missing.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 class Base
   extend T::Generic
 

--- a/test/testdata/resolver/type_member_missing_then_use.rb
+++ b/test/testdata/resolver/type_member_missing_then_use.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 class Child < Parent; end # error: Type `X` declared by parent `Parent` must be re-declared in `Child`
 class Parent < Grandparent; end # error: Type `X` declared by parent `Grandparent` must be re-declared in `Parent`
 class Grandparent

--- a/test/testdata/resolver/type_member_parent_missing.rb
+++ b/test/testdata/resolver/type_member_parent_missing.rb
@@ -1,5 +1,5 @@
 # typed: strict
-
+# disable-fast-path: true
 
   class Foo1
 # ^^^^^^^^^^ error: Type `Elem` declared by parent `Enumerable` must be re-declared in `Foo1`

--- a/test/testdata/resolver/type_members.rb
+++ b/test/testdata/resolver/type_members.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 class CovariantNotAllowed
   extend T::Generic
   Elem = type_member(:in) # error: can only have invariant type members

--- a/test/testdata/resolver/type_template_missing.rb
+++ b/test/testdata/resolver/type_template_missing.rb
@@ -1,5 +1,5 @@
 # typed: true
-
+# disable-fast-path: true
 class Base
   extend T::Generic
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After the changes in #6422, we're seeing the p50 fast path time move from ~50ms
to ~225ms and the p99 fast path time move from ~300ms to ~600ms. And the change
won't be fully rolled out for at least another few business days (as people
update their merge bases).

It seems like the cause for this almost entirely spent in `incremental_resolve`.
The time spent in `incremental_naming` is basically unchanged vs before.

That's odd, because #6422 basically only changed namer, and left resolver
untouched. Except that after those changes, we increase the number of files on
the fast path. The p50 `num_files` on the fast path moves from 1 to 2 (so far)
and the p99 `num_files` moves from <6 to ~10.

### Summary

The contents of this change regress how we handle `type_member`'s on the fast
path. That's not great, and it will definitely cause us to miss reporting some
errors on the fast path that we should, but at least it won't slow down
literally every completion request.

Reopens #1906.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests for correctness

Existing metrics for seeing performance changes in production.