### PR TITLE
Update Hash#shift RBI

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -1198,14 +1198,14 @@ class Hash < Object
   def filter!(&blk); end
 
   # Removes a key-value pair from *hsh* and returns it as the two-item array `[`
-  # *key, value* `]`, or the hash's default value if the hash is empty.
+  # *key, value* `]`, or nil if the hash is empty.
   #
   # ```ruby
   # h = { 1 => "a", 2 => "b", 3 => "c" }
   # h.shift   #=> [1, "a"]
   # h         #=> {2=>"b", 3=>"c"}
   # ```
-  sig {returns(T::Array[T.any(K, V)])}
+  sig {returns(T.nilable(T::Array[T.any(K, V)]))}
   def shift(); end
 
   # Returns the number of key-value pairs in the hash.

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -97,3 +97,6 @@ T.reveal_type(T::Hash[Symbol, Integer].new.any? do |(key, value)| # error: Revea
   T.reveal_type(key) # error: Revealed type: `Symbol`
   T.reveal_type(value) # error: Revealed type: `Integer`
 end)
+
+T.assert_type!({a: 1}.shift, T.nilable(T::Array[T.untyped]))
+T.assert_type!({}.shift, T.nilable(T::Array[T.untyped]))


### PR DESCRIPTION
### Motivation
As outlined in [this Ruby Bug](https://bugs.ruby-lang.org/issues/16908), fixed in [this PR](https://github.com/ruby/ruby/pull/5360), `Hash#shift` has been updated to return `nil` when the hash is empty. Previously it would return the value returned from `hash.default(nil)` which depending on the `default_proc` could produce weird results. This PR updates the `Hash` RBI so that `shift` now reflects the returned value as of 3.2 


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
