### PR TITLE
Do not call rename after move method refactoring

### DIFF
--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -201,17 +201,6 @@ vector<unique_ptr<TextEdit>> moveMethod(LSPTypecheckerDelegate &typechecker, con
 
 } // namespace
 
-unique_ptr<Position> getNewModuleLocation(const core::GlobalState &gs, const core::lsp::MethodDefResponse &definition,
-                                          LSPTypecheckerDelegate &typechecker) {
-    auto fref = definition.termLoc.file();
-
-    auto &rootTree = typechecker.getIndexed({fref});
-    auto insertPosition = Range::fromLoc(gs, core::Loc(fref, rootTree.tree.loc().copyWithZeroLength()));
-    auto newModuleSymbol = insertPosition->start->copy();
-    newModuleSymbol->character += moduleKeyword.size() + 1;
-    return newModuleSymbol;
-}
-
 vector<unique_ptr<TextDocumentEdit>> getMoveMethodEdits(LSPTypecheckerDelegate &typechecker,
                                                         const LSPConfiguration &config,
                                                         const core::lsp::MethodDefResponse &definition) {

--- a/main/lsp/MoveMethod.h
+++ b/main/lsp/MoveMethod.h
@@ -11,10 +11,6 @@ std::vector<std::unique_ptr<TextDocumentEdit>> getMoveMethodEdits(LSPTypechecker
                                                                   const LSPConfiguration &config,
                                                                   const core::lsp::MethodDefResponse &definition);
 
-std::unique_ptr<Position> getNewModuleLocation(const core::GlobalState &gs,
-                                               const core::lsp::MethodDefResponse &definition,
-                                               LSPTypecheckerDelegate &typechecker);
-
 } // namespace sorbet::realmain::lsp
 
 #endif

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -171,15 +171,6 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
                 auto action = make_unique<CodeAction>("Move method to a new module");
                 action->kind = CodeActionKind::RefactorExtract;
 
-                auto newModuleLoc = getNewModuleLocation(gs, *def, typechecker);
-                auto renameCommand = make_unique<Command>("Rename Symbol", "sorbet.rename");
-                auto arg = make_unique<TextDocumentPositionParams>(
-                    make_unique<TextDocumentIdentifier>(params->textDocument->uri), move(newModuleLoc));
-                auto args = vector<unique_ptr<TextDocumentPositionParams>>();
-                args.emplace_back(move(arg));
-
-                renameCommand->arguments = move(args);
-                action->command = move(renameCommand);
                 if (canResolveLazily) {
                     action->data = move(params);
                 } else {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Per the tin

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The call to rename new module takes too long and breaks UX

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
