### PR TITLE
Add SLOW_DEBUG_ONLY

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -65,6 +65,11 @@ constexpr bool skip_slow_enforce = false;
         X;            \
     }
 
+#define SLOW_DEBUG_ONLY(X)                                      \
+    if constexpr (!::sorbet::skip_slow_enforce && debug_mode) { \
+        X;                                                      \
+    }
+
 constexpr bool skip_check_memory_layout = debug_mode || emscripten_build;
 
 template <typename ToCheck, std::size_t ExpectedSize, std::size_t RealSize = sizeof(ToCheck)> struct check_size {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1669,8 +1669,8 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
 FileRef GlobalState::enterFile(const shared_ptr<File> &file) {
     ENFORCE(!fileTableFrozen);
 
-    DEBUG_ONLY(for (auto &f
-                    : this->files) {
+    SLOW_DEBUG_ONLY(for (auto &f
+                         : this->files) {
         if (f) {
             if (f->path() == file->path()) {
                 Exception::raise("Request to `enterFile` for already-entered file path?");

--- a/core/NameSubstitution.cc
+++ b/core/NameSubstitution.cc
@@ -8,7 +8,7 @@ namespace sorbet::core {
 NameSubstitution::NameSubstitution(const GlobalState &from, GlobalState &to) : toGlobalStateId(to.globalStateId) {
     Timer timeit(to.tracer(), "NameSubstitution.new", from.creation);
 
-    from.sanityCheck();
+    SLOW_DEBUG_ONLY(from.sanityCheck());
 
     {
         UnfreezeNameTable unfreezeNames(to);
@@ -53,7 +53,7 @@ NameSubstitution::NameSubstitution(const GlobalState &from, GlobalState &to) : t
         extension->merge(from, to, *this);
     }
 
-    to.sanityCheck();
+    SLOW_DEBUG_ONLY(to.sanityCheck());
 }
 
 LazyNameSubstitution::LazyNameSubstitution(const GlobalState &fromGS, GlobalState &toGS) : fromGS(fromGS), toGS(toGS) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4201,7 +4201,7 @@ vector<ast::ParsedFile> resolveSigs(core::GlobalState &gs, vector<ast::ParsedFil
     return trees;
 }
 void sanityCheck(const core::GlobalState &gs, vector<ast::ParsedFile> &trees) {
-    if (debug_mode) {
+    if (debug_mode && !skip_slow_enforce) {
         Timer timeit(gs.tracer(), "resolver.sanity_check");
         ResolveSanityCheckWalk sanity;
         for (auto &tree : trees) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4201,7 +4201,7 @@ vector<ast::ParsedFile> resolveSigs(core::GlobalState &gs, vector<ast::ParsedFil
     return trees;
 }
 void sanityCheck(const core::GlobalState &gs, vector<ast::ParsedFile> &trees) {
-    if (debug_mode && !skip_slow_enforce) {
+    SLOW_DEBUG_ONLY({
         Timer timeit(gs.tracer(), "resolver.sanity_check");
         ResolveSanityCheckWalk sanity;
         for (auto &tree : trees) {
@@ -4209,7 +4209,7 @@ void sanityCheck(const core::GlobalState &gs, vector<ast::ParsedFile> &trees) {
             ENFORCE(tree.tree);
             ast::TreeWalk::apply(ctx, sanity, tree.tree);
         }
-    }
+    });
 }
 
 void verifyLinearizationComputed(const core::GlobalState &gs) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It takes a very large amount of time to typecheck Stripe's codebase in
the release-debug-linux configuration.

After I generated a web-trace-file from one of these runs, I realized that the
`index` phase doesn't even start until about 50% into the run. That meant that
things coming before `index` were somehow taking half the time, which should not
be the case.

The slowdown blames to this ENFORCE, which, while a good ENFORCE, is
accidentally quadratic in the number of files in the codebase (with some extra
factor for how many common prefixes the files share).

We have precedent for `SLOW_ENFORCE` which are good ENFORCEs that are too slow
to run on large codebases. This adds `SLOW_DEBUG_ONLY`, and uses it for one
particularly slow region of code.

This change nearly cuts the time to run a release-debug-build on Stripe's
codebase in half.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested manually by building in release-debug-linux configuration and generating
a new web-trace-file on Stripe's codebase.