### PR TITLE
Start to bring the parser up-to-date with Ruby 3.2

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -870,6 +870,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::location *lloc, ruby_parser:
                       driver.lex.set_state_expr_beg();
                       driver.lex.unset_command_start();
                       driver.pattern_variables.push();
+                      driver.pattern_hash_keys.push();
 
                       $<boolean>$ = driver.lex.context.inKwarg;
                       driver.lex.context.inKwarg = true;
@@ -884,6 +885,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::location *lloc, ruby_parser:
                       driver.lex.set_state_expr_beg();
                       driver.lex.unset_command_start();
                       driver.pattern_variables.push();
+                      driver.pattern_hash_keys.push();
 
                       $<boolean>$ = driver.lex.context.inKwarg;
                       driver.lex.context.inKwarg = true;

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -3215,26 +3215,15 @@ lcurly_block_start:
                       $$ = $1;
                       $$->emplace_back($2);
                     }
-                | p_args_head tSTAR tIDENTIFIER
+                | p_args_head p_rest
                     {
                       $$ = $1;
-                      $$->emplace_back(driver.build.match_rest(self, $2, $3));
+                      $$->emplace_back($2);
                     }
-                | p_args_head tSTAR tIDENTIFIER tCOMMA p_args_post
+                | p_args_head p_rest tCOMMA p_args_post
                     {
                       $$ = $1;
-                      $$->emplace_back(driver.build.match_rest(self, $2, $3));
-                      $$->concat($5);
-                    }
-                | p_args_head tSTAR
-                    {
-                      $$ = $1;
-                      $$->emplace_back(driver.build.match_rest(self, $2, nullptr));
-                    }
-                | p_args_head tSTAR tCOMMA p_args_post
-                    {
-                      $$ = $1;
-                      $$->emplace_back(driver.build.match_rest(self, $2, nullptr));
+                      $$->emplace_back($2);
                       $$->concat($4);
                     }
                 | p_args_tail

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -4405,7 +4405,7 @@ f_opt_paren_args: f_paren_args
                       $$ = $2;
                     }
 
-         trailer:  | tNL | tCOMMA
+         trailer: opt_nl | tCOMMA
 
             term: tSEMI
                   {

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -3731,22 +3731,11 @@ regexp_contents: // nothing
                     {
                       $$ = driver.build.ident(self, $1);
                     }
-                | tIVAR
-                    {
-                      $$ = driver.build.ivar(self, $1);
-                    }
-                | tGVAR
-                    {
-                      $$ = driver.build.gvar(self, $1);
-                    }
                 | tCONSTANT
                     {
                       $$ = driver.build.const_(self, $1);
                     }
-                | tCVAR
-                    {
-                      $$ = driver.build.cvar(self, $1);
-                    }
+                | nonlocal_var
 
 keyword_variable: kNIL
                     {

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -4369,7 +4369,7 @@ f_opt_paren_args: f_paren_args
                     }
 
        operation: tIDENTIFIER | tCONSTANT | tFID
-      operation2: tIDENTIFIER | tCONSTANT | tFID | op
+      operation2: operation | op
       operation3: tIDENTIFIER | tFID | op
     dot_or_colon: call_op | tCOLON2
          call_op: tDOT

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -3404,7 +3404,7 @@ lcurly_block_start:
                       auto non_lvar = driver.build.accessible(self, $2);
                       $$ = driver.build.pin(self, $1, non_lvar);
                     }
-      p_expr_ref: tCARET tLPAREN expr_value tRPAREN
+      p_expr_ref: tCARET tLPAREN expr_value rparen
                     {
                       auto expr = driver.build.begin(self, $2, $3, $4);
                       $$ = driver.build.pin(self, $1, expr);

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_4.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_4.parse-tree-whitequark.exp
@@ -1,0 +1,11 @@
+s(:begin,
+  s(:match_pattern_p,
+    s(:hash,
+      s(:pair,
+        s(:sym, :key),
+        s(:sym, :value))),
+    s(:hash_pattern,
+      s(:pair,
+        s(:sym, :key),
+        s(:match_var, :value)))),
+  s(:lvar, :value))

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_4.rb
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_4.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+{key: :value} in key: value; value

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_5.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_5.parse-tree-whitequark.exp
@@ -1,0 +1,11 @@
+s(:begin,
+  s(:match_pattern,
+    s(:hash,
+      s(:pair,
+        s(:sym, :key),
+        s(:sym, :value))),
+    s(:hash_pattern,
+      s(:pair,
+        s(:sym, :key),
+        s(:match_var, :value)))),
+  s(:lvar, :value))

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_5.rb
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_5.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+{key: :value} => key: value; value

--- a/test/whitequark/test_pin_expr_6.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pin_expr_6.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:pin,
+      s(:begin,
+        s(:int, "1"))), nil, nil), nil)

--- a/test/whitequark/test_pin_expr_6.rb
+++ b/test/whitequark/test_pin_expr_6.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+case foo; in ^(1
+); end

--- a/tools/scripts/import_whitequark.sh
+++ b/tools/scripts/import_whitequark.sh
@@ -14,8 +14,8 @@
 set -euo pipefail
 set -x
 
-REF=3e421d6bc4d7a480d0a0e7aae23afe714a61ea87
-TARGET_RUBY_VERSION="3.1"
+REF=fbc2d7b14b838845af35b3c4596ae61c3f696ad1
+TARGET_RUBY_VERSION="3.2"
 
 SCRIPT=$(realpath "$0")
 ROOT="$(cd "$(dirname "$SCRIPT")/../.."; pwd)"
@@ -54,6 +54,7 @@ bundle exec racc --superclass=Parser::Base lib/parser/ruby26.y -o lib/parser/rub
 bundle exec racc --superclass=Parser::Base lib/parser/ruby27.y -o lib/parser/ruby27.rb --no-line-convert
 bundle exec racc --superclass=Parser::Base lib/parser/ruby30.y -o lib/parser/ruby30.rb --no-line-convert
 bundle exec racc --superclass=Parser::Base lib/parser/ruby31.y -o lib/parser/ruby31.rb --no-line-convert
+bundle exec racc --superclass=Parser::Base lib/parser/ruby32.y -o lib/parser/ruby32.rb --no-line-convert
 bundle exec racc --superclass=Parser::Base lib/parser/macruby.y -o lib/parser/macruby.rb --no-line-convert
 bundle exec racc --superclass=Parser::Base lib/parser/rubymotion.y -o lib/parser/rubymotion.rb --no-line-convert
 


### PR DESCRIPTION
Every commit in this PR corresponds to a [commit on the whitequark parser for Ruby 3.2](https://github.com/whitequark/parser/commits/master/lib/parser/ruby32.y). It will probably be easiest to review this PR by going commit-by-commit and comparing to the corresponding whitequark commit, which I've linked in the commit messages.

### Motivation
The primary motivation of this PR is to group together a bunch of small changes/refactors to the parser that reflect the current state of the whitequark parser. A couple of larger changes will be created in separate PRs.

### Test plan
New whitequark parser tests have been imported using the `tools/scripts/import_whitequark.sh` script.

### Note

There are two sets of changes that I have not brought over in this PR:

1. whitequark/parser@820cc04b8d176c6f46ccc9a010c55f6113f4b2ad or whitequark/parser@1d275fc21227f538a2dda74a54939cd55b1c9200 -- there are some aspects of translating them to the Sorbet parser grammar that I don't understand yet, but I'll try to address them in a future PR.

2. Forwarding anonymous rest and kwrest args -- this requires changes in the Desugarer and probably in the resolver, so I will make those changes separately.
