### PR TITLE
Allow different type as fallback of `Array#fetch`

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1279,18 +1279,20 @@ class Array < Object
     .returns(Elem)
   end
   sig do
-    params(
+    type_parameters(:Fallback)
+    .params(
         arg0: Integer,
-        arg1: Elem,
+        arg1: T.type_parameter(:Fallback),
     )
-    .returns(Elem)
+    .returns(T.any(Elem, T.type_parameter(:Fallback)))
   end
   sig do
-    params(
+    type_parameters(:Fallback)
+    .params(
         arg0: Integer,
-        blk: T.proc.params(arg0: Integer).returns(Elem),
+        blk: T.proc.params(arg0: Integer).returns(T.type_parameter(:Fallback)),
     )
-    .returns(Elem)
+    .returns(T.any(Elem, T.type_parameter(:Fallback)))
   end
   def fetch(arg0, arg1=T.unsafe(nil), &blk); end
 


### PR DESCRIPTION
Adds a new `:Fallback` type parameter to the method to represent the type of the fallback value when present, and allows the method to return `T.any(Elem, :Fallback)` in such cases. This broader definition more closely matches the actual possibilities in Ruby.

### Motivation
This addresses a problem where seemingly correct Ruby code using `Array#fetch` is [rejected by Sorbet](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0A%5B1%2C2%2C3%5D.fetch%280%2C%20'error'%29).

```ruby
[1,2,3].fetch(0, 'error')
```

The issue stems from the type signature of `#fetch`, which expects its fallback value (or block) to be of (or return) the same type contained in the array. While this seems like a sensible choice of types, it will prevent valid Ruby code from passing typechecking.

### Test plan
This is only a trivial change in a RBI file. Please let me know if tests are needed.
