### PR TITLE
Add docs for sorbet-runtime environment variables

### DIFF
--- a/gems/sorbet-runtime/README.md
+++ b/gems/sorbet-runtime/README.md
@@ -6,32 +6,6 @@ Full docs are at:
 - https://sorbet.org/docs/runtime
 - https://sorbet.org/docs/tconfiguration
 
-## Environment variables
-
-There are a number of environment variables that `sorbet-runtime` reads from to change its
-behavior:
-
-- `SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS`
-
-  Announces to Sorbet that we are currently in a test environment, so it
-  should treat any sigs which are marked `.checked(:tests)` as if they were
-  just a normal sig.
-
-  This can also be done by calling `T::Configuration.enable_checking_for_sigs_marked_checked_tests`
-  but the environment variable ensures this value gets set before any sigs
-  are evaluated.
-
-- `SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL`
-
-  Configure the default checked level for a sig with no explicit `.checked`
-  builder. When unset, the default checked level is `:always`.
-
-  This can also be done by calling `T::Configuration.default_checked_level = ...`
-  but the environment variable ensures this value gets set before any sigs
-  are evaluated.
-
-## Testing
-
 To run the tests for sorbet-runtime locally:
 
 ```

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -271,6 +271,10 @@ default checked level can also be configured. For example:
 T::Configuration.default_checked_level = :tests
 ```
 
+This can also be set via the `SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL`
+environment variable, see [Environment Variables](tconfiguration.md#environment-variables)
+for more.
+
 Writing this will make it so that any sig which does not have a `.checked(...)`
 call in it will behave as if the user had written `.checked(:tests)`. To prevent
 accidental misuse, `sorbet-runtime` will require that this setting is changed
@@ -283,6 +287,10 @@ point is a test, run:
 ```ruby
 T::Configuration.enable_checking_for_sigs_marked_checked_tests
 ```
+
+This can also be set via the `SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS`
+environment variable, see [Environment Variables](tconfiguration.md#environment-variables)
+for more.
 
 For example, this should probably be placed as the first line of any `rake test`
 target, as well as any other entry point to a project's tests. If this line is

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -271,8 +271,8 @@ default checked level can also be configured. For example:
 T::Configuration.default_checked_level = :tests
 ```
 
-This can also be set via the `SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL`
-environment variable, see [Environment Variables](tconfiguration.md#environment-variables)
+This can also be set via the `SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL` environment
+variable, see [Environment Variables](tconfiguration.md#environment-variables)
 for more.
 
 Writing this will make it so that any sig which does not have a `.checked(...)`
@@ -289,8 +289,8 @@ T::Configuration.enable_checking_for_sigs_marked_checked_tests
 ```
 
 This can also be set via the `SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS`
-environment variable, see [Environment Variables](tconfiguration.md#environment-variables)
-for more.
+environment variable, see
+[Environment Variables](tconfiguration.md#environment-variables) for more.
 
 For example, this should probably be placed as the first line of any `rake test`
 target, as well as any other entry point to a project's tests. If this line is

--- a/website/docs/tconfiguration.md
+++ b/website/docs/tconfiguration.md
@@ -104,3 +104,28 @@ T::Configuration.sig_validation_error_handler = lambda do |error, opts|
   puts error.message
 end
 ```
+
+## Environment variables
+
+There are a number of environment variables that `sorbet-runtime` reads from
+to change its behavior:
+
+### `SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS`
+
+Announces to Sorbet that we are currently in a test environment, so it
+should treat any sigs which are marked `.checked(:tests)` as if they were
+just a normal sig. This can be set to any truthy value to take effect.
+
+This can also be done by calling `T::Configuration.enable_checking_for_sigs_marked_checked_tests`
+but the environment variable ensures this value gets set before any sigs
+are evaluated.
+
+### `SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL`
+
+Configure the default checked level for a sig with no explicit `.checked`
+builder. When unset, the default checked level is `:always`. This must be
+set to a valid checked level (e.g. `always` or `tests`).
+
+This can also be done by calling `T::Configuration.default_checked_level = ...`
+but the environment variable ensures this value gets set before any sigs
+are evaluated.

--- a/website/docs/tconfiguration.md
+++ b/website/docs/tconfiguration.md
@@ -107,25 +107,25 @@ end
 
 ## Environment variables
 
-There are a number of environment variables that `sorbet-runtime` reads from
-to change its behavior:
+There are a number of environment variables that `sorbet-runtime` reads from to
+change its behavior:
 
 ### `SORBET_RUNTIME_ENABLE_CHECKING_IN_TESTS`
 
-Announces to Sorbet that we are currently in a test environment, so it
-should treat any sigs which are marked `.checked(:tests)` as if they were
-just a normal sig. This can be set to any truthy value to take effect.
+Announces to Sorbet that we are currently in a test environment, so it should
+treat any sigs which are marked `.checked(:tests)` as if they were just a normal
+sig. This can be set to any truthy value to take effect.
 
-This can also be done by calling `T::Configuration.enable_checking_for_sigs_marked_checked_tests`
-but the environment variable ensures this value gets set before any sigs
-are evaluated.
+This can also be done by calling
+`T::Configuration.enable_checking_for_sigs_marked_checked_tests` but the
+environment variable ensures this value gets set before any sigs are evaluated.
 
 ### `SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL`
 
 Configure the default checked level for a sig with no explicit `.checked`
-builder. When unset, the default checked level is `:always`. This must be
-set to a valid checked level (e.g. `always` or `tests`).
+builder. When unset, the default checked level is `:always`. This must be set to
+a valid checked level (e.g. `always` or `tests`).
 
 This can also be done by calling `T::Configuration.default_checked_level = ...`
-but the environment variable ensures this value gets set before any sigs
-are evaluated.
+but the environment variable ensures this value gets set before any sigs are
+evaluated.


### PR DESCRIPTION
Adds docs for environment variables added in #6668. Happy to edit/modify the test if necessary, or reviewers can feel free to make the edits themselves.

### Motivation

Addresses https://github.com/sorbet/sorbet/pull/6668#discussion_r1085991360

### Test plan

n/a