### PR TITLE
Delete autoload shim directories for packages onboarded to path-based autoloading

### DIFF
--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -43,6 +43,10 @@ public:
     // prevent the caller from needing to try/catch removeDir.
     static bool removeEmptyDir(const std::string &path);
 
+    // Removes directories recursively, but they have to be completely empty. Useful for cleaning up dangling
+    // autoloader shim directories after an autogen run.
+    static void removeEmptyDirsRecursively(const std::string &dirPath);
+
     static void removeFile(const std::string &path);
 
     /**

--- a/common/common.cc
+++ b/common/common.cc
@@ -93,7 +93,7 @@ bool sorbet::FileOps::ensureDir(const string &path) {
 void sorbet::FileOps::removeDir(const string &path) {
     auto err = rmdir(path.c_str());
     if (err) {
-        throw sorbet::CreateDirException(fmt::format("Error in removeDir('{}'): {}", path, errno));
+        throw sorbet::RemoveDirException(fmt::format("Error in removeDir('{}'): {}", path, errno));
     }
 }
 
@@ -103,7 +103,7 @@ bool sorbet::FileOps::removeEmptyDir(const string &path) {
         if (errno == ENOTEMPTY) {
             return false;
         }
-        throw sorbet::CreateDirException(fmt::format("Error in removeEmptyDir('{}'): {}", path, errno));
+        throw sorbet::RemoveDirException(fmt::format("Error in removeEmptyDir('{}'): {}", path, errno));
     }
 
     return true;
@@ -137,14 +137,14 @@ void sorbet::FileOps::removeEmptyDirsRecursively(const std::string &dirPath) {
 
             removeEmptyDirsRecursively(std::move(innerDirPath));
         } else {
-            throw sorbet::CreateDirException(
+            throw sorbet::RemoveDirException(
                 fmt::format("Error in removeEmptyDirsRecursively('{}'), file {} exists.", dirPath, entry->d_name));
         }
     }
 
     auto err = rmdir(dirPathCStr);
     if (err) {
-        throw sorbet::CreateDirException(fmt::format("Error in removeEmptyDirsRecursively('{}'): {}", dirPath, errno));
+        throw sorbet::RemoveDirException(fmt::format("Error in removeEmptyDirsRecursively('{}'): {}", dirPath, errno));
     }
 }
 

--- a/common/exception/Exception.h
+++ b/common/exception/Exception.h
@@ -31,6 +31,11 @@ public:
     CreateDirException(const std::string &message) : SorbetException(message) {}
 };
 
+class RemoveDirException : SorbetException {
+public:
+    RemoveDirException(const std::string &message) : SorbetException(message) {}
+};
+
 class RemoveFileException : SorbetException {
 public:
     RemoveFileException(const std::string &message) : SorbetException(message) {}

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -137,8 +137,6 @@ private:
 };
 
 class AutoloadWriter {
-    static void removeEmptiedDirRecursively(const std::string &dirPath, WorkerPool &workers);
-
 public:
     static void writeAutoloads(const core::GlobalState &gs, WorkerPool &workers, const AutoloaderConfig &,
                                const std::string &path, const DefTree &root);

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -137,6 +137,8 @@ private:
 };
 
 class AutoloadWriter {
+    static void removeEmptiedDirRecursively(const std::string &dirPath, WorkerPool &workers);
+
 public:
     static void writeAutoloads(const core::GlobalState &gs, WorkerPool &workers, const AutoloaderConfig &,
                                const std::string &path, const DefTree &root);

--- a/test/cli/autogen-pkg-autoloader/test.out
+++ b/test/cli/autogen-pkg-autoloader/test.out
@@ -135,3 +135,4 @@ class RootPackage::Yabba::Dabba::Quuz < AWS::String
 end
 
 Opus::Require.for_autoload(RootPackage::Yabba::Dabba::Quuz, "test/cli/autogen-pkg-autoloader/bar.rb")
+output/RootPackage/Nested correctly deleted

--- a/test/cli/autogen-pkg-autoloader/test.sh
+++ b/test/cli/autogen-pkg-autoloader/test.sh
@@ -13,6 +13,10 @@ cp -r test/cli/autogen-pkg-autoloader "$tmp/test/cli"
 cd "$tmp" || exit 1
 
 mkdir output
+dir_to_delete="output/RootPackage/Nested"
+inner_dir_to_delete="${dir_to_delete}/Inner"
+mkdir -p $inner_dir_to_delete
+touch "$inner_dir_to_delete/__file_to_delete.rb"
 
 "$cwd/main/sorbet" --silence-dev-message --stop-after=namer \
   --stripe-packages \
@@ -30,5 +34,11 @@ for file in $(find output -type f | sort | grep -v "_mtime_stamp"); do
   printf "\n--- %s\n" "$file"
   cat "$file"
 done
+
+if test -d $dir_to_delete; then
+  echo "ERROR: $dir_to_delete exists"
+else
+  echo "$dir_to_delete correctly deleted"
+fi
 
 rm -rf "$tmp"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Deletes any directory containing autoload shims for packages onboarded to path-based autoloading using Zeitwerk.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
When a package is onboarded to path-based autoloading (i.e. marked as `autoloader_compatibility "strict"`), we need to ensure that any existing directory-level shims for that package are deleted in order prevent "dangling" autoloads.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.