### PR TITLE
Fix compilation errors in fuzz test.

### DIFF
--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -70,7 +70,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     }
 
     indexed = realmain::pipeline::index(*gs, inputFiles, *opts, *workers, kvstore);
-    indexed = move(realmain::pipeline::resolve(gs, move(indexed), *opts, *workers).result());
-    realmain::pipeline::typecheck(gs, move(indexed), *opts, *workers);
+    auto foundHashes = nullptr;
+    indexed = move(realmain::pipeline::resolve(gs, move(indexed), *opts, *workers, foundHashes).result());
+    realmain::pipeline::typecheck(*gs, move(indexed), *opts, *workers);
     return 0;
 }


### PR DESCRIPTION
### Motivation

Without this, running `bazel test //...` in the root fails. (Even with this patch, it still fails due to a [generated by conflicting actions](https://sorbet-ruby.slack.com/archives/CFT8Y4909/p1673239228231249) error, but that can be worked around by using `--notrim_test_configuration`)

### Test plan

Should be covered by existing tests.
