### PR TITLE
Fix type member of ObjectSpace::WeakMap

### DIFF
--- a/rbi/stdlib/objspace.rbi
+++ b/rbi/stdlib/objspace.rbi
@@ -168,7 +168,7 @@ class ObjectSpace::WeakMap < Object
   include Enumerable
 
   extend T::Generic
-  Elem = type_member(:out)
+  Elem = type_member {{ fixed: T.untyped }}
 
   # Retrieves a weakly referenced object with the given key
   def [](_); end

--- a/test/testdata/rbi/objspace.rb
+++ b/test/testdata/rbi/objspace.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+ObjectSpace::WeakMap.new
+X = ObjectSpace::WeakMap.new


### PR DESCRIPTION
### Motivation

This class is provided by `objspace` and shouldn't be made generic since `WeakMap[Anything].new` will raise at runtime.

Let's fix the type member to `T.untyped`.

### Test plan

See included automated tests.
