### PR TITLE
Save 8 bytes in SendResponse via FileRef

### DIFF
--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -18,7 +18,8 @@ const SendResponse *QueryResponse::isSend() const {
 }
 
 const optional<core::Loc> SendResponse::getMethodNameLoc(const core::GlobalState &gs) const {
-    return (this->funLoc.exists() && !this->funLoc.empty()) ? make_optional<core::Loc>(this->funLoc) : nullopt;
+    auto existsNonEmpty = (this->funLocOffsets.exists() && !this->funLocOffsets.empty());
+    return existsNonEmpty ? make_optional<core::Loc>(this->funLoc()) : nullopt;
 }
 
 const IdentResponse *QueryResponse::isIdent() const {
@@ -49,7 +50,7 @@ core::Loc QueryResponse::getLoc() const {
     if (auto ident = isIdent()) {
         return ident->termLoc;
     } else if (auto send = isSend()) {
-        return send->termLoc;
+        return send->termLoc();
     } else if (auto literal = isLiteral()) {
         return literal->termLoc;
     } else if (auto constant = isConstant()) {

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -10,24 +10,35 @@ class TypeConstraint;
 
 class SendResponse final {
 public:
-    SendResponse(core::Loc termLoc, std::shared_ptr<core::DispatchResult> dispatchResult, core::NameRef callerSideName,
-                 bool isPrivateOk, core::MethodRef enclosingMethod, core::Loc receiverLoc, core::Loc funLoc,
-                 size_t totalArgs)
-        : dispatchResult(std::move(dispatchResult)), callerSideName(callerSideName), termLoc(termLoc),
-          isPrivateOk(isPrivateOk), enclosingMethod(enclosingMethod), receiverLoc(receiverLoc), funLoc(funLoc),
-          totalArgs(totalArgs){};
+    SendResponse(std::shared_ptr<core::DispatchResult> dispatchResult, size_t totalArgs, core::NameRef callerSideName,
+                 core::MethodRef enclosingMethod, bool isPrivateOk, core::FileRef file, core::LocOffsets termLocOffsets,
+                 core::LocOffsets receiverLocOffsets, core::LocOffsets funLocOffsets)
+        : dispatchResult(std::move(dispatchResult)), totalArgs(totalArgs), callerSideName(callerSideName),
+          enclosingMethod(enclosingMethod), isPrivateOk(isPrivateOk), file(file), termLocOffsets(termLocOffsets),
+          receiverLocOffsets(receiverLocOffsets), funLocOffsets(funLocOffsets){};
     const std::shared_ptr<core::DispatchResult> dispatchResult;
-    const core::NameRef callerSideName;
-    const core::Loc termLoc;
-    const bool isPrivateOk;
-    const core::MethodRef enclosingMethod;
-    const core::Loc receiverLoc;
-    const core::Loc funLoc;
     const size_t totalArgs;
+    const core::NameRef callerSideName;
+    const core::MethodRef enclosingMethod;
+    const bool isPrivateOk;
+    const core::FileRef file;
+    const core::LocOffsets termLocOffsets;
+    const core::LocOffsets receiverLocOffsets;
+    const core::LocOffsets funLocOffsets;
+
+    core::Loc termLoc() const {
+        return core::Loc(file, termLocOffsets);
+    }
+    core::Loc receiverLoc() const {
+        return core::Loc(file, receiverLocOffsets);
+    }
+    core::Loc funLoc() const {
+        return core::Loc(file, funLocOffsets);
+    }
 
     const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const;
 };
-CheckSize(SendResponse, 72, 8);
+CheckSize(SendResponse, 64, 8);
 
 class IdentResponse final {
 public:

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1143,9 +1143,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         }
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::SendResponse(ctx.locAt(bind.loc), retainedResult, fun, send.isPrivateOk,
-                                                     ctx.owner.asMethodRef(), ctx.locAt(send.receiverLoc),
-                                                     ctx.locAt(send.funLoc), send.args.size()));
+                        ctx,
+                        core::lsp::SendResponse(retainedResult, send.args.size(), fun, ctx.owner.asMethodRef(),
+                                                send.isPrivateOk, ctx.file, bind.loc, send.receiverLoc, send.funLoc));
                 }
                 if (send.link) {
                     // This should eventually become ENFORCEs but currently they are wrong

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -280,7 +280,7 @@ LSPTask::extractLocations(const core::GlobalState &gs,
     auto queryResponsesFiltered = LSPQuery::filterAndDedup(gs, queryResponses);
     for (auto &q : queryResponsesFiltered) {
         if (auto *send = q->isSend()) {
-            addLocIfExists(gs, locations, send->funLoc);
+            addLocIfExists(gs, locations, send->funLoc());
         } else {
             addLocIfExists(gs, locations, q->getLoc());
         }

--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -148,7 +148,7 @@ public:
                 }
             }
 
-            edits[sendResp->receiverLoc] = newName;
+            edits[sendResp->receiverLoc()] = newName;
         }
     }
     void addSymbol(const core::SymbolRef symbol) override {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1272,7 +1272,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
 
     if (auto sendResp = resp->isSend()) {
         auto callerSideName = sendResp->callerSideName;
-        auto prefix = (callerSideName == core::Names::methodNameMissing() || !sendResp->funLoc.contains(queryLoc))
+        auto prefix = (callerSideName == core::Names::methodNameMissing() || !sendResp->funLoc().contains(queryLoc))
                           ? ""
                           : callerSideName.shortName(gs);
         if (prefix == "" && queryLoc.adjust(gs, -2, 0).source(gs) == "::") {
@@ -1307,7 +1307,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
             // and the user's intent might have been to complete a local or a keyword.  In the former case, we
             // know that the user doesn't want such completion results, since they have already written something
             // prefixed with `self.`.
-            auto explicitSelfReceiver = sendResp->receiverLoc.source(gs) == "self";
+            auto explicitSelfReceiver = sendResp->receiverLoc().source(gs) == "self";
             auto wantLocalsAndKeywords = sendResp->isPrivateOk && !explicitSelfReceiver;
             auto suggestKeywords = wantLocalsAndKeywords;
             // `enclosingMethod` existing indicates whether we want local variable completion results.

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -151,7 +151,7 @@ private:
             return "";
         }
         // TODO(jez) Use Loc::adjust here?
-        string::size_type methodNameOffset = methodNameLoc->beginPos() - sendResp->termLoc.beginPos();
+        string::size_type methodNameOffset = methodNameLoc->beginPos() - sendResp->termLocOffsets.beginPos();
         auto newsrc = replaceAt(source, methodNameOffset);
         return newsrc;
     }

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -80,7 +80,7 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
         auto resp = move(queryResponses[0]);
         // only triggers on sends. Some SignatureHelps are triggered when the variable is being typed.
         if (auto sendResp = resp->isSend()) {
-            auto sendLocIndex = sendResp->termLoc.beginPos();
+            auto sendLocIndex = sendResp->termLoc().beginPos();
 
             auto fref = config.uri2FileRef(gs, params->textDocument->uri);
             if (!fref.exists()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These `Loc`'s are always using the same file. We can just take the
`FileRef` explicitly:

    12 + 12 + 12 = 36

vs

    4 + 8 + 8 + 8 = 28

which gives a savings of 8 bytes. (We're quickly going to regress this
win because I plan on adding some more stuff to this in a coming PR.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.