### PR TITLE
Add RBIs for `Regexp.timeout` and `Regexp.timeout=`

### DIFF
--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -1308,6 +1308,20 @@ class Regexp < Object
   end
   def self.quote(arg0); end
 
+  # It returns the current default timeout interval for Regexp matching in
+  # second. nil means no default timeout configuration.
+  sig { returns(T.nilable(Float)) }
+  def self.timeout; end
+
+  # It sets the default timeout interval for
+  # [`Regexp`](https://docs.ruby-lang.org/en/3.2/Regexp.html) matching in
+  # second. `nil` means no default timeout configuration. This configuration
+  # is process-global. If you want to set timeout for each
+  # [`Regexp`](https://docs.ruby-lang.org/en/3.2/Regexp.html), use `timeout`
+  # keyword for `Regexp.new`.
+  sig { params(value: T.nilable(Float)).returns(T.nilable(Float)) }
+  def self.timeout=(value); end
+
   # Equality---Two regexps are equal if their patterns are identical, they have
   # the same character set code, and their `casefold?` values are the same.
   #

--- a/test/testdata/rbi/regexp.rb
+++ b/test/testdata/rbi/regexp.rb
@@ -32,3 +32,8 @@ T.reveal_type(/foo/.match?('foo', 1))  # error: type: `T::Boolean`
 T.reveal_type(Regexp.compile('foo')) # error: type: `Regexp`
 T.reveal_type(Regexp.compile('foo', Regexp::EXTENDED | Regexp::IGNORECASE)) # error: type: `Regexp`
 T.reveal_type(Regexp.compile(/foo/)) # error: type: `Regexp`
+
+T.reveal_type(Regexp.timeout) # error: type: `T.nilable(Float)`
+T.reveal_type(Regexp.timeout = 3.0) # error: type: `Float(3.000000)`
+T.reveal_type(Regexp.timeout) # error: type: `T.nilable(Float)`
+T.reveal_type(Regexp.timeout = nil) # error: type: `NilClass`


### PR DESCRIPTION
### Motivation
Ruby 3.2 adds some new class methods to `Regexp`: `timeout` and `timeout=`, which are used to read and write a global regex timeout.

Read more about that here: https://bugs.ruby-lang.org/issues/17837

This PR adds RBIs for these methods!

### Test plan
See included automated tests.
