### PR TITLE
Skip calling into dispatchCall from type_syntax.cc

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -193,7 +193,8 @@ public:
     // Called both from type_syntax.cc during sig parsing and from infer after encountering
     // something that look like type syntax in a method body.
     static TypePtr applyTypeArguments(const GlobalState &gs, const CallLocs &locs, uint16_t numPosArgs,
-                                      InlinedVector<const TypeAndOrigins *, 2> &args, ClassOrModuleRef genericClass);
+                                      const InlinedVector<const TypeAndOrigins *, 2> &args,
+                                      ClassOrModuleRef genericClass);
 };
 
 struct Intrinsic {

--- a/core/Types.h
+++ b/core/Types.h
@@ -171,6 +171,24 @@ public:
     // be intrinsics so that this can become an anonymous helper function in calls.cc.
     static core::ClassOrModuleRef getRepresentedClass(const GlobalState &gs, const core::TypePtr &ty);
 
+    /**
+     * unwrapType is used to take an expression that's parsed at the value-level,
+     * and turn it into a type. For example, consider the following two expressions:
+     *
+     * > Integer.sqrt 10
+     * > T::Array[Integer].new
+     *
+     * In both lines, `Integer` is initially resolved as the singleton class of
+     * `Integer`. This is because it's not immediately clear if we want to refer
+     * to the type `Integer` or if we want the singleton class of Integer for
+     * calling singleton methods. In the first line this was the correct choice, as
+     * we're just invoking the singleton method `sqrt`. In the second case we need
+     * to fix up the `Integer` sub-expression, and turn it back into the type of
+     * integer values. This is what `unwrapType` does, it turns the value-level
+     * expression back into a type-level one.
+     */
+    static TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp);
+
     // Converts type syntax like `GenericClass[Arg0, Arg1]` into a TypePtr.
     //
     // Called both from type_syntax.cc during sig parsing and from infer after encountering

--- a/core/Types.h
+++ b/core/Types.h
@@ -145,7 +145,6 @@ public:
      * tc.solve(). If the constraint has already been solved, use `instantiate` instead.
      */
     static TypePtr approximate(const GlobalState &gs, const TypePtr &what, const TypeConstraint &tc);
-    static TypePtr dispatchCallWithoutBlock(const GlobalState &gs, const TypePtr &recv, const DispatchArgs &args);
     static TypePtr dropLiteral(const GlobalState &gs, const TypePtr &tp);
 
     /** Internal implementation. You should probably use all(). */

--- a/core/Types.h
+++ b/core/Types.h
@@ -170,6 +170,12 @@ public:
     // This is an internal method for implementing intrinsics. In the future we should make all updateKnowledge methods
     // be intrinsics so that this can become an anonymous helper function in calls.cc.
     static core::ClassOrModuleRef getRepresentedClass(const GlobalState &gs, const core::TypePtr &ty);
+
+    // Converts type syntax like `GenericClass[Arg0, Arg1]` into a TypePtr.
+    //
+    // Called both from type_syntax.cc during sig parsing and from infer after encountering
+    // something that look like type syntax in a method body.
+    static TypePtr applyTypeArguments(const GlobalState &gs, const DispatchArgs &args, ClassOrModuleRef genericClass);
 };
 
 struct Intrinsic {

--- a/core/Types.h
+++ b/core/Types.h
@@ -193,7 +193,8 @@ public:
     //
     // Called both from type_syntax.cc during sig parsing and from infer after encountering
     // something that look like type syntax in a method body.
-    static TypePtr applyTypeArguments(const GlobalState &gs, const DispatchArgs &args, ClassOrModuleRef genericClass);
+    static TypePtr applyTypeArguments(const GlobalState &gs, const CallLocs &locs, uint16_t numPosArgs,
+                                      InlinedVector<const TypeAndOrigins *, 2> &args, ClassOrModuleRef genericClass);
 };
 
 struct Intrinsic {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2093,127 +2093,6 @@ public:
     }
 } Class_subclasses;
 
-class T_Generic_squareBrackets : public IntrinsicMethod {
-public:
-    // This method is actually special: not only is it called from processBinding in infer, it's
-    // also called directly by type_syntax parsing in resolver (because this method checks some
-    // invariants of generics that we want to hold even in `typed: false` files).
-    //
-    // Unfortunately, this means that some errors are double reported (once by resolver, and then
-    // again by infer).
-    static TypePtr applyTypeArguments(const GlobalState &gs, const DispatchArgs &args, ClassOrModuleRef genericClass) {
-        genericClass = genericClass.maybeUnwrapBuiltinGenericForwarder();
-
-        if (genericClass.data(gs)->typeMembers().empty()) {
-            return Types::untypedUntracked();
-        }
-
-        int arity;
-        if (genericClass == Symbols::Hash()) {
-            arity = 2;
-        } else {
-            arity = genericClass.data(gs)->typeArity(gs);
-        }
-
-        // This is something like Generic[T1,...,foo: bar...]
-        auto numKwArgs = args.args.size() - args.numPosArgs;
-        if (numKwArgs > 0) {
-            auto begin = args.locs.args[args.numPosArgs].beginPos();
-            auto end = args.locs.args.back().endPos();
-            core::Loc kwargsLoc{args.locs.file, begin, end};
-
-            if (auto e = gs.beginError(kwargsLoc, errors::Infer::GenericArgumentKeywordArgs)) {
-                e.setHeader("Keyword arguments given to `{}`", genericClass.show(gs));
-                // offer an autocorrect to turn the keyword args into a hash if there is no double-splat
-                if (numKwArgs % 2 == 0 && kwargsLoc.exists()) {
-                    e.replaceWith(fmt::format("Wrap with braces"), kwargsLoc, "{{{}}}", kwargsLoc.source(gs).value());
-                }
-            }
-        }
-
-        if (args.numPosArgs != arity) {
-            if (auto e = gs.beginError(args.argsLoc(), errors::Infer::GenericArgumentCountMismatch)) {
-                e.setHeader("Wrong number of type parameters for `{}`. Expected: `{}`, got: `{}`",
-                            genericClass.show(gs), arity, args.numPosArgs);
-            }
-        }
-
-        vector<TypePtr> targs;
-        auto it = args.args.begin();
-        int i = -1;
-        targs.reserve(genericClass.data(gs)->typeMembers().size());
-        for (auto mem : genericClass.data(gs)->typeMembers()) {
-            ++i;
-
-            auto memData = mem.data(gs);
-
-            auto *memType = cast_type<LambdaParam>(memData->resultType);
-            ENFORCE(memType != nullptr);
-
-            if (memData->flags.isFixed) {
-                // Fixed args are implicitly applied, and won't consume type
-                // arguments from the list that's supplied.
-                targs.emplace_back(memType->upperBound);
-            } else if (it != args.args.end()) {
-                auto loc = args.argLoc(it - args.args.begin());
-                auto argType = unwrapType(gs, loc, (*it)->type);
-                bool validBounds = true;
-
-                // Validate type parameter bounds.
-                if (!Types::isSubType(gs, argType, memType->upperBound)) {
-                    validBounds = false;
-                    if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
-                        auto argStr = argType.show(gs);
-                        e.setHeader("`{}` is not a subtype of upper bound of type member `{}`", argStr,
-                                    mem.showFullName(gs));
-                        e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", mem.showFullName(gs),
-                                       "upper", memType->upperBound.show(gs));
-                    }
-                }
-
-                if (!Types::isSubType(gs, memType->lowerBound, argType)) {
-                    validBounds = false;
-
-                    if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
-                        auto argStr = argType.show(gs);
-                        e.setHeader("`{}` is not a supertype of lower bound of type member `{}`", argStr,
-                                    mem.showFullName(gs));
-                        e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", mem.showFullName(gs),
-                                       "lower", memType->lowerBound.show(gs));
-                    }
-                }
-
-                if (validBounds) {
-                    targs.emplace_back(argType);
-                } else {
-                    targs.emplace_back(Types::untypedUntracked());
-                }
-
-                ++it;
-            } else if (genericClass == Symbols::Hash() && i == 2) {
-                auto tupleArgs = targs;
-                targs.emplace_back(make_type<TupleType>(tupleArgs));
-            } else {
-                targs.emplace_back(Types::untypedUntracked());
-            }
-        }
-
-        return make_type<MetaType>(make_type<AppliedType>(genericClass, move(targs)));
-    }
-
-    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto mustExist = true;
-        ClassOrModuleRef self = unwrapSymbol(gs, args.thisType, mustExist);
-        auto attachedClass = self.data(gs)->attachedClass(gs);
-
-        if (!attachedClass.exists()) {
-            return;
-        }
-
-        res.returnType = applyTypeArguments(gs, args, attachedClass);
-    }
-} T_Generic_squareBrackets;
-
 void applySig(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res, size_t argsToDropOffEnd) {
     // We should always have the actual receiver plus whatever args we're going
     // to ignore for dispatching purposes.
@@ -4395,6 +4274,131 @@ public:
         res.returnType = Types::Boolean();
     }
 } T_Enum_tripleEq;
+
+} // namespace
+
+class T_Generic_squareBrackets : public IntrinsicMethod {
+public:
+    // This method is actually special: not only is it called from processBinding in infer, it's
+    // also called directly by type_syntax parsing in resolver (because this method checks some
+    // invariants of generics that we want to hold even in `typed: false` files).
+    //
+    // Unfortunately, this means that some errors are double reported (once by resolver, and then
+    // again by infer).
+    static TypePtr applyTypeArguments(const GlobalState &gs, const DispatchArgs &args, ClassOrModuleRef genericClass) {
+        genericClass = genericClass.maybeUnwrapBuiltinGenericForwarder();
+
+        if (genericClass.data(gs)->typeMembers().empty()) {
+            return Types::untypedUntracked();
+        }
+
+        int arity;
+        if (genericClass == Symbols::Hash()) {
+            arity = 2;
+        } else {
+            arity = genericClass.data(gs)->typeArity(gs);
+        }
+
+        // This is something like Generic[T1,...,foo: bar...]
+        auto numKwArgs = args.args.size() - args.numPosArgs;
+        if (numKwArgs > 0) {
+            auto begin = args.locs.args[args.numPosArgs].beginPos();
+            auto end = args.locs.args.back().endPos();
+            core::Loc kwargsLoc{args.locs.file, begin, end};
+
+            if (auto e = gs.beginError(kwargsLoc, errors::Infer::GenericArgumentKeywordArgs)) {
+                e.setHeader("Keyword arguments given to `{}`", genericClass.show(gs));
+                // offer an autocorrect to turn the keyword args into a hash if there is no double-splat
+                if (numKwArgs % 2 == 0 && kwargsLoc.exists()) {
+                    e.replaceWith(fmt::format("Wrap with braces"), kwargsLoc, "{{{}}}", kwargsLoc.source(gs).value());
+                }
+            }
+        }
+
+        if (args.numPosArgs != arity) {
+            if (auto e = gs.beginError(args.argsLoc(), errors::Infer::GenericArgumentCountMismatch)) {
+                e.setHeader("Wrong number of type parameters for `{}`. Expected: `{}`, got: `{}`",
+                            genericClass.show(gs), arity, args.numPosArgs);
+            }
+        }
+
+        vector<TypePtr> targs;
+        auto it = args.args.begin();
+        int i = -1;
+        targs.reserve(genericClass.data(gs)->typeMembers().size());
+        for (auto mem : genericClass.data(gs)->typeMembers()) {
+            ++i;
+
+            auto memData = mem.data(gs);
+
+            auto *memType = cast_type<LambdaParam>(memData->resultType);
+            ENFORCE(memType != nullptr);
+
+            if (memData->flags.isFixed) {
+                // Fixed args are implicitly applied, and won't consume type
+                // arguments from the list that's supplied.
+                targs.emplace_back(memType->upperBound);
+            } else if (it != args.args.end()) {
+                auto loc = args.argLoc(it - args.args.begin());
+                auto argType = unwrapType(gs, loc, (*it)->type);
+                bool validBounds = true;
+
+                // Validate type parameter bounds.
+                if (!Types::isSubType(gs, argType, memType->upperBound)) {
+                    validBounds = false;
+                    if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
+                        auto argStr = argType.show(gs);
+                        e.setHeader("`{}` is not a subtype of upper bound of type member `{}`", argStr,
+                                    mem.showFullName(gs));
+                        e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", mem.showFullName(gs),
+                                       "upper", memType->upperBound.show(gs));
+                    }
+                }
+
+                if (!Types::isSubType(gs, memType->lowerBound, argType)) {
+                    validBounds = false;
+
+                    if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
+                        auto argStr = argType.show(gs);
+                        e.setHeader("`{}` is not a supertype of lower bound of type member `{}`", argStr,
+                                    mem.showFullName(gs));
+                        e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", mem.showFullName(gs),
+                                       "lower", memType->lowerBound.show(gs));
+                    }
+                }
+
+                if (validBounds) {
+                    targs.emplace_back(argType);
+                } else {
+                    targs.emplace_back(Types::untypedUntracked());
+                }
+
+                ++it;
+            } else if (genericClass == Symbols::Hash() && i == 2) {
+                auto tupleArgs = targs;
+                targs.emplace_back(make_type<TupleType>(tupleArgs));
+            } else {
+                targs.emplace_back(Types::untypedUntracked());
+            }
+        }
+
+        return make_type<MetaType>(make_type<AppliedType>(genericClass, move(targs)));
+    }
+
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        auto mustExist = true;
+        ClassOrModuleRef self = unwrapSymbol(gs, args.thisType, mustExist);
+        auto attachedClass = self.data(gs)->attachedClass(gs);
+
+        if (!attachedClass.exists()) {
+            return;
+        }
+
+        res.returnType = applyTypeArguments(gs, args, attachedClass);
+    }
+} T_Generic_squareBrackets;
+
+namespace {
 
 const vector<Intrinsic> intrinsics{
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::untyped(), &T_untyped},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2214,7 +2214,6 @@ public:
     }
 } T_Generic_squareBrackets;
 
-namespace {
 void applySig(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res, size_t argsToDropOffEnd) {
     // We should always have the actual receiver plus whatever args we're going
     // to ignore for dispatching purposes.
@@ -2242,7 +2241,6 @@ void applySig(const GlobalState &gs, const DispatchArgs &args, DispatchResult &r
                                       recv.type, args.block, args.originForUninitialized, args.isPrivateOk,
                                       args.suppressErrors});
 }
-} // namespace
 
 class SorbetPrivateStatic_sig : public IntrinsicMethod {
 public:
@@ -3366,8 +3364,6 @@ public:
     }
 } Tuple_concat;
 
-namespace {
-
 optional<Loc> locOfValueForKey(const GlobalState &gs, const Loc origin, const NameRef key, const TypePtr expectedType) {
     if (!isa_type<ClassType>(expectedType)) {
         return nullopt;
@@ -3412,8 +3408,6 @@ optional<Loc> locOfValueForKey(const GlobalState &gs, const Loc origin, const Na
 
     return nullopt;
 }
-
-} // namespace
 
 class Shape_squareBracketsEq : public IntrinsicMethod {
 public:
@@ -3690,8 +3684,6 @@ class Magic_mergeHashValues : public IntrinsicMethod {
     }
 } Magic_mergeHashValues;
 
-namespace {
-
 void digImplementation(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res, NameRef methodToDigWith) {
     if (args.args.size() == 0 || args.numPosArgs != args.args.size()) {
         // A type error was already reported for arg mismatch
@@ -3797,8 +3789,6 @@ void digImplementation(const GlobalState &gs, const DispatchArgs &args, Dispatch
 
     res.returnType = move(recursiveDispatch.returnType);
 }
-
-} // namespace
 
 class Hash_dig : public IntrinsicMethod {
 public:

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2093,6 +2093,21 @@ public:
     }
 } Class_subclasses;
 
+class T_Generic_squareBrackets : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        auto mustExist = true;
+        ClassOrModuleRef self = unwrapSymbol(gs, args.thisType, mustExist);
+        auto attachedClass = self.data(gs)->attachedClass(gs);
+
+        if (!attachedClass.exists()) {
+            return;
+        }
+
+        res.returnType = Types::applyTypeArguments(gs, args, attachedClass);
+    }
+} T_Generic_squareBrackets;
+
 void applySig(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res, size_t argsToDropOffEnd) {
     // We should always have the actual receiver plus whatever args we're going
     // to ignore for dispatching purposes.
@@ -4274,131 +4289,6 @@ public:
         res.returnType = Types::Boolean();
     }
 } T_Enum_tripleEq;
-
-} // namespace
-
-// This method is actually special: not only is it called from processBinding in infer, it's
-// also called directly by type_syntax parsing in resolver (because this method checks some
-// invariants of generics that we want to hold even in `typed: false` files).
-//
-// Unfortunately, this means that some errors are double reported (once by resolver, and then
-// again by infer).
-static TypePtr applyTypeArguments(const GlobalState &gs, const DispatchArgs &args, ClassOrModuleRef genericClass) {
-    genericClass = genericClass.maybeUnwrapBuiltinGenericForwarder();
-
-    if (genericClass.data(gs)->typeMembers().empty()) {
-        return Types::untypedUntracked();
-    }
-
-    int arity;
-    if (genericClass == Symbols::Hash()) {
-        arity = 2;
-    } else {
-        arity = genericClass.data(gs)->typeArity(gs);
-    }
-
-    // This is something like Generic[T1,...,foo: bar...]
-    auto numKwArgs = args.args.size() - args.numPosArgs;
-    if (numKwArgs > 0) {
-        auto begin = args.locs.args[args.numPosArgs].beginPos();
-        auto end = args.locs.args.back().endPos();
-        core::Loc kwargsLoc{args.locs.file, begin, end};
-
-        if (auto e = gs.beginError(kwargsLoc, errors::Infer::GenericArgumentKeywordArgs)) {
-            e.setHeader("Keyword arguments given to `{}`", genericClass.show(gs));
-            // offer an autocorrect to turn the keyword args into a hash if there is no double-splat
-            if (numKwArgs % 2 == 0 && kwargsLoc.exists()) {
-                e.replaceWith(fmt::format("Wrap with braces"), kwargsLoc, "{{{}}}", kwargsLoc.source(gs).value());
-            }
-        }
-    }
-
-    if (args.numPosArgs != arity) {
-        if (auto e = gs.beginError(args.argsLoc(), errors::Infer::GenericArgumentCountMismatch)) {
-            e.setHeader("Wrong number of type parameters for `{}`. Expected: `{}`, got: `{}`", genericClass.show(gs),
-                        arity, args.numPosArgs);
-        }
-    }
-
-    vector<TypePtr> targs;
-    auto it = args.args.begin();
-    int i = -1;
-    targs.reserve(genericClass.data(gs)->typeMembers().size());
-    for (auto mem : genericClass.data(gs)->typeMembers()) {
-        ++i;
-
-        auto memData = mem.data(gs);
-
-        auto *memType = cast_type<LambdaParam>(memData->resultType);
-        ENFORCE(memType != nullptr);
-
-        if (memData->flags.isFixed) {
-            // Fixed args are implicitly applied, and won't consume type
-            // arguments from the list that's supplied.
-            targs.emplace_back(memType->upperBound);
-        } else if (it != args.args.end()) {
-            auto loc = args.argLoc(it - args.args.begin());
-            auto argType = unwrapType(gs, loc, (*it)->type);
-            bool validBounds = true;
-
-            // Validate type parameter bounds.
-            if (!Types::isSubType(gs, argType, memType->upperBound)) {
-                validBounds = false;
-                if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
-                    auto argStr = argType.show(gs);
-                    e.setHeader("`{}` is not a subtype of upper bound of type member `{}`", argStr,
-                                mem.showFullName(gs));
-                    e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", mem.showFullName(gs), "upper",
-                                   memType->upperBound.show(gs));
-                }
-            }
-
-            if (!Types::isSubType(gs, memType->lowerBound, argType)) {
-                validBounds = false;
-
-                if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
-                    auto argStr = argType.show(gs);
-                    e.setHeader("`{}` is not a supertype of lower bound of type member `{}`", argStr,
-                                mem.showFullName(gs));
-                    e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", mem.showFullName(gs), "lower",
-                                   memType->lowerBound.show(gs));
-                }
-            }
-
-            if (validBounds) {
-                targs.emplace_back(argType);
-            } else {
-                targs.emplace_back(Types::untypedUntracked());
-            }
-
-            ++it;
-        } else if (genericClass == Symbols::Hash() && i == 2) {
-            auto tupleArgs = targs;
-            targs.emplace_back(make_type<TupleType>(tupleArgs));
-        } else {
-            targs.emplace_back(Types::untypedUntracked());
-        }
-    }
-
-    return make_type<MetaType>(make_type<AppliedType>(genericClass, move(targs)));
-}
-
-namespace {
-
-class T_Generic_squareBrackets : public IntrinsicMethod {
-public:
-    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto mustExist = true;
-        ClassOrModuleRef self = unwrapSymbol(gs, args.thisType, mustExist);
-        auto attachedClass = self.data(gs)->attachedClass(gs);
-
-        if (!attachedClass.exists()) {
-            return;
-        }
-
-        res.returnType = applyTypeArguments(gs, args, attachedClass);
-    }
-} T_Generic_squareBrackets;
 
 const vector<Intrinsic> intrinsics{
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::untyped(), &T_untyped},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2016,7 +2016,7 @@ public:
             return;
         }
 
-        res.returnType = Types::applyTypeArguments(gs, args, attachedClass);
+        res.returnType = Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, attachedClass);
     }
 } T_Generic_squareBrackets;
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4277,8 +4277,6 @@ public:
 
 } // namespace
 
-class T_Generic_squareBrackets : public IntrinsicMethod {
-public:
     // This method is actually special: not only is it called from processBinding in infer, it's
     // also called directly by type_syntax parsing in resolver (because this method checks some
     // invariants of generics that we want to hold even in `typed: false` files).
@@ -4385,6 +4383,10 @@ public:
         return make_type<MetaType>(make_type<AppliedType>(genericClass, move(targs)));
     }
 
+namespace {
+
+class T_Generic_squareBrackets : public IntrinsicMethod {
+public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         auto mustExist = true;
         ClassOrModuleRef self = unwrapSymbol(gs, args.thisType, mustExist);
@@ -4397,8 +4399,6 @@ public:
         res.returnType = applyTypeArguments(gs, args, attachedClass);
     }
 } T_Generic_squareBrackets;
-
-namespace {
 
 const vector<Intrinsic> intrinsics{
     {Symbols::T(), Intrinsic::Kind::Singleton, Names::untyped(), &T_untyped},

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -54,16 +54,7 @@ string argTypeForUnresolvedAppliedType(const GlobalState &gs, const TypePtr &t, 
 
 string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) const {
     string resolvedString = options.showForRBI ? "" : " (unresolved)";
-    ClassOrModuleRef symForPrinting;
-
-    if (options.showForRBI) {
-        auto attachedClass = this->klass.data(gs)->attachedClass(gs);
-        symForPrinting = attachedClass;
-    } else {
-        symForPrinting = this->klass;
-    }
-
-    return fmt::format("{}[{}]{}", symForPrinting.show(gs, options),
+    return fmt::format("{}[{}]{}", this->klass.show(gs, options),
                        fmt::map_join(targs, ", ",
                                      [&](auto targ) {
                                          return options.showForRBI ? argTypeForUnresolvedAppliedType(gs, targ, options)

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -23,18 +23,6 @@ namespace sorbet::core {
 
 using namespace std;
 
-TypePtr Types::dispatchCallWithoutBlock(const GlobalState &gs, const TypePtr &recv, const DispatchArgs &args) {
-    auto dispatched = recv.dispatchCall(gs, args);
-    auto link = &dispatched;
-    while (link != nullptr) {
-        for (auto &err : link->main.errors) {
-            gs._error(move(err));
-        }
-        link = link->secondary.get();
-    }
-    return move(dispatched.returnType);
-}
-
 TypePtr Types::top() {
     return make_type<ClassType>(Symbols::top());
 }

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -8,6 +8,8 @@
 #include "core/Names.h"
 #include "core/Symbols.h"
 #include "core/TypeConstraint.h"
+#include "core/errors/infer.h"
+#include "core/errors/resolver.h"
 #include <utility>
 
 #include "core/Types.h"
@@ -884,6 +886,112 @@ core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const T
         singleton = at->klass;
     }
     return singleton.data(gs)->attachedClass(gs);
+}
+
+// This method is actually special: not only is it called from dispatchCall in calls.cc, it's
+// also called directly by type_syntax parsing in resolver (because this method checks some
+// invariants of generics that we want to hold even in `typed: false` files).
+//
+// Unfortunately, this means that some errors are double reported (once by resolver, and then
+// again by infer).
+TypePtr Types::applyTypeArguments(const GlobalState &gs, const DispatchArgs &args, ClassOrModuleRef genericClass) {
+    genericClass = genericClass.maybeUnwrapBuiltinGenericForwarder();
+
+    if (genericClass.data(gs)->typeMembers().empty()) {
+        return Types::untypedUntracked();
+    }
+
+    int arity;
+    if (genericClass == Symbols::Hash()) {
+        arity = 2;
+    } else {
+        arity = genericClass.data(gs)->typeArity(gs);
+    }
+
+    // This is something like Generic[T1,...,foo: bar...]
+    auto numKwArgs = args.args.size() - args.numPosArgs;
+    if (numKwArgs > 0) {
+        auto begin = args.locs.args[args.numPosArgs].beginPos();
+        auto end = args.locs.args.back().endPos();
+        core::Loc kwargsLoc{args.locs.file, begin, end};
+
+        if (auto e = gs.beginError(kwargsLoc, errors::Infer::GenericArgumentKeywordArgs)) {
+            e.setHeader("Keyword arguments given to `{}`", genericClass.show(gs));
+            // offer an autocorrect to turn the keyword args into a hash if there is no double-splat
+            if (numKwArgs % 2 == 0 && kwargsLoc.exists()) {
+                e.replaceWith(fmt::format("Wrap with braces"), kwargsLoc, "{{{}}}", kwargsLoc.source(gs).value());
+            }
+        }
+    }
+
+    if (args.numPosArgs != arity) {
+        if (auto e = gs.beginError(args.argsLoc(), errors::Infer::GenericArgumentCountMismatch)) {
+            e.setHeader("Wrong number of type parameters for `{}`. Expected: `{}`, got: `{}`", genericClass.show(gs),
+                        arity, args.numPosArgs);
+        }
+    }
+
+    vector<TypePtr> targs;
+    auto it = args.args.begin();
+    int i = -1;
+    targs.reserve(genericClass.data(gs)->typeMembers().size());
+    for (auto mem : genericClass.data(gs)->typeMembers()) {
+        ++i;
+
+        auto memData = mem.data(gs);
+
+        auto *memType = cast_type<LambdaParam>(memData->resultType);
+        ENFORCE(memType != nullptr);
+
+        if (memData->flags.isFixed) {
+            // Fixed args are implicitly applied, and won't consume type
+            // arguments from the list that's supplied.
+            targs.emplace_back(memType->upperBound);
+        } else if (it != args.args.end()) {
+            auto loc = args.argLoc(it - args.args.begin());
+            auto argType = unwrapType(gs, loc, (*it)->type);
+            bool validBounds = true;
+
+            // Validate type parameter bounds.
+            if (!Types::isSubType(gs, argType, memType->upperBound)) {
+                validBounds = false;
+                if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
+                    auto argStr = argType.show(gs);
+                    e.setHeader("`{}` is not a subtype of upper bound of type member `{}`", argStr,
+                                mem.showFullName(gs));
+                    e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", mem.showFullName(gs), "upper",
+                                   memType->upperBound.show(gs));
+                }
+            }
+
+            if (!Types::isSubType(gs, memType->lowerBound, argType)) {
+                validBounds = false;
+
+                if (auto e = gs.beginError(loc, errors::Resolver::GenericTypeParamBoundMismatch)) {
+                    auto argStr = argType.show(gs);
+                    e.setHeader("`{}` is not a supertype of lower bound of type member `{}`", argStr,
+                                mem.showFullName(gs));
+                    e.addErrorLine(memData->loc(), "`{}` is `{}` bounded by `{}` here", mem.showFullName(gs), "lower",
+                                   memType->lowerBound.show(gs));
+                }
+            }
+
+            if (validBounds) {
+                targs.emplace_back(argType);
+            } else {
+                targs.emplace_back(Types::untypedUntracked());
+            }
+
+            ++it;
+        } else if (genericClass == Symbols::Hash() && i == 2) {
+            auto tupleArgs = targs;
+            targs.emplace_back(make_type<TupleType>(tupleArgs));
+        } else {
+            targs.emplace_back(Types::untypedUntracked());
+        }
+    }
+
+    return make_type<MetaType>(make_type<AppliedType>(genericClass, move(targs)));
 }
 
 Loc DispatchArgs::blockLoc(const GlobalState &gs) const {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -956,7 +956,7 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
 // again by infer).
 
 TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, uint16_t numPosArgs,
-                                  InlinedVector<const TypeAndOrigins *, 2> &args, ClassOrModuleRef genericClass) {
+                                  const InlinedVector<const TypeAndOrigins *, 2> &args, ClassOrModuleRef genericClass) {
     genericClass = genericClass.maybeUnwrapBuiltinGenericForwarder();
 
     if (genericClass.data(gs)->typeMembers().empty()) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1294,9 +1294,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
             for (auto &targ : targs) {
                 targPtrs.push_back(targ->type);
             }
-            auto correctedSingleton = genericClass.data(ctx)->lookupSingletonClass(ctx);
-            ENFORCE_NO_TIMER(correctedSingleton.exists());
-            result.type = core::make_type<core::UnresolvedAppliedType>(correctedSingleton, move(targPtrs));
+            result.type = core::make_type<core::UnresolvedAppliedType>(genericClass, move(targPtrs));
             return result;
         }
         if (auto *mt = core::cast_type<core::MetaType>(out)) {

--- a/test/testdata/core/fuzz_bad_subtyping.rb
+++ b/test/testdata/core/fuzz_bad_subtyping.rb
@@ -6,7 +6,7 @@ module MyEnumerable
   A = type_member
   sig {params(a: MyEnumerable[])}
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: No return type specified. Specify one with .returns()
-  #              ^^^^^^^^^^^^^^ error: Wrong number of type parameters for `MyEnumerable`.
+  #                          ^^ error: Wrong number of type parameters for `MyEnumerable`.
   #                          ^^ error: Wrong number of type parameters for `MyEnumerable`.
   #    ^^^^^^ error: Method `params` does not exist on `T.class_of(MyEnumerable)`
 # ^^^ error: Method `sig` does not exist on `T.class_of(MyEnumerable)`

--- a/test/testdata/lsp/fast_path/static_field_change_type__def.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_change_type__def.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: strict
 # assert-fast-path: static_field_change_type__def.rb,static_field_change_type__use.rb
 
-STATIC_FIELD = T.let({}, T::Hash[Symbol, ]) # error-with-dupes: Not enough arguments provided
+STATIC_FIELD = T.let({}, T::Hash[Symbol, ]) # error: Not enough arguments provided
                                # ^^^^^^ error-with-dupes: Wrong number of type parameters


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- This skips running the dynamic dispatch and arg-matching parts of `infer`,
  which are not actually required for type syntax parsing (saves small amount of
  performance).

- This avoids having to round trip from
  `symbol->lookupSingletonClass->attachedClass`, which might fail if `symbol` is
  already a singleton class (because only instance classes are guaranteed to
  have a singleton class created after `finalizeSymbols`).

  This is a no-op now, but would allow us to support syntax like
  `T.class_of(...)[...]` in a future change (where the singleton class is the
  generic class in an applied type).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavior change—covered by existing tests.