### PR TITLE
eliminate double-checked locking in autoloader generation

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -455,10 +455,6 @@ struct RenderAutoloadTask {
     const DefTree &node;
 };
 
-struct ModificationState {
-    bool modified;
-};
-
 // This function has two duties:
 // * It creates autoload rendering tasks which will occur in a later parallel phase.
 // * It creates subdirectories when needed, as they are required to write the autoloader output.
@@ -526,9 +522,6 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
         populateAutoloadTasksAndCreateDirectories(gs, tasks, dirsToDelete, alCfg, path, root);
     }
 
-    auto modificationState = ModificationState{false};
-    std::mutex modificationMutex;
-
     if (FileOps::exists(path)) {
         Timer timeit(gs.tracer(), "removeExistingFiles");
 
@@ -551,14 +544,15 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
 
     // Parallelize writing the files.
     auto inputq = make_shared<ConcurrentBoundedQueue<int>>(tasks.size());
-    auto outputq = make_shared<BlockingBoundedQueue<CounterState>>(tasks.size());
+    auto outputq = make_shared<BlockingBoundedQueue<pair<CounterState, bool>>>(tasks.size());
     for (int i = 0; i < tasks.size(); ++i) {
         inputq->push(i, 1);
     }
 
     workers.multiplexJob(
-        "runAutogenWriteAutoloads", [&gs, &tasks, &alCfg, inputq, outputq, &modificationState, &modificationMutex]() {
+        "runAutogenWriteAutoloads", [&gs, &tasks, &alCfg, inputq, outputq]() {
             int n = 0;
+            bool anyFilesModified = false;
             {
                 Timer timeit(gs.tracer(), "autogenWriteAutoloadsWorker");
                 int idx = 0;
@@ -571,32 +565,26 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
                     task.node.renderAutoloadSrc(buf, gs, alCfg);
                     bool rewritten = FileOps::writeIfDifferent(task.filePath, string_view{&buf.data()[0], buf.size()});
 
-                    // Initial read should be cheap, read outside mutex
-                    if (rewritten && !modificationState.modified) {
-                        modificationMutex.lock();
-                        // Re-test inside mutex
-                        if (!modificationState.modified) {
-                            modificationState.modified = true;
-                        }
-                        modificationMutex.unlock();
-                    }
+                    anyFilesModified = anyFilesModified || rewritten;
                 }
             }
 
-            outputq->push(getAndClearThreadCounters(), n);
+            outputq->push(make_pair(getAndClearThreadCounters(), anyFilesModified), n);
         });
 
-    CounterState out;
+    bool modified = false;
+    pair<CounterState, bool> out;
     for (auto res = outputq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), gs.tracer()); !res.done();
          res = outputq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
         if (!res.gotItem()) {
             continue;
         }
-        counterConsume(move(out));
+        counterConsume(move(out.first));
+        modified = modified || out.second;
     }
 
     const std::string mtimeFile = join(path, "_mtime_stamp");
-    if (!FileOps::exists(mtimeFile) || modificationState.modified) {
+    if (!FileOps::exists(mtimeFile) || modified) {
         FileOps::write(mtimeFile, to_string(std::time(0)));
     }
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Manual mutexes are kind of unusual in Sorbet, and there's no need for them here; we can just map-reduce modification status just like most other parallel loops in Sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
