### PR TITLE
Revert "✨ Better support pretty_print/inspect in PrettyPrintable"

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
+++ b/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
@@ -1,52 +1,18 @@
 # frozen_string_literal: true
 # typed: true
-require 'pp'
 
 module T::Props::PrettyPrintable
   include T::Props::Plugin
 
-  # Override the PP gem with something that's similar, but gives us a hook to do redaction and customization
-  def pretty_print(pp)
-    clazz = T.unsafe(T.cast(self, Object).class).decorator
-    multiline = pp.is_a?(PP)
-    pp.group(1, "<#{T.unsafe(self).class}", ">") do
-      clazz.all_props.sort.each do |prop|
-        pp.breakable
-        val = clazz.get(self, prop)
-        rules = clazz.prop_rules(prop)
-        pp.text("#{prop}=")
-        if (custom_inspect = rules[:inspect])
-          inspected = if T::Utils.arity(custom_inspect) == 1
-            custom_inspect.call(val)
-          else
-            custom_inspect.call(val, {multiline: multiline})
-          end
-          pp.text(inspected.nil? ? "nil" : "\"#{inspected}\"")
-        elsif rules[:sensitivity] && !rules[:sensitivity].empty? && !val.nil?
-          pp.text("<REDACTED #{rules[:sensitivity].join(', ')}>")
-        else
-          val.pretty_print(pp)
-        end
-      end
-      clazz.pretty_print_extra(self, pp)
-    end
-  end
-
-  # Overridable method to add anything that is not a prop
-  def pretty_print_extra(instance, pp); end
-
-  # Return a string representation of this object and all of its props in a single line
+  # Return a string representation of this object and all of its props
   def inspect
-    string = +""
-    PP.singleline_pp(self, string)
-    string
+    T.unsafe(T.cast(self, Object).class).decorator.inspect_instance(self)
   end
 
-  # Return a pretty string representation of this object and all of its props
+  # Override the PP gem with something that's similar, but gives us a hook
+  # to do redaction
   def pretty_inspect
-    string = +""
-    PP.pp(self, string)
-    string
+    T.unsafe(T.cast(self, Object).class).decorator.inspect_instance(self, multiline: true)
   end
 
   module DecoratorMethods
@@ -55,6 +21,87 @@ module T::Props::PrettyPrintable
     sig {params(key: Symbol).returns(T::Boolean).checked(:never)}
     def valid_rule_key?(key)
       super || key == :inspect
+    end
+
+    sig do
+      params(instance: T::Props::PrettyPrintable, multiline: T::Boolean, indent: String)
+      .returns(String)
+    end
+    def inspect_instance(instance, multiline: false, indent: '  ')
+      components =
+        inspect_instance_components(
+          instance,
+          multiline: multiline,
+          indent: indent
+        )
+          .reject(&:empty?)
+
+      # Not using #<> here as that makes pry highlight these objects
+      # as if they were all comments, whereas this makes them look
+      # like the structured thing they are.
+      if multiline
+        "#{components[0]}:\n" + T.must(components[1..-1]).join("\n")
+      else
+        "<#{components.join(' ')}>"
+      end
+    end
+
+    sig do
+      params(instance: T::Props::PrettyPrintable, multiline: T::Boolean, indent: String)
+      .returns(T::Array[String])
+    end
+    private def inspect_instance_components(instance, multiline:, indent:)
+      pretty_props = T.unsafe(self).all_props.map do |prop|
+        [prop, inspect_prop_value(instance, prop, multiline: multiline, indent: indent)]
+      end
+
+      joined_props = join_props_with_pretty_values(
+        pretty_props,
+        multiline: multiline,
+        indent: indent
+      )
+
+      [
+        T.unsafe(self).decorated_class.to_s,
+        joined_props,
+      ]
+    end
+
+    sig do
+      params(instance: T::Props::PrettyPrintable, prop: Symbol, multiline: T::Boolean, indent: String)
+      .returns(String)
+      .checked(:never)
+    end
+    private def inspect_prop_value(instance, prop, multiline:, indent:)
+      val = T.unsafe(self).get(instance, prop)
+      rules = T.unsafe(self).prop_rules(prop)
+      if (custom_inspect = rules[:inspect])
+        if T::Utils.arity(custom_inspect) == 1
+          custom_inspect.call(val)
+        else
+          custom_inspect.call(val, {multiline: multiline, indent: indent})
+        end
+      elsif rules[:sensitivity] && !rules[:sensitivity].empty? && !val.nil?
+        "<REDACTED #{rules[:sensitivity].join(', ')}>"
+      else
+        val.inspect
+      end
+    end
+
+    sig do
+      params(pretty_kvs: T::Array[[Symbol, String]], multiline: T::Boolean, indent: String)
+      .returns(String)
+    end
+    private def join_props_with_pretty_values(pretty_kvs, multiline:, indent: '  ')
+      pairs = pretty_kvs
+        .sort_by {|k, _v| k.to_s}
+        .map {|k, v| "#{k}=#{v}"}
+
+      if multiline
+        indent + pairs.join("\n#{indent}")
+      else
+        pairs.join(', ')
+      end
     end
   end
 end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -338,18 +338,14 @@ module T::Props::Serializable::DecoratorMethods
     end
   end
 
-  # adds to the default result of T::Props::PrettyPrintable
-  def pretty_print_extra(instance, pp)
+  # overrides T::Props::PrettyPrintable
+  private def inspect_instance_components(instance, multiline:, indent:)
     if (extra_props = extra_props(instance)) && !extra_props.empty?
-      pp.breakable
-      pp.text("@_extra_props=")
-      pp.group(1, "<", ">") do
-        extra_props.each_with_index do |(prop, value), i|
-          pp.breakable unless i.zero?
-          pp.text("#{prop}=")
-          value.pretty_print(pp)
-        end
-      end
+      pretty_kvs = extra_props.map {|k, v| [k.to_sym, v.inspect]}
+      extra = join_props_with_pretty_values(pretty_kvs, multiline: false)
+      super + ["@_extra_props=<#{extra}>"]
+    else
+      super
     end
   end
 end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -148,20 +148,20 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'inspects' do
       obj = a_serializable
       str = obj.inspect
-      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"} name="Bob">', str)
+      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"}, name="Bob">', str)
     end
 
     it 'inspects with extra props' do
       obj = a_serializable
       obj = obj.class.from_hash(obj.serialize.merge('not_a_prop' => 'but_here_anyway'))
       str = obj.inspect
-      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"} name="Bob" @_extra_props=<not_a_prop="but_here_anyway">>', str)
+      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"}, name="Bob" @_extra_props=<not_a_prop="but_here_anyway">>', str)
     end
 
     it 'inspects frozen structs' do
       obj = a_serializable.freeze
       str = obj.inspect
-      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"} name="Bob">', str)
+      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"}, name="Bob">', str)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -76,49 +76,4 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
       end
     end
   end
-
-  class NestedStruct < T::Struct
-    const :data, T::Hash[Symbol, String]
-    const :sensitive, T.nilable(String), sensitivity: ['reason']
-    const :custom, T.nilable(String), inspect: proc {|value, opts| "Inspected '#{value}' (opts: #{opts})" unless value.nil?}
-    const :nested, T.nilable(NestedStruct)
-  end
-
-  describe "inspection" do
-    def make_struct
-      NestedStruct.new(
-        data: {
-          one: "one",
-          two: "two",
-        },
-        custom: "something",
-        nested: NestedStruct.new(data: {three: "three"}, sensitive: "something sensitive")
-      )
-    end
-
-    it "inspects in a single line" do
-      struct = make_struct
-      expected_result = "<Opus::Types::Test::StructValidationTest::NestedStruct " \
-      "custom=\"Inspected 'something' (opts: {:multiline=>false})\" data={:one=>\"one\", :two=>\"two\"} " \
-      "nested=<Opus::Types::Test::StructValidationTest::NestedStruct custom=nil data={:three=>\"three\"} " \
-      "nested=nil sensitive=<REDACTED reason>> sensitive=nil>"
-      assert_equal(expected_result, struct.inspect)
-    end
-
-    it "pretty inspects" do
-      struct = make_struct
-      expected_result = <<~INSPECT
-        <Opus::Types::Test::StructValidationTest::NestedStruct
-         custom="Inspected 'something' (opts: {:multiline=>true})"
-         data={:one=>"one", :two=>"two"}
-         nested=<Opus::Types::Test::StructValidationTest::NestedStruct
-          custom=nil
-          data={:three=>"three"}
-          nested=nil
-          sensitive=<REDACTED reason>>
-         sensitive=nil>
-      INSPECT
-      assert_equal(expected_result, struct.pretty_inspect)
-    end
-  end
 end


### PR DESCRIPTION
Reverts sorbet/sorbet#6592

We made a mistake when testing this in pay-server, and there are a couple of legacy use-cases that this no longer supports.

I'll go back to the drawing board, and try to clean up those cases.