### PR TITLE
Fix `X = A.new` change for generic classes and modules

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2816,7 +2816,8 @@ public:
             // make sure that it's even possible to be valid.
             auto *cnst = ast::cast_tree<ast::ConstantLit>(cast->typeExpr);
             ENFORCE(cnst != nullptr, "Rewriter should always use const for typeExpr, which should now be resolved");
-            if (!cnst->symbol.isClassOrModule() || cnst->symbol.asClassOrModuleRef().data(ctx)->typeArity(ctx) > 0) {
+            if (!cnst->symbol.isClassOrModule() || cnst->symbol.asClassOrModuleRef().data(ctx)->flags.isModule ||
+                cnst->symbol.asClassOrModuleRef().data(ctx)->typeArity(ctx) > 0) {
                 // The rewriter was over-eager in attempting to infer type `A` for `A.new` because
                 // `A` was not a class (or was a generic class, and thus generated the wrong annotation).
                 // Get rid of the cast, replace it with the original arg.

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2816,9 +2816,10 @@ public:
             // make sure that it's even possible to be valid.
             auto *cnst = ast::cast_tree<ast::ConstantLit>(cast->typeExpr);
             ENFORCE(cnst != nullptr, "Rewriter should always use const for typeExpr, which should now be resolved");
-            if (!cnst->symbol.isClassOrModule()) {
+            if (!cnst->symbol.isClassOrModule() || cnst->symbol.asClassOrModuleRef().data(ctx)->typeArity(ctx) > 0) {
                 // The rewriter was over-eager in attempting to infer type `A` for `A.new` because
-                // `A` was not a class. Get rid of the cast, replace it with the original arg.
+                // `A` was not a class (or was a generic class, and thus generated the wrong annotation).
+                // Get rid of the cast, replace it with the original arg.
                 tree = move(cast->arg);
                 return;
             }

--- a/test/testdata/rewriter/constant_assume_type.rb
+++ b/test/testdata/rewriter/constant_assume_type.rb
@@ -36,6 +36,15 @@ class GenericClassWithFixed
   Elem = type_member {{fixed: Integer}}
 end
 
+module ModuleWithCustomNew
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def self.new
+    0
+  end
+end
+
 A = NormalClass.new
 T.reveal_type(A) # error: `NormalClass`
 
@@ -80,3 +89,6 @@ T.reveal_type(J) # error: `T.untyped`
 
 K = GenericClassWithFixed.new
 T.reveal_type(K) # error: `GenericClassWithFixed`
+
+L = ModuleWithCustomNew.new
+T.reveal_type(L) # error: `T.untyped`

--- a/test/testdata/rewriter/constant_assume_type.rb
+++ b/test/testdata/rewriter/constant_assume_type.rb
@@ -30,6 +30,12 @@ class GenericClass
   Elem = type_member
 end
 
+class GenericClassWithFixed
+  extend T::Generic
+
+  Elem = type_member {{fixed: Integer}}
+end
+
 A = NormalClass.new
 T.reveal_type(A) # error: `NormalClass`
 
@@ -71,3 +77,6 @@ T.reveal_type(I) # error: `T.untyped`
 
 J = GenericClass.new
 T.reveal_type(J) # error: `T.untyped`
+
+K = GenericClassWithFixed.new
+T.reveal_type(K) # error: `GenericClassWithFixed`

--- a/test/testdata/rewriter/constant_assume_type.rb
+++ b/test/testdata/rewriter/constant_assume_type.rb
@@ -24,6 +24,12 @@ end
 class NewIsSpecificChild < NewIsSpecific
 end
 
+class GenericClass
+  extend T::Generic
+
+  Elem = type_member
+end
+
 A = NormalClass.new
 T.reveal_type(A) # error: `NormalClass`
 
@@ -62,3 +68,6 @@ NotAClass = SomethingThatHasNew.new
 
 I = NotAClass.new
 T.reveal_type(I) # error: `T.untyped`
+
+J = GenericClass.new
+T.reveal_type(J) # error: `T.untyped`

--- a/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
+++ b/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
@@ -31,6 +31,12 @@ class GenericClass
   Elem = type_member
 end
 
+class GenericClassWithFixed
+  extend T::Generic
+
+  Elem = type_member {{fixed: Integer}}
+end
+
 A = NormalClass.new
 T.reveal_type(A) # error: `NormalClass`
 
@@ -72,4 +78,7 @@ T.reveal_type(I) # error: `T.untyped`
 
 J = GenericClass.new
 T.reveal_type(J) # error: `T.untyped`
+
+K = GenericClassWithFixed.new
+T.reveal_type(K) # error: `GenericClassWithFixed`
 # ------------------------------

--- a/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
+++ b/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
@@ -25,6 +25,12 @@ end
 class NewIsSpecificChild < NewIsSpecific
 end
 
+class GenericClass
+  extend T::Generic
+
+  Elem = type_member
+end
+
 A = NormalClass.new
 T.reveal_type(A) # error: `NormalClass`
 
@@ -63,4 +69,7 @@ NotAClass = SomethingThatHasNew.new
 
 I = NotAClass.new
 T.reveal_type(I) # error: `T.untyped`
+
+J = GenericClass.new
+T.reveal_type(J) # error: `T.untyped`
 # ------------------------------

--- a/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
+++ b/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
@@ -37,6 +37,15 @@ class GenericClassWithFixed
   Elem = type_member {{fixed: Integer}}
 end
 
+module ModuleWithCustomNew
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def self.new
+    0
+  end
+end
+
 A = NormalClass.new
 T.reveal_type(A) # error: `NormalClass`
 
@@ -81,4 +90,7 @@ T.reveal_type(J) # error: `T.untyped`
 
 K = GenericClassWithFixed.new
 T.reveal_type(K) # error: `GenericClassWithFixed`
+
+L = ModuleWithCustomNew.new
+T.reveal_type(L) # error: `T.untyped`
 # ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In #6599, we attempted to infer the type of `X = A.new`.

Our simplistic approach breaks down when `A` is a generic, and we would leak
that to the user.

We should abort attempting to infer the type for generic classes, and require an
explicit annotation at `# typed: strict` for these cases.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.