### PR TITLE
Fix keyword arguments parsing if the send node has a block

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -825,8 +825,15 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 } else {
                     int numPosArgs = send->args.size();
                     if (numPosArgs > 0) {
-                        // Deconstruct the kwargs hash in the last argument if it's present.
-                        if (auto *hash = parser::cast_node<parser::Hash>(send->args.back().get())) {
+                        // The keyword arguments hash can be the last argument if there is no block
+                        // or second to last argument otherwise
+                        int kwargsHashIndex = send->args.size() - 1;
+                        if (!parser::isa_node<parser::Hash>(send->args[kwargsHashIndex].get())) {
+                            kwargsHashIndex = max(0, kwargsHashIndex - 1);
+                        }
+
+                        // Deconstruct the kwargs hash if it's present.
+                        if (auto *hash = parser::cast_node<parser::Hash>(send->args[kwargsHashIndex].get())) {
                             if (hash->kwargs) {
                                 numPosArgs--;
 
@@ -839,8 +846,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                                         return parser::isa_node<parser::Kwsplat>(node.get());
                                     })) {
                                     // hold a reference to the node, and remove it from the back fo the send list
-                                    auto node = std::move(send->args.back());
-                                    send->args.pop_back();
+                                    auto node = std::move(send->args[kwargsHashIndex]);
+                                    send->args.erase(send->args.begin() + kwargsHashIndex);
 
                                     // inline the hash into the send args
                                     for (auto &entry : hash->pairs) {

--- a/test/testdata/infer/ruby3_keyword_args.rb
+++ b/test/testdata/infer/ruby3_keyword_args.rb
@@ -11,3 +11,19 @@ arghash = {y: 42}
 takes_kwargs(99, arghash) # error: Keyword argument hash without `**` is deprecated
 
 takes_kwargs(99, **arghash)
+
+sig do
+  params(
+    name: String,
+    tags: T::Hash[T.untyped, T.untyped],
+    x: Integer,
+    blk: T.proc.returns(String)
+  )
+  .returns(String)
+end
+def foo(name, tags: {}, x: 42, &blk)
+  yield
+end
+
+blk = Proc.new
+foo("", tags: {}, x: 1, &blk)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

While working on an implicit keyword argument conversions for the Ruby 3, I've noticed that Sorbet was erroring weirdly:

```ruby
# typed: true
# experimental-ruby3-keyword-args: true

sig do
  params(
    name: String,
    tags: T::Hash[T.untyped, T.untyped],
    x: Integer,
    blk: T.proc.returns(String)
  )
  .returns(String)
end
def foo(name, tags: {}, x: 42, &blk); end

foo(
  "",
  tags: {},
# ^^^^ error: Keyword argument hash without `**` is deprecated

  x: 1,
  &blk
)
```

And the proposed autocorrect looked like this and generated an invalid Ruby syntax
```ruby
foo(
  "",
  **tags: {},
  x: 1,
  &blk
)
```



Turns out, it was a bug in Desugarer. It would inline keyword arguments to the arguments store in a send node only if the send node didn't have a block. So from Sorbet perspective the call above after desugaring looked like this
```ruby
foo(
  "",
  {
    tags: {},
    x: 1
  },
  &blk
)
```

From that point of view the autocorrect makes much more sense! But it is still incorrect.

The bug happened, because the Desugarer looked for the keyword args hash at the last position in the arguments store. However, if the block is present, it will be the last argument, and the keywords hash is kept as it is in this case. 

The PR changes Desugarer to check the last two arguments in a search of the keyword args hash.

This change didn't cause any new errors in the Stripe's codebase

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Correct autocorrects!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not sure what would be the best place to put a test for this behaviour. I've added a case to the ruby 3 keyword test for now.
