### PR TITLE
fix weird interaction in static-init

### DIFF
--- a/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
@@ -9,7 +9,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb4(rubyRegionId=1)
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
     <unconditional> -> bb1
@@ -31,8 +31,8 @@ bb4[rubyRegionId=1, firstDead=2]():
 # backedges
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](a: T.nilable(Integer), <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](a: T.nilable(Integer), <gotoDeadTemp>$12: T.nilable(TrueClass)):
+    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
@@ -45,14 +45,14 @@ bb7[rubyRegionId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>)):
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1]():
-    <gotoDeadTemp>$11: TrueClass = true
+    <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=3](a: Integer(2)):
-    <statTemp>$14: Integer(3) = 3
-    <returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$14: Integer(3))
+bb10[rubyRegionId=0, firstDead=3](a: Integer(2)):
+    <statTemp>$15: Integer(3) = 3
+    <returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$15: Integer(3))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/rescue.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue.rb.cfg-text.exp
@@ -8,7 +8,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -37,27 +37,28 @@ bb5[rubyRegionId=4, firstDead=-1](<self>: Object):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
-    <throwAwayTemp>$13: T.untyped = <self>: Object.d()
-    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+    <throwAwayTemp>$14: T.untyped = <self>: Object.d()
+    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: Object, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: Object.b()
+    <statTemp>$11: T.untyped = <self>: Object.b()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$11
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$12: TrueClass = true
+    <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -123,7 +123,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb11(rubyRegionId=0)
+# - bb13(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -150,43 +150,45 @@ bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
 # backedges
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
-# - bb9(rubyRegionId=2)
 # - bb10(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
-    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb11)
+# - bb11(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$18: T.nilable(TrueClass)):
+    <gotoDeadTemp>$18 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
+    <statTemp>$10: T.untyped = <self>: TestRescue.baz()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$10
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$13: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$14: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$13: T.class_of(StandardError))
-    <isaCheckTemp>$14 -> (T.untyped ? bb9 : bb10)
+    <cfgAlias>$14: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$15: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$14: T.class_of(StandardError))
+    <isaCheckTemp>$15 -> (T.untyped ? bb10 : bb11)
 
 # backedges
 # - bb8(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+bb10[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$11: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
+    <keepForCfgTemp>$12: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <statTemp>$16: T.untyped = <self>: TestRescue.bar()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$16
     <unconditional> -> bb6
 
 # backedges
 # - bb8(rubyRegionId=2)
-bb10[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$16: TrueClass = true
+bb11[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+    <gotoDeadTemp>$18: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb11[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb13[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -202,7 +204,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb10(rubyRegionId=0)
+# - bb11(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -231,8 +233,8 @@ bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb9(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
-    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb10)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$14: T.nilable(TrueClass)):
+    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb11)
 
 # backedges
 # - bb3(rubyRegionId=2)
@@ -253,12 +255,12 @@ bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <magic>$5: T.
 # backedges
 # - bb8(rubyRegionId=2)
 bb9[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$13: TrueClass = true
+    <gotoDeadTemp>$14: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb11[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -274,7 +276,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -302,27 +304,28 @@ bb5[rubyRegionId=4, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.un
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <throwAwayTemp>$12: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+    <throwAwayTemp>$13: T.untyped = <self>: TestRescue.bar()
+    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
+    <statTemp>$10: T.untyped = <self>: TestRescue.baz()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$10
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$11: TrueClass = true
+    <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -338,7 +341,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -365,25 +368,26 @@ bb5[rubyRegionId=4, firstDead=-1]():
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$9: T.nilable(TrueClass)):
-    <gotoDeadTemp>$9 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$10: T.nilable(TrueClass)):
+    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<magic>$4: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: Sorbet::Private::Static::Void = <magic>$4: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <returnMethodTemp>$2: NilClass = <statTemp>$9
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1]():
-    <gotoDeadTemp>$9: TrueClass = true
+    <gotoDeadTemp>$10: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1]():
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -399,7 +403,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -427,26 +431,27 @@ bb5[rubyRegionId=4, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
-    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
-    <statTemp>$4: NilClass = nil
+    <statTemp>$12: NilClass = nil
+    <statTemp>$4: NilClass = <statTemp>$12
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
-    <gotoDeadTemp>$12: TrueClass = true
+    <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
+bb10[rubyRegionId=0, firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -463,7 +468,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -491,26 +496,27 @@ bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
+    <statTemp>$10: T.untyped = <self>: TestRescue.bar()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$10
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$11: TrueClass = true
+    <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -526,7 +532,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -555,26 +561,27 @@ bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
+    <statTemp>$10: T.untyped = <self>: TestRescue.bar()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$10
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$11: TrueClass = true
+    <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -590,7 +597,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -619,27 +626,28 @@ bb5[rubyRegionId=4, firstDead=-1](<self>: TestRescue):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
-    <throwAwayTemp>$13: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+    <throwAwayTemp>$14: T.untyped = <self>: TestRescue.bar()
+    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
+    <statTemp>$11: T.untyped = <self>: TestRescue.baz()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$11
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$12: TrueClass = true
+    <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -655,7 +663,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -683,26 +691,27 @@ bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
+    <statTemp>$10: T.untyped = <self>: TestRescue.foo()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$10
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$11: TrueClass = true
+    <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -718,7 +727,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -747,26 +756,27 @@ bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
+    <statTemp>$10: T.untyped = <self>: TestRescue.bar()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$10
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$11: TrueClass = true
+    <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -775,7 +785,7 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 method ::TestRescue#parse_resbody_var_1 {
 
 bb0[rubyRegionId=0, firstDead=-1]():
-    @ex$11: T.nilable(StandardError) = alias @ex
+    @ex$12: T.nilable(StandardError) = alias @ex
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
@@ -783,14 +793,14 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>), @ex$12: T.nilable(StandardError)):
     <rescueTemp>$2: T.untyped = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
@@ -798,7 +808,7 @@ bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.un
 
 # backedges
 # - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$12: T.nilable(StandardError)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
@@ -812,27 +822,28 @@ bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
-    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$14: T.nilable(TrueClass)):
+    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: T.untyped, @ex$11: T.nilable(StandardError)):
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: T.untyped, @ex$12: T.nilable(StandardError)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    @ex$11: T.untyped = <rescueTemp>$2
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
+    @ex$12: T.untyped = <rescueTemp>$2
+    <statTemp>$10: T.untyped = <self>: TestRescue.bar()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$10
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$13: TrueClass = true
+    <gotoDeadTemp>$14: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -849,7 +860,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -877,26 +888,27 @@ bb5[rubyRegionId=4, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untype
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
-    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$14: T.nilable(TrueClass)):
+    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
-    <statTemp>$4: T.untyped = <self>: TestRescue.bar()
+    <statTemp>$12: T.untyped = <self>: TestRescue.bar()
+    <statTemp>$4: T.untyped = <statTemp>$12
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
-    <gotoDeadTemp>$13: TrueClass = true
+    <gotoDeadTemp>$14: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
+bb10[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: T.untyped)
     <returnMethodTemp>$2: T.untyped = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -914,7 +926,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -943,26 +955,27 @@ bb5[rubyRegionId=4, firstDead=0](foo: NilClass):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](foo: NilClass, <gotoDeadTemp>$12: T.nilable(TrueClass)):
-    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](foo: NilClass, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<magic>$7: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    foo: NilClass = nil
+    <statTemp>$12: NilClass = nil
+    foo: NilClass = <statTemp>$12
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](foo: NilClass):
-    <gotoDeadTemp>$12: TrueClass = true
+    <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=2](foo: NilClass):
+bb10[rubyRegionId=0, firstDead=2](foo: NilClass):
     <returnMethodTemp>$2: NilClass = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
@@ -980,7 +993,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -1009,26 +1022,27 @@ bb5[rubyRegionId=4, firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass)
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$14: T.nilable(TrueClass)):
-    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$15: T.nilable(TrueClass)):
+    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>)):
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
-    <statTemp>$4: NilClass = nil
+    <statTemp>$14: NilClass = nil
+    <statTemp>$4: NilClass = <statTemp>$14
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
-    <gotoDeadTemp>$14: TrueClass = true
+    <gotoDeadTemp>$15: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
+bb10[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: NilClass)
     <returnMethodTemp>$2: T.untyped = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -1049,7 +1063,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -1078,26 +1092,27 @@ bb5[rubyRegionId=4, firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: N
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$22: T.nilable(TrueClass)):
-    <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$23: T.nilable(TrueClass)):
+    <gotoDeadTemp>$23 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>)):
     <exceptionValue>$13: NilClass = nil
     <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)
-    <statTemp>$12: NilClass = nil
+    <statTemp>$22: NilClass = nil
+    <statTemp>$12: NilClass = <statTemp>$22
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
-    <gotoDeadTemp>$22: TrueClass = true
+    <gotoDeadTemp>$23: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
+bb10[rubyRegionId=0, firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
     <statTemp>$8: T.untyped = <statTemp>$9: T.untyped.+(<statTemp>$12: NilClass)
     <returnMethodTemp>$2: T.untyped = []$3: T.untyped.[]=([]$4: Integer(0), <statTemp>$8: T.untyped)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -8,7 +8,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb9(rubyRegionId=3)
-# - bb12(rubyRegionId=0)
+# - bb13(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -44,25 +44,26 @@ bb6[rubyRegionId=4, firstDead=-1]():
 # - bb6(rubyRegionId=4)
 # - bb10(rubyRegionId=2)
 # - bb11(rubyRegionId=2)
-bb9[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$10: T.nilable(TrueClass)):
-    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb12)
+bb9[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$11: T.nilable(TrueClass)):
+    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb10[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <magic>$5: T.class_of(<Magic>)):
+bb10[rubyRegionId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <returnMethodTemp>$2: NilClass = <statTemp>$10
     <unconditional> -> bb9
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb11[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
-    <gotoDeadTemp>$10: TrueClass = true
+    <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb9
 
 # backedges
 # - bb9(rubyRegionId=3)
-bb12[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
+bb13[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
@@ -8,7 +8,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -41,26 +41,27 @@ bb5[rubyRegionId=4, firstDead=0](<returnMethodTemp>$2: NilClass):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass)):
-    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$16: T.nilable(TrueClass)):
+    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<magic>$8: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$9: Sorbet::Private::Static::Void = <magic>$8: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: Integer(3) = 3
+    <statTemp>$15: Integer(3) = 3
+    <returnMethodTemp>$2: Integer(3) = <statTemp>$15
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$15: TrueClass = true
+    <gotoDeadTemp>$16: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/rescue_let_var.rb
+++ b/test/testdata/cfg/rescue_let_var.rb
@@ -1,0 +1,34 @@
+# typed: true
+# frozen_string_literal: true
+
+extend T::Sig
+
+def mismatched_but_for_effect(params)
+  error_messages = T.let([], T::Array[String])
+
+  begin
+    T.let(params[:contents], T::Hash[String, String])
+  rescue TypeError
+    error_messages << "contents must be a hash of {path : contents}" # error: Incompatible assignment to variable declared via `let`: `T::Array[String]` is not a subtype of `NilClass`
+  end
+  nil
+end
+
+def mismatched_return_value(params)
+  error_messages = T.let([], T::Array[String])
+
+  begin
+    T.let(params[:contents], T::Hash[String, String])
+  rescue TypeError
+    error_messages << "contents must be a hash of {path : contents}" # error: Incompatible assignment to variable declared via `let`: `T::Array[String]` is not a subtype of `T::Hash[String, String]`
+  end
+end
+
+error_messages = T.let([], T::Array[String])
+params = { contents: "thing" }
+
+begin
+  T.let(params[:contents], T::Hash[String, String])
+rescue TypeError
+  error_messages << "contents must be a hash of {path : contents}" # error: Incompatible assignment to variable declared via `let`: `T::Array[String]` is not a subtype of `NilClass`
+end

--- a/test/testdata/cfg/rescue_let_var.rb
+++ b/test/testdata/cfg/rescue_let_var.rb
@@ -9,7 +9,7 @@ def mismatched_but_for_effect(params)
   begin
     T.let(params[:contents], T::Hash[String, String])
   rescue TypeError
-    error_messages << "contents must be a hash of {path : contents}" # error: Incompatible assignment to variable declared via `let`: `T::Array[String]` is not a subtype of `NilClass`
+    error_messages << "contents must be a hash of {path : contents}"
   end
   nil
 end
@@ -30,5 +30,5 @@ params = { contents: "thing" }
 begin
   T.let(params[:contents], T::Hash[String, String])
 rescue TypeError
-  error_messages << "contents must be a hash of {path : contents}" # error: Incompatible assignment to variable declared via `let`: `T::Array[String]` is not a subtype of `NilClass`
+  error_messages << "contents must be a hash of {path : contents}"
 end

--- a/test/testdata/cfg/rescue_let_var.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_let_var.rb.cfg-text.exp
@@ -17,7 +17,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -53,27 +53,27 @@ bb5[rubyRegionId=4, firstDead=-1]():
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$34: T.nilable(TrueClass)):
-    <gotoDeadTemp>$34 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$35: T.nilable(TrueClass)):
+    <gotoDeadTemp>$35 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](error_messages: T::Array[String], <magic>$27: T.class_of(<Magic>)):
     <exceptionValue>$14: NilClass = nil
     <keepForCfgTemp>$28: Sorbet::Private::Static::Void = <magic>$27: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$14: NilClass)
-    <statTemp>$33: String("contents must be a hash of {path : contents}") = "contents must be a hash of {path : contents}"
-    <statTemp>$13: NilClass = error_messages: T::Array[String].<<(<statTemp>$33: String("contents must be a hash of {path : contents}"))
+    <statTemp>$34: String("contents must be a hash of {path : contents}") = "contents must be a hash of {path : contents}"
+    <statTemp>$32: T::Array[String] = error_messages: T::Array[String].<<(<statTemp>$34: String("contents must be a hash of {path : contents}"))
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1]():
-    <gotoDeadTemp>$34: TrueClass = true
+    <gotoDeadTemp>$35: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=2]():
+bb10[rubyRegionId=0, firstDead=2]():
     <returnMethodTemp>$2: NilClass = nil
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
@@ -99,7 +99,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -135,27 +135,28 @@ bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T::Hash[String, String])
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(T::Hash[String, String]), <gotoDeadTemp>$33: T.nilable(TrueClass)):
-    <gotoDeadTemp>$33 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(T::Hash[String, String]), <gotoDeadTemp>$34: T.nilable(TrueClass)):
+    <gotoDeadTemp>$34 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(T::Hash[String, String]), error_messages: T::Array[String], <magic>$26: T.class_of(<Magic>)):
     <exceptionValue>$13: NilClass = nil
     <keepForCfgTemp>$27: Sorbet::Private::Static::Void = <magic>$26: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)
-    <statTemp>$32: String("contents must be a hash of {path : contents}") = "contents must be a hash of {path : contents}"
-    <returnMethodTemp>$2: T::Hash[String, String] = error_messages: T::Array[String].<<(<statTemp>$32: String("contents must be a hash of {path : contents}"))
+    <statTemp>$33: String("contents must be a hash of {path : contents}") = "contents must be a hash of {path : contents}"
+    <statTemp>$31: T::Array[String] = error_messages: T::Array[String].<<(<statTemp>$33: String("contents must be a hash of {path : contents}"))
+    <returnMethodTemp>$2: T::Hash[String, String] = <statTemp>$31
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(T::Hash[String, String])):
-    <gotoDeadTemp>$33: TrueClass = true
+    <gotoDeadTemp>$34: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T::Hash[String, String]):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T::Hash[String, String]):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Hash[String, String]
     <unconditional> -> bb1
 
@@ -186,7 +187,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -222,27 +223,27 @@ bb5[rubyRegionId=4, firstDead=-1]():
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$46: T.nilable(TrueClass)):
-    <gotoDeadTemp>$46 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$47: T.nilable(TrueClass)):
+    <gotoDeadTemp>$47 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](error_messages: T::Array[String], <magic>$39: T.class_of(<Magic>)):
     <exceptionValue>$26: NilClass = nil
     <keepForCfgTemp>$40: Sorbet::Private::Static::Void = <magic>$39: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$26: NilClass)
-    <statTemp>$45: String("contents must be a hash of {path : contents}") = "contents must be a hash of {path : contents}"
-    <statTemp>$25: NilClass = error_messages: T::Array[String].<<(<statTemp>$45: String("contents must be a hash of {path : contents}"))
+    <statTemp>$46: String("contents must be a hash of {path : contents}") = "contents must be a hash of {path : contents}"
+    <statTemp>$44: T::Array[String] = error_messages: T::Array[String].<<(<statTemp>$46: String("contents must be a hash of {path : contents}"))
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1]():
-    <gotoDeadTemp>$46: TrueClass = true
+    <gotoDeadTemp>$47: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1]():
+bb10[rubyRegionId=0, firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/rescue_let_var.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_let_var.rb.cfg-text.exp
@@ -1,0 +1,250 @@
+method ::Object#mismatched_but_for_effect {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: Object = cast(<self>: NilClass, Object);
+    params: T.untyped = load_arg(params)
+    <cfgAlias>$6: T.class_of(T::Array) = alias <C Array>
+    <cfgAlias>$8: T.class_of(T) = alias <C T>
+    <cfgAlias>$10: T.class_of(String) = alias <C String>
+    keep_for_ide$4: Runtime object representing type: T::Array[String] = <cfgAlias>$6: T.class_of(T::Array).[](<cfgAlias>$10: T.class_of(String))
+    keep_for_ide$4: T.untyped = <keep-alive> keep_for_ide$4
+    <magic>$12: T.class_of(<Magic>) = alias <C <Magic>>
+    <castTemp>$11: [] = <magic>$12: T.class_of(<Magic>).<build-array>()
+    error_messages: T::Array[String] = cast(<castTemp>$11: [], T::Array[String]);
+    <magic>$27: T.class_of(<Magic>) = alias <C <Magic>>
+    <exceptionValue>$14: T.untyped = <get-current-exception>
+    <exceptionValue>$14 -> (T.untyped ? bb3 : bb4)
+
+# backedges
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](error_messages: T::Array[String], <exceptionValue>$14: T.untyped, <magic>$27: T.class_of(<Magic>)):
+    <cfgAlias>$30: T.class_of(TypeError) = alias <C TypeError>
+    <isaCheckTemp>$31: T.untyped = <exceptionValue>$14: T.untyped.is_a?(<cfgAlias>$30: T.class_of(TypeError))
+    <isaCheckTemp>$31 -> (T.untyped ? bb7 : bb8)
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](params: T.untyped, error_messages: T::Array[String], <magic>$27: T.class_of(<Magic>)):
+    <cfgAlias>$17: T.class_of(T::Hash) = alias <C Hash>
+    <cfgAlias>$19: T.class_of(T) = alias <C T>
+    <cfgAlias>$21: T.class_of(String) = alias <C String>
+    <cfgAlias>$23: T.class_of(String) = alias <C String>
+    keep_for_ide$15: Runtime object representing type: T::Hash[String, String] = <cfgAlias>$17: T.class_of(T::Hash).[](<cfgAlias>$21: T.class_of(String), <cfgAlias>$23: T.class_of(String))
+    keep_for_ide$15: T.untyped = <keep-alive> keep_for_ide$15
+    <statTemp>$26: Symbol(:contents) = :contents
+    <castTemp>$24: T.untyped = params: T.untyped.[](<statTemp>$26: Symbol(:contents))
+    <statTemp>$13: T::Hash[String, String] = cast(<castTemp>$24: T.untyped, T::Hash[String, String]);
+    <exceptionValue>$14: T.untyped = <get-current-exception>
+    <exceptionValue>$14 -> (T.untyped ? bb3 : bb5)
+
+# backedges
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1]():
+    <unconditional> -> bb6
+
+# backedges
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$34: T.nilable(TrueClass)):
+    <gotoDeadTemp>$34 -> (T.nilable(TrueClass) ? bb1 : bb9)
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](error_messages: T::Array[String], <magic>$27: T.class_of(<Magic>)):
+    <exceptionValue>$14: NilClass = nil
+    <keepForCfgTemp>$28: Sorbet::Private::Static::Void = <magic>$27: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$14: NilClass)
+    <statTemp>$33: String("contents must be a hash of {path : contents}") = "contents must be a hash of {path : contents}"
+    <statTemp>$13: NilClass = error_messages: T::Array[String].<<(<statTemp>$33: String("contents must be a hash of {path : contents}"))
+    <unconditional> -> bb6
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1]():
+    <gotoDeadTemp>$34: TrueClass = true
+    <unconditional> -> bb6
+
+# backedges
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=2]():
+    <returnMethodTemp>$2: NilClass = nil
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+}
+
+method ::Object#mismatched_return_value {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: Object = cast(<self>: NilClass, Object);
+    params: T.untyped = load_arg(params)
+    <cfgAlias>$6: T.class_of(T::Array) = alias <C Array>
+    <cfgAlias>$8: T.class_of(T) = alias <C T>
+    <cfgAlias>$10: T.class_of(String) = alias <C String>
+    keep_for_ide$4: Runtime object representing type: T::Array[String] = <cfgAlias>$6: T.class_of(T::Array).[](<cfgAlias>$10: T.class_of(String))
+    keep_for_ide$4: T.untyped = <keep-alive> keep_for_ide$4
+    <magic>$12: T.class_of(<Magic>) = alias <C <Magic>>
+    <castTemp>$11: [] = <magic>$12: T.class_of(<Magic>).<build-array>()
+    error_messages: T::Array[String] = cast(<castTemp>$11: [], T::Array[String]);
+    <magic>$26: T.class_of(<Magic>) = alias <C <Magic>>
+    <exceptionValue>$13: T.untyped = <get-current-exception>
+    <exceptionValue>$13 -> (T.untyped ? bb3 : bb4)
+
+# backedges
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(T::Hash[String, String]), error_messages: T::Array[String], <exceptionValue>$13: T.untyped, <magic>$26: T.class_of(<Magic>)):
+    <cfgAlias>$29: T.class_of(TypeError) = alias <C TypeError>
+    <isaCheckTemp>$30: T.untyped = <exceptionValue>$13: T.untyped.is_a?(<cfgAlias>$29: T.class_of(TypeError))
+    <isaCheckTemp>$30 -> (T.untyped ? bb7 : bb8)
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](params: T.untyped, error_messages: T::Array[String], <magic>$26: T.class_of(<Magic>)):
+    <cfgAlias>$16: T.class_of(T::Hash) = alias <C Hash>
+    <cfgAlias>$18: T.class_of(T) = alias <C T>
+    <cfgAlias>$20: T.class_of(String) = alias <C String>
+    <cfgAlias>$22: T.class_of(String) = alias <C String>
+    keep_for_ide$14: Runtime object representing type: T::Hash[String, String] = <cfgAlias>$16: T.class_of(T::Hash).[](<cfgAlias>$20: T.class_of(String), <cfgAlias>$22: T.class_of(String))
+    keep_for_ide$14: T.untyped = <keep-alive> keep_for_ide$14
+    <statTemp>$25: Symbol(:contents) = :contents
+    <castTemp>$23: T.untyped = params: T.untyped.[](<statTemp>$25: Symbol(:contents))
+    <returnMethodTemp>$2: T::Hash[String, String] = cast(<castTemp>$23: T.untyped, T::Hash[String, String]);
+    <exceptionValue>$13: T.untyped = <get-current-exception>
+    <exceptionValue>$13 -> (T.untyped ? bb3 : bb5)
+
+# backedges
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T::Hash[String, String]):
+    <unconditional> -> bb6
+
+# backedges
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(T::Hash[String, String]), <gotoDeadTemp>$33: T.nilable(TrueClass)):
+    <gotoDeadTemp>$33 -> (T.nilable(TrueClass) ? bb1 : bb9)
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(T::Hash[String, String]), error_messages: T::Array[String], <magic>$26: T.class_of(<Magic>)):
+    <exceptionValue>$13: NilClass = nil
+    <keepForCfgTemp>$27: Sorbet::Private::Static::Void = <magic>$26: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)
+    <statTemp>$32: String("contents must be a hash of {path : contents}") = "contents must be a hash of {path : contents}"
+    <returnMethodTemp>$2: T::Hash[String, String] = error_messages: T::Array[String].<<(<statTemp>$32: String("contents must be a hash of {path : contents}"))
+    <unconditional> -> bb6
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(T::Hash[String, String])):
+    <gotoDeadTemp>$33: TrueClass = true
+    <unconditional> -> bb6
+
+# backedges
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T::Hash[String, String]):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Hash[String, String]
+    <unconditional> -> bb1
+
+}
+
+method ::<Class:<root>>#<static-init> {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
+    <cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$8: T.class_of(T) = alias <C T>
+    <statTemp>$3: T.class_of(<root>) = <self>: T.class_of(<root>).extend(<cfgAlias>$6: T.class_of(T::Sig))
+    <cfgAlias>$14: T.class_of(T::Array) = alias <C Array>
+    <cfgAlias>$16: T.class_of(T) = alias <C T>
+    <cfgAlias>$18: T.class_of(String) = alias <C String>
+    keep_for_ide$12: Runtime object representing type: T::Array[String] = <cfgAlias>$14: T.class_of(T::Array).[](<cfgAlias>$18: T.class_of(String))
+    keep_for_ide$12: T.untyped = <keep-alive> keep_for_ide$12
+    <magic>$20: T.class_of(<Magic>) = alias <C <Magic>>
+    <castTemp>$19: [] = <magic>$20: T.class_of(<Magic>).<build-array>()
+    error_messages: T::Array[String] = cast(<castTemp>$19: [], T::Array[String]);
+    <hashTemp>$22: Symbol(:contents) = :contents
+    <hashTemp>$23: String("thing") = "thing"
+    <magic>$24: T.class_of(<Magic>) = alias <C <Magic>>
+    params: {contents: String("thing")} = <magic>$24: T.class_of(<Magic>).<build-hash>(<hashTemp>$22: Symbol(:contents), <hashTemp>$23: String("thing"))
+    <magic>$39: T.class_of(<Magic>) = alias <C <Magic>>
+    <exceptionValue>$26: T.untyped = <get-current-exception>
+    <exceptionValue>$26 -> (T.untyped ? bb3 : bb4)
+
+# backedges
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](error_messages: T::Array[String], <exceptionValue>$26: T.untyped, <magic>$39: T.class_of(<Magic>)):
+    <cfgAlias>$42: T.class_of(TypeError) = alias <C TypeError>
+    <isaCheckTemp>$43: T.untyped = <exceptionValue>$26: T.untyped.is_a?(<cfgAlias>$42: T.class_of(TypeError))
+    <isaCheckTemp>$43 -> (T.untyped ? bb7 : bb8)
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](error_messages: T::Array[String], params: {contents: String("thing")}, <magic>$39: T.class_of(<Magic>)):
+    <cfgAlias>$29: T.class_of(T::Hash) = alias <C Hash>
+    <cfgAlias>$31: T.class_of(T) = alias <C T>
+    <cfgAlias>$33: T.class_of(String) = alias <C String>
+    <cfgAlias>$35: T.class_of(String) = alias <C String>
+    keep_for_ide$27: Runtime object representing type: T::Hash[String, String] = <cfgAlias>$29: T.class_of(T::Hash).[](<cfgAlias>$33: T.class_of(String), <cfgAlias>$35: T.class_of(String))
+    keep_for_ide$27: T.untyped = <keep-alive> keep_for_ide$27
+    <statTemp>$38: Symbol(:contents) = :contents
+    <castTemp>$36: T.untyped = params: {contents: String("thing")}.[](<statTemp>$38: Symbol(:contents))
+    <statTemp>$25: T::Hash[String, String] = cast(<castTemp>$36: T.untyped, T::Hash[String, String]);
+    <exceptionValue>$26: T.untyped = <get-current-exception>
+    <exceptionValue>$26 -> (T.untyped ? bb3 : bb5)
+
+# backedges
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1]():
+    <unconditional> -> bb6
+
+# backedges
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$46: T.nilable(TrueClass)):
+    <gotoDeadTemp>$46 -> (T.nilable(TrueClass) ? bb1 : bb9)
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](error_messages: T::Array[String], <magic>$39: T.class_of(<Magic>)):
+    <exceptionValue>$26: NilClass = nil
+    <keepForCfgTemp>$40: Sorbet::Private::Static::Void = <magic>$39: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$26: NilClass)
+    <statTemp>$45: String("contents must be a hash of {path : contents}") = "contents must be a hash of {path : contents}"
+    <statTemp>$25: NilClass = error_messages: T::Array[String].<<(<statTemp>$45: String("contents must be a hash of {path : contents}"))
+    <unconditional> -> bb6
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1]():
+    <gotoDeadTemp>$46: TrueClass = true
+    <unconditional> -> bb6
+
+# backedges
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1]():
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+}
+

--- a/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
@@ -10,7 +10,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 # - bb4(rubyRegionId=1)
 # - bb6(rubyRegionId=3)
 # - bb7(rubyRegionId=2)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
     <unconditional> -> bb1
@@ -31,27 +31,27 @@ bb4[rubyRegionId=1, firstDead=2]():
 
 # backedges
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <gotoDeadTemp>$12: TrueClass):
-    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <gotoDeadTemp>$13: TrueClass):
+    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=4](<magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <returnTemp>$11: Integer(2) = 2
-    <statTemp>$3: T.noreturn = return <returnTemp>$11: Integer(2)
+    <returnTemp>$12: Integer(2) = 2
+    <statTemp>$11: T.noreturn = return <returnTemp>$12: Integer(2)
     <unconditional> -> bb1
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: Object):
-    <gotoDeadTemp>$12: TrueClass = true
+    <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=0](<self>: Object):
+bb10[rubyRegionId=0, firstDead=0](<self>: Object):
     <returnMethodTemp>$2 = <self>.deadcode()
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
@@ -8,7 +8,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -38,29 +38,30 @@ bb5[rubyRegionId=4, firstDead=0](<returnMethodTemp>$2: NilClass):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$16: T.nilable(TrueClass)):
-    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$17: T.nilable(TrueClass)):
+    <gotoDeadTemp>$17 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>), <rescueTemp>$2: T.untyped):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <cfgAlias>$14: T.class_of(MyClass) = alias <C MyClass>
-    <statTemp>$12: MyClass = <cfgAlias>$14: T.class_of(MyClass).new()
-    <statTemp>$11: T.untyped = <statTemp>$12: MyClass.foo=(<rescueTemp>$2: T.untyped)
-    <returnMethodTemp>$2: Integer(3) = 3
+    <cfgAlias>$15: T.class_of(MyClass) = alias <C MyClass>
+    <statTemp>$13: MyClass = <cfgAlias>$15: T.class_of(MyClass).new()
+    <statTemp>$12: T.untyped = <statTemp>$13: MyClass.foo=(<rescueTemp>$2: T.untyped)
+    <statTemp>$11: Integer(3) = 3
+    <returnMethodTemp>$2: Integer(3) = <statTemp>$11
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$16: TrueClass = true
+    <gotoDeadTemp>$17: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
@@ -9,7 +9,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb4(rubyRegionId=1)
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$3 = <get-current-exception>
     <unconditional> -> bb1
@@ -31,25 +31,26 @@ bb4[rubyRegionId=1, firstDead=2]():
 # backedges
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$10: T.nilable(TrueClass)):
-    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <returnMethodTemp>$2: NilClass = <statTemp>$10
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1]():
-    <gotoDeadTemp>$10: TrueClass = true
+    <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1]():
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/retry.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry.rb.cfg-text.exp
@@ -8,7 +8,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb9(rubyRegionId=3)
-# - bb12(rubyRegionId=0)
+# - bb13(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -59,29 +59,29 @@ bb8[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
 # backedges
 # - bb8(rubyRegionId=4)
 # - bb11(rubyRegionId=2)
-bb9[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$24: T.nilable(TrueClass)):
-    <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb12)
+bb9[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$25: T.nilable(TrueClass)):
+    <gotoDeadTemp>$25 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb10[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$14: Sorbet::Private::Static::Void = <magic>$13: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <statTemp>$20: String("rescue") = "rescue"
-    <statTemp>$18: NilClass = <self>: Object.puts(<statTemp>$20: String("rescue"))
-    <magic>$22: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$23: Sorbet::Private::Static::Void = <magic>$22: T.class_of(<Magic>).<retry>()
+    <statTemp>$21: String("rescue") = "rescue"
+    <statTemp>$19: NilClass = <self>: Object.puts(<statTemp>$21: String("rescue"))
+    <magic>$23: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$24: Sorbet::Private::Static::Void = <magic>$23: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb11[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$24: TrueClass = true
+    <gotoDeadTemp>$25: TrueClass = true
     <unconditional> -> bb9
 
 # backedges
 # - bb9(rubyRegionId=3)
-bb12[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
+bb13[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
@@ -8,14 +8,14 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb12(rubyRegionId=3)
-# - bb17(rubyRegionId=0)
+# - bb19(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb13(rubyRegionId=2)
-# - bb15(rubyRegionId=2)
+# - bb16(rubyRegionId=2)
 bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
@@ -79,48 +79,48 @@ bb11[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
 
 # backedges
 # - bb11(rubyRegionId=4)
-# - bb16(rubyRegionId=2)
-bb12[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$46: T.nilable(TrueClass)):
-    <gotoDeadTemp>$46 -> (T.nilable(TrueClass) ? bb1 : bb17)
+# - bb17(rubyRegionId=2)
+bb12[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$48: T.nilable(TrueClass)):
+    <gotoDeadTemp>$48 -> (T.nilable(TrueClass) ? bb1 : bb19)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb13[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$26: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <statTemp>$32: String("rescue A ") = "rescue A "
-    <statTemp>$30: NilClass = <self>: Object.puts(<statTemp>$32: String("rescue A "))
-    <magic>$34: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$35: Sorbet::Private::Static::Void = <magic>$34: T.class_of(<Magic>).<retry>()
+    <statTemp>$33: String("rescue A ") = "rescue A "
+    <statTemp>$31: NilClass = <self>: Object.puts(<statTemp>$33: String("rescue A "))
+    <magic>$35: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$36: Sorbet::Private::Static::Void = <magic>$35: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb14[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$25: T.class_of(<Magic>)):
-    <cfgAlias>$38: T.class_of(B) = alias <C B>
-    <isaCheckTemp>$39: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$38: T.class_of(B))
-    <isaCheckTemp>$39 -> (T.untyped ? bb15 : bb16)
+    <cfgAlias>$39: T.class_of(B) = alias <C B>
+    <isaCheckTemp>$40: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$39: T.class_of(B))
+    <isaCheckTemp>$40 -> (T.untyped ? bb16 : bb17)
 
 # backedges
 # - bb14(rubyRegionId=2)
-bb15[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb16[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$36: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <statTemp>$42: String("rescue B ") = "rescue B "
-    <statTemp>$40: NilClass = <self>: Object.puts(<statTemp>$42: String("rescue B "))
-    <magic>$44: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$45: Sorbet::Private::Static::Void = <magic>$44: T.class_of(<Magic>).<retry>()
+    <keepForCfgTemp>$37: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
+    <statTemp>$44: String("rescue B ") = "rescue B "
+    <statTemp>$42: NilClass = <self>: Object.puts(<statTemp>$44: String("rescue B "))
+    <magic>$46: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$47: Sorbet::Private::Static::Void = <magic>$46: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb2
 
 # backedges
 # - bb14(rubyRegionId=2)
-bb16[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$46: TrueClass = true
+bb17[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+    <gotoDeadTemp>$48: TrueClass = true
     <unconditional> -> bb12
 
 # backedges
 # - bb12(rubyRegionId=3)
-bb17[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
+bb19[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/retry_nested.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg-text.exp
@@ -3,34 +3,34 @@ method ::Object#main {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
-    <magic>$42: T.class_of(<Magic>) = alias <C <Magic>>
+    <magic>$43: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
 # - bb15(rubyRegionId=7)
-# - bb20(rubyRegionId=3)
-# - bb23(rubyRegionId=0)
+# - bb21(rubyRegionId=3)
+# - bb25(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
 # - bb0(rubyRegionId=0)
-# - bb21(rubyRegionId=2)
-bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb22(rubyRegionId=2)
+bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
 
 # backedges
 # - bb2(rubyRegionId=0)
-# - bb18(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
-    <cfgAlias>$45: T.class_of(B) = alias <C B>
-    <isaCheckTemp>$46: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$45: T.class_of(B))
-    <isaCheckTemp>$46 -> (T.untyped ? bb21 : bb22)
+# - bb19(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
+    <cfgAlias>$46: T.class_of(B) = alias <C B>
+    <isaCheckTemp>$47: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$46: T.class_of(B))
+    <isaCheckTemp>$47 -> (T.untyped ? bb22 : bb23)
 
 # backedges
 # - bb2(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <statTemp>$7: String("top") = "top"
     <statTemp>$5: NilClass = <self>: Object.puts(<statTemp>$7: String("top"))
     <magic>$29: T.class_of(<Magic>) = alias <C <Magic>>
@@ -39,28 +39,28 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
 # backedges
 # - bb4(rubyRegionId=1)
 # - bb16(rubyRegionId=6)
-bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <exceptionValue>$8: T.untyped = <get-current-exception>
     <exceptionValue>$8 -> (T.untyped ? bb6 : bb7)
 
 # backedges
 # - bb5(rubyRegionId=1)
 # - bb13(rubyRegionId=5)
-bb6[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: T.untyped, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb6[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: T.untyped, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <cfgAlias>$32: T.class_of(A) = alias <C A>
     <isaCheckTemp>$33: T.untyped = <exceptionValue>$8: T.untyped.is_a?(<cfgAlias>$32: T.class_of(A))
     <isaCheckTemp>$33 -> (T.untyped ? bb16 : bb17)
 
 # backedges
 # - bb5(rubyRegionId=1)
-bb7[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb7[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <statTemp>$11: Integer(3) = 3
     <ifTemp>$9: T::Boolean = try: Integer(0).<(<statTemp>$11: Integer(3))
     <ifTemp>$9 -> (T::Boolean ? bb8 : bb9)
 
 # backedges
 # - bb7(rubyRegionId=5)
-bb8[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb8[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <statTemp>$13: Integer(0) = try
     <statTemp>$14: Integer(1) = 1
     try: Integer = <statTemp>$13: Integer(0).+(<statTemp>$14: Integer(1))
@@ -71,14 +71,14 @@ bb8[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.
 
 # backedges
 # - bb7(rubyRegionId=5)
-bb9[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb9[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <statTemp>$21: Integer(6) = 6
     <ifTemp>$19: T::Boolean = try: Integer(0).<(<statTemp>$21: Integer(6))
     <ifTemp>$19 -> (T::Boolean ? bb10 : bb13)
 
 # backedges
 # - bb9(rubyRegionId=5)
-bb10[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb10[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <statTemp>$23: Integer(0) = try
     <statTemp>$24: Integer(1) = 1
     try: Integer = <statTemp>$23: Integer(0).+(<statTemp>$24: Integer(1))
@@ -91,75 +91,75 @@ bb10[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T
 # - bb8(rubyRegionId=5)
 # - bb9(rubyRegionId=5)
 # - bb10(rubyRegionId=5)
-bb13[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb13[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <exceptionValue>$8: T.untyped = <get-current-exception>
     <exceptionValue>$8 -> (T.untyped ? bb6 : bb14)
 
 # backedges
 # - bb13(rubyRegionId=5)
-bb14[rubyRegionId=8, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb14[rubyRegionId=8, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <unconditional> -> bb15
 
 # backedges
 # - bb14(rubyRegionId=8)
 # - bb17(rubyRegionId=6)
-bb15[rubyRegionId=7, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: T.nilable(TrueClass), <magic>$42: T.class_of(<Magic>)):
-    <gotoDeadTemp>$40 -> (T.nilable(TrueClass) ? bb1 : bb18)
+bb15[rubyRegionId=7, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$41: T.nilable(TrueClass), <magic>$43: T.class_of(<Magic>)):
+    <gotoDeadTemp>$41 -> (T.nilable(TrueClass) ? bb1 : bb19)
 
 # backedges
 # - bb6(rubyRegionId=6)
-bb16[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb16[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <exceptionValue>$8: NilClass = nil
     <keepForCfgTemp>$30: Sorbet::Private::Static::Void = <magic>$29: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$8: NilClass)
-    <statTemp>$36: String("rescue A") = "rescue A"
-    <statTemp>$34: NilClass = <self>: Object.puts(<statTemp>$36: String("rescue A"))
-    <magic>$38: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$39: Sorbet::Private::Static::Void = <magic>$38: T.class_of(<Magic>).<retry>()
+    <statTemp>$37: String("rescue A") = "rescue A"
+    <statTemp>$35: NilClass = <self>: Object.puts(<statTemp>$37: String("rescue A"))
+    <magic>$39: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$40: Sorbet::Private::Static::Void = <magic>$39: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb5
 
 # backedges
 # - bb6(rubyRegionId=6)
-bb17[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>)):
-    <gotoDeadTemp>$40: TrueClass = true
+bb17[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$43: T.class_of(<Magic>)):
+    <gotoDeadTemp>$41: TrueClass = true
     <unconditional> -> bb15
 
 # backedges
 # - bb15(rubyRegionId=7)
-bb18[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb19[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb19)
+    <exceptionValue>$4 -> (T.untyped ? bb3 : bb20)
 
 # backedges
-# - bb18(rubyRegionId=1)
-bb19[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <unconditional> -> bb20
+# - bb19(rubyRegionId=1)
+bb20[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
+    <unconditional> -> bb21
 
 # backedges
-# - bb19(rubyRegionId=4)
-# - bb22(rubyRegionId=2)
-bb20[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$53: T.nilable(TrueClass)):
-    <gotoDeadTemp>$53 -> (T.nilable(TrueClass) ? bb1 : bb23)
+# - bb20(rubyRegionId=4)
+# - bb23(rubyRegionId=2)
+bb21[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$55: T.nilable(TrueClass)):
+    <gotoDeadTemp>$55 -> (T.nilable(TrueClass) ? bb1 : bb25)
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb21[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb22[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$41: NilClass, <magic>$43: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$43: Sorbet::Private::Static::Void = <magic>$42: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <statTemp>$49: String("rescue B ") = "rescue B "
-    <statTemp>$47: NilClass = <self>: Object.puts(<statTemp>$49: String("rescue B "))
-    <magic>$51: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$52: Sorbet::Private::Static::Void = <magic>$51: T.class_of(<Magic>).<retry>()
+    <keepForCfgTemp>$44: Sorbet::Private::Static::Void = <magic>$43: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
+    <statTemp>$51: String("rescue B ") = "rescue B "
+    <statTemp>$49: NilClass = <self>: Object.puts(<statTemp>$51: String("rescue B "))
+    <magic>$53: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$54: Sorbet::Private::Static::Void = <magic>$53: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb22[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$53: TrueClass = true
-    <unconditional> -> bb20
+bb23[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+    <gotoDeadTemp>$55: TrueClass = true
+    <unconditional> -> bb21
 
 # backedges
-# - bb20(rubyRegionId=3)
-bb23[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
+# - bb21(rubyRegionId=3)
+bb25[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -11,7 +11,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -49,29 +49,29 @@ bb5[rubyRegionId=4, firstDead=-1](<self>: T.class_of(<root>)):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <gotoDeadTemp>$29: T.nilable(TrueClass)):
-    <statTemp>$32: String("done") = "done"
-    <throwAwayTemp>$30: NilClass = <self>: T.class_of(<root>).p(<statTemp>$32: String("done"))
-    <gotoDeadTemp>$29 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <gotoDeadTemp>$30: T.nilable(TrueClass)):
+    <statTemp>$33: String("done") = "done"
+    <throwAwayTemp>$31: NilClass = <self>: T.class_of(<root>).p(<statTemp>$33: String("done"))
+    <gotoDeadTemp>$30 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <magic>$22: T.class_of(<Magic>)):
     <exceptionValue>$11: NilClass = nil
     <keepForCfgTemp>$23: Sorbet::Private::Static::Void = <magic>$22: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$11: NilClass)
-    <statTemp>$28: String("whoops") = "whoops"
-    <statTemp>$10: NilClass = <self>: T.class_of(<root>).p(<statTemp>$28: String("whoops"))
+    <statTemp>$29: String("whoops") = "whoops"
+    <statTemp>$27: NilClass = <self>: T.class_of(<root>).p(<statTemp>$29: String("whoops"))
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>)):
-    <gotoDeadTemp>$29: TrueClass = true
+    <gotoDeadTemp>$30: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1]():
+bb10[rubyRegionId=0, firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/uaf1.rb.cfg-text.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg-text.exp
@@ -32,8 +32,8 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb0(rubyRegionId=0)
-# - bb13(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: NilClass, <gotoDeadTemp>$15: NilClass):
+# - bb14(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: NilClass, <gotoDeadTemp>$16: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
@@ -46,7 +46,7 @@ bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Stati
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: NilClass, <gotoDeadTemp>$15: NilClass):
+bb5[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: NilClass, <gotoDeadTemp>$16: NilClass):
     # outerLoops: 1
     <self>: A = loadSelf(map)
     <magic>$10: T.class_of(<Magic>) = alias <C <Magic>>
@@ -56,7 +56,7 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
 # backedges
 # - bb5(rubyRegionId=1)
 # - bb8(rubyRegionId=2)
-bb7[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: T.untyped, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$15: NilClass):
+bb7[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: T.untyped, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$16: NilClass):
     # outerLoops: 1
     se$1: T.untyped = <exceptionValue>$9
     <cfgAlias>$13: T.class_of(StandardError) = alias <C StandardError>
@@ -65,7 +65,7 @@ bb7[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
 
 # backedges
 # - bb5(rubyRegionId=1)
-bb8[rubyRegionId=2, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$15: NilClass):
+bb8[rubyRegionId=2, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$16: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$8: Integer(1) = 1
     <exceptionValue>$9: T.untyped = <get-current-exception>
@@ -73,7 +73,7 @@ bb8[rubyRegionId=2, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
 
 # backedges
 # - bb8(rubyRegionId=2)
-bb9[rubyRegionId=5, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: Integer(1), <gotoDeadTemp>$15: NilClass):
+bb9[rubyRegionId=5, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: Integer(1), <gotoDeadTemp>$16: NilClass):
     # outerLoops: 1
     <unconditional> -> bb10
 
@@ -81,31 +81,32 @@ bb9[rubyRegionId=5, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
 # - bb9(rubyRegionId=5)
 # - bb11(rubyRegionId=3)
 # - bb12(rubyRegionId=3)
-bb10[rubyRegionId=4, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass)):
+bb10[rubyRegionId=4, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer), <gotoDeadTemp>$16: T.nilable(TrueClass)):
     # outerLoops: 1
-    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb13)
+    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb14)
 
 # backedges
 # - bb7(rubyRegionId=3)
-bb11[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$15: NilClass):
+bb11[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$16: NilClass):
     # outerLoops: 1
     <exceptionValue>$9: NilClass = nil
     <keepForCfgTemp>$11: Sorbet::Private::Static::Void = <magic>$10: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$9: NilClass)
-    <blockReturnTemp>$8: Integer(2) = 2
+    <statTemp>$15: Integer(2) = 2
+    <blockReturnTemp>$8: Integer(2) = <statTemp>$15
     <unconditional> -> bb10
 
 # backedges
 # - bb7(rubyRegionId=3)
 bb12[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer)):
     # outerLoops: 1
-    <gotoDeadTemp>$15: TrueClass = true
+    <gotoDeadTemp>$16: TrueClass = true
     <unconditional> -> bb10
 
 # backedges
 # - bb10(rubyRegionId=4)
-bb13[rubyRegionId=1, firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: Integer, <gotoDeadTemp>$15: NilClass):
+bb14[rubyRegionId=1, firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: Integer, <gotoDeadTemp>$16: NilClass):
     # outerLoops: 1
-    <blockReturnTemp>$17: T.noreturn = blockreturn<map> <blockReturnTemp>$8: Integer
+    <blockReturnTemp>$18: T.noreturn = blockreturn<map> <blockReturnTemp>$8: Integer
     <unconditional> -> bb2
 
 }

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -785,7 +785,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -819,29 +819,30 @@ bb5[rubyRegionId=4, firstDead=-1](<self>: String, <returnMethodTemp>$2: String):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$19: T.nilable(TrueClass)):
-    <cfgAlias>$22: T.class_of(T) = alias <C T>
-    <throwAwayTemp>$20: String = <cfgAlias>$22: T.class_of(T).reveal_type(<self>: String)
-    <gotoDeadTemp>$19 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$20: T.nilable(TrueClass)):
+    <cfgAlias>$23: T.class_of(T) = alias <C T>
+    <throwAwayTemp>$21: String = <cfgAlias>$23: T.class_of(T).reveal_type(<self>: String)
+    <gotoDeadTemp>$20 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: String, <magic>$11: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$12: Sorbet::Private::Static::Void = <magic>$11: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <cfgAlias>$17: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: String = <cfgAlias>$17: T.class_of(T).reveal_type(<self>: String)
+    <cfgAlias>$18: T.class_of(T) = alias <C T>
+    <statTemp>$16: String = <cfgAlias>$18: T.class_of(T).reveal_type(<self>: String)
+    <returnMethodTemp>$2: String = <statTemp>$16
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String)):
-    <gotoDeadTemp>$19: TrueClass = true
+    <gotoDeadTemp>$20: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String
     <unconditional> -> bb1
 
@@ -854,13 +855,13 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <magic>$11: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <self>: String = cast(<castTemp>$7: NilClass, String);
-    <self>: Integer = cast(<castTemp>$19: NilClass, Integer);
-    <self>: Float = cast(<castTemp>$28: NilClass, Float);
+    <self>: Integer = cast(<castTemp>$20: NilClass, Integer);
+    <self>: Float = cast(<castTemp>$29: NilClass, Float);
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -894,39 +895,40 @@ bb5[rubyRegionId=4, firstDead=-1](<self>: String, <returnMethodTemp>$2: String):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <gotoDeadTemp>$23: T.nilable(TrueClass)):
-    <cfgAlias>$27: T.class_of(Float) = alias <C Float>
-    keep_for_ide$26: T.class_of(Float) = <cfgAlias>$27
-    keep_for_ide$26: T.untyped = <keep-alive> keep_for_ide$26
-    <castTemp>$28: T.any(Float, String, Integer) = <self>
-    <self>: Float = cast(<castTemp>$28: T.any(Float, String, Integer), Float);
-    <cfgAlias>$30: T.class_of(T) = alias <C T>
-    <throwAwayTemp>$24: Float = <cfgAlias>$30: T.class_of(T).reveal_type(<self>: Float)
-    <gotoDeadTemp>$23 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <gotoDeadTemp>$24: T.nilable(TrueClass)):
+    <cfgAlias>$28: T.class_of(Float) = alias <C Float>
+    keep_for_ide$27: T.class_of(Float) = <cfgAlias>$28
+    keep_for_ide$27: T.untyped = <keep-alive> keep_for_ide$27
+    <castTemp>$29: T.any(Float, String, Integer) = <self>
+    <self>: Float = cast(<castTemp>$29: T.any(Float, String, Integer), Float);
+    <cfgAlias>$31: T.class_of(T) = alias <C T>
+    <throwAwayTemp>$25: Float = <cfgAlias>$31: T.class_of(T).reveal_type(<self>: Float)
+    <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <magic>$11: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$12: Sorbet::Private::Static::Void = <magic>$11: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <cfgAlias>$18: T.class_of(Integer) = alias <C Integer>
-    keep_for_ide$17: T.class_of(Integer) = <cfgAlias>$18
-    keep_for_ide$17: T.untyped = <keep-alive> keep_for_ide$17
-    <castTemp>$19: T.any(Float, String) = <self>
-    <self>: Integer = cast(<castTemp>$19: T.any(Float, String), Integer);
-    <cfgAlias>$21: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: Integer = <cfgAlias>$21: T.class_of(T).reveal_type(<self>: Integer)
+    <cfgAlias>$19: T.class_of(Integer) = alias <C Integer>
+    keep_for_ide$18: T.class_of(Integer) = <cfgAlias>$19
+    keep_for_ide$18: T.untyped = <keep-alive> keep_for_ide$18
+    <castTemp>$20: T.any(Float, String) = <self>
+    <self>: Integer = cast(<castTemp>$20: T.any(Float, String), Integer);
+    <cfgAlias>$22: T.class_of(T) = alias <C T>
+    <statTemp>$16: Integer = <cfgAlias>$22: T.class_of(T).reveal_type(<self>: Integer)
+    <returnMethodTemp>$2: Integer = <statTemp>$16
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String)):
-    <gotoDeadTemp>$23: TrueClass = true
+    <gotoDeadTemp>$24: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.any(Integer, String)):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.any(Integer, String)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.any(Integer, String)
     <unconditional> -> bb1
 
@@ -945,7 +947,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -979,27 +981,28 @@ bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: String):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$23: T.nilable(TrueClass)):
-    <gotoDeadTemp>$23 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$24: T.nilable(TrueClass)):
+    <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb7[rubyRegionId=2, firstDead=-1](<self>: String, <magic>$15: T.class_of(<Magic>)):
     <exceptionValue>$7: NilClass = nil
     <keepForCfgTemp>$16: Sorbet::Private::Static::Void = <magic>$15: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$7: NilClass)
-    <cfgAlias>$21: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: String = <cfgAlias>$21: T.class_of(T).reveal_type(<self>: String)
+    <cfgAlias>$22: T.class_of(T) = alias <C T>
+    <statTemp>$20: String = <cfgAlias>$22: T.class_of(T).reveal_type(<self>: String)
+    <returnMethodTemp>$2: String = <statTemp>$20
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(String)):
-    <gotoDeadTemp>$23: TrueClass = true
+    <gotoDeadTemp>$24: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String
     <unconditional> -> bb1
 
@@ -1021,8 +1024,8 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb0(rubyRegionId=0)
-# - bb13(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: NilClass, <castTemp>$14: NilClass, <gotoDeadTemp>$26: NilClass):
+# - bb14(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: NilClass, <castTemp>$14: NilClass, <gotoDeadTemp>$27: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
@@ -1035,7 +1038,7 @@ bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$6: Sorbet::Private::Stati
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: NilClass, <castTemp>$14: NilClass, <gotoDeadTemp>$26: NilClass):
+bb5[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: NilClass, <castTemp>$14: NilClass, <gotoDeadTemp>$27: NilClass):
     # outerLoops: 1
     <self>: T.class_of(Rescues) = loadSelf(takes_block)
     <magic>$18: T.class_of(<Magic>) = alias <C <Magic>>
@@ -1046,7 +1049,7 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-t
 # backedges
 # - bb5(rubyRegionId=1)
 # - bb8(rubyRegionId=2)
-bb7[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: T.nilable(Integer), <exceptionValue>$10: T.untyped, <castTemp>$14: T.nilable(Integer), <magic>$18: T.class_of(<Magic>), <gotoDeadTemp>$26: NilClass):
+bb7[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: T.nilable(Integer), <exceptionValue>$10: T.untyped, <castTemp>$14: T.nilable(Integer), <magic>$18: T.class_of(<Magic>), <gotoDeadTemp>$27: NilClass):
     # outerLoops: 1
     <cfgAlias>$21: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$22: T.untyped = <exceptionValue>$10: T.untyped.is_a?(<cfgAlias>$21: T.class_of(StandardError))
@@ -1054,7 +1057,7 @@ bb7[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorb
 
 # backedges
 # - bb5(rubyRegionId=1)
-bb8[rubyRegionId=2, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <magic>$18: T.class_of(<Magic>), <gotoDeadTemp>$26: NilClass):
+bb8[rubyRegionId=2, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <magic>$18: T.class_of(<Magic>), <gotoDeadTemp>$27: NilClass):
     # outerLoops: 1
     <cfgAlias>$13: T.class_of(Integer) = alias <C Integer>
     keep_for_ide$12: T.class_of(Integer) = <cfgAlias>$13
@@ -1068,7 +1071,7 @@ bb8[rubyRegionId=2, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorb
 
 # backedges
 # - bb8(rubyRegionId=2)
-bb9[rubyRegionId=5, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: Integer, <castTemp>$14: Integer, <gotoDeadTemp>$26: NilClass):
+bb9[rubyRegionId=5, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: Integer, <castTemp>$14: Integer, <gotoDeadTemp>$27: NilClass):
     # outerLoops: 1
     <unconditional> -> bb10
 
@@ -1076,32 +1079,33 @@ bb9[rubyRegionId=5, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorb
 # - bb9(rubyRegionId=5)
 # - bb11(rubyRegionId=3)
 # - bb12(rubyRegionId=3)
-bb10[rubyRegionId=4, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: T.nilable(Integer), <castTemp>$14: T.nilable(Integer), <gotoDeadTemp>$26: T.nilable(TrueClass)):
+bb10[rubyRegionId=4, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: T.nilable(Integer), <castTemp>$14: T.nilable(Integer), <gotoDeadTemp>$27: T.nilable(TrueClass)):
     # outerLoops: 1
-    <gotoDeadTemp>$26 -> (T.nilable(TrueClass) ? bb1 : bb13)
+    <gotoDeadTemp>$27 -> (T.nilable(TrueClass) ? bb1 : bb14)
 
 # backedges
 # - bb7(rubyRegionId=3)
-bb11[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <castTemp>$14: T.nilable(Integer), <magic>$18: T.class_of(<Magic>), <gotoDeadTemp>$26: NilClass):
+bb11[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <castTemp>$14: T.nilable(Integer), <magic>$18: T.class_of(<Magic>), <gotoDeadTemp>$27: NilClass):
     # outerLoops: 1
     <exceptionValue>$10: NilClass = nil
     <keepForCfgTemp>$19: Sorbet::Private::Static::Void = <magic>$18: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$10: NilClass)
-    <cfgAlias>$24: T.class_of(T) = alias <C T>
-    <blockReturnTemp>$9: Integer = <cfgAlias>$24: T.class_of(T).reveal_type(<self>: Integer)
+    <cfgAlias>$25: T.class_of(T) = alias <C T>
+    <statTemp>$23: Integer = <cfgAlias>$25: T.class_of(T).reveal_type(<self>: Integer)
+    <blockReturnTemp>$9: Integer = <statTemp>$23
     <unconditional> -> bb10
 
 # backedges
 # - bb7(rubyRegionId=3)
 bb12[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: T.nilable(Integer), <castTemp>$14: T.nilable(Integer)):
     # outerLoops: 1
-    <gotoDeadTemp>$26: TrueClass = true
+    <gotoDeadTemp>$27: TrueClass = true
     <unconditional> -> bb10
 
 # backedges
 # - bb10(rubyRegionId=4)
-bb13[rubyRegionId=1, firstDead=1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: Integer, <castTemp>$14: T.nilable(Integer), <gotoDeadTemp>$26: NilClass):
+bb14[rubyRegionId=1, firstDead=1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$9: Integer, <castTemp>$14: T.nilable(Integer), <gotoDeadTemp>$27: NilClass):
     # outerLoops: 1
-    <blockReturnTemp>$28: T.noreturn = blockreturn<takes_block> <blockReturnTemp>$9: Integer
+    <blockReturnTemp>$29: T.noreturn = blockreturn<takes_block> <blockReturnTemp>$9: Integer
     <unconditional> -> bb2
 
 }

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -27,7 +27,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb6(rubyRegionId=3)
-# - bb24(rubyRegionId=0)
+# - bb25(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
@@ -55,8 +55,8 @@ bb5[rubyRegionId=4, firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError), <gotoDeadTemp>$10: T.nilable(TrueClass)):
-    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError), <gotoDeadTemp>$11: T.nilable(TrueClass)):
+    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3(rubyRegionId=2)
@@ -69,73 +69,73 @@ bb7[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <mag
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
-    <gotoDeadTemp>$10: TrueClass = true
+    <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError)):
+bb10[rubyRegionId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError)):
     is_successful: T::Boolean = err: T.nilable(StandardError).nil?()
-    is_successful -> (T::Boolean ? bb10 : bb11)
+    is_successful -> (T::Boolean ? bb11 : bb12)
 
 # backedges
-# - bb9(rubyRegionId=0)
-bb10[rubyRegionId=0, firstDead=-1](foo: T.untyped, err: NilClass, is_successful: TrueClass):
+# - bb10(rubyRegionId=0)
+bb11[rubyRegionId=0, firstDead=-1](foo: T.untyped, err: NilClass, is_successful: TrueClass):
     ||$2: TrueClass = is_successful
-    ||$2 -> (TrueClass ? bb13 : bb14)
+    ||$2 -> (TrueClass ? bb14 : bb15)
 
 # backedges
-# - bb9(rubyRegionId=0)
-bb11[rubyRegionId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: StandardError, is_successful: FalseClass):
+# - bb10(rubyRegionId=0)
+bb12[rubyRegionId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: StandardError, is_successful: FalseClass):
     ||$2: T.untyped = final_attempt
-    ||$2 -> (T.untyped ? bb13 : bb14)
+    ||$2 -> (T.untyped ? bb14 : bb15)
 
 # backedges
-# - bb10(rubyRegionId=0)
 # - bb11(rubyRegionId=0)
-bb13[rubyRegionId=0, firstDead=-1](is_successful: T::Boolean, ||$2: T.untyped):
-    <ifTemp>$14: T.untyped = ||$2
-    <ifTemp>$14 -> (T.untyped ? bb19 : bb24)
+# - bb12(rubyRegionId=0)
+bb14[rubyRegionId=0, firstDead=-1](is_successful: T::Boolean, ||$2: T.untyped):
+    <ifTemp>$15: T.untyped = ||$2
+    <ifTemp>$15 -> (T.untyped ? bb20 : bb25)
 
 # backedges
-# - bb10(rubyRegionId=0)
 # - bb11(rubyRegionId=0)
-bb14[rubyRegionId=0, firstDead=-1](foo: T.untyped, err: StandardError, is_successful: FalseClass):
-    err -> (StandardError ? bb15 : bb16)
+# - bb12(rubyRegionId=0)
+bb15[rubyRegionId=0, firstDead=-1](foo: T.untyped, err: StandardError, is_successful: FalseClass):
+    err -> (StandardError ? bb16 : bb17)
 
 # backedges
-# - bb14(rubyRegionId=0)
-bb15[rubyRegionId=0, firstDead=-1](foo: T.untyped, is_successful: FalseClass):
-    <ifTemp>$14: T.untyped = foo
-    <ifTemp>$14 -> (T.untyped ? bb19 : bb24)
-
-# backedges
-# - bb14(rubyRegionId=0)
-bb16[rubyRegionId=0, firstDead=0](err: StandardError, is_successful: FalseClass):
-    <ifTemp>$14 = err
-    <ifTemp>$14 -> (<nullptr> ? bb19 : bb24)
-
-# backedges
-# - bb13(rubyRegionId=0)
 # - bb15(rubyRegionId=0)
-# - bb16(rubyRegionId=0)
-bb19[rubyRegionId=0, firstDead=-1](is_successful: T::Boolean):
-    <ifTemp>$19: T::Boolean = is_successful: T::Boolean.!()
-    <ifTemp>$19 -> (T::Boolean ? bb21 : bb24)
+bb16[rubyRegionId=0, firstDead=-1](foo: T.untyped, is_successful: FalseClass):
+    <ifTemp>$15: T.untyped = foo
+    <ifTemp>$15 -> (T.untyped ? bb20 : bb25)
 
 # backedges
-# - bb19(rubyRegionId=0)
-bb21[rubyRegionId=0, firstDead=-1]():
+# - bb15(rubyRegionId=0)
+bb17[rubyRegionId=0, firstDead=0](err: StandardError, is_successful: FalseClass):
+    <ifTemp>$15 = err
+    <ifTemp>$15 -> (<nullptr> ? bb20 : bb25)
+
+# backedges
+# - bb14(rubyRegionId=0)
+# - bb16(rubyRegionId=0)
+# - bb17(rubyRegionId=0)
+bb20[rubyRegionId=0, firstDead=-1](is_successful: T::Boolean):
+    <ifTemp>$20: T::Boolean = is_successful: T::Boolean.!()
+    <ifTemp>$20 -> (T::Boolean ? bb22 : bb25)
+
+# backedges
+# - bb20(rubyRegionId=0)
+bb22[rubyRegionId=0, firstDead=-1]():
     <returnMethodTemp>$2: Integer(1) = 1
-    <unconditional> -> bb24
+    <unconditional> -> bb25
 
 # backedges
-# - bb13(rubyRegionId=0)
-# - bb15(rubyRegionId=0)
+# - bb14(rubyRegionId=0)
 # - bb16(rubyRegionId=0)
-# - bb19(rubyRegionId=0)
-# - bb21(rubyRegionId=0)
-bb24[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
+# - bb17(rubyRegionId=0)
+# - bb20(rubyRegionId=0)
+# - bb22(rubyRegionId=0)
+bb25[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Somebody at Stripe reported a bug ([sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%23%20frozen_string_literal%3A%20true%0A%0Aerror_messages%20%3D%20T.let%28%5B%5D%2C%20T%3A%3AArray%5BString%5D%29%0Aparams%20%3D%20%7B%20contents%3A%20%22thing%22%20%7D%0A%0Abegin%0A%20%20T.let%28params%5B%3Acontents%5D%2C%20T%3A%3AHash%5BString%2C%20String%5D%29%0Arescue%20TypeError%0A%20%20error_messages%20%3C%3C%20%22contents%20must%20be%20a%20hash%20of%20%7Bpath%20%3A%20contents%7D%22%0Aend)) with a weird error message.

I don't exactly understand why having the `begin`/`rescue`/`end` in non-value position makes Sorbet think that the derived type is `NilClass`.  I'm sure there's something weird about how the exception handling mechanism works that makes things come out to be `NilClass`.

This PR fixes the bug; intuitively, I think the idea is that the `rescue` body actually has its own result value, which it should generate into a fresh temporary, rather than generating directly into whatever temporary the context of the entire `begin`/`rescue`/`end` is using.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  Ideally the tests prove that actually using the result of `begin`/`rescue`/`end` still works properly, along with whatever other tests might depend on that.
