### PR TITLE
Allow `T.attached_class` as argument of bounded generic

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -422,7 +422,8 @@ template <> inline TypePtr make_type<SelfTypeParam, core::TypeArgumentRef &>(cor
     return make_type<SelfTypeParam>(sym);
 }
 
-template <> inline TypePtr make_type<SelfTypeParam, core::TypeMemberRef &>(core::TypeMemberRef &definition) {
+template <>
+inline TypePtr make_type<SelfTypeParam, const core::TypeMemberRef &>(const core::TypeMemberRef &definition) {
     auto sym = SymbolRef(definition);
     return make_type<SelfTypeParam>(sym);
 }

--- a/core/Types.h
+++ b/core/Types.h
@@ -422,6 +422,11 @@ template <> inline TypePtr make_type<SelfTypeParam, core::TypeArgumentRef &>(cor
     return make_type<SelfTypeParam>(sym);
 }
 
+template <> inline TypePtr make_type<SelfTypeParam, core::TypeMemberRef &>(core::TypeMemberRef &definition) {
+    auto sym = SymbolRef(definition);
+    return make_type<SelfTypeParam>(sym);
+}
+
 template <> inline SelfTypeParam cast_type_nonnull<SelfTypeParam>(const TypePtr &what) {
     ENFORCE_NO_TIMER(isa_type<SelfTypeParam>(what));
     return SelfTypeParam(core::SymbolRef::fromRaw(what.inlinedValue()));

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -880,7 +880,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             } else {
                 // All singletons have an AttachedClass type member, created by `singletonClass`
-                auto attachedClass =
+                const auto attachedClass =
                     owner.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass()).asTypeMemberRef();
                 return TypeSyntax::ResultType{core::make_type<core::SelfTypeParam>(attachedClass),
                                               core::Symbols::noClassOrModule()};

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -882,7 +882,8 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
                 // All singletons have an AttachedClass type member, created by `singletonClass`
                 auto attachedClass =
                     owner.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass()).asTypeMemberRef();
-                return TypeSyntax::ResultType{attachedClass.data(ctx)->resultType, core::Symbols::noClassOrModule()};
+                return TypeSyntax::ResultType{core::make_type<core::SelfTypeParam>(attachedClass),
+                                              core::Symbols::noClassOrModule()};
             }
         }
         case core::Names::noreturn().rawId():

--- a/test/testdata/resolver/attached_class_bound.rb
+++ b/test/testdata/resolver/attached_class_bound.rb
@@ -1,0 +1,68 @@
+# typed: strict
+
+class Wrapper
+  extend T::Sig
+  extend T::Generic
+
+  X = type_member(:out) { {upper: ParentThing} }
+
+  sig {params(x: X).void}
+  def initialize(x)
+    @x = x
+  end
+end
+
+class ParentThing
+  extend T::Sig
+  extend T::Generic
+
+  # ParentThing::<AttachedClass>   <:   ParentThing
+  #
+  # so
+  #
+  # Wrapper[ParentThing::<AttachedClass>]   <:   Wrapper[ParentThing]
+
+  sig {void}
+  def self.example
+    x = self.new
+    T.reveal_type(x) # error: `T.attached_class (of ParentThing)`
+    y = T.let(x, ParentThing)
+
+    ex = Wrapper[T.attached_class].new(x)
+    T.reveal_type(ex) # error: `Wrapper[T.attached_class (of ParentThing)]`
+    ex2 = T.let(ex, Wrapper[ParentThing])
+  end
+
+  sig {returns(Wrapper[T.attached_class])}
+  def self.make_thing_and_wrap
+    thing = self.new
+    T.reveal_type(thing) # error: `T.attached_class (of ParentThing)`
+    x = Wrapper[T.attached_class].new(thing)
+    p(x)
+    x
+  end
+end
+
+class ChildThing < ParentThing
+end
+
+parent_thing = ParentThing.make_thing_and_wrap
+T.reveal_type(parent_thing) # error: `Wrapper[ParentThing]`
+
+child_thing = ChildThing.make_thing_and_wrap
+T.reveal_type(child_thing) # error: `Wrapper[ChildThing]`
+
+class Unrelated
+  extend T::Sig
+  extend T::Generic
+
+  sig {returns(Wrapper[T.attached_class])}
+  #                    ^^^^^^^^^^^^^^^^ error: `T.attached_class (of Unrelated)` is not a subtype of upper bound of type member `::Wrapper::X
+  def self.foo
+    unrelated = self.new
+    x = Wrapper[T.attached_class].new(unrelated)
+    #           ^^^^^^^^^^^^^^^^ error: `T.attached_class (of Unrelated)` is not a subtype of upper bound of type member `::Wrapper::X
+    p(x)
+    x
+  end
+end


### PR DESCRIPTION
Fixes #6736


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If you look what we do for other type members in type_syntax parsing, we
say that the `result.type` of the parse is a `SelfTypeParam` type. For
some reason, here we were using the `resultType` of the symbol itself,
which is a `LambdaParam`. Thus, this change does what we were doing for
the normal type member case, and that makes the test pass.

I don't have a great way to explain why we need a `SelfTypeParam` here
instead of a `LambdaParam`, because I've only learned what they mean the
same way a native speaker might learn grammar—the best I can do is say
something akin to it "sounds weird" trying to use `LambdaParam` here.

I can back up the weirdness in this particular case, because the code in
`isSubTypeUnderConstraint` doesn't actually implement the case for
`t1 <: t2` if only one of them is a `LambdaParam`. There are some
commented out ENFORCEs there that seem to suggest we wish it were the
case that we never even had code for `LambdaParam` there:

<https://github.com/sorbet/sorbet/blob/d4f8fa8d6f8639310d1af224324d3045fbc90dcc/core/types/subtyping.cc#L1135>


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.