### PR TITLE
Ensure that print_document_symbols is built in CI

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -114,6 +114,14 @@ cc_binary(
     ],
 )
 
+sh_test(
+    name = "print_document_symbols_builds",
+    srcs = ["print_document_symbols_builds.sh"],
+    data = [
+        ":print_document_symbols",
+    ],
+)
+
 cc_test(
     name = "hello-test",
     size = "small",

--- a/test/print_document_symbols.cc
+++ b/test/print_document_symbols.cc
@@ -34,7 +34,7 @@ UnorderedMap<string, TestFile> loadFiles(const vector<string> &files) {
         OSFileSystem fs;
         vector<string> fileContents;
         string uri;
-        fileContents.push_back(fs.readFile(filePath));
+        fileContents.push_back(fs.readFile(string(filePath)));
         if (extension == ".rbupdate") {
             // Find basename[.]version.rbupdate
             const auto versionIdx = filePath.rfind('.', idx - 1);

--- a/test/print_document_symbols_builds.sh
+++ b/test/print_document_symbols_builds.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# The way we regenerate document symbols is different from the way that we test
+# document symbols are correct, so this "test" is just a forcing function to
+# make sure that the print_document_symbols target is built in CI.
+test -f test/print_document_symbols


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It looks like we shipped a change in #6531 that introduced a compile-time error
in print_document_symbols.cc, but no one noticed until running the
`update_testdata_exp.sh` script.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- Build fails before fixing document symbols test:
  - https://buildkite.com/sorbet/sorbet/builds/25460#01848c4d-2d79-446f-ad65-4bf8cd43b90e/209-252
- Build passes after the fix