### PR TITLE
Correct syntax for example in documentation describing how to work around `T::Struct` inheritance limitations.

### DIFF
--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -197,6 +197,7 @@ child class:
 ```ruby
 module Common
   extend T::Helpers
+  extend T::Sig
   interface!
   sig {abstract.returns(Integer)}
   def foo; end

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -198,9 +198,9 @@ child class:
 module Common
   extend T::Helpers
   interface!
-  sig {returns(Integer)}
+  sig {abstract.returns(Integer)}
   def foo; end
-  sig {params(Integer).returns(Integer)}
+  sig {abstract.params(foo: Integer).returns(Integer)}
   def foo=(foo); end
 end
 


### PR DESCRIPTION
This corrects an example given in documentation for how to work around `T::Struct` inheritance limitations. It should have no impact to the library itself.

### Motivation

I recently copied this example to modify it in a personal project, but found that the code was incorrect. This was only a minor inconvenience, but it seemed to me to be worth correct.

### Test plan

This change only affects documentation, and so should not need tests.
