### PR TITLE
runtime: Treat shapes/tuples as subtypes of Hash/Array

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -62,13 +62,13 @@ module T::Types
       when TypedArray
         # warning: covariant arrays
 
-        value_1, value_2, *values_rest = types
-        if !value_2.nil?
-          value_type = T::Types::Union::Private::Pool.union_of_types(value_1, value_2, values_rest)
-        elsif value_1.nil?
-          value_type = T.untyped
+        value1, value2, *values_rest = types
+        value_type = if !value2.nil?
+          T::Types::Union::Private::Pool.union_of_types(value1, value2, values_rest)
+        elsif value1.nil?
+          T.untyped
         else
-          value_type = value_1
+          value1
         end
 
         T::Types::TypedArray.new(value_type).subtype_of?(other)

--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -59,6 +59,19 @@ module T::Types
         @types.size == other.types.size && @types.zip(other.types).all? do |t1, t2|
           t1.subtype_of?(t2)
         end
+      when TypedArray
+        # warning: covariant arrays
+
+        value_1, value_2, *values_rest = types
+        if !value_2.nil?
+          value_type = T::Types::Union::Private::Pool.union_of_types(value_1, value_2, values_rest)
+        elsif value_1.nil?
+          value_type = T.untyped
+        else
+          value_type = value_1
+        end
+
+        T::Types::TypedArray.new(value_type).subtype_of?(other)
       else
         false
       end

--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -38,6 +38,28 @@ module T::Types
       when FixedHash
         # Using `subtype_of?` here instead of == would be unsound
         @types == other.types
+      when TypedHash
+        # warning: covariant hashes
+
+        key_1, key_2, *keys_rest = types.keys.map {|key| T::Utils.coerce(key.class)}
+        if !key_2.nil?
+          key_type = T::Types::Union::Private::Pool.union_of_types(key_1, key_2, keys_rest)
+        elsif key_1.nil?
+          key_type = T.untyped
+        else
+          key_type = key_1
+        end
+
+        value_1, value_2, *values_rest = types.values
+        if !value_2.nil?
+          value_type = T::Types::Union::Private::Pool.union_of_types(value_1, value_2, values_rest)
+        elsif value_1.nil?
+          value_type = T.untyped
+        else
+          value_type = value_1
+        end
+
+        T::Types::TypedHash.new(keys: key_type, values: value_type).subtype_of?(other)
       else
         false
       end

--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -41,22 +41,22 @@ module T::Types
       when TypedHash
         # warning: covariant hashes
 
-        key_1, key_2, *keys_rest = types.keys.map {|key| T::Utils.coerce(key.class)}
-        if !key_2.nil?
-          key_type = T::Types::Union::Private::Pool.union_of_types(key_1, key_2, keys_rest)
-        elsif key_1.nil?
-          key_type = T.untyped
+        key1, key2, *keys_rest = types.keys.map {|key| T::Utils.coerce(key.class)}
+        key_type = if !key2.nil?
+          T::Types::Union::Private::Pool.union_of_types(key1, key2, keys_rest)
+        elsif key1.nil?
+          T.untyped
         else
-          key_type = key_1
+          key1
         end
 
-        value_1, value_2, *values_rest = types.values
-        if !value_2.nil?
-          value_type = T::Types::Union::Private::Pool.union_of_types(value_1, value_2, values_rest)
-        elsif value_1.nil?
-          value_type = T.untyped
+        value1, value2, *values_rest = types.values
+        value_type = if !value2.nil?
+          T::Types::Union::Private::Pool.union_of_types(value1, value2, values_rest)
+        elsif value1.nil?
+          T.untyped
         else
-          value_type = value_1
+          value1
         end
 
         T::Types::TypedHash.new(keys: key_type, values: value_type).subtype_of?(other)

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1477,6 +1477,31 @@ module Opus::Types::Test
           refute_subtype([String, Numeric], [String, Integer])
           refute_subtype([String], [String, Object])
         end
+
+        it 'compares upwards to TypedArray' do
+          assert_subtype([], T::Array[Integer])
+          assert_subtype([], T::Array[String])
+          assert_subtype([Integer], T::Array[Integer])
+          assert_subtype([Integer, String], T::Array[T.any(Integer, String)])
+
+          refute_subtype([Integer], T::Array[String])
+          refute_subtype([Integer, String], T::Array[Integer])
+        end
+      end
+
+      describe 'shapes' do
+        it 'compares upwards to TypedHash' do
+          assert_subtype({}, T::Hash[Integer, String])
+          assert_subtype({}, T::Hash[String, Symbol])
+          assert_subtype({key: Integer}, T::Hash[Symbol, Integer])
+          assert_subtype({'key' => Integer}, T::Hash[String, Integer])
+          assert_subtype({key: Integer, 'another' => Float}, T::Hash[T.any(Symbol, String), T.any(Integer, Float)])
+
+          refute_subtype({key: Integer}, T::Hash[String, Integer])
+          refute_subtype({key: Integer}, T::Hash[Symbol, Float])
+          refute_subtype({key: Integer, 'another' => Float}, T::Hash[Symbol, T.any(Integer, Float)])
+          refute_subtype({key: Integer, 'another' => Float}, T::Hash[T.any(Symbol, String), Integer])
+        end
       end
 
       describe 'untyped' do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is unsound but it at least matches the unsoundness in the static
system.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.