### PR TITLE
Fix error with jemalloc build on macOS

### DIFF
--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -35,12 +35,14 @@ JEMALLOC_BUILD_COMMAND = """
 
   LDFLAGS="$${LTOFLAGS}"
 
+  AUTOGEN_FLAGS=
   case "$$(uname)" in
     Linux)
       LDFLAGS="$${LDFLAGS} -fuse-ld=lld"
       ;;
     Darwin)
       LDFLAGS="$${LDFLAGS} -mlinker-version=400"
+      AUTOGEN_FLAGS=--with-lg-vaddr=48
       ;;
   esac
 
@@ -51,7 +53,7 @@ JEMALLOC_BUILD_COMMAND = """
 
   pushd $$(dirname $(location autogen.sh)) > /dev/null
 
-  if compile_output=$$(./autogen.sh --without-export --disable-shared --enable-static 2>&1 && make build_lib_static -j4 2>&1); then
+  if compile_output=$$(./autogen.sh --without-export --disable-shared --enable-static $AUTOGEN_FLAGS 2>&1 && make build_lib_static -j4 2>&1); then
     popd > /dev/null
     mv $$(dirname $(location autogen.sh))/lib/libjemalloc.a $(location lib/libjemalloc.a)
     mv $$(dirname $(location autogen.sh))/include/jemalloc/jemalloc.h $(location include/jemalloc/jemalloc.h)

--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -53,7 +53,7 @@ JEMALLOC_BUILD_COMMAND = """
 
   pushd $$(dirname $(location autogen.sh)) > /dev/null
 
-  if compile_output=$$(./autogen.sh --without-export --disable-shared --enable-static $AUTOGEN_FLAGS 2>&1 && make build_lib_static -j4 2>&1); then
+  if compile_output=$$(./autogen.sh --without-export --disable-shared --enable-static $$AUTOGEN_FLAGS 2>&1 && make build_lib_static -j4 2>&1); then
     popd > /dev/null
     mv $$(dirname $(location autogen.sh))/lib/libjemalloc.a $(location lib/libjemalloc.a)
     mv $$(dirname $(location autogen.sh))/include/jemalloc/jemalloc.h $(location include/jemalloc/jemalloc.h)


### PR DESCRIPTION
Further discussion here:
<https://github.com/jemalloc/jemalloc/issues/1997>

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Original error output, when I ran `bazel build //main:sorbet
--config=release-mac` on macOS 13.3:

    include/jemalloc/internal/rtree.h:118:3: error: constant expression evaluates to -12 which cannot be narrowed to type 'unsigned int' [-Wc++11-narrowing]
            {RTREE_NSB, RTREE_NHIB + RTREE_NSB}
             ^~~~~~~~~
    include/jemalloc/internal/rtree.h:22:19: note: expanded from macro 'RTREE_NSB'
    #define RTREE_NSB (LG_VADDR - RTREE_NLIB)
                      ^~~~~~~~~~~~~~~~~~~~~~~
    include/jemalloc/internal/rtree.h:118:3: note: insert an explicit cast to silence this issue
            {RTREE_NSB, RTREE_NHIB + RTREE_NSB}
             ^~~~~~~~~
             static_cast<unsigned int>( )
    include/jemalloc/internal/rtree.h:22:19: note: expanded from macro 'RTREE_NSB'
    #define RTREE_NSB (LG_VADDR - RTREE_NLIB)
                      ^~~~~~~~~~~~~~~~~~~~~~~


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.