### PR TITLE
Remove two redundant Timer

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1060,7 +1060,6 @@ vector<uint8_t> Serializer::store(GlobalState &gs) {
 }
 
 std::vector<uint8_t> Serializer::storePayloadAndNameTable(GlobalState &gs) {
-    Timer timeit(gs.tracer(), "Serializer::storePayloadAndNameTable");
     Pickler p = SerializerImpl::pickle(gs, true);
     return p.result();
 }

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -98,7 +98,6 @@ bool retainGlobalState(core::GlobalState &gs, const realmain::options::Options &
         // Verify that no other GlobalState was written to kvstore between when we read GlobalState and wrote it
         // into the databaase.
         if (kvstoreUnchangedSinceGsCreation(gs, maybeGsBytes.data)) {
-            Timer timeit(gs.tracer(), "write_global_state.kvstore");
             // Generate a new UUID, since this GS has changed since it was read.
             gs.kvstoreUuid = Random::uniformU4();
             kvstore->write(GLOBAL_STATE_KEY, core::serialize::Serializer::storePayloadAndNameTable(gs));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These timers 100% overlap with each other, which because of our very minimal
support for generating trace files from timers, means that certain trace viewers
fail to stack these timers properly.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.