### PR TITLE
ignore tmp directory when generating config file

### DIFF
--- a/gems/sorbet/lib/create-config.rb
+++ b/gems/sorbet/lib/create-config.rb
@@ -24,6 +24,7 @@ class Sorbet::Private::CreateConfig
     File.open(SORBET_CONFIG_FILE, 'w') do |f|
       f.puts('--dir')
       f.puts('.')
+      f.puts('--ignore=/tmp/')
       f.puts('--ignore=/vendor/bundle')
     end
   end


### PR DESCRIPTION
### Motivation

Was surprised to see some sorbet errors in my project without making any changes. Noticed that they are coming from tmp directory. So I think its reasonable to ignore `tmp` directory by default

### Test plan

Not sure about this, feel free to take over this PR and add the tests.

