### PR TITLE
delete `rules_rust` from dependencies

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -314,15 +314,6 @@ def register_sorbet_dependencies():
     )
 
     http_archive(
-        name = "rules_rust",
-        sha256 = "727b93eb5d57ec411f2afda7e3993e22d7772d0b2555ba745c3dec7323ea955a",
-        strip_prefix = "rules_rust-0768a7f00de134910c3cbdab7bbfdd011d995766",
-
-        # Master branch as of 2021-06-29
-        urls = _github_public_urls("bazelbuild/rules_rust/archive/0768a7f00de134910c3cbdab7bbfdd011d995766.tar.gz"),
-    )
-
-    http_archive(
         name = "bazel_skylib",
         sha256 = "9a737999532daca978a158f94e77e9af6a6a169709c0cee274f0a4c3359519bd",
         strip_prefix = "bazel-skylib-1.0.0",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We no longer need this after `rubyfmt` has been moved to a separate repository.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
