### PR TITLE
optimize typechecking for `T.class_of` types

### DIFF
--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -89,6 +89,12 @@ module SorbetBenchmarks
         type.valid?('hi')
       end
 
+      type = T::Utils.coerce(T.class_of(Numeric))
+      time_block("T.class_of.valid?", iterations_in_block: 2) do
+        type.valid?(Integer)
+        type.valid?(String)
+      end
+
       time_block("T.let(..., Integer)") do
         T.let(0, Integer)
         T.let(1, Integer)

--- a/gems/sorbet-runtime/lib/types/types/class_of.rb
+++ b/gems/sorbet-runtime/lib/types/types/class_of.rb
@@ -17,7 +17,9 @@ module T::Types
 
     # overrides Base
     def valid?(obj)
-      obj.is_a?(Module) && obj <= @type
+      # This is essentially `obj.is_a?(Module) && obj <= @type`, but it's
+      # ~30% faster due to more efficient codepaths in the Ruby VM.
+      (@type <=> obj)&.>=(0)
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1223,6 +1223,12 @@ module Opus::Types::Test
         assert_nil(msg)
       end
 
+      it 'fails validation with a superclass' do
+        type = T.class_of(Sub)
+        msg = check_error_message_for_obj(type, Base)
+        assert_equal("Expected type T.class_of(Opus::Types::Test::TypesTest::Sub), got Opus::Types::Test::TypesTest::Base", msg)
+      end
+
       it 'fails validation with some other class' do
         msg = check_error_message_for_obj(@type, InterfaceImplementor1)
         assert_equal("Expected type T.class_of(Opus::Types::Test::TypesTest::Base), got Opus::Types::Test::TypesTest::InterfaceImplementor1", msg)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@vasi-stripe had some profiles of Stripe API requests that showed typechecking for `T.class_of` types was relatively hot.  We can make the code here slightly faster by rearranging things; `Module#<=>` does the `is_a?(Module)` check for us, but more efficiently inside the VM.

Benchmark before: `T.class_of.valid?: 76.361 ns`
Benchmark after: `T.class_of.valid?: 54.025 ns`

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I added the missing test to help me be sure I was checking the correct value for the return value of `Module#<=>`.
