### PR TITLE
Allow visible_to check to be skipped for certain allow-listed packages

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2279,6 +2279,7 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTe
                                      const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                                      const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
                                      const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
+                                     const std::vector<std::string> &skipImportVisibilityCheckFor,
                                      std::string errorHint) {
     ENFORCE(packageDB_.secondaryTestPackageNamespaceRefs_.size() == 0);
     ENFORCE(!packageDB_.frozen);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -13,12 +13,14 @@
 #include "core/hashing/hashing.h"
 #include "core/lsp/Task.h"
 #include "core/lsp/TypecheckEpochManager.h"
+#include <string_view>
 #include <utility>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "core/ErrorQueue.h"
 #include "core/errors/infer.h"
+#include "core/packages/MangledName.h"
 #include "main/pipeline/semantic_extension/SemanticExtension.h"
 
 template class std::vector<std::pair<unsigned int, unsigned int>>;
@@ -2291,6 +2293,14 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTe
     packageDB_.extraPackageFilesDirectoryUnderscorePrefixes_ = extraPackageFilesDirectoryUnderscorePrefixes;
     packageDB_.extraPackageFilesDirectorySlashPrefixes_ = extraPackageFilesDirectorySlashPrefixes;
     packageDB_.skipRBIExportEnforcementDirs_ = packageSkipRBIExportEnforcementDirs;
+
+    std::vector<core::NameRef> skipImportVisibilityCheckFor_;
+    for (const string &pkgName : skipImportVisibilityCheckFor) {
+        std::vector<string_view> pkgNameParts = absl::StrSplit(pkgName, "::");
+        auto mangledName = core::packages::MangledName::mangledNameFromParts(*this, pkgNameParts);
+        skipImportVisibilityCheckFor_.emplace_back(mangledName);
+    }
+    packageDB_.skipImportVisibilityCheckFor_ = skipImportVisibilityCheckFor_;
     packageDB_.errorHint_ = errorHint;
 }
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -164,7 +164,8 @@ public:
     void setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
                             const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                             const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
-                            const std::vector<std::string> &packageSkipRBIExportEnforcementDirs, std::string errorHint);
+                            const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
+                            const std::vector<std::string> &skipImportVisibilityCheckFor, std::string errorHint);
     packages::UnfreezePackages unfreezePackages();
 
     NameRef nextMangledName(ClassOrModuleRef owner, NameRef origName);

--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -1,0 +1,26 @@
+#include "core/packages/MangledName.h"
+#include "absl/strings/str_join.h"
+#include "core/GlobalState.h"
+#include "core/Names.h"
+
+using namespace std;
+
+namespace sorbet::core::packages {
+core::NameRef MangledName::mangledNameFromParts(core::MutableContext ctx, std::vector<std::string> &parts) {
+    // Foo::Bar => Foo_Bar_Package
+    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_"), core::PACKAGE_SUFFIX);
+
+    auto utf8Name = ctx.state.enterNameUTF8(mangledName);
+    auto packagerName = ctx.state.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
+    return ctx.state.enterNameConstant(packagerName);
+}
+
+core::NameRef MangledName::mangledNameFromParts(core::MutableContext ctx, std::vector<core::NameRef> &parts) {
+    // Foo::Bar => Foo_Bar_Package
+    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(ctx)), core::PACKAGE_SUFFIX);
+
+    auto utf8Name = ctx.state.enterNameUTF8(mangledName);
+    auto packagerName = ctx.state.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
+    return ctx.state.enterNameConstant(packagerName);
+}
+} // namespace sorbet::core::packages

--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -6,21 +6,21 @@
 using namespace std;
 
 namespace sorbet::core::packages {
-core::NameRef MangledName::mangledNameFromParts(core::MutableContext ctx, std::vector<std::string> &parts) {
+core::NameRef MangledName::mangledNameFromParts(core::GlobalState &gs, std::vector<std::string_view> &parts) {
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(parts, "_"), core::PACKAGE_SUFFIX);
 
-    auto utf8Name = ctx.state.enterNameUTF8(mangledName);
-    auto packagerName = ctx.state.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-    return ctx.state.enterNameConstant(packagerName);
+    auto utf8Name = gs.enterNameUTF8(mangledName);
+    auto packagerName = gs.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
+    return gs.enterNameConstant(packagerName);
 }
 
-core::NameRef MangledName::mangledNameFromParts(core::MutableContext ctx, std::vector<core::NameRef> &parts) {
+core::NameRef MangledName::mangledNameFromParts(core::GlobalState &gs, std::vector<core::NameRef> &parts) {
     // Foo::Bar => Foo_Bar_Package
-    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(ctx)), core::PACKAGE_SUFFIX);
+    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(gs)), core::PACKAGE_SUFFIX);
 
-    auto utf8Name = ctx.state.enterNameUTF8(mangledName);
-    auto packagerName = ctx.state.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-    return ctx.state.enterNameConstant(packagerName);
+    auto utf8Name = gs.enterNameUTF8(mangledName);
+    auto packagerName = gs.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
+    return gs.enterNameConstant(packagerName);
 }
 } // namespace sorbet::core::packages

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -1,0 +1,30 @@
+#ifndef SORBET_CORE_PACKAGES_MANGLEDNAME_H
+#define SORBET_CORE_PACKAGES_MANGLEDNAME_H
+
+#include "core/Context.h"
+#include "core/LocOffsets.h"
+#include "core/NameRef.h"
+#include <vector>
+
+namespace sorbet::core::packages {
+class MangledName final {
+public:
+    static core::NameRef mangledNameFromParts(core::MutableContext ctx, std::vector<std::string> &parts);
+    static core::NameRef mangledNameFromParts(core::MutableContext ctx, std::vector<core::NameRef> &parts);
+};
+
+class NameFormatter final {
+    const core::GlobalState &gs;
+
+public:
+    NameFormatter(const core::GlobalState &gs) : gs(gs) {}
+
+    void operator()(std::string *out, core::NameRef name) const {
+        out->append(name.shortName(gs));
+    }
+    void operator()(std::string *out, std::pair<core::NameRef, core::LocOffsets> p) const {
+        out->append(p.first.shortName(gs));
+    }
+};
+} // namespace sorbet::core::packages
+#endif

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -1,7 +1,7 @@
 #ifndef SORBET_CORE_PACKAGES_MANGLEDNAME_H
 #define SORBET_CORE_PACKAGES_MANGLEDNAME_H
 
-#include "core/Context.h"
+#include "core/GlobalState.h"
 #include "core/LocOffsets.h"
 #include "core/NameRef.h"
 #include <vector>
@@ -9,8 +9,8 @@
 namespace sorbet::core::packages {
 class MangledName final {
 public:
-    static core::NameRef mangledNameFromParts(core::MutableContext ctx, std::vector<std::string> &parts);
-    static core::NameRef mangledNameFromParts(core::MutableContext ctx, std::vector<core::NameRef> &parts);
+    static core::NameRef mangledNameFromParts(core::GlobalState &gs, std::vector<std::string_view> &parts);
+    static core::NameRef mangledNameFromParts(core::GlobalState &gs, std::vector<core::NameRef> &parts);
 };
 
 class NameFormatter final {

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -245,6 +245,10 @@ const std::string_view PackageDB::errorHint() const {
     return errorHint_;
 }
 
+bool PackageDB::skipImportVisibilityCheckFor(core::NameRef mangledName) const {
+    return absl::c_find(skipImportVisibilityCheckFor_, mangledName) != skipImportVisibilityCheckFor_.end();
+}
+
 PackageDB PackageDB::deepCopy() const {
     ENFORCE(frozen);
     PackageDB result;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -59,6 +59,7 @@ public:
     const std::vector<std::string> &skipRBIExportEnforcementDirs() const;
 
     const std::string_view errorHint() const;
+    bool skipImportVisibilityCheckFor(const core::NameRef mangledName) const;
 
 private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -66,6 +66,7 @@ private:
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes_;
     std::string errorHint_;
     std::vector<std::string> skipRBIExportEnforcementDirs_;
+    std::vector<NameRef> skipImportVisibilityCheckFor_;
 
     // This vector is kept in sync with the size of the file table in the global state by
     // `Packager::setPackageNameOnFiles`. A `FileRef` being out of bounds in this vector is treated as the file having

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -394,6 +394,11 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         "Secondary top-level namespaces which contain test code (in addition to Test, which is primary). "
         "This option must be used in conjunction with --stripe-packages",
         cxxopts::value<vector<string>>(), "string");
+    options.add_options("dev")("skip-package-import-visibility-check-for",
+                               "Packages for which the visible_to check does not apply. They can import any package "
+                               "regardless of visible_to annotations."
+                               "This option must be used in conjunction with --stripe-packages",
+                               cxxopts::value<vector<string>>(), "string");
 
     options.add_options("advanced")(
         "autogen-autoloader-exclude-require",
@@ -1005,6 +1010,25 @@ void readOptions(Options &opts,
                 opts.secondaryTestPackageNamespaces.emplace_back(ns);
             }
         }
+
+        if (raw.count("skip-package-import-visibility-check-for")) {
+            if (!opts.stripePackages) {
+                logger->error(
+                    "--skip-package-import-visibility-check-for can only be specified in --stripe-packages mode");
+                throw EarlyReturnWithCode(1);
+            }
+            std::regex nsValid("[A-Z][a-zA-Z0-9:]+");
+            for (const string &ns : raw["skip-package-import-visibility-check-for"].as<vector<string>>()) {
+                if (!std::regex_match(ns, nsValid)) {
+                    logger->error(
+                        "--skip-package-import-visibility-check-for must contain items that start with a capital "
+                        "letter and are alphanumeric.");
+                    throw EarlyReturnWithCode(1);
+                }
+                opts.skipPackageImportVisibilityCheckFor.emplace_back(ns);
+            }
+        }
+
         opts.stripePackagesHint = raw["stripe-packages-hint-message"].as<string>();
         if (!opts.stripePackagesHint.empty() && !opts.stripePackages) {
             if (!opts.stripePackages) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -181,6 +181,7 @@ struct Options {
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes;
     std::vector<std::string> secondaryTestPackageNamespaces;
+    std::vector<std::string> skipPackageImportVisibilityCheckFor;
     std::string typedSource = "";
     std::string cacheDir = "";
     // This configured both maximum filesystem db size and max virtual memory usage

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -680,10 +680,10 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
         {
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
-            gs.setPackagerOptions(opts.secondaryTestPackageNamespaces,
-                                  opts.extraPackageFilesDirectoryUnderscorePrefixes,
-                                  opts.extraPackageFilesDirectorySlashPrefixes,
-                                  opts.packageSkipRBIExportEnforcementDirs, {}, opts.stripePackagesHint);
+            gs.setPackagerOptions(
+                opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
+                opts.skipPackageImportVisibilityCheckFor, opts.stripePackagesHint);
         }
         what = packager::Packager::run(gs, workers, move(what));
         if (opts.print.Packager.enabled) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -683,7 +683,7 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
             gs.setPackagerOptions(opts.secondaryTestPackageNamespaces,
                                   opts.extraPackageFilesDirectoryUnderscorePrefixes,
                                   opts.extraPackageFilesDirectorySlashPrefixes,
-                                  opts.packageSkipRBIExportEnforcementDirs, opts.stripePackagesHint);
+                                  opts.packageSkipRBIExportEnforcementDirs, {}, opts.stripePackagesHint);
         }
         what = packager::Packager::run(gs, workers, move(what));
         if (opts.print.Packager.enabled) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -664,10 +664,10 @@ int realmain(int argc, char *argv[]) {
             {
                 core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
                 core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-                gs->setPackagerOptions(opts.secondaryTestPackageNamespaces,
-                                       opts.extraPackageFilesDirectoryUnderscorePrefixes,
-                                       opts.extraPackageFilesDirectorySlashPrefixes,
-                                       opts.packageSkipRBIExportEnforcementDirs, opts.stripePackagesHint);
+                gs->setPackagerOptions(
+                    opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                    opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
+                    opts.skipPackageImportVisibilityCheckFor, opts.stripePackagesHint);
             }
 
             packages = packager::Packager::findPackages(*gs, *workers, move(packages));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -13,6 +13,7 @@
 #include "core/AutocorrectSuggestion.h"
 #include "core/Unfreeze.h"
 #include "core/errors/packager.h"
+#include "core/packages/MangledName.h"
 #include "core/packages/PackageInfo.h"
 #include <algorithm>
 #include <cctype>
@@ -67,20 +68,6 @@ struct FullyQualifiedName {
     }
 };
 
-class NameFormatter final {
-    const core::GlobalState &gs;
-
-public:
-    NameFormatter(const core::GlobalState &gs) : gs(gs) {}
-
-    void operator()(std::string *out, core::NameRef name) const {
-        out->append(name.shortName(gs));
-    }
-    void operator()(std::string *out, pair<core::NameRef, core::LocOffsets> p) const {
-        out->append(p.first.shortName(gs));
-    }
-};
-
 struct PackageName {
     core::LocOffsets loc;
     core::NameRef mangledName = core::NameRef::noName();
@@ -89,7 +76,7 @@ struct PackageName {
 
     // Pretty print the package's (user-observable) name (e.g. Foo::Bar)
     string toString(const core::GlobalState &gs) const {
-        return absl::StrJoin(fullName.parts, "::", NameFormatter(gs));
+        return absl::StrJoin(fullName.parts, "::", core::packages::NameFormatter(gs));
     }
 
     bool operator==(const PackageName &rhs) const {
@@ -438,11 +425,7 @@ PackageName getPackageName(core::MutableContext ctx, ast::UnresolvedConstantLit 
     pName.fullTestPkgName = pName.fullName.withPrefix(TEST_NAME);
 
     // Foo::Bar => Foo_Bar_Package
-    auto mangledName = absl::StrCat(absl::StrJoin(pName.fullName.parts, "_", NameFormatter(ctx)), core::PACKAGE_SUFFIX);
-
-    auto utf8Name = ctx.state.enterNameUTF8(mangledName);
-    auto packagerName = ctx.state.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-    pName.mangledName = ctx.state.enterNameConstant(packagerName);
+    pName.mangledName = core::packages::MangledName::mangledNameFromParts(ctx, pName.fullName.parts);
 
     return pName;
 }
@@ -917,7 +900,8 @@ private:
         auto reqMangledName = namespaces.packageForNamespace();
         if (reqMangledName.exists()) {
             auto &reqPkg = gs.packageDB().getPackageInfo(reqMangledName);
-            auto givenNamespace = absl::StrJoin(namespaces.currentConstantName(), "::", NameFormatter(gs));
+            auto givenNamespace =
+                absl::StrJoin(namespaces.currentConstantName(), "::", core::packages::NameFormatter(gs));
             e.addErrorLine(reqPkg.declLoc(), "Must belong to this package, given constant name `{}`", givenNamespace);
         }
     }
@@ -1618,7 +1602,7 @@ public:
     ImportFormatter(const core::GlobalState &gs) : gs(gs) {}
 
     void operator()(std::string *out, const vector<core::NameRef> &name) const {
-        fmt::format_to(back_inserter(*out), "\"{}\"", absl::StrJoin(name, "::", NameFormatter(gs)));
+        fmt::format_to(back_inserter(*out), "\"{}\"", absl::StrJoin(name, "::", core::packages::NameFormatter(gs)));
     }
 };
 
@@ -1652,7 +1636,8 @@ public:
         const auto &pkg = gs.packageDB().getPackageInfo(mangledName);
         out->append("{{");
         out->append("\"name\":");
-        fmt::format_to(back_inserter(*out), "\"{}\",", absl::StrJoin(pkg.fullName(), "::", NameFormatter(gs)));
+        fmt::format_to(back_inserter(*out), "\"{}\",",
+                       absl::StrJoin(pkg.fullName(), "::", core::packages::NameFormatter(gs)));
         out->append("\"imports\":[");
         fmt::format_to(back_inserter(*out), absl::StrJoin(pkg.imports(), ",", ImportFormatter(gs)));
         out->append("],\"testImports\":[");

--- a/test/cli/package-skip-import-visibility-check-for/__package.rb
+++ b/test/cli/package-skip-import-visibility-check-for/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Project::Root < PackageSpec
+  import Project::A
+end
+

--- a/test/cli/package-skip-import-visibility-check-for/a/__package.rb
+++ b/test/cli/package-skip-import-visibility-check-for/a/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Project::A < PackageSpec
+  visible_to Project::B
+end

--- a/test/cli/package-skip-import-visibility-check-for/b/__package.rb
+++ b/test/cli/package-skip-import-visibility-check-for/b/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Project::B < PackageSpec
+  import Project::A
+end

--- a/test/cli/package-skip-import-visibility-check-for/test.out
+++ b/test/cli/package-skip-import-visibility-check-for/test.out
@@ -1,0 +1,1 @@
+No errors! Great job.

--- a/test/cli/package-skip-import-visibility-check-for/test.sh
+++ b/test/cli/package-skip-import-visibility-check-for/test.sh
@@ -1,0 +1,5 @@
+cd test/cli/package-skip-import-visibility-check-for || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --skip-package-import-visibility-check-for=Project::Root --max-threads=0 . 2>&1
+
+

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -61,6 +61,7 @@ const UnorderedMap<
         {"apply-rename", ApplyRenameAssertion::make},
         {"extra-package-files-directory-prefix-underscore", StringPropertyAssertion::make},
         {"extra-package-files-directory-prefix-slash", StringPropertyAssertion::make},
+        {"skip-package-import-visibility-check-for", StringPropertyAssertion::make},
         {"implementation", ImplementationAssertion::make},
         {"find-implementation", FindImplementationAssertion::make},
         {"show-symbol", ShowSymbolAssertion::make},

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -331,6 +331,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         vector<std::string> extraPackageFilesDirectorySlashPrefixes;
         vector<std::string> secondaryTestPackageNamespaces = {"Critic"};
         vector<std::string> skipRBIExportEnforcementDirs;
+        vector<std::string> skipImportVisibilityCheckFor;
 
         auto extraDirUnderscore =
             StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);
@@ -344,11 +345,18 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             extraPackageFilesDirectorySlashPrefixes.emplace_back(extraDirSlash.value());
         }
 
+        auto skipImportVisibility =
+            StringPropertyAssertion::getValue("skip-package-import-visibility-check-for", assertions);
+        if (skipImportVisibility.has_value()) {
+            skipImportVisibilityCheckFor.emplace_back(skipImportVisibility.value());
+        }
+
         {
             core::UnfreezeNameTable packageNS(*gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
             gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryUnderscorePrefixes,
-                                   extraPackageFilesDirectorySlashPrefixes, {}, "PACKAGE_ERROR_HINT");
+                                   extraPackageFilesDirectorySlashPrefixes, {}, skipImportVisibilityCheckFor,
+                                   "PACKAGE_ERROR_HINT");
         }
 
         // Packager runs over all trees.

--- a/test/testdata/packager/visibility/foo/__package.rb
+++ b/test/testdata/packager/visibility/foo/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# skip-package-import-visibility-check-for: SkipCheck::For
 
 class Foo < PackageSpec
   visible_to Bar

--- a/test/testdata/packager/visibility/skip_check/__package.rb
+++ b/test/testdata/packager/visibility/skip_check/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class SkipCheck::For < PackageSpec
+  import Foo
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Per the tin, adds a new CLI-flag-driven feature that allows certain packages to bypass the `visible_to` check and import other packages regardless of the presence/absence of the annotation.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In the Stripe codebase, we have autogenerated "god" packages that import multiple other packages in the codebase. Adding `visible_to` annotations for these packages creates unnecessary churn on our developers. Hence, I am introducing this feature so that people do not need to add annotations for these packages -- the `visible_to` check will simply be skipped for them.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.