### PR TITLE
VSCode blogpost - link to source code instead of issue template

### DIFF
--- a/website/blog/2022-01-06-open-sourcing-sorbet-vscode.md
+++ b/website/blog/2022-01-06-open-sourcing-sorbet-vscode.md
@@ -22,8 +22,10 @@ Today’s release includes:
 - The
   [pre-built extension](https://marketplace.visualstudio.com/items?itemName=sorbet.sorbet-vscode-extension)
   on the Visual Studio Marketplace
-- The [source code](https://github.com/sorbet/sorbet/issues/new/choose) for the
-  extension, located in the `vscode_extension/` folder of the Sorbet repo
+- The
+  [source code](https://github.com/sorbet/sorbet/tree/master/vscode_extension)
+  for the extension, located in the `vscode_extension/` folder of the Sorbet
+  repo
 - Full [installation and usage instructions](https://sorbet.org/docs/vscode) in
   the Sorbet docs
 


### PR DESCRIPTION
I had originally suggested this in https://github.com/sorbet/sorbet/pull/5053#discussion_r780131380, not sure if you deem this change worth it?
