### PR TITLE
Update MatchData RBI for 3.2 changes

### DIFF
--- a/rbi/core/match_data.rbi
+++ b/rbi/core/match_data.rbi
@@ -141,6 +141,26 @@ class MatchData < Object
   end
   def begin(n); end
 
+  # Returns a two-element array containing the beginning and ending byte-based
+  # offsets of the nth match. n can be a string or symbol to reference a named capture.
+  #
+  # ```ruby
+  # m = /(.)(.)(\d+)(\d)/.match("THX1138.")
+  # m.byteoffset(0)      #=> [1, 7]
+  # m.byteoffset(4)      #=> [6, 7]
+  #
+  # m = /(?<foo>.)(.)(?<bar>.)/.match("hoge")
+  # m.byteoffset(:foo)   #=> [0, 1]
+  # m.byteoffset(:bar)   #=> [2, 3]
+  # ```
+  sig do
+    params(
+      n: T.any(Integer, Symbol, String),
+    )
+    .returns(T::Array[Integer])
+  end
+  def byteoffset(n); end
+
   # Returns the array of captures; equivalent to `mtch.to_a[1..-1]`.
   #
   # ```ruby


### PR DESCRIPTION
### Motivation
Adding new `MatchData#byteoffset` method to the RBI for new 3.2 changes. 

[Docs](https://docs.ruby-lang.org/en/3.2/MatchData.html)
[Applied in changeset](https://bugs.ruby-lang.org/projects/ruby-master/repository/git/revisions/c8817d6a3ebc9bbc151625bca198b8f327d1d68f)


### Test plan
I've not added tests since there were no RBI tests for `MatchData` happy to add this if it's deemed necessary now. 