### PR TITLE
Better ergonomics for `--web-trace-file` and LSP

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -37,6 +37,22 @@ To collect a trace, run Sorbet with the `--web-trace-file=<file>` flag:
 Sorbet will typecheck the file or codebase like normal, and then write out
 `trace.json` (or whatever `<file>` name you chose).
 
+### Tracing and LSP
+
+The traces Sorbet submits are the same as the [metrics] that Sorbet submits to
+StatsD (if enabled with the `--statsd-host` option).
+
+[metrics]: https://sorbet.org/docs/metrics
+
+For better performance in LSP mode, Sorbet will only report stats to the
+specified host after it finishes processing a task **and** it's been 5 minutes
+since the last stats dump.
+
+Passing `--web-trace-file` overrides this behavior, forcibly flushing the trace
+file and the StatsD stats after **every** task (no matter how long ago the last
+flush was). This is often desired when debugging but can potentially cause
+increased traffic on StatsD and/or slower IDE performance in normal operation.
+
 ## Loading a trace into the viewer
 
 Once you've [Collected a trace](#collecting-a-trace), you can load it into the


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Right now it's a bit annoying to debug performance of LSP using
`--web-trace-file` because you have to wait 5 minutes and then make a
task.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Manually testing on Stripe's codebase