### PR TITLE
Fix undefined behavior in signature override validation

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -265,13 +265,17 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
         for (auto req : left.kw.required) {
             auto corresponding =
                 absl::c_find_if(right.kw.required, [&](const auto &r) { return r.get().name == req.get().name; });
-            if (corresponding == right.kw.required.end()) {
+
+            auto hasCorrespondingRequired = corresponding != right.kw.required.end();
+            if (!hasCorrespondingRequired) {
                 corresponding =
                     absl::c_find_if(right.kw.optional, [&](const auto &r) { return r.get().name == req.get().name; });
             }
 
+            auto hasCorrespondingOptional = corresponding != right.kw.optional.end();
+
             // if there is a corresponding parameter, make sure it has the right type
-            if (corresponding != right.kw.required.end() && corresponding != right.kw.optional.end()) {
+            if (hasCorrespondingRequired || hasCorrespondingOptional) {
                 if (!checkSubtype(ctx, *constr, corresponding->get().type, method, req.get().type, superMethod,
                                   core::Polarity::Negative)) {
                     if (auto e =

--- a/test/testdata/resolver/abstract_override_kwargs.rb
+++ b/test/testdata/resolver/abstract_override_kwargs.rb
@@ -1,0 +1,85 @@
+# typed: strict
+
+module I
+  extend T::Sig
+  extend T::Helpers
+  interface!
+
+  sig do
+    abstract.params(
+      a: Integer,
+      b: Integer,
+      c: Integer,
+      d: Integer,
+      e: Integer,
+      f: Integer,
+      g: Integer,
+      h: Integer,
+      i: Integer,
+      j: Integer,
+      k: Integer,
+      l: Integer,
+      m: Integer,
+      n: Integer
+    ).returns(Integer)
+  end
+  def foo(
+    a:,
+    b:,
+    c:,
+    d:,
+    e:,
+    f:,
+    g: 10,
+    h: 10,
+    i: 10,
+    j: 10,
+    k: 10,
+    l: 10,
+    m: 10,
+    n: 10
+  )
+  end
+end
+
+class C
+  extend T::Sig
+  include I
+
+  sig do
+    override.params(
+      a: Integer,
+      b: Integer,
+      c: Integer,
+      d: Integer,
+      e: Integer,
+      f: Integer,
+      g: Integer,
+      h: Integer,
+      i: Integer,
+      j: Integer,
+      k: Integer,
+      l: Integer,
+      m: Integer,
+      n: Integer
+    ).returns(Integer)
+  end
+  def foo(
+    a:,
+    b:,
+    c:,
+    d:,
+    e:,
+    f:,
+    g: 10,
+    h: 10,
+    i: 10,
+    j: 10,
+    k: 10,
+    l: 10,
+    m: 10,
+    n: 10
+  )
+    10
+  end
+end


### PR DESCRIPTION
Running Sorbet against this example will randomly fail:

```rb
# typed: strict

module I
  extend T::Sig
  extend T::Helpers
  interface!

  sig do
    abstract.params(
      a: Integer,
      b: Integer,
      c: Integer,
      d: Integer,
      e: Integer,
      f: Integer,
      g: Integer,
      h: Integer,
      i: Integer,
      j: Integer,
      k: Integer,
      l: Integer,
      m: Integer,
      n: Integer
    ).returns(Integer)
  end
  def foo(
    a:,
    b:,
    c:,
    d:,
    e:,
    f:,
    g: 10,
    h: 10,
    i: 10,
    j: 10,
    k: 10,
    l: 10,
    m: 10,
    n: 10
  )
  end
end

class C
  extend T::Sig
  include I

  sig do
    override.params(
      a: Integer,
      b: Integer,
      c: Integer,
      d: Integer,
      e: Integer,
      f: Integer,
      g: Integer,
      h: Integer,
      i: Integer,
      j: Integer,
      k: Integer,
      l: Integer,
      m: Integer,
      n: Integer
    ).returns(Integer)
  end
  def foo(
    a:,
    b:,
    c:,
    d:,
    e:,
    f:,
    g: 10,
    h: 10,
    i: 10,
    j: 10,
    k: 10,
    l: 10,
    m: 10,
    n: 10
  )
    10
  end
end
```

Error:

```
test.rb:67: Implementation of abstract method I#foo is missing required keyword argument a https://srb.help/5035
    67 |  def foo(
    68 |    a:,
    69 |    b:,
    70 |    c:,
    71 |    d:,
       |...
    78 |    k: 10,
    79 |    l: 10,
    80 |    m: 10,
    81 |    n: 10
    82 |  )
    test.rb:26: Base method defined here
    26 |  def foo(
    27 |    a:,
    28 |    b:,
    29 |    c:,
    30 |    d:,
       |...
    37 |    k: 10,
    38 |    l: 10,
    39 |    m: 10,
    40 |    n: 10
    41 |  )
Errors: 1
```

This happens somewhat randomly so we need to run it many times:

```sh
for i in {1..50}; do sorbet test.rb; done
```

To validate signatures overrides, for each required and optional parameter from the super method we check if the corresponding parameter in the overriding method is defined with a valid type.

Before this change, the override validation was checking if the corresponding parameter was both in the `required` and `optional` list. But in the case where the parameter was in the `required` list, we shouldn't look into the `optional` one. If we do, we're going to compare the wrong iterator against the wrong `end` and get an undefined behavior which could, in some cases, return true.

Reading the code it seems that what we actually want to do is check the type if the parameter from the super method is found in the overriding method so changing the `&&` for a `||` should be enough.