### PR TITLE
Disallow exporting enum values directly in __package.rb files

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -192,6 +192,18 @@ class PropagateVisibility final {
                 e.addErrorLine(sym.loc(ctx), "Defined here");
             }
         }
+
+        // If sym is an enum value, it can't be exported directly. Instead, its wrapping enum class must be exported.
+        if (sym.isStaticField(ctx) && sym.owner(ctx).isClassOrModule()) {
+            auto scope = sym.owner(ctx).asClassOrModuleRef();
+            if (scope.data(ctx)->superClass() == core::Symbols::T_Enum()) {
+                if (auto e = ctx.beginError(loc, core::errors::Packager::InvalidExport)) {
+                    e.setHeader("Cannot export enum value `{}`. Instead, export the entire enum `{}`", sym.show(ctx),
+                                scope.show(ctx));
+                    e.addErrorLine(sym.loc(ctx), "Defined here");
+                }
+            }
+        }
     }
 
     PropagateVisibility(const core::packages::PackageInfo &package) : package{package} {}

--- a/test/cli/package-disallow-enum-value-exports/my_package/__package.rb
+++ b/test/cli/package-disallow-enum-value-exports/my_package/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class MyPackage < PackageSpec
+  export MyPackage::A::Val1 # error
+end

--- a/test/cli/package-disallow-enum-value-exports/my_package/a.rb
+++ b/test/cli/package-disallow-enum-value-exports/my_package/a.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+module MyPackage
+  class A < T::Enum
+    enums do
+      Val1 = new
+      Val2 = new
+    end
+  end
+end

--- a/test/cli/package-disallow-enum-value-exports/test.out
+++ b/test/cli/package-disallow-enum-value-exports/test.out
@@ -4,4 +4,8 @@ my_package/__package.rb:4: Cannot export enum value `MyPackage::A::Val1`. Instea
     my_package/a.rb:6: Defined here
      6 |      Val1 = new
               ^^^^
+  Autocorrect: Use `-a` to autocorrect
+    my_package/__package.rb:4: Replace with `export MyPackage::A`
+     4 |  export MyPackage::A::Val1 # error
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1

--- a/test/cli/package-disallow-enum-value-exports/test.out
+++ b/test/cli/package-disallow-enum-value-exports/test.out
@@ -1,0 +1,7 @@
+my_package/__package.rb:4: Cannot export enum value `MyPackage::A::Val1`. Instead, export the entire enum `MyPackage::A` https://srb.help/3721
+     4 |  export MyPackage::A::Val1 # error
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
+    my_package/a.rb:6: Defined here
+     6 |      Val1 = new
+              ^^^^
+Errors: 1

--- a/test/cli/package-disallow-enum-value-exports/test.sh
+++ b/test/cli/package-disallow-enum-value-exports/test.sh
@@ -1,0 +1,5 @@
+cd test/cli/package-disallow-enum-value-exports || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+
+

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -790,6 +790,34 @@ class A::B < PackageSpec
 end
 ```
 
+Additional signatures of error 3721 include:
+
+- A package exporting a constant only defined in .rbi files. RBI files are shims
+  to enable typechecking in places where Ruby metaprogramming prevents Sorbet
+  from statically interpreting the behavior of a class or module. Generally,
+  these files declare additional methods on classes defined in Ruby source
+  files, and should not define any new constants. However, there are some rare
+  exceptions where these files can define net-new constants. For these cases, we
+  enforce that these constants cannot be exported.
+- A package exporting an enum value:
+
+```ruby
+module MyPackage
+  class A < T::Enum
+    enums do
+      Val1 = new
+      Val2 = new
+    end
+  end
+end
+
+# -- my_package/__package.rb --
+
+class MyPackage < PackageSpec
+  export A::Val1 # not allowed, instead the full enum should be exported with `export A`
+end
+```
+
 ## 3722
 
 > This error is specific to Stripe's custom `--stripe-packages` mode. If you are


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Disallows exporting individual enum values directly, instead users will have to export the wrapping enum class.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This is a feature already present in our automatic package-file generation tooling at Stripe. Bringing this into Sorbet to ensure parity between the tools (and prevent the generation tooling from making spurious changes).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.