### PR TITLE
Add `Struct`-like pattern-matching to `T::Struct`

### DIFF
--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -5,6 +5,30 @@ class T::InexactStruct
   include T::Props
   include T::Props::Serializable
   include T::Props::Constructor
+
+  def deconstruct_keys(keys)
+    h = serialize
+
+    return h.to_h { |k, v| [k.to_sym, v] } if keys.nil?
+    raise TypeError, "wrong argument type #{keys.class} (expected Array or nil)" unless keys.is_a?(Array)
+    return {} if h.count < keys.count
+
+    result = {}
+
+    keys.each do |k, v|
+      case k
+      when String then  result[k] = h.fetch(k)
+      when Symbol then  result[k] = h.fetch(k.to_s)
+      when Integer then result[k] = h.values.fetch(k)
+      end
+    rescue KeyError, IndexError
+      break
+    end
+
+    result
+  end
+
+  def deconstruct = serialize.values
 end
 
 class T::Struct < T::InexactStruct

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -142,5 +142,89 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
       expected_result = "<Opus::Types::Test::StructValidationTest::StructWithDecoratedName[decorated] data=\"test\">"
       assert_equal(expected_result, struct.inspect)
     end
+
+    class Point < T::Struct
+      const :x, Integer
+      const :y, Integer
+    end
+
+    describe "#deconstruct" do # Adapted from `spec/ruby/core/struct/deconstruct_spec.rb`
+      it "returns an array of attribute values" do
+        p = Point.new(x: 1, y: 2)
+
+        assert_equal([1, 2], p.deconstruct)
+      end
+    end
+
+    describe "#deconstruct_keys" do # Adapted from `spec/ruby/core/struct/deconstruct_keys_spec.rb`
+      it "returns a hash of attributes" do
+        p = Point.new(x: 1, y: 2)
+
+        assert_equal({x: 1, y: 2}, p.deconstruct_keys(%i[x y]))
+      end
+
+      it "requires one argument" do
+        p = Point.new(x: 1, y: 2)
+
+        e = assert_raises(ArgumentError) {p.deconstruct_keys}
+        assert_match(/wrong number of arguments \(given 0, expected 1\)/, e.message)
+      end
+
+      it "returns only specified keys" do
+        p = Point.new(x: 1, y: 2)
+
+        assert_equal({x: 1, y: 2}, p.deconstruct_keys(%i[x y]))
+        assert_equal({x: 1}, p.deconstruct_keys(%i[x]))
+        assert_equal({}, p.deconstruct_keys(%i[]))
+      end
+
+      it "accepts string attribute names" do
+        p = Point.new(x: 1, y: 2)
+
+        assert_equal({'x' => 1, 'y' => 2}, p.deconstruct_keys(%w[x y]))
+      end
+
+      it "accepts argument position number as well but returns them as keys" do
+        p = Point.new(x: 1, y: 2)
+
+        assert_equal({0 => 1, 1 => 2}, p.deconstruct_keys([0, 1]))
+        assert_equal({0 => 1}, p.deconstruct_keys([0]))
+      end
+
+      it "returns an empty hash when there are more keys than attributes" do
+        p = Point.new(x: 1, y: 2)
+
+        assert_equal({}, p.deconstruct_keys(%i[x y a]))
+      end
+
+      it "returns at first not existing attribute name" do
+        p = Point.new(x: 1, y: 2)
+
+        assert_equal({}, p.deconstruct_keys(%i[a x]))
+        assert_equal({x: 1}, p.deconstruct_keys(%i[x a]))
+      end
+
+      it "accepts nil argument and return all the attributes" do
+        p = Point.new(x: 1, y: 2)
+
+        assert_equal({x: 1, y: 2}, p.deconstruct_keys(nil))
+      end
+
+      it "raise TypeError if passed anything accept nil or array" do
+        p = Point.new(x: 1, y: 2)
+
+        e = assert_raises(TypeError) {p.deconstruct_keys('x')}
+        assert_match(/expected Array or nil/, e.message)
+
+        e = assert_raises(TypeError) {p.deconstruct_keys(1)}
+        assert_match(/expected Array or nil/, e.message)
+
+        e = assert_raises(TypeError) {p.deconstruct_keys(:x)}
+        assert_match(/expected Array or nil/, e.message)
+
+        e = assert_raises(TypeError) {p.deconstruct_keys({})}
+        assert_match(/expected Array or nil/, e.message)
+      end
+    end
   end
 end


### PR DESCRIPTION
We might actually want to reconsider this, depending on how closely we want `T::Struct` to have parity with `Struct`. There's some pretty whacky behaviour. Some examples:





### Motivation

Closes #6232

### Test plan

See included automated tests.

They've been written to match the tests in:

1. [`spec/ruby/core/struct/deconstruct_spec.rb`](https://github.com/ruby/ruby/blob/master/spec/ruby/core/struct/deconstruct_spec.rb)
1. [`spec/ruby/core/struct/deconstruct_keys_spec.rb`](https://github.com/ruby/ruby/blob/master/spec/ruby/core/struct/deconstruct_keys_spec.rb)
