### PR TITLE
Make autocorrects more like rubyfmt

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -172,8 +172,8 @@ void autocorrectReceiver(const core::GlobalState &gs, core::ErrorBuilder &e, cor
             if (blockPassLoc.exists()) {
                 auto blockPassSource = blockPassLoc.source(gs).value();
                 if (blockPassSource == fmt::format("(&:{})", shortName)) {
-                    e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc, " {{|x| {}(x).{}}}",
-                                  wrapInFn, shortName);
+                    e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc,
+                                  " {{ |x| {}(x).{} }}", wrapInFn, shortName);
                 }
             }
         } else {
@@ -795,7 +795,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         auto blockPassSource = blockPassLoc.source(gs).value();
                         if (blockPassSource == fmt::format("(&:{})", shortName)) {
                             e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc,
-                                          " {{|x| {}(x).{}}}", wrapInFn, shortName);
+                                          " {{ |x| {}(x).{} }}", wrapInFn, shortName);
                         }
                     }
                 } else if (errLoc == args.funLoc() &&

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -421,7 +421,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     if (enclosingClass.data(ctx)->flags.isFinal) {
         fmt::format_to(std::back_inserter(ss), "(:final)");
     }
-    fmt::format_to(std::back_inserter(ss), " {{");
+    fmt::format_to(std::back_inserter(ss), " {{ ");
 
     ENFORCE(!methodSymbol.data(ctx)->arguments.empty(), "There should always be at least one arg (the block arg).");
     bool onlyArgumentIsBlkArg = methodSymbol.data(ctx)->arguments.size() == 1 &&
@@ -483,9 +483,9 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
                          !guessedReturnType.isUntyped() && !guessedReturnType.isBottom());
 
     if (suggestsVoid) {
-        fmt::format_to(std::back_inserter(ss), "void}}");
+        fmt::format_to(std::back_inserter(ss), "void }}");
     } else {
-        fmt::format_to(std::back_inserter(ss), "returns({})}}", guessedReturnType.show(ctx));
+        fmt::format_to(std::back_inserter(ss), "returns({}) }}", guessedReturnType.show(ctx));
     }
 
     auto [replacementLoc, padding] = loc.findStartOfLine(ctx);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1448,6 +1448,7 @@ private:
 
 public:
     void deleteOldDefinitions(core::MutableContext ctx, const SymbolDefiner::State &state) {
+        Timer timeit(ctx.state.tracer(), "deleteOldDefinitions");
         if (oldFoundHashes.has_value()) {
             const auto &oldFoundHashesVal = oldFoundHashes.value();
 
@@ -1908,7 +1909,8 @@ public:
                     insertLoc, fmt::format(" do\n{0}  {{{1}}}\n{0}end", indent, kwArgsSource)});
             }
         } else {
-            edits.emplace_back(core::AutocorrectSuggestion::Edit{insertLoc, fmt::format(" {{{{{}}}}}", kwArgsSource)});
+            edits.emplace_back(
+                core::AutocorrectSuggestion::Edit{insertLoc, fmt::format(" {{ {{{}}} }}", kwArgsSource)});
         }
         e.addAutocorrect(core::AutocorrectSuggestion{
             fmt::format("Convert `{}` to block form", send->fun.show(ctx)),

--- a/resolver/CorrectTypeAlias.cc
+++ b/resolver/CorrectTypeAlias.cc
@@ -41,10 +41,10 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
 
     if (start.line == end.line) {
         if (wrapHash) {
-            e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias {{{{{}}}}}",
+            e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias {{ {{{}}} }}",
                           argsLoc.source(ctx).value());
         } else {
-            e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias {{{}}}",
+            e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias {{ {} }}",
                           argsLoc.source(ctx).value());
         }
     } else {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -869,7 +869,7 @@ private:
                 e.addErrorLine(rhsSym.loc(ctx), "Originally defined here");
                 auto rhsLoc = ctx.locAt(it.rhs->loc);
                 if (rhsLoc.exists()) {
-                    e.replaceWith("Declare as type alias", rhsLoc, "T.type_alias {{{}}}", rhsLoc.source(ctx).value());
+                    e.replaceWith("Declare as type alias", rhsLoc, "T.type_alias {{ {} }}", rhsLoc.source(ctx).value());
                 }
             }
             it.lhs.setResultType(ctx, core::Types::untypedUntracked());

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -324,7 +324,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
                     e.setHeader("The argument to `{}` must be a lambda", "foreign:");
                     auto foreignLoc = core::Loc{ctx.file, ret.foreign.loc()};
                     if (auto foreignSource = foreignLoc.source(ctx)) {
-                        e.replaceWith("Convert to lambda", foreignLoc, "-> {{{}}}", foreignSource.value());
+                        e.replaceWith("Convert to lambda", foreignLoc, "-> {{ {} }}", foreignSource.value());
                     }
                 }
             }

--- a/test/cli/autocorrect-extend/test.out
+++ b/test/cli/autocorrect-extend/test.out
@@ -1,34 +1,34 @@
 # typed: strict
 
 # Don't extend T::Sig for this one, because the class wasn't defined here.
-sig {returns(NilClass)}
+sig { returns(NilClass) }
 def top_level; end
 
 # Should only add one extend
 class SuggestSigAndExtend
   extend T::Sig
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def foo; end
 
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def bar; end
 end
 
 # This doesn't work right now, for both the injected 'sig' and 'extend'.
-sig {returns(NilClass)}
+sig { returns(NilClass) }
 class SigAndExtendOneLine; def foo; end; end
   extend T::Sig
 
 class DontSuggestExtend
   extend T::Sig
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def foo; end
 end
 
 class Parent; end
 class Child < Parent
   extend T::Sig
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def foo; end
 end
 
@@ -37,13 +37,13 @@ def project(x); x; end
 class MethodBetweenExtendAndSig
   extend T::Sig
   project :sorbet
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def foo; end
 end
 
 class MethodOnSelf
   extend T::Sig
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def self.foo; end
 end
 
@@ -51,13 +51,13 @@ end
 class ProperIndentation
   extend T::Sig
 
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def foo; end
 
   class Nested
     extend T::Sig
 
-    sig {returns(NilClass)}
+    sig { returns(NilClass) }
     def bar; end
   end
 end

--- a/test/cli/autocorrect-lazy-type-alias/test.out
+++ b/test/cli/autocorrect-lazy-type-alias/test.out
@@ -2,7 +2,7 @@ autocorrect-lazy-type-alias.rb:1: No block given to `T.type_alias` https://srb.h
      1 |MyAlias = T.type_alias(T.any(Integer, String))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    autocorrect-lazy-type-alias.rb:1: Replaced with `T.type_alias {T.any(Integer, String)}`
+    autocorrect-lazy-type-alias.rb:1: Replaced with `T.type_alias { T.any(Integer, String) }`
      1 |MyAlias = T.type_alias(T.any(Integer, String))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -10,7 +10,7 @@ autocorrect-lazy-type-alias.rb:3: No block given to `T.type_alias` https://srb.h
      3 |HashWithCurly = T.type_alias({foo: String, bar: Integer})
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    autocorrect-lazy-type-alias.rb:3: Replaced with `T.type_alias {{foo: String, bar: Integer}}`
+    autocorrect-lazy-type-alias.rb:3: Replaced with `T.type_alias { {foo: String, bar: Integer} }`
      3 |HashWithCurly = T.type_alias({foo: String, bar: Integer})
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -18,7 +18,7 @@ autocorrect-lazy-type-alias.rb:5: No block given to `T.type_alias` https://srb.h
      5 |BareHash = T.type_alias(foo: String, bar: Integer)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    autocorrect-lazy-type-alias.rb:5: Replaced with `T.type_alias {{foo: String, bar: Integer}}`
+    autocorrect-lazy-type-alias.rb:5: Replaced with `T.type_alias { {foo: String, bar: Integer} }`
      5 |BareHash = T.type_alias(foo: String, bar: Integer)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -59,11 +59,11 @@ Errors: 5
 
 --------------------------------------------------------------------------
 
-MyAlias = T.type_alias {T.any(Integer, String)}
+MyAlias = T.type_alias { T.any(Integer, String) }
 
-HashWithCurly = T.type_alias {{foo: String, bar: Integer}}
+HashWithCurly = T.type_alias { {foo: String, bar: Integer} }
 
-BareHash = T.type_alias {{foo: String, bar: Integer}}
+BareHash = T.type_alias { {foo: String, bar: Integer} }
 
 module Bar
   class Foo

--- a/test/cli/dash-e/test.out
+++ b/test/cli/dash-e/test.out
@@ -13,7 +13,7 @@ class ::<root> < ::Object ()
      2 |def foo; end
         ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    -e:2: Insert `sig {returns(NilClass)}`
+    -e:2: Insert `sig { returns(NilClass) }`
      2 |def foo; end
         ^
 Errors: 1

--- a/test/cli/isolate-error-code/test.out
+++ b/test/cli/isolate-error-code/test.out
@@ -2,7 +2,7 @@ test/cli/isolate-error-code/isolate-error-code.rb:6: The method `foo` does not h
      6 | def foo
          ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `sig {returns(Integer)}`
+    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `sig { returns(Integer) }`
      6 | def foo
          ^
     test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `extend T::Sig`
@@ -14,7 +14,7 @@ test/cli/isolate-error-code/isolate-error-code.rb:6: The method `foo` does not h
      6 | def foo
          ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `sig {returns(Integer)}`
+    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `sig { returns(Integer) }`
      6 | def foo
          ^
     test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `extend T::Sig`

--- a/test/cli/print_generics/test.out
+++ b/test/cli/print_generics/test.out
@@ -2,7 +2,7 @@ test/cli/print_generics/print_generics.rb:5: The method `foo` does not have a `s
      5 |def foo(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:5: Insert `sig {params(x: T.untyped).returns(T::Array[Integer])}`
+    test/cli/print_generics/print_generics.rb:5: Insert `sig { params(x: T.untyped).returns(T::Array[Integer]) }`
      5 |def foo(x)
         ^
 
@@ -10,7 +10,7 @@ test/cli/print_generics/print_generics.rb:9: The method `bar` does not have a `s
      9 |def bar(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:9: Insert `sig {params(x: T.untyped).returns(T::Hash[Symbol, Integer])}`
+    test/cli/print_generics/print_generics.rb:9: Insert `sig { params(x: T.untyped).returns(T::Hash[Symbol, Integer]) }`
      9 |def bar(x)
         ^
 
@@ -18,7 +18,7 @@ test/cli/print_generics/print_generics.rb:13: The method `qux` does not have a `
     13 |def qux(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:13: Insert `sig {params(x: T.untyped).returns(T::Enumerable[Integer])}`
+    test/cli/print_generics/print_generics.rb:13: Insert `sig { params(x: T.untyped).returns(T::Enumerable[Integer]) }`
     13 |def qux(x)
         ^
 
@@ -26,7 +26,7 @@ test/cli/print_generics/print_generics.rb:17: The method `wub` does not have a `
     17 |def wub(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:17: Insert `sig {params(x: T.untyped).returns(T::Range[Integer])}`
+    test/cli/print_generics/print_generics.rb:17: Insert `sig { params(x: T.untyped).returns(T::Range[Integer]) }`
     17 |def wub(x)
         ^
 
@@ -34,7 +34,7 @@ test/cli/print_generics/print_generics.rb:21: The method `zan` does not have a `
     21 |def zan(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:21: Insert `sig {params(x: T.untyped).returns(T::Set[Integer])}`
+    test/cli/print_generics/print_generics.rb:21: Insert `sig { params(x: T.untyped).returns(T::Set[Integer]) }`
     21 |def zan(x)
         ^
 
@@ -42,7 +42,7 @@ test/cli/print_generics/print_generics.rb:25: The method `gaz` does not have a `
     25 |def gaz(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:25: Insert `sig {params(x: T.untyped).returns(T::Enumerator[Integer])}`
+    test/cli/print_generics/print_generics.rb:25: Insert `sig { params(x: T.untyped).returns(T::Enumerator[Integer]) }`
     25 |def gaz(x)
         ^
 Errors: 6

--- a/test/cli/suggest-foreign-lambda/test.out
+++ b/test/cli/suggest-foreign-lambda/test.out
@@ -2,7 +2,7 @@ suggest-foreign-lambda.rb:7: The argument to `foreign:` must be a lambda https:/
      7 |  prop :my_model, String, foreign: MyModel
                                            ^^^^^^^
   Autocorrect: Done
-    suggest-foreign-lambda.rb:7: Replaced with `-> {MyModel}`
+    suggest-foreign-lambda.rb:7: Replaced with `-> { MyModel }`
      7 |  prop :my_model, String, foreign: MyModel
                                            ^^^^^^^
 Errors: 1
@@ -15,5 +15,5 @@ class MyModel; end
 
 class MyOtherModel
   include T::Props
-  prop :my_model, String, foreign: -> {MyModel}
+  prop :my_model, String, foreign: -> { MyModel }
 end

--- a/test/cli/suggest-sig-literal/test.out
+++ b/test/cli/suggest-sig-literal/test.out
@@ -2,7 +2,7 @@ suggest-sig-literal.rb:2: The method `index_for_live` does not have a `sig` http
      2 |def index_for_live(fields)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig-literal.rb:2: Inserted `sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]])}`
+    suggest-sig-literal.rb:2: Inserted `sig { params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]]) }`
      2 |def index_for_live(fields)
         ^
 Errors: 1
@@ -10,7 +10,7 @@ Errors: 1
 --------------------------------------------------------------------------
 
 # typed: strict
-sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]])}
+sig { params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]]) }
 def index_for_live(fields)
   [[:deleted_at, 1]] + fields
 end

--- a/test/cli/suggest-sig-override-edge/test.out
+++ b/test/cli/suggest-sig-override-edge/test.out
@@ -7,7 +7,7 @@ class ParentInitialize
   def initialize; end
 end
 class ChildInitialize < ParentInitialize
-  sig {void}
+  sig { void }
   def initialize; end
 end
 
@@ -46,22 +46,22 @@ class ParentIsAbstract
   def multiline_x_to_returns(x); end
 end
 class ChildNeedsOverride < ParentIsAbstract
-  sig {override.void}
+  sig { override.void }
   def just_void; end
 
-  sig {override.returns(NilClass)}
+  sig { override.returns(NilClass) }
   def just_returns; end
 
-  sig {override.params(x: Integer).void}
+  sig { override.params(x: Integer).void }
   def x_to_void(x); end
 
-  sig {override.params(x: Integer).returns(NilClass)}
+  sig { override.params(x: Integer).returns(NilClass) }
   def x_to_returns(x); end
 
-  sig {override.params(x: Integer).void}
+  sig { override.params(x: Integer).void }
   def multiline_x_to_void(x); end
 
-  sig {override.params(x: Integer).returns(NilClass)}
+  sig { override.params(x: Integer).returns(NilClass) }
   def multiline_x_to_returns(x); end
 end
 
@@ -70,13 +70,13 @@ class DoesntNeedOverridable
   extend T::Sig
   # random words to trip up our hacky text search:
   # void return sig params generated
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def nope; end
 end
 
 class ChildOfDoesntNeedOverridable < DoesntNeedOverridable
   extend T::Sig
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def nope; end
 end
 
@@ -90,7 +90,7 @@ end
 
 class ChildOfDoesntNeedGenerated < DoesntNeedGenerated
   extend T::Sig
-  sig {override.void}
+  sig { override.void }
   def already_overridable; end
 end
 
@@ -101,6 +101,6 @@ end
 
 class DSLChild < DSLParent
   extend T::Sig
-  sig {returns(T.nilable(String))}
+  sig { returns(T.nilable(String)) }
   def opt_string; end
 end

--- a/test/cli/suggest-sig-override/test.out
+++ b/test/cli/suggest-sig-override/test.out
@@ -14,11 +14,11 @@ extend T::Sig
 
 class ParentNoSig
   extend T::Sig
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def foo; end
 end
 class ChildNoSig < ParentNoSig
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def foo; end
 end
 
@@ -28,7 +28,7 @@ class ParentStandardSig
   def foo; end
 end
 class ChildStandardSig < ParentStandardSig
-  sig {void}
+  sig { void }
   def foo; end
 end
 
@@ -38,7 +38,7 @@ class ParentOverridable
   def foo; end
 end
 class ChildOverridable < ParentOverridable
-  sig {override.void}
+  sig { override.void }
   def foo; end
 end
 
@@ -50,7 +50,7 @@ class ParentAbstract
   def foo; end
 end
 class ChildAbstract < ParentAbstract
-  sig {override.void}
+  sig { override.void }
   def foo; end
 end
 
@@ -65,7 +65,7 @@ class ParentOverride < GrandParentOverride
   def foo; end
 end
 class ChildOverride < ParentOverride
-  sig {override.void}
+  sig { override.void }
   def foo; end
 end
 
@@ -82,6 +82,6 @@ class ParentImplementation < GrandParentImplementation
   def foo; end
 end
 class ChildImplementation < ParentImplementation
-  sig {override.void}
+  sig { override.void }
   def foo; end
 end

--- a/test/cli/suggest-sig/test.out
+++ b/test/cli/suggest-sig/test.out
@@ -36,7 +36,7 @@ suggest-sig.rb:5: The method `hazTwoArgs` does not have a `sig` https://srb.help
      5 |def hazTwoArgs(a, b); 1; end;
         ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:5: Inserted `sig {params(a: T.untyped, b: T.untyped).returns(Integer)}`
+    suggest-sig.rb:5: Inserted `sig { params(a: T.untyped, b: T.untyped).returns(Integer) }`
      5 |def hazTwoArgs(a, b); 1; end;
         ^
 
@@ -48,7 +48,7 @@ suggest-sig.rb:7: The method `baz` does not have a `sig` https://srb.help/7017
      7 |def baz
         ^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:7: Inserted `sig {returns(T.any(T::Array[T.untyped], String))}`
+    suggest-sig.rb:7: Inserted `sig { returns(T.any(T::Array[T.untyped], String)) }`
      7 |def baz
         ^
 
@@ -56,7 +56,7 @@ suggest-sig.rb:18: The method `bla` does not have a `sig` https://srb.help/7017
     18 |def bla; give_me_void; end
         ^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:18: Inserted `sig {void}`
+    suggest-sig.rb:18: Inserted `sig { void }`
     18 |def bla; give_me_void; end
         ^
 
@@ -68,7 +68,7 @@ suggest-sig.rb:20: The method `bbq` does not have a `sig` https://srb.help/7017
     20 |def bbq
         ^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:20: Inserted `sig {void}`
+    suggest-sig.rb:20: Inserted `sig { void }`
     20 |def bbq
         ^
 
@@ -80,7 +80,7 @@ suggest-sig.rb:30: The method `give_me_literal` does not have a `sig` https://sr
     30 |def give_me_literal; 1; end;
         ^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:30: Inserted `sig {returns(Integer)}`
+    suggest-sig.rb:30: Inserted `sig { returns(Integer) }`
     30 |def give_me_literal; 1; end;
         ^
 
@@ -88,7 +88,7 @@ suggest-sig.rb:32: The method `give_me_literal_nested` does not have a `sig` htt
     32 |def give_me_literal_nested; [[1]]; end;
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:32: Inserted `sig {returns(T::Array[T::Array[Integer]])}`
+    suggest-sig.rb:32: Inserted `sig { returns(T::Array[T::Array[Integer]]) }`
     32 |def give_me_literal_nested; [[1]]; end;
         ^
 
@@ -96,7 +96,7 @@ suggest-sig.rb:34: The method `root_private` does not have a `sig` https://srb.h
     34 |private def root_private; end
                 ^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:34: Inserted `sig {returns(NilClass)}`
+    suggest-sig.rb:34: Inserted `sig { returns(NilClass) }`
     34 |private def root_private; end
         ^
 
@@ -104,7 +104,7 @@ suggest-sig.rb:36: The method `root_protected` does not have a `sig` https://srb
     36 |protected def root_protected; end
                   ^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:36: Inserted `sig {returns(NilClass)}`
+    suggest-sig.rb:36: Inserted `sig { returns(NilClass) }`
     36 |protected def root_protected; end
         ^
 
@@ -112,7 +112,7 @@ suggest-sig.rb:46: The method `foo` does not have a `sig` https://srb.help/7017
     46 |def foo(a)
         ^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:46: Inserted `sig {params(a: Integer).returns(Integer)}`
+    suggest-sig.rb:46: Inserted `sig { params(a: Integer).returns(Integer) }`
     46 |def foo(a)
         ^
 
@@ -120,7 +120,7 @@ suggest-sig.rb:56: The method `fooCond` does not have a `sig` https://srb.help/7
     56 |def fooCond(a, cond)
         ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:56: Inserted `sig {params(a: T.any(Integer, String), cond: T.untyped).void}`
+    suggest-sig.rb:56: Inserted `sig { params(a: T.any(Integer, String), cond: T.untyped).void }`
     56 |def fooCond(a, cond)
         ^
 
@@ -128,7 +128,7 @@ suggest-sig.rb:64: The method `fooWhile` does not have a `sig` https://srb.help/
     64 |def fooWhile(a, cond1, cond2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:64: Inserted `sig {params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass)}`
+    suggest-sig.rb:64: Inserted `sig { params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass) }`
     64 |def fooWhile(a, cond1, cond2)
         ^
 
@@ -136,7 +136,7 @@ suggest-sig.rb:74: The method `takesBlock` does not have a `sig` https://srb.hel
     74 |def takesBlock
         ^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:74: Inserted `sig {returns(Integer)}`
+    suggest-sig.rb:74: Inserted `sig { returns(Integer) }`
     74 |def takesBlock
         ^
 
@@ -144,7 +144,7 @@ suggest-sig.rb:79: The method `list_ints_or_empty_list` does not have a `sig` ht
     79 |def list_ints_or_empty_list
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:79: Inserted `sig {returns(T::Array[T.untyped])}`
+    suggest-sig.rb:79: Inserted `sig { returns(T::Array[T.untyped]) }`
     79 |def list_ints_or_empty_list
         ^
 
@@ -188,7 +188,7 @@ suggest-sig.rb:84: The method `dead` does not have a `sig` https://srb.help/7017
     84 |def dead(x)
         ^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:84: Inserted `sig {params(x: Integer).void}`
+    suggest-sig.rb:84: Inserted `sig { params(x: Integer).void }`
     84 |def dead(x)
         ^
 
@@ -196,7 +196,7 @@ suggest-sig.rb:92: The method `with_block` does not have a `sig` https://srb.hel
     92 |def with_block
         ^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:92: Inserted `sig {returns(NilClass)}`
+    suggest-sig.rb:92: Inserted `sig { returns(NilClass) }`
     92 |def with_block
         ^
 
@@ -212,7 +212,7 @@ suggest-sig.rb:118: The method `cantRun` does not have a `sig` https://srb.help/
      118 |def cantRun(a)
           ^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:118: Inserted `sig {params(a: T.untyped).returns(Integer)}`
+    suggest-sig.rb:118: Inserted `sig { params(a: T.untyped).returns(Integer) }`
      118 |def cantRun(a)
           ^
 
@@ -220,7 +220,7 @@ suggest-sig.rb:155: The method `explicitly_named_block_parameter` does not have 
      155 |def explicitly_named_block_parameter(&blk)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:155: Inserted `sig {params(blk: T.untyped).returns(Integer)}`
+    suggest-sig.rb:155: Inserted `sig { params(blk: T.untyped).returns(Integer) }`
      155 |def explicitly_named_block_parameter(&blk)
           ^
 
@@ -258,7 +258,7 @@ suggest-sig.rb:41: The method `a_private` does not have a `sig` https://srb.help
     41 |  private def a_private; end
                   ^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:41: Inserted `sig {returns(NilClass)}`
+    suggest-sig.rb:41: Inserted `sig { returns(NilClass) }`
     41 |  private def a_private; end
           ^
 
@@ -266,7 +266,7 @@ suggest-sig.rb:43: The method `a_protected` does not have a `sig` https://srb.he
     43 |  protected def a_protected; end
                     ^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:43: Inserted `sig {returns(NilClass)}`
+    suggest-sig.rb:43: Inserted `sig { returns(NilClass) }`
     43 |  protected def a_protected; end
           ^
 
@@ -302,7 +302,7 @@ suggest-sig.rb:112: The method `load_account_business_profile` does not have a `
      112 |  def self.load_account_business_profile(merchant)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:112: Inserted `sig {params(merchant: TestCarash::Merchant).returns(Integer)}`
+    suggest-sig.rb:112: Inserted `sig { params(merchant: TestCarash::Merchant).returns(Integer) }`
      112 |  def self.load_account_business_profile(merchant)
             ^
     suggest-sig.rb:105: Inserted `extend T::Sig`
@@ -325,7 +325,7 @@ suggest-sig.rb:166: The method `test1` does not have a `sig` https://srb.help/70
      166 |  def self.test1(x:, y:)
             ^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:166: Inserted `sig {params(x: Integer, y: String).void}`
+    suggest-sig.rb:166: Inserted `sig { params(x: Integer, y: String).void }`
      166 |  def self.test1(x:, y:)
             ^
 
@@ -333,7 +333,7 @@ suggest-sig.rb:170: The method `test2` does not have a `sig` https://srb.help/70
      170 |  def self.test2(x:, y:)
             ^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:170: Inserted `sig {params(x: Integer, y: String).void}`
+    suggest-sig.rb:170: Inserted `sig { params(x: Integer, y: String).void }`
      170 |  def self.test2(x:, y:)
             ^
 
@@ -341,7 +341,7 @@ suggest-sig.rb:174: The method `test3` does not have a `sig` https://srb.help/70
      174 |  def self.test3(x:, y:)
             ^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:174: Inserted `sig {params(x: Integer, y: T.untyped).void}`
+    suggest-sig.rb:174: Inserted `sig { params(x: Integer, y: T.untyped).void }`
      174 |  def self.test3(x:, y:)
             ^
 
@@ -349,7 +349,7 @@ suggest-sig.rb:186: The method `test1` does not have a `sig` https://srb.help/70
      186 |  def self.test1(y)
             ^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:186: Inserted `sig {params(y: T.untyped).void}`
+    suggest-sig.rb:186: Inserted `sig { params(y: T.untyped).void }`
      186 |  def self.test1(y)
             ^
 
@@ -357,7 +357,7 @@ suggest-sig.rb:191: The method `test2` does not have a `sig` https://srb.help/70
      191 |  def self.test2(y)
             ^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:191: Inserted `sig {params(y: T.untyped).void}`
+    suggest-sig.rb:191: Inserted `sig { params(y: T.untyped).void }`
      191 |  def self.test2(y)
             ^
 
@@ -365,7 +365,7 @@ suggest-sig.rb:204: The method `returns_int` does not have a `sig` https://srb.h
      204 |  def returns_int; 42; end
             ^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:204: Inserted `sig(:final) {returns(Integer)}`
+    suggest-sig.rb:204: Inserted `sig(:final) { returns(Integer) }`
      204 |  def returns_int; 42; end
             ^
 Errors: 47
@@ -376,10 +376,10 @@ Errors: 47
 
 extend T::Sig
 
-sig {params(a: T.untyped, b: T.untyped).returns(Integer)}
+sig { params(a: T.untyped, b: T.untyped).returns(Integer) }
 def hazTwoArgs(a, b); 1; end;
 
-sig {returns(T.any(T::Array[T.untyped], String))}
+sig { returns(T.any(T::Array[T.untyped], String)) }
 def baz
   if someCondition
     []
@@ -391,10 +391,10 @@ end
 sig {void}
 def give_me_void; end
 
-sig {void}
+sig { void }
 def bla; give_me_void; end
 
-sig {void}
+sig { void }
 def bbq
   if someCondition
     give_me_void
@@ -405,29 +405,29 @@ end
 
 def idk(a); a / a + a * a; end
 
-sig {returns(Integer)}
+sig { returns(Integer) }
 def give_me_literal; 1; end;
 
-sig {returns(T::Array[T::Array[Integer]])}
+sig { returns(T::Array[T::Array[Integer]]) }
 def give_me_literal_nested; [[1]]; end;
 
-sig {returns(NilClass)}
+sig { returns(NilClass) }
 private def root_private; end
 
-sig {returns(NilClass)}
+sig { returns(NilClass) }
 protected def root_protected; end
 
 class A
   extend T::Sig
 
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   private def a_private; end
 
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   protected def a_protected; end
 end
 
-sig {params(a: Integer).returns(Integer)}
+sig { params(a: Integer).returns(Integer) }
 def foo(a)
  1 + a
 end
@@ -438,7 +438,7 @@ def takesInt(a); end;
 sig {params(a: String).void}
 def takesString(a); end;
 
-sig {params(a: T.any(Integer, String), cond: T.untyped).void}
+sig { params(a: T.any(Integer, String), cond: T.untyped).void }
 def fooCond(a, cond)
   if cond
     takesInt(a)
@@ -447,7 +447,7 @@ def fooCond(a, cond)
   end
 end
 
-sig {params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass)}
+sig { params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass) }
 def fooWhile(a, cond1, cond2)
   while cond2
     if cond1
@@ -458,19 +458,19 @@ def fooWhile(a, cond1, cond2)
   end
 end
 
-sig {returns(Integer)}
+sig { returns(Integer) }
 def takesBlock
   yield 1
   2
 end
 
-sig {returns(T::Array[T.untyped])}
+sig { returns(T::Array[T.untyped]) }
 def list_ints_or_empty_list
   x = T.let(1, T.nilable(Integer))
   x.nil? ? [x] : []
 end
 
-sig {params(x: Integer).void}
+sig { params(x: Integer).void }
 def dead(x)
   if true || qux || blah
     takesInt(x)
@@ -479,7 +479,7 @@ def dead(x)
   end
 end
 
-sig {returns(NilClass)}
+sig { returns(NilClass) }
 def with_block
   yield
   nil
@@ -501,14 +501,14 @@ class TestCarash
   def self.blar(merchant:)
   end
 
-  sig {params(merchant: TestCarash::Merchant).returns(Integer)}
+  sig { params(merchant: TestCarash::Merchant).returns(Integer) }
   def self.load_account_business_profile(merchant)
     blar(merchant: merchant)
     1
   end
 end
 
-sig {params(a: T.untyped).returns(Integer)}
+sig { params(a: T.untyped).returns(Integer) }
 def cantRun(a)
   takesInt(a)
   takesString(a)
@@ -546,7 +546,7 @@ class Abstract
   def abstract_foo(a); end
 end
 
-sig {params(blk: T.untyped).returns(Integer)}
+sig { params(blk: T.untyped).returns(Integer) }
 def explicitly_named_block_parameter(&blk)
   42
 end
@@ -558,17 +558,17 @@ module ReorderedKeywordArgs
   def self.bar(x:, y: 'default')
   end
 
-  sig {params(x: Integer, y: String).void}
+  sig { params(x: Integer, y: String).void }
   def self.test1(x:, y:)
     self.bar(x: x, y: y)
   end
 
-  sig {params(x: Integer, y: String).void}
+  sig { params(x: Integer, y: String).void }
   def self.test2(x:, y:)
     self.bar(y: y, x: x)
   end
 
-  sig {params(x: Integer, y: T.untyped).void}
+  sig { params(x: Integer, y: T.untyped).void }
   def self.test3(x:, y:)
     self.bar(x: x)
   end
@@ -581,13 +581,13 @@ module KwHashSendSuggest
   def self.foo(x:)
   end
 
-  sig {params(y: T.untyped).void}
+  sig { params(y: T.untyped).void }
   def self.test1(y)
     # signature suggestion driven by an implicit keyword args hash
     self.foo(y)
   end
 
-  sig {params(y: T.untyped).void}
+  sig { params(y: T.untyped).void }
   def self.test2(y)
     # signature suggestion driven by an explicit kwsplat
     self.foo(**y)
@@ -601,6 +601,6 @@ class MyFinalClass
 
   final!
 
-  sig(:final) {returns(Integer)}
+  sig(:final) { returns(Integer) }
   def returns_int; 42; end
 end

--- a/test/cli/suggest-type-alias/test.out
+++ b/test/cli/suggest-type-alias/test.out
@@ -5,7 +5,7 @@ suggest-type-alias.rb:4: Reassigning a type alias is not allowed https://srb.hel
      3 |A = T.type_alias {Integer}
         ^
   Autocorrect: Done
-    suggest-type-alias.rb:4: Replaced with `T.type_alias {A}`
+    suggest-type-alias.rb:4: Replaced with `T.type_alias { A }`
      4 |B = A
             ^
 Errors: 1
@@ -15,4 +15,4 @@ Errors: 1
 # typed: strict
 
 A = T.type_alias {Integer}
-B = T.type_alias {A}
+B = T.type_alias { A }

--- a/test/cli/suggest_t_must/test.out
+++ b/test/cli/suggest_t_must/test.out
@@ -34,7 +34,7 @@ suggest_t_must.rb:8: Method `even?` does not exist on `NilClass` component of `T
      8 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^
   Autocorrect: Done
-    suggest_t_must.rb:8: Replaced with `{|x| T.must(x).even?}`
+    suggest_t_must.rb:8: Replaced with `{ |x| T.must(x).even? }`
      8 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                             ^^^^^^^^^
 
@@ -76,7 +76,7 @@ T.must(foo)[0]
 
 "hi" + T.must(foo)
 
-T::Array[T.nilable(Integer)].new.map {|x| T.must(x).even?}
+T::Array[T.nilable(Integer)].new.map { |x| T.must(x).even? }
 
 class A
   extend T::Sig

--- a/test/cli/suggest_t_unsafe/test.out
+++ b/test/cli/suggest_t_unsafe/test.out
@@ -78,7 +78,7 @@ suggest_t_unsafe.rb:17: Method `even?` does not exist on `NilClass` component of
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^
   Autocorrect: Done
-    suggest_t_unsafe.rb:17: Replaced with `{|x| T.unsafe(x).even?}`
+    suggest_t_unsafe.rb:17: Replaced with `{ |x| T.unsafe(x).even? }`
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                             ^^^^^^^^^
 Errors: 6
@@ -101,7 +101,7 @@ T.unsafe(bar).even?
 
 "hi" + T.unsafe(1)
 
-T::Array[T.nilable(Integer)].new.map {|x| T.unsafe(x).even?}
+T::Array[T.nilable(Integer)].new.map { |x| T.unsafe(x).even? }
 
 sig {params(str: String).void}
 def takes_string_kw(str:); end
@@ -194,7 +194,7 @@ suggest_t_unsafe.rb:17: Method `even?` does not exist on `NilClass` component of
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^
   Autocorrect: Done
-    suggest_t_unsafe.rb:17: Replaced with `{|x| custom_wrapper(x).even?}`
+    suggest_t_unsafe.rb:17: Replaced with `{ |x| custom_wrapper(x).even? }`
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                             ^^^^^^^^^
 Errors: 6
@@ -217,7 +217,7 @@ custom_wrapper(bar).even?
 
 "hi" + custom_wrapper(1)
 
-T::Array[T.nilable(Integer)].new.map {|x| custom_wrapper(x).even?}
+T::Array[T.nilable(Integer)].new.map { |x| custom_wrapper(x).even? }
 
 sig {params(str: String).void}
 def takes_string_kw(str:); end

--- a/test/cli/type_argument_suggest_unsafe/test.out
+++ b/test/cli/type_argument_suggest_unsafe/test.out
@@ -115,7 +115,7 @@ type_argument_suggest_unsafe.rb:53: Call to method `foo` on unconstrained generi
     53 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
                   ^
   Autocorrect: Done
-    type_argument_suggest_unsafe.rb:53: Replaced with `{|x| T.unsafe(x).foo}`
+    type_argument_suggest_unsafe.rb:53: Replaced with `{ |x| T.unsafe(x).foo }`
     53 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
                 ^^^^^^^
   Note:
@@ -176,5 +176,5 @@ sig do
     .void
 end
 def example4(xs)
-  xs.map {|x| T.unsafe(x).foo} # error: Method `foo` does not exist on `Object#example4#U`
+  xs.map { |x| T.unsafe(x).foo } # error: Method `foo` does not exist on `Object#example4#U`
 end

--- a/test/testdata/infer/block_pass_splat.rb.autocorrects.exp
+++ b/test/testdata/infer/block_pass_splat.rb.autocorrects.exp
@@ -16,7 +16,7 @@ end
 
 sig {params(xs: T::Array[T.nilable(Integer)]).void}
 def example2(xs)
-  xs.map {|x| T.must(x).even?}
+  xs.map { |x| T.must(x).even? }
   #       ^^^^^^ error: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)`
 end
 

--- a/test/testdata/infer/kwsplat_is_sometimes_okay.rb.autocorrects.exp
+++ b/test/testdata/infer/kwsplat_is_sometimes_okay.rb.autocorrects.exp
@@ -23,11 +23,11 @@ def takes_some_required_untyped(x:, y: ''); end
 sig {params(x: String, y: String).void}
 def takes_all_optional_untyped(x: '', y: ''); end
 
-sig {params(x: T.untyped, y: T.untyped).returns(NilClass)}
+sig { params(x: T.untyped, y: T.untyped).returns(NilClass) }
 def takes_all_required_unsigged(x:, y:); end # error: does not have a `sig`
-sig {params(x: T.untyped, y: T.untyped).returns(NilClass)}
+sig { params(x: T.untyped, y: T.untyped).returns(NilClass) }
 def takes_some_required_unsigged(x:, y: ''); end # error: does not have a `sig`
-sig {params(x: T.untyped, y: T.untyped).returns(NilClass)}
+sig { params(x: T.untyped, y: T.untyped).returns(NilClass) }
 def takes_all_optional_unsigged(x: '', y: ''); end # error: does not have a `sig`
 
 sig {params(x: Integer, y: String).void}

--- a/test/testdata/infer/multi_file_autocorrect.autocorrects.exp
+++ b/test/testdata/infer/multi_file_autocorrect.autocorrects.exp
@@ -3,7 +3,7 @@
 
 class MyClass1
   extend T::Sig
-  sig {returns(NilClass)}
+  sig { returns(NilClass) }
   def missing_sig; end # error: The method `missing_sig` does not have a `sig`
 end
 # ------------------------------

--- a/test/testdata/infer/suggest_sig_type_member.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_sig_type_member.rb.autocorrects.exp
@@ -18,9 +18,9 @@ end
 class Child < Parent
   X = type_member
   Y = type_template
-  sig {params(x: X).void}
+  sig { params(x: X).void }
   def foo(x); end # error: does not have a `sig`
-  sig {params(y: Y).void}
+  sig { params(y: Y).void }
   def self.foo(y); end # error: does not have a `sig`
 end
 # ------------------------------

--- a/test/testdata/lsp/code_actions/sig_missing__child.A.rbedited
+++ b/test/testdata/lsp/code_actions/sig_missing__child.A.rbedited
@@ -4,9 +4,9 @@
 require_relative './sig_missing__parent.rb'
 
 class FooChild < Foo
-  sig {override.void}
+  sig { override.void }
   def self.bar
 # ^^^^^^^^^^^^ error: The method `bar` does not have a `sig`
-# ^^^^^^^^^^^^ apply-code-action: [A] Add `sig {override.void}`
+# ^^^^^^^^^^^^ apply-code-action: [A] Add `sig { override.void }`
   end
 end

--- a/test/testdata/lsp/code_actions/sig_missing__child.rb
+++ b/test/testdata/lsp/code_actions/sig_missing__child.rb
@@ -6,6 +6,6 @@ require_relative './sig_missing__parent.rb'
 class FooChild < Foo
   def self.bar
 # ^^^^^^^^^^^^ error: The method `bar` does not have a `sig`
-# ^^^^^^^^^^^^ apply-code-action: [A] Add `sig {override.void}`
+# ^^^^^^^^^^^^ apply-code-action: [A] Add `sig { override.void }`
   end
 end

--- a/test/testdata/lsp/code_actions/sig_missing__parent.A.rbedited
+++ b/test/testdata/lsp/code_actions/sig_missing__parent.A.rbedited
@@ -4,7 +4,7 @@
 class Foo
   extend T::Sig
 
-  sig {generated.overridable.void}
+  sig { generated.overridable.void }
   def self.bar
   end
 end

--- a/test/testdata/lsp/completion/sig.A.rbedited
+++ b/test/testdata/lsp/completion/sig.A.rbedited
@@ -7,7 +7,7 @@
 class Normal
   extend T::Sig
 
-  sig {returns(NilClass)}${0} # error: no block
+  sig { returns(NilClass) }${0} # error: no block
   #  ^ completion: sig
   #  ^ apply-completion: [A] item: 0
   def nullary_returns_nil

--- a/test/testdata/lsp/completion/sig.B.rbedited
+++ b/test/testdata/lsp/completion/sig.B.rbedited
@@ -13,7 +13,7 @@ class Normal
   def nullary_returns_nil
   end
 
-  sig {params(x: Integer).returns(Integer)}${0} # error: no block
+  sig { params(x: Integer).returns(Integer) }${0} # error: no block
   #  ^ completion: sig
   #  ^ apply-completion: [B] item: 0
   def typed_params_and_returns(x)

--- a/test/testdata/lsp/completion/sig_all_untyped.A.rbedited
+++ b/test/testdata/lsp/completion/sig_all_untyped.A.rbedited
@@ -7,7 +7,7 @@ extend T::Sig
 # the sig unconditionally, so that it at least gives users something to start
 # filling in the holes.
 
-sig {params(x: ${1:T.untyped}).returns(${2:T.untyped})}${0} # error: no block
+sig { params(x: ${1:T.untyped}).returns(${2:T.untyped}) }${0} # error: no block
 #  ^ apply-completion: [A] item: 0
 def all_untyped(x)
   T.unsafe(nil)

--- a/test/testdata/lsp/completion/sig_many_defs.A.rbedited
+++ b/test/testdata/lsp/completion/sig_many_defs.A.rbedited
@@ -13,7 +13,7 @@ class A
     ''
   end
 
-  sig {returns(Symbol)}${0} # error: no block
+  sig { returns(Symbol) }${0} # error: no block
   #  ^ apply-completion: [A] item: 0
 
   def returns_symbol

--- a/test/testdata/lsp/completion/sig_redefinition__1.A.rbedited
+++ b/test/testdata/lsp/completion/sig_redefinition__1.A.rbedited
@@ -5,7 +5,7 @@ class Module
 end
 
 class A
-  sig {returns(NilClass)}${0} # error: no block
+  sig { returns(NilClass) }${0} # error: no block
   #  ^ apply-completion: [A] item: 0
   def foo; end
 

--- a/test/testdata/lsp/completion/sig_redefinition__2.B.rbedited
+++ b/test/testdata/lsp/completion/sig_redefinition__2.B.rbedited
@@ -3,7 +3,7 @@
 class A
   def foo; end
 
-  sig {returns(NilClass)}${0} # error: no block
+  sig { returns(NilClass) }${0} # error: no block
   #  ^ apply-completion: [B] item: 0
   def bar; end
 end

--- a/test/testdata/lsp/completion/sig_root.A.rbedited
+++ b/test/testdata/lsp/completion/sig_root.A.rbedited
@@ -3,6 +3,6 @@ extend T::Sig
 
 # Tests an edge case arising from the difference between <root> and Object
 
-sig {returns(NilClass)}${0} # error: no block
+sig { returns(NilClass) }${0} # error: no block
 #  ^ apply-completion: [A] item: 0
 def foo; end

--- a/test/testdata/lsp/completion/sig_singleton.A.rbedited
+++ b/test/testdata/lsp/completion/sig_singleton.A.rbedited
@@ -5,7 +5,7 @@ class Module
 end
 
 class A
-  sig {returns(Integer)}${0} # error: no block
+  sig { returns(Integer) }${0} # error: no block
   #  ^ apply-completion: [A] item: 0
   def self.foo
     1

--- a/test/testdata/lsp/completion/sig_singleton.B.rbedited
+++ b/test/testdata/lsp/completion/sig_singleton.B.rbedited
@@ -12,7 +12,7 @@ class A
   end
 end
 
-sig {returns(String)}${0} # error: no block
+sig { returns(String) }${0} # error: no block
 #  ^ apply-completion: [B] item: 0
 def self.main
   ''

--- a/test/testdata/lsp/completion/sig_snippet.A.rbedited
+++ b/test/testdata/lsp/completion/sig_snippet.A.rbedited
@@ -17,7 +17,7 @@ sig {params(x: {y: String}).void}
 def takes_shape(x)
 end
 
-sig {params(x: T.proc.params(arg0: ${1:T.untyped}).returns(${2:T.untyped}), f: ${3:T.untyped}).returns(${4:T.untyped})}${0} # error: no block
+sig { params(x: T.proc.params(arg0: ${1:T.untyped}).returns(${2:T.untyped}), f: ${3:T.untyped}).returns(${4:T.untyped}) }${0} # error: no block
 #  ^ apply-completion: [A] item: 0
 def passes_untyped_proc(x, f)
   takes_untyped_proc(x)

--- a/test/testdata/lsp/completion/sig_snippet.B.rbedited
+++ b/test/testdata/lsp/completion/sig_snippet.B.rbedited
@@ -24,7 +24,7 @@ def passes_untyped_proc(x, f)
   T.unsafe(nil)
 end
 
-sig {params(x: String).returns(${1:T.untyped})}${0} # error: no block
+sig { params(x: String).returns(${1:T.untyped}) }${0} # error: no block
 #  ^ apply-completion: [B] item: 0
 def passes_string(x)
   takes_string(x)

--- a/test/testdata/lsp/completion/sig_snippet.C.rbedited
+++ b/test/testdata/lsp/completion/sig_snippet.C.rbedited
@@ -31,7 +31,7 @@ def passes_string(x)
   T.unsafe(nil)
 end
 
-sig {params(xs: T::Array[${1:T.untyped}]).returns(${2:T.untyped})}${0} # error: no block
+sig { params(xs: T::Array[${1:T.untyped}]).returns(${2:T.untyped}) }${0} # error: no block
 #  ^ apply-completion: [C] item: 0
 def passes_array_untyped(xs)
   takes_array_untyped(xs)

--- a/test/testdata/lsp/completion/sig_snippet.D.rbedited
+++ b/test/testdata/lsp/completion/sig_snippet.D.rbedited
@@ -38,7 +38,7 @@ def passes_array_untyped(xs)
   T.unsafe(nil)
 end
 
-sig {params(x: T::Hash[${1:T.untyped}, ${2:T.untyped}]).returns(${3:T.untyped})}${0} # error: no block
+sig { params(x: T::Hash[${1:T.untyped}, ${2:T.untyped}]).returns(${3:T.untyped}) }${0} # error: no block
 #  ^ apply-completion: [D] item: 0
 def passes_shape(x)
   takes_shape(x)

--- a/test/testdata/namer/type_member_autocorrect_multiline.rb.autocorrects.exp
+++ b/test/testdata/namer/type_member_autocorrect_multiline.rb.autocorrects.exp
@@ -21,12 +21,12 @@ module Example
   B1 = type_member(
     :out,
     # error: syntax for bounds has changed
-  ) {{fixed: Integer}}
+  ) { {fixed: Integer} }
   B2 = type_member(
     :out,
    
-  ) {{lower: Integer, # error: syntax for bounds has changed
-    upper: T.any(Integer, String)}}
+  ) { {lower: Integer, # error: syntax for bounds has changed
+    upper: T.any(Integer, String)} }
 
   C1 = type_member do
     {
@@ -36,9 +36,9 @@ module Example
       ),
     }
   end
-  C2 = type_member(:out) {{fixed: T.any( # error: syntax for bounds has changed
+  C2 = type_member(:out) { {fixed: T.any( # error: syntax for bounds has changed
     Integer,
     String
-  )}}
+  )} }
 end
 # ------------------------------

--- a/test/testdata/namer/type_member_eager_to_lazy.rb.autocorrects.exp
+++ b/test/testdata/namer/type_member_eager_to_lazy.rb.autocorrects.exp
@@ -5,51 +5,51 @@ module A
   extend T::Generic
 
   A1 = type_member()
-  A2 = type_member {{fixed: Integer}}
+  A2 = type_member { {fixed: Integer} }
   #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
   #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{fixed: T.class_of(Integer)}` for argument `variance`
-  A3 = type_member {{lower: Integer}}
+  A3 = type_member { {lower: Integer} }
   #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
   #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer)}` for argument `variance`
-  A4 = type_member {{upper: Integer}}
+  A4 = type_member { {upper: Integer} }
   #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
   #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{upper: T.class_of(Integer)}` for argument `variance`
-  A5 = type_member {{lower: Integer, upper: Integer}}
+  A5 = type_member { {lower: Integer, upper: Integer} }
   #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: syntax for bounds has changed
   #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer), upper: T.class_of(Integer)}` for argument `variance`
 
   B1 = type_member
-  B2 = type_member {{fixed: Integer}}
+  B2 = type_member { {fixed: Integer} }
   #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
   #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{fixed: T.class_of(Integer)}` for argument `variance`
-  B3 = type_member {{lower: Integer}}
+  B3 = type_member { {lower: Integer} }
   #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
   #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer)}` for argument `variance`
-  B4 = type_member {{upper: Integer}}
+  B4 = type_member { {upper: Integer} }
   #                ^^^^^^^^^^^^^^ error: syntax for bounds has changed
   #                ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{upper: T.class_of(Integer)}` for argument `variance`
-  B5 = type_member {{lower: Integer, upper: Integer}}
+  B5 = type_member { {lower: Integer, upper: Integer} }
   #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: syntax for bounds has changed
   #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{lower: T.class_of(Integer), upper: T.class_of(Integer)}` for argument `variance`
 
   C1 = type_member(:out)
-  C2 = type_member(:out) {{fixed: Integer}} # error: syntax for bounds has changed
+  C2 = type_member(:out) { {fixed: Integer} } # error: syntax for bounds has changed
   #                      ^^^^^^^^^^^^^^ error: Too many arguments
-  C3 = type_member(:out) {{lower: Integer}} # error: syntax for bounds has changed
+  C3 = type_member(:out) { {lower: Integer} } # error: syntax for bounds has changed
   #                      ^^^^^^^^^^^^^^ error: Too many arguments
-  C4 = type_member(:out) {{upper: Integer}} # error: syntax for bounds has changed
+  C4 = type_member(:out) { {upper: Integer} } # error: syntax for bounds has changed
   #                      ^^^^^^^^^^^^^^ error: Too many arguments
-  C5 = type_member(:out) {{lower: Integer, upper: Integer}} # error: syntax for bounds has changed
+  C5 = type_member(:out) { {lower: Integer, upper: Integer} } # error: syntax for bounds has changed
   #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments
 
   D1 = type_member :out
-  D2 = type_member :out {{fixed: Integer}} # error: syntax for bounds has changed
+  D2 = type_member :out { {fixed: Integer} } # error: syntax for bounds has changed
   #                      ^^^^^^^^^^^^^^ error: Too many arguments
-  D3 = type_member :out {{lower: Integer}} # error: syntax for bounds has changed
+  D3 = type_member :out { {lower: Integer} } # error: syntax for bounds has changed
   #                      ^^^^^^^^^^^^^^ error: Too many arguments
-  D4 = type_member :out {{upper: Integer}} # error: syntax for bounds has changed
+  D4 = type_member :out { {upper: Integer} } # error: syntax for bounds has changed
   #                      ^^^^^^^^^^^^^^ error: Too many arguments
-  D5 = type_member :out {{lower: Integer, upper: Integer}} # error: syntax for bounds has changed
+  D5 = type_member :out { {lower: Integer, upper: Integer} } # error: syntax for bounds has changed
   #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments
 end
 # ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These autocorrects were always a little weird, because Stripe had a Ruby
style that diverged from the rest of the industry.

With Stripe having deployed rubyfmt over the entire codebase, we may as
well change some of these autocorrects to match what rubyfmt does, which is
also what the majority of the Ruby community expects.

Mostly, these autocorrects are just adding spaces inside curly blocks.

cc @reese


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.