### PR TITLE
update `bazel-toolchain` fork with arm64 linux support

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -177,9 +177,9 @@ def register_sorbet_dependencies():
     # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("sorbet/bazel-toolchain/archive/a685e1e6bd1e7cc9a5b84f832539585bb68d8ab4.zip"),
-        sha256 = "90c59f14cada755706a38bdd0f5ad8f0402cbf766387929cfbee9c3f1b4c82d7",
-        strip_prefix = "bazel-toolchain-a685e1e6bd1e7cc9a5b84f832539585bb68d8ab4",
+        urls = _github_public_urls("sorbet/bazel-toolchain/archive/4124470e037b4464a88db71c8565ad44af29664d.zip"),
+        sha256 = "23e9aa7318a6c3bfb2712c4c85e731f1cde8bfdd0d84b39aab6b8746ab7c391e",
+        strip_prefix = "bazel-toolchain-4124470e037b4464a88db71c8565ad44af29664d",
     )
 
     http_archive(


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Being able to compile Sorbet natively on arm64 linux.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested this on a Stripe graviton devbox and was able to successfully run `//test:test_corpus{,_lsp}` on default (i.e. `ENFORCE`s enabled) and `-c opt`.  CI will tell us if I broke anything on the platforms we currently support.
