### PR TITLE
Improve Sorbet runtime caller frame matching logic

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -117,6 +117,11 @@ module T::Private::Methods
     @signatures_by_method[key]
   end
 
+  # Fetch the directory name of the file that defines the `T::Private` constant and
+  # add a trailing slash to allow us to match it as a directory prefix.
+  SORBET_RUNTIME_LIB_PATH = File.dirname(T.const_source_location(:Private).first) + File::SEPARATOR
+  private_constant :SORBET_RUNTIME_LIB_PATH
+
   # when target includes a module with instance methods source_method_names, ensure there is zero intersection between
   # the final instance methods of target and source_method_names. so, for every m in source_method_names, check if there
   # is already a method defined on one of target_ancestors with the same name that is final.
@@ -158,7 +163,7 @@ module T::Private::Methods
 
         definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
         is_redefined = target == ancestor
-        caller_loc = caller_locations&.find {|l| !l.to_s.match?(%r{sorbet-runtime[^/]*/lib/})}
+        caller_loc = caller_locations&.find {|l| !l.to_s.start_with?(SORBET_RUNTIME_LIB_PATH)}
         extra_info = "\n"
         if caller_loc
           extra_info = (is_redefined ? "Redefined" : "Overridden") + " here: #{caller_loc.path}:#{caller_loc.lineno}\n"


### PR DESCRIPTION
Currently Sorbet runtime matches caller locations against what it assumes are Sorbet runtime source file locations by using a regular expression. The regular expression expects the Sorbet runtime `lib` folder to be directly placed in a folder whose name includes the string `"sorbet-runtime"`. This kind of matching usually works but is prone to breakage if there are other gems that have the string `"sorbet-runtime"` in their folder names, or if the `lib` folder is placed in a folder that is named differently.

This PR improves the matching logic by storing the full path to the `lib` folder in a constant, and then filtering caller location paths that start with that path.

In order to get the full path to the `lib` folder, we rely on the const source location of the `T::Private` module, which is almost always guaranteed to be defined in `lib/sorbet_runtime.rb`. The `File.dirname` of that string gives us the full path to the `lib` folder for the running Sorbet runtime gem.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #6650 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests pass.
