### PR TITLE
Set type to `T.untyped` if constraint fails to solve

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1507,6 +1507,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 e.addErrorSection(constr->explain(gs));
                 result.main.errors.emplace_back(e.build());
             }
+            // This mimics the behavior of the SolveConstraint case in processBinding
+            resultType = Types::untypedUntracked();
         }
         ENFORCE(!data->arguments.empty(), "Every method should at least have a block arg.");
         ENFORCE(data->arguments.back().flags.isBlock, "The last arg should be the block arg.");

--- a/test/testdata/infer/no_valid_instantiation_result.rb
+++ b/test/testdata/infer/no_valid_instantiation_result.rb
@@ -18,6 +18,5 @@ def main(str)
   f = T.let(->(y) { y }, T.proc.params(x: Integer).void)
   res = apply_f(str, f)
   #     ^^^^^^^ error: Could not find valid instantiation of type parameters for `Object#apply_f`
-  #     ^^^^^^^^^^^^^^^ error: Expression does not have a fully-defined type (Did you reference another class's type members?)
   T.reveal_type(res) # error: `T.untyped`
 end

--- a/test/testdata/infer/no_valid_instantiation_result.rb
+++ b/test/testdata/infer/no_valid_instantiation_result.rb
@@ -1,0 +1,23 @@
+# typed: true
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(
+      x: T.type_parameter(:U),
+      f: T.proc.params(x: T.type_parameter(:U)).void,
+    )
+    .returns(T.type_parameter(:U))
+end
+def apply_f(x, f)
+  x
+end
+
+sig {params(str: String).void}
+def main(str)
+  f = T.let(->(y) { y }, T.proc.params(x: Integer).void)
+  res = apply_f(str, f)
+  #     ^^^^^^^ error: Could not find valid instantiation of type parameters for `Object#apply_f`
+  #     ^^^^^^^^^^^^^^^ error: Expression does not have a fully-defined type (Did you reference another class's type members?)
+  T.reveal_type(res) # error: `T.untyped`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The "Expression does not have a fully-defined type" error that Sorbet reports is
almost always a bug in Sorbet—except in the case it mentions, where the type is
not fully defined because it references someone else's type member explicitly,
the error has been caused because there was some part of Sorbet's inference
algorithm that either forgot to (or in this case: couldn't) instantiate
a generic type, leaving it not fully-defined.

The SolveConstraint case in `processBinding` already has a case that says "if
the constraint fails to resolve, set the result type to `T.untyped`," but that
logic only fires when a method call has been passed a block. In this test case,
the method call has been given no block and is solved as soon as all arguments
are type checked. This PR copies the `SolveConstraint` logic into calls.cc.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.