### PR TITLE
Move multiple behavior defs check to defineSymbols pass in namer

### DIFF
--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -28,7 +28,9 @@ bool definesBehavior(const ExpressionPtr &expr) {
         },
 
         [&](const ast::Assign &asgn) {
-            if (ast::isa_tree<ast::ConstantLit>(asgn.lhs)) {
+            // this check can fire before the namer converts lhs constants in assignments from UnresolvedConstantLit ->
+            // ConstantLit, so we have to allow for both types.
+            if (ast::isa_tree<ast::ConstantLit>(asgn.lhs) || ast::isa_tree<ast::UnresolvedConstantLit>(asgn.lhs)) {
                 result = false;
             } else {
                 result = true;

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -107,6 +107,7 @@ struct FoundClass final {
     core::NameRef name;
     core::LocOffsets loc;
     core::LocOffsets declLoc;
+    bool definesBehavior = false;
 
     enum class Kind : uint8_t {
         Unknown,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

As a refactor, I'm moving the multiple behavior definitions check to the defineSymbols pass in the namer.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This change is a necessary refactor to land a [fix](https://github.com/sorbet/sorbet/pull/6641) in the packaging logic which needs to keep track of behavior-defining classes. 

Also, it simplifies behavior-defs logic as it no longer needs to merge maps from parallel workers.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing automated tests, plus testing on Stripe codebase.