### PR TITLE
Remove generic param from Vector/Matrix RBI

### DIFF
--- a/rbi/stdlib/matrix.rbi
+++ b/rbi/stdlib/matrix.rbi
@@ -76,8 +76,6 @@
 class Vector
   include ::Enumerable
 
-  Elem = type_member(:out)
-
   # [`Vector.new`](https://docs.ruby-lang.org/en/2.7.0/Vector.html#method-c-new)
   # is private; use Vector[] or
   # [`Vector.elements`](https://docs.ruby-lang.org/en/2.7.0/Vector.html#method-c-elements)
@@ -320,8 +318,6 @@ end
 # determinant, or eigensystem.
 class Matrix
   include ::Enumerable
-
-  Elem = type_member(:out)
 
   # Yields all elements of the matrix, starting with those of the first row, or
   # returns an

--- a/rbi/stdlib/matrix.rbi
+++ b/rbi/stdlib/matrix.rbi
@@ -76,6 +76,8 @@
 class Vector
   include ::Enumerable
 
+  Elem = type_member {{ fixed: T.untyped }}
+
   # [`Vector.new`](https://docs.ruby-lang.org/en/2.7.0/Vector.html#method-c-new)
   # is private; use Vector[] or
   # [`Vector.elements`](https://docs.ruby-lang.org/en/2.7.0/Vector.html#method-c-elements)
@@ -318,6 +320,8 @@ end
 # determinant, or eigensystem.
 class Matrix
   include ::Enumerable
+
+  Elem = type_member {{ fixed: T.untyped }}
 
   # Yields all elements of the matrix, starting with those of the first row, or
   # returns an

--- a/test/testdata/rbi/matrix.rb
+++ b/test/testdata/rbi/matrix.rb
@@ -1,0 +1,11 @@
+# typed: true
+require "matrix"
+
+class Foo
+  extend T::Sig
+
+  sig { params(matrix: Matrix).void }
+  def initialize(matrix:)
+    @matrix = matrix
+  end
+end


### PR DESCRIPTION
This removes the generic macros from the vendored RBIs for [`Matrix`](https://ruby-doc.org/stdlib-3.1.2/libdoc/matrix/rdoc/index.html) and its collaborating class `Vector`. Using the current RBI file the `Matrix` class is not usable in a signature at any `typed:` level (including `false`).  [For example](https://sorbet.run/#%23%20typed%3A%20false%0A%0Arequire%20'sorbet-runtime'%0Arequire%20'matrix'%0A%0Aclass%20Foo%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20params%28matrix%3A%20Matrix%29.void%20%7D%0A%20%20def%20initialize%28matrix%3A%29%0A%20%20%20%20%40matrix%20%3D%20matrix%0A%20%20end%0Aend%0A%0AFoo.new%28matrix%3A%20Matrix.zero%282%29%29).

Any reference to the class as a type, for example `sig { params(x: Matrix).void }`, fails static typechecks with:

    5045: Malformed type declaration. Generic class without type arguments `Matrix`

This cannot be fixed by using e.g. `Matrix[Integer]` because it will blow up at runtime since `Matrix.[]` exists and checks its arguments. `srb tc -a` will autocorrect to `Matrix[T.untyped]` which also fails at runtime unless runtime checking is disabled.  The runtime error looks like the following:

    lib/ruby/gems/3.1.0/gems/matrix-0.4.2/lib/matrix.rb:1756:in `convert_to_array': undefined method `to_ary' for #<T::Types::Untyped:0x000000010ada39e0> (NoMethodError)

      converted = obj.to_ary
                     ^^^^^^^
    from lib/ruby/gems/3.1.0/gems/matrix-0.4.2/lib/matrix.rb:93:in `block in rows'
    from lib/ruby/gems/3.1.0/gems/matrix-0.4.2/lib/matrix.rb:92:in `map!'
    from lib/ruby/gems/3.1.0/gems/matrix-0.4.2/lib/matrix.rb:92:in `rows'
    from lib/ruby/gems/3.1.0/gems/matrix-0.4.2/lib/matrix.rb:79:in `[]'
    from repro.rb:9:in `block in <class:Foo>'
    from lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10565/lib/types/private/methods/_methods.rb:351:in `instance_exec'
    from lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10565/lib/types/private/methods/_methods.rb:351:in `run_builder'
    from lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10565/lib/types/private/methods/_methods.rb:331:in `run_sig'
    from lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10565/lib/types/private/methods/_methods.rb:241:in `block in _on_method_added'
    from lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10565/lib/types/private/methods/_methods.rb:440:in `run_sig_block_for_key'
    from lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10565/lib/types/private/methods/_methods.rb:420:in `maybe_run_sig_block_for_key'
    from lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10565/lib/types/private/methods/_methods.rb:251:in `block in _on_method_added'

It's no great loss to lose the generics here since the RBI doesn't use them in any meaningful way. At any rate, the Matrix class is not a general purpose multidimensional array, it's specifically intended to be used with numeric members.

### Motivation

The `matrix` stdlib class (moved to [standard gem](https://github.com/ruby/matrix) in 3.1) is not usable with sorbet because of a malformed RBI vendored in sorbet.

### Test plan

I've added a testcase that fails before this change.



