### PR TITLE
Don't generate send responses for suggest-constant-type (fixes #6229)

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1129,7 +1129,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 // by desugar and redacting the `SendResponse` so LSP features work
                 // more like developers expect.
                 const bool isDesugarTripleEqSend = send.fun == core::Names::tripleEq() && send.funLoc.empty();
-                // Something like `X = Foo` will be rewritten to `X = Magic.<suggest-constant-type>(Foo)`
+                // Something like `X = Foo` will be rewritten to `X = Magic.<suggest-constant-type>(Foo)` if `Foo` fails to resolve.
                 // We don't want to report a send response for the <suggest-constant-type> call here.
                 const bool isSuggestConstantType = send.fun == core::Names::suggestConstantType();
                 if (lspQueryMatch && !isDesugarTripleEqSend && !isSuggestConstantType) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1129,10 +1129,12 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 // by desugar and redacting the `SendResponse` so LSP features work
                 // more like developers expect.
                 const bool isDesugarTripleEqSend = send.fun == core::Names::tripleEq() && send.funLoc.empty();
-                // Something like `X = Foo` will be rewritten to `X = Magic.<suggest-constant-type>(Foo)` if `Foo` fails to resolve.
-                // We don't want to report a send response for the <suggest-constant-type> call here.
+                // Something like `X = Foo` will be rewritten to `X = Magic.<suggest-constant-type>(Foo)` if `Foo` fails
+                // to resolve. We don't want to report a send response for the <suggest-constant-type> call here.
                 const bool isSuggestConstantType = send.fun == core::Names::suggestConstantType();
-                if (lspQueryMatch && !isDesugarTripleEqSend && !isSuggestConstantType) {
+
+                const bool ignoreSendForLSPQuery = isDesugarTripleEqSend || isSuggestConstantType;
+                if (lspQueryMatch && !ignoreSendForLSPQuery) {
                     auto fun = send.fun;
                     if (fun == core::Names::checkAndAnd() && core::isa_type<core::NamedLiteralType>(args[1]->type)) {
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[2]->type);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1129,7 +1129,10 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 // by desugar and redacting the `SendResponse` so LSP features work
                 // more like developers expect.
                 const bool isDesugarTripleEqSend = send.fun == core::Names::tripleEq() && send.funLoc.empty();
-                if (lspQueryMatch && !isDesugarTripleEqSend) {
+                // Something like `X = Foo` will be rewritten to `X = Magic.<suggest-constant-type>(Foo)`
+                // We don't want to report a send response for the <suggest-constant-type> call here.
+                const bool isSuggestConstantType = send.fun == core::Names::suggestConstantType();
+                if (lspQueryMatch && !isDesugarTripleEqSend && !isSuggestConstantType) {
                     auto fun = send.fun;
                     if (fun == core::Names::checkAndAnd() && core::isa_type<core::NamedLiteralType>(args[1]->type)) {
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[2]->type);

--- a/test/testdata/lsp/completion/keywords.rb
+++ b/test/testdata/lsp/completion/keywords.rb
@@ -44,7 +44,7 @@ defined # error: does not exist
 d # error: does not exist
 #^ completion: def, defined?, do, ...
 
-# `else` is more common--be sureit comes before `ensure`
+# `else` is more common--be sure it comes before `ensure`
 els # error: does not exist
 #  ^ completion: else, elsif
 

--- a/test/testdata/lsp/constant_completion.rb
+++ b/test/testdata/lsp/constant_completion.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class A
+  module Namespace; end
+  Namespac # error: Unable to resolve constant `Namespac`
+  #       ^ completion: Namespace
+end
+
+class B
+  module Namespace; end
+  X = Namespac # error: Unable to resolve constant `Namespac`
+  #           ^ completion: Namespace
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

If we hit a `lspQueryMatch` for a send, but the method is `<suggest-constant-type>`, we will not generate a send response (similar to what we do for `===`).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`completion.cc` would use the `SendResponse` for the `<suggest-constant-type>` method, so the completion provided to the user was not useful.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
