### PR TITLE
add tests for typing `Kernel#p`

### DIFF
--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -65,9 +65,16 @@ T.assert_type!(obj.object_id, Integer)
 obj = T.let("foo", String)
 T.assert_type!(obj.itself, String)
 
-y = loop do
-end
-puts y # error: This code is unreachable
+
+# These types are deliberately wrong, because `Kernel#p` is difficult to type
+# in an RBI.  See the comments in kernel.rbi.
+p_result = Kernel.p 1
+T.reveal_type(p_result) # error: Revealed type: `NilClass`
+p_result = p "string"
+T.reveal_type(p_result) # error: Revealed type: `NilClass`
+# This should actually be typed as an array.
+p_result = p 1, 2
+T.reveal_type(p_result) # error: Revealed type: `NilClass`
 
 class CustomError < StandardError
   def initialize(cause, team)
@@ -87,3 +94,7 @@ end
 def fail_class_message
   fail StandardError, "message"
 end
+
+y = loop do
+end
+puts y # error: This code is unreachable


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Inspired by @jez's comments in #6659, add some tests for `Kernel#p` so the edge case of `Kernel#p` returning multiple arguments will be slightly more visible to anybody who comes along and tries to change the signature in `kernel.rbi` (or who is super-motivated and adds code in `core/types/calls.cc` for this).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  There are some additional changes because I added tests at the end of the file initially and was confused why errors weren't being issued.  It took me a while to figure out that the infinite `loop` was marking all the code after it as dead, so I moved the existing code that *was* after the `loop` prior to it.  Fortunately, it still passes tests.
