### PR TITLE
Make the autocorrect for unresolved constants case-insensitive

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -880,8 +880,6 @@ ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
                             }
                         }
 
-                        // auto thisDistance = Levenstein::distance(
-                        //     currentName, member.first.dataCnst(gs)->original.dataUtf8(gs)->utf8, best.distance);
                         auto thisDistance = caseInsensitiveAndSensitiveDist(
                             currentName, member.first.dataCnst(gs)->original.dataUtf8(gs)->utf8, best.distance);
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -837,6 +837,8 @@ ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
         best.distance = 1 + (currentName.size() / 2);
     }
 
+    best.vectorDist = make_pair(best.distance, best.distance);
+
     bool onlySuggestPackageSpecs = ref(gs).isPackageSpecSymbol(gs);
 
     // Find the closest by following outer scopes

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -521,7 +521,7 @@ public:
         SymbolRef symbol;
         NameRef name;
         int distance;
-        std::pair<int, int> vectorDist;
+        int insensitiveDistance;
     };
 
     std::vector<FuzzySearchResult> findMemberFuzzyMatch(const GlobalState &gs, NameRef name, int betterThan = -1) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -521,6 +521,7 @@ public:
         SymbolRef symbol;
         NameRef name;
         int distance;
+        std::pair<int, int> vectorDist;
     };
 
     std::vector<FuzzySearchResult> findMemberFuzzyMatch(const GlobalState &gs, NameRef name, int betterThan = -1) const;
@@ -611,6 +612,9 @@ private:
     FuzzySearchResult findMemberFuzzyMatchUTF8(const GlobalState &gs, NameRef name, int betterThan = -1) const;
     std::vector<FuzzySearchResult> findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
                                                                 int betterThan = -1) const;
+
+    static std::pair<int, int> caseInsensitiveAndSensitiveDist(std::string_view s1, std::string_view s2,
+                                                               int bound) noexcept;
 
     /*
      * mixins and superclasses: `superClass` is *not* included in the


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The autocorrect for unresolved constants used a case-insensitive Levenstein (edit) distance. This PR changes it to be case **insensitive** edit distance, with ties broken by case-sensitive edit distance (i.e. `d(s1, s2) = (insensitive(s1, s2), sensitive(s1, s2))`). 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
(1) the case sensitive metric misses out on obvious capitalization typos, (2) this would help significantly accelerate/enable an ongoing codemod at Stripe.

### Test plan
eg fixture:
<img width="256" alt="Screen Shot 2023-01-25 at 12 12 47 PM" src="https://user-images.githubusercontent.com/111023001/214679290-7d2471b7-d62e-4568-ba93-65a20cefcfab.png">

previous autocorrect:
<img width="643" alt="Screen Shot 2023-01-25 at 12 12 15 PM" src="https://user-images.githubusercontent.com/111023001/214679302-4ee72c55-ce95-4918-ace1-5aba8bd55672.png">

new autocorrect:
<img width="666" alt="Screen Shot 2023-01-25 at 12 09 56 PM" src="https://user-images.githubusercontent.com/111023001/214679305-5458b529-5fad-4d48-a736-8340657eb279.png">

<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
