### PR TITLE
Add Kernel#callcc and Kernel#set_trace_func type definitions

### DIFF
--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -102,3 +102,30 @@ end
 y = loop do
 end
 puts y # error: This code is unreachable
+
+class Test
+  def test
+    a = 1
+    b = 2
+  end
+end
+
+set_trace_func proc { |event, file, line, id, binding, classname|
+    printf "%8s %s:%-2d %10s %8s\n", event, file, line, id, classname
+}
+t = Test.new
+t.test
+
+set_trace_func(nil)
+
+require "continuation"
+callcc {|cont|
+  for i in 0..4
+    print "\n#{i}: "
+    for j in i*5...(i+1)*5
+      cont.call() if j == 17
+      printf "%3d", j
+    end
+  end
+}
+puts


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds type definitions for [`Kernel#callcc`](https://ruby-doc.org/3.2.1/Kernel.html#method-i-callcc) and [`Kernel#set_trace_func`](https://ruby-doc.org/3.2.1/Kernel.html#method-i-set_trace_func)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Resolves https://github.com/sorbet/sorbet/issues/6879

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. (However, I'm unable to test locally due to https://github.com/sorbet/sorbet/issues/6811 )
