### PR TITLE
Match signature of Enumerable#find to detect

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1818,17 +1818,28 @@ module Enumerable
   # (1..100).find          { |i| i % 5 == 0 && i % 7 == 0 }   #=> 35
   # ```
   sig do
-    params(
-        ifnone: Proc,
+    type_parameters(:U)
+      .params(
+        ifnone: T.proc.returns(T.type_parameter(:U)),
         blk: T.proc.params(arg0: Elem).returns(BasicObject),
+      )
+      .returns(T.any(T.type_parameter(:U), Elem))
+  end
+  sig do
+    type_parameters(:U)
+      .params(
+        ifnone: T.proc.returns(T.type_parameter(:U)),
+      )
+      .returns(T::Enumerator[T.any(T.type_parameter(:U), Elem)])
+  end
+  sig do
+    params(
+      blk: T.proc.params(arg0: Elem).returns(BasicObject),
     )
     .returns(T.nilable(Elem))
   end
   sig do
-    params(
-        ifnone: Proc,
-    )
-    .returns(T::Enumerator[Elem])
+    returns(T::Enumerator[Elem])
   end
   def find(ifnone=T.unsafe(nil), &blk); end
 

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -54,6 +54,15 @@ T.reveal_type([1,2].detect(-> {})) # error: Revealed type: `T::Enumerator[T.unty
 T.reveal_type([1,2].detect(p) {|x| false}) # error: Revealed type: `Integer`
 T.reveal_type([1,2].detect(p)) # error: Revealed type: `T::Enumerator[Integer]`
 
+# find
+p = T.let(->{ 1 }, T.proc.returns(Integer))
+T.reveal_type([1,2].find) # error: Revealed type: `T::Enumerator[Integer]`
+T.reveal_type([1,2].find {|x| false}) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type([1,2].find(-> {}) {|x| false}) # error: Revealed type: `T.untyped`
+T.reveal_type([1,2].find(-> {})) # error: Revealed type: `T::Enumerator[T.untyped]`
+T.reveal_type([1,2].find(p) {|x| false}) # error: Revealed type: `Integer`
+T.reveal_type([1,2].find(p)) # error: Revealed type: `T::Enumerator[Integer]`
+
 sig {params(xs: T::Array[Integer]).void}
 def example(xs)
   res = xs.reduce('') do |acc, x|


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://github.com/sorbet/sorbet/pull/3375 updated the signatures for `Enumerable#detect` but not `Enumerable#find` which is an alias. The existing signature for `find` means that something like [this](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Asig%20%7Breturns%28String%29%7D%0Adef%20foo%0A%20%20%5B%22a%22%2C%20%22few%22%2C%20%22words%22%5D.find%28-%3E%20%7B%22default%22%7D%29%20%7B%7Cword%7C%20word.length%20%3E%203%7D%0Aend) won't typecheck:
```ruby
sig {returns(String)}
def foo
  ["a", "few", "words"].find(-> {"default"}) {|word| word.length > 3}
  # Expected String but found T.nilable(String) for method result type https://srb.help
end
```

Whereas [this](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Asig%20%7Breturns%28String%29%7D%0Adef%20foo%0A%20%20%5B%22a%22%2C%20%22few%22%2C%20%22words%22%5D.detect%28-%3E%20%7B%22default%22%7D%29%20%7B%7Cword%7C%20word.length%20%3E%203%7D%0Aend) shows that the equivalent code would typecheck with the right signature:
```ruby
sig {returns(String)}
def foo
  ["a", "few", "words"].detect(-> {"default"}) {|word| word.length > 3}
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
