### PR TITLE
Update mode type on IO#initialize RBI

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -1565,7 +1565,7 @@ class IO < Object
   sig do
     params(
         fd: Integer,
-        mode: Integer,
+        mode: T.any(String, Integer),
         opt: T.untyped,
     )
     .void


### PR DESCRIPTION
The IO classes' initializer allows for the `mode` argument to be either a String or an Integer ([docs](https://ruby-doc.org/3.2.1/IO.html#method-c-new)). This RBI for this does not allow for a string. This allows for both strings and integers to be passed here.

### Motivation

We had some code that Sorbet flagged in the type checker, which should be valid.

```ruby
io = IO.new(fd, "w")
```

The doc block above uses strings for the mode argument.

### Test plan
Since this is a simple RBI change, I didn't think any further tests were necessary to add in.
