### PR TITLE
`//tools/config:linux` → `@platforms//os:linux`

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -19,7 +19,7 @@ cc_library(
         "typecase.h",
     ],
     linkopts = select({
-        "//tools/config:linux": ["-lm"],
+        "@platforms//os:linux": ["-lm"],
         "//conditions:default": [],
     }),
     linkstatic = select({

--- a/common/concurrency/BUILD
+++ b/common/concurrency/BUILD
@@ -14,7 +14,7 @@ cc_library(
         "WorkerPool.h",
     ],
     linkopts = select({
-        "//tools/config:linux": ["-lm"],
+        "@platforms//os:linux": ["-lm"],
         "//conditions:default": [],
     }),
     linkstatic = select({

--- a/common/crypto_hashing/BUILD
+++ b/common/crypto_hashing/BUILD
@@ -9,7 +9,7 @@ cc_library(
     deps = ["//common"] + select({
         "//tools/config:webasm": ["@com_github_blake2_blake2"],
         "//tools/config:darwin": ["@com_github_blake2_libb2"],
-        "//tools/config:linux": ["@com_github_blake2_libb2"],
+        "@platforms//os:linux": ["@com_github_blake2_libb2"],
         "//conditions:default": ["@com_github_blake2_blake2"],
     }),
 )

--- a/common/json2msgpack/BUILD
+++ b/common/json2msgpack/BUILD
@@ -13,7 +13,7 @@ cc_library(
         "json2msgpack.h",
     ],
     linkopts = select({
-        "//tools/config:linux": ["-lm"],
+        "@platforms//os:linux": ["-lm"],
         "//conditions:default": [],
     }),
     linkstatic = select({

--- a/common/kvstore/BUILD
+++ b/common/kvstore/BUILD
@@ -8,7 +8,7 @@ cc_library(
         "KeyValueStore.h",
     ],
     linkopts = select({
-        "//tools/config:linux": ["-lm"],
+        "@platforms//os:linux": ["-lm"],
         "//conditions:default": [],
     }),
     linkstatic = select({

--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -98,7 +98,7 @@ cc_library(
     srcs = [":jemalloc_genrule"],
     hdrs = ["include/jemalloc/jemalloc.h"],
     linkopts = select({
-        "@com_stripe_ruby_typer//tools/config:linux": ["-ldl"],  # side step https://github.com/jemalloc/jemalloc/issues/948
+        "@platforms//os:linux": ["-ldl"],  # side step https://github.com/jemalloc/jemalloc/issues/948
         "//conditions:default": [],
     }),
     linkstatic = 1,

--- a/third_party/openssl/linux.BUILD
+++ b/third_party/openssl/linux.BUILD
@@ -1,8 +1,8 @@
 cc_import(
     name = "ssl-import",
     shared_library = select({
-        "@com_stripe_ruby_typer//tools/config:linux": "lib/x86_64-linux-gnu/libssl.so",
-        "@com_stripe_ruby_typer//tools/config:linux_arm64": "lib/aarch64-linux-gnu/libssl.so",
+        "@platforms//cpu:x86_64": "lib/x86_64-linux-gnu/libssl.so",
+        "@platforms//cpu:arm64": "lib/aarch64-linux-gnu/libssl.so",
     }),
     visibility = ["//visibility:private"],
 )
@@ -17,8 +17,8 @@ cc_library(
 cc_import(
     name = "crypto-import",
     shared_library = select({
-        "@com_stripe_ruby_typer//tools/config:linux": "lib/x86_64-linux-gnu/libcrypto.so",
-        "@com_stripe_ruby_typer//tools/config:linux_arm64": "lib/aarch64-linux-gnu/libcrypto.so",
+        "@platforms//cpu:x86_64": "lib/x86_64-linux-gnu/libcrypto.so",
+        "@platforms//cpu:arm64": "lib/aarch64-linux-gnu/libcrypto.so",
     }),
     visibility = ["//visibility:private"],
 )

--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -39,7 +39,7 @@ ruby(
         "@bundler_stripe//file",
     ],
     linkopts = select({
-        "@com_stripe_ruby_typer//tools/config:linux": [
+        "@platforms//os:linux": [
             "-Wl,-Bsymbolic-functions",
             "-Wl,-z,relro",
             "-Wl,-z,noexecstack",
@@ -55,11 +55,7 @@ ruby(
             "@system_ssl_darwin//:ssl",
             "@system_ssl_darwin//:crypto",
         ],
-        "@com_stripe_ruby_typer//tools/config:linux_arm64": [
-            "@system_ssl_linux//:ssl",
-            "@system_ssl_linux//:crypto",
-        ],
-        "@com_stripe_ruby_typer//tools/config:linux": [
+        "@platforms//os:linux": [
             "@system_ssl_linux//:ssl",
             "@system_ssl_linux//:crypto",
         ],

--- a/third_party/ruby/ruby_for_compiler.BUILD
+++ b/third_party/ruby/ruby_for_compiler.BUILD
@@ -45,7 +45,7 @@ ruby(
         "@bundler_stripe//file",
     ],
     linkopts = select({
-        "@com_stripe_ruby_typer//tools/config:linux": [
+        "@platforms//os:linux": [
             "-Wl,-Bsymbolic-functions",
             "-Wl,-z,relro",
             "-Wl,-z,noexecstack",
@@ -62,7 +62,7 @@ ruby(
             "@system_ssl_darwin//:ssl",
             "@system_ssl_darwin//:crypto",
         ],
-        "@com_stripe_ruby_typer//tools/config:linux": [
+        "@platforms//os:linux": [
             "@system_ssl_linux//:ssl",
             "@system_ssl_linux//:crypto",
         ],


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Some places were using this config setting (which pins both the CPU and
the OS), when they don't actually care about the CPU.

Trying to clean up build config settings.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.