### PR TITLE
Fixes Typo in Array#intersect?

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1578,7 +1578,7 @@ class Array < Object
   # a.intersect?(c)   #=> false
   # ```
   sig { params(other_ary: T.untyped).returns(T::Boolean) }
-  def intersect(other_ary); end
+  def intersect?(other_ary); end
 
   # Returns a string created by converting each element of the array to a
   # string, separated by the given `separator`. If the `separator` is `nil`, it

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -59,3 +59,8 @@ T.reveal_type(['a','b','c'].bsearch_index {|x| x == 'a'}) # error: Revealed type
 
 T.assert_type!([1, 2].to_set { |x| x + 1 }, T::Set[T.untyped])
 T.assert_type!([1, 2].to_set, T::Set[T.untyped])
+
+# intersecting
+arr = [1, 2, 3]
+T.assert_type!(arr.intersection([3, 5]), T::Array[Integer])
+T.assert_type!(arr.intersect?([2, 7]), T::Boolean)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes typo that slipped in: https://github.com/sorbet/sorbet/pull/6658


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet does not recognize `Array#intersect?`, and falsely suggests `Array#intersect`

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
