### PR TITLE
Runtime override checking should ignore type variables

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -54,6 +54,12 @@ module T::Types
         return t1.aliased_type.subtype_of?(t2)
       end
 
+      if t1.is_a?(T::Types::TypeVariable) || t2.is_a?(T::Types::TypeVariable)
+        # Generics are erased at runtime. Let's treat them like `T.untyped` for
+        # the purpose of things like override checking.
+        return true
+      end
+
       # pairs to cover: 1  (_, _)
       #                 2  (_, And)
       #                 3  (_, Or)

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1503,6 +1503,13 @@ module Opus::Types::Test
                          T::Types::TypeMember.new(:out))
         end
 
+        it 'everything is a subtype of type members' do
+          assert_subtype(T.untyped, T::Types::TypeMember.new(:in))
+          assert_subtype(String, T::Types::TypeMember.new(:in))
+          assert_subtype(T::Types::TypeMember.new(:out),
+                         T::Types::TypeMember.new(:in))
+        end
+
         it 'type parameters are subtypes of everything' do
           assert_subtype(T::Types::TypeParameter.new(:T), T.untyped)
           assert_subtype(T::Types::TypeParameter.new(:T), String)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Since generics are erased at runtime, it's not possible for Sorbet to
properly check whether something is a subtype of a TypeVariable.

We already implement `TypeVariable#subtype_of_single?` to
unconditionally return `true` for this reason, but we didn't do the
other direction.

Fixes #1886


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.