### PR TITLE
Add settings for building ruby on linux-arm64

### DIFF
--- a/third_party/openssl/linux.BUILD
+++ b/third_party/openssl/linux.BUILD
@@ -1,6 +1,9 @@
 cc_import(
     name = "ssl-import",
-    shared_library = "lib/x86_64-linux-gnu/libssl.so",
+    shared_library = select({
+        "@com_stripe_ruby_typer//tools/config:linux": "lib/x86_64-linux-gnu/libssl.so",
+        "@com_stripe_ruby_typer//tools/config:linux_arm64": "lib/aarch64-linux-gnu/libssl.so",
+    }),
     visibility = ["//visibility:private"],
 )
 
@@ -13,7 +16,10 @@ cc_library(
 
 cc_import(
     name = "crypto-import",
-    shared_library = "lib/x86_64-linux-gnu/libcrypto.so",
+    shared_library = select({
+        "@com_stripe_ruby_typer//tools/config:linux": "lib/x86_64-linux-gnu/libcrypto.so",
+        "@com_stripe_ruby_typer//tools/config:linux_arm64": "lib/aarch64-linux-gnu/libcrypto.so",
+    }),
     visibility = ["//visibility:private"],
 )
 

--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -55,6 +55,10 @@ ruby(
             "@system_ssl_darwin//:ssl",
             "@system_ssl_darwin//:crypto",
         ],
+        "@com_stripe_ruby_typer//tools/config:linux_arm64": [
+            "@system_ssl_linux//:ssl",
+            "@system_ssl_linux//:crypto",
+        ],
         "@com_stripe_ruby_typer//tools/config:linux": [
             "@system_ssl_linux//:ssl",
             "@system_ssl_linux//:crypto",

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -17,6 +17,14 @@ platform(
 )
 
 config_setting(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
     name = "darwin",
     constraint_values = [
         "@platforms//os:osx",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Be able to produce a linux-arm64 compatible version of sorbet_ruby for internal testing at Stripe.

cc @froydnj 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Built a single version in a Docker VM like so. Will follow up with internal CI results.
```
bazel-5.2.0-linux-arm64 build @sorbet_ruby_2_7//:ruby.tar.gz --crosstool_top=@bazel_tools//tools/cpp:toolchain
```