### PR TITLE
Change sig of GC.stat_heap to be Integer

### DIFF
--- a/rbi/core/gc.rbi
+++ b/rbi/core/gc.rbi
@@ -161,7 +161,7 @@ module GC
   # If the optional argument, hash, is given, it is overwritten and returned.
   #
   # This method is only expected to work on CRuby.
-  sig { returns(T::Hash[Numeric, T::Hash[Symbol, Numeric]]) }
+  sig { returns(T::Hash[Integer, T::Hash[Symbol, Integer]]) }
   sig { params(heap_name: T.any(Integer, String), hash_or_key: Symbol).returns(Integer) }
   sig do
     params(
@@ -169,7 +169,7 @@ module GC
       hash_or_key: T::Hash[T.untyped, T.untyped],
     ).returns(T::Hash[T.untyped, T.untyped])
   end
-  sig { params(heap_name: T.any(Integer, String)).returns(T::Hash[Symbol, Numeric]) }
+  sig { params(heap_name: T.any(Integer, String)).returns(T::Hash[Symbol, Integer]) }
   def self.stat_heap(heap_name = nil, hash_or_key = nil); end
 
   # Returns current status of

--- a/test/testdata/rbi/gc.rbi
+++ b/test/testdata/rbi/gc.rbi
@@ -2,12 +2,12 @@
 
 T.assert_type!(
   GC.stat_heap,
-  T::Hash[Numeric, T::Hash[Symbol, Numeric]]
+  T::Hash[Integer, T::Hash[Symbol, Integer]]
 )
 
 T.assert_type!(
   GC.stat_heap(0),
-  T::Hash[Symbol, Numeric]
+  T::Hash[Symbol, Integer]
 )
 
 T.assert_type!(


### PR DESCRIPTION
### Motivation

The signature of GC.stat_heap should be consistent with the one for GC.stat where all the values in the hash are Integers rather than the more generic Numeric type.


### Test plan

N/A.
