### PR TITLE
Remove a reundant arg from AbstractRenamer

### DIFF
--- a/main/lsp/AbstractRenamer.cc
+++ b/main/lsp/AbstractRenamer.cc
@@ -133,7 +133,7 @@ void AbstractRenamer::addDispatchRelatedMethods(const core::GlobalState &gs, con
     }
 }
 
-void AbstractRenamer::getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol, string newName) {
+void AbstractRenamer::getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol) {
     const core::GlobalState &gs = typechecker.state();
     auto originalName = symbol.name(gs).show(gs);
 

--- a/main/lsp/AbstractRenamer.h
+++ b/main/lsp/AbstractRenamer.h
@@ -30,7 +30,7 @@ public:
     std::variant<JSONNullObject, std::unique_ptr<WorkspaceEdit>> buildWorkspaceEdit();
     virtual void addSymbol(const core::SymbolRef) = 0;
 
-    void getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol, std::string newName);
+    void getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol);
 
     bool getInvalid();
     std::string getError();

--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -223,7 +223,7 @@ vector<unique_ptr<TextDocumentEdit>> getMoveMethodEdits(LSPTypecheckerDelegate &
     auto edits = moveMethod(typechecker, config, definition, newModuleName.value());
 
     auto renamer = make_shared<MethodCallSiteRenamer>(gs, config, definition.name.show(gs), newModuleName.value());
-    renamer->getRenameEdits(typechecker, definition.symbol, newModuleName.value());
+    renamer->getRenameEdits(typechecker, definition.symbol);
     auto callSiteEdits = renamer->buildTextDocumentEdits();
 
     if (callSiteEdits.has_value()) {

--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -203,10 +203,8 @@ unique_ptr<Position> getNewModuleLocation(const core::GlobalState &gs, const cor
                                           LSPTypecheckerDelegate &typechecker) {
     auto fref = definition.termLoc.file();
 
-    auto trees = typechecker.getResolved({fref});
-    ENFORCE(!trees.empty());
-    auto &rootTree = trees[0].tree;
-    auto insertPosition = Range::fromLoc(gs, core::Loc(fref, rootTree.loc().copyWithZeroLength()));
+    auto &rootTree = typechecker.getIndexed({fref});
+    auto insertPosition = Range::fromLoc(gs, core::Loc(fref, rootTree.tree.loc().copyWithZeroLength()));
     auto newModuleSymbol = insertPosition->start->copy();
     newModuleSymbol->character += moduleKeyword.size() + 1;
     return newModuleSymbol;

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -317,20 +317,20 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
         }
         if (isValidRenameLocation(constResp->symbolBeforeDealias, gs, response)) {
             renamer = makeRenamer(gs, config, constResp->symbolBeforeDealias, params->newName);
-            renamer->getRenameEdits(typechecker, constResp->symbolBeforeDealias, params->newName);
+            renamer->getRenameEdits(typechecker, constResp->symbolBeforeDealias);
             enrichResponse(response, renamer);
         }
     } else if (auto defResp = resp->isMethodDef()) {
         if (isValidRenameLocation(defResp->symbol, gs, response)) {
             renamer = makeRenamer(gs, config, defResp->symbol, params->newName);
-            renamer->getRenameEdits(typechecker, defResp->symbol, params->newName);
+            renamer->getRenameEdits(typechecker, defResp->symbol);
             enrichResponse(response, renamer);
         }
     } else if (auto sendResp = resp->isSend()) {
         // We don't need to handle dispatchResult->secondary here, because it will be checked in getRenameEdits.
         auto method = sendResp->dispatchResult->main.method;
         renamer = makeRenamer(gs, config, method, params->newName);
-        renamer->getRenameEdits(typechecker, method, params->newName);
+        renamer->getRenameEdits(typechecker, method);
         enrichResponse(response, renamer);
     } else if (auto identResp = resp->isIdent()) {
         if (identResp->enclosingMethod.exists()) {
@@ -352,7 +352,7 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
         }
     } else if (auto fieldResp = resp->isField()) {
         renamer = makeRenamer(gs, config, fieldResp->symbol, params->newName);
-        renamer->getRenameEdits(typechecker, fieldResp->symbol, params->newName);
+        renamer->getRenameEdits(typechecker, fieldResp->symbol);
         enrichResponse(response, renamer);
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


No one is using this.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.