### PR TITLE
Add `export_all!` to packages

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -604,6 +604,9 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::visible_to()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_visible_to());
 
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::exportAll()).build();
+    ENFORCE(method == Symbols::PackageSpec_export_all());
+
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ResolvedSig());
     ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSig());
     klass = Symbols::Sorbet_Private_Static_ResolvedSig().data(*this)->singletonClass(*this);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1034,13 +1034,10 @@ public:
 
     static MethodRef PackageSpec_visible_to() {
         return MethodRef::fromRaw(14);
+    }
 
     static MethodRef PackageSpec_export_all() {
         return MethodRef::fromRaw(15);
-    }
-
-    static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
-        return ClassOrModuleRef::fromRaw(88);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1034,6 +1034,13 @@ public:
 
     static MethodRef PackageSpec_visible_to() {
         return MethodRef::fromRaw(14);
+
+    static MethodRef PackageSpec_export_all() {
+        return MethodRef::fromRaw(15);
+    }
+
+    static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
+        return ClassOrModuleRef::fromRaw(88);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,7 +23,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 210;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 49;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 50;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 108;

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -63,6 +63,11 @@ public:
         return false;
     }
 
+    bool exportAll() const {
+        notImplemented();
+        return false;
+    }
+
     std::vector<std::vector<core::NameRef>> exports() const {
         return vector<vector<core::NameRef>>();
     }

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -77,15 +77,16 @@ core::ClassOrModuleRef getParentNamespaceSym(const core::GlobalState &gs, const 
 core::ClassOrModuleRef lookupNameOn(const core::GlobalState &gs, const core::ClassOrModuleRef root,
                                     const std::vector<core::NameRef> &name) {
     auto curSym = root;
+    if (!curSym.exists()) {
+        return {};
+    }
+
     for (const auto part : name) {
         auto member = curSym.data(gs)->findMember(gs, part);
-        if (!member.isClassOrModule()) {
+        if (!member.exists() || !member.isClassOrModule()) {
             return {};
         }
         curSym = member.asClassOrModuleRef();
-        if (!curSym.exists()) {
-            return {};
-        }
     }
 
     return curSym;

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -74,6 +74,36 @@ core::ClassOrModuleRef getParentNamespaceSym(const core::GlobalState &gs, const 
     return core::Symbols::root();
 }
 
+core::ClassOrModuleRef PackageInfo::getPackageScope(const core::GlobalState &gs) const {
+    auto curSym = core::Symbols::root();
+
+    for (const auto part : fullName()) {
+        curSym = curSym.data(gs)->findMember(gs, part).asClassOrModuleRef();
+        if (!curSym.exists()) {
+            return curSym;
+        }
+    }
+
+    return curSym;
+}
+
+core::ClassOrModuleRef PackageInfo::getPackageTestScope(const core::GlobalState &gs) const {
+    auto curSym = core::Symbols::root().data(gs)->findMember(gs, core::Names::Constants::Test()).asClassOrModuleRef();
+
+    if (!curSym.exists()) {
+        return curSym;
+    }
+
+    for (const auto part : fullName()) {
+        curSym = curSym.data(gs)->findMember(gs, part).asClassOrModuleRef();
+        if (!curSym.exists()) {
+            return curSym;
+        }
+    }
+
+    return curSym;
+}
+
 // Given a package named Project::MyPackage, returns the class/module ref corresponding to
 // the symbol Project::MyPackage or Test::Project::MyPackage, depending on whether the suggestion scope
 // is a primary namespace constant or a test namespace constant. See packager/packager.cc for further explanation of

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -62,6 +62,7 @@ public:
 
     virtual bool ownsSymbol(const core::GlobalState &gs, core::SymbolRef symbol) const = 0;
     virtual bool strictAutoloaderCompatibility() const = 0;
+    virtual bool exportAll() const = 0;
 
     // Utilities:
 

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -38,6 +38,9 @@ public:
     core::ClassOrModuleRef getRootSymbolForAutocorrectSearch(const core::GlobalState &gs,
                                                              core::SymbolRef suggestionScope) const;
 
+    core::ClassOrModuleRef getPackageScope(const core::GlobalState &gs) const;
+    core::ClassOrModuleRef getPackageTestScope(const core::GlobalState &gs) const;
+
     virtual std::optional<ImportType> importsPackage(core::NameRef mangledName) const = 0;
 
     // autocorrects

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -453,6 +453,7 @@ NameDef names[] = {
     {"legacy"},
     {"strict"},
     {"visible_to"},
+    {"exportAll", "export_all!"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageSpecRegistry", "<PackageSpecRegistry>", true},
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -330,6 +330,9 @@ public:
         // directives in the previous pass; we should instead export
         // the package root
         if (package.exportAll()) {
+            // we check if these exist because if no constants were
+            // defined in the package then we might not have actually
+            // ever created the relevant namespaces
             auto pkgRoot = package.getPackageScope(gs);
             if (pkgRoot.exists()) {
                 pass.recursiveExportSymbol(gs, true, pkgRoot);
@@ -337,7 +340,6 @@ public:
 
             auto pkgTestRoot = package.getPackageTestScope(gs);
             if (pkgTestRoot.exists()) {
-                gs.tracer().error("+++ => {}", pkgTestRoot.show(gs));
                 pass.recursiveExportSymbol(gs, true, pkgTestRoot);
             }
         }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -210,9 +210,9 @@ public:
     vector<Export> exports_;
 
     // Whether the code in this package is compatible for path-based autoloading.
-    bool strictAutoloaderCompatibility_ : 1;
+    bool strictAutoloaderCompatibility_;
     // Whether this package should just export everything
-    bool exportAll_ : 1;
+    bool exportAll_;
 
     // The other packages to which this package is visible. If this vector is empty, then it means
     // the package is fully public and can be imported by anything.

--- a/test/testdata/packager/export_all/__package.rb
+++ b/test/testdata/packager/export_all/__package.rb
@@ -5,6 +5,9 @@
 class Foo::Bar < PackageSpec
   export_all!
 
+  export_all!(:with_argument)
+            # ^^^^^^^^^^^^^^ error: Too many arguments
+
   export Foo::Bar::Thing
        # ^^^^^^^^^^^^^^^ error: Package `Foo::Bar` declares `export_all!` and therefore should not use explicit exports
 

--- a/test/testdata/packager/export_all/__package.rb
+++ b/test/testdata/packager/export_all/__package.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar < PackageSpec
+  export_all!
+
+  export Foo::Bar::Thing
+       # ^^^^^^^^^^^^^^^ error: Package `Foo::Bar` declares `export_all!` and therefore should not use explicit exports
+
+end

--- a/test/testdata/packager/export_all/foo_bar.rb
+++ b/test/testdata/packager/export_all/foo_bar.rb
@@ -1,0 +1,13 @@
+# typed: strict
+
+module Foo::Bar
+  class Thing
+    extend T::Sig
+
+    sig {void}
+    def self.hello; end
+  end
+
+  class OtherThing
+  end
+end

--- a/test/testdata/packager/export_all/foo_bar_baz/__package.rb
+++ b/test/testdata/packager/export_all/foo_bar_baz/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar::Baz < PackageSpec
+end

--- a/test/testdata/packager/export_all/foo_bar_baz/foo_bar_baz.rb
+++ b/test/testdata/packager/export_all/foo_bar_baz/foo_bar_baz.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module Foo::Bar::Baz
+  class Quux
+  end
+end

--- a/test/testdata/packager/export_all/other/__package.rb
+++ b/test/testdata/packager/export_all/other/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Other < PackageSpec
+  import Foo::Bar
+end

--- a/test/testdata/packager/export_all/other/other.rb
+++ b/test/testdata/packager/export_all/other/other.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Other::OtherClass
+  Foo::Bar::Thing.hello # This ref still works
+  Foo::Bar::OtherThing # anything from the package should be fine
+end

--- a/test/testdata/packager/export_all/other/other.rb
+++ b/test/testdata/packager/export_all/other/other.rb
@@ -4,4 +4,13 @@
 class Other::OtherClass
   Foo::Bar::Thing.hello # This ref still works
   Foo::Bar::OtherThing # anything from the package should be fine
+
+  # because `Foo::Bar::Baz` is a subpackage, the export walk should stop
+  # and not export the stuff under that namespace
+  Foo::Bar::Baz::Quux
+# ^^^^^^^^^^^^^^^^^^^ error: `Foo::Bar::Baz::Quux` resolves but is not exported
+
+  Typical::Example # packages that don't use `export_all` are not affected
+  Typical::NonExported # packages that don't use `export_all` are not affected
+# ^^^^^^^^^^^^^^^^^^^^ error: `Typical::NonExported` resolves but is not exported
 end

--- a/test/testdata/packager/export_all/typical/__package.rb
+++ b/test/testdata/packager/export_all/typical/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Typical < PackageSpec
+  export Typical::Example
+end

--- a/test/testdata/packager/export_all/typical/typical.rb
+++ b/test/testdata/packager/export_all/typical/typical.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module Typical
+  class Example; end
+  class NonExported; end
+end

--- a/test/testdata/packager/export_all_in_test/__package.rb
+++ b/test/testdata/packager/export_all_in_test/__package.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar < PackageSpec
+  export_all!
+
+  export Test::Foo::Bar::Thing
+       # ^^^^^^^^^^^^^^^^^^^^^ error: Package `Foo::Bar` declares `export_all!` and therefore should not use explicit exports
+
+end

--- a/test/testdata/packager/export_all_in_test/other/__package.rb
+++ b/test/testdata/packager/export_all_in_test/other/__package.rb
@@ -2,7 +2,6 @@
 # typed: strict
 
 class Other < PackageSpec
-  import Foo::Bar
-  import Foo::Bar::Baz
-  import Typical
+  test_import Foo::Bar
+  test_import Typical
 end

--- a/test/testdata/packager/export_all_in_test/other/test/other.test.rb
+++ b/test/testdata/packager/export_all_in_test/other/test/other.test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Test::Other::OtherClass
+  Test::Foo::Bar::Thing.hello # This ref still works
+  Test::Foo::Bar::OtherThing # anything from the package should be fine
+
+  Test::Typical::Example # packages that don't use `export_all` are not affected
+  Test::Typical::NonExported # packages that don't use `export_all` are not affected
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Typical::NonExported` resolves but is not exported
+end

--- a/test/testdata/packager/export_all_in_test/test/foo_bar.test.rb
+++ b/test/testdata/packager/export_all_in_test/test/foo_bar.test.rb
@@ -1,0 +1,13 @@
+# typed: strict
+
+module Test::Foo::Bar
+  class Thing
+    extend T::Sig
+
+    sig {void}
+    def self.hello; end
+  end
+
+  class OtherThing
+  end
+end

--- a/test/testdata/packager/export_all_in_test/typical/__package.rb
+++ b/test/testdata/packager/export_all_in_test/typical/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Typical < PackageSpec
+  export Test::Typical::Example
+end

--- a/test/testdata/packager/export_all_in_test/typical/test/typical.test.rb
+++ b/test/testdata/packager/export_all_in_test/typical/test/typical.test.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module Test::Typical
+  class Example; end
+  class NonExported; end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This adds a package feature which recognizes `export_all!` in lieu of explicit exports. If a package marks `export_all!`, then
1. any constant owned by the package can be imported by any other package, and 
2. it is an error to include any `export` line in the package itself.

For packages which have a very wide surface area, export many constants, and currently see a lot of churn because of edits to the export list, this could prevent a lot of churn and merge conflicts.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a test suite that shows `export_all!` behavior, and another that shows the same behavior with tests. This package also includes a subpackage to show that the export walk does stop when it hits the subpackage boundary.
