### PR TITLE
Use `new`, not `initialize`, to enforce runtime abstract

### DIFF
--- a/gems/sorbet-runtime/.rubocop.yml
+++ b/gems/sorbet-runtime/.rubocop.yml
@@ -69,6 +69,8 @@ Naming/FileName:
 # You can convey semantic meaning by using is_foo?
 Naming/PredicateName:
   Enabled: false
+Naming/MethodParameterName:
+  Enabled: false
 
 Lint/MissingSuper:
   Exclude:

--- a/gems/sorbet-runtime/test/types/validate_override_shape.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_shape.rb
@@ -227,5 +227,21 @@ module Opus::Types::Test
       end
       assert_equal(0, klass.new.foo)
     end
+
+    it "raises if initialize is not compatible with parent" do
+      klass = Class.new(AbstractBase) do
+        extend T::Sig
+        sig do
+          override
+          .params(x: Integer)
+          .void
+        end
+        def initialize(x); end
+      end
+      err = assert_raises(RuntimeError) do
+        klass.new(0)
+      end
+      assert_includes(err.message, "must have no more than 0 required argument(s) to be compatible")
+    end
   end
 end

--- a/gems/sorbet-runtime/test/types/validate_override_shape.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_shape.rb
@@ -220,7 +220,10 @@ module Opus::Types::Test
         extend T::Sig
         sig {override.void}
         def initialize; end
-        def foo; 0; end
+
+        def foo
+          0
+        end
       end
       assert_equal(0, klass.new.foo)
     end

--- a/gems/sorbet-runtime/test/types/validate_override_shape.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_shape.rb
@@ -23,6 +23,12 @@ module Opus::Types::Test
       def foo(req, opt=nil, kwreq:, kwopt: nil, &blk); end
     end
 
+    class AbstractBase
+      extend T::Sig
+      sig {abstract.void}
+      def initialize; end
+    end
+
     it "succeeds if the override matches the shape" do
       klass = Class.new(Base) do
         extend T::Sig
@@ -207,6 +213,16 @@ module Opus::Types::Test
         def foo; end
       end
       klass.new.foo
+    end
+
+    it "does opt-in override checking on initialize" do
+      klass = Class.new(AbstractBase) do
+        extend T::Sig
+        sig {override.void}
+        def initialize; end
+        def foo; 0; end
+      end
+      assert_equal(0, klass.new.foo)
     end
   end
 end


### PR DESCRIPTION
**Note to users**: this PR might cause new errors in any code that was
previously defining `initialize` in an `abstract!` class and then trying to
instantiate it at runtime.

Doing that would have had the effect of redefining the method that
`sorbet-runtime` previously defined to enforce that abstract classes can't be
instantiated, which would have allowed the instantiation. This will not happen
anymore.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #3388

The general idea is that people want both:

- runtime enforcement that abstract classes are not instantiated
- the ability to have common initialization code in an abstract class's
  constructor

By moving the "no new" enforcement to happen in `self.new` instead of
`initialize`, we can accomplish this. It's far, far more rare for people to have
valid use cases for overriding `self.new`.

This also unblocks being able to override `initialize` at runtime and mark it
`abstract`, so that it can be used to enforce that all subclasses conform to a
standard contract for constructing new instances.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

I tested this against Stripe's codebase and 17 tests failed that were errantly
attempting to instantiate an abstract class at runtime in a way that Sorbet
couldn't catch statically.