### PR TITLE
Improve Pathname sigs

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -244,14 +244,14 @@ class Pathname < Object
   # [`Dir.glob`](https://docs.ruby-lang.org/en/2.7.0/Dir.html#method-c-glob).
   sig do
     params(
-        p1: T.any(String, Pathname),
+        p1: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         p2: Integer,
     )
     .returns(T::Array[Pathname])
   end
   sig do
     params(
-        p1: T.any(String, Pathname),
+        p1: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         p2: Integer,
         blk: T.proc.params(arg0: Pathname).void,
     )
@@ -864,14 +864,14 @@ class Pathname < Object
 
   sig do
     params(
-        p1: T.any(String, Pathname),
+        p1: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         p2: Integer,
     )
     .returns(T::Array[Pathname])
   end
   sig do
     params(
-        p1: T.any(String, Pathname),
+        p1: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         p2: Integer,
         blk: T.proc.params(arg0: Pathname).void
     )
@@ -1450,6 +1450,6 @@ module Kernel
   # See also
   # [`Pathname::new`](https://docs.ruby-lang.org/en/2.7.0/Pathname.html#method-c-new)
   # for more information.
-  sig { params(path: String).returns(Pathname) }
+  sig { params(path: T.any(String, Pathname)).returns(Pathname) }
   def Pathname(path); end
 end

--- a/test/testdata/rbi/pathname.rb
+++ b/test/testdata/rbi/pathname.rb
@@ -9,3 +9,10 @@ end
 T.reveal_type(md_file) # error: `T.nilable(Pathname)`
 
 T.reveal_type(Pathname('/')) # error: `Pathname`
+T.reveal_type(Pathname(Pathname('/'))) # error: `Pathname`
+
+T.reveal_type(Pathname.glob(['*.rb', Pathname('/')])) # error: `T::Array[Pathname]`
+T.reveal_type(Pathname.glob(['*.rb', Pathname('/')]) { puts _1 }) # error: `NilClass`
+
+T.reveal_type(Pathname('/usr/bin').glob(['*.d', Pathname('/')])) # error: `T::Array[Pathname]`
+T.reveal_type(Pathname('/usr/bin').glob(['*.d', Pathname('/')]) { puts _1 }) # error: `NilClass`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Enhances sigs for a couple of underdocumented `Pathname` methods:
`Pathname()` accepts `Pathname` in addition to `String`
`glob` accepts an array of `Pathname`/`String`


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
