### PR TITLE
Update Module RBI for 3.2 changes

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -1640,6 +1640,27 @@ class Module < Object
   end
   def refine(arg0, &blk); end
 
+  # Returns a list of refinements included in the receiver.
+  #
+  # ```ruby
+  # module A
+  #   refine Integer do
+  #   end
+
+  #   refine String do
+  #   end
+  # end
+
+  # p A.refinements
+  # ```
+  # *produces:*
+  #
+  # ```ruby
+  # [#<refinement:Integer@A>, #<refinement:String@B>]
+  # ```
+  sig {returns(T::Array[Module])}
+  def refinements; end
+
   # Removes the named class variable from the receiver, returning that
   # variable's value.
   #

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -535,9 +535,10 @@ class Module < Object
   # ```
   sig do
     params(
-      const_added: T.any(Symbol)
+      const_name: T.any(Symbol)
     )
     .returns(T.untyped)
+  end
   def const_added(const_name); end
 
   # Says whether *mod* or its ancestors have a constant with the given name:
@@ -1871,4 +1872,30 @@ class Module < Object
   # [B, A]
   # ```
   def self.used_modules; end
+
+  # Returns an array of all refinements used in the current scope. The ordering
+  # of refinements in the resulting array is not defined.
+  # ```ruby
+  # module A
+  #   refine Object do
+  #   end
+  # end
+  #
+  # module B
+  #   refine Object do
+  #   end
+  # end
+  #
+  # using A
+  # using B
+  # p Module.used_refinements
+  # ```
+  #
+  # *produces:*
+  #
+  # ```ruby
+  # [#<refinement:Object@B>, #<refinement:Object@A>]
+  # ```
+  sig {returns(T::Array[Module])}
+  def self.used_refinements; end
 end

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -516,6 +516,30 @@ class Module < Object
   end
   def class_variables(inherit=T.unsafe(nil)); end
 
+  # Invoked as a callback whenever a constant is assigned on the receiver
+  #
+  # ```ruby
+  # module Chatty
+  #   def self.const_added(const_name)
+  #     super
+  #     puts "Added #{const_name.inspect}"
+  #   end
+  #   FOO = 1
+  # end
+  # ```
+  #
+  # *produces:*
+  #
+  # ```
+  # Added :FOO
+  # ```
+  sig do
+    params(
+      const_added: T.any(Symbol)
+    )
+    .returns(T.untyped)
+  def const_added(const_name); end
+
   # Says whether *mod* or its ancestors have a constant with the given name:
   #
   # ```ruby


### PR DESCRIPTION
### Motivation
**Adding new `Module::used_refinements` method to the RBI for new 3.2 changes.**
[Docs](https://docs.ruby-lang.org/en/3.2/Module.html#method-c-used_refinements)
[Applied in changeset](https://bugs.ruby-lang.org/projects/ruby-master/repository/git/revisions/21ee5341f8fc4ca513295dff2148f7c203c908a7)

**Adding new `Module#refinements` method to the RBI for new 3.2 changes.**
[Docs](https://docs.ruby-lang.org/en/3.2/Module.html#method-i-refinements)
[Applied in changeset](https://bugs.ruby-lang.org/projects/ruby-master/repository/git/revisions/54198c7b97d3d353f7ac233e0360034b6e7b6cb6)

**Adding new `Module::const_added` method to the RBI for new 3.2 changes.**
[Docs](https://docs.ruby-lang.org/en/3.2/Module.html#method-i-const_added)
[Applied in changeset](https://bugs.ruby-lang.org/projects/ruby-master/repository/git/revisions/8d05047d72d0a4b97f57b23bddbca639375bbd03)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
