### PR TITLE
Fix crash in ivar assignment with begin/end

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -632,7 +632,12 @@ public:
             return false;
         }
 
-        auto *cast = ast::cast_tree<ast::Cast>(asgn.rhs);
+        auto *recur = &asgn.rhs;
+        while (auto *outer = ast::cast_tree<ast::InsSeq>(*recur)) {
+            recur = &outer->expr;
+        }
+
+        auto *cast = ast::cast_tree<ast::Cast>(*recur);
         if (cast == nullptr) {
             return false;
         }

--- a/test/testdata/namer/ivar_insseq.rb
+++ b/test/testdata/namer/ivar_insseq.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class A
+  extend T::Sig
+  sig { returns(Integer) }
+  def foo
+    @bar ||= begin; x = 1; T.let(x, Integer); end
+  # ^^^^ error: The instance variable `@bar` must be declared inside `initialize` or declared nilable
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: This code is unreachable
+  end
+
+  def other
+    T.reveal_type(@bar) # error: `Integer`
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #6766

The code here mimics the loop that resolver does in `handleFieldDeclaration`:

<https://github.com/sorbet/sorbet/blob/ec02be89e3d1895ea51bc72464538073d27b812c/resolver/resolver.cc#L2665-L2668>

Resolver was looping like this assuming that namer would always do the same
loop when deciding to enter fields in the first place.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.