### PR TITLE
Add a Darwin build of sorbet-staic without a kernel version

### DIFF
--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -40,6 +40,9 @@ if [[ "mac" == "$platform" ]]; then
         gem build sorbet-static.gemspec
         mv sorbet-static.gemspec.bak sorbet-static.gemspec
     done
+    sed -i.bak "s/Gem::Platform::CURRENT/'universal-darwin'/" sorbet-static.gemspec
+    gem build sorbet-static.gemspec
+    mv sorbet-static.gemspec.bak sorbet-static.gemspec
 else
     gem build sorbet-static.gemspec
 fi


### PR DESCRIPTION
This leaves all of the other kernel versioned gmes, but adds one that can be used by any kernel.

### Motivation

If you're using nix, most of the time you get ruby from a build cache, and it comes built as `RUBY_PLATFORM="arm64-darwin22"`. This `RUBY_PLATFORM` is set to 22 even if you're not actually using Ventura, and instead on the previous release of darwin kernel 21. To use a ruby project in nix you use bundix to generate gemsets, and you have to pick a single version of sorbet-static. And so you pick the universal-darwin-22 one, because that's what `RUBY_PLATFORM` is set to.

And that all works okay for a while. However if you ever miss the nix cache, and build a version of ruby from scratch, it will be built as `arm64-darwin21`. This can happen if you're trying out a prerelease, or right now when the version of ruby in nixpkgs is still on 3.1.2 and you want to use 3.1.3. Then if ruby is built as `arm64-darwin21`, bundler wont be able to load the sorbet-static for darwin-22. 

Other gems, like [nokogiri](https://rubygems.org/gems/nokogiri/versions) have dropped the kernel versions from their pre-built releases, and for them there is no problem with bundler selecting it no matter what `RUBY_PLATFORM` is set to. In my project's gems, Sorbet is the only one still adding kernel versions.

I understand that dropping all of them may be too big of a change, but I hope adding a versionless one is small enough to be acceptable. 

### Test plan

I've built a local version-less gem and it seems to work.
