### PR TITLE
Skip `finalizeSymbols` in incrementalResolve

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4038,7 +4038,8 @@ ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::Par
     return result;
 }
 
-ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> trees, bool ranIncrementalNamer) {
+ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> trees,
+                                                     bool ranIncrementalNamer) {
     auto workers = WorkerPool::create(0, gs.tracer());
     trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
     // NOTE: Linearization does not need to be recomputed as we do not mutate mixins() during incremental resolve.

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -21,7 +21,7 @@ public:
      *
      * These two versions are explicitly instantiated in resolver.cc
      */
-    static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
+    static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees, bool ranIncrementalNamer);
 
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -21,7 +21,8 @@ public:
      *
      * These two versions are explicitly instantiated in resolver.cc
      */
-    static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees, bool ranIncrementalNamer);
+    static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
+                                                      bool ranIncrementalNamer);
 
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -752,6 +752,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         }
     }
 
+    bool ranIncremantalNamer = false;
     {
         // namer
         for (auto &tree : trees) {
@@ -765,6 +766,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             // Here, to complement those tests, we just run Namer::run (not Namer::runIncremental)
             // to stress the codepath where Namer is not tasked with deleting anything when run for
             // the fast path.
+            ENFORCE(!ranIncremantalNamer);
             vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundHashes).result());
             tree = testSerialize(*gs, move(vTmp[0]));
 
@@ -774,7 +776,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     // resolver
-    trees = move(resolver::Resolver::runIncremental(*gs, move(trees)).result());
+    trees = move(resolver::Resolver::runIncremental(*gs, move(trees), ranIncremantalNamer).result());
 
     if (enablePackager) {
         trees = packager::VisibilityChecker::run(*gs, *workers, move(trees));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`finalizeSymbols` does a global scan over the symbol table. This
consistently takes 200ms at p50, and after #6422 we were doing it on
every edit.

That's too slow to run on every edit, but luckily it's only needed in
cases where we had to run incremental namer.

As a (temporary?) fix, we can skip doing that work unless required. This
only works because of the changes landed in #6570, which skip running
incremental namer unless required.

Ideally, this is only temporary because it means that it's **still** holding us
back from being able to quickly service edits that **must** run
incremental namer. I haven't looked carefully yet, but there might be a
way we can make a `finalizeSymbolsIncremental` function somehow.

As such, this will only affect the p50 (and maybe the p90 or so).
Luckily changes to definitions are much more rare than changes inside a
method body (so basically: this will improve completion times, but not
necessarily improve diagnostic times for definition edits). That's a
better spot than we were in this time last week though, and we can keep
figuring out ways to do less work in a bit.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.