### PR TITLE
Add RBI for Ruby 3.1's `Array#intersect?(other_ary)`

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1566,6 +1566,20 @@ class Array < Object
   end
   def intersection(*arrays); end
 
+
+  # Returns `true` if the array and `other_ary` have at least one element in
+  # common, otherwise returns `false`:
+  #
+  # ```ruby
+  # a = [ 1, 2, 3 ]
+  # b = [ 3, 4, 5 ]
+  # c = [ 5, 6, 7 ]
+  # a.intersect?(b)   #=> true
+  # a.intersect?(c)   #=> false
+  # ```
+  sig { params(other_ary: T.untyped).returns(T::Boolean) }
+  def intersect(other_ary); end
+
   # Returns a string created by converting each element of the array to a
   # string, separated by the given `separator`. If the `separator` is `nil`, it
   # uses current `$,`. If both the `separator` and `$,` are `nil`, it uses an


### PR DESCRIPTION
This adds an RBI entry for `Array#intersect?(other_ary)`, which was added in Ruby 3.1, as per https://bugs.ruby-lang.org/issues/15198.

`other_ary` is typed as `T.untyped` as it can be any object that implicitly converts into an `Array` (i.e. responds to `to_ary`).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The method exists, so Sorbet should know about it. 😄

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I am unfamiliar with how RBIs are tested, if at all. I'm glad to add tests if appropriate.

I did check the docs and try out `intersect?` in the console and can confirm that in addition to any `Array`, it will accept objects responding to `to_ary`:

```ruby
arbitrary_object = Object.new
def arbitrary_object.to_ary = [1, 2, 3]
[3, 4, 5].intersect?(arbitrary_object) # => true
```

However, it rejects object that don't:

```ruby
[].intersect?(Object.new) # no implicit conversion of Object into Array (TypeError)
[].intersect?(nil)        # no implicit conversion of nil into Array (TypeError)
```
