### PR TITLE
special-case `T::Private::Types::SimplePairUnion` in some `T::Utils` code

### DIFF
--- a/gems/sorbet-runtime/bench/tasks.rb
+++ b/gems/sorbet-runtime/bench/tasks.rb
@@ -7,6 +7,7 @@ require_relative 'constructor'
 require_relative 'deserialize'
 require_relative 'prop_definition'
 require_relative 'serialize_custom_type'
+require_relative 'tutils'
 require_relative 'typecheck'
 
 namespace :bench do
@@ -38,5 +39,9 @@ namespace :bench do
     SorbetBenchmarks::Typecheck.run
   end
 
-  task all: %i[getters setters constructor deserialize prop_definition serialize_custom_type typecheck]
+  task :tutils do
+    SorbetBenchmarks::TUtils.run
+  end
+
+  task all: %i[getters setters constructor deserialize prop_definition serialize_custom_type tuils typecheck]
 end

--- a/gems/sorbet-runtime/bench/tutils.rb
+++ b/gems/sorbet-runtime/bench/tutils.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module TUtils
+    extend T::Sig
+
+    def self.time_block(name, iterations_of_block: 1_000_000, &blk)
+      1_000.times(&blk) # warmup
+
+      GC.start
+      GC.disable
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      iterations_of_block.times(&blk)
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+
+      GC.enable
+
+      ns_per_iter = duration_s * 1_000_000_000 / iterations_of_block
+      duration_str = ns_per_iter >= 1000 ? "#{(ns_per_iter / 1000).round(3)} μs" : "#{ns_per_iter.round(3)} ns"
+      puts "#{name}: #{duration_str}"
+    end
+
+    def self.run
+      type = T::Utils.coerce(Integer)
+      time_block("T.unwrap_nilable(#{type})") do
+        T::Utils.unwrap_nilable(type)
+      end
+
+      time_block("get_underlying_type(#{type})") do
+        T::Utils::Nilable.get_underlying_type(type)
+      end
+
+      type = T::Utils.coerce(T.nilable(Integer))
+      time_block("T.unwrap_nilable(#{type})") do
+        T::Utils.unwrap_nilable(type)
+      end
+
+      time_block("get_underlying_type(#{type})") do
+        T::Utils::Nilable.get_underlying_type(type)
+      end
+
+      type = T::Utils.coerce(T.any(Integer, Float))
+      time_block("T.unwrap_nilable(#{type})") do
+        T::Utils.unwrap_nilable(type)
+      end
+
+      time_block("get_underlying_type(#{type})") do
+        T::Utils::Nilable.get_underlying_type(type)
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/private/types/simple_pair_union.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/simple_pair_union.rb
@@ -40,6 +40,7 @@ class T::Private::Types::SimplePairUnion < T::Types::Union
     ]
   end
 
+  # overrides Union
   def unwrap_nilable
     a_nil = @raw_a.equal?(NilClass)
     b_nil = @raw_b.equal?(NilClass)

--- a/gems/sorbet-runtime/lib/types/private/types/simple_pair_union.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/simple_pair_union.rb
@@ -39,4 +39,16 @@ class T::Private::Types::SimplePairUnion < T::Types::Union
       T::Types::Simple::Private::Pool.type_for_module(@raw_b),
     ]
   end
+
+  def unwrap_nilable
+    a_nil = @raw_a.equal?(NilClass)
+    b_nil = @raw_b.equal?(NilClass)
+    if a_nil
+      return types[1]
+    end
+    if b_nil
+      return types[0]
+    end
+    nil
+  end
 end

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -64,6 +64,17 @@ module T::Types
       raise "This should never be reached if you're going through `subtype_of?` (and you should be)"
     end
 
+    def unwrap_nilable
+      non_nil_types = types.reject {|t| t == T::Utils::Nilable::NIL_TYPE}
+      return nil if types.length == non_nil_types.length
+      case non_nil_types.length
+      when 0 then nil
+      when 1 then non_nil_types.first
+      else
+        T::Types::Union::Private::Pool.union_of_types(non_nil_types[0], non_nil_types[1], non_nil_types[2..-1])
+      end
+    end
+
     module Private
       module Pool
         EMPTY_ARRAY = [].freeze

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -98,6 +98,8 @@ module T::Utils
   def self.unwrap_nilable(type)
     case type
     when T::Types::Union
+      return type.unwrap_nilable if type.is_a?(T::Private::Types::SimplePairUnion)
+
       non_nil_types = type.types.reject {|t| t == Nilable::NIL_TYPE}
       return nil if type.types.length == non_nil_types.length
       case non_nil_types.length
@@ -193,9 +195,12 @@ module T::Utils
     #  - if the type is A, the function returns A
     #  - if the type is T.nilable(A), the function returns A
     def self.get_underlying_type(prop_type)
-      type_info = get_type_info(prop_type)
-      if type_info.is_union_type
-        type_info.non_nilable_type || prop_type
+      if prop_type.is_a?(T::Types::Union)
+        non_nilable_type = T::Utils.unwrap_nilable(prop_type)
+        if non_nilable_type&.is_a?(T::Types::Simple)
+          non_nilable_type = non_nilable_type.raw_type
+        end
+        non_nilable_type || prop_type
       elsif prop_type.is_a?(T::Types::Simple)
         prop_type.raw_type
       else

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -172,7 +172,7 @@ module T::Utils
 
     def self.get_type_info(prop_type)
       if prop_type.is_a?(T::Types::Union)
-        non_nilable_type = T::Utils.unwrap_nilable(prop_type)
+        non_nilable_type = prop_type.unwrap_nilable
         if non_nilable_type&.is_a?(T::Types::Simple)
           non_nilable_type = non_nilable_type.raw_type
         end

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -98,16 +98,7 @@ module T::Utils
   def self.unwrap_nilable(type)
     case type
     when T::Types::Union
-      return type.unwrap_nilable if type.is_a?(T::Private::Types::SimplePairUnion)
-
-      non_nil_types = type.types.reject {|t| t == Nilable::NIL_TYPE}
-      return nil if type.types.length == non_nil_types.length
-      case non_nil_types.length
-      when 0 then nil
-      when 1 then non_nil_types.first
-      else
-        T::Types::Union::Private::Pool.union_of_types(non_nil_types[0], non_nil_types[1], non_nil_types[2..-1])
-      end
+      type.unwrap_nilable
     else
       nil
     end
@@ -196,7 +187,7 @@ module T::Utils
     #  - if the type is T.nilable(A), the function returns A
     def self.get_underlying_type(prop_type)
       if prop_type.is_a?(T::Types::Union)
-        non_nilable_type = T::Utils.unwrap_nilable(prop_type)
+        non_nilable_type = prop_type.unwrap_nilable
         if non_nilable_type&.is_a?(T::Types::Simple)
           non_nilable_type = non_nilable_type.raw_type
         end

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -11,6 +11,11 @@ module Opus::Types::Test
         assert(T.any(String, Float).subtype_of?(unwrapped))
         assert(unwrapped.subtype_of?(T.any(String, Float)))
       end
+
+      it 'unwraps with a simple pair' do
+        type = T.any(String, Float)
+        assert_nil(T::Utils.unwrap_nilable(type))
+      end
     end
 
     describe 'T::Utils.signature_for_method' do


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`T::Utils.unwrap_nilable` and `T::Utils::Nilable.get_underlying_type` turn out to be relatively hot functions in some serialization code in Stripe's codebase.  We can do a better job by adding some special cases for our `SimplePairUnion` specialization.  We can also duplicate a small amount of code so that we don't have to go through `T::Utils.get_type_info` and thereby avoid the allocation of `TypeInfo`.

Benchmarks before:

```
T.unwrap_nilable(Integer): 88.166 ns
get_underlying_type(Integer): 278.329 ns
T.unwrap_nilable(T.nilable(Integer)): 620.187 ns
get_underlying_type(T.nilable(Integer)): 913.333 ns
T.unwrap_nilable(T.any(Float, Integer)): 603.966 ns
get_underlying_type(T.any(Float, Integer)): 843.252 ns
```

After:

```
T.unwrap_nilable(Integer): 92.836 ns
get_underlying_type(Integer): 90.258 ns
T.unwrap_nilable(T.nilable(Integer)): 195.653 ns
get_underlying_type(T.nilable(Integer)): 275.813 ns
T.unwrap_nilable(T.any(Float, Integer)): 156.667 ns
get_underlying_type(T.any(Float, Integer)): 201.998 ns
```

`get_underlying_type` is 3-4x faster; `unwrap_nilable` gets 3-4x faster on `SimplePairUnion`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
