### PR TITLE
Fix out-of-order reference check -- remove first-def-locs sharing & checking undeclared constants

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -139,7 +139,7 @@ private:
     // There will be a map like this for each file that resolver processes, but it will outlive the initial treewalk
     // to find ConstantResolutionItems and only get released once all ConstantResolutionItems for that file have been
     // handled.
-    shared_ptr<UnorderedMap<core::SymbolRef, core::LocOffsets>> firstDefinitionLocs;
+    UnorderedMap<core::SymbolRef, core::LocOffsets> firstDefinitionLocs;
 
     // Increments to track whether we're at a class top level or whether we're inside a block/method body.
     int loadScopeDepth_;
@@ -150,7 +150,6 @@ private:
         bool resolutionFailed = false;
         bool possibleGenericType = false;
         bool loadTimeScope = false;
-        shared_ptr<UnorderedMap<core::SymbolRef, core::LocOffsets>> firstDefinitionLocs;
 
         ConstantResolutionItem() = default;
         ConstantResolutionItem(const shared_ptr<Nesting> &scope, ast::ConstantLit *lit) : scope(scope), out(lit) {}
@@ -317,13 +316,13 @@ private:
     // then, report an error.
     static void
     checkReferenceOrder(core::Context ctx, core::SymbolRef resolutionResult, const ast::UnresolvedConstantLit &c,
-                        const shared_ptr<UnorderedMap<core::SymbolRef, core::LocOffsets>> &firstDefinitionLocs) {
+                        UnorderedMap<core::SymbolRef, core::LocOffsets> &firstDefinitionLocs) {
         if (!ctx.file.data(ctx).isRBI() && resolutionResult.exists() &&
             resolutionResult.isOnlyDefinedInFile(ctx.state, ctx.file)) {
             core::LocOffsets defLoc;
-            const auto it = firstDefinitionLocs.get()->find(resolutionResult);
+            const auto it = firstDefinitionLocs.find(resolutionResult);
 
-            if (it != firstDefinitionLocs.get()->end()) {
+            if (it != firstDefinitionLocs.end()) {
                 // Use the loc from the local first defs table, if it exists.
                 // When the symbol is declared multiple times in the same file, we want to ensure that
                 // we compare against the *first* definition.
@@ -348,14 +347,9 @@ private:
 
     static core::SymbolRef
     resolveConstant(core::Context ctx, const shared_ptr<Nesting> &nesting, const ast::UnresolvedConstantLit &c,
-                    bool &resolutionFailed, bool loadTimeScope,
-                    const shared_ptr<UnorderedMap<core::SymbolRef, core::LocOffsets>> &firstDefinitionLocs) {
+                    bool &resolutionFailed) {
         if (ast::isa_tree<ast::EmptyTree>(c.scope)) {
             core::SymbolRef result = resolveLhs(ctx, nesting, c.cnst);
-
-            if (loadTimeScope) {
-                checkReferenceOrder(ctx, result, c, firstDefinitionLocs);
-            }
 
             return result;
         }
@@ -386,10 +380,6 @@ private:
                 if (auto e = ctx.beginError(c.loc, core::errors::Resolver::PrivateConstantReferenced)) {
                     e.setHeader("Non-private reference to private constant `{}` referenced", result.show(ctx));
                 }
-            }
-
-            if (loadTimeScope) {
-                checkReferenceOrder(ctx, result, c, firstDefinitionLocs);
             }
 
             return result;
@@ -700,8 +690,7 @@ private:
 
         bool singlePackageRbiGeneration = ctx.state.singlePackageImports.has_value();
 
-        auto resolved = resolveConstant(ctx.withOwner(job.scope->scope), job.scope, original, job.resolutionFailed,
-                                        job.loadTimeScope, job.firstDefinitionLocs);
+        auto resolved = resolveConstant(ctx.withOwner(job.scope->scope), job.scope, original, job.resolutionFailed);
         if (resolved.exists() && resolved.isTypeAlias(ctx)) {
             auto resolvedField = resolved.asFieldRef();
             if (resolvedField.data(ctx)->resultType == nullptr) {
@@ -847,8 +836,7 @@ private:
 
     static bool
     resolveConstantJob(core::Context ctx, const shared_ptr<Nesting> &nesting, ast::ConstantLit *out,
-                       bool &resolutionFailed, const bool possibleGenericType, const bool loadTimeScope,
-                       const shared_ptr<UnorderedMap<core::SymbolRef, core::LocOffsets>> &firstDefinitionLocs) {
+                       bool &resolutionFailed, const bool possibleGenericType) {
         if (isAlreadyResolved(ctx, *out)) {
             if (possibleGenericType) {
                 return false;
@@ -856,8 +844,7 @@ private:
             return true;
         }
         auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(out->original);
-        auto resolved = resolveConstant(ctx.withOwner(nesting->scope), nesting, original, resolutionFailed,
-                                        loadTimeScope, firstDefinitionLocs);
+        auto resolved = resolveConstant(ctx.withOwner(nesting->scope), nesting, original, resolutionFailed);
         if (!resolved.exists()) {
             return false;
         }
@@ -875,8 +862,7 @@ private:
     }
 
     static bool resolveJob(core::Context ctx, ConstantResolutionItem &job) {
-        return resolveConstantJob(ctx, job.scope, job.out, job.resolutionFailed, job.possibleGenericType,
-                                  job.loadTimeScope, job.firstDefinitionLocs);
+        return resolveConstantJob(ctx, job.scope, job.out, job.resolutionFailed, job.possibleGenericType);
     }
 
     static bool resolveConstantResolutionItems(const core::GlobalState &gs,
@@ -1374,15 +1360,14 @@ private:
             auto *constant = ast::cast_tree<ast::ConstantLit>(out);
             bool resolutionFailed = false;
             const bool possibleGenericType = false;
-            const bool loadTimeScope = (loadScopeDepth_ == 0);
-            if (resolveConstantJob(ctx, nesting_, constant, resolutionFailed, possibleGenericType, loadTimeScope,
-                                   firstDefinitionLocs)) {
+            if (resolveConstantJob(ctx, nesting_, constant, resolutionFailed, possibleGenericType)) {
                 categoryCounterInc("resolve.constants.nonancestor", "firstpass");
+                if (loadScopeDepth_ == 0) {
+                    checkReferenceOrder(ctx, constant->symbol, *c, firstDefinitionLocs);
+                }
             } else {
                 ConstantResolutionItem job{nesting_, constant};
                 job.resolutionFailed = resolutionFailed;
-                job.loadTimeScope = loadTimeScope;
-                job.firstDefinitionLocs = firstDefinitionLocs;
                 todo_.emplace_back(std::move(job));
             }
             tree = std::move(out);
@@ -1398,9 +1383,7 @@ private:
     }
 
 public:
-    ResolveConstantsWalk() : nesting_(nullptr), loadScopeDepth_(0) {
-        firstDefinitionLocs = make_unique<UnorderedMap<core::SymbolRef, core::LocOffsets>>();
-    }
+    ResolveConstantsWalk() : nesting_(nullptr), loadScopeDepth_(0) {}
 
     void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         ENFORCE(loadScopeDepth_ >= 0);
@@ -1450,7 +1433,7 @@ public:
                     // If the insert succeeds below, the current definition is the first one.
                     // We need to use the first def for out-of-order checking, since any
                     // reference *before* the first def will be out of order.
-                    firstDefinitionLocs->insert(std::make_pair(sym, declLoc));
+                    firstDefinitionLocs.insert(std::make_pair(sym, declLoc));
                 }
             }
         }
@@ -1604,7 +1587,7 @@ public:
                     // If the insert succeeds below, the current definition is the first one.
                     // We need to use the first def for out-of-order checking, since any
                     // reference *before* the first def will be out of order.
-                    firstDefinitionLocs->insert(std::make_pair(id->symbol, declLoc));
+                    firstDefinitionLocs.insert(std::make_pair(id->symbol, declLoc));
                 }
             }
         }
@@ -1681,8 +1664,6 @@ public:
                 // In single-package RBI generation mode, we treat Constant[...] as
                 // possible generic types.
                 ConstantResolutionItem job{nesting_, recvAsConstantLit};
-                job.loadTimeScope = (loadScopeDepth_ == 0);
-                job.firstDefinitionLocs = firstDefinitionLocs;
                 job.possibleGenericType = true;
                 if (!resolveJob(ctx, job)) {
                     todo_.emplace_back(std::move(job));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -145,7 +145,6 @@ private:
         ast::ConstantLit *out;
         bool resolutionFailed = false;
         bool possibleGenericType = false;
-        bool loadTimeScope = false;
 
         ConstantResolutionItem() = default;
         ConstantResolutionItem(const shared_ptr<Nesting> &scope, ast::ConstantLit *lit) : scope(scope), out(lit) {}

--- a/test/testdata/lsp/fast_path/out_of_order.1.rbupdate
+++ b/test/testdata/lsp/fast_path/out_of_order.1.rbupdate
@@ -2,7 +2,6 @@
 # assert-fast-path: out_of_order.rb
 
 X = A
-#   ^ error: `A` referenced before it is defined
 
 class A::Foo
 end

--- a/test/testdata/lsp/fast_path/out_of_order.rb
+++ b/test/testdata/lsp/fast_path/out_of_order.rb
@@ -21,7 +21,6 @@
 # access that's out of bounds when reporting errors.
 
 X = A
-#   ^ error: `A` referenced before it is defined
 
 class A::Foo
 end

--- a/test/testdata/resolver/basic_constant_out_of_order__1.rb
+++ b/test/testdata/resolver/basic_constant_out_of_order__1.rb
@@ -46,4 +46,8 @@ module Foo
   end
 
   Y = 3
+
+  p(Foo::Z) # this is ok since Foo::Z is also defined in another file
+  class Z
+  end
 end

--- a/test/testdata/resolver/basic_constant_out_of_order__3.rb
+++ b/test/testdata/resolver/basic_constant_out_of_order__3.rb
@@ -1,0 +1,8 @@
+# check-out-of-order-constant-references: true
+# typed: strict
+
+module Foo
+  class Z
+  end
+end
+

--- a/test/testdata/resolver/constant_out_of_order_filler.rb
+++ b/test/testdata/resolver/constant_out_of_order_filler.rb
@@ -1,8 +1,7 @@
 # check-out-of-order-constant-references: true
 # typed: true
 
-X = A
-#   ^ error: `A` referenced before it is defined
+X = A # No error. We do not report undeclared (implicit definition) symbols.
 
 class A::Foo
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Makes two changes, one refactor and one feature change.

1. Removes cross-treewalk sharing of `firstDefinitionLocs` in resolver. For the purpose of out-of-order checking, it turns out that cross-walk-sharing is unnecessary, and purely local resolution is enough. Thus, we do not need to maintain this info after the first resolution pass of a file.

2. Turns off the out-of-order reference check for undeclared namespaces, e.g.
```
X = A # out-of-order, but we won't report it now, because `A` is an "undeclared" filler namespace

module A::C
end
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
**For change 1**
This change simplifies the logic and mitigates memory issues and crashes. We don't hold on to shared pointers after a walk is finished; the RAII of the walk works more intuitively.

**For change 2**
I had made a fix https://github.com/sorbet/sorbet/pull/6777 for the out-of-order reference check crashing on the fast path. This creates some other issues, however. To explain, I'm going to provide a bit of background context:

_Background for #6777_ 
The out-of-order reference check was crashing on the fast path due to undeclared namespaces not updating locs across edits, e.g. consider the same above file:
```
X = A

module A::C
end
```

On the fast-path, we were crashing in `checkReferenceOrder` if there was an edit that **moved up** the declaration of `module A::C`. This was because `A` is an undeclared namespace -- for which we didn't used to update locs on the fast path, as per the reason given [here](https://github.com/sorbet/sorbet/pull/6777/files#diff-199cb30223d3e0c80ca7608d1f39363f1dfc9b153f51638bf741c01dfbd128a0L1178-L1183). When we don't update the loc, the `beginError` logic necessarily crashes because the previously preserved `loc` exceeds the size of the updated source file.

I made https://github.com/sorbet/sorbet/pull/6777 which changes the behavior to update undeclared symbol locs if the symbol is defined in the same file. This mitigated the crashes and other issues called out in that linked comment. 

_Problem caused by #6777_
However, this created a situation where code like this incorrectly reports an OOO error:

```
class Baz::A # line 1
  p(Baz) # this incorrectly reports an error
end

class Baz::B # line 5
end
```

This happens because after #6777, the loc of `Baz` gets recorded as line 5. `Baz` is an undeclared namespace, defined only in this file -- and so, the change in #6777 effectively pushes the **last** **seen** loc as the canonical loc of `Baz` as the namer passes over the file. This behavior is regardless of fast-path, slow-path, etc. For most cases where we need the canonical loc for an undeclared namespace, this is harmless. But it causes an issue for the ooo check.

There are 2 options here:
1). Fix the ooo check to handle undeclared namespaces "properly". This will require a bit of work.
2). Don't report undeclared namespaces.

I think 2) is okay. From a Ruby standpoint, `class X::A` is _not_ a declaration of `X` at all. So there's no practical reason for us to check out-of-order-ness relative to such declarations.

The obvious question is: now that I'm removing undeclared namespace checking completely the from out-of-order enforcement, should I also revert #6777 ? I think the answer to that (somewhat counter-intuitively) is no. I think that #6777 is good for other reasons. The previous loc update logic in the namer caused other issues during fast-path updates, so it's still valuable to have that fix.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.