### PR TITLE
Collapse duplicate hover results for union types

### DIFF
--- a/main/lsp/LSPLoop.h
+++ b/main/lsp/LSPLoop.h
@@ -94,6 +94,9 @@ std::optional<std::string> findDocumentation(std::string_view sourceCode, int be
 bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym);
 std::unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, std::string_view rubyMarkup,
                                                 std::optional<std::string_view> explanation);
+std::string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method);
+std::string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
+                               core::TypePtr retType, const core::TypeConstraint *constraint);
 std::string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
                                 const core::TypePtr &retType, const core::TypeConstraint *constraint);
 std::string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -22,8 +22,13 @@ string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retTyp
         if (component.method.exists()) {
             auto method = component.method;
 
-            contents.push_back(
-                prettySigForMethod(gs, method, component.receiver, method.data(gs)->resultType, constraint.get()));
+            auto localRetType =
+                getResultType(gs, method.data(gs)->resultType, method, component.receiver, constraint.get());
+            if (localRetType == nullptr || localRetType.isUntyped()) {
+                localRetType = retType;
+            }
+
+            contents.push_back(prettySigForMethod(gs, method, component.receiver, localRetType, constraint.get()));
         }
         start = start->secondary.get();
     }

--- a/test/testdata/lsp/hover_union.rb
+++ b/test/testdata/lsp/hover_union.rb
@@ -1,0 +1,42 @@
+# typed: true
+extend T::Sig
+
+class A
+  extend T::Sig
+
+  # Docs for A#foo
+  sig {returns(String)}
+  def foo; ''; end
+end
+
+class B
+  extend T::Sig
+
+  # Docs for B#foo
+  sig {returns(Integer)}
+  def foo; 0; end
+end
+
+sig {params(x: T.any(A, B)).void}
+def multiple(x)
+  x.foo
+  # ^ hover-line: 1 ```ruby
+  # ^ hover-line: 2 sig {returns(String)}
+  # ^ hover-line: 3 sig {returns(Integer)}
+  # ^ hover-line: 5 -> T.any(String, Integer)
+  # ^ hover-line: 6 def foo; end
+  # ^ hover-line: 7 ```
+  # ^ hover-line: 9 ---
+  # ^ hover-line: 11 Docs for A#foo
+end
+
+sig {params(x: A).void}
+def single(x)
+  x.foo
+  # ^ hover-line: 1 ```ruby
+  # ^ hover-line: 2 sig {returns(String)}
+  # ^ hover-line: 3 def foo; end
+  # ^ hover-line: 4 ```
+  # ^ hover-line: 6 ---
+  # ^ hover-line: 8 Docs for A#foo
+end


### PR DESCRIPTION
### Motivation
Fixes: #4150

Relies on https://github.com/sorbet/sorbet/pull/6691 being merged.

### Commit Summary

- **Update methodInfoString to collapse duplicate items** ([a48d71a](https://github.com/sorbet/sorbet/pull/6687/commits/a48d71ac56929ee849f6faaa42ef71ee345dd5e5))

In `hover.cc` I've updated `methodInfoString` to create a list of the method signatures in the order found in dispatch. If there are more than 1 method signatures generated this way, it will add an additional `-> <retType>` to the info before adding the method definition. Otherwise it will just add the method definition. These two cases look like so: 
```ruby 
# Multiple
sig {returns(String)}
sig {returns(Integer)}

-> T.any(String, Integer)
def foo; end

# Single 
sig {returns(String)}
def foo; end
```

- **Add hover union test harness** ([f166267](https://github.com/sorbet/sorbet/pull/6687/commits/f166267308623f823d7c811d613912bd0522bb71))

I've added a test harness based off of the case outlined in the issue (linked above), aiming to validate that the duplicate method type is now removed. 

### Test plan

See included automated tests.
