### PR TITLE
Delete --enable-experimental-lsp-fast-path

### DIFF
--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -246,8 +246,6 @@ struct LocalSymbolTableHashes {
     uint32_t hierarchyHash = HASH_STATE_NOT_COMPUTED;
     // A fingerprint for the classes and modules contained in the file.
     uint32_t classModuleHash = HASH_STATE_NOT_COMPUTED;
-    // A fingerprint for the type argument symbols contained in the file.
-    uint32_t typeArgumentHash = HASH_STATE_NOT_COMPUTED;
     // A fingerprint for the type member symbols contained in the file.
     uint32_t typeMemberHash = HASH_STATE_NOT_COMPUTED;
     // A fingerprint for the fields contained in the file.
@@ -287,7 +285,6 @@ struct LocalSymbolTableHashes {
         LocalSymbolTableHashes ret;
         ret.hierarchyHash = HASH_STATE_INVALID_PARSE;
         ret.classModuleHash = HASH_STATE_INVALID_PARSE;
-        ret.typeArgumentHash = HASH_STATE_INVALID_PARSE;
         ret.typeMemberHash = HASH_STATE_INVALID_PARSE;
         ret.fieldHash = HASH_STATE_INVALID_PARSE;
         ret.staticFieldHash = HASH_STATE_INVALID_PARSE;
@@ -300,7 +297,6 @@ struct LocalSymbolTableHashes {
         DEBUG_ONLY(
             if (hierarchyHash == HASH_STATE_INVALID_PARSE) {
                 ENFORCE(classModuleHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(typeArgumentHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(typeMemberHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(fieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(staticFieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
@@ -308,7 +304,6 @@ struct LocalSymbolTableHashes {
                 ENFORCE(methodHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
             } else {
                 ENFORCE(classModuleHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(typeArgumentHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(typeMemberHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(fieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
                 ENFORCE(staticFieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -294,9 +294,6 @@ public:
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
 
-    // If 'true', enable the experimental, symbol-deletion-based fast path mode
-    bool lspExperimentalFastPathEnabled = false;
-
     // When present, this indicates that single-package rbi generation is being performed, and contains metadata about
     // the packages that are imported by the one whose interface is being generated.
     std::optional<packages::ImportInfo> singlePackageImports;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2261,13 +2261,6 @@ ClassOrModuleRef SymbolRef::enclosingClass(const GlobalState &gs) const {
 
 uint32_t ClassOrModule::hash(const GlobalState &gs, bool skipTypeMemberNames) const {
     uint32_t result = _hash(name.shortName(gs));
-    if (!gs.lspExperimentalFastPathEnabled) {
-        // resultType on a ClassOrModule is just externalType(), which is a function of this class
-        // (including singletons and attached classes) and its type members. If any of those things
-        // change, either they will be reflected elsewhere in the hash, or they don't need to be
-        // included in the hash at all.
-        result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
-    }
     result = mix(result, this->flags.serialize());
     result = mix(result, this->owner.id());
     result = mix(result, this->superClass_.id());
@@ -2282,12 +2275,11 @@ uint32_t ClassOrModule::hash(const GlobalState &gs, bool skipTypeMemberNames) co
                 continue;
             }
 
-            if (e.second.isMethod() &&
-                (gs.lspExperimentalFastPathEnabled || e.second.asMethodRef().data(gs)->ignoreInHashing(gs))) {
+            if (e.second.isMethod()) {
                 continue;
             }
 
-            if (gs.lspExperimentalFastPathEnabled && e.second.isFieldOrStaticField()) {
+            if (e.second.isFieldOrStaticField()) {
                 const auto &field = e.second.asFieldRef().data(gs);
                 if (field->flags.isStaticField && !field->isClassAlias()) {
                     continue;
@@ -2308,7 +2300,7 @@ uint32_t ClassOrModule::hash(const GlobalState &gs, bool skipTypeMemberNames) co
                 }
             }
 
-            if (skipTypeMemberNames && gs.lspExperimentalFastPathEnabled && e.second.isTypeMember()) {
+            if (skipTypeMemberNames && e.second.isTypeMember()) {
                 // skipTypeMemberNames is currently the difference between `hash` and `classOrModuleShapeHash`
                 // (It felt wasteful to dupe this whole method.) Type member names have to be in the
                 // full hash so that a change to a type member name causes the right downstream
@@ -2332,13 +2324,6 @@ uint32_t ClassOrModule::hash(const GlobalState &gs, bool skipTypeMemberNames) co
     for (const auto &e : mixins_) {
         if (e.exists() && !e.data(gs)->ignoreInHashing(gs)) {
             result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
-        }
-    }
-    if (!gs.lspExperimentalFastPathEnabled) {
-        for (const auto &e : typeMembers()) {
-            if (e.exists()) {
-                result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
-            }
         }
     }
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -241,7 +241,6 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
     p.putU1(1);
     p.putU4(fh->localSymbolTableHashes.hierarchyHash);
     p.putU4(fh->localSymbolTableHashes.classModuleHash);
-    p.putU4(fh->localSymbolTableHashes.typeArgumentHash);
     p.putU4(fh->localSymbolTableHashes.typeMemberHash);
     p.putU4(fh->localSymbolTableHashes.fieldHash);
     p.putU4(fh->localSymbolTableHashes.staticFieldHash);
@@ -297,7 +296,6 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
 
     ret.localSymbolTableHashes.hierarchyHash = p.getU4();
     ret.localSymbolTableHashes.classModuleHash = p.getU4();
-    ret.localSymbolTableHashes.typeArgumentHash = p.getU4();
     ret.localSymbolTableHashes.typeMemberHash = p.getU4();
     ret.localSymbolTableHashes.fieldHash = p.getU4();
     ret.localSymbolTableHashes.staticFieldHash = p.getU4();

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -90,7 +90,6 @@ core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<cor
     lgs = core::GlobalState::makeEmptyGlobalStateForHashing(logger);
     lgs->requiresAncestorEnabled = hashingOpts.requiresAncestorEnabled;
     lgs->ruby3KeywordArgs = hashingOpts.ruby3KeywordArgs;
-    lgs->lspExperimentalFastPathEnabled = hashingOpts.lspExperimentalFastPathEnabled;
     {
         core::UnfreezeFileTable fileTableAccess(*lgs);
         auto fref = lgs->enterFile(forWhat);

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -13,7 +13,10 @@ unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::log
     if (opts.cacheDir.empty()) {
         return nullptr;
     }
-    auto flavor = opts.lspExperimentalFastPathEnabled ? "experimentalfastpath" : "normalfastpath";
+    // Despite being called "experimental," this feature is actually stable. We just didn't want to
+    // bust all existing caches when we promoted the experimental-at-the-time incremental fast path
+    // to the stable version.
+    auto flavor = "experimentalfastpath";
     return make_unique<OwnedKeyValueStore>(make_unique<KeyValueStore>(logger, sorbet_full_version_string, opts.cacheDir,
                                                                       move(flavor), opts.maxCacheSizeBytes));
 }

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -132,8 +132,6 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
             // Also record some information about what might have changed.
             const bool classesDiffer =
                 newHash.localSymbolTableHashes.classModuleHash != oldHash.localSymbolTableHashes.classModuleHash;
-            const bool typeArgumentsDiffer =
-                newHash.localSymbolTableHashes.typeArgumentHash != oldHash.localSymbolTableHashes.typeArgumentHash;
             const bool typeMembersDiffer =
                 newHash.localSymbolTableHashes.typeMemberHash != oldHash.localSymbolTableHashes.typeMemberHash;
             const bool fieldsDiffer =
@@ -144,14 +142,10 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
                 newHash.localSymbolTableHashes.classAliasHash != oldHash.localSymbolTableHashes.classAliasHash;
             const bool methodsDiffer =
                 newHash.localSymbolTableHashes.methodHash != oldHash.localSymbolTableHashes.methodHash;
-            const uint32_t differCount = int(classesDiffer) + int(typeArgumentsDiffer) + int(typeMembersDiffer) +
-                                         int(fieldsDiffer) + int(staticFieldsDiffer) + int(classAliasesDiffer) +
-                                         int(methodsDiffer);
+            const uint32_t differCount = int(classesDiffer) + int(typeMembersDiffer) + int(fieldsDiffer) +
+                                         int(staticFieldsDiffer) + int(classAliasesDiffer) + int(methodsDiffer);
             if (classesDiffer) {
                 prodCategoryCounterInc("lsp.slow_path_changed_def", "classmodule");
-            }
-            if (typeArgumentsDiffer) {
-                prodCategoryCounterInc("lsp.slow_path_changed_def", "typeargument");
             }
             if (typeMembersDiffer) {
                 prodCategoryCounterInc("lsp.slow_path_changed_def", "typemember");
@@ -171,8 +165,6 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
             if (differCount == 1) {
                 if (classesDiffer) {
                     prodCategoryCounterInc("lsp.slow_path_changed_def", "onlyclassmodule");
-                } else if (typeArgumentsDiffer) {
-                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlytypeargument");
                 } else if (typeMembersDiffer) {
                     prodCategoryCounterInc("lsp.slow_path_changed_def", "onlytypemembers");
                 } else if (fieldsDiffer) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -217,8 +217,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     config->logger->debug("Added {} files that were not part of the edit to the update set", result.extraFiles.size());
     UnorderedMap<core::FileRef, core::FoundDefHashes> oldFoundHashesForFiles;
     auto toTypecheck = move(result.extraFiles);
-    auto shouldRunIncrementalNamer =
-        config->opts.lspExperimentalFastPathEnabled && !result.changedSymbolNameHashes.empty();
+    auto shouldRunIncrementalNamer = !result.changedSymbolNameHashes.empty();
     for (auto [fref, idx] : result.changedFiles) {
         if (shouldRunIncrementalNamer) {
             // Only set oldFoundHashesForFiles if we're processing a real edit.

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -160,28 +160,10 @@ unique_ptr<LSPMessage> MultiThreadedLSPWrapper::read(int timeoutMs) {
 }
 
 void LSPWrapper::enableAllExperimentalFeatures() {
-    enableExperimentalFeature(LSPExperimentalFeature::DocumentHighlight);
-    enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
-    enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
-    enableExperimentalFeature(LSPExperimentalFeature::DocumentFormat);
-    enableExperimentalFeature(LSPExperimentalFeature::ExperimentalFastPath);
-}
-
-void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
-    switch (feature) {
-        case LSPExperimentalFeature::DocumentHighlight:
-            opts->lspDocumentHighlightEnabled = true;
-            break;
-        case LSPExperimentalFeature::DocumentSymbol:
-            opts->lspDocumentSymbolEnabled = true;
-            break;
-        case LSPExperimentalFeature::SignatureHelp:
-            opts->lspSignatureHelpEnabled = true;
-            break;
-        case LSPExperimentalFeature::DocumentFormat:
-            opts->lspDocumentFormatRubyfmtEnabled = true;
-            break;
-    }
+    opts->lspDocumentHighlightEnabled = true;
+    opts->lspDocumentSymbolEnabled = true;
+    opts->lspSignatureHelpEnabled = true;
+    opts->lspDocumentFormatRubyfmtEnabled = true;
 }
 
 int LSPWrapper::getTypecheckCount() {

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -26,7 +26,6 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
 
     gs.requiresAncestorEnabled = options.requiresAncestorEnabled;
     gs.ruby3KeywordArgs = options.ruby3KeywordArgs;
-    gs.lspExperimentalFastPathEnabled = options.lspExperimentalFastPathEnabled;
 
     // Ensure LSP is enabled.
     options.runLSP = true;
@@ -181,9 +180,6 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::DocumentFormat:
             opts->lspDocumentFormatRubyfmtEnabled = true;
-            break;
-        case LSPExperimentalFeature::ExperimentalFastPath:
-            opts->lspExperimentalFastPathEnabled = true;
             break;
     }
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -50,7 +50,6 @@ public:
         SignatureHelp = 7,
         DocumentHighlight = 9,
         DocumentFormat = 10,
-        ExperimentalFastPath = 11,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -45,25 +45,12 @@ protected:
                bool disableFastPath);
 
 public:
-    enum class LSPExperimentalFeature {
-        DocumentSymbol = 6,
-        SignatureHelp = 7,
-        DocumentHighlight = 9,
-        DocumentFormat = 10,
-    };
-
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.
     const std::shared_ptr<options::Options> opts;
 
     virtual ~LSPWrapper();
 
     const LSPConfiguration &config() const;
-
-    /**
-     * Enable an experimental LSP feature.
-     * Note: Use this method *before* the client performs initialization with the server.
-     */
-    void enableExperimentalFeature(LSPExperimentalFeature feature);
 
     /**
      * Enable all experimental LSP features.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -274,10 +274,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
 
     fmt::format_to(std::back_inserter(all_prints), "Print: [{}]",
                    fmt::map_join(
-                       print_options, ", ", [](const auto &pr) -> auto{ return pr.option; }));
+                       print_options, ", ", [](const auto &pr) -> auto { return pr.option; }));
     fmt::format_to(std::back_inserter(all_stop_after), "Stop After: [{}]",
                    fmt::map_join(
-                       stop_after_options, ", ", [](const auto &pr) -> auto{ return pr.option; }));
+                       stop_after_options, ", ", [](const auto &pr) -> auto { return pr.option; }));
 
     // Advanced options
     options.add_options("advanced")("dir", "Input directory", cxxopts::value<vector<string>>());

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -274,10 +274,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
 
     fmt::format_to(std::back_inserter(all_prints), "Print: [{}]",
                    fmt::map_join(
-                       print_options, ", ", [](const auto &pr) -> auto { return pr.option; }));
+                       print_options, ", ", [](const auto &pr) -> auto{ return pr.option; }));
     fmt::format_to(std::back_inserter(all_stop_after), "Stop After: [{}]",
                    fmt::map_join(
-                       stop_after_options, ", ", [](const auto &pr) -> auto { return pr.option; }));
+                       stop_after_options, ", ", [](const auto &pr) -> auto{ return pr.option; }));
 
     // Advanced options
     options.add_options("advanced")("dir", "Input directory", cxxopts::value<vector<string>>());
@@ -346,9 +346,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "Enable experimental LSP feature: Document Highlight");
     options.add_options("advanced")("enable-experimental-lsp-signature-help",
                                     "Enable experimental LSP feature: Signature Help");
-    options.add_options("advanced")("enable-experimental-lsp-fast-path",
-                                    "Enable experimental LSP feature: a faster fast path using symbol deletions",
-                                    cxxopts::value<bool>()->default_value("true"));
     options.add_options("advanced")("enable-experimental-requires-ancestor",
                                     "Enable experimental `requires_ancestor` annotation");
 
@@ -792,8 +789,6 @@ void readOptions(Options &opts,
         opts.lspDocumentFormatRubyfmtEnabled =
             FileOps::exists(opts.rubyfmtPath) &&
             (enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>());
-
-        opts.lspExperimentalFastPathEnabled = raw["enable-experimental-lsp-fast-path"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {
             auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -264,7 +264,6 @@ struct Options {
     bool lspDocumentSymbolEnabled = false;
     bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
-    bool lspExperimentalFastPathEnabled = false;
 
     // Experimental feature `requires_ancestor`
     bool requiresAncestorEnabled = false;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -515,7 +515,6 @@ int realmain(int argc, char *argv[]) {
         gs->includeErrorSections = false;
     }
     gs->ruby3KeywordArgs = opts.ruby3KeywordArgs;
-    gs->lspExperimentalFastPathEnabled = opts.lspExperimentalFastPathEnabled;
     if (!opts.stripeMode) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced in Stripe code.
         if (opts.isolateErrorCode.empty()) {

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -34,7 +34,6 @@ void ProtocolTest::resetState(std::shared_ptr<realmain::options::Options> opts) 
         }
         opts->cacheDir = cacheDir;
     }
-    opts->lspExperimentalFastPathEnabled = true;
 
     if (useMultithreading) {
         lspWrapper = MultiThreadedLSPWrapper::create(rootPath, opts);

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -565,7 +565,6 @@ TEST_CASE("LSPTest") {
         }
         opts->disableWatchman = true;
         opts->rubyfmtPath = "test/testdata/lsp/rubyfmt-stub/rubyfmt";
-        opts->lspExperimentalFastPathEnabled = true;
 
         // Set to a number that is reasonable large for tests, but small enough that we can have a test to handle
         // this edge case. If you change this number, `fast_path/{too_many_files,not_enough_files,initialize}` will

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -201,7 +201,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     gs->censorForSnapshotTests = true;
-    gs->lspExperimentalFastPathEnabled = true;
     auto workers = WorkerPool::create(0, gs->tracer());
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This has been stable and enabled by default for a while now.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We have always tested the newer version of the fast path exclusively since it
was built.