### PR TITLE
Add some kwarg splats to `const`

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -139,9 +139,9 @@ module T::Props
       end
 
       if cls_or_args.is_a?(Hash)
-        self.prop(name, cls_or_args.merge(immutable: true))
+        self.prop(name, **cls_or_args.merge(immutable: true))
       else
-        self.prop(name, cls_or_args, args.merge(immutable: true))
+        self.prop(name, cls_or_args, **args.merge(immutable: true))
       end
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This add some `**` to places where we mean to be passing keyword args.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on pay-server ([c.f. go/builds/bui_N220HpW1KHvcj4](https://go/builds/bui_N220HpW1KHvcj4)) and with kwarg warnings ([c.f. go/builds/pay-server--bui_N22L7diRn2TC1e](https://go/builds/pay-server--bui_N22L7diRn2TC1e), and note that we _expect_ this to fail: it just fails less).
