### PR TITLE
remove the `Enumerable` sig from `Array#+`

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -445,12 +445,6 @@ class Array < Object
   # [`Array#concat`](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-concat).
   sig do
     params(
-        arg0: T::Enumerable[Elem],
-    )
-    .returns(T::Array[Elem])
-  end
-  sig do
-    params(
         arg0: T::Array[Elem],
     )
     .returns(T::Array[Elem])


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`Array#+`, at least in Ruby 2.7, requires its arg to be an array.  Even if it does permit the more general form in Ruby (we'd have to check), the `Enumerable` sig should come second as the more general case.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
