### PR TITLE
complain about redundant `T.let` checks in `initialize`

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -15,5 +15,6 @@ constexpr ErrorClass ComputedBySymbol{3509, StrictLevel::False};
 constexpr ErrorClass InitializeReturnType{3510, StrictLevel::False};
 constexpr ErrorClass InvalidStructMember{3511, StrictLevel::False};
 constexpr ErrorClass NilableUntyped{3512, StrictLevel::False};
+constexpr ErrorClass RedundantInitializeLet{3513, StrictLevel::True};
 } // namespace sorbet::core::errors::Rewriter
 #endif


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is sort of #2255, I think.  Polishing up type equivalance might be necessary for this to land, but I'm curious how the dirt-simple version works.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
