### PR TITLE
✨ Better support pretty_print/inspect in PrettyPrintable

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
+++ b/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
@@ -1,18 +1,52 @@
 # frozen_string_literal: true
 # typed: true
+require 'pp'
 
 module T::Props::PrettyPrintable
   include T::Props::Plugin
 
-  # Return a string representation of this object and all of its props
-  def inspect
-    T.unsafe(T.cast(self, Object).class).decorator.inspect_instance(self)
+  # Override the PP gem with something that's similar, but gives us a hook to do redaction and customization
+  def pretty_print(pp)
+    clazz = T.unsafe(T.cast(self, Object).class).decorator
+    multiline = pp.is_a?(PP)
+    pp.group(1, "<#{T.unsafe(self).class}", ">") do
+      clazz.all_props.sort.each do |prop|
+        pp.breakable
+        val = clazz.get(self, prop)
+        rules = clazz.prop_rules(prop)
+        pp.text("#{prop}=")
+        if (custom_inspect = rules[:inspect])
+          inspected = if T::Utils.arity(custom_inspect) == 1
+            custom_inspect.call(val)
+          else
+            custom_inspect.call(val, {multiline: multiline})
+          end
+          pp.text(inspected.nil? ? "nil" : "\"#{inspected}\"")
+        elsif rules[:sensitivity] && !rules[:sensitivity].empty? && !val.nil?
+          pp.text("<REDACTED #{rules[:sensitivity].join(', ')}>")
+        else
+          val.pretty_print(pp)
+        end
+      end
+      clazz.pretty_print_extra(self, pp)
+    end
   end
 
-  # Override the PP gem with something that's similar, but gives us a hook
-  # to do redaction
+  # Overridable method to add anything that is not a prop
+  def pretty_print_extra(instance, pp); end
+
+  # Return a string representation of this object and all of its props in a single line
+  def inspect
+    string = +""
+    PP.singleline_pp(self, string)
+    string
+  end
+
+  # Return a pretty string representation of this object and all of its props
   def pretty_inspect
-    T.unsafe(T.cast(self, Object).class).decorator.inspect_instance(self, multiline: true)
+    string = +""
+    PP.pp(self, string)
+    string
   end
 
   module DecoratorMethods
@@ -21,87 +55,6 @@ module T::Props::PrettyPrintable
     sig {params(key: Symbol).returns(T::Boolean).checked(:never)}
     def valid_rule_key?(key)
       super || key == :inspect
-    end
-
-    sig do
-      params(instance: T::Props::PrettyPrintable, multiline: T::Boolean, indent: String)
-      .returns(String)
-    end
-    def inspect_instance(instance, multiline: false, indent: '  ')
-      components =
-        inspect_instance_components(
-          instance,
-          multiline: multiline,
-          indent: indent
-        )
-          .reject(&:empty?)
-
-      # Not using #<> here as that makes pry highlight these objects
-      # as if they were all comments, whereas this makes them look
-      # like the structured thing they are.
-      if multiline
-        "#{components[0]}:\n" + T.must(components[1..-1]).join("\n")
-      else
-        "<#{components.join(' ')}>"
-      end
-    end
-
-    sig do
-      params(instance: T::Props::PrettyPrintable, multiline: T::Boolean, indent: String)
-      .returns(T::Array[String])
-    end
-    private def inspect_instance_components(instance, multiline:, indent:)
-      pretty_props = T.unsafe(self).all_props.map do |prop|
-        [prop, inspect_prop_value(instance, prop, multiline: multiline, indent: indent)]
-      end
-
-      joined_props = join_props_with_pretty_values(
-        pretty_props,
-        multiline: multiline,
-        indent: indent
-      )
-
-      [
-        T.unsafe(self).decorated_class.to_s,
-        joined_props,
-      ]
-    end
-
-    sig do
-      params(instance: T::Props::PrettyPrintable, prop: Symbol, multiline: T::Boolean, indent: String)
-      .returns(String)
-      .checked(:never)
-    end
-    private def inspect_prop_value(instance, prop, multiline:, indent:)
-      val = T.unsafe(self).get(instance, prop)
-      rules = T.unsafe(self).prop_rules(prop)
-      if (custom_inspect = rules[:inspect])
-        if T::Utils.arity(custom_inspect) == 1
-          custom_inspect.call(val)
-        else
-          custom_inspect.call(val, {multiline: multiline, indent: indent})
-        end
-      elsif rules[:sensitivity] && !rules[:sensitivity].empty? && !val.nil?
-        "<REDACTED #{rules[:sensitivity].join(', ')}>"
-      else
-        val.inspect
-      end
-    end
-
-    sig do
-      params(pretty_kvs: T::Array[[Symbol, String]], multiline: T::Boolean, indent: String)
-      .returns(String)
-    end
-    private def join_props_with_pretty_values(pretty_kvs, multiline:, indent: '  ')
-      pairs = pretty_kvs
-        .sort_by {|k, _v| k.to_s}
-        .map {|k, v| "#{k}=#{v}"}
-
-      if multiline
-        indent + pairs.join("\n#{indent}")
-      else
-        pairs.join(', ')
-      end
     end
   end
 end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -338,14 +338,18 @@ module T::Props::Serializable::DecoratorMethods
     end
   end
 
-  # overrides T::Props::PrettyPrintable
-  private def inspect_instance_components(instance, multiline:, indent:)
+  # adds to the default result of T::Props::PrettyPrintable
+  def pretty_print_extra(instance, pp)
     if (extra_props = extra_props(instance)) && !extra_props.empty?
-      pretty_kvs = extra_props.map {|k, v| [k.to_sym, v.inspect]}
-      extra = join_props_with_pretty_values(pretty_kvs, multiline: false)
-      super + ["@_extra_props=<#{extra}>"]
-    else
-      super
+      pp.breakable
+      pp.text("@_extra_props=")
+      pp.group(1, "<", ">") do
+        extra_props.each_with_index do |(prop, value), i|
+          pp.breakable unless i.zero?
+          pp.text("#{prop}=")
+          value.pretty_print(pp)
+        end
+      end
     end
   end
 end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -148,20 +148,20 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'inspects' do
       obj = a_serializable
       str = obj.inspect
-      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"}, name="Bob">', str)
+      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"} name="Bob">', str)
     end
 
     it 'inspects with extra props' do
       obj = a_serializable
       obj = obj.class.from_hash(obj.serialize.merge('not_a_prop' => 'but_here_anyway'))
       str = obj.inspect
-      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"}, name="Bob" @_extra_props=<not_a_prop="but_here_anyway">>', str)
+      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"} name="Bob" @_extra_props=<not_a_prop="but_here_anyway">>', str)
     end
 
     it 'inspects frozen structs' do
       obj = a_serializable.freeze
       str = obj.inspect
-      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"}, name="Bob">', str)
+      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"} name="Bob">', str)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -76,4 +76,49 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
       end
     end
   end
+
+  class NestedStruct < T::Struct
+    const :data, T::Hash[Symbol, String]
+    const :sensitive, T.nilable(String), sensitivity: ['reason']
+    const :custom, T.nilable(String), inspect: proc {|value, opts| "Inspected '#{value}' (opts: #{opts})" unless value.nil?}
+    const :nested, T.nilable(NestedStruct)
+  end
+
+  describe "inspection" do
+    def make_struct
+      NestedStruct.new(
+        data: {
+          one: "one",
+          two: "two",
+        },
+        custom: "something",
+        nested: NestedStruct.new(data: {three: "three"}, sensitive: "something sensitive")
+      )
+    end
+
+    it "inspects in a single line" do
+      struct = make_struct
+      expected_result = "<Opus::Types::Test::StructValidationTest::NestedStruct " \
+      "custom=\"Inspected 'something' (opts: {:multiline=>false})\" data={:one=>\"one\", :two=>\"two\"} " \
+      "nested=<Opus::Types::Test::StructValidationTest::NestedStruct custom=nil data={:three=>\"three\"} " \
+      "nested=nil sensitive=<REDACTED reason>> sensitive=nil>"
+      assert_equal(expected_result, struct.inspect)
+    end
+
+    it "pretty inspects" do
+      struct = make_struct
+      expected_result = <<~INSPECT
+        <Opus::Types::Test::StructValidationTest::NestedStruct
+         custom="Inspected 'something' (opts: {:multiline=>true})"
+         data={:one=>"one", :two=>"two"}
+         nested=<Opus::Types::Test::StructValidationTest::NestedStruct
+          custom=nil
+          data={:three=>"three"}
+          nested=nil
+          sensitive=<REDACTED reason>>
+         sensitive=nil>
+      INSPECT
+      assert_equal(expected_result, struct.pretty_inspect)
+    end
+  end
 end


### PR DESCRIPTION
### Motivation
I had a really interesting problem of a weird interaction between ruby/debug and Sorbet, which makes looking at variables in the debugger extremely slow (internal Stripe reference: [[DEVE-1913] Debugger is extremely slow to show variables when stopped in breakpoint](https://jira.corp.stripe.com/browse/DEVE-1913))

This is a minimally reproducible example:

```ruby
require 'sorbet-runtime'

class Foo < T::Struct
  const :bar, T::Hash[T.untyped, T.untyped]
end
hash = (1..10_000).map do |i|
  [i, {
    index: i,
    content: (1..1000).map do |j|
               "I'm content #{j}"
             end
  }]
end.to_h

a = Foo.new(bar: hash) # put a breakpoint here [1]
puts 'done' # put a breakpoint here [2]
```

You should be able to paste that into a file, open it with VSCode, and try to debug it. Once it hits [1], you’ll immediately see the variables in the left panel. When hitting `continue`, the variables in the panel will have a spinning wheel, and it will stay there for a while.

The problem is that [this call to PP.singleline_pp](https://github.com/ruby/debug/blob/ec5ae5aebd61a99dc84028d8dffa8e7e165c1ec6/lib/debug/session.rb#L2293) in the debugger, doesn't interact nicely with Sorbet’s [PrettyPrintable](https://github.com/sorbet/sorbet/blob/4f146522e25047f6527a98797672f9b1c462eced/gems/sorbet-runtime/lib/types/props/pretty_printable.rb). The expectation is that `inspect` (which is what ends up being called by `PP`, in case of there not being a `pretty_print`) would signal where it can break by using `breakable` (see [docs](https://docs.ruby-lang.org/en/2.7.0/PrettyPrint.html#method-i-breakable)), which allows to break early once it has enough characters.

Along the way, I made some small changes that make this implementation, IMO, a bit better:

1. Now `pretty_print` actually prints prettily, by not putting everything into a line, but indenting correctly when nesting
2. Used `' '` as a separator (the default/standard when using `inspect`) instead of `,`
3. I removed support for `indent` in the Stripe-specific `custom_inspect` implementation, as there are no uses of it (there are only a few cases of `inspect` anyway, and they are all in what seem to be deprecated classes, which makes me think that we'll eventually be able to remove this completely)
 
### Test plan
- Added + automated tests
- Used the `ruby/debug` gem, and verified that large objects no longer take a long time to be displayed
- Internal Stripe build: https://cibot.corp.stripe.com/builds/pay-server--bui_MvdwJjxMXzMWiM