### PR TITLE
Delete vestiges of RuntimeProfiled

### DIFF
--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -179,17 +179,13 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
         sym.data(gs)->unsafeComputeExternalType(gs);
         auto singleton = sym.data(gs)->lookupSingletonClass(gs);
         if (singleton.exists()) {
-            // AttachedClass doesn't exist on `T.untyped`, which is a problem
-            // with RuntimeProfiled.
             auto attachedClass = singleton.data(gs)->findMember(gs, core::Names::Constants::AttachedClass());
-            if (attachedClass.exists()) {
-                auto *lambdaParam =
-                    core::cast_type<core::LambdaParam>(attachedClass.asTypeMemberRef().data(gs)->resultType);
-                ENFORCE(lambdaParam != nullptr);
+            auto *lambdaParam =
+                core::cast_type<core::LambdaParam>(attachedClass.asTypeMemberRef().data(gs)->resultType);
+            ENFORCE(lambdaParam != nullptr);
 
-                lambdaParam->lowerBound = core::Types::bottom();
-                lambdaParam->upperBound = sym.data(gs)->externalType();
-            }
+            lambdaParam->lowerBound = core::Types::bottom();
+            lambdaParam->upperBound = sym.data(gs)->externalType();
         }
     }
 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2519,13 +2519,8 @@ class ResolveTypeMembersAndFieldsWalk {
             return;
         }
 
-        // NOTE: AttachedClass will not exist on `T.untyped`, which is a problem
-        // because RuntimeProfiled is used as a synonym for `T.untyped`
-        // internally.
         auto attachedClass = singleton.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass());
-        if (!attachedClass.exists()) {
-            return;
-        }
+        ENFORCE(attachedClass.exists());
         auto attachedClassTypeMember = attachedClass.asTypeMemberRef();
         auto *lambdaParam = core::cast_type<core::LambdaParam>(attachedClassTypeMember.data(ctx)->resultType);
         ENFORCE(lambdaParam != nullptr);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We removed RuntimeProfiled in #3562, which means these comments don't apply
anymore and we can convert `if` conditions into `ENFORCE`s.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests