### PR TITLE
Add patch to expose need_major_by via GC.latest_gc_info

### DIFF
--- a/third_party/ruby/gc-add-need-major-by.patch
+++ b/third_party/ruby/gc-add-need-major-by.patch
@@ -1,16 +1,7 @@
-From 5484a6da6fb63ec2be679e0d1aadc01aaf4ed5ff Mon Sep 17 00:00:00 2001
-From: Mirek Klimos <mirek@stripe.com>
-Date: Tue, 22 Nov 2022 11:41:19 -0800
-Subject: [PATCH] [GC] Expose need_major_gc via GC.latest_gc_info
-
----
- gc.c | 19 +++++++++++++++++--
- 1 file changed, 17 insertions(+), 2 deletions(-)
-
-diff --git a/gc.c b/gc.c
+diff --git gc.c gc.c
 index 67a709ff79..2825466788 100644
---- a/gc.c
-+++ b/gc.c
+--- gc.c
++++ gc.c
 @@ -8738,7 +8738,7 @@ gc_count(rb_execution_context_t *ec, VALUE self)
  static VALUE
  gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const int orig_flags)
@@ -59,6 +50,3 @@ index 67a709ff79..2825466788 100644
      SET(gc_by,
          (flags & GPR_FLAG_NEWOBJ) ? sym_newobj :
          (flags & GPR_FLAG_MALLOC) ? sym_malloc :
--- 
-2.38.1
-

--- a/third_party/ruby/gc-add-need-major-by.patch
+++ b/third_party/ruby/gc-add-need-major-by.patch
@@ -1,0 +1,64 @@
+From 5484a6da6fb63ec2be679e0d1aadc01aaf4ed5ff Mon Sep 17 00:00:00 2001
+From: Mirek Klimos <mirek@stripe.com>
+Date: Tue, 22 Nov 2022 11:41:19 -0800
+Subject: [PATCH] [GC] Expose need_major_gc via GC.latest_gc_info
+
+---
+ gc.c | 19 +++++++++++++++++--
+ 1 file changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/gc.c b/gc.c
+index 67a709ff79..2825466788 100644
+--- a/gc.c
++++ b/gc.c
+@@ -8738,7 +8738,7 @@ gc_count(rb_execution_context_t *ec, VALUE self)
+ static VALUE
+ gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const int orig_flags)
+ {
+-    static VALUE sym_major_by = Qnil, sym_gc_by, sym_immediate_sweep, sym_have_finalizer, sym_state;
++    static VALUE sym_major_by = Qnil, sym_gc_by, sym_immediate_sweep, sym_have_finalizer, sym_state, sym_need_major_by;
+     static VALUE sym_nofree, sym_oldgen, sym_shady, sym_force, sym_stress;
+ #if RGENGC_ESTIMATE_OLDMALLOC
+     static VALUE sym_oldmalloc;
+@@ -8746,8 +8746,9 @@ gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const int orig_
+     static VALUE sym_newobj, sym_malloc, sym_method, sym_capi;
+     static VALUE sym_none, sym_marking, sym_sweeping;
+     VALUE hash = Qnil, key = Qnil;
+-    VALUE major_by;
++    VALUE major_by, need_major_by;
+     VALUE flags = orig_flags ? orig_flags : objspace->profile.latest_gc_info;
++    unsigned int need_major_flags = objspace->rgengc.need_major_gc;
+ 
+     if (SYMBOL_P(hash_or_key)) {
+         key = hash_or_key;
+@@ -8766,6 +8767,7 @@ gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const int orig_
+         S(immediate_sweep);
+         S(have_finalizer);
+         S(state);
++        S(need_major_by);
+ 
+         S(stress);
+         S(nofree);
+@@ -8803,6 +8805,19 @@ gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const int orig_
+       Qnil;
+     SET(major_by, major_by);
+ 
++    if (orig_flags == 0) { /* set need_major_by only if flags not set explicitly */
++        need_major_by =
++            (need_major_flags & GPR_FLAG_MAJOR_BY_NOFREE) ? sym_nofree :
++            (need_major_flags & GPR_FLAG_MAJOR_BY_OLDGEN) ? sym_oldgen :
++            (need_major_flags & GPR_FLAG_MAJOR_BY_SHADY)  ? sym_shady :
++            (need_major_flags & GPR_FLAG_MAJOR_BY_FORCE)  ? sym_force :
++#if RGENGC_ESTIMATE_OLDMALLOC
++            (need_major_flags & GPR_FLAG_MAJOR_BY_OLDMALLOC) ? sym_oldmalloc :
++#endif
++            Qnil;
++        SET(need_major_by, need_major_by);
++    }
++
+     SET(gc_by,
+         (flags & GPR_FLAG_NEWOBJ) ? sym_newobj :
+         (flags & GPR_FLAG_MALLOC) ? sym_malloc :
+-- 
+2.38.1
+

--- a/third_party/ruby/gc-fix-malloc-increase-calculation.patch
+++ b/third_party/ruby/gc-fix-malloc-increase-calculation.patch
@@ -1,0 +1,31 @@
+diff --git gc.c gc.c
+index 67a709ff79..57996b2f9d 100644
+--- gc.c
++++ gc.c
+@@ -7166,7 +7166,7 @@ ready_to_gc(rb_objspace_t *objspace)
+ }
+
+ static void
+-gc_reset_malloc_info(rb_objspace_t *objspace)
++gc_reset_malloc_info(rb_objspace_t *objspace, bool full_mark)
+ {
+     gc_prof_set_malloc_info(objspace);
+     {
+@@ -7200,7 +7200,7 @@ gc_reset_malloc_info(rb_objspace_t *objspace)
+
+     /* reset oldmalloc info */
+ #if RGENGC_ESTIMATE_OLDMALLOC
+-    if (!is_full_marking(objspace)) {
++    if (!full_mark) {
+ 	if (objspace->rgengc.oldmalloc_increase > objspace->rgengc.oldmalloc_increase_limit) {
+ 	    objspace->rgengc.need_major_gc |= GPR_FLAG_MAJOR_BY_OLDMALLOC;
+ 	    objspace->rgengc.oldmalloc_increase_limit =
+@@ -7343,7 +7343,7 @@ gc_start(rb_objspace_t *objspace, int reason)
+     objspace->profile.total_allocated_objects_at_gc_start = objspace->total_allocated_objects;
+     objspace->profile.heap_used_at_gc_start = heap_allocated_pages;
+     gc_prof_setup_new_record(objspace, reason);
+-    gc_reset_malloc_info(objspace);
++    gc_reset_malloc_info(objspace, do_full_mark);
+     rb_transient_heap_start_marking(do_full_mark);
+
+     gc_event_hook(objspace, RUBY_INTERNAL_EVENT_GC_START, 0 /* TODO: pass minor/immediate flag? */);

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -47,7 +47,8 @@ def register_ruby_dependencies():
             "@com_stripe_ruby_typer//third_party/ruby:gc-remove-write-barrier.patch",
             "@com_stripe_ruby_typer//third_party/ruby:dtoa.patch",
             "@com_stripe_ruby_typer//third_party/ruby:penelope_procc.patch",
-            "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:gc-fix-malloc-increase-calculation.patch",  # https://github.com/ruby/ruby/pull/4860
+            "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by.patch",  # https://github.com/ruby/ruby/pull/6791
         ],
     )
 

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -47,6 +47,7 @@ def register_ruby_dependencies():
             "@com_stripe_ruby_typer//third_party/ruby:gc-remove-write-barrier.patch",
             "@com_stripe_ruby_typer//third_party/ruby:dtoa.patch",
             "@com_stripe_ruby_typer//third_party/ruby:penelope_procc.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by.patch",
         ],
     )
 


### PR DESCRIPTION
### Motivation

Adding two patches that enable us to optimize GC and get efficiency savings

1. https://github.com/ruby/ruby/pull/6791 - open, but I hope I'll be able to get some version of this in. This will enable us to get rid of unnecessary minor GCs that we currently run to prevent major GCs during request processing.

    > We trigger GC out-of-band to reduce latency impact on synchronous request processing. It’s not perfect, but it works. One thing we really want to avoid is major GC during request processing - so we don’t want to start request processing in a state where need_major_gc is set. If there is a risk of major GC, we prefer to run it out-of-band, where it doesn't matter for request latency.
    > 
    > Unfortunately, this state is currently not exposed - so we can’t know whether the next GC is set to be major or not. As a workaround, we trigger minor GC twice in a row - if a major GC threshold is hit during the first GC, the second GC is upgraded to major and there is no immediate risk of another major GC. This mostly works, but it's not great and it's not efficient (the second GC is not cheap and it's unnecessary in most cases); this PR makes it possible to do that in a better way by exposing need_major_gc.
    > 
    > It may seem strange to expose it under GC.latest_gc_info but I think it’s a reasonable place because the decision was made during the latest GC.


2. https://github.com/ruby/ruby/pull/4860 - merged long time ago, included in Ruby 3.1. This will remove some unnecessary major GCs due to incorrect calculations


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
