### PR TITLE
Backfill some T::Struct tests

### DIFF
--- a/gems/sorbet-runtime/bench/constructor.rb
+++ b/gems/sorbet-runtime/bench/constructor.rb
@@ -8,6 +8,21 @@ require_relative '../lib/sorbet-runtime'
 module SorbetBenchmarks
   module Constructor
 
+    class ExamplePoro
+      def initialize(hash)
+        @prop1 = hash.fetch(:prop1, nil)
+        @prop2 = hash.fetch(:prop2, 0)
+        @prop3 = hash.fetch(:prop3)
+        @prop4 = hash.fetch(:prop4)
+        @prop5 = hash.fetch(:prop5, [])
+        @prop6 = hash.fetch(:prop6)
+        @prop7 = hash.fetch(:prop7, {})
+        @prop8 = hash.fetch(:prop8, nil)
+        @prop9 = hash.fetch(:prop9, [])
+        @prop10 = hash.fetch(:prop10, {})
+      end
+    end
+
     class Example < T::Struct
       class Subdoc < T::Struct
         prop :prop, String
@@ -31,6 +46,19 @@ module SorbetBenchmarks
         prop4: [],
         prop6: {},
       }.freeze
+
+      100_000.times do
+        ExamplePoro.new(input)
+      end
+
+      result = Benchmark.measure do
+        1_000_000.times do
+          ExamplePoro.new(input)
+        end
+      end
+
+      puts "Plain Ruby (μs/iter):"
+      puts result
 
       100_000.times do
         Example.new(input)

--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -75,7 +75,7 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
     prop :color, T.nilable(String)
     prop :type, T.nilable(String), raise_on_nil_write: true
 
-    def initialize(hash = {})
+    def initialize(hash={})
       @name = 'Doe'
       @greeting = nil
       @farewell = 'Ciao'
@@ -112,7 +112,7 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
     prop :color, T.nilable(String)
     prop :type, T.nilable(String), raise_on_nil_write: true
 
-    def initialize(hash = {})
+    def initialize(hash={})
       @name = 'Doe'
       @greeting = nil
       @farewell = 'Ciao'

--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -62,4 +62,87 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
   it 'can default untyped fields' do
     UntypedField.new
   end
+
+  class WeakConstructorCustomInitializeStruct
+    include T::Props
+    include T::Props::Serializable
+    include T::Props::WeakConstructor
+
+    prop :name, String
+    prop :greeting, String, default: "Hi"
+    prop :farewell, String, default: "Bye"
+    prop :bool, T::Boolean
+    prop :color, T.nilable(String)
+    prop :type, T.nilable(String), raise_on_nil_write: true
+
+    def initialize(hash = {})
+      @name = 'Doe'
+      @greeting = nil
+      @farewell = 'Ciao'
+      @bool = false
+      @color = 'red'
+      @type = 'value'
+      super
+    end
+  end
+
+  it 'does not clobber custom initialize T::Props::WeakConstructor' do
+    c = WeakConstructorCustomInitializeStruct.new
+    assert_equal('Doe', c.name)
+    assert_equal('Hi', c.greeting)
+    assert_equal('Bye', c.farewell)
+    assert_equal(false, c.bool)
+    assert_equal('red', c.color)
+    assert_equal('value', c.type)
+
+    c = WeakConstructorCustomInitializeStruct.new(name: 'Alex', greeting: 'hello', farewell: 'goodbye', bool: true, color: 'blue', type: 'other')
+    assert_equal('Alex', c.name)
+    assert_equal('hello', c.greeting)
+    assert_equal('goodbye', c.farewell)
+    assert_equal(true, c.bool)
+    assert_equal('blue', c.color)
+    assert_equal('other', c.type)
+  end
+
+  class CustomInitializeStruct < T::Struct
+    prop :name, String
+    prop :greeting, String, default: "Hi"
+    prop :farewell, String, default: "Bye"
+    prop :bool, T::Boolean
+    prop :color, T.nilable(String)
+    prop :type, T.nilable(String), raise_on_nil_write: true
+
+    def initialize(hash = {})
+      @name = 'Doe'
+      @greeting = nil
+      @farewell = 'Ciao'
+      @bool = false
+      @color = 'red'
+      @type = 'value'
+      super
+    end
+  end
+
+  it 'does not clobber custom initialize for T::Struct' do
+    c = CustomInitializeStruct.new(name: 'Alex', bool: true, type: 'other')
+    assert_equal('Alex', c.name)
+    assert_equal('Hi', c.greeting)
+    assert_equal('Bye', c.farewell)
+    assert_equal(true, c.bool)
+    assert_nil(c.color)
+    assert_equal('other', c.type)
+
+    c = CustomInitializeStruct.new(name: 'Alex', greeting: 'hello', farewell: 'goodbye', bool: true, color: 'blue', type: 'other')
+    assert_equal('Alex', c.name)
+    assert_equal('hello', c.greeting)
+    assert_equal('goodbye', c.farewell)
+    assert_equal(true, c.bool)
+    assert_equal('blue', c.color)
+    assert_equal('other', c.type)
+
+    err = assert_raises(ArgumentError) do
+      CustomInitializeStruct.new(bool: true, type: 'other')
+    end
+    assert_equal("Missing required prop `name` for class `Opus::Types::Test::Props::ConstructorTest::CustomInitializeStruct`", err.message)
+  end
 end

--- a/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
@@ -6,9 +6,10 @@ class Opus::Types::Test::Props::Private::SetterFactoryTest < Critic::Unit::UnitT
     include T::Props
     include T::Props::WeakConstructor
 
-    prop :validated, T.untyped, setter_validate: ->(_prop, _value) {raise Error.new 'invalid'}
+    prop :validated, Integer, setter_validate: ->(_prop, _value) {raise Error.new 'invalid'}
     prop :nilable_validated, T.nilable(Integer), setter_validate: ->(_prop, _value) {raise Error.new 'invalid'}
-    prop :unvalidated, T.untyped, setter_validate: ->(prop, _value) {raise Error.new 'bad prop' unless prop == :unvalidated}
+    prop :unvalidated, Integer, setter_validate: ->(prop, _value) {raise Error.new 'bad prop' unless prop == :unvalidated}
+    prop :untyped, T.untyped, setter_validate: ->(_prop, _value) {raise Error.new 'invalid'}
 
   end
 
@@ -40,6 +41,15 @@ class Opus::Types::Test::Props::Private::SetterFactoryTest < Critic::Unit::UnitT
 
     it 'runs when validate_prop_value is called' do
       ex = assert_raises {TestSetValidate.validate_prop_value(:validated, 5)}
+      assert_equal('invalid', ex.message)
+    end
+
+    it 'runs on T.untyped' do
+      obj = TestSetValidate.new
+      ex = assert_raises {obj.untyped = 5}
+      assert_equal('invalid', ex.message)
+
+      ex = assert_raises {TestSetValidate.new(untyped: 5)}
       assert_equal('invalid', ex.message)
     end
 


### PR DESCRIPTION
Some pre-work for #6693, backfill some tests for T::Struct. I also pulled in the addition of the PORO benchmark. This is only changing specs and benchmarks, no actual runtime code is affected.

### Motivation

An issue was raised from Stripe's codebase (see https://github.com/sorbet/sorbet/pull/6684#issuecomment-1412171863) that was due to the different behavior of `T::Props::Constructor` (used in `T::Struct`) and `T::Props::WeakConstructor` for props without defaults. This was previously untested so this PR adds some tests to lock in the current behavior, namely:
- With `WeakConstructor`: if there is no default, only set the ivar if the key is present
- With `Constructor`: if there is no default, always set the ivar

With the latter behavior, we'll clobber the existing value of the ivar (e.g. if one was set in a custom `initialize` method).

### Test plan

See included automated tests.
