### PR TITLE
Use lazy type_member syntax in rbi_gen

### DIFF
--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -523,7 +523,7 @@ private:
 
         auto &lambdaParam = core::cast_type_nonnull<core::LambdaParam>(tm.data(gs)->resultType);
         if (tm.data(gs)->flags.isFixed) {
-            bounds = fmt::format(" {{{{ fixed: {} }}}}", showType(lambdaParam.upperBound));
+            bounds = fmt::format(" {{{{fixed: {}}}}}", showType(lambdaParam.upperBound));
         } else if (lambdaParam.lowerBound != core::Types::bottom() || lambdaParam.upperBound != core::Types::top()) {
             bounds = " {{";
             if (lambdaParam.lowerBound != core::Types::bottom()) {

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1131,9 +1131,9 @@ private:
         // If this is a type template, there will be an alias type defined on the non-singleton class w/ the same name.
         auto details = typeMemberDetails(tm);
         if (tm.data(gs)->owner.asClassOrModuleRef().data(gs)->isSingletonClass(gs)) {
-            out.println("{} = type_template({})", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
+            out.println("{} = type_template { {} }", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
         } else {
-            out.println("{} = type_member({})", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
+            out.println("{} = type_member { {} }", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
         }
     }
 

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1131,9 +1131,9 @@ private:
         // If this is a type template, there will be an alias type defined on the non-singleton class w/ the same name.
         auto details = typeMemberDetails(tm);
         if (tm.data(gs)->owner.asClassOrModuleRef().data(gs)->isSingletonClass(gs)) {
-            out.println("{} = type_template { {} }", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
+            out.println("{} = type_template {{ {} }}", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
         } else {
-            out.println("{} = type_member { {} }", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
+            out.println("{} = type_member {{ {} }}", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
         }
     }
 

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -524,11 +524,10 @@ private:
         auto &lambdaParam = core::cast_type_nonnull<core::LambdaParam>(tm.data(gs)->resultType);
         if (tm.data(gs)->flags.isFixed) {
             bounds = fmt::format(" {{{{ fixed: {} }}}}", showType(lambdaParam.upperBound));
-        } else if (lambdaParam.upperBound != core::Types::top() || lambdaParam.lowerBound != core::Types::bottom()) {
+        } else if (lambdaParam.lowerBound != core::Types::bottom() || lambdaParam.upperBound != core::Types::top()) {
             bounds = " {{";
-
             if (lambdaParam.lowerBound != core::Types::bottom()) {
-                fmt::format("lower: {}", showType(lambdaParam.lowerBound));
+                bounds += fmt::format("lower: {}", showType(lambdaParam.lowerBound));
             }
 
             if (lambdaParam.upperBound != core::Types::top()) {

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1131,9 +1131,9 @@ private:
         // If this is a type template, there will be an alias type defined on the non-singleton class w/ the same name.
         auto details = typeMemberDetails(tm);
         if (tm.data(gs)->owner.asClassOrModuleRef().data(gs)->isSingletonClass(gs)) {
-            out.println("{} = type_template {{ {} }}", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
+            out.println("{} = type_template {{{{ {} }}}}", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
         } else {
-            out.println("{} = type_member {{ {} }}", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
+            out.println("{} = type_member {{{{ {} }}}}", tm.data(gs)->name.show(gs), fmt::join(details, ", "));
         }
     }
 

--- a/test/cli/rbi-gen-single/test.out
+++ b/test/cli/rbi-gen-single/test.out
@@ -125,7 +125,7 @@ Errors: 2
 # typed: true
 
 class Util::GenericMessage
-  Elem = type_member()
+  Elem = type_member
   sig {params(x: Elem).void}
   def initialize(x)
     @x = T.let(T.unsafe(nil), Elem)

--- a/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
+++ b/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
@@ -115,15 +115,15 @@ end
 module RBIGen::Public::ModuleWithTypeParams
   A = type_member(:in)
   B = type_member(:out)
-  C = type_member(upper: RBIGen::Public::Parent)
-  D = type_member(lower: RBIGen::Public::Child)
-  E = type_member(upper: RBIGen::Public::Parent, lower: RBIGen::Public::Child)
-  F = type_member(:in, upper: RBIGen::Public::Parent)
-  G = type_member(:in, lower: RBIGen::Public::Child)
-  H = type_member(:in, upper: RBIGen::Public::Parent, lower: RBIGen::Public::Child)
-  I = type_member(:out, upper: RBIGen::Public::Parent)
-  J = type_member(:out, lower: RBIGen::Public::Child)
-  K = type_member(:out, upper: RBIGen::Public::Parent, lower: RBIGen::Public::Child)
+  C = type_member {{upper: RBIGen::Public::Parent}}
+  D = type_member {{lower: RBIGen::Public::Child}}
+  E = type_member {{lower: RBIGen::Public::Child, upper: RBIGen::Public::Parent}}
+  F = type_member(:in) {{upper: RBIGen::Public::Parent}}
+  G = type_member(:in) {{lower: RBIGen::Public::Child}}
+  H = type_member(:in) {{lower: RBIGen::Public::Child, upper: RBIGen::Public::Parent}}
+  I = type_member(:out) {{upper: RBIGen::Public::Parent}}
+  J = type_member(:out) {{lower: RBIGen::Public::Child}}
+  K = type_member(:out) {{lower: RBIGen::Public::Child, upper: RBIGen::Public::Parent}}
   extend T::Generic
   extend T::Helpers
 end
@@ -232,14 +232,14 @@ class RBIGen::Public::CustomStruct
   extend T::Sig
 end
 class RBIGen::Public::ClassWithTypeParams
-  C = type_member()
-  D = type_member(upper: RBIGen::Public::Parent)
-  E = type_member(lower: RBIGen::Public::Child)
-  F = type_member(upper: RBIGen::Public::Parent, lower: RBIGen::Public::Child)
+  C = type_member
+  D = type_member {{upper: RBIGen::Public::Parent}}
+  E = type_member {{lower: RBIGen::Public::Child}}
+  F = type_member {{lower: RBIGen::Public::Child, upper: RBIGen::Public::Parent}}
   extend T::Generic
   extend T::Helpers
-  A = type_template(fixed: RBIGen::Private::PrivateClassPulledInByTypeTemplate)
-  B = type_template()
+  A = type_template {{fixed: RBIGen::Private::PrivateClassPulledInByTypeTemplate}}
+  B = type_template
 end
 class RBIGen::Public::ClassWithPrivateMethods
   extend T::Sig


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Looks like we don't have enough tests for this--I would have expected
this to be caught when we made the change to enforce lazy type members
in #5639.

I'm prototyping things right now. We can either land this now without tests or
leave this as an open PR pending tests. (Though: it's possible that the
prototype will go in another direction and not need rbi_gen, so I'm leaning
towards merging without tests.)