### PR TITLE
don't pass an explicit `--platforms` for `release-linux` config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -96,7 +96,7 @@ build:release-debug-common --config=skipslowenforce
 
 # harden: mark relocation sections read-only
 build:release-linux --linkopt=-Wl,-z,relro,-z,now
-build:release-linux --config=lto-linux --config=release-common --platforms=@//tools/platforms:linux_x86_64
+build:release-linux --config=lto-linux --config=release-common
 
 # This is to turn on vector instructions where available.
 # We used to do this unconditionally, but Rosetta 2 doesn't translate all vector instructions well.


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Changing this means that builds for Linux can just use `--config=release-linux` without regards to what architecture they're running on.  (Maybe this breaks emscripten, which would be unfortunate?)

It's not obvious to me why #5231 added `--platforms` in various places in the first place.  The explanation given in the discussion for that PR says that they are useful for cross compiling...but I would argue that cross-compiling is juuust exotic enough that you should force people to be explicit about what they're doing and pass the `--platforms` option themselves.  (e.g. Cargo would default to native compilation and requires you to do extra work in the cross-compilation case.  I think Go is roughly the same?)  AIUI, Bazel is capable of selecting the right platform by default.  (I guess this means we should alter the `build:dbg-*` lines in `.bazelrc` that add `--platforms` for Linux, too?)

I think we still have to have `--platforms` for Mac so we don't get universal binaries or somesuch.  And the cross-compilation argument is maybe slightly more compelling there?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Ran `./bazel build --config=release-linux //main:sorbet` and things seem to still work; I confirmed that the objects in `bazel-out/k8-opt` are LLVM IR bitcode rather than regular ELF objects.
