### PR TITLE
Release memory after deduping

### DIFF
--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -85,6 +85,7 @@ WithoutUniqueNameHash::WithoutUniqueNameHash(const GlobalState &gs, NameRef nm)
 void WithoutUniqueNameHash::sortAndDedupe(std::vector<core::WithoutUniqueNameHash> &hashes) {
     fast_sort(hashes);
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
+    hashes.shrink_to_fit();
 }
 
 FullNameHash::FullNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(hashFullNameRef(gs, nm))) {}
@@ -92,6 +93,7 @@ FullNameHash::FullNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZe
 void FullNameHash::sortAndDedupe(std::vector<core::FullNameHash> &hashes) {
     fast_sort(hashes);
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
+    hashes.shrink_to_fit();
 }
 
 FoundDefinitionRef FoundStaticFieldHash::owner() const {

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -35,6 +35,7 @@ public:
 
     uint32_t _hashValue;
 };
+CheckSize(WithoutUniqueNameHash, 4, 4);
 
 template <typename H> H AbslHashValue(H h, const WithoutUniqueNameHash &m) {
     return H::combine(std::move(h), m._hashValue);
@@ -66,6 +67,7 @@ public:
 
     uint32_t _hashValue;
 };
+CheckSize(FullNameHash, 4, 4);
 
 template <typename H> H AbslHashValue(H h, const FullNameHash &m) {
     return H::combine(std::move(h), m._hashValue);
@@ -89,6 +91,7 @@ struct SymbolHash {
         return this->nameHash < h.nameHash || (!(h.nameHash < this->nameHash) && this->symbolHash < h.symbolHash);
     }
 };
+CheckSize(SymbolHash, 8, 4);
 
 // 28 is the same as the size of an ID in FoundDefinitionRef::_storage
 //
@@ -313,6 +316,7 @@ struct LocalSymbolTableHashes {
         return hierarchyHash == HASH_STATE_INVALID_PARSE;
     }
 };
+CheckSize(LocalSymbolTableHashes, 56, 8);
 
 // This structure represents every time a name was used in a place where it could be referencing the
 // name of a (Sorbet) symbol. For example, this program:
@@ -348,6 +352,7 @@ struct FileHash {
     FileHash() = default;
     FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages, FoundDefHashes &&foundHashes);
 };
+CheckSize(FileHash, 176, 8);
 
 }; // namespace sorbet::core
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We call `sortAndDedupe` to shrink the `nameHashes` field of `UsageHash`.
(This structure is used to remember the names of symbols that a file might
use, so we know which downstream files might need to be retypechecked.)

This was causing all `FileHash`'s in Stripe's codebase to take up about 6x
the space that it needed to. After shrinking, Sorbet uses about 1/6th the
memory to store all `FileHash` objects.

Note that this cost was only paid for cold-cache runs of LSP. Warm cache
runs of LSP would read file hashes from the cache, which would not have
serialized the unused capacity in these vectors.

So while this is definitely an improvement, it's not an improvement that
applies to 100% of LSP initializations. (But it does reduce the worst
case.)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

For correctness: existing tests

To check memory reduction: I have a WIP branch, based on top of #6827, which
adds a _lot_ of writes to the trace file. It also adds another metric for
`current_rss`. This lets me see correlate the current RSS with given phases of
Sorbet. I can see that the current and max RSS values drop by the expected
amount for cold-cache LSP initialization requests.