### PR TITLE
Update Exception#initialize to accept any type

### DIFF
--- a/rbi/core/exception.rbi
+++ b/rbi/core/exception.rbi
@@ -213,7 +213,7 @@ class Exception < Object
 
   sig do
     params(
-        arg0: T.any(String, Symbol, NilClass, Exception),
+        arg0: BasicObject,
     )
     .void
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Changes the signature for `Exception#initialize` to accept any type

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
After https://github.com/sorbet/sorbet/pull/6681 we're seeing typechecking errors when the second argument to `raise` is not a `T.any(String, Symbol, NilClass, Exception)`. From my brief experimenting Ruby **effectively** converts any argument into a string and uses it as the message:

```rb
irb(main):001:0> Exception.new([1,2,3])
=> #<Exception: [1, 2, 3]>
irb(main):002:0> class Foo; end
=> nil
irb(main):003:0> Exception.new(Foo)
=> #<Exception: Foo>
irb(main):004:0> Exception.new(Foo.new)
=> #<Exception: #<Foo:0x0000000100fb85f0>>
irb(main):005:0> Exception.new(123)
=> #<Exception: 123>
irb(main):006:0> Exception.new({a: 1})
=> #<Exception: {:a=>1}>
irb(main):007:0>
```

C source: https://github.com/ruby/ruby/blob/d61a4cec618b8f5554398fff2ee4656763aeec4e/error.c#L1148-L1173
### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
