### PR TITLE
Support setting `checked_tests` and `default_checked_level` via environment variables

### DIFF
--- a/gems/sorbet-runtime/README.md
+++ b/gems/sorbet-runtime/README.md
@@ -6,6 +6,32 @@ Full docs are at:
 - https://sorbet.org/docs/runtime
 - https://sorbet.org/docs/tconfiguration
 
+## Environment variables
+
+There are a number of environment variables that `sorbet-runtime` reads from to change it's
+behavior:
+
+- `SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS`
+
+  Announces to Sorbet that we are currently in a test environment, so it
+  should treat any sigs which are marked `.checked(:tests)` as if they were
+  just a normal sig.
+
+  This can also be done by calling `T::Configuration.enable_checking_for_sigs_marked_checked_tests`
+  but the environment variable ensures this value gets set before any sigs
+  are evaluated.
+
+- `SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL`
+
+  Configure the default checked level for a sig with no explicit `.checked`
+  builder. When unset, the default checked level is `:always`.
+
+  This can also be done by calling `T::Configuration.default_checked_level = ...`
+  but the environment variable ensures this value gets set before any sigs
+  are evaluated.
+
+## Testing
+
 To run the tests for sorbet-runtime locally:
 
 ```

--- a/gems/sorbet-runtime/README.md
+++ b/gems/sorbet-runtime/README.md
@@ -8,7 +8,7 @@ Full docs are at:
 
 ## Environment variables
 
-There are a number of environment variables that `sorbet-runtime` reads from to change it's
+There are a number of environment variables that `sorbet-runtime` reads from to change its
 behavior:
 
 - `SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS`

--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
@@ -53,6 +53,10 @@ module T::Private::RuntimeLevels
     if @has_read_default_checked_level
       raise "Set the default checked level earlier. There are already some methods whose sig blocks have evaluated which would not be affected by the new default."
     end
+    if !LEVELS.include?(default_checked_level)
+      raise "Invalid `checked` level '#{default_checked_level}'. Use one of: #{LEVELS}."
+    end
+
     @default_checked_level = default_checked_level
   end
 

--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
@@ -63,4 +63,19 @@ module T::Private::RuntimeLevels
   def self._toggle_checking_tests(checked)
     @check_tests = checked
   end
+
+  private_class_method def self.set_enable_checking_in_tests_from_environment
+    if ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS']
+      enable_checking_in_tests
+    end
+  end
+  set_enable_checking_in_tests_from_environment
+
+  private_class_method def self.set_default_checked_level_from_environment
+    level = ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL']
+    if level
+      self.default_checked_level = level.to_sym
+    end
+  end
+  set_default_checked_level_from_environment
 end

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -389,5 +389,39 @@ module Opus::Types::Test
         end
       end
     end
+
+    describe 'default_checked_level=' do
+      before do
+        @orig_has_read_default_checked_level = T::Private::RuntimeLevels.instance_variable_get(:@has_read_default_checked_level)
+        @orig_default_checked_level = T::Private::RuntimeLevels.instance_variable_get(:@default_checked_level)
+
+        # Within these specs pretend we haven't yet read this value
+        T::Private::RuntimeLevels.instance_variable_set(:@has_read_default_checked_level, false)
+      end
+
+      after do
+        T::Private::RuntimeLevels.instance_variable_set(:@default_checked_level, @orig_default_checked_level)
+        T::Private::RuntimeLevels.instance_variable_set(:@has_read_default_checked_level, @orig_has_read_default_checked_level)
+      end
+
+      it 'fails when given the wrong typed level' do
+        ex = assert_raises do
+          T::Configuration.default_checked_level = :foo
+        end
+        assert_includes(ex.message, "Invalid `checked` level 'foo'. Use one of: [:always, :tests, :never, :compiled].")
+      end
+
+      it 'fails when default_checked_level has already been read' do
+        T::Configuration.default_checked_level = :never
+        T::Configuration.default_checked_level = :tests
+
+        assert_equal(T::Private::RuntimeLevels.default_checked_level, :tests)
+
+        ex = assert_raises do
+          T::Configuration.default_checked_level = :never
+        end
+        assert_includes(ex.message, "Set the default checked level earlier. There are already some methods whose sig blocks have evaluated which would not be affected by the new default.")
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/test/types/runtime_levels.rb
+++ b/gems/sorbet-runtime/test/types/runtime_levels.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class RuntimeLevelsTest < Critic::Unit::UnitTest
+    describe 'set_enable_checking_in_tests_from_environment' do
+      before do
+        @orig_wrapped_tests_with_validation = T::Private::RuntimeLevels.instance_variable_get(:@wrapped_tests_with_validation)
+        @orig_check_tests = T::Private::RuntimeLevels.instance_variable_get(:@check_tests)
+
+        # Within these specs pretend we haven't yet read this value
+        T::Private::RuntimeLevels.instance_variable_set(:@wrapped_tests_with_validation, false)
+      end
+
+      after do
+        T::Private::RuntimeLevels.instance_variable_set(:@check_tests, @orig_check_tests)
+        T::Private::RuntimeLevels.instance_variable_set(:@wrapped_tests_with_validation, @orig_wrapped_tests_with_validation)
+      end
+
+      it 'does not change check_tests' do
+        # Reaching into a private method for testing purposes
+        T::Private::RuntimeLevels.send(:set_enable_checking_in_tests_from_environment)
+
+        assert_equal(T::Private::RuntimeLevels.check_tests?, false)
+      end
+
+      describe 'when SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS env variable is set' do
+        before do
+          @orig_SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS = ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS']
+          ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS'] = '1'
+        end
+
+        after do
+          ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS'] = @orig_SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS
+        end
+
+        it 'updates check_tests' do
+          # Reaching into a private method for testing purposes
+          T::Private::RuntimeLevels.send(:set_enable_checking_in_tests_from_environment)
+
+          assert_equal(T::Private::RuntimeLevels.check_tests?, true)
+        end
+      end
+    end
+
+    describe 'set_default_checked_level_from_environment' do
+      before do
+        @orig_has_read_default_checked_level = T::Private::RuntimeLevels.instance_variable_get(:@has_read_default_checked_level)
+        @orig_default_checked_level = T::Private::RuntimeLevels.instance_variable_get(:@default_checked_level)
+
+        # Within these specs pretend we haven't yet read this value
+        T::Private::RuntimeLevels.instance_variable_set(:@has_read_default_checked_level, false)
+      end
+
+      after do
+        T::Private::RuntimeLevels.instance_variable_set(:@default_checked_level, @orig_default_checked_level)
+        T::Private::RuntimeLevels.instance_variable_set(:@has_read_default_checked_level, @orig_has_read_default_checked_level)
+      end
+
+      it 'does not change default_typed_level' do
+        # Reaching into a private method for testing purposes
+        T::Private::RuntimeLevels.send(:set_default_checked_level_from_environment)
+
+        assert_equal(T::Private::RuntimeLevels.default_checked_level, :always)
+      end
+
+      describe 'when SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL env variable is set' do
+        before do
+          @orig_SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL = ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL']
+          ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL'] = 'never'
+        end
+
+        after do
+          ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL'] = @orig_SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL
+        end
+
+        it 'updates default_typed_level' do
+          # Reaching into a private method for testing purposes
+          T::Private::RuntimeLevels.send(:set_default_checked_level_from_environment)
+
+          assert_equal(T::Private::RuntimeLevels.default_checked_level, :never)
+        end
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/test/types/runtime_levels.rb
+++ b/gems/sorbet-runtime/test/types/runtime_levels.rb
@@ -26,12 +26,12 @@ module Opus::Types::Test
 
       describe 'when SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS env variable is set' do
         before do
-          @orig_SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS = ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS']
+          @orig_sorbet_runtime_enable_checking_in_tests = ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS']
           ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS'] = '1'
         end
 
         after do
-          ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS'] = @orig_SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS
+          ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS'] = @orig_sorbet_runtime_enable_checking_in_tests
         end
 
         it 'updates check_tests' do
@@ -66,12 +66,12 @@ module Opus::Types::Test
 
       describe 'when SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL env variable is set' do
         before do
-          @orig_SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL = ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL']
+          @orig_sorbet_runtime_default_checked_level = ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL']
           ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL'] = 'never'
         end
 
         after do
-          ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL'] = @orig_SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL
+          ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL'] = @orig_sorbet_runtime_default_checked_level
         end
 
         it 'updates default_typed_level' do

--- a/gems/sorbet-runtime/test/types/runtime_levels.rb
+++ b/gems/sorbet-runtime/test/types/runtime_levels.rb
@@ -7,31 +7,35 @@ module Opus::Types::Test
       before do
         @orig_wrapped_tests_with_validation = T::Private::RuntimeLevels.instance_variable_get(:@wrapped_tests_with_validation)
         @orig_check_tests = T::Private::RuntimeLevels.instance_variable_get(:@check_tests)
+        @orig_sorbet_runtime_enable_checking_in_tests = ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS']
 
-        # Within these specs pretend we haven't yet read this value
+        # Within these specs pretend we haven't yet read this value and checked_tests is false
         T::Private::RuntimeLevels.instance_variable_set(:@wrapped_tests_with_validation, false)
+        T::Private::RuntimeLevels.instance_variable_set(:@check_tests, false)
       end
 
       after do
         T::Private::RuntimeLevels.instance_variable_set(:@check_tests, @orig_check_tests)
         T::Private::RuntimeLevels.instance_variable_set(:@wrapped_tests_with_validation, @orig_wrapped_tests_with_validation)
+        ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS'] = @orig_sorbet_runtime_enable_checking_in_tests
       end
 
-      it 'does not change check_tests' do
-        # Reaching into a private method for testing purposes
-        T::Private::RuntimeLevels.send(:set_enable_checking_in_tests_from_environment)
+      describe 'when SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS env variable is not set' do
+        before do
+          ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS'] = nil
+        end
 
-        assert_equal(T::Private::RuntimeLevels.check_tests?, false)
+        it 'does not change check_tests' do
+          # Reaching into a private method for testing purposes
+          T::Private::RuntimeLevels.send(:set_enable_checking_in_tests_from_environment)
+
+          assert_equal(T::Private::RuntimeLevels.check_tests?, false)
+        end
       end
 
       describe 'when SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS env variable is set' do
         before do
-          @orig_sorbet_runtime_enable_checking_in_tests = ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS']
           ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS'] = '1'
-        end
-
-        after do
-          ENV['SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS'] = @orig_sorbet_runtime_enable_checking_in_tests
         end
 
         it 'updates check_tests' do
@@ -47,31 +51,35 @@ module Opus::Types::Test
       before do
         @orig_has_read_default_checked_level = T::Private::RuntimeLevels.instance_variable_get(:@has_read_default_checked_level)
         @orig_default_checked_level = T::Private::RuntimeLevels.instance_variable_get(:@default_checked_level)
+        @orig_sorbet_runtime_default_checked_level = ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL']
 
-        # Within these specs pretend we haven't yet read this value
+        # Within these specs pretend we haven't yet read this value and default_checked_level is always
         T::Private::RuntimeLevels.instance_variable_set(:@has_read_default_checked_level, false)
+        T::Private::RuntimeLevels.instance_variable_set(:@default_checked_level, :always)
       end
 
       after do
         T::Private::RuntimeLevels.instance_variable_set(:@default_checked_level, @orig_default_checked_level)
         T::Private::RuntimeLevels.instance_variable_set(:@has_read_default_checked_level, @orig_has_read_default_checked_level)
+        ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL'] = @orig_sorbet_runtime_default_checked_level
       end
 
-      it 'does not change default_typed_level' do
-        # Reaching into a private method for testing purposes
-        T::Private::RuntimeLevels.send(:set_default_checked_level_from_environment)
+      describe 'when SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL env variable is not set' do
+        before do
+          ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL'] = nil
+        end
 
-        assert_equal(T::Private::RuntimeLevels.default_checked_level, :always)
+        it 'does not change default_typed_level' do
+          # Reaching into a private method for testing purposes
+          T::Private::RuntimeLevels.send(:set_default_checked_level_from_environment)
+
+          assert_equal(T::Private::RuntimeLevels.default_checked_level, :always)
+        end
       end
 
       describe 'when SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL env variable is set' do
         before do
-          @orig_sorbet_runtime_default_checked_level = ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL']
           ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL'] = 'never'
-        end
-
-        after do
-          ENV['SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL'] = @orig_sorbet_runtime_default_checked_level
         end
 
         it 'updates default_typed_level' do


### PR DESCRIPTION
There are two methods that affect runtime type checking:
- `T::Configuration.default_checked_level = ...`
- `T::Configuration.enable_checking_for_sigs_marked_checked_tests`

These methods blow up if you've already read the underlying values you're intending to change so they need to be called high enough up the stack. However, this presents a potentially brittle load-order issue, especially as more gems/libraries start to be typed with sorbet.

This PR enables setting those values via an environment variable so that they're guaranteed to be set to your desired values at the time sorbet is loaded

### Motivation

- Have a way to guarantee these values are set properly in a way that doesn't require any change to how sorbet-runtime is loaded.
- Provides a solution to an open issue described in #6667 

### Test plan

See included automated tests.