### PR TITLE
Only swap if absolutely required

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -286,8 +286,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             return OrType::make_shared(t1, t2);
         }
 
-        bool ltr = a1->klass == a2->klass || a2->klass.data(gs)->derivesFrom(gs, a1->klass);
-        bool rtl = !ltr && a1->klass.data(gs)->derivesFrom(gs, a2->klass);
+        bool rtl = a1->klass == a2->klass || a1->klass.data(gs)->derivesFrom(gs, a2->klass);
+        bool ltr = !rtl && a2->klass.data(gs)->derivesFrom(gs, a1->klass);
         if (!rtl && !ltr) {
             return OrType::make_shared(t1, t2);
         }

--- a/test/testdata/infer/collapse_hash_nil_union.rb
+++ b/test/testdata/infer/collapse_hash_nil_union.rb
@@ -1,0 +1,21 @@
+# typed: true
+extend T::Sig
+
+sig {returns(T.nilable(T::Hash[String, String]))}
+def returns_nilable_hash
+  {}
+end
+
+if T.unsafe(nil)
+  foo =
+    if T.unsafe(nil)
+      unless T.unsafe(nil)
+        returns_nilable_hash
+      else
+        nil
+      end
+    else
+      T::Hash[String, String].new
+    end
+  T.reveal_type(foo) # error: T.nilable(T::Hash[String, String])
+end

--- a/test/testdata/infer/dropsubtypesof.rb
+++ b/test/testdata/infer/dropsubtypesof.rb
@@ -21,7 +21,7 @@ def foo(x)
     puts "got nil"
   else
     y = T.let(x, T.any(T::Array[Integer], T::Array[String]))
-    T.reveal_type(y) # error: Revealed type: `T::Array[T.any(String, Integer)]`
+    T.reveal_type(y) # error: Revealed type: `T::Array[T.any(Integer, String)]`
   end
 end
 
@@ -32,7 +32,7 @@ def bar(x)
     puts "got nil"
   else
     y = T.let(x, T.any(T::Array[Integer], T::Array[String]))
-    T.reveal_type(y) # error: Revealed type: `T::Array[T.any(String, Integer)]`
+    T.reveal_type(y) # error: Revealed type: `T::Array[T.any(Integer, String)]`
   end
 end
 
@@ -43,7 +43,7 @@ def qux(x)
     puts "got nil"
   else
     y = T.let(x, T.any(T::Array[Integer], T::Array[String]))
-    T.reveal_type(y) # error: Revealed type: `T::Array[T.any(String, Integer)]`
+    T.reveal_type(y) # error: Revealed type: `T::Array[T.any(Integer, String)]`
   end
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5827

Many parts of Sorbet's subtyping depend on using reference equality as a
shortcut for structural equality. When that breaks down, you can get somewhat
weird types like seen in the issue above, where a type is repeated twice.

By more carefully tracking when we can reuse types, we can fix the bug above.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.