### PR TITLE
Attempt to fix //test/cli:test_folder-input-not-found

### DIFF
--- a/common/common.cc
+++ b/common/common.cc
@@ -48,11 +48,13 @@ string sorbet::FileOps::read(const string &filename) {
         fclose(fp);
         if (readBytes != contents.size()) {
             // Error reading file?
-            throw sorbet::FileNotFoundException(fmt::format("Error reading file: `{}`: {}", filename, errno));
+            auto msg = fmt::format("Error reading file: `{}`: {}", filename, errno);
+            throw sorbet::FileNotFoundException(msg);
         }
         return contents;
     }
-    throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}`", filename));
+    auto msg = fmt::format("Cannot open file `{}`", filename);
+    throw sorbet::FileNotFoundException(msg);
 }
 
 void sorbet::FileOps::write(const string &filename, const vector<uint8_t> &data) {
@@ -62,7 +64,8 @@ void sorbet::FileOps::write(const string &filename, const vector<uint8_t> &data)
         fclose(fp);
         return;
     }
-    throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}` for writing", filename));
+    auto msg = fmt::format("Cannot open file `{}` for writing", filename);
+    throw sorbet::FileNotFoundException(msg);
 }
 
 bool sorbet::FileOps::dirExists(const string &path) {
@@ -73,7 +76,8 @@ bool sorbet::FileOps::dirExists(const string &path) {
 void sorbet::FileOps::createDir(const string &path) {
     auto err = mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     if (err) {
-        throw sorbet::CreateDirException(fmt::format("Error in createDir('{}'): {}", path, errno));
+        auto msg = fmt::format("Error in createDir('{}'): {}", path, errno);
+        throw sorbet::CreateDirException(msg);
     }
 }
 
@@ -84,7 +88,8 @@ bool sorbet::FileOps::ensureDir(const string &path) {
             return false;
         }
 
-        throw sorbet::CreateDirException(fmt::format("Error in createDir('{}'): {}", path, errno));
+        auto msg = fmt::format("Error in createDir('{}'): {}", path, errno);
+        throw sorbet::CreateDirException(msg);
     }
 
     return true;
@@ -93,7 +98,8 @@ bool sorbet::FileOps::ensureDir(const string &path) {
 void sorbet::FileOps::removeDir(const string &path) {
     auto err = rmdir(path.c_str());
     if (err) {
-        throw sorbet::RemoveDirException(fmt::format("Error in removeDir('{}'): {}", path, errno));
+        auto msg = fmt::format("Error in removeDir('{}'): {}", path, errno);
+        throw sorbet::RemoveDirException(msg);
     }
 }
 
@@ -103,7 +109,8 @@ bool sorbet::FileOps::removeEmptyDir(const string &path) {
         if (errno == ENOTEMPTY) {
             return false;
         }
-        throw sorbet::RemoveDirException(fmt::format("Error in removeEmptyDir('{}'): {}", path, errno));
+        auto msg = fmt::format("Error in removeEmptyDir('{}'): {}", path, errno);
+        throw sorbet::RemoveDirException(msg);
     }
 
     return true;
@@ -121,7 +128,8 @@ void sorbet::FileOps::removeEmptyDirsRecursively(const std::string &dirPath) {
             }
             default:
                 // Mirrors other FileOps functions: Assume other errors are from FileNotFound.
-                throw sorbet::FileNotFoundException(fmt::format("Couldn't open directory `{}`", dirPath));
+                auto msg = fmt::format("Couldn't open directory `{}`", dirPath);
+                throw sorbet::FileNotFoundException(msg);
         }
     }
 
@@ -137,21 +145,24 @@ void sorbet::FileOps::removeEmptyDirsRecursively(const std::string &dirPath) {
 
             removeEmptyDirsRecursively(std::move(innerDirPath));
         } else {
-            throw sorbet::RemoveDirException(
-                fmt::format("Error in removeEmptyDirsRecursively('{}'), file {} exists.", dirPath, entry->d_name));
+            auto msg =
+                fmt::format("Error in removeEmptyDirsRecursively('{}'), file {} exists.", dirPath, entry->d_name);
+            throw sorbet::RemoveDirException(msg);
         }
     }
 
     auto err = rmdir(dirPathCStr);
     if (err) {
-        throw sorbet::RemoveDirException(fmt::format("Error in removeEmptyDirsRecursively('{}'): {}", dirPath, errno));
+        auto msg = fmt::format("Error in removeEmptyDirsRecursively('{}'): {}", dirPath, errno);
+        throw sorbet::RemoveDirException(msg);
     }
 }
 
 void sorbet::FileOps::removeFile(const string &path) {
     auto err = remove(path.c_str());
     if (err) {
-        throw sorbet::RemoveFileException(fmt::format("Error in removeFile('{}'): {}", path, errno));
+        auto msg = fmt::format("Error in removeFile('{}'): {}", path, errno);
+        throw sorbet::RemoveFileException(msg);
     }
 }
 
@@ -162,7 +173,8 @@ void sorbet::FileOps::write(const string &filename, string_view text) {
         fclose(fp);
         return;
     }
-    throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}` for writing", filename));
+    auto msg = fmt::format("Cannot open file `{}` for writing", filename);
+    throw sorbet::FileNotFoundException(msg);
 }
 
 bool sorbet::FileOps::writeIfDifferent(const string &filename, string_view text) {
@@ -180,7 +192,8 @@ void sorbet::FileOps::append(const string &filename, string_view text) {
         fclose(fp);
         return;
     }
-    throw sorbet::FileNotFoundException(fmt::format("Cannot open file `{}` for writing", filename));
+    auto msg = fmt::format("Cannot open file `{}` for writing", filename);
+    throw sorbet::FileNotFoundException(msg);
 }
 
 string_view sorbet::FileOps::getFileName(string_view path) {
@@ -365,7 +378,8 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
                         }
                         default:
                             // Mirrors other FileOps functions: Assume other errors are from FileNotFound.
-                            throw sorbet::FileNotFoundException(fmt::format("Couldn't open directory `{}`", path));
+                            auto msg = fmt::format("Couldn't open directory `{}`", path);
+                            throw sorbet::FileNotFoundException(msg);
                     }
                 }
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -694,8 +694,8 @@ void addFilesFromDir(Options &opts, string_view dir, WorkerPool &workerPool, sha
     try {
         containedFiles = opts.fs->listFilesInDir(fileNormalized, opts.allowedExtensions, workerPool, true,
                                                  opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
-    } catch (sorbet::FileNotFoundException e) {
-        logger->error(e.what());
+    } catch (sorbet::FileNotFoundException &e) {
+        logger->error("{}", e.what());
         throw EarlyReturnWithCode(1);
     } catch (sorbet::FileNotDirException) {
         logger->error("Path `{}` is not a directory", dir);


### PR DESCRIPTION
<https://buildkite.com/sorbet/sorbet/builds/25777#01857c76-e8f5-45c8-b991-6f19076cd69a>

We're getting a sanitizer failure on this CLI test. I was unable to get
this to repro locally.

The error is coming from a logger inside `addFilesFromDir`. There are
only two places in that function that log, and one of them is calling
`e.what()` which returns a `const char *`. I'm wondering if it's
possible that the `std::string` temporaries that we're creating before
constructing `FileNotFoundException`'s are getting released somehow.

Some changes which might help:

- We now catch by reference, which seems to be a best practice?

  <https://stackoverflow.com/questions/2023032/catch-exception-by-pointer-in-c>

- We're no longer throwing anonymous `std::string` temporaries in most
  file-related exceptions. As far as I can tell, this _shouldn't_
  matter, because the string should live as least as long as it takes
  for `FileNotFoundException` to finish using it for construction:

  <https://stackoverflow.com/questions/63270037/c-anonymous-string-destruction-time>

  But I think this shouldn't hurt anyways (it should now live as long as
  the enclosing scope, instead of the enclosing expression). The call
  site was going to take it by `const string&` anyways, so it's not like
  we're doing an extra copy. But this change is mostly a shot in the
  dark.

- We now use `"{}", e.what()`, just in case `what()` had `{}` in it
  and were to be treated as a format string (which I'm pretty sure it
  doesn't for this test, but better safe than sorry).

I'm not confident this will help but I'm pretty confident it won't hurt.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->