### PR TITLE
Reject `T.attached_class` in modules

### DIFF
--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -873,11 +873,9 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
             auto owner = ctx.owner.asClassOrModuleRef();
             auto ownerData = owner.data(ctx);
 
+            // Can only use `T.attached_class` on singleton methods in a class (not a module)
             auto attachedClassIsAllowed =
-                // isModule is never true for a singleton class, so this implies that this is a module instance method
-                !ownerData->isModule() &&
-                // In classes, can only use `T.attached_class` on singleton methods
-                (ownerData->isSingletonClass(ctx) && ownerData->attachedClass(ctx).data(ctx)->isClass());
+                ownerData->isSingletonClass(ctx) && ownerData->attachedClass(ctx).data(ctx)->isClass();
             if (!attachedClassIsAllowed) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("`{}` may only be used in a singleton class method context, and not in modules",

--- a/test/testdata/infer/attached_class_module.rb
+++ b/test/testdata/infer/attached_class_module.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+module M
+  extend T::Sig
+
+  sig {returns(T.attached_class)}
+  #            ^^^^^^^^^^^^^^^^ error: `T.attached_class` may only be used in a singleton class method context, and not in modules
+  def instance_method
+  end
+
+  sig {returns(T.attached_class)}
+  #            ^^^^^^^^^^^^^^^^ error: `T.attached_class` may only be used in a singleton class method context, and not in modules
+  def self.class_method
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'd like to be able to unlock some memory savings by not creating
`<AttachedClass>` type members inside modules, because I don't think that it
ever makes sense to use `T.attached_class` in a singleton class method on a
module (because you can't instantiate an instance of a module from its singleton
class, nor can you inherit those singleton class methods in some child class
where an instantiation would be possible).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.