### PR TITLE
make `MAX_SYNTHETIC_*_SYMBOLS` defined out-of-line

### DIFF
--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1076,11 +1076,11 @@ public:
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - 1);
     }
 
-    static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 209;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 48;
-    static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
-    static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
-    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 107;
+    static const int MAX_SYNTHETIC_CLASS_SYMBOLS;
+    static const int MAX_SYNTHETIC_METHOD_SYMBOLS;
+    static const int MAX_SYNTHETIC_FIELD_SYMBOLS;
+    static const int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS;
+    static const int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS;
 };
 
 template <typename H> H AbslHashValue(H h, const SymbolRef &m) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -22,6 +22,12 @@ namespace sorbet::core {
 
 using namespace std;
 
+const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 209;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 48;
+const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
+const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
+const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 107;
+
 namespace {
 constexpr string_view COLON_SEPARATOR = "::"sv;
 constexpr string_view HASH_SEPARATOR = "#"sv;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Having these constants defined in the header makes life inconvenient when you go to add a new builtin (`<Magic>.<magic-name>` or equivalent):

1. Modify `core/GlobalState.cc` and `core/tools/generate_names.cc`
2. Build the entire world because the names changed.
3. Hit an error because you forgot to update one of these constants.
4. Modify `core/SymbolRef.h` to update.
5. Build the world again, because everything depends on `core/SymbolRef.h`.

This PR moves the constants to be defined out-of-line.  You'll still hit part 3 in the above sequence, but since you have to modify a C++ file in step 4, you will not have to rebuild the entire world, and can pick up more-or-less where you left off.

This change will affect non-release builds (where we don't inline these constants anymore and instead have to load them from memory), but LTO should take care of inlining these constants where necessary in release builds.  As the primary uses of these symbols are in `ENFORCE`s, `SymbolRef::Proc0`, and `SymbolRef::isSynthetic()`, which I think is only used in printing things for `--print`, the impact should be pretty small.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I checked the section sizes for `--config=release-linux` builds before and after, and the section sizes for all the loadable sections (i.e. actual code, data, etc.) were identical.  I would expect them to be different if this changed codegen; it's possible that the instruction sequences used to load constants from memory is identical to whatever instructions have these values inline, but I would be surprised by that (plus loading things from memory changes e.g. register allocation etc., so other instructions are going to change too).

Debug info sections changed slightly, which is not surprising.