### PR TITLE
[WIP] Track aliases and evaluate in run_all_sig_blocks

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -25,6 +25,8 @@ module T::Private::Methods
   # enabling final checks for when those hooks are called. the 'hooks' here don't have anything to do with the 'hooks'
   # in installed_hooks.
   @old_hooks = nil
+  # maps keys for methods created by `alias` or `alias_method` to the key for each aliased original method
+  @aliases = {}
 
   ARG_NOT_PROVIDED = Object.new
   PROC_TYPE = Object.new
@@ -224,9 +226,19 @@ module T::Private::Methods
       current_declaration = T::Private::DeclState.current.active_declaration
     end
 
+    original_method = mod.instance_method(method_name)
+
     if current_declaration.nil?
+      if original_method.original_name != method_name
+        aliased_key = method_owner_and_name_to_key(mod, original_method.original_name)
+        if has_sig_block_for_key(aliased_key)
+          @aliases[method_owner_and_name_to_key(mod, method_name)] = aliased_key
+        end
+      end
+
       return
     end
+
     T::Private::DeclState.current.reset!
 
     if method_name == :method_added || method_name == :singleton_method_added
@@ -236,7 +248,6 @@ module T::Private::Methods
       )
     end
 
-    original_method = mod.instance_method(method_name)
     sig_block = lambda do
       T::Private::Methods.run_sig(hook_mod, method_name, original_method, current_declaration)
     end
@@ -315,9 +326,11 @@ module T::Private::Methods
     # that here.
     receiving_method = receiving_class.instance_method(callee)
     if receiving_method != original_method && receiving_method.original_name == original_method.name
-      aliasing_mod = receiving_method.owner
-      method_sig = method_sig.as_alias(callee)
-      unwrap_method(aliasing_mod, method_sig, original_method)
+      unwrap_aliasing_method(
+        receiving_method,
+        original_method,
+        method_sig
+      )
     end
 
     method_sig
@@ -447,6 +460,7 @@ module T::Private::Methods
     end
 
     @sig_wrappers.delete(key)
+    @aliases.delete(key) # We could hit this case if we call an alias without having called `run_all_sig_blocks`
     sig
   end
 
@@ -456,6 +470,23 @@ module T::Private::Methods
       key, = @sig_wrappers.first
       run_sig_block_for_key(key)
     end
+
+    @aliases.each do |aliasing_key, aliased_key|
+      unwrap_aliasing_method(
+        key_to_method(aliasing_key),
+        key_to_method(aliased_key),
+        signature_for_key(aliased_key)
+      )
+    end
+    @aliases.clear
+  end
+
+  private_class_method def self.unwrap_aliasing_method(aliasing_method, original_method, method_sig)
+    unwrap_method(
+      aliasing_method.owner,
+      method_sig.as_alias(aliasing_method.name),
+      original_method
+    )
   end
 
   def self.all_checked_tests_sigs


### PR DESCRIPTION
This PR affects patterns like:
```ruby
sig {returns(Integer)}
def foo
  0
end

alias_method :bar, :foo
```

Before this PR, the `alias_method` would trigger our `method_added` hook, but we'd bail because there's no `current_declaration`. Then at runtime, the first call to `bar` would hit the method wrapper for `foo` which existed at the time the `alias_method` was evaluated, which would be the initial slow one. That would replace itself and be ok going forward, but would be slow on first requests and unfortunately not affected by `run_all_sig_blocks`.

With this PR, we don't just bail, but first track the existence of an alias, so that we can eagerly evaluate it in `run_all_sig_blocks`. That means at runtime, even the first call to `bar` will use the fast wrapper.

This does mean we pay the cost of grabbing an UnboundMethod object for methods without signatures, since we have to pull that before the `current_declaration` check, but hopefully that's not a big deal?

### Motivation
https://github.com/sorbet/sorbet/issues/6425

This is the general fix, which I tackled via nerdsnipe. If there isn't a great way to gain confidence in its correctness, we can probably just replace calls to `decorator.get` with `decorator.prop_get_if_set`, though I don't know where exactly it would matter.

### Test plan
This is the part I'm not sure about. I don't like the tests I've included here - they touch a bunch of internals and are super brittle - but I don't know how to do it better. I can't figure out how to call `run_all_sig_blocks` in a test without it blowing up in a nondeterministic way from junk left around by other tests.