### PR TITLE
Fix FileUtils cp_r sig

### DIFF
--- a/rbi/stdlib/fileutils.rbi
+++ b/rbi/stdlib/fileutils.rbi
@@ -123,7 +123,7 @@ module FileUtils
     params(
       src: T.any(String, Pathname),
       dest: T.any(String, Pathname),
-      preserve: T.nilable(T::Hash[Symbol, T::Boolean]),
+      preserve: T.nilable(T::Boolean),
       noop: T.nilable(T::Boolean),
       verbose: T.nilable(T::Boolean),
       dereference_root: T::Boolean,

--- a/test/testdata/rbi/fileutils.rb
+++ b/test/testdata/rbi/fileutils.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+FileUtils.cp_r('src0.txt', 'dest0.txt', preserve: true)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The `preserve:` kwarg is boolean, like the other methods in the module (`cp`, `copy`, `copy_entry`, `copy_file`, `install`)

https://ruby-doc.org/3.2.1/stdlibs/fileutils/FileUtils.html#method-c-cp_r

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
