### PR TITLE
Move ENFORCE from LSP to resolver

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -465,10 +465,6 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
             return;
         }
 
-        auto &resolved = maybeResolved.result();
-        for (auto &tree : resolved) {
-            ENFORCE(tree.file.exists());
-        }
         if (gs->sleepInSlowPathSeconds.has_value()) {
             auto sleepDuration = gs->sleepInSlowPathSeconds.value();
             for (int i = 0; i < sleepDuration * 10; i++) {
@@ -519,7 +515,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
             return;
         }
 
-        auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
+        auto sorted = sortParsedFiles(*gs, *errorReporter, move(maybeResolved.result()));
         const auto presorted = true;
         pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, preemptManager, presorted);
     });

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4047,6 +4047,7 @@ void sanityCheck(const core::GlobalState &gs, vector<ast::ParsedFile> &trees) {
         ResolveSanityCheckWalk sanity;
         for (auto &tree : trees) {
             core::Context ctx(gs, core::Symbols::root(), tree.file);
+            ENFORCE(tree.tree);
             ast::TreeWalk::apply(ctx, sanity, tree.tree);
         }
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was a change I made while working on LSP fast path stuff.

This also skips a `for` loop that would otherwise have an empty body,
because the `sanityCheck` method guards the `for` loop by a `debug_mode`
check.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.