### PR TITLE
don't reference count nesting scopes in resolver unnecessarily

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -845,10 +845,10 @@ private:
         }
     }
 
-    static bool resolveConstantJob(core::Context ctx, const shared_ptr<Nesting> &nesting,
-                                   ast::ConstantLit *out, bool &resolutionFailed, const bool possibleGenericType,
-                                   const bool loadTimeScope,
-                                   const shared_ptr<UnorderedMap<core::SymbolRef, core::LocOffsets>> &firstDefinitionLocs) {
+    static bool
+    resolveConstantJob(core::Context ctx, const shared_ptr<Nesting> &nesting, ast::ConstantLit *out,
+                       bool &resolutionFailed, const bool possibleGenericType, const bool loadTimeScope,
+                       const shared_ptr<UnorderedMap<core::SymbolRef, core::LocOffsets>> &firstDefinitionLocs) {
         if (isAlreadyResolved(ctx, *out)) {
             if (possibleGenericType) {
                 return false;
@@ -1375,8 +1375,8 @@ private:
             bool resolutionFailed = false;
             const bool possibleGenericType = false;
             const bool loadTimeScope = (loadScopeDepth_ == 0);
-            if (resolveConstantJob(ctx, nesting_, constant, resolutionFailed, possibleGenericType,
-                                   loadTimeScope, firstDefinitionLocs)) {
+            if (resolveConstantJob(ctx, nesting_, constant, resolutionFailed, possibleGenericType, loadTimeScope,
+                                   firstDefinitionLocs)) {
                 categoryCounterInc("resolve.constants.nonancestor", "firstpass");
             } else {
                 ConstantResolutionItem job{nesting_, constant};


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We keep a (debug-only) metric on how many constants resolve in the "first pass", without needing a separate resolution step.  On a recent-ish debug build of Stripe's codebase, almost 99% of constants resolve on the first try.

However, the way that we do this first pass is that we create a `ConstantResolutionItem` and attempt to resolve it.  If we fail, that job can be pushed, as-is, onto the queue of things to be retried.  This temporary job takes shared references to the current nesting scope of `ResolveConstantsWalk` and the `firstDefinitionLocs` table that we now maintain after #6671.

Taking those shared references requires atomic reference counting, which is (relatively) expensive.  And the aforementioned 99% of the time, we don't need to take shared references to those two things. 

Hence this PR: we split out a separate interface for being able to resolve individual constants without taking those shared references and use it from the appropriate places.

I took measurements that #6671 slows resolver down by about 3%; this PR seems to win that back.  Without #6671 applied, it looked like this PR would win ~2%, but I guess there is some unavoidable overhead from that PR?  It's also possible that there's just some noise in the measurements and I happened to get the right combination of 10 runs with and without these changes.

cc @aadi-stripe 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
