### PR TITLE
be somewhat more efficient when updating knowledge in `assumeKnowledge`

### DIFF
--- a/infer/environment.h
+++ b/infer/environment.h
@@ -156,6 +156,8 @@ class Environment {
         VariableState() = default;
         VariableState(core::TypePtr type, core::Loc loc)
             : typeAndOrigins(std::move(type), loc) {}
+        VariableState(const core::TypeAndOrigins &typeAndOrigins)
+            : typeAndOrigins(typeAndOrigins) {}
     };
     // TODO(jvilk): Use vectors.
     UnorderedMap<cfg::LocalRef, VariableState> _vars;

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -152,6 +152,10 @@ class Environment {
         core::TypeAndOrigins typeAndOrigins;
         TestedKnowledge knowledge;
         bool knownTruthy;
+
+        VariableState() = default;
+        VariableState(core::TypePtr type, core::Loc loc)
+            : typeAndOrigins(std::move(type), loc) {}
     };
     // TODO(jvilk): Use vectors.
     UnorderedMap<cfg::LocalRef, VariableState> _vars;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We do any number of redundant hash lookups here, plus copies and constructing temporary objects we don't really need.  I'm not 100% sure that it is worth the efficiency squeeze, as the code is somewhat harder to understand now.  I think it's possible that there could be some kind of abstraction around the `fnd` and `taoType` variables, plus the `try_emplace` vs. modifying the hashtable entry directly, and that might make things better.

This change shaves ~3-5% off typechecking time (`typecheck.value` counter) on Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
