### PR TITLE
Add RBI for URI::WS

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -651,6 +651,11 @@ module URI::Escape
 
 end
 
+# The "file" [`URI`](https://docs.ruby-lang.org/en/2.7.0/URI.html) is defined by
+# RFC8089.
+class URI::File < URI::Generic
+end
+
 # [`FTP`](https://docs.ruby-lang.org/en/2.7.0/URI/FTP.html)
 # [`URI`](https://docs.ruby-lang.org/en/2.7.0/URI.html) syntax is defined by
 # RFC1738 section 3.2.
@@ -2350,9 +2355,4 @@ class URI::RFC3986_Parser < Object
 end
 
 module URI::Util
-end
-
-# The "file" [`URI`](https://docs.ruby-lang.org/en/2.7.0/URI.html) is defined by
-# RFC8089.
-class URI::File < URI::Generic
 end

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -2356,3 +2356,52 @@ end
 
 module URI::Util
 end
+
+# The syntax of WS URIs is defined in RFC6455 section 3.
+#
+# Note that the Ruby URI library allows WS URLs containing usernames and
+# passwords. This is not legal as per the RFC, but used to be
+# supported in Internet Explorer 5 and 6, before the MS04-004 security
+# update. See <URL:http://support.microsoft.com/kb/834489>.
+class URI::WS
+  # A Default port of 80 for URI::WS.
+  DEFAULT_PORT = T.let(T.unsafe(nil), Integer)
+
+  # An Array of the available components for URI::WS.
+  COMPONENT = T.let(T.unsafe(nil), T::Array[Symbol])
+
+  # == Description
+  #
+  # Creates a new URI::WS object from components, with syntax checking.
+  #
+  # The components accepted are userinfo, host, port, path, and query.
+  #
+  # The components should be provided either as an Array, or as a Hash
+  # with keys formed by preceding the component names with a colon.
+  #
+  # If an Array is used, the components must be passed in the
+  # order <code>[userinfo, host, port, path, query]</code>.
+  #
+  # Example:
+  #
+  #     uri = URI::WS.build(host: 'www.example.com', path: '/foo/bar')
+  #
+  #     uri = URI::WS.build([nil, "www.example.com", nil, "/path", "query"])
+  #
+  # Currently, if passed userinfo components this method generates
+  # invalid WS URIs as per RFC 1738.
+  def self.build(args); end
+
+  # == Description
+  #
+  # Returns the full path for a WS URI, as required by Net::HTTP::Get.
+  #
+  # If the URI contains a query, the full path is URI#path + '?' + URI#query.
+  # Otherwise, the path is simply URI#path.
+  #
+  # Example:
+  #
+  #     uri = URI::WS.build(path: '/foo/bar', query: 'test=true')
+  #     uri.request_uri #  => "/foo/bar?test=true"
+  def request_uri; end
+end


### PR DESCRIPTION
### Motivation

Add missing payload definition for the `URI::WS` class: https://github.com/ruby/ruby/blob/v3_0_5/lib/uri/ws.rb#L22.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
