### PR TITLE
Add flagged logic in autoloader to onboard all non-legacy packages to path-based autoloading

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -63,6 +63,11 @@ public:
         return false;
     }
 
+    bool legacyAutoloaderCompatibility() const {
+        notImplemented();
+        return true;
+    }
+
     bool exportAll() const {
         notImplemented();
         return false;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -65,6 +65,7 @@ public:
 
     virtual bool ownsSymbol(const core::GlobalState &gs, core::SymbolRef symbol) const = 0;
     virtual bool strictAutoloaderCompatibility() const = 0;
+    virtual bool legacyAutoloaderCompatibility() const = 0;
     virtual bool exportAll() const = 0;
 
     // Utilities:

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -339,8 +339,9 @@ void DefTreeBuilder::markPackages(const core::GlobalState &gs, DefTree &root, co
 
     for (auto nr : gs.packageDB().packages()) {
         auto &pkg = gs.packageDB().getPackageInfo(nr);
-        if (pkg.strictAutoloaderCompatibility()) {
-            // Only mark strictly path-based autoload compatible packages for now to reduce
+        if (pkg.strictAutoloaderCompatibility() ||
+            (alCfg.pbalNonAnnotatedPackages && !pkg.legacyAutoloaderCompatibility())) {
+            // Only mark path-based autoload compatible packages for now to reduce
             // computation / code generation, given this is the only current use-case for registering
             // packages in this context in the Stripe codebase.
 

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -38,13 +38,6 @@ bool AutoloaderConfig::sameFileCollapsable(const vector<core::NameRef> &module) 
     return !nonCollapsableModuleNames.contains(module);
 }
 
-bool AutoloaderConfig::registeredForPBAL(const vector<core::NameRef> &pkgParts) const {
-    return pbalNamespaces.empty() || (absl::c_any_of(pbalNamespaces, [&pkgParts](auto &pbalNamespace) {
-               return pbalNamespace.size() <= pkgParts.size() &&
-                      std::equal(pbalNamespace.begin(), pbalNamespace.end(), pkgParts.begin());
-           }));
-}
-
 string_view AutoloaderConfig::normalizePath(const core::GlobalState &gs, core::FileRef file) const {
     auto path = file.data(gs).path();
     for (const auto &prefix : stripPrefixes) {
@@ -73,13 +66,6 @@ AutoloaderConfig AutoloaderConfig::enterConfig(core::GlobalState &gs, const real
             refs.emplace_back(gs.enterNameConstant(name));
         }
         out.nonCollapsableModuleNames.emplace(refs);
-    }
-    for (auto &nameParts : cfg.pbalNamespaces) {
-        vector<core::NameRef> refs;
-        for (auto &name : nameParts) {
-            refs.emplace_back(gs.enterNameConstant(name));
-        }
-        out.pbalNamespaces.emplace(refs);
     }
     out.absoluteIgnorePatterns = cfg.absoluteIgnorePatterns;
     out.relativeIgnorePatterns = cfg.relativeIgnorePatterns;
@@ -361,9 +347,6 @@ void DefTreeBuilder::markPackages(const core::GlobalState &gs, DefTree &root, co
             // TODO: (aadi-stripe, 10/24/2022) Remove this functionality once we no longer require
             // special registration.
             auto &pkgFullName = pkg.fullName();
-            if (!alCfg.registeredForPBAL(pkgFullName)) {
-                continue;
-            }
 
             root.markPackageNamespace(pkg.mangledName(), pkgFullName);
             if (testRoot != nullptr) {

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -344,10 +344,6 @@ void DefTreeBuilder::markPackages(const core::GlobalState &gs, DefTree &root, co
             // Only mark path-based autoload compatible packages for now to reduce
             // computation / code generation, given this is the only current use-case for registering
             // packages in this context in the Stripe codebase.
-
-            // Additionally this package must be registed for path-based autoloading.
-            // TODO: (aadi-stripe, 10/24/2022) Remove this functionality once we no longer require
-            // special registration.
             auto &pkgFullName = pkg.fullName();
 
             root.markPackageNamespace(pkg.mangledName(), pkgFullName);

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -70,6 +70,7 @@ AutoloaderConfig AutoloaderConfig::enterConfig(core::GlobalState &gs, const real
     out.absoluteIgnorePatterns = cfg.absoluteIgnorePatterns;
     out.relativeIgnorePatterns = cfg.relativeIgnorePatterns;
     out.stripPrefixes = cfg.stripPrefixes;
+    out.pbalNonAnnotatedPackages = cfg.pbalNonAnnotatedPackages;
     return out;
 }
 

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -40,6 +40,7 @@ struct AutoloaderConfig {
     std::vector<std::string> absoluteIgnorePatterns;
     std::vector<std::string> relativeIgnorePatterns;
     std::vector<std::string> stripPrefixes;
+    bool pbalNonAnnotatedPackages = false;
 
     AutoloaderConfig() = default;
     AutoloaderConfig(const AutoloaderConfig &) = delete;

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -27,8 +27,6 @@ struct AutoloaderConfig {
     // Should definitions in this namespace be collapsed into their
     // parent if they all are from the same file?
     bool sameFileCollapsable(const std::vector<core::NameRef> &module) const;
-    // This package is registered for path-based autoloading
-    bool registeredForPBAL(const std::vector<core::NameRef> &pkgParts) const;
     // normalize the path relative to the provided prefixes
     std::string_view normalizePath(const core::GlobalState &gs, core::FileRef file) const;
 
@@ -39,7 +37,6 @@ struct AutoloaderConfig {
     UnorderedSet<core::NameRef> topLevelNamespaceRefs;
     UnorderedSet<core::NameRef> excludedRequireRefs;
     UnorderedSet<std::vector<core::NameRef>> nonCollapsableModuleNames;
-    UnorderedSet<std::vector<core::NameRef>> pbalNamespaces;
     std::vector<std::string> absoluteIgnorePatterns;
     std::vector<std::string> relativeIgnorePatterns;
     std::vector<std::string> stripPrefixes;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -422,6 +422,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "Modules that should never be collapsed into their parent. This helps break cycles "
                                     "in certain cases. (e.g. Foo::Bar::Baz)",
                                     cxxopts::value<vector<string>>());
+    options.add_options("advanced")("autogen-autoloader-pbal-non-annotated",
+                                    "When this flag is set, packages that don't have 'autoloader_compatibility' "
+                                    "annotations use path-based autoloading",
+                                    cxxopts::value<bool>());
     options.add_options("advanced")("autogen-autoloader-strip-prefix",
                                     "Prefixes to strip from file output paths. "
                                     "If path does not start with prefix, nothing is stripped",
@@ -680,6 +684,7 @@ bool extractAutoloaderConfig(cxxopts::ParseResult &raw, Options &opts, shared_pt
     cfg.preamble = raw["autogen-autoloader-preamble"].as<string>();
     cfg.registryModule = raw["autogen-registry-module"].as<string>();
     cfg.rootDir = stripTrailingSlashes(raw["autogen-autoloader-root"].as<string>());
+    cfg.pbalNonAnnotatedPackages = raw["autogen-autoloader-pbal-non-annotated"].as<bool>();
 
     cfg.rootObject = raw["autogen-root-object"].as<string>();
     return true;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -422,9 +422,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "Modules that should never be collapsed into their parent. This helps break cycles "
                                     "in certain cases. (e.g. Foo::Bar::Baz)",
                                     cxxopts::value<vector<string>>());
-    options.add_options("advanced")("autogen-autoloader-pbal-namespaces",
-                                    "Namespaces for which path-based autoloading is enabled.",
-                                    cxxopts::value<vector<string>>());
     options.add_options("advanced")("autogen-autoloader-strip-prefix",
                                     "Prefixes to strip from file output paths. "
                                     "If path does not start with prefix, nothing is stripped",
@@ -678,11 +675,6 @@ bool extractAutoloaderConfig(cxxopts::ParseResult &raw, Options &opts, shared_pt
     if (raw.count("autogen-autoloader-samefile") > 0) {
         for (auto &fullName : raw["autogen-autoloader-samefile"].as<vector<string>>()) {
             cfg.sameFileModules.emplace_back(absl::StrSplit(fullName, "::"));
-        }
-    }
-    if (raw.count("autogen-autoloader-pbal-namespaces") > 0) {
-        for (auto &fullName : raw["autogen-autoloader-pbal-namespaces"].as<vector<string>>()) {
-            cfg.pbalNamespaces.emplace_back(absl::StrSplit(fullName, "::"));
         }
     }
     cfg.preamble = raw["autogen-autoloader-preamble"].as<string>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -118,6 +118,7 @@ struct AutoloaderConfig {
 
     std::vector<std::string> absoluteIgnorePatterns;
     std::vector<std::string> relativeIgnorePatterns;
+    bool pbalNonAnnotatedPackages = false;
 };
 
 struct AutogenConstCacheConfig {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -114,7 +114,6 @@ struct AutoloaderConfig {
     std::string rootObject;
     std::vector<std::string> requireExcludes;
     std::vector<std::vector<std::string>> sameFileModules;
-    std::vector<std::vector<std::string>> pbalNamespaces;
     std::vector<std::string> stripPrefixes;
 
     std::vector<std::string> absoluteIgnorePatterns;

--- a/test/cli/autogen-pkg-autoloader-non-annotated/__package.rb
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# frozen_string_literal: true
+
+class RootPackage < PackageSpec
+  autoloader_compatibility 'legacy'
+
+  export RootPackage::Yabba
+end

--- a/test/cli/autogen-pkg-autoloader-non-annotated/bar.rb
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/bar.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+module RootPackage::Yabba
+  module Dabba
+    class Quuz < AWS::String
+      p 'x'
+    end
+
+    class Jazz
+      class JazBaz
+        VALUE = 1
+        p 'x'
+      end
+    end
+  end
+end

--- a/test/cli/autogen-pkg-autoloader-non-annotated/bar2.rb
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/bar2.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module RootPackage::Yabba::Dabba
+  class Bar2
+    p 'x'
+  end
+
+  class NoBehavior; end
+end

--- a/test/cli/autogen-pkg-autoloader-non-annotated/errors.rb
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/errors.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+module RootPackage::Foo
+  module Errors
+    class BaseError < StandardError
+      def foo
+        'hi'
+      end
+    end
+
+    class MyError1 < BaseError
+      def foo
+        '1'
+      end
+    end
+
+    class MyError2 < BaseError
+      def foo
+        '2'
+      end
+    end
+  end
+end

--- a/test/cli/autogen-pkg-autoloader-non-annotated/foo.rb
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/foo.rb
@@ -1,0 +1,34 @@
+# typed: true
+
+require 'byebug'
+require 'my_gem'
+
+module RootPackage::Foo
+
+  # :Foo doesn't define behavior therefore this constant should get its own
+  # autoloader file.
+  TOP_LEVEL_CONST = some_method
+  # This should also happen for aliases.
+  Dabba = Yabba::Dabba
+
+  module Bar
+    class Quuz
+      p 'x'
+    end
+
+    class Jazz < Quuz
+      class JazBaz
+        p 'x'
+        require 'in_class'
+
+        def honk
+          require 'in_method'
+        end
+      end
+    end
+  end
+end
+
+module ::DontInclude
+  p 1
+end

--- a/test/cli/autogen-pkg-autoloader-non-annotated/inplace.rb
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/inplace.rb
@@ -1,0 +1,3 @@
+module RootPackage::Foo
+  p 1
+end

--- a/test/cli/autogen-pkg-autoloader-non-annotated/nested/__package.rb
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/nested/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# frozen_string_literal: true
+
+class RootPackage::Nested < PackageSpec
+end
+

--- a/test/cli/autogen-pkg-autoloader-non-annotated/nested/nested.rb
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/nested/nested.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RootPackage::Nested; end

--- a/test/cli/autogen-pkg-autoloader-non-annotated/scripts/baz.rb
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/scripts/baz.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+# This file should be excluded
+require 'script_gem'
+
+module RootPackage::Foo::Baz
+  p 'x'
+end

--- a/test/cli/autogen-pkg-autoloader-non-annotated/test.out
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/test.out
@@ -1,0 +1,138 @@
+No errors! Great job.
+
+--- output/RootPackage/Foo/Bar/Jazz.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+
+class RootPackage::Foo::Bar::Jazz < RootPackage::Foo::Bar::Quuz
+end
+
+Opus::Require.for_autoload(RootPackage::Foo::Bar::Jazz, "test/cli/autogen-pkg-autoloader-non-annotated/foo.rb")
+
+--- output/RootPackage/Foo/Bar/Quuz.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+
+class RootPackage::Foo::Bar::Quuz
+end
+
+Opus::Require.for_autoload(RootPackage::Foo::Bar::Quuz, "test/cli/autogen-pkg-autoloader-non-annotated/foo.rb")
+
+--- output/RootPackage/Foo/Dabba.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+
+Opus::Require.for_autoload(nil, "test/cli/autogen-pkg-autoloader-non-annotated/foo.rb", [RootPackage::Foo, :Dabba])
+
+--- output/RootPackage/Foo/Errors/BaseError.rb
+# frozen_string_literal: true
+# typed: true
+
+
+class RootPackage::Foo::Errors::BaseError < StandardError
+end
+
+Opus::Require.for_autoload(RootPackage::Foo::Errors::BaseError, "test/cli/autogen-pkg-autoloader-non-annotated/errors.rb")
+
+--- output/RootPackage/Foo/Errors/MyError1.rb
+# frozen_string_literal: true
+# typed: true
+
+
+class RootPackage::Foo::Errors::MyError1 < RootPackage::Foo::Errors::BaseError
+end
+
+Opus::Require.for_autoload(RootPackage::Foo::Errors::MyError1, "test/cli/autogen-pkg-autoloader-non-annotated/errors.rb")
+
+--- output/RootPackage/Foo/Errors/MyError2.rb
+# frozen_string_literal: true
+# typed: true
+
+
+class RootPackage::Foo::Errors::MyError2 < RootPackage::Foo::Errors::BaseError
+end
+
+Opus::Require.for_autoload(RootPackage::Foo::Errors::MyError2, "test/cli/autogen-pkg-autoloader-non-annotated/errors.rb")
+
+--- output/RootPackage/Foo/TOP_LEVEL_CONST.rb
+# frozen_string_literal: true
+# typed: true
+
+require 'in_class'
+require 'in_method'
+require 'my_gem'
+
+Opus::Require.for_autoload(nil, "test/cli/autogen-pkg-autoloader-non-annotated/foo.rb", [RootPackage::Foo, :TOP_LEVEL_CONST])
+
+--- output/RootPackage/Nested.rb
+# frozen_string_literal: true
+# typed: true
+
+
+module RootPackage::Nested
+end
+
+Opus::Require.pbal_register_package(RootPackage::Nested, 'test/cli/autogen-pkg-autoloader-non-annotated/nested/')
+
+Opus::Require.for_autoload(RootPackage::Nested, "test/cli/autogen-pkg-autoloader-non-annotated/nested/nested.rb")
+
+--- output/RootPackage/Yabba/Dabba/Bar2.rb
+# frozen_string_literal: true
+# typed: true
+
+
+class RootPackage::Yabba::Dabba::Bar2
+end
+
+Opus::Require.for_autoload(RootPackage::Yabba::Dabba::Bar2, "test/cli/autogen-pkg-autoloader-non-annotated/bar2.rb")
+
+--- output/RootPackage/Yabba/Dabba/Jazz.rb
+# frozen_string_literal: true
+# typed: true
+
+
+class RootPackage::Yabba::Dabba::Jazz
+end
+
+--- output/RootPackage/Yabba/Dabba/Jazz/JazBaz.rb
+# frozen_string_literal: true
+# typed: true
+
+
+class RootPackage::Yabba::Dabba::Jazz::JazBaz
+end
+
+Opus::Require.for_autoload(RootPackage::Yabba::Dabba::Jazz::JazBaz, "test/cli/autogen-pkg-autoloader-non-annotated/bar.rb")
+
+--- output/RootPackage/Yabba/Dabba/NoBehavior.rb
+# frozen_string_literal: true
+# typed: true
+
+
+class RootPackage::Yabba::Dabba::NoBehavior
+end
+
+Opus::Require.for_autoload(RootPackage::Yabba::Dabba::NoBehavior, "test/cli/autogen-pkg-autoloader-non-annotated/bar2.rb")
+
+--- output/RootPackage/Yabba/Dabba/Quuz.rb
+# frozen_string_literal: true
+# typed: true
+
+
+class RootPackage::Yabba::Dabba::Quuz < AWS::String
+end
+
+Opus::Require.for_autoload(RootPackage::Yabba::Dabba::Quuz, "test/cli/autogen-pkg-autoloader-non-annotated/bar.rb")
+output/RootPackage/Nested correctly deleted

--- a/test/cli/autogen-pkg-autoloader-non-annotated/test.sh
+++ b/test/cli/autogen-pkg-autoloader-non-annotated/test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eu
+
+preamble="# frozen_string_literal: true
+# typed: true
+"
+
+cwd="$(pwd)"
+tmp=$(mktemp -d)
+mkdir -p "$tmp/test/cli"
+cp -r test/cli/autogen-pkg-autoloader-non-annotated "$tmp/test/cli"
+
+cd "$tmp" || exit 1
+
+mkdir output
+dir_to_delete="output/RootPackage/Nested"
+inner_dir_to_delete="${dir_to_delete}/Inner"
+mkdir -p $inner_dir_to_delete
+touch "$inner_dir_to_delete/__file_to_delete.rb"
+
+"$cwd/main/sorbet" --silence-dev-message --stop-after=namer \
+  --stripe-packages \
+  -p autogen-autoloader:output \
+  --autogen-autoloader-modules=RootPackage \
+  --autogen-autoloader-exclude-require=byebug \
+  --autogen-autoloader-ignore=scripts/ \
+  --autogen-autoloader-preamble "$preamble" \
+  --autogen-autoloader-pbal-non-annotated \
+  test/cli/autogen-pkg-autoloader-non-annotated/{foo,bar,bar2,errors,__package}.rb \
+  test/cli/autogen-pkg-autoloader-non-annotated/nested/*.rb \
+  test/cli/autogen-pkg-autoloader-non-annotated/scripts/baz.rb 2>&1
+
+for file in $(find output -type f | sort | grep -v "_mtime_stamp"); do
+  printf "\n--- %s\n" "$file"
+  cat "$file"
+done
+
+if test -d $dir_to_delete; then
+  echo "ERROR: $dir_to_delete exists"
+else
+  echo "$dir_to_delete correctly deleted"
+fi
+
+rm -rf "$tmp"

--- a/test/cli/autogen-pkg-autoloader/test.sh
+++ b/test/cli/autogen-pkg-autoloader/test.sh
@@ -25,7 +25,6 @@ touch "$inner_dir_to_delete/__file_to_delete.rb"
   --autogen-autoloader-exclude-require=byebug \
   --autogen-autoloader-ignore=scripts/ \
   --autogen-autoloader-preamble "$preamble" \
-  --autogen-autoloader-pbal-namespaces RootPackage \
   test/cli/autogen-pkg-autoloader/{foo,bar,bar2,errors,__package}.rb \
   test/cli/autogen-pkg-autoloader/nested/*.rb \
   test/cli/autogen-pkg-autoloader/scripts/baz.rb 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds logic behind a new flag `--autogen-autoloader-pbal-non-annotated`, which will onboard all packages that don't have a `autoloader_compatibility 'legacy'` annotation to path-based autoloading (PBAL).

Also removes an unused flag `--autogen-autoloader-pbal-namespaces`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Ensure that new code in the Stripe codebase is path-based-autoloaded by default.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on the Stripe codebase.