### PR TITLE
Add Refinement RBI for 3.2 changes

### DIFF
--- a/rbi/core/refinement.rbi
+++ b/rbi/core/refinement.rbi
@@ -1,0 +1,54 @@
+# typed: __STDLIB_INTERNAL
+
+# [Refinement](https://docs.ruby-lang.org/en/3.2/Refinement.html) is a class of
+# the self (current context) inside refine statement. It allows to import
+# methods from other modules, see
+# [import_methods](https://docs.ruby-lang.org/en/3.2/Refinement.html#method-i-import_methods).
+class Refinement < Object
+  # Imports methods from modules. Unlike
+  # [Module#include](https://docs.ruby-lang.org/en/3.2/Module.html#method-i-include),
+  # [Refinement#import_methods](https://docs.ruby-lang.org/en/3.2/Refinement.html#method-i-import_methods)
+  # copies methods and adds them into the refinement, so the refinement is
+  # activated in the imported methods.
+  #
+  # Note that due to method copying, only methods defined in Ruby code can be imported.
+  #
+  # ```ruby
+  # module StrUtils
+  #   def indent(level)
+  #     ' ' * level + self
+  #   end
+  # end
+  #
+  # module M
+  #   refine String do
+  #     import_methods StrUtils
+  #   end
+  # end
+  #
+  # using M
+  # "foo".indent(3)
+  # #=> "   foo"
+  #
+  # module M
+  #   refine String do
+  #     import_methods Enumerable
+  #     # Can't import method which is not defined with Ruby code: Enumerable#drop
+  #   end
+  # end
+  # ```
+  #
+  # Also aliased as: import_methods
+  sig do
+    params(
+      mod: Module,
+      rest: Module,
+    )
+    .returns(Refinement)
+  end
+  def import_methods(mod, *rest); end
+
+  # Return the class refined by the receiver.
+  sig {returns(T.class_of(Object))}
+  def refined_class; end
+end


### PR DESCRIPTION
### Motivation
`Refinement` didn't previously have an RBI, so I added it with the one existing method of `import_methods`. 

**Adding new `Refinement#refined_class` method to the RBI for new 3.2 changes.**
[Docs](https://docs.ruby-lang.org/en/3.2/Refinement.html)
[Applied in changeset](https://bugs.ruby-lang.org/projects/ruby-master/repository/git/revisions/54198c7b97d3d353f7ac233e0360034b6e7b6cb6)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
