### PR TITLE
deletableDefinitions -> nonClassConstants

### DIFF
--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -210,7 +210,7 @@ CheckSize(FoundField, 20, 4);
 class FoundDefinitions final {
     // Contains references to items in _staticFields and _typeMembers.
     // Used so there is a consistent definition & redefinition ordering.
-    std::vector<FoundDefinitionRef> _deletableDefinitions;
+    std::vector<FoundDefinitionRef> _nonClassConstants;
     // Contains all classes defined in the file.
     std::vector<FoundClass> _klasses;
     // Contains all methods defined in the file.
@@ -224,7 +224,7 @@ class FoundDefinitions final {
     // Contains all class and instance variables defined in the file.
     std::vector<FoundField> _fields;
 
-    FoundDefinitionRef addDefinition(FoundDefinitionRef ref) {
+    FoundDefinitionRef addNonClassConstant(FoundDefinitionRef ref) {
         DEBUG_ONLY(switch (ref.kind()) {
             case FoundDefinitionRef::Kind::StaticField:
             case FoundDefinitionRef::Kind::TypeMember:
@@ -236,7 +236,7 @@ class FoundDefinitions final {
             case FoundDefinitionRef::Kind::Symbol:
                 ENFORCE(false, "Attempted to give unexpected FoundDefinitionRef kind to addDefinition");
         });
-        _deletableDefinitions.emplace_back(ref);
+        _nonClassConstants.emplace_back(ref);
         return ref;
     }
 
@@ -261,13 +261,13 @@ public:
     FoundDefinitionRef addStaticField(FoundStaticField &&staticField) {
         const uint32_t idx = _staticFields.size();
         _staticFields.emplace_back(std::move(staticField));
-        return addDefinition(FoundDefinitionRef(FoundDefinitionRef::Kind::StaticField, idx));
+        return addNonClassConstant(FoundDefinitionRef(FoundDefinitionRef::Kind::StaticField, idx));
     }
 
     FoundDefinitionRef addTypeMember(FoundTypeMember &&typeMember) {
         const uint32_t idx = _typeMembers.size();
         _typeMembers.emplace_back(std::move(typeMember));
-        return addDefinition(FoundDefinitionRef(FoundDefinitionRef::Kind::TypeMember, idx));
+        return addNonClassConstant(FoundDefinitionRef(FoundDefinitionRef::Kind::TypeMember, idx));
     }
 
     FoundDefinitionRef addField(FoundField &&field) {
@@ -284,9 +284,9 @@ public:
         _modifiers.emplace_back(std::move(mod));
     }
 
-    // See documentation on _deletableDefinitions
-    const std::vector<FoundDefinitionRef> &deletableDefinitions() const {
-        return _deletableDefinitions;
+    // See documentation on _nonClassConstants
+    const std::vector<FoundDefinitionRef> &nonClassConstants() const {
+        return _nonClassConstants;
     }
 
     // See documentation on _klasses

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1525,12 +1525,12 @@ public:
     }
 
     void enterNewDefinitions(core::MutableContext ctx, SymbolDefiner::State &&state) {
-        // We have to defer defining "deletable" symbols until this (second) phase of incremental
+        // We have to defer defining non-class constant symbols until this (second) phase of incremental
         // namer so that we don't delete and immediately re-enter a symbol (possibly keeping it
         // alive, if it had multiple locs at the time of deletion) before SymbolDefiner has had a
         // chance to process _all_ files.
 
-        for (auto ref : foundDefs.deletableDefinitions()) {
+        for (auto ref : foundDefs.nonClassConstants()) {
             switch (ref.kind()) {
                 case core::FoundDefinitionRef::Kind::StaticField: {
                     const auto &staticField = ref.staticField(foundDefs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This name doesn't make much sense anymore--it doesn't have methods nor
fields, which are also deletable definitions. Maybe its usefulness will
one day go away if we make edits to classes take the fast path too. But
for the time being, it's here to stay so we may as well make the name
change.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests