### PR TITLE
Use cwd from config and expand workspaceFolder

### DIFF
--- a/vscode_extension/src/LanguageClient.ts
+++ b/vscode_extension/src/LanguageClient.ts
@@ -272,9 +272,11 @@ export default class SorbetLanguageClient implements ErrorHandler {
       ...args
     ] = this._sorbetExtensionConfig.activeLspConfig!.command;
     this._outputChannel.appendLine(`    ${command} ${args.join(" ")}`);
-    this._sorbetProcess = spawn(command, args, {
-      cwd: workspace.rootPath,
-    });
+    const cwd = this._sorbetExtensionConfig.activeLspConfig!.cwd.replace(
+      "${workspaceFolder}", // eslint-disable-line no-template-curly-in-string
+      workspace.rootPath || "",
+    );
+    this._sorbetProcess = spawn(command, args, { cwd });
     // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
     // So, we need to handle both events. ¯\_(ツ)_/¯
     this._sorbetProcess.on(

--- a/vscode_extension/src/LanguageClient.ts
+++ b/vscode_extension/src/LanguageClient.ts
@@ -272,10 +272,13 @@ export default class SorbetLanguageClient implements ErrorHandler {
       ...args
     ] = this._sorbetExtensionConfig.activeLspConfig!.command;
     this._outputChannel.appendLine(`    ${command} ${args.join(" ")}`);
-    const cwd = this._sorbetExtensionConfig.activeLspConfig!.cwd.replace(
-      "${workspaceFolder}", // eslint-disable-line no-template-curly-in-string
-      workspace.rootPath || "",
-    );
+    const cwdTemplate = this._sorbetExtensionConfig.activeLspConfig!.cwd;
+    const cwd = cwdTemplate
+      ? cwdTemplate.replace(
+          "${workspaceFolder}", // eslint-disable-line no-template-curly-in-string
+          workspace.rootPath || "",
+        )
+      : workspace.rootPath || "";
     this._sorbetProcess = spawn(command, args, { cwd });
     // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
     // So, we need to handle both events. ¯\_(ツ)_/¯


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes https://github.com/sorbet/sorbet/issues/6701

There was a previous attempt at fixing this that floundered on variable expansion: https://github.com/sorbet/sorbet/pull/5529

I've done something fairly limited here and just replaced `${workspaceFolder}` with `workspace.rootPath`, this isn't ideal since it other variables won't work, but it has the upside of being backwards compatible.

There doesn't appear to be any API for doing this variable extension properly, at least according to:

https://stackoverflow.com/questions/43972354/how-can-an-extension-expand-configuration-variables-in-vscode


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I'm unclear on how to add automated tests for this. I did build the extension and try it out locally. I can confirm it fixed the linked issue.
