### PR TITLE
Add an error for using bind on pos arg

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3460,9 +3460,7 @@ private:
             if (spec != sig.argTypes.end()) {
                 ENFORCE(spec->type != nullptr);
 
-                // TODO(#4095) Raise error if `bind` used for non-`&blk` arg
-                if (!isBlkArg && (spec->rebind == core::Symbols::MagicBindToAttachedClass() ||
-                                  spec->rebind == core::Symbols::MagicBindToSelfType())) {
+                if (!isBlkArg && spec->rebind.exists()) {
                     if (auto e = ctx.state.beginError(spec->nameLoc, core::errors::Resolver::BindNonBlockParameter)) {
                         e.setHeader("Using `{}` is not permitted here", "bind");
                         e.addErrorNote("Only block arguments can use `{}`", "bind");

--- a/test/testdata/resolver/positional_bind.rb
+++ b/test/testdata/resolver/positional_bind.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  # it doesn't make sense to use `.bind` for
+  # anything other than a `&blk` argument
+  sig {params(f: T.proc.bind(A).void).void}
+  #           ^ error: Using `bind` is not permitted here
+  def self.takes_fn(f)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #4095

Previously, `.bind` here was silently ignored. Using `.bind` for
positional arguments has always had no effect. This just makes that
explicitly with an error.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.