### PR TITLE
Add some more SLOW_DEBUG_ONLY

### DIFF
--- a/core/NameSubstitution.cc
+++ b/core/NameSubstitution.cc
@@ -8,7 +8,7 @@ namespace sorbet::core {
 NameSubstitution::NameSubstitution(const GlobalState &from, GlobalState &to) : toGlobalStateId(to.globalStateId) {
     Timer timeit(to.tracer(), "NameSubstitution.new", from.creation);
 
-    from.sanityCheck();
+    SLOW_DEBUG_ONLY(from.sanityCheck());
 
     {
         UnfreezeNameTable unfreezeNames(to);
@@ -53,7 +53,7 @@ NameSubstitution::NameSubstitution(const GlobalState &from, GlobalState &to) : t
         extension->merge(from, to, *this);
     }
 
-    to.sanityCheck();
+    SLOW_DEBUG_ONLY(to.sanityCheck());
 }
 
 LazyNameSubstitution::LazyNameSubstitution(const GlobalState &fromGS, GlobalState &toGS) : fromGS(fromGS), toGS(toGS) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4201,7 +4201,7 @@ vector<ast::ParsedFile> resolveSigs(core::GlobalState &gs, vector<ast::ParsedFil
     return trees;
 }
 void sanityCheck(const core::GlobalState &gs, vector<ast::ParsedFile> &trees) {
-    if (debug_mode) {
+    if (debug_mode && !skip_slow_enforce) {
         Timer timeit(gs.tracer(), "resolver.sanity_check");
         ResolveSanityCheckWalk sanity;
         for (auto &tree : trees) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is based on #6840

Disabling these two sanityChecks is maybe a little more coarse grained, but it
saves another minute of runtime running release-debug-linux on Stripe's codebase.

Personally, I have never seen these ENFORCEs fire, even in tests, even long ago.
So while I think they are good things to ENFORCE, I think we can skip them in
release-debug-linux mode.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested by running web-trace-file on Stripe's codebase.