### PR TITLE
`config:linux` → `config:linux_x86_64`

### DIFF
--- a/third_party/llvm/llvm.bzl
+++ b/third_party/llvm/llvm.bzl
@@ -307,7 +307,7 @@ llvm_all_cmake_vars = select({
             darwin_cmake_vars,
         ),
     ),
-    "@com_stripe_ruby_typer//tools/config:linux": cmake_var_string(
+    "@com_stripe_ruby_typer//tools/config:linux_x86_64": cmake_var_string(
         _dict_add(
             cmake_vars,
             llvm_target_cmake_vars("X86", "x86_64-unknown-linux_gnu"),

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -1,14 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 config_setting(
-    name = "linux_arm64",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:arm64",
-    ],
-)
-
-config_setting(
     name = "darwin",
     constraint_values = [
         "@platforms//os:osx",
@@ -21,6 +13,14 @@ config_setting(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
     ],
 )
 

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -17,7 +17,7 @@ config_setting(
 )
 
 config_setting(
-    name = "linux",
+    name = "linux_x86_64",
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After #6815, this is the only place where we're using `config:linux` to
mean both a CPU + OS pair (as all other places that only cared about the OS
have been replaced with platform `constraint_value`'s).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.