### PR TITLE
fix argument type for `MatchData#{begin,end}`

### DIFF
--- a/rbi/core/match_data.rbi
+++ b/rbi/core/match_data.rbi
@@ -135,7 +135,7 @@ class MatchData < Object
   # ```
   sig do
     params(
-        n: Integer,
+        n: T.any(Integer, Symbol, String),
     )
     .returns(Integer)
   end
@@ -168,7 +168,7 @@ class MatchData < Object
   # ```
   sig do
     params(
-        n: Integer,
+        n: T.any(Integer, Symbol, String),
     )
     .returns(Integer)
   end

--- a/test/testdata/rbi/regexp.rb
+++ b/test/testdata/rbi/regexp.rb
@@ -3,6 +3,25 @@
 maybe_match = /foo/.match('foo')
 T.reveal_type(maybe_match) # error: type: `T.nilable(MatchData)`
 
+if maybe_match
+  b1 = maybe_match.begin(0)
+  T.reveal_type(b1) # error: type: `Integer`
+  e1 = maybe_match.end(0)
+  T.reveal_type(e1) # error: type: `Integer`
+
+  # These are nonsensical because there are no capture groups in
+  # the original regexp, but Sorbet doesn't know that.
+  b2 = maybe_match.begin(:nope)
+  T.reveal_type(b2) # error: type: `Integer`
+  e2 = maybe_match.end(:nope)
+  T.reveal_type(e2) # error: type: `Integer`
+
+  b3 = maybe_match.begin("nope")
+  T.reveal_type(b3) # error: type: `Integer`
+  e3 = maybe_match.begin("nope")
+  T.reveal_type(e3) # error: type: `Integer`
+end
+
 /foo/.match('foo') do |m|
   T.reveal_type(m) # error: type: `MatchData`
 end

--- a/test/testdata/rbi/regexp.rb
+++ b/test/testdata/rbi/regexp.rb
@@ -18,7 +18,7 @@ if maybe_match
 
   b3 = maybe_match.begin("nope")
   T.reveal_type(b3) # error: type: `Integer`
-  e3 = maybe_match.begin("nope")
+  e3 = maybe_match.end("nope")
   T.reveal_type(e3) # error: type: `Integer`
 end
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The documentation for these methods says they can take strings or symbols in addition to integers.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
