### PR TITLE
Continue exporting through behavior-less namespaces for exports

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -40,8 +40,14 @@ class PropagateVisibility final {
     }
 
     void recursiveExportSymbol(core::GlobalState &gs, bool firstSymbol, core::ClassOrModuleRef klass) {
-        // We only mark symbols from this package.
-        if (!this->definedByThisPackage(gs, klass)) {
+        // We only mark symbols from this package. However, there's a
+        // tough case where non-behavior-defining "namespace-like"
+        // constants might get attributed to other packages (since we
+        // don't have a canonical location, so we use the first place
+        // we see them... which might be in a subpackage) and
+        // therefore this might stop too soon. That's why we only stop
+        // recursing if the thing is actually behavior-defining.
+        if (!this->definedByThisPackage(gs, klass) && klass.data(gs)->flags.isBehaviorDefining) {
             return;
         }
 

--- a/test/testdata/packager/export_all/foo_bar_baz/foo_bar_baz.rb
+++ b/test/testdata/packager/export_all/foo_bar_baz/foo_bar_baz.rb
@@ -2,5 +2,9 @@
 
 module Foo::Bar::Baz
   class Quux
+    extend T::Sig
+
+    sig { void }
+    def example; end
   end
 end


### PR DESCRIPTION
This fixes problems with `export_all!` in some packages.

Writing a reliable test here would require some invariants on file ordering that I'm not sure about, which is why this doesn't include a test for the behavior it's fixing.


### Motivation
In the case of a class or module that defines "behavior", we can come up with a single canonical location for it, and use that location to figure out which package it belongs in. However, for behavior-less modules, this can pose a problem. Imagine that we've got a package `A` and a package `A::B::C`. Ideally, we'd know that `module A::B` belongs to package `A`, but there are situations in which the first definition we see of `module A::B` is in a file that belongs to package `A::B::C` and therefore that becomes the first location. In that case, we might incorrectly believe that the "owner" of that namespace is `A::B::C`. If we try to `export_all!` in `A`, then it previously would miss constants like `A::B::D` because of that misconception.

This technically exports more than it needs to, but only behavior-less namespaces; all _meaningful_ things in the package should be prevented from being exported.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested to verify that the behavior on pay-server is correct with this change.
