### PR TITLE
Speed up move method by skipping incrementalResolve

### DIFF
--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -203,10 +203,8 @@ unique_ptr<Position> getNewModuleLocation(const core::GlobalState &gs, const cor
                                           LSPTypecheckerDelegate &typechecker) {
     auto fref = definition.termLoc.file();
 
-    auto trees = typechecker.getResolved({fref});
-    ENFORCE(!trees.empty());
-    auto &rootTree = trees[0].tree;
-    auto insertPosition = Range::fromLoc(gs, core::Loc(fref, rootTree.loc().copyWithZeroLength()));
+    auto &rootTree = typechecker.getIndexed({fref});
+    auto insertPosition = Range::fromLoc(gs, core::Loc(fref, rootTree.tree.loc().copyWithZeroLength()));
     auto newModuleSymbol = insertPosition->start->copy();
     newModuleSymbol->character += moduleKeyword.size() + 1;
     return newModuleSymbol;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This method is trying to get the first location in the file after the comments
at the top of the file. It does that by getting the location of the
`class <root>` tree in the file, which has the loc of the first piece of syntax
in the file. But it doesn't need to run incrementalResolve to get that--the same
loc is present in the indexed trees.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests