### PR TITLE
Include thread_mattr_accessor in Mattr dsl

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -251,6 +251,8 @@ NameDef names[] = {
     {"cattrAccessor", "cattr_accessor"},
     {"cattrReader", "cattr_reader"},
     {"cattrWriter", "cattr_writer"},
+    {"threadMattrAccessor", "thread_mattr_accessor"},
+    {"threadCattrAccessor", "thread_cattr_accessor"},
     {"instanceReader", "instance_reader"},
     {"instanceWriter", "instance_writer"},
     {"instanceAccessor", "instance_accessor"},

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -41,7 +41,8 @@ vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send 
         doReaders = true;
     } else if (send->fun == core::Names::mattrWriter() || send->fun == core::Names::cattrWriter()) {
         doWriters = true;
-    } else if (send->fun == core::Names::mattrAccessor() || send->fun == core::Names::cattrAccessor()) {
+    } else if (send->fun == core::Names::mattrAccessor() || send->fun == core::Names::cattrAccessor() ||
+               send->fun == core::Names::threadMattrAccessor() || send->fun == core::Names::threadCattrAccessor()) {
         doReaders = true;
         doWriters = true;
     } else if (classDefKind == ast::ClassDef::Kind::Class && send->fun == core::Names::classAttribute()) {

--- a/test/testdata/rewriter/rails/thread_cattr_accessor.rb
+++ b/test/testdata/rewriter/rails/thread_cattr_accessor.rb
@@ -1,0 +1,42 @@
+# typed: strict
+
+class GoodUsages
+  extend T::Sig
+  thread_cattr_accessor :both, :foo
+  thread_cattr_accessor :no_instance, instance_accessor: false
+  thread_cattr_accessor :no_instance_reader, instance_reader: false
+  thread_cattr_accessor :bar, :no_instance_writer, instance_writer: false
+
+  sig {void}
+  def usages
+    both
+    self.both = 1
+
+    no_instance # error: Method `no_instance` does not exist
+    self.no_instance = 1 # error: Method `no_instance=` does not exist
+
+    no_instance_reader # error: Method `no_instance_reader` does not exist
+    self.no_instance_reader= 1
+
+    no_instance_writer
+    self.no_instance_writer = 1 # error: Method `no_instance_writer=` does not exist
+  end
+
+  both
+  self.both = 1
+
+  no_instance
+  self.no_instance = 1
+
+  no_instance_reader
+  self.no_instance_reader = 1
+
+  no_instance_writer
+  self.no_instance_writer = 1
+end
+
+class IgnoredUsages
+  thread_cattr_accessor # error: Method `thread_cattr_accessor` does not exist
+  thread_cattr_accessor instance_accessor: false # error: Method `thread_cattr_accessor` does not exist
+  thread_cattr_accessor "foo" # error: Method `thread_cattr_accessor` does not exist
+end

--- a/test/testdata/rewriter/rails/thread_cattr_accessor.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/thread_cattr_accessor.rb.rewrite-tree.exp
@@ -1,0 +1,238 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C GoodUsages><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def both<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.both<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def both=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.both=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def foo<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.foo<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def foo=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.foo=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.no_instance<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.no_instance=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.no_instance_reader<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def no_instance_reader=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.no_instance_reader=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def bar<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.bar<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.bar=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def no_instance_writer<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.no_instance_writer<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.no_instance_writer=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def usages<<todo method>>(&<blk>)
+      begin
+        <self>.both()
+        <self>.both=(1)
+        <self>.no_instance()
+        <self>.no_instance=(1)
+        <self>.no_instance_reader()
+        <self>.no_instance_reader=(1)
+        <self>.no_instance_writer()
+        <self>.no_instance_writer=(1)
+      end
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of both>
+
+    <runtime method definition of self.both>
+
+    <runtime method definition of both=>
+
+    <runtime method definition of self.both=>
+
+    <runtime method definition of foo>
+
+    <runtime method definition of self.foo>
+
+    <runtime method definition of foo=>
+
+    <runtime method definition of self.foo=>
+
+    <runtime method definition of self.no_instance>
+
+    <runtime method definition of self.no_instance=>
+
+    <runtime method definition of self.no_instance_reader>
+
+    <runtime method definition of no_instance_reader=>
+
+    <runtime method definition of self.no_instance_reader=>
+
+    <runtime method definition of bar>
+
+    <runtime method definition of self.bar>
+
+    <runtime method definition of self.bar=>
+
+    <runtime method definition of no_instance_writer>
+
+    <runtime method definition of self.no_instance_writer>
+
+    <runtime method definition of self.no_instance_writer=>
+
+    <runtime method definition of usages>
+
+    <self>.both()
+
+    <self>.both=(1)
+
+    <self>.no_instance()
+
+    <self>.no_instance=(1)
+
+    <self>.no_instance_reader()
+
+    <self>.no_instance_reader=(1)
+
+    <self>.no_instance_writer()
+
+    <self>.no_instance_writer=(1)
+  end
+
+  class <emptyTree>::<C IgnoredUsages><<C <todo sym>>> < (::<todo sym>)
+    <self>.thread_cattr_accessor()
+
+    <self>.thread_cattr_accessor(:instance_accessor, false)
+
+    <self>.thread_cattr_accessor("foo")
+  end
+end

--- a/test/testdata/rewriter/rails/thread_mattr_accessor.rb
+++ b/test/testdata/rewriter/rails/thread_mattr_accessor.rb
@@ -1,0 +1,42 @@
+# typed: strict
+
+class GoodUsages
+  extend T::Sig
+  thread_mattr_accessor :both, :foo
+  thread_mattr_accessor :no_instance, instance_accessor: false
+  thread_mattr_accessor :no_instance_reader, instance_reader: false
+  thread_mattr_accessor :bar, :no_instance_writer, instance_writer: false
+
+  sig {void}
+  def usages
+    both
+    self.both = 1
+
+    no_instance # error: Method `no_instance` does not exist
+    self.no_instance = 1 # error: Method `no_instance=` does not exist
+
+    no_instance_reader # error: Method `no_instance_reader` does not exist
+    self.no_instance_reader= 1
+
+    no_instance_writer
+    self.no_instance_writer = 1 # error: Method `no_instance_writer=` does not exist
+  end
+
+  both
+  self.both = 1
+
+  no_instance
+  self.no_instance = 1
+
+  no_instance_reader
+  self.no_instance_reader = 1
+
+  no_instance_writer
+  self.no_instance_writer = 1
+end
+
+class IgnoredUsages
+  thread_mattr_accessor # error: Method `thread_mattr_accessor` does not exist
+  thread_mattr_accessor instance_accessor: false # error: Method `thread_mattr_accessor` does not exist
+  thread_mattr_accessor "foo" # error: Method `thread_mattr_accessor` does not exist
+end

--- a/test/testdata/rewriter/rails/thread_mattr_accessor.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/thread_mattr_accessor.rb.rewrite-tree.exp
@@ -1,0 +1,238 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C GoodUsages><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def both<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.both<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def both=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.both=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def foo<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.foo<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def foo=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.foo=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.no_instance<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.no_instance=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.no_instance_reader<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def no_instance_reader=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.no_instance_reader=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def bar<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.bar<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.bar=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def no_instance_writer<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.untyped())
+    end
+
+    def self.no_instance_writer<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, ::T.untyped()).returns(::T.untyped())
+    end
+
+    def self.no_instance_writer=<<todo method>>(arg0, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def usages<<todo method>>(&<blk>)
+      begin
+        <self>.both()
+        <self>.both=(1)
+        <self>.no_instance()
+        <self>.no_instance=(1)
+        <self>.no_instance_reader()
+        <self>.no_instance_reader=(1)
+        <self>.no_instance_writer()
+        <self>.no_instance_writer=(1)
+      end
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of both>
+
+    <runtime method definition of self.both>
+
+    <runtime method definition of both=>
+
+    <runtime method definition of self.both=>
+
+    <runtime method definition of foo>
+
+    <runtime method definition of self.foo>
+
+    <runtime method definition of foo=>
+
+    <runtime method definition of self.foo=>
+
+    <runtime method definition of self.no_instance>
+
+    <runtime method definition of self.no_instance=>
+
+    <runtime method definition of self.no_instance_reader>
+
+    <runtime method definition of no_instance_reader=>
+
+    <runtime method definition of self.no_instance_reader=>
+
+    <runtime method definition of bar>
+
+    <runtime method definition of self.bar>
+
+    <runtime method definition of self.bar=>
+
+    <runtime method definition of no_instance_writer>
+
+    <runtime method definition of self.no_instance_writer>
+
+    <runtime method definition of self.no_instance_writer=>
+
+    <runtime method definition of usages>
+
+    <self>.both()
+
+    <self>.both=(1)
+
+    <self>.no_instance()
+
+    <self>.no_instance=(1)
+
+    <self>.no_instance_reader()
+
+    <self>.no_instance_reader=(1)
+
+    <self>.no_instance_writer()
+
+    <self>.no_instance_writer=(1)
+  end
+
+  class <emptyTree>::<C IgnoredUsages><<C <todo sym>>> < (::<todo sym>)
+    <self>.thread_mattr_accessor()
+
+    <self>.thread_mattr_accessor(:instance_accessor, false)
+
+    <self>.thread_mattr_accessor("foo")
+  end
+end


### PR DESCRIPTION
[`thread_mattr_accessor`][thread_mattr_accessor] (and it's alias `thread_cattr_accessor`) defines the same set of methods as `mattr_accessor` and `cattr_accessor` (support for those was added in https://github.com/sorbet/sorbet/pull/1252). 

[thread_mattr_accessor]: https://api.rubyonrails.org/classes/Module.html#method-i-thread_mattr_accessor

This commit adds support for these additional methods. They might not be used as often as `mattr_accessor` and friends, but I thought it might still be worth adding since it's such a small change.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was recently confused about why one of these methods worked out of the box and the other gave me an error. Since they are such similar methods, I assumed they would either both work or both error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests, which follow the same pattern as the tests from https://github.com/sorbet/sorbet/pull/1252
