### PR TITLE
derive the type of transpose on arrays of tuples more correctly

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -56,6 +56,7 @@ NameDef names[] = {
     {"undef"},
     {"each"},
     {"subclasses"},
+    {"transpose"},
 
     // Used in parser for error recovery
     {"methodNameMissing", "<method-name-missing>"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4061,6 +4061,31 @@ public:
     }
 } Array_zip;
 
+class Array_transpose : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        auto *ap = cast_type<AppliedType>(args.thisType);
+        ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()));
+        ENFORCE(!ap->targs.empty());
+        auto &elementType = ap->targs.front();
+
+        auto *tuple = cast_type<TupleType>(elementType);
+        if (tuple == nullptr) {
+            return;
+        }
+
+        // The transpose of an array of tuples is a tuple of arrays.
+        vector<TypePtr> transposed;
+        transposed.reserve(tuple->elems.size());
+
+        for (auto &elem : tuple->elems) {
+            transposed.emplace_back(Types::arrayOf(gs, elem));
+        }
+
+        res.returnType = make_type<TupleType>(move(transposed));
+    }
+} Array_transpose;
+
 class Symbol_eqeq : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
@@ -4445,6 +4470,7 @@ const vector<Intrinsic> intrinsics{
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::compact(), &Array_compact},
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::plus(), &Array_plus},
     {Symbols::Array(), Intrinsic::Kind::Instance, Names::zip(), &Array_zip},
+    {Symbols::Array(), Intrinsic::Kind::Instance, Names::transpose(), &Array_transpose},
 
     {Symbols::Symbol(), Intrinsic::Kind::Instance, Names::eqeq(), &Symbol_eqeq},
     {Symbols::String(), Intrinsic::Kind::Instance, Names::eqeq(), &String_eqeq},

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -64,3 +64,6 @@ T.assert_type!([1, 2].to_set, T::Set[T.untyped])
 arr = [1, 2, 3]
 T.assert_type!(arr.intersection([3, 5]), T::Array[Integer])
 T.assert_type!(arr.intersect?([2, 7]), T::Boolean)
+
+x = [[1, "a"], [2, "b"]]
+T.reveal_type(x.transpose) # error: Revealed type: `[T::Array[Integer], T::Array[String]] (2-tuple)`


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@sushain97 wanted to know how hard this was.  Not hard. 😛 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
