### PR TITLE
Add a sig for slice of Sorbet::Private::Static::ENVClass

### DIFF
--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -338,6 +338,18 @@ class Sorbet::Private::Static::ENVClass
   sig {returns(T::Enumerator[Elem])}
   def select!(&blk); end
 
+  # Returns a Hash of the given ENV names and their corresponding values
+  #
+  # ```ruby
+  # ENV.slice('foo', 'baz') # => {"foo"=>"0", "baz"=>"2"}
+  # ENV.slice('baz', 'foo') # => {"baz"=>"2", "foo"=>"0"}
+  # ```
+  sig do
+    params(names: String)
+    .returns(T::Hash[String, String])
+  end
+  def slice(*names); end
+
   sig do
     returns(T::Hash[String, T.nilable(String)])
   end


### PR DESCRIPTION
Refs #2174

### Motivation
When type checking this code:
```ruby
ENV.slice("USER_ID", "USER_NAME")
```
Sorbet complained with:
```
Method slice does not exist on Sorbet::Private::Static::ENVClass
```
while actually [slice is present on ENV](https://ruby-doc.org/core-2.7.2/ENV.html#method-c-slice).

This PR aims to allow calling slice on ENV by adding an appropriate signature to Sorbet.

### Test plan

```ruby
# sorbet/rbi/sorbet/sorbet.rbi
class Sorbet::Private::Static::ENVClass # monkey patch to test
  extend T::Generic
  include Enumerable

  # Returns a Hash of the given ENV names and their corresponding values
  #
  # ```ruby
  # ENV.slice('foo', 'baz') # => {"foo"=>"0", "baz"=>"2"}
  # ENV.slice('baz', 'foo') # => {"baz"=>"2", "foo"=>"0"}
  # ```
  sig do
    params(names: String)
      .returns(T::Hash[String, String])
  end
  def slice(*names); end
end
```

```ruby
# foo.rb
# typed: true

require 'sorbet-runtime'

class Main
  extend T::Sig

  sig { returns(T.nilable(String))}
  def self.main
    ENV.slice["foo"]
  end
end

Main.main
```

And run

```txt
srb tc foo.rb
No errors! Great job.
```

Without the sorbet.rbi monkey patch, the follow error is raised:

```txt
./foo.rb:10: Method slice does not exist on Sorbet::Private::Static::ENVClass https://srb.help/7003
    10 |    ENV.slice["foo"]
                ^^^^^
  Got Sorbet::Private::Static::ENVClass originating from:
    https://github.com/sorbet/sorbet/tree/5395cb663a1fc8bf4ba7a129f4138e3596530d54/rbi/sorbet/sorbet.rbi#L380:
     380 |::ENV = T.let(T.unsafe(nil), Sorbet::Private::Static::ENVClass)
          ^^^^^
Errors: 1
```
