### PR TITLE
Add signature for `Class#attached_object` method

### DIFF
--- a/rbi/core/class.rbi
+++ b/rbi/core/class.rbi
@@ -89,6 +89,23 @@ class Class < Module
   sig {returns(T.untyped)}
   def allocate(); end
 
+
+  # Returns the object for which the receiver is the singleton class.
+  #
+  # Raises a `TypeError` if the class is not a singleton class.
+  #
+  # ```ruby
+  # class Foo; end
+  #
+  # Foo.singleton_class.attached_object        #=> Foo
+  # Foo.attached_object                        #=> TypeError: `Foo' is not a singleton class
+  # Foo.new.singleton_class.attached_object    #=> #<Foo:0x000000010491a370>
+  # TrueClass.attached_object                  #=> TypeError: `TrueClass' is not a singleton class
+  # NilClass.attached_object                   #=> TypeError: `NilClass' is not a singleton class
+  # ```
+  sig { returns(BasicObject) }
+  def attached_object; end
+
   ### Sorbet hijacks Class#new to re-use the sig from MyClass#initialize when creating new instances of a class.
   ### This method must be here so that all calls to MyClass.new aren't forced to take 0 arguments.
 

--- a/test/testdata/rbi/class.rb
+++ b/test/testdata/rbi/class.rb
@@ -4,6 +4,10 @@ class Parent
   def self.foo; end
 end
 
+Parent.singleton_class.attached_object
+Parent.attached_object
+Parent.new.singleton_class.attached_object
+
 c1 = Class.new
 T.reveal_type(c1) # error: Revealed type: `Class`
 T.reveal_type(c1.new) # error: Revealed type: `Object`


### PR DESCRIPTION
This PR adds a sig for the `Class#attached_object` method, which was introduced in Ruby 3.2. This method will return the object for which the receiver is a singleton class, and if the receiver is not a singleton class, it will raise a `TypeError`.

For more information, see https://github.com/ruby/ruby/pull/6450 and https://bugs.ruby-lang.org/issues/12084.

### Test plan
See included automated tests.