### PR TITLE
Don't attempt to format files outside of the current workspace

### DIFF
--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -75,7 +75,11 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
     string_view sourceView;
     if (maybeFileContents.has_value()) {
         sourceView = maybeFileContents.value();
-    } else {
+    } else if (sorbet::FileOps::exists(path)) {
+        // If the requested file path isn't in the workspace,
+        // we won't be able to load it, in which case
+        // we leave sourceView as empty and this becomes a no-op
+
         // In this case, the request is for a file that's
         // not open in the IDE, so we read it from disk instead
         sourceView = sorbet::FileOps::read(path);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

We previously were attempting to always format files, regardless of whether or not they're in the current workspace. Since the server won't be have access to files not in the current workspace, this file read would fail and crash the server.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Attempting to read files not in the workspace causes the server to crash.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I manually tested this by running the server in pay-server, then opening a random other file (`code ~/other_file.rb`) outside the workspace and saving it, which now saves without crashing.

I would add an automated test for this, but the current automated tests assume the files are in the current workspace, and spinning up a custom test scaffolding for this seemed excessive -- but open to other thoughts there.