### PR TITLE
Add HoverMultilineAssertion functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,13 @@ If a location should report the empty string, use the special label `(nothing)`:
 # ^ hover: (nothing)
 ```
 
+Assert the contents of a specific line of the hover response with `hover-line` assertions:
+
+```ruby
+  a = 10
+# ^ hover-line: 1 Integer(10)
+```
+
 #### Testing completion
 
 LSP tests can also assert the contents of completion responses with `completion`

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -276,6 +276,29 @@ public:
     std::string toString() const override;
 };
 
+// # ^ hover-line: 1 foo
+class HoverLineAssertion final : public RangeAssertion {
+public:
+    static std::shared_ptr<HoverLineAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                    int assertionLine, std::string_view assertionContents,
+                                                    std::string_view assertionType);
+    /** Checks all HoverLineAssertions within the assertion vector. Skips over non-hover assertions.*/
+    static void checkAll(const std::vector<std::shared_ptr<RangeAssertion>> &assertions,
+                         const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
+                         LSPWrapper &wrapper, int &nextId, std::string errorPrefix = "");
+
+    HoverLineAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, int lineno,
+                       std::string_view message);
+
+    const int lineno;
+    const std::string message;
+
+    void check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents, LSPWrapper &wrapper,
+               int &nextId, std::string errorPrefix = "");
+
+    std::string toString() const override;
+};
+
 // # ^ completion: foo
 class CompletionAssertion final : public RangeAssertion {
 public:

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -821,6 +821,9 @@ TEST_CASE("LSPTest") {
     // Hover assertions
     HoverAssertion::checkAll(assertions, test.sourceFileContents, *lspWrapper, nextId);
 
+    // Hover multiline assertions
+    HoverLineAssertion::checkAll(assertions, test.sourceFileContents, *lspWrapper, nextId);
+
     // sorbet/showSymbol assertions
     ShowSymbolAssertion::checkAll(assertions, test.sourceFileContents, *lspWrapper, nextId);
 
@@ -920,6 +923,9 @@ TEST_CASE("LSPTest") {
 
             // Check any new HoverAssertions in the updates.
             HoverAssertion::checkAll(assertions, updatesAndContents, *lspWrapper, nextId);
+
+            // Check and new HoverMultilneAsserions assertions
+            HoverLineAssertion::checkAll(assertions, test.sourceFileContents, *lspWrapper, nextId);
         }
     }
 

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -81,11 +81,11 @@ class BigFoo; extend T::Sig
   # Tests return markdown output
   sig {void}
   def tests_return_markdown
-    # ^^^^^^^^^^^^^^^^^^^^^ hover: ```ruby
-    # ^^^^^^^^^^^^^^^^^^^^^ hover: sig {void}
-    # ^^^^^^^^^^^^^^^^^^^^^ hover: ```
-    # ^^^^^^^^^^^^^^^^^^^^^ hover: ---
-    # ^^^^^^^^^^^^^^^^^^^^^ hover: Tests return markdown output
+    # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 1 ```ruby
+    # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 2 sig {void}
+    # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 4 ```
+    # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 6 ---
+    # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 8 Tests return markdown output
   end
 end
 


### PR DESCRIPTION
### Motivation
Off the back of a discussion on [another PR of mine](https://github.com/sorbet/sorbet/pull/6687). It was suggested (by this comment) to add a new assertion for targeting specific line numbers of hovers. This would allow that PR to ensure that no duplicate signatures were present. 

Without it, these two cases would be valid and not fail: 
```ruby 
# target sig 
sig {returns(String)}
def foo; end
sig {returns(String)}
def foo; end
---
Docs

# hover test
foo
# ^ hover: sig {returns(String)
# ^ hover: def foo; end
# ^ hover: ---
# ^ hover: Docs
```
This test case doesn't account for the fact that the signature appears twice. 

```ruby 
# target sig 
sig {returns(String)}
def foo; end
---
Docs

# hover test
foo
# ^ hover: sig {returns(String)
# ^ hover: def foo; end
# ^ hover: sig {returns(String)
# ^ hover: def foo; end
# ^ hover: ---
# ^ hover: Docs
```
On the inverse of the above test, this test checks for two signatures, but doesn't acknowledge that it has already been checked, thus double checking the same sig and passing still. 

The hover multiline check solves this by adding a line number to the start of the declaration to specifically check if that line number matches up with the expectation. Thus the first test would now look like: 
```ruby 
# target sig 
sig {returns(String)}
def foo; end
sig {returns(String)}
def foo; end
---
Docs

# hover test
foo
# ^ hover-multiline: 0 sig {returns(String)
# ^ hover-multiline: 1 def foo; end
# ^ hover-multiline: 2 ---
# ^ hover-multiline: 3 Docs
```

### Test plan

See included automated tests. I've updated an existing test to use this multiline behaviour. 
