### PR TITLE
use x86-64 platforms for `@com_github_blake2_libb2`

### DIFF
--- a/common/crypto_hashing/BUILD
+++ b/common/crypto_hashing/BUILD
@@ -8,8 +8,8 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = ["//common"] + select({
         "//tools/config:webasm": ["@com_github_blake2_blake2"],
-        "@platforms//os:osx": ["@com_github_blake2_libb2"],
-        "@platforms//os:linux": ["@com_github_blake2_libb2"],
+        "//tools/config:darwin_x86_64": ["@com_github_blake2_libb2"],
+        "//tools/config:linux_x86_64": ["@com_github_blake2_libb2"],
         "//conditions:default": ["@com_github_blake2_blake2"],
     }),
 )


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These implementations are x86-specific, so we should only use them when we are compiling for x86-specific platforms.  Fortunately, we now have the configury to write that concisely.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
