### PR TITLE
don't allocate hashes for zero-{type ,}parameter functions

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -231,15 +231,17 @@ module T::Private::Methods
         decl.on_failure = nil
       end
       if decl.params.equal?(ARG_NOT_PROVIDED)
-        decl.params = {}
+        decl.params = FROZEN_HASH
       end
       if decl.type_parameters.equal?(ARG_NOT_PROVIDED)
-        decl.type_parameters = {}
+        decl.type_parameters = FROZEN_HASH
       end
 
       decl.finalized = true
 
       self
     end
+
+    FROZEN_HASH = {}.freeze
   end
 end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This PR allocates slightly less and makes the API of `Decl` slightly cleaner in that `type_parameters` can no longer be accessed.

The title of the PR is about `type_parameters`, but I am sneaking in a small change for not allocating hashes for zero-parameter functions as well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
