### PR TITLE
Reduce Sorbet runtime retained memory by releasing location information as soon as possible

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -341,7 +341,7 @@ module T::Private::Methods
 
     signature =
       if current_declaration
-        build_sig(hook_mod, method_name, original_method, current_declaration, declaration_block.loc)
+        build_sig(hook_mod, method_name, original_method, current_declaration)
       else
         Signature.new_untyped(method: original_method)
       end
@@ -358,7 +358,7 @@ module T::Private::Methods
       .decl
   end
 
-  def self.build_sig(hook_mod, method_name, original_method, current_declaration, loc)
+  def self.build_sig(hook_mod, method_name, original_method, current_declaration)
     begin
       # We allow `sig` in the current module's context (normal case) and
       if hook_mod != current_declaration.mod &&

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -339,6 +339,8 @@ module T::Private::Methods
         nil
       end
 
+    declaration_block.loc = nil
+
     signature =
       if current_declaration
         build_sig(hook_mod, method_name, original_method, current_declaration)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
It seems like the location information in `DeclarationBlock` is only needed to be able to pass it to `sig_builder_error_handler`, so we should be able to just release it after we are able to build a `Declaration` object.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
@byroot noticed a surprising amount of "backtrace" objects lying around in Shopify Core monolith memory that are all marked as `uncollectible`. Peaking at them, the common relation is:
```
(IMEMO: ment) -> (DATA: proc) -> (IMEMO: env) -> (STRUCT: (null)) -> (DATA: frame_info) -> (DATA: backtrace)
```
which we've found points to the `Kernel.caller_locations(1, 1)&.first` call inside the `T::Sig#sig` method.

The `loc` field of `DeclarationBlock` is used to store the location of the signature declaration. However, the value stored in that field is a `Thread::Backtrace::Location` object that was returned from `caller_locations`.

Holding onto this object is problematic since `caller_locations` materializes a `Thread::Backtrace` object, and each `Thread::Backtrace::Location` object holds a reference to that backtrace. Before Ruby 3, a call to `caller_locations` would materialize the whole backtrace, even if the `caller_locations(1, 1)` form was used. Ruby 3 has improved this situation by implementing partial backtraces, but holding on the the `loc` value still retains a `Location` and `Backtrace` object regardless.

This means that if Sorbet runtime does not release the location object as soon as possible, it would end up retaining a lot of backtraces, namely one for each signature defined. This causes a lot of memory growth for no good reason. 

This is significantly more important for codebases that are still running on Ruby 2.7, but is still relevant to post Ruby 3 codebase, since `Backtrace` objects have not had write-barriers until a recent change on Ruby `master`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I am not sure how we could test this, tbh. Happy to implement a test if you can give me guidance.
