### PR TITLE
RSpecCompatibility: Fixed behaviour when a method does not exist to match the original

### DIFF
--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -27,8 +27,10 @@ if defined? ::RSpec::Mocks
       module RSpecCompatibility
         module RecorderExtensions
           def observe!(method_name)
-            method = @klass.instance_method(method_name.to_sym)
-            T::Private::Methods.maybe_run_sig_block_for_method(method)
+            if @klass.method_defined?(method_name.to_sym)
+              method = @klass.instance_method(method_name.to_sym)
+              T::Private::Methods.maybe_run_sig_block_for_method(method)
+            end
             super(method_name)
           end
         end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

An error is raised by sorbet-runtime if a non-existent instance method is specified in allow_any_instance_of.
And no particular error without sorbet-runtime.
It would be better if we did not define unnecessary mocks, but we thought it would be more natural if the behaviour was the same as the original behaviour.

Since there is no need for consideration on the sorbet-runtime side for methods that do not exist, a method existence check has been added.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```ruby
method = @klass.instance_method(method_name.to_sym)
```
The above expression will raise a NameError if method is not defined, so it should only be executed if there is a method definition.
