### PR TITLE
Show all defs if class def'd multiple times but in RBIs

### DIFF
--- a/test/testdata/lsp/rbi_definition__1.rb
+++ b/test/testdata/lsp/rbi_definition__1.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+p(MyClass)
+# ^^^^^^^ usage: MyClass

--- a/test/testdata/lsp/rbi_definition__2.rbi
+++ b/test/testdata/lsp/rbi_definition__2.rbi
@@ -1,0 +1,5 @@
+# typed: true
+
+class MyClass
+  #   ^^^^^^^ def: MyClass
+end

--- a/test/testdata/lsp/rbi_definition__3.rbi
+++ b/test/testdata/lsp/rbi_definition__3.rbi
@@ -1,0 +1,5 @@
+# typed: true
+
+class MyClass
+  #   ^^^^^^^ def: MyClass
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, classes with multiple definition locs in RBI files would show zero
results.

For example, `String` has a definition in `string.rbi` and `BigDecimal.rbi`, and
that meant that Sorbet would report no definition locations for jump-to-def on
`String`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The test case failed previously.