### PR TITLE
Disable runtime type check in CustomType.scalar_type?

### DIFF
--- a/gems/sorbet-runtime/bench/serialize_custom_type.rb
+++ b/gems/sorbet-runtime/bench/serialize_custom_type.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module SerializeCustomType
+
+    class MyCustomType
+      extend T::Props::CustomType
+
+      attr_accessor :value
+
+      def initialize(value)
+        @value = value
+      end
+
+      # Not used in this benchmark.
+      def self.deserialize(value)
+        result = new
+        result.value = value.clone.freeze
+        result
+      end
+
+      def self.serialize(instance)
+        instance.value
+      end
+    end
+
+    def self.run
+      input = MyCustomType.new(123)
+
+      100_000.times do
+        T::Props::CustomType.checked_serialize(input)
+      end
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          T::Props::CustomType.checked_serialize(input)
+        end
+      end
+
+      puts "T::Props::CustomType.checked_serialize (μs/iter):"
+      puts result
+    end
+  end
+end

--- a/gems/sorbet-runtime/bench/serialize_custom_type.rb
+++ b/gems/sorbet-runtime/bench/serialize_custom_type.rb
@@ -7,7 +7,6 @@ require_relative '../lib/sorbet-runtime'
 
 module SorbetBenchmarks
   module SerializeCustomType
-
     class MyCustomType
       extend T::Props::CustomType
 

--- a/gems/sorbet-runtime/bench/tasks.rb
+++ b/gems/sorbet-runtime/bench/tasks.rb
@@ -6,6 +6,7 @@ require_relative 'setters'
 require_relative 'constructor'
 require_relative 'deserialize'
 require_relative 'prop_definition'
+require_relative 'serialize_custom_type'
 require_relative 'typecheck'
 
 namespace :bench do
@@ -29,9 +30,13 @@ namespace :bench do
     SorbetBenchmarks::PropDefinition.run
   end
 
+  task :serialize_custom_type do
+    SorbetBenchmarks::SerializeCustomType.run
+  end
+
   task :typecheck do
     SorbetBenchmarks::Typecheck.run
   end
 
-  task all: %i[getters setters constructor deserialize prop_definition typecheck]
+  task all: %i[getters setters constructor deserialize prop_definition serialize_custom_type typecheck]
 end

--- a/gems/sorbet-runtime/lib/types/props/custom_type.rb
+++ b/gems/sorbet-runtime/lib/types/props/custom_type.rb
@@ -57,13 +57,12 @@ module T::Props
       raise 'Please use "extend", not "include" to attach this module'
     end
 
-    sig(:final) {params(val: Object).returns(T::Boolean).checked(:never)}
+    sig(:final) {params(val: T.untyped).returns(T::Boolean).checked(:never)}
     def self.scalar_type?(val)
       # We don't need to check for val's included modules in
       # T::Configuration.scalar_types, because T::Configuration.scalar_types
       # are all classes.
-      # We elide `klass : T.nilable(Class)` to avoid allocations.
-      klass = T.unsafe(val.class)
+      klass = val.class
       until klass.nil?
         return true if T::Configuration.scalar_types.include?(klass.to_s)
         klass = klass.superclass

--- a/gems/sorbet-runtime/lib/types/props/custom_type.rb
+++ b/gems/sorbet-runtime/lib/types/props/custom_type.rb
@@ -62,7 +62,8 @@ module T::Props
       # We don't need to check for val's included modules in
       # T::Configuration.scalar_types, because T::Configuration.scalar_types
       # are all classes.
-      klass = T.let(val.class, T.nilable(Class))
+      # We elide `klass : T.nilable(Class)` to avoid allocations.
+      klass = T.unsafe(val.class)
       until klass.nil?
         return true if T::Configuration.scalar_types.include?(klass.to_s)
         klass = klass.superclass


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
`T::Props::CustomType.checked_serialize` is called a fair amount during serialization. Creating this PR to check whether removing the runtime type check has any effect on performance in practice.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Behavior should be unchanged. Added a new microbenchmark.

Before:
```
$ bundle exec rake bench:serialize_custom_type
T::Props::CustomType.checked_serialize (μs/iter):
  1.118573   0.005625   1.124198 (  1.125563)
```
After:
```
$ bundle exec rake bench:serialize_custom_type
T::Props::CustomType.checked_serialize (μs/iter):
  0.477603   0.002454   0.480057 (  0.480592)
```