### PR TITLE
Update RBI for URI::WS

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -2363,7 +2363,7 @@ end
 # passwords. This is not legal as per the RFC, but used to be
 # supported in Internet Explorer 5 and 6, before the MS04-004 security
 # update. See <URL:http://support.microsoft.com/kb/834489>.
-class URI::WS
+class URI::WS < URI::Generic
   # A Default port of 80 for URI::WS.
   DEFAULT_PORT = T.let(T.unsafe(nil), Integer)
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`URI::WS` inherits from `URI::Generic`: https://github.com/ruby/uri/blob/master/lib/uri/ws.rb#L22


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Tapioca correctly generated the RBI as `class URI::WS < ::URI::Generic` which clashes with this payload.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
