### PR TITLE
Fix Pathname#binread return type

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -414,7 +414,7 @@ class Pathname < Object
         length: Integer,
         offset: Integer,
     )
-    .returns(String)
+    .returns(T.nilable(String))
   end
   def binread(length=T.unsafe(nil), offset=T.unsafe(nil)); end
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`Pathname#binread` is `nil` when the file is empty, or when the offset exceeds the length of the file