### PR TITLE
Invalidate cache on autoloader_compatibility change

### DIFF
--- a/main/autogen/constant_hash.cc
+++ b/main/autogen/constant_hash.cc
@@ -74,6 +74,16 @@ struct ConstantHashWalk {
                 hashConstant(ctx, arg);
             }
             hashSoFar = core::mix(hashSoFar, core::_hash(")"));
+        } else if (send.fun == core::Names::autoloader_compatibility()) {
+            hashSoFar = core::mix(hashSoFar, core::_hash("(a"));
+            if (send.hasPosArgs()) {
+                if (auto str = ast::cast_tree<ast::Literal>(send.posArgs().front())) {
+                    if (str->isString()) {
+                        hashSoFar = core::mix(hashSoFar, core::_hash(str->asString().shortName(ctx)));
+                    }
+                }
+            }
+            hashSoFar = core::mix(hashSoFar, core::_hash(")"));
         }
     }
 

--- a/main/autogen/test/constant_hash_test.cc
+++ b/main/autogen/test/constant_hash_test.cc
@@ -186,6 +186,18 @@ TEST_CASE("Require") { // NOLINT
                                      "do_the_thing!"));
 }
 
+TEST_CASE("Package Autoloader Compatibility") { // NOLINT
+    Helper helper;
+
+    auto req = helper.hashExample("autoloader_compatibility 'legacy'\n");
+
+    // removing the annotation should affect the hash
+    CHECK_NE(req, helper.hashExample("\n"));
+
+    // changing the annotation should affect the hash
+    CHECK_NE(req, helper.hashExample("autoloader_compatibility 'strict'\n"));
+}
+
 TEST_CASE("Extend/Include") {
     Helper helper;
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
With path-based autoloading, we need to fully run `DependencyStep` when a package's `autoloader_compatibility` changes as the autoloader shims will change. Currently, it sometimes doesn't change the shims, leading to constants not loading correctly.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added tests
