### PR TITLE
[Ruby3] Delete deprecated methods from RBIs

### DIFF
--- a/rbi/core/argf.rbi
+++ b/rbi/core/argf.rbi
@@ -226,22 +226,6 @@ module ARGF
   def self.each_codepoint(*several_variants, &blk)
     #This is a stub, used for indexing
   end
-  # This is a deprecated alias for <code>each_line</code>.
-  def self.lines(*args, &blk)
-    #This is a stub, used for indexing
-  end
-  # This is a deprecated alias for <code>each_byte</code>.
-  def self.bytes(&blk)
-    #This is a stub, used for indexing
-  end
-  # This is a deprecated alias for <code>each_char</code>.
-  def self.chars(&blk)
-    #This is a stub, used for indexing
-  end
-  # This is a deprecated alias for <code>each_codepoint</code>.
-  def self.codepoints(&blk)
-    #This is a stub, used for indexing
-  end
   # ARGF.read([length [, outbuf]])    -> string, outbuf, or nil
   #
   # Reads _length_ bytes from ARGF. The files named on the command line

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -788,8 +788,6 @@ class Hash < Object
   # [`Object#hash`](https://docs.ruby-lang.org/en/2.7.0/Object.html#method-i-hash).
   def hash; end
 
-  def index(_); end
-
   sig {void}
   sig {params(default: V).void}
   sig do

--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -3423,39 +3423,6 @@ class IO < Object
   end
   def self.for_fd(fd, mode=T.unsafe(nil), opt=T.unsafe(nil)); end
 
-  # This is a deprecated alias for
-  # [`each_byte`](https://docs.ruby-lang.org/en/2.7.0/IO.html#method-i-each_byte).
-  sig do
-    params(
-        blk: T.proc.params(arg0: Integer).returns(BasicObject),
-    )
-    .returns(T.self_type)
-  end
-  sig {returns(T::Enumerator[Integer])}
-  def bytes(&blk); end
-
-  # This is a deprecated alias for
-  # [`each_char`](https://docs.ruby-lang.org/en/2.7.0/IO.html#method-i-each_char).
-  sig do
-    params(
-        blk: T.proc.params(arg0: String).returns(BasicObject),
-    )
-    .returns(T.self_type)
-  end
-  sig {returns(T::Enumerator[String])}
-  def chars(&blk); end
-
-  # This is a deprecated alias for
-  # [`each_codepoint`](https://docs.ruby-lang.org/en/2.7.0/IO.html#method-i-each_codepoint).
-  sig do
-    params(
-        blk: T.proc.params(arg0: Integer).returns(BasicObject),
-    )
-    .returns(T.self_type)
-  end
-  sig {returns(T::Enumerator[Integer])}
-  def codepoints(&blk); end
-
   # Executes the block for every line in *ios*, where lines are separated by
   # *sep*. *ios* must be opened for reading or an
   # [`IOError`](https://docs.ruby-lang.org/en/2.7.0/IOError.html) will be
@@ -3545,25 +3512,6 @@ class IO < Object
   # Alias for: [`eof`](https://docs.ruby-lang.org/en/2.7.0/IO.html#method-i-eof)
   sig {returns(T::Boolean)}
   def eof?(); end
-
-  # This is a deprecated alias for
-  # [`each_line`](https://docs.ruby-lang.org/en/2.7.0/IO.html#method-i-each_line).
-  sig do
-    params(
-        sep: String,
-        limit: Integer,
-        blk: T.proc.params(arg0: String).returns(BasicObject),
-    )
-    .returns(T.self_type)
-  end
-  sig do
-    params(
-        sep: String,
-        limit: Integer,
-    )
-    .returns(T::Enumerator[String])
-  end
-  def lines(sep=T.unsafe(nil), limit=T.unsafe(nil), &blk); end
 
   # Returns the integer file descriptor for the stream:
   #

--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -845,15 +845,6 @@ class Thread < Object
   sig {params(abort_on_exception: T.untyped).returns(T.untyped)}
   def self.abort_on_exception=(abort_on_exception); end
 
-  # Wraps the block in a single, VM-global
-  # [`Mutex.synchronize`](https://docs.ruby-lang.org/en/2.7.0/Mutex.html#method-i-synchronize),
-  # returning the value of the block. A thread executing inside the exclusive
-  # section will only block other threads which also use the
-  # [`Thread.exclusive`](https://docs.ruby-lang.org/en/2.7.0/Thread.html#method-c-exclusive)
-  # mechanism.
-  sig {params(block: T.untyped).returns(T.untyped)}
-  def self.exclusive(&block); end
-
   # Terminates the currently running thread and schedules another thread to be
   # run.
   #

--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -1093,24 +1093,6 @@ class Time < Object
   sig {returns(Numeric)}
   def subsec(); end
 
-  # Returns a new [`Time`](https://docs.ruby-lang.org/en/2.7.0/Time.html)
-  # object, one second later than *time*.
-  # [`Time#succ`](https://docs.ruby-lang.org/en/2.7.0/Time.html#method-i-succ)
-  # is obsolete since 1.9.2 for time is not a discrete value.
-  #
-  # ```ruby
-  # t = Time.now       #=> 2007-11-19 08:23:57 -0600
-  # t.succ             #=> 2007-11-19 08:23:58 -0600
-  # ```
-  #
-  # Use instead `time + 1`
-  #
-  # ```ruby
-  # t + 1              #=> 2007-11-19 08:23:58 -0600
-  # ```
-  sig {returns(Time)}
-  def succ(); end
-
   # Returns `true` if *time* represents Sunday.
   #
   # ```ruby

--- a/rbi/stdlib/rdoc.rbi
+++ b/rbi/stdlib/rdoc.rbi
@@ -1509,10 +1509,6 @@ class RDoc::Context::Section
   def remove_comment(comment); end
 
   # [`Section`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Context/Section.html)
-  # sequence number (deprecated)
-  def sequence; end
-
-  # [`Section`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Context/Section.html)
   # title
   def title; end
 end

--- a/rbi/stdlib/stringio.rbi
+++ b/rbi/stdlib/stringio.rbi
@@ -493,39 +493,6 @@ class StringIO
   end
   def write(arg0); end
 
-  # This is a deprecated alias for
-  # [`each_byte`](https://docs.ruby-lang.org/en/2.7.0/StringIO.html#method-i-each_byte).
-  sig do
-    params(
-        blk: T.proc.params(arg0: Integer).returns(BasicObject),
-    )
-    .returns(T.self_type)
-  end
-  sig {returns(T::Enumerator[Integer])}
-  def bytes(&blk); end
-
-  # This is a deprecated alias for
-  # [`each_char`](https://docs.ruby-lang.org/en/2.7.0/StringIO.html#method-i-each_char).
-  sig do
-    params(
-        blk: T.proc.params(arg0: String).returns(BasicObject),
-    )
-    .returns(T.self_type)
-  end
-  sig {returns(T::Enumerator[String])}
-  def chars(&blk); end
-
-  # This is a deprecated alias for
-  # [`each_codepoint`](https://docs.ruby-lang.org/en/2.7.0/StringIO.html#method-i-each_codepoint).
-  sig do
-    params(
-        blk: T.proc.params(arg0: Integer).returns(BasicObject),
-    )
-    .returns(T.self_type)
-  end
-  sig {returns(T::Enumerator[Integer])}
-  def codepoints(&blk); end
-
   # See [`IO#each`](https://docs.ruby-lang.org/en/2.7.0/IO.html#method-i-each).
   sig do
     params(
@@ -548,25 +515,6 @@ class StringIO
   # The stream must be opened for reading or an `IOError` will be raised.
   sig {returns(T::Boolean)}
   def eof?(); end
-
-  # This is a deprecated alias for
-  # [`each_line`](https://docs.ruby-lang.org/en/2.7.0/StringIO.html#method-i-each_line).
-  sig do
-    params(
-        sep: String,
-        limit: Integer,
-        blk: T.proc.params(arg0: String).returns(BasicObject),
-    )
-    .returns(T.self_type)
-  end
-  sig do
-    params(
-        sep: String,
-        limit: Integer,
-    )
-    .returns(T::Enumerator[String])
-  end
-  def lines(sep=T.unsafe(nil), limit=T.unsafe(nil), &blk); end
 end
 
 # Pseudo I/O on [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html)

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -101,8 +101,6 @@ end
 #     *   URI::REGEXP::PATTERN - (in uri/common.rb)
 #
 # *   URI::Util - (in uri/common.rb)
-# *   [`URI::Escape`](https://docs.ruby-lang.org/en/2.7.0/URI/Escape.html) - (in
-#     uri/common.rb)
 # *   [`URI::Error`](https://docs.ruby-lang.org/en/2.7.0/URI/Error.html) - (in
 #     uri/common.rb)
 #     *   [`URI::InvalidURIError`](https://docs.ruby-lang.org/en/2.7.0/URI/InvalidURIError.html)
@@ -272,14 +270,6 @@ module URI
     )
     .returns(String)
   end
-  sig do
-    params(
-        arg: String,
-        arg0: String,
-    )
-    .returns(String)
-  end
-  def self.escape(arg, *arg0); end
 
   # ## Synopsis
   #
@@ -510,14 +500,6 @@ module URI
   sig do
     params(
         arg: String,
-    )
-    .returns(String)
-  end
-  def self.unescape(*arg); end
-
-  sig do
-    params(
-        arg: String,
         arg0: Regexp,
     )
     .returns(String)
@@ -548,107 +530,6 @@ end
 # Base class for all [`URI`](https://docs.ruby-lang.org/en/2.7.0/URI.html)
 # exceptions.
 class URI::Error < StandardError
-end
-
-# [`Module`](https://docs.ruby-lang.org/en/2.7.0/Module.html) for escaping
-# unsafe characters with codes.
-module URI::Escape
-  # Alias for:
-  # [`unescape`](https://docs.ruby-lang.org/en/2.7.0/URI/Escape.html#method-i-unescape)
-  def decode(*arg); end
-
-  # Alias for:
-  # [`escape`](https://docs.ruby-lang.org/en/2.7.0/URI/Escape.html#method-i-escape)
-  def encode(*arg); end
-
-  # ## Synopsis
-  #
-  # ```
-  # URI.escape(str [, unsafe])
-  # ```
-  #
-  # ## Args
-  #
-  # `str`
-  # :   [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html) to replaces
-  #     in.
-  # `unsafe`
-  # :   [`Regexp`](https://docs.ruby-lang.org/en/2.7.0/Regexp.html) that matches
-  #     all symbols that must be replaced with codes. By default uses `UNSAFE`.
-  #     When this argument is a
-  #     [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html), it
-  #     represents a character set.
-  #
-  #
-  # ## Description
-  #
-  # Escapes the string, replacing all unsafe characters with codes.
-  #
-  # This method is obsolete and should not be used. Instead, use
-  # [`CGI.escape`](https://docs.ruby-lang.org/en/2.7.0/CGI/Util.html#method-i-escape),
-  # [`URI.encode_www_form`](https://docs.ruby-lang.org/en/2.7.0/URI.html#method-c-encode_www_form)
-  # or
-  # [`URI.encode_www_form_component`](https://docs.ruby-lang.org/en/2.7.0/URI.html#method-c-encode_www_form_component)
-  # depending on your specific use case.
-  #
-  # ## Usage
-  #
-  # ```ruby
-  # require 'uri'
-  #
-  # enc_uri = URI.escape("http://example.com/?a=\11\15")
-  # # => "http://example.com/?a=%09%0D"
-  #
-  # URI.unescape(enc_uri)
-  # # => "http://example.com/?a=\t\r"
-  #
-  # URI.escape("@?@!", "!?")
-  # # => "@%3F@%21"
-  # ```
-  #
-  #
-  # Also aliased as:
-  # [`encode`](https://docs.ruby-lang.org/en/2.7.0/URI/Escape.html#method-i-encode)
-  def escape(*arg); end
-
-  # ## Synopsis
-  #
-  # ```ruby
-  # URI.unescape(str)
-  # ```
-  #
-  # ## Args
-  #
-  # `str`
-  # :   [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html) to unescape.
-  #
-  #
-  # ## Description
-  #
-  # This method is obsolete and should not be used. Instead, use
-  # [`CGI.unescape`](https://docs.ruby-lang.org/en/2.7.0/CGI/Util.html#method-i-unescape),
-  # [`URI.decode_www_form`](https://docs.ruby-lang.org/en/2.7.0/URI.html#method-c-decode_www_form)
-  # or
-  # [`URI.decode_www_form_component`](https://docs.ruby-lang.org/en/2.7.0/URI.html#method-c-decode_www_form_component)
-  # depending on your specific use case.
-  #
-  # ## Usage
-  #
-  # ```ruby
-  # require 'uri'
-  #
-  # enc_uri = URI.escape("http://example.com/?a=\11\15")
-  # # => "http://example.com/?a=%09%0D"
-  #
-  # URI.unescape(enc_uri)
-  # # => "http://example.com/?a=\t\r"
-  # ```
-  #
-  #
-  # Also aliased as:
-  # [`decode`](https://docs.ruby-lang.org/en/2.7.0/URI/Escape.html#method-i-decode)
-  def unescape(*arg); end
-
 end
 
 # The "file" [`URI`](https://docs.ruby-lang.org/en/2.7.0/URI.html) is defined by

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -263,14 +263,6 @@ module URI
   end
   def self.encode_www_form_component(str, enc=nil); end
 
-  sig do
-    params(
-        arg: String,
-        arg0: Regexp,
-    )
-    .returns(String)
-  end
-
   # ## Synopsis
   #
   # ```

--- a/test/testdata/rbi/argf.rb
+++ b/test/testdata/rbi/argf.rb
@@ -20,10 +20,6 @@ ARGF.each
 ARGF.each_byte
 ARGF.each_char
 ARGF.each_codepoint
-ARGF.lines
-ARGF.bytes
-ARGF.chars
-ARGF.codepoints
 ARGF.read
 ARGF.readpartial
 ARGF.read_nonblock


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

**Heads up**: this change removes some deprecated methods from RBIs shipped inside Sorbet. The methods were deleted from Ruby’s standard library with the release of version 3.0.

If those methods exist in the version of Ruby your project is using, and you want to update to the latest Sorbet, you will need to add your own hand-written RBIs backfilling these deprecated methods.

Feel free to check [the commit list](https://github.com/sorbet/sorbet/pull/6800/commits) for more details about which methods got removed, and what signatures they previously had.

- - - - -

The change updates some RBI's to stand with Ruby 3 stdlib. 

It's hard to find all method deletions, because there is no standard way to mark a method as deprecated in Ruby VM. So I grepped git log with `git log --grep="deprecated"`. I went through matching commits from 2020 and updated RBIs accordingly.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Ruby 3

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
