### PR TITLE
Complain if comparing `String` and `Symbol` incorrectly

### DIFF
--- a/.buildkite/test-compiler.sh
+++ b/.buildkite/test-compiler.sh
@@ -10,6 +10,7 @@ case "${unameOut}" in
 esac
 
 if [[ "linux" == "$platform" ]]; then
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
     apt-get update
     apt-get install -yy libncurses5-dev libncursesw5-dev xxd
 elif [[ "mac" == "$platform" ]]; then

--- a/.buildkite/test-vscode-extension.sh
+++ b/.buildkite/test-vscode-extension.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 # TODO: We probably want to move this into https://github.com/sorbet/sorbet-build-image eventually
 
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 apt-get update
 apt-get install -y libxshmfence-dev libnss3-dev libatk1.0-0 libatk-bridge2.0-0 \
  libdrm2 xvfb libgdk-pixbuf2.0-0 libgtk-3-0 libgbm1	libasound2

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -48,6 +48,7 @@ constexpr ErrorClass AttachedClassOnInstance{7040, StrictLevel::True};
 constexpr ErrorClass UntypedFieldSuggestion{7043, StrictLevel::Strict};
 constexpr ErrorClass DigExtraArgs{7044, StrictLevel::True};
 constexpr ErrorClass IncorrectlyAssumedType{7045, StrictLevel::True};
+constexpr ErrorClass NonOverlappingEqual{7046, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -48,7 +48,6 @@ constexpr ErrorClass AttachedClassOnInstance{7040, StrictLevel::True};
 constexpr ErrorClass UntypedFieldSuggestion{7043, StrictLevel::Strict};
 constexpr ErrorClass DigExtraArgs{7044, StrictLevel::True};
 constexpr ErrorClass IncorrectlyAssumedType{7045, StrictLevel::True};
-constexpr ErrorClass NonOverlappingEqual{7046, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4101,6 +4101,11 @@ public:
         // NOTE:
         // If you update this, please update error-reference to mention which types this check applies to
         if (isOnlyString &&
+            // This extra `isSubType` is here (not in Symbol_eqeq) because of how implicit String#==
+            // allows implicit conversions with `to_str`. In essence, this check implements the
+            // assumption that `Symbol` is final and thus no subclass can implement `to_str` (we
+            // could also implement the actual final logic for arbitrary classes, but have opted not
+            // to because it would likely be a cause for surprise).
             Types::isSubType(gs, args.args[0]->type, Types::any(gs, Types::nilClass(), Types::Symbol())) &&
             Types::all(gs, args.fullType.type, args.args[0]->type).isBottom()) {
             auto funLoc = args.funLoc();

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4068,6 +4068,8 @@ public:
             return;
         }
 
+        // NOTE:
+        // If you update this, please update error-reference to mention which types this check applies to
         auto isOnlySymbol =
             Types::isSubType(gs, args.fullType.type, Types::any(gs, Types::nilClass(), Types::Symbol()));
         if (isOnlySymbol && Types::all(gs, args.fullType.type, args.args[0]->type).isBottom()) {
@@ -4096,6 +4098,8 @@ public:
         auto isOnlyString =
             Types::isSubType(gs, args.fullType.type, Types::any(gs, Types::nilClass(), Types::String()));
 
+        // NOTE:
+        // If you update this, please update error-reference to mention which types this check applies to
         if (isOnlyString &&
             Types::isSubType(gs, args.args[0]->type, Types::any(gs, Types::nilClass(), Types::Symbol())) &&
             Types::all(gs, args.fullType.type, args.args[0]->type).isBottom()) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4068,6 +4068,7 @@ public:
             return;
         }
 
+        // TODO(jez) handle `nil`?
         if (args.fullType.type == Types::Symbol() && args.args[0]->type == Types::String()) {
             auto funLoc = args.funLoc();
             auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
@@ -4075,6 +4076,7 @@ public:
                 e.setHeader("Comparison between `{}` and `{}` is always false", "Symbol", "String");
                 e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
                 e.addErrorSection(args.args[0]->explainGot(gs, args.originForUninitialized));
+                // TODO(jez) Add autocorrect tack on `.to_sym`
             }
         }
     }
@@ -4087,6 +4089,7 @@ public:
             return;
         }
 
+        // TODO(jez) handle `nil`?
         if (args.fullType.type == Types::String() && args.args[0]->type == Types::Symbol()) {
             auto funLoc = args.funLoc();
             auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
@@ -4094,6 +4097,7 @@ public:
                 e.setHeader("Comparison between `{}` and `{}` is always false", "String", "Symbol");
                 e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
                 e.addErrorSection(args.args[0]->explainGot(gs, args.originForUninitialized));
+                // TODO(jez) Add autocorrect tack on `.to_sym`
             }
         }
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1453,23 +1453,6 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
 
     TypePtr &resultType = result.returnType;
 
-    if (args.name == core::Names::eqeq() && args.args.size() == 1) {
-        // TODO(jez) Using `fullType` will report identical errors twice...
-        auto left = Types::dropSubtypesOf(gs, args.fullType.type, Symbols::NilClass());
-        auto right = Types::dropSubtypesOf(gs, args.args[0]->type, Symbols::NilClass());
-
-        if (!Types::isSubTypeUnderConstraint(gs, *constr, left, right, UntypedMode::AlwaysCompatible) ||
-            !Types::isSubTypeUnderConstraint(gs, *constr, right, left, UntypedMode::AlwaysCompatible)) {
-            if (auto e = gs.beginError(errLoc, errors::Infer::NonOverlappingEqual)) {
-                e.setHeader("`{}` and `{}` do not overlap so comparison is always false", args.fullType.type.show(gs),
-                            args.args[0]->type.show(gs));
-                e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
-                e.addErrorSection(args.args[0]->explainGot(gs, args.originForUninitialized));
-            }
-            // TODO(jez) Also set resultType to FalseClass?
-        }
-    }
-
     auto *intrinsic = method.data(gs)->getIntrinsic();
     if (intrinsic != nullptr) {
         intrinsic->apply(gs, args, result);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4061,6 +4061,25 @@ public:
     }
 } Array_zip;
 
+class Symbol_eqeq : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        if (args.args.size() != 1) {
+            return;
+        }
+
+        if (args.fullType.type == Types::Symbol() && args.args[0]->type == Types::String()) {
+            auto funLoc = args.funLoc();
+            auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
+            if (auto e = gs.beginError(errLoc, errors::Infer::NonOverlappingEqual)) {
+                e.setHeader("Comparison between `{}` and `{}` is always false", "Symbol", "String");
+                e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
+                e.addErrorSection(args.args[0]->explainGot(gs, args.originForUninitialized));
+            }
+        }
+    }
+} Symbol_eqeq;
+
 class Kernel_proc : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
@@ -4317,6 +4336,8 @@ const vector<Intrinsic> intrinsics{
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::compact(), &Array_compact},
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::plus(), &Array_plus},
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::zip(), &Array_zip},
+
+    {Symbols::Symbol(), Intrinsic::Kind::Instance, Names::eqeq(), &Symbol_eqeq},
 
     {Symbols::Kernel(), Intrinsic::Kind::Instance, Names::proc(), &Kernel_proc},
     {Symbols::Kernel(), Intrinsic::Kind::Instance, Names::lambda(), &Kernel_proc},

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1436,8 +1436,8 @@ class Array < Object
   # a.include?("z")   #=> false
   # ```
   sig do
-    type_parameters(:U).params(
-        arg0: T.type_parameter(:U),
+    params(
+        arg0: Elem,
     )
     .returns(T::Boolean)
   end

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1436,8 +1436,8 @@ class Array < Object
   # a.include?("z")   #=> false
   # ```
   sig do
-    params(
-        arg0: T.nilable(Elem),
+    type_parameters(:U).params(
+        arg0: T.type_parameter(:U),
     )
     .returns(T::Boolean)
   end

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1437,7 +1437,7 @@ class Array < Object
   # ```
   sig do
     params(
-        arg0: Elem,
+        arg0: T.nilable(Elem),
     )
     .returns(T::Boolean)
   end

--- a/test/testdata/infer/eqeq.rb
+++ b/test/testdata/infer/eqeq.rb
@@ -36,7 +36,7 @@ def example1(x)
   end
 
   if x.str == x.sym
-    #      ^^ error: Comparison between `Symbol` and `String` is always false
+    #      ^^ error: Comparison between `String` and `Symbol` is always false
     p(x)
   end
 

--- a/test/testdata/infer/eqeq.rb
+++ b/test/testdata/infer/eqeq.rb
@@ -1,0 +1,106 @@
+# typed: true
+extend T::Sig
+
+class ConvertsToInteger
+  def ==(other)
+    other.is_a?(ConvertsToInteger) || other == 0
+  end
+end
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+  end
+end
+
+class A < T::Struct
+  const :sym, Symbol
+  const :str, String
+  const :maybe_sym, T.nilable(Symbol)
+  const :maybe_str, T.nilable(String)
+  const :str_or_sym, T.any(String, Symbol)
+  const :int_or_sym, T.any(Integer, Symbol)
+  const :str_or_int, T.any(String, Integer)
+  const :converts_to_integer, ConvertsToInteger
+  const :my_enum, MyEnum
+end
+
+sig do
+  params(x: A).void
+end
+def example1(x)
+  if x.sym == x.str
+    #      ^^ error: Comparison between `Symbol` and `String` is always false
+    p(x)
+  end
+
+  if x.str == x.sym
+    #      ^^ error: Comparison between `Symbol` and `String` is always false
+    p(x)
+  end
+
+  if x.sym == x.maybe_str
+    #      ^^ error: Comparison between `Symbol` and `T.nilable(String)` is always false
+    p(x)
+  end
+
+  if x.maybe_sym == x.str
+    #            ^^ error: Comparison between `T.nilable(Symbol)` and `String` is always false
+    p(x)
+  end
+
+  if x.maybe_sym == x.maybe_str
+    p(x)
+  end
+
+  if x.str_or_sym == x.str
+    p(x)
+  end
+
+  if x.str_or_sym == x.sym
+    p(x)
+  end
+
+  if x.sym == x.str_or_sym
+    p(x)
+  end
+
+  if x.str_or_sym == x.str_or_sym
+    p(x)
+  end
+
+  if x.int_or_sym == x.str_or_sym
+    p(x)
+  end
+
+  if x.int_or_sym == x.maybe_str
+    p(x)
+  end
+
+  if x.maybe_sym == x.str_or_int
+    #            ^^ error: Comparison between `T.nilable(Symbol)` and `T.any(String, Integer)` is always false
+    p(x)
+  end
+
+  if x.int_or_sym == x.converts_to_integer
+    p(x)
+  end
+
+  if x.sym == x.my_enum
+    #      ^^ error: Comparison between `Symbol` and `MyEnum` is always false
+    p(x)
+  end
+
+  if x.maybe_sym == x.my_enum
+    #            ^^ error: Comparison between `T.nilable(Symbol)` and `MyEnum` is always false
+    p(x)
+  end
+
+  if x.int_or_sym == x.my_enum
+    p(x)
+  end
+end
+
+
+

--- a/test/testdata/infer/eqeq.rb
+++ b/test/testdata/infer/eqeq.rb
@@ -45,10 +45,21 @@ def example1(x)
     p(x)
   end
 
+  if x.str == x.maybe_sym
+    #      ^^ error: Comparison between `String` and `T.nilable(Symbol)` is always false
+    p(x)
+  end
+
   if x.maybe_sym == x.str
     #            ^^ error: Comparison between `T.nilable(Symbol)` and `String` is always false
     p(x)
   end
+
+  if x.maybe_str == x.sym
+    #            ^^ error: Comparison between `T.nilable(String)` and `Symbol` is always false
+    p(x)
+  end
+
 
   if x.maybe_sym == x.maybe_str
     p(x)
@@ -66,11 +77,23 @@ def example1(x)
     p(x)
   end
 
+  if x.str == x.str_or_sym
+    p(x)
+  end
+
   if x.str_or_sym == x.str_or_sym
     p(x)
   end
 
   if x.int_or_sym == x.str_or_sym
+    p(x)
+  end
+
+  if x.str_or_int == x.maybe_sym
+    p(x)
+  end
+
+  if x.str_or_int == x.str_or_sym
     p(x)
   end
 

--- a/test/testdata/infer/eqeq.rb.autocorrects.exp
+++ b/test/testdata/infer/eqeq.rb.autocorrects.exp
@@ -1,0 +1,131 @@
+# -- test/testdata/infer/eqeq.rb --
+# typed: true
+extend T::Sig
+
+class ConvertsToInteger
+  def ==(other)
+    other.is_a?(ConvertsToInteger) || other == 0
+  end
+end
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+  end
+end
+
+class A < T::Struct
+  const :sym, Symbol
+  const :str, String
+  const :maybe_sym, T.nilable(Symbol)
+  const :maybe_str, T.nilable(String)
+  const :str_or_sym, T.any(String, Symbol)
+  const :int_or_sym, T.any(Integer, Symbol)
+  const :str_or_int, T.any(String, Integer)
+  const :converts_to_integer, ConvertsToInteger
+  const :my_enum, MyEnum
+end
+
+sig do
+  params(x: A).void
+end
+def example1(x)
+  if x.sym == x.str.to_sym
+    #      ^^ error: Comparison between `Symbol` and `String` is always false
+    p(x)
+  end
+
+  if x.str.to_sym == x.sym
+    #      ^^ error: Comparison between `Symbol` and `String` is always false
+    p(x)
+  end
+
+  if x.sym == x.maybe_str
+    #      ^^ error: Comparison between `Symbol` and `T.nilable(String)` is always false
+    p(x)
+  end
+
+  if x.str == x.maybe_sym
+    #      ^^ error: Comparison between `String` and `T.nilable(Symbol)` is always false
+    p(x)
+  end
+
+  if x.maybe_sym == x.str.to_sym
+    #            ^^ error: Comparison between `T.nilable(Symbol)` and `String` is always false
+    p(x)
+  end
+
+  if x.maybe_str.to_sym == x.sym
+    #            ^^ error: Comparison between `T.nilable(String)` and `Symbol` is always false
+    p(x)
+  end
+
+
+  if x.maybe_sym == x.maybe_str
+    p(x)
+  end
+
+  if x.str_or_sym == x.str
+    p(x)
+  end
+
+  if x.str_or_sym == x.sym
+    p(x)
+  end
+
+  if x.sym == x.str_or_sym
+    p(x)
+  end
+
+  if x.str == x.str_or_sym
+    p(x)
+  end
+
+  if x.str_or_sym == x.str_or_sym
+    p(x)
+  end
+
+  if x.int_or_sym == x.str_or_sym
+    p(x)
+  end
+
+  if x.str_or_int == x.maybe_sym
+    p(x)
+  end
+
+  if x.str_or_int == x.str_or_sym
+    p(x)
+  end
+
+  if x.int_or_sym == x.maybe_str
+    p(x)
+  end
+
+  if x.maybe_sym == x.str_or_int
+    #            ^^ error: Comparison between `T.nilable(Symbol)` and `T.any(String, Integer)` is always false
+    p(x)
+  end
+
+  if x.int_or_sym == x.converts_to_integer
+    p(x)
+  end
+
+  if x.sym == x.my_enum
+    #      ^^ error: Comparison between `Symbol` and `MyEnum` is always false
+    p(x)
+  end
+
+  if x.maybe_sym == x.my_enum
+    #            ^^ error: Comparison between `T.nilable(Symbol)` and `MyEnum` is always false
+    p(x)
+  end
+
+  if x.int_or_sym == x.my_enum
+    p(x)
+  end
+end
+
+
+
+# ------------------------------

--- a/test/testdata/infer/eqeq.rb.autocorrects.exp
+++ b/test/testdata/infer/eqeq.rb.autocorrects.exp
@@ -37,7 +37,7 @@ def example1(x)
   end
 
   if x.str.to_sym == x.sym
-    #      ^^ error: Comparison between `Symbol` and `String` is always false
+    #      ^^ error: Comparison between `String` and `Symbol` is always false
     p(x)
   end
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3956,12 +3956,12 @@ operand of `==` is:
 
 Sorbet is unable to apply these checks for all types, because `==` can be
 overridden in arbitrary ways, including to allow for implicit conversion between
-types unrelated types. This means that Sorbet will sometimes miss reporting this
-error in places where we would like it to, and can't be changed to report an
-error without breaking valid code.
+unrelated types. This means that Sorbet will sometimes miss reporting this error
+in places where we would like it to, and can't be changed to report an error
+without breaking valid code.
 
 To fix this error, ensure that the left and right operands' types match before
-doing the comparison. For example try converting `String`s to `Symbol`s with
+doing the comparison. For example, try converting `String`s to `Symbol`s with
 `to_sym` (or vice versa with `to_s`).
 
 <!-- -->

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3945,6 +3945,25 @@ To fix this error, provide an explicit annotation (or simply accept the
 For more information, read
 [Why does Sorbet sometimes need type annotations?](why-type-annotations.md).
 
+## 7046
+
+For a limited number of types, Sorbet checks whether it looks like a call to
+`==` is out of place. Currently, Sorbet only does these checks when the left
+operand of `==` is:
+
+- `Symbol`
+- `String`
+
+Sorbet is unable to apply these checks for all types, because `==` can be
+overridden in arbitrary ways, including to allow for implicit conversion between
+types unrelated types. This means that Sorbet will sometimes miss reporting this
+error in places where we would like it to, and can't be changed to report an
+error without breaking valid code.
+
+To fix this error, ensure that the left and right operands' types match before
+doing the comparison. For example try converting `String`s to `Symbol`s with
+`to_sym` (or vice versa with `to_s`).
+
 <!-- -->
 
 [report an issue]: https://github.com/sorbet/sorbet/issues


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After quite a while trying to get something good working here, I ended up with just something that's okay.

For more context, I'm going to post a blog post. For posterity, here's the draft:

[problems-typing-ruby-equality.pdf](https://github.com/sorbet/sorbet/files/10387645/problems-typing-ruby-equality.pdf)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

<img width="1004" alt="Screen Shot 2023-01-10 at 6 13 01 PM" src="https://user-images.githubusercontent.com/5544532/211701992-4c9b61af-ede9-4587-a1d1-a33b38dd3336.png">
