### PR TITLE
Stop crashing for type_member/type_template mismatch

### DIFF
--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -440,6 +440,7 @@ public:
     bool isTypeAlias(const GlobalState &gs) const;
     bool isField(const GlobalState &gs) const;
     bool isStaticField(const GlobalState &gs) const;
+    bool isClassAlias(const GlobalState &gs) const;
 
     uint32_t classOrModuleIndex() const {
         ENFORCE_NO_TIMER(kind() == Kind::ClassOrModule);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -232,6 +232,19 @@ bool SymbolRef::isStaticField(const GlobalState &gs) const {
     return isFieldOrStaticField() && asFieldRef().dataAllowingNone(gs)->flags.isStaticField;
 }
 
+bool SymbolRef::isClassAlias(const GlobalState &gs) const {
+    if (!isFieldOrStaticField()) {
+        return false;
+    }
+
+    const auto &data = asFieldRef().dataAllowingNone(gs);
+    if (!data->flags.isStaticField) {
+        return false;
+    }
+
+    return data->isClassAlias();
+}
+
 ClassOrModuleData ClassOrModuleRef::dataAllowingNone(GlobalState &gs) const {
     ENFORCE_NO_TIMER(_id < gs.classAndModulesUsed());
     return ClassOrModuleData(gs.classAndModules[_id], gs);

--- a/test/testdata/core/fuzz_bad_subtyping.rb
+++ b/test/testdata/core/fuzz_bad_subtyping.rb
@@ -13,7 +13,7 @@ module MyEnumerable
   def -(a) end
   class MySet
     include MyEnumerable
-    A = # error: Type variable `A` needs to be declared as `= type_member(SOMETHING)`
+    A = # error: Type variable `A` needs to be declared as a type_member or type_template, not a static-field
       new - MySet.new()
   end
 end

--- a/test/testdata/resolver/redeclare_type_member_template.rb
+++ b/test/testdata/resolver/redeclare_type_member_template.rb
@@ -1,0 +1,30 @@
+# typed: true
+# disable-fast-path: true
+extend T::Sig
+
+class Parent
+  extend T::Generic
+  extend T::Sig
+
+  X = type_member
+  sig {returns(X)}
+  def foo; raise "unimplemented"; end
+end
+
+class Child1 < Parent
+  extend T::Generic
+
+  X = type_template { {fixed: Integer} } # error: `X` must be declared as a type_member (not a type_template) to match the parent
+
+  def main
+    x = foo
+  end
+end
+
+class Child2 < Parent # error: Type `X` declared by parent `Parent` must be re-declared in `Child2`
+  extend T::Generic
+
+  def main
+    x = foo
+  end
+end

--- a/test/testdata/resolver/redefinition_of_subclass_type_member.rb
+++ b/test/testdata/resolver/redefinition_of_subclass_type_member.rb
@@ -26,6 +26,6 @@ end
 
 class Bar < Foo # error: Type `V` declared by parent `Foo` must be re-declared in `Bar`
   K = Bar[String,String].new.foo('a', 2)
-# ^ error: Type variable `K` needs to be declared as `= type_member(SOMETHING)`
+# ^ error: Type variable `K` needs to be declared as a type_member or type_template, not a static-field
   #       ^^^^^^^^^^^^^ error: Wrong number of type parameters
 end

--- a/test/testdata/resolver/type_member_parent_missing.rb
+++ b/test/testdata/resolver/type_member_parent_missing.rb
@@ -19,7 +19,7 @@
 # ^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each`
     include Enumerable
     Elem = T.let(0, Integer)
-  # ^^^^ error: Type variable `Elem` needs to be declared as `= type_member(SOMETHING)`
+  # ^^^^ error: Type variable `Elem` needs to be declared as a type_member or type_template, not a static-field
   end
 
   class Bar2 < Foo2

--- a/test/testdata/resolver/type_member_static_field.rb
+++ b/test/testdata/resolver/type_member_static_field.rb
@@ -1,14 +1,15 @@
 # typed: true
+# disable-fast-path: true
 
-# class Parent1
-#   extend T::Generic
+class Parent1
+  extend T::Generic
 
-#   X = type_member
-# end
-# class Child1 < Parent1
-#   Elem = type_template
-#   X = Elem
-# end
+  X = type_member
+end
+class Child1 < Parent1
+  Elem = type_template
+  X = Elem # error: Type variable `X` needs to be declared as a type_member or type_template, not a static-field
+end
 
 class Parent2
   extend T::Generic
@@ -18,5 +19,5 @@ end
 
 class Child2 < Parent2
   Elem = type_member
-  X = Elem
+  X = Elem # error: Type variable `X` needs to be declared as a type_member or type_template, not a static-field
 end

--- a/test/testdata/resolver/type_member_static_field.rb
+++ b/test/testdata/resolver/type_member_static_field.rb
@@ -1,0 +1,22 @@
+# typed: true
+
+# class Parent1
+#   extend T::Generic
+
+#   X = type_member
+# end
+# class Child1 < Parent1
+#   Elem = type_template
+#   X = Elem
+# end
+
+class Parent2
+  extend T::Generic
+
+  X = type_member
+end
+
+class Child2 < Parent2
+  Elem = type_member
+  X = Elem
+end

--- a/test/testdata/resolver/type_member_type_template_mismatch.rb
+++ b/test/testdata/resolver/type_member_type_template_mismatch.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# disable-fast-path: true
+
+class AbstractRPCMethod
+  extend T::Generic
+
+  RPCInput = type_member
+end
+
+class TextDocumentHoverMethod < AbstractRPCMethod
+  RPCInput = type_template # error: `RPCInput` must be declared as a type_member (not a type_template) to match the parent
+end

--- a/test/testdata/resolver/type_members.rb
+++ b/test/testdata/resolver/type_members.rb
@@ -56,5 +56,5 @@ class BadChild2 < Parent # error: must be re-declared
 end
 
 class BadChild3 < Parent
-  Elem = 3 # error: Type variable `Elem` needs to be declared as `= type_member(SOMETHING)`
+  Elem = 3 # error: Type variable `Elem` needs to be declared as a type_member or type_template, not a static-field
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5719
Fixes #5281

### Commit summary

- **Add test showing existing behavior** (6ddceee11)

  The commented out section crashes, but surprisingly, there's no error
  for the other part. I don't think people should be relying on it working
  that way, and I intend to make that an error.

- **Fix crash via findMemberNoDealias** (213d2bfbf)

  The fix for the crash is one line: `findMember` -> `findMemberNoDealias`

  What was happening before was that for an example like this (from the
  test suite):

      class AbstractRPCMethod
       extend T::Generic

        RPCInput = type_member
     end

      class TextDocumentHoverMethod < AbstractRPCMethod
       RPCInput = type_template
     end

  Sorbet thought that it `foundAll` parent type members in the child. That
  was deceptive though, because what was actually happening was:

  - it found the static field class alias we create in
    `TextDocumentHoverMethod` called `RPCInput` that forwards to the
    _real_ type_template on `T.class_of(TextDocumentHoverMethod)`
  - it just so happened that the thing it resolves to `isTypeMember` and
     has the same name, so Sorbet would think that it found what it was
     looking for.

  I've decided to fix this by not allowing any type members to be
  redeclared indirectly via an alias. This prevents some code that used to
  work from working, but I can only imagine contrived use cases for that,
  and this seems wholly better to ban it.

  The error handling code implements a special case for the
  type_member/type_template mismatch (not out of necessity but instead to
  prevent confusion).

- **Some tests change** (697addf2f)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.