### PR TITLE
ARM Linux builds, cont'd

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,7 @@ common:test --test_env=GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1
 ##
 ##  Custom toolchain.
 ##
-build --crosstool_top=@llvm_toolchain_12_0_0//:toolchain --copt=-D_LIBCPP_ENABLE_NODISCARD
+build --incompatible_enable_cc_toolchain_resolution --copt=-D_LIBCPP_ENABLE_NODISCARD
 
 ##
 ##  Common build options across all build configurations
@@ -98,6 +98,10 @@ build:release-debug-common --config=skipslowenforce
 build:release-linux --linkopt=-Wl,-z,relro,-z,now
 build:release-linux --config=lto-linux --config=release-common --platforms=@//tools/config:linux_x86_64
 
+build:release-linux-aarch64 --linkopt=-Wl,-z,relro,-z,now
+build:release-linux-aarch64 --config=lto-linux --config=release-common --platforms=@//tools/config:linux_aarch64
+
+
 # This is to turn on vector instructions where available.
 # We used to do this unconditionally, but Rosetta 2 doesn't translate all vector instructions well.
 #
@@ -111,7 +115,7 @@ build:release-sanitized-linux --copt=-march=sandybridge
 
 build:release-mac --config=release-common --platforms=@//tools/config:darwin_x86_64
 
-build:release-debug-linux --config=release-linux
+build:release-debug-linux --config=release-linux-x86_64
 build:release-debug-linux --config=release-debug-common
 
 build:release-debug-mac --config=release-mac

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -26,14 +26,6 @@ case "$platform" in
     ;;
 esac
 
-
-if [[ "linux" == "$platform" ]]; then
-  CONFIG_OPTS="--config=release-linux"
-elif [[ "mac" == "$platform" ]]; then
-  CONFIG_OPTS="--config=release-mac"
-  command -v autoconf >/dev/null 2>&1 || brew install autoconf
-fi
-
 echo will run with $CONFIG_OPTS
 
 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
@@ -47,7 +39,7 @@ pushd gems/sorbet-static
 git_commit_count=$(git rev-list --count HEAD)
 release_version="0.5.${git_commit_count}"
 sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-static.gemspec
-if [[ "mac" == "$platform" ]]; then
+if [[ "darwin" == "$kernel_name" ]]; then
     # Our binary should work on almost all OSes. The oldest v8 publishes is -14
     # so I'm going with that for now.
     for i in {14..22}; do
@@ -85,7 +77,7 @@ rbenv exec gem uninstall --all --executables --ignore-dependencies minitest moch
 rbenv exec gem uninstall --all --executables --ignore-dependencies sorbet sorbet-static
 trap 'rbenv exec gem uninstall --all --executables --ignore-dependencies sorbet sorbet-static' EXIT
 
-if [[ "mac" == "$platform" ]]; then
+if [[ "darwin" == "$kernel_name" ]]; then
   gem_platform="$(ruby -e "(platform = Gem::Platform.local).cpu = 'universal'; puts(platform.to_s)")"
   rbenv exec gem install ../../gems/sorbet-static/sorbet-static-*-"$gem_platform".gem
 else

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,10 +17,10 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 llvm_toolchain(
     name = "llvm_toolchain_12_0_0",
     absolute_paths = True,
-    llvm_mirror_prefixes = [
-        "https://sorbet-deps.s3-us-west-2.amazonaws.com/",
-        "https://artifactory-content.stripe.build/artifactory/github-archives/llvm/llvm-project/releases/download/llvmorg-",
-        "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    alternative_llvm_sources = [
+        "https://sorbet-deps.s3-us-west-2.amazonaws.com/{llvm_version}/{basename}",
+        "https://artifactory-content.stripe.build/artifactory/github-archives/llvm/llvm-project/releases/download/llvmorg-{llvm_version}/{basename}",
+        "https://github.com/llvm/llvm-project/releases/download/llvmorg-{llvm_version}/{basename}",
     ],
     llvm_version = "12.0.0",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,6 +25,10 @@ llvm_toolchain(
     llvm_version = "12.0.0",
 )
 
+load("@llvm_toolchain_12_0_0//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()
+
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
@@ -58,6 +62,8 @@ node_repositories()
 BAZEL_VERSION = "5.2.0"
 
 BAZEL_INSTALLER_VERSION_LINUX_X86_64_SHA = "7d9ef51beab5726c55725fb36675c6fed0518576d3ba51fb4067580ddf7627c4"
+
+BAZEL_INSTALLER_VERSION_LINUX_ARM64_SHA = "ae50cb7d64aebee986287134ff8ca0335651a0c1685348b3216f3fdfa20ff7e7"
 
 BAZEL_INSTALLER_VERSION_DARWIN_X86_64_SHA = "645e7c335efc3207905e98f0c56a598b7cb0282d54d9470e80f38fb698064fb3"
 

--- a/bazel
+++ b/bazel
@@ -55,6 +55,7 @@ processor_name="$(uname -m)"
 bazel_installer_platform="${kernel_name}-${processor_name}"
 case "$bazel_installer_platform" in
   linux-x86_64) ;;
+  linux-arm64) ;;
   darwin-x86_64) ;;
   darwin-arm64)
     # Pseudo Apple Silicon support by forcing x86_64 (Rosetta) for now

--- a/common/crypto_hashing/BUILD
+++ b/common/crypto_hashing/BUILD
@@ -8,8 +8,8 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = ["//common"] + select({
         "//tools/config:webasm": ["@com_github_blake2_blake2"],
-        "//tools/config:darwin": ["@com_github_blake2_libb2"],
-        "//tools/config:linux": ["@com_github_blake2_libb2"],
+        "//tools/config:darwin": ["@com_github_blake2_blake2"],
+        "//tools/config:linux": ["@com_github_blake2_blake2"],
         "//conditions:default": ["@com_github_blake2_blake2"],
     }),
 )

--- a/common/crypto_hashing/BUILD
+++ b/common/crypto_hashing/BUILD
@@ -8,8 +8,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = ["//common"] + select({
         "//tools/config:webasm": ["@com_github_blake2_blake2"],
-        "//tools/config:darwin": ["@com_github_blake2_blake2"],
-        "//tools/config:linux": ["@com_github_blake2_blake2"],
+        "//tools/config:x86_64": ["@com_github_blake2_libb2"],
         "//conditions:default": ["@com_github_blake2_blake2"],
     }),
 )

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -168,15 +168,11 @@ def register_sorbet_dependencies():
         strip_prefix = "bazel-compilation-database-6b9329e37295eab431f82af5fe24219865403e0f",
     )
 
-    LLVM_BAZEL_TOOLCHAIN_TAG = "0.7.2"
-    LLVM_BAZEL_TOOLCHAIN_SHA = "f7aa8e59c9d3cafde6edb372d9bd25fb4ee7293ab20b916d867cd0baaa642529"
-
     http_archive(
         name = "com_grail_bazel_toolchain",
-        sha256 = LLVM_BAZEL_TOOLCHAIN_SHA,
-        strip_prefix = "bazel-toolchain-{tag}".format(tag = LLVM_BAZEL_TOOLCHAIN_TAG),
-        canonical_id = LLVM_BAZEL_TOOLCHAIN_TAG,
-        url = "https://github.com/grailbio/bazel-toolchain/archive/{tag}.tar.gz".format(tag = LLVM_BAZEL_TOOLCHAIN_TAG),
+        urls = _github_public_urls("radiopaedia/bazel-toolchain/archive/29883c8ee6eeab161f1fcc10900e3db5a8d86e8b.zip"),
+        sha256 = "264d0f25322697819af99e6d2269aeca464c832b219387f30d858090ec28da66",
+        strip_prefix = "bazel-toolchain-29883c8ee6eeab161f1fcc10900e3db5a8d86e8b",
     )
 
     http_archive(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -112,6 +112,9 @@ def register_sorbet_dependencies():
         sha256 = "1cc1ec93701868691c73b371eb87e5452257996279a42303a91caad355374439",
         build_file = "@com_stripe_ruby_typer//third_party:jemalloc.BUILD",
         strip_prefix = "jemalloc-20f9802e4f25922884448d9581c66d76cc905c0c",
+        patches = [
+            "@com_stripe_ruby_typer//third_party:jemalloc/configure.ac.patch",
+        ],
     )
 
     http_archive(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -168,12 +168,15 @@ def register_sorbet_dependencies():
         strip_prefix = "bazel-compilation-database-6b9329e37295eab431f82af5fe24219865403e0f",
     )
 
-    # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain
+    LLVM_BAZEL_TOOLCHAIN_TAG = "0.7.2"
+    LLVM_BAZEL_TOOLCHAIN_SHA = "f7aa8e59c9d3cafde6edb372d9bd25fb4ee7293ab20b916d867cd0baaa642529"
+
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("sorbet/bazel-toolchain/archive/a685e1e6bd1e7cc9a5b84f832539585bb68d8ab4.zip"),
-        sha256 = "90c59f14cada755706a38bdd0f5ad8f0402cbf766387929cfbee9c3f1b4c82d7",
-        strip_prefix = "bazel-toolchain-a685e1e6bd1e7cc9a5b84f832539585bb68d8ab4",
+        sha256 = LLVM_BAZEL_TOOLCHAIN_SHA,
+        strip_prefix = "bazel-toolchain-{tag}".format(tag = LLVM_BAZEL_TOOLCHAIN_TAG),
+        canonical_id = LLVM_BAZEL_TOOLCHAIN_TAG,
+        url = "https://github.com/grailbio/bazel-toolchain/archive/{tag}.tar.gz".format(tag = LLVM_BAZEL_TOOLCHAIN_TAG),
     )
 
     http_archive(
@@ -196,7 +199,7 @@ def register_sorbet_dependencies():
         strip_prefix = "buildtools-5bcc31df55ec1de770cb52887f2e989e7068301f",
     )
 
-    # optimized version of blake2 hashing algorithm
+    # optimized version of blake2 hashing algorithm	
     http_archive(
         name = "com_github_blake2_libb2",
         urls = _github_public_urls("BLAKE2/libb2/archive/fa83ddbe179912e9a7a57edf0333b33f6ff83056.zip"),

--- a/third_party/jemalloc/configure.ac.patch
+++ b/third_party/jemalloc/configure.ac.patch
@@ -1,0 +1,13 @@
+--- configure.ac	2023-01-01 20:16:12
++++ configure.ac	2023-01-01 20:16:09
+@@ -495,6 +495,10 @@
+ 	if (vaddr > (sizeof(void *) << 3)) {
+ 		vaddr = sizeof(void *) << 3;
+ 	}
++	if (vaddr == 0) {
++		/* HACK: See https://github.com/jemalloc/jemalloc/issues/1997. */
++		vaddr = 48;
++	}
+ 	fprintf(f, "%u", vaddr);
+ 	fclose(f);
+ 	return 0;

--- a/third_party/llvm/llvm.bzl
+++ b/third_party/llvm/llvm.bzl
@@ -307,10 +307,18 @@ llvm_all_cmake_vars = select({
             darwin_cmake_vars,
         ),
     ),
-    "@com_stripe_ruby_typer//tools/config:linux": cmake_var_string(
+    "@com_stripe_ruby_typer//tools/config:linux_x86_64": cmake_var_string(
         _dict_add(
             cmake_vars,
             llvm_target_cmake_vars("X86", "x86_64-unknown-linux_gnu"),
+            posix_cmake_vars,
+            linux_cmake_vars,
+        ),
+    ),
+    "@com_stripe_ruby_typer//tools/config:linux_aarch64": cmake_var_string(
+        _dict_add(
+            cmake_vars,
+            llvm_target_cmake_vars("AARCH64", "aarch64-unknown-linux_gnu"),
             posix_cmake_vars,
             linux_cmake_vars,
         ),

--- a/tools/clang.bzl
+++ b/tools/clang.bzl
@@ -30,6 +30,6 @@ _clang_tool = rule(
 def clang_tool(name):
     _clang_tool(
         name = name,
-        tool = "@llvm_toolchain_12_0_0//:bin/" + name,
+        tool = "@llvm_toolchain_12_0_0//:" + name,
         visibility = ["//visibility:public"],
     )

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -16,6 +16,14 @@ platform(
     ],
 )
 
+platform(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
 config_setting(
     name = "darwin",
     constraint_values = [
@@ -28,7 +36,6 @@ config_setting(
     name = "linux",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
     ],
 )
 

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -40,6 +40,13 @@ config_setting(
 )
 
 config_setting(
+    name = "x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
     name = "opt",
     values = {"compilation_mode": "opt"},
 )


### PR DESCRIPTION
This is a continuation of @ethankhall's work from #6485, rebased and brought up to speed. There is a complimentary PR for the `bazel-toolchain` fork which brings your changes in [sorbet/bazel-toolchain](https://github.com/sorbet/bazel-toolchain/tree/sorbet) up-to-date with [grailbio/bazel-toolchain](https://github.com/grailbio/bazel-toolchain) at https://github.com/sorbet/bazel-toolchain/pull/2.

While Linux ARM builds can be successfully made with this, I haven't quite gotten all the rebasing and rejigging such that _other_ builds are unaffected. I haven't yet tested platform/arch combos outside of Linux/arm64 and Darwin/{x86_64,arm64}.

This is largely due to the change to using `--incompatible_enable_cc_toolchain_resolution`. This appears to be the way forward for Bazel/C++, so I've been trying to work towards getting this working properly.

<details><summary>Build log and test run on Linux arm64</summary>

```
ubuntu-linux-20-04-desktop ~/C/sorbet (ethankhall/arm-build|✔) $ git rev-parse HEAD
d99e80344789b6bc45ae146f5eda30636143ae88
ubuntu-linux-20-04-desktop ~/C/sorbet (ethankhall/arm-build|✔) $ git status
On branch ethankhall/arm-build
Your branch is up to date with 'origin/ethankhall/arm-build'.

nothing to commit, working tree clean
ubuntu-linux-20-04-desktop ~/C/sorbet (ethankhall/arm-build|✔) $ time ../bazelisk clean --expunge
Starting local Bazel server and connecting to it...
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.

________________________________________________________
Executed in    1.18 secs   fish           external
   usr time    6.38 millis  950.00 micros    5.43 millis
   sys time   11.31 millis  481.00 micros   10.83 millis

ubuntu-linux-20-04-desktop ~/C/sorbet (ethankhall/arm-build|✔) $ time ../bazelisk build //main:sorbet --config=release-linux-aarch64 --strip=always
Starting local Bazel server and connecting to it...
WARNING: The following configs were expanded more than once: [static-libs]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
INFO: Analyzed target //main:sorbet (150 packages loaded, 3733 targets configured).
INFO: Found 1 target...
Target //main:sorbet up-to-date:
  bazel-bin/main/sorbet
INFO: Elapsed time: 652.571s, Critical Path: 144.83s
INFO: 1401 processes: 227 internal, 1174 local.
INFO: Build completed successfully, 1401 total actions

________________________________________________________
Executed in  652.64 secs   fish           external
   usr time   92.83 millis  424.00 micros   92.41 millis
   sys time   50.44 millis  217.00 micros   50.22 millis

ubuntu-linux-20-04-desktop ~/C/sorbet (ethankhall/arm-build|✔) $ bazel-bin/main/sorbet -e "Time.now - nil"
-e:1: Expected Time but found NilClass for argument arg0 https://srb.help/7002
     1 |Time.now - nil
                   ^^^
  Expected Time for argument arg0 of method Time#-:
    https://github.com/sorbet/sorbet/tree/d99e80344789b6bc45ae146f5eda30636143ae88/rbi/core/time.rbi#L358:
     358 |        arg0: Time,
                  ^^^^
  Got NilClass originating from:
    -e:1:
     1 |Time.now - nil
                   ^^^
Errors: 1
ubuntu-linux-20-04-desktop ~/C/sorbet (ethankhall/arm-build|✔) [100] $
```

</details>


cc @tonybruess

### M1 notes

I'm currently testing Darwin builds on an M1 thru Rosetta. **Building from arm64 natively is not yet supported.**

There's a hack included that patches `jemalloc`'s configure step to make this work. This is required because Rosetta 2 doesn't seem to be exposing some information about the emulated architecture's addressing system via `cpuid` correctly; see https://github.com/jemalloc/jemalloc/issues/1997. I haven't yet tested building on native Darwin x86_64 — I do assume it should work OK.

Be warned, if you have a Homebrew-compiled arm64 `python3` on path, attempting to build via Rosetta (e.g. my release build invocation looks like  `arch -x86_64 bazelisk build //main:sorbet --config=release-mac`) will fail in very weird and wonderful ways. `bazel-toolchain`'s host OS detection mechanism calls out to `python3`, and if the system one is on path (i.e. a Universal binary), it will run as whatever arch you invoked bazel as and correctly report accordingly, but if an arm64-only Homebrew built `python3` is on path instead, it'll end up always reporting arm64. Thus the build will proceed with some parts thinking they're x86_64 and other parts arm64, and it's a real mess. I just `brew unlink python3`'d for this one.

<details><summary>Build log and test run on Darwin x86_64 via Rosetta</summary>

```
skye ~/C/sorbet (ethankhall/arm-build|✔) $ git rev-parse HEAD
d99e80344789b6bc45ae146f5eda30636143ae88
skye ~/C/sorbet (ethankhall/arm-build|✔) $ git status
On branch ethankhall/arm-build
Your branch is up to date with 'origin/ethankhall/arm-build'.

nothing to commit, working tree clean
skye ~/C/sorbet (ethankhall/arm-build|✔) $ time arch -x86_64 bazelisk clean --expunge
INFO: Invocation ID: 5088a1c8-4849-4496-b773-cdc7a9812445
INFO: Starting clean.

________________________________________________________
Executed in    2.18 secs      fish           external
   usr time   33.01 millis    0.07 millis   32.94 millis
   sys time   39.61 millis    1.55 millis   38.06 millis

skye ~/C/sorbet (ethankhall/arm-build|✔) $ time arch -x86_64 bazelisk build //main:sorbet --config=release-mac --strip=always
Starting local Bazel server and connecting to it...
INFO: Invocation ID: 113f9ebf-65c7-4602-91e2-bc5c8e8dbdde
INFO: Analyzed target //main:sorbet (151 packages loaded, 3918 targets configured).
INFO: Found 1 target...
INFO: From Compiling gnulib/lib/vasnprintf.c [for host]:
external/m4_v1.4.18/gnulib/lib/vasnprintf.c:3185:35: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                                  sprintf ((char *) p, "%+d", exponent);
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
external/m4_v1.4.18/gnulib/lib/vasnprintf.c:3193:35: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                                  sprintf (expbuf, "%+d", exponent);
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
external/m4_v1.4.18/gnulib/lib/vasnprintf.c:3336:35: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                                  sprintf ((char *) p, "%+d", exponent);
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
external/m4_v1.4.18/gnulib/lib/vasnprintf.c:3344:35: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                                  sprintf (expbuf, "%+d", exponent);
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
4 warnings generated.
INFO: From Compiling gnulib/lib/vasnprintf.c [for host]:
external/bison_v3.3.2/gnulib/lib/vasnprintf.c:3185:35: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                                  sprintf ((char *) p, "%+d", exponent);
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
external/bison_v3.3.2/gnulib/lib/vasnprintf.c:3193:35: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                                  sprintf (expbuf, "%+d", exponent);
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
external/bison_v3.3.2/gnulib/lib/vasnprintf.c:3336:35: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                                  sprintf ((char *) p, "%+d", exponent);
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
external/bison_v3.3.2/gnulib/lib/vasnprintf.c:3344:35: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                                  sprintf (expbuf, "%+d", exponent);
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
4 warnings generated.
INFO: From Linking external/m4_v1.4.18/bin/m4 [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking parser/parser/generate_diagnostics [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking parser/generate_ast [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking external/bison_v3.3.2/bin/bison [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking external/rules_bison/bison/internal/m4_deny_shell [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking external/com_google_absl/absl/strings/libstrings.a [for host]:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/host/bin/external/com_google_absl/absl/strings/_objs/strings/string_view.o has no symbols
INFO: From Linking external/com_google_absl/absl/debugging/libdebugging_internal.a [for host]:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/host/bin/external/com_google_absl/absl/debugging/_objs/debugging_internal/elf_mem_image.o has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/host/bin/external/com_google_absl/absl/debugging/_objs/debugging_internal/vdso_support.o has no symbols
INFO: From Linking external/com_google_absl/absl/types/libbad_variant_access.a [for host]:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/host/bin/external/com_google_absl/absl/types/_objs/bad_variant_access/bad_variant_access.o has no symbols
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: archive library: bazel-out/host/bin/external/com_google_absl/absl/types/libbad_variant_access.a the table of contents is empty (no object file members in the library define global symbols)
INFO: From Linking external/com_google_absl/absl/types/libbad_optional_access.a [for host]:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/host/bin/external/com_google_absl/absl/types/_objs/bad_optional_access/bad_optional_access.o has no symbols
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: archive library: bazel-out/host/bin/external/com_google_absl/absl/types/libbad_optional_access.a the table of contents is empty (no object file members in the library define global symbols)
INFO: From Linking external/com_google_protobuf/libprotobuf_lite.a [for host]:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/host/bin/external/com_google_protobuf/_objs/protobuf_lite/io_win32.o has no symbols
INFO: From Linking external/com_google_protobuf/libprotobuf.a [for host]:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/host/bin/external/com_google_protobuf/_objs/protobuf/error_listener.o has no symbols
INFO: From Linking external/com_google_protobuf/protoc [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking rbi/generate_procs [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Compiling ragel/gendata.cpp [for host]:
external/ragel_v6.10/ragel/gendata.cpp:77:2: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
        sprintf( buf, "%i", i );
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
INFO: From Compiling ragel/parsetree.cpp [for host]:
external/ragel_v6.10/ragel/parsetree.cpp:185:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                sprintf( actName, "store%i", lmi->longestMatchId );
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
external/ragel_v6.10/ragel/parsetree.cpp:198:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                sprintf( actName, "last%i", lmi->longestMatchId );
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
external/ragel_v6.10/ragel/parsetree.cpp:212:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                sprintf( actName, "next%i", lmi->longestMatchId );
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
external/ragel_v6.10/ragel/parsetree.cpp:225:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                sprintf( actName, "lag%i", lmi->longestMatchId );
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
4 warnings generated.
INFO: From Compiling ragel/cdsplit.cpp [for host]:
external/ragel_v6.10/ragel/cdsplit.cpp:351:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                sprintf( suffix, suffFormat, p );
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
INFO: From Compiling ragel/cssplit.cpp [for host]:
external/ragel_v6.10/ragel/cssplit.cpp:343:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
                sprintf( suffix, suffFormat, p );
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
INFO: From Linking external/com_google_absl/absl/debugging/libdebugging_internal.a:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/darwin-opt/bin/external/com_google_absl/absl/debugging/_objs/debugging_internal/elf_mem_image.o has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/darwin-opt/bin/external/com_google_absl/absl/debugging/_objs/debugging_internal/vdso_support.o has no symbols
INFO: From Linking external/ragel_v6.10/bin/ragel [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking external/com_google_absl/absl/types/libbad_variant_access.a:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/darwin-opt/bin/external/com_google_absl/absl/types/_objs/bad_variant_access/bad_variant_access.o has no symbols
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: archive library: bazel-out/darwin-opt/bin/external/com_google_absl/absl/types/libbad_variant_access.a the table of contents is empty (no object file members in the library define global symbols)
INFO: From Linking external/com_google_absl/absl/types/libbad_optional_access.a:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/darwin-opt/bin/external/com_google_absl/absl/types/_objs/bad_optional_access/bad_optional_access.o has no symbols
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: archive library: bazel-out/darwin-opt/bin/external/com_google_absl/absl/types/libbad_optional_access.a the table of contents is empty (no object file members in the library define global symbols)
INFO: From Linking external/com_google_protobuf/libprotobuf.a:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/darwin-opt/bin/external/com_google_protobuf/_objs/protobuf/error_listener.o has no symbols
INFO: From Linking external/com_google_protobuf/libprotobuf_lite.a:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/darwin-opt/bin/external/com_google_protobuf/_objs/protobuf_lite/io_win32.o has no symbols
INFO: From Linking external/com_google_absl/absl/strings/libstrings.a:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/darwin-opt/bin/external/com_google_absl/absl/strings/_objs/strings/string_view.o has no symbols
INFO: From Linking core/generate_names [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking payload/binary/gen_state_payload [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking main/lsp/generate_lsp_messages [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking payload/text/generate_payload [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking third_party/licenses/generate_licenses [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking payload/libtext.a [for host]:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/host/bin/payload/_objs/text/otherwise_compdb_bugs_out.o has no symbols
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: archive library: bazel-out/host/bin/payload/libtext.a the table of contents is empty (no object file members in the library define global symbols)
INFO: From Linking payload/libpayload.a:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: bazel-out/darwin-opt/bin/payload/_objs/payload/otherwise_compdb_bugs_out.o has no symbols
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: archive library: bazel-out/darwin-opt/bin/payload/libpayload.a the table of contents is empty (no object file members in the library define global symbols)
INFO: From Linking main/sorbet-orig [for host]:
ld: warning: -undefined dynamic_lookup may not work with chained fixups
INFO: From Linking main/sorbet:
ld: warning: -no_pie is deprecated when targeting new OS versions
ld: warning: -undefined dynamic_lookup may not work with chained fixups
Target //main:sorbet up-to-date:
  bazel-bin/main/sorbet
INFO: Elapsed time: 114.690s, Critical Path: 26.83s
INFO: 1735 processes: 1312 disk cache hit, 400 internal, 23 local.
INFO: Build completed successfully, 1735 total actions

________________________________________________________
Executed in  114.87 secs      fish           external
   usr time   57.14 millis    0.06 millis   57.08 millis
   sys time   53.93 millis    1.12 millis   52.81 millis

skye ~/C/sorbet (ethankhall/arm-build|✔) $ bazel-bin/main/sorbet -e "Time.now - nil"
-e:1: Expected Time but found NilClass for argument arg0 https://srb.help/7002
     1 |Time.now - nil
                   ^^^
  Expected Time for argument arg0 of method Time#-:
    https://github.com/sorbet/sorbet/tree/d99e80344789b6bc45ae146f5eda30636143ae88/rbi/core/time.rbi#L358:
     358 |        arg0: Time,
                  ^^^^
  Got NilClass originating from:
    -e:1:
     1 |Time.now - nil
                   ^^^
Errors: 1
skye ~/C/sorbet (ethankhall/arm-build|✔) [100] $
```

</details>