### PR TITLE
delete `sorbet_ruby_2_7_unpatched` from potential Ruby versions

### DIFF
--- a/third_party/ruby/ruby-versions.txt
+++ b/third_party/ruby/ruby-versions.txt
@@ -1,4 +1,3 @@
-sorbet_ruby_2_7_unpatched
 sorbet_ruby_2_7
 sorbet_ruby_3_0
 sorbet_ruby_3_1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Realized yesterday that we don't need to be providing this as a version to Stripe's CI...and we wouldn't want it for anything, given that we have some significant performance patches to 2.7 already.

(We have the unpatched version to solve a circular dependency when building the compiler, so we need a definition in Bazel, but not here.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
