### PR TITLE
wip - Do not report out-of-order reference error for undeclared namespaces

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -320,6 +320,10 @@ private:
                         const shared_ptr<UnorderedMap<core::SymbolRef, core::LocOffsets>> &firstDefinitionLocs) {
         if (!ctx.file.data(ctx).isRBI() && resolutionResult.exists() &&
             resolutionResult.isOnlyDefinedInFile(ctx.state, ctx.file)) {
+            if (resolutionResult.isClassOrModule() && !resolutionResult.asClassOrModuleRef().data(ctx)->isDeclared()) {
+                return;
+            }
+
             core::LocOffsets defLoc;
             const auto it = firstDefinitionLocs.get()->find(resolutionResult);
 

--- a/test/testdata/lsp/fast_path/out_of_order.1.rbupdate
+++ b/test/testdata/lsp/fast_path/out_of_order.1.rbupdate
@@ -2,7 +2,6 @@
 # assert-fast-path: out_of_order.rb
 
 X = A
-#   ^ error: `A` referenced before it is defined
 
 class A::Foo
 end

--- a/test/testdata/lsp/fast_path/out_of_order.rb
+++ b/test/testdata/lsp/fast_path/out_of_order.rb
@@ -21,7 +21,6 @@
 # access that's out of bounds when reporting errors.
 
 X = A
-#   ^ error: `A` referenced before it is defined
 
 class A::Foo
 end

--- a/test/testdata/resolver/basic_constant_out_of_order__1.rb
+++ b/test/testdata/resolver/basic_constant_out_of_order__1.rb
@@ -5,6 +5,8 @@ module Foo
   # This reports an error despite Foo::X also having a definition in the RBI file.
   A = X 
   #   ^ error: `Foo::X` referenced before it is defined
+  
+  foo arg: [ X ] # error: `Foo::X` referenced before it is defined
 
   def self.foo(arg:)
     X # this is ok

--- a/test/testdata/resolver/basic_constant_out_of_order__3.rb
+++ b/test/testdata/resolver/basic_constant_out_of_order__3.rb
@@ -1,0 +1,12 @@
+# typed: strict
+
+module Bar
+  p(Baz)
+
+  class Baz::A
+    p(Baz)
+  end
+
+  class Baz::B
+  end
+end

--- a/test/testdata/resolver/constant_out_of_order_filler.rb
+++ b/test/testdata/resolver/constant_out_of_order_filler.rb
@@ -1,8 +1,7 @@
 # check-out-of-order-constant-references: true
 # typed: true
 
-X = A
-#   ^ error: `A` referenced before it is defined
+X = A # No error
 
 class A::Foo
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Turn off the out-of-order reference check for undeclared namespaces, e.g.
```
X = A # out-of-order, but we won't report it now, because `A` is an "undeclared" filler namespace, not a properly declared class/module/casgn

module A::C
end
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
I had made a fix https://github.com/sorbet/sorbet/pull/6777 for the out-of-order reference check crashing on the fast path. This creates some other issues, however. A bit of background context:

The out-of-order reference check was crashing on the fast path due to undeclared namespaces not updating locs across edits, e.g. consider the same above file:
```
X = A

module A::C
end
```

On the fast-path, we were crashing in `checkReferenceOrder` if there was an edit that **moved up** the declaration of `module A::C`. This was because `A` is an undeclared namespace -- for which we didn't used to update locs on the fast path, as per the reason given [here](https://github.com/sorbet/sorbet/pull/6777/files#diff-199cb30223d3e0c80ca7608d1f39363f1dfc9b153f51638bf741c01dfbd128a0L1178-L1183). When we don't update the loc, the `beginError` logic necessarily crashes because the previously preserved `loc` exceeds the size of the updated source file.

I made https://github.com/sorbet/sorbet/pull/6777 which changes the behavior to update locs if the symbol hasn't been declared if it is defined in the same file. This mitigated the crashes and other issues called out in that linked comment. However, it  now creates a situation where code like this incorrectly reports an OOO error during normal execution (regardless of fast-path, etc):

```
class Baz::A # line 1
  p(Baz) # this incorrectly reports an error
end

class Baz::B # line 5
end
```

This happens because after #6777, the loc of `Baz` gets recorded as line 5. Given `Baz` isn't declared **and** defined only in this file, the change in #6777 effectively pushes the **last** **seen** loc as the canonical loc of `Baz` as the namer passes over the file. This happens regardless of fast-path, slow-path, etc. For most cases where we need the canonical loc for an undeclared namespace, this is harmless. But this actually causes an issue for the ooo check.

There are 2 options here:
1). Fix the ooo check to handle undeclared namespaces properly. This will require a bit of work.
2). Don't report undeclared namespaces.

I think 2) is okay. The Stripe codebase has extremely rare cases of **undeclared** out-of-order namespaces, and when this _would_ actually be a problem, the more relevant error is necessarily the fact a filler namespace was just magically declared. Such code would fail to load regardless of the out-of-order-ness.

The obvious question is: now that I'm removing undeclared namespace checking completely the from out-of-order enforcement, should I also revert #6777 ? I think the answer to that (somewhat counter-intuitively) is no. I think that #6777 is good for other reasons. The previous loc update logic in the namer caused other issues during fast-path updates, so it's still valuable to have the fix from #6777.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.
