### PR TITLE
add more context for behavior definition errors outside package namespaces

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -817,11 +817,12 @@ public:
                     "Class or method behavior may not be defined outside of the enclosing package namespace `{}`",
                     fmt::map_join(pkgName, "::", [&](const auto &nr) { return nr.show(ctx); }));
                 if (packageForNamespace.exists()) {
-                    auto &namespaceParts = ctx.state.packageDB().getPackageInfo(packageForNamespace).fullName();
+                    auto &packageInfo = ctx.state.packageDB().getPackageInfo(packageForNamespace);
                     const auto &constantName = namespaces.currentConstantName();
-                    e.addErrorNote("Attempting to define class or method behavior in `{}`, which is in package namespace `{}`",
-                                   fmt::map_join(constantName, "::", [&](const auto &nr) { return nr.first.show(ctx); }),
-                                   fmt::map_join(namespaceParts, "::", [&](const auto &nr) { return nr.show(ctx); }));
+                    e.addErrorLine(
+                        ctx.locAt(constantName.back().second), "Attempting to define class or method behavior in `{}`",
+                        fmt::map_join(constantName, "::", [&](const auto &nr) { return nr.first.show(ctx); }));
+                    e.addErrorLine(packageInfo.declLoc(), "Enclosing package declared here");
                 }
             }
         }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -805,7 +805,9 @@ public:
                     fmt::map_join(pkgName, "::", [&](const auto &nr) { return nr.show(ctx); }));
                 if (packageForNamespace.exists()) {
                     auto &namespaceParts = ctx.state.packageDB().getPackageInfo(packageForNamespace).fullName();
-                    e.addErrorNote("Attempting to define class or method behavior in package namespace `{}`",
+                    const auto &constantName = namespaces.currentConstantName();
+                    e.addErrorNote("Attempting to define class or method behavior in `{}`, which is in package namespace `{}`",
+                                   fmt::map_join(constantName, "::", [&](const auto &nr) { return nr.show(ctx); }),
                                    fmt::map_join(namespaceParts, "::", [&](const auto &nr) { return nr.show(ctx); }));
                 }
             }

--- a/test/cli/package-prefix-enforcement/test.out
+++ b/test/cli/package-prefix-enforcement/test.out
@@ -8,20 +8,32 @@ nested/nested.rb:5: File belongs to package `Root::Nested` but defines a constan
 nested/nested.rb:40: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
     40 |  sig {returns(NilClass)}
           ^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Attempting to define class or method behavior in package namespace `Root`
+    nested/nested.rb:36: Attempting to define class or method behavior in `Root`
+    36 |module Root
+               ^^^^
+    __package.rb:3: Enclosing package declared here
+     3 |class Root < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^
 
 nested/nested.rb:41: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
     41 |  def self.method
           ^^^^^^^^^^^^^^^
-  Note:
-    Attempting to define class or method behavior in package namespace `Root`
+    nested/nested.rb:36: Attempting to define class or method behavior in `Root`
+    36 |module Root
+               ^^^^
+    __package.rb:3: Enclosing package declared here
+     3 |class Root < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^
 
 nested/nested.rb:37: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
     37 |  extend T::Sig
           ^^^^^^^^^^^^^
-  Note:
-    Attempting to define class or method behavior in package namespace `Root`
+    nested/nested.rb:36: Attempting to define class or method behavior in `Root`
+    36 |module Root
+               ^^^^
+    __package.rb:3: Enclosing package declared here
+     3 |class Root < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^
 
 nested/nested.rb:38: File belongs to package `Root::Nested` but defines a constant that does not match this namespace https://srb.help/3713
     38 |  NOT_IN_PACKAGE = T.let(1, Integer)

--- a/test/cli/package-prefix-enforcement/test.out
+++ b/test/cli/package-prefix-enforcement/test.out
@@ -5,33 +5,42 @@ nested/nested.rb:5: File belongs to package `Root::Nested` but defines a constan
      3 |class Root::Nested < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-nested/nested.rb:40: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
+nested/nested.rb:40: This file must only define behavior in enclosing package `Root::Nested` https://srb.help/3713
     40 |  sig {returns(NilClass)}
           ^^^^^^^^^^^^^^^^^^^^^^^
-    nested/nested.rb:36: Attempting to define class or method behavior in `Root`
+    nested/nested.rb:36: Defining behavior in `Root` instead:
     36 |module Root
                ^^^^
-    __package.rb:3: Enclosing package declared here
+    nested/__package.rb:3: Enclosing package `Root::Nested` declared here
+     3 |class Root::Nested < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    __package.rb:3: Package `Root` declared here
      3 |class Root < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-nested/nested.rb:41: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
+nested/nested.rb:41: This file must only define behavior in enclosing package `Root::Nested` https://srb.help/3713
     41 |  def self.method
           ^^^^^^^^^^^^^^^
-    nested/nested.rb:36: Attempting to define class or method behavior in `Root`
+    nested/nested.rb:36: Defining behavior in `Root` instead:
     36 |module Root
                ^^^^
-    __package.rb:3: Enclosing package declared here
+    nested/__package.rb:3: Enclosing package `Root::Nested` declared here
+     3 |class Root::Nested < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    __package.rb:3: Package `Root` declared here
      3 |class Root < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-nested/nested.rb:37: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
+nested/nested.rb:37: This file must only define behavior in enclosing package `Root::Nested` https://srb.help/3713
     37 |  extend T::Sig
           ^^^^^^^^^^^^^
-    nested/nested.rb:36: Attempting to define class or method behavior in `Root`
+    nested/nested.rb:36: Defining behavior in `Root` instead:
     36 |module Root
                ^^^^
-    __package.rb:3: Enclosing package declared here
+    nested/__package.rb:3: Enclosing package `Root::Nested` declared here
+     3 |class Root::Nested < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    __package.rb:3: Package `Root` declared here
      3 |class Root < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/test/testdata/packager/nested_package_enforcement/inner/inner.rb
+++ b/test/testdata/packager/nested_package_enforcement/inner/inner.rb
@@ -3,7 +3,7 @@
 
 module Outer
   def self.bad
-# ^^^^^^^^^^^^ error: Class or method behavior may not be defined outside of the enclosing package namespace `Outer::Inner`
+# ^^^^^^^^^^^^ error: This file must only define behavior in enclosing package `Outer::Inner`
   end
 
 
@@ -13,5 +13,5 @@ module Outer
   end
 
   include Inner::Mixin
-# ^^^^^^^^^^^^^^^^^^^^ error: Class or method behavior may not be defined outside of the enclosing package namespace `Outer::Inner`
+# ^^^^^^^^^^^^^^^^^^^^ error: This file must only define behavior in enclosing package `Outer::Inner`
 end

--- a/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
+++ b/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
@@ -41,7 +41,7 @@ module Root
 end
 
   class Root::Stringy < String
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: This file must only define behavior in enclosing package `Root::Nested`
 end
 
 class Root::Nested::Stringy < String
@@ -49,14 +49,14 @@ end
 
 module Root
   extend T::Sig
-# ^^^^^^^^^^^^^ error: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested`
+# ^^^^^^^^^^^^^ error: This file must only define behavior in enclosing package `Root::Nested`
   NOT_IN_PACKAGE = T.let(1, Integer)
 # ^^^^^^^^^^^^^^ error: File belongs to package `Root::Nested` but defines a constant that does not match this namespace
 
   sig {returns(NilClass)}
-# ^^^^^^^^^^^^^^^^^^^^^^^ error: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested`
+# ^^^^^^^^^^^^^^^^^^^^^^^ error: This file must only define behavior in enclosing package `Root::Nested`
   def self.method
-# ^^^^^^^^^^^^^^^ error: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested`
+# ^^^^^^^^^^^^^^^ error: This file must only define behavior in enclosing package `Root::Nested`
     nil
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In #6359, it was suggested that we could add some more context, specifically directing the user to the enclosing scope that things were being defined in.  This PR does that.

I would have liked to track the locs directly in `nameParts`, rather than having a separate member variable, but it turned out that this required propagating `vector<pair<core::NameRef, core::LocOffsets>>` into places that took only `vector<core::NameRef>`.  I hacked around one instance with `if constexpr` in lambda functions (!), but there were too many other places to update, so I settled for the patch you see here.  The `NameFormatter::operator()` changes are a taste of the sort of thing that was necessary.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

The only thing I am not sure about is what happens when the enclosing scope is something like `class Name::Subname`; I think the code as-is only highlights `Subname`.  It would be better to highlight the full name, but I don't think we have enough information to track that.
