### PR TITLE
Use old receiver location when synthesizing Sorbet::Private::Static 

### DIFF
--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -147,7 +147,9 @@ core::LocOffsets Send::locWithoutBlock(core::LocOffsets bindLoc) {
     }
 
     if (!this->argLocs.empty()) {
-        return this->receiverLoc.join(this->argLocs.back());
+        // For sig, the arg will often be a reference to an implicit self,
+        // so the back of argLocs is a zero width loc.
+        return this->receiverLoc.join(this->funLoc).join(this->argLocs.back());
     }
 
     return this->receiverLoc.join(this->funLoc);

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -51,7 +51,9 @@ bool SigRewriter::run(core::MutableContext &ctx, ast::Send *send) {
     // Keep track of old receiver at this point so that we can report whether a method called
     // sig with the right arity even existed at this point.
     auto oldRecv = std::move(send->recv);
-    send->recv = ast::MK::Constant(send->loc, core::Symbols::Sorbet_Private_Static());
+    // Even though the receiver is now Sorbet::Private::Static, the loc of the old receiver
+    // is more relevant.
+    send->recv = ast::MK::Constant(oldRecv.loc(), core::Symbols::Sorbet_Private_Static());
     send->insertPosArg(0, std::move(oldRecv));
     return true;
 }

--- a/test/testdata/lsp/completion/send_with_block.rb
+++ b/test/testdata/lsp/completion/send_with_block.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+class A
+  extend T::Sig
+  1.times do end
+    #       ^ completion: (nothing)
+  # end
+end
+
+class B
+  extend T::Sig
+  sig do end # error-with-dupes: Malformed `sig`
+    #   ^ completion: (nothing)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5680

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
