### PR TITLE
Make Levenstein distance case-insensitive for unresolved constant autocorrect

### DIFF
--- a/common/Levenstein.cc
+++ b/common/Levenstein.cc
@@ -29,7 +29,10 @@ int sorbet::Levenstein::distance(string_view s1, string_view s2, int bound) noex
         int lastDiagonal = x - 1;
         for (auto y = 1; y <= s1len; y++) {
             int oldDiagonal = column[y];
-            auto possibilities = {column[y] + 1, column[y - 1] + 1, lastDiagonal + (s1[y - 1] == s2[x - 1] ? 0 : 1)};
+            auto possibilities = {
+                column[y] + 1, column[y - 1] + 1,
+                lastDiagonal +
+                    (std::tolower(s1[y - 1], std::locale()) == std::tolower(s2[x - 1], std::locale()) ? 0 : 1)};
             column[y] = min(possibilities);
             lastDiagonal = oldDiagonal;
         }

--- a/test/cli/constant-fuzzy/test.out
+++ b/test/cli/constant-fuzzy/test.out
@@ -8,6 +8,13 @@ test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Yieldr`
     https://github.com/sorbet/sorbet/tree/master/rbi/core/enumerator.rbi#LCENSORED: `Enumerator::Yielder` defined here
       NN |class Enumerator::Yielder < Object
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Did you mean `NIL`? Use `-a` to autocorrect
+    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `NIL`
+     3 |Yieldr.foo(Intege, Int)
+        ^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/constants.rbi#LCENSORED: `NIL` defined here
+    NN |::NIL = T.let(T.unsafe(nil), NilClass)
+        ^^^^^
   Did you mean `File`? Use `-a` to autocorrect
     test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `File`
      3 |Yieldr.foo(Intege, Int)
@@ -15,13 +22,6 @@ test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Yieldr`
     https://github.com/sorbet/sorbet/tree/master/rbi/core/file.rbi#LCENSORED: `File` defined here
     NN |class File < IO
         ^^^^^^^^^^^^^^^
-  Did you mean `Dir`? Use `-a` to autocorrect
-    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Dir`
-     3 |Yieldr.foo(Intege, Int)
-        ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
 
 test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Intege` https://srb.help/5002
      3 |Yieldr.foo(Intege, Int)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
on the tin

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
(1) the case sensitive metric misses out on obvious capitalization typos, (2) this would help significantly accelerate/enable an ongoing codemod at Stripe.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
eg fixture:
<img width="256" alt="Screen Shot 2023-01-25 at 12 12 47 PM" src="https://user-images.githubusercontent.com/111023001/214679290-7d2471b7-d62e-4568-ba93-65a20cefcfab.png">

previous autocorrect:
<img width="643" alt="Screen Shot 2023-01-25 at 12 12 15 PM" src="https://user-images.githubusercontent.com/111023001/214679302-4ee72c55-ce95-4918-ace1-5aba8bd55672.png">

new autocorrect:
<img width="666" alt="Screen Shot 2023-01-25 at 12 09 56 PM" src="https://user-images.githubusercontent.com/111023001/214679305-5458b529-5fad-4d48-a736-8340657eb279.png">
See included automated tests.
