### PR TITLE
[Ruby3] Add errors on implicit hash to kwarg conversion

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -542,6 +542,35 @@ optional<core::AutocorrectSuggestion> maybeSuggestExtendModule(const GlobalState
         {core::AutocorrectSuggestion::Edit{nextLineLoc.value(), fmt::format("{}extend {}\n", prefix, modStr)}}};
 }
 
+void maybeSuggestDoubleSplat(const core::GlobalState &gs, core::ErrorBuilder &e, core::Loc kwSplatArgLoc) {
+    if (!kwSplatArgLoc.exists()) {
+        return;
+    }
+
+    auto replaceLoc = kwSplatArgLoc;
+    string maybeStarStar = "**";
+    if (kwSplatArgLoc.adjustLen(gs, 0, 2).source(gs) == "**") {
+        replaceLoc = kwSplatArgLoc.adjust(gs, 2, 0);
+        maybeStarStar = "";
+    }
+
+    auto title = fmt::format("Use `{}` for the keyword argument hash", "**");
+    auto replaceValue = replaceLoc.source(gs).value();
+    if (absl::c_all_of(replaceValue, [](char c) { return absl::ascii_isalnum(c) || c == '_'; }) ||
+        (absl::StartsWith(replaceValue, "{") && absl::EndsWith(replaceValue, "}"))) {
+        e.replaceWith(title, replaceLoc, "{}{}", maybeStarStar, replaceValue);
+    } else {
+        e.replaceWith(title, replaceLoc, "{}{{{}}}", maybeStarStar, replaceValue);
+    }
+}
+
+inline bool checkHashKeys(TypePtr argType) {
+    return absl::c_any_of((cast_type<ShapeType>(argType))->keys, [](const TypePtr keyType) {
+        return !isa_type<NamedLiteralType>(keyType) ||
+               cast_type_nonnull<NamedLiteralType>(keyType).literalKind != NamedLiteralType::LiteralTypeKind::Symbol;
+    });
+}
+
 void maybeSuggestUnsafeKwsplat(const core::GlobalState &gs, core::ErrorBuilder &e, core::Loc kwSplatArgLoc) {
     if (!kwSplatArgLoc.exists()) {
         return;
@@ -856,15 +885,23 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         if (spec.flags.isKeyword) {
             break;
         }
-        if (ait + 1 == aend && hasKwargs && (spec.flags.isDefault || spec.flags.isRepeated) &&
-            Types::approximate(gs, arg->type, *constr).derivesFrom(gs, Symbols::Hash())) {
-            break;
-        }
 
         auto offset = ait - args.args.begin();
-        if (auto e = matchArgType(gs, *constr, args.receiverLoc(), symbol, method, *arg, spec, args.selfType, targs,
-                                  args.argLoc(offset), args.originForUninitialized, args.args.size() == 1)) {
-            result.main.errors.emplace_back(std::move(e));
+        auto argType = Types::approximate(gs, arg->type, *constr);
+
+        auto argTypeMatchErr =
+            matchArgType(gs, *constr, args.receiverLoc(), symbol, method, *arg, spec, args.selfType, targs,
+                         args.argLoc(offset), args.originForUninitialized, args.args.size() == 1);
+
+        if (ait + 1 == aend && hasKwargs && (spec.flags.isDefault || spec.flags.isRepeated) && !argType.isUntyped() &&
+            argType.derivesFrom(gs, Symbols::Hash())) {
+            if (!(!argTypeMatchErr && isa_type<ShapeType>(argType) && pit->flags.isDefault && checkHashKeys(argType))) {
+                break;
+            }
+        }
+
+        if (argTypeMatchErr) {
+            result.main.errors.emplace_back(std::move(argTypeMatchErr));
         }
 
         if (!spec.flags.isRepeated) {
@@ -876,11 +913,12 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     // If positional arguments remain, the method accepts keyword arguments, and no keyword arguments were provided in
     // the send, assume that the last argument is an implicit keyword args hash.
     bool implicitKwsplat = false;
+    UnorderedSet<Loc> kwErrors;
     if (ait != aPosEnd && hasKwargs && args.args.size() == args.numPosArgs) {
         auto splatLoc = args.argLoc(args.args.size() - 1);
 
         // If --experimental-ruby3-keyword-args is set, we will treat "**-less" keyword hash argument as an error.
-        if (gs.ruby3KeywordArgs) {
+        if (gs.ruby3KeywordArgs && kwErrors.count(splatLoc) == 0) {
             if (auto e = gs.beginError(splatLoc, errors::Infer::KeywordArgHashWithoutSplat)) {
                 e.setHeader("Keyword argument hash without `{}` is deprecated", "**");
                 e.addErrorLine(splatLoc, "This produces a runtime warning in Ruby 2.7, "
@@ -889,6 +927,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     e.replaceWith(fmt::format("Use `{}` for the keyword argument hash", "**"), splatLoc, "**{}",
                                   source.value());
                 }
+                kwErrors.insert(splatLoc);
             }
         }
         hasKwsplat = true;
@@ -1043,26 +1082,23 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 auto kwSplatValueType = appliedType.targs[1];
 
                 if (hasRequiredKwParam) {
-                    if (auto e = gs.beginError(kwSplatArgLoc, errors::Infer::UntypedSplat)) {
-                        // Unfortunately, this prevents even valid splats:
-                        //     def f(x:, y: 0); end
-                        //     f(x: 0, **opts)
-                        // This should work, but we currently handle kwsplat even before we check
-                        // which keyword args have already been consumed (see below for that).
-                        // This is harder to support, but maybe also less likely:
-                        //     f(**opts, x: 0)
-                        e.setHeader("Cannot call `{}` with a `{}` keyword splat because the method has required "
-                                    "keyword parameters",
-                                    method.show(gs), "Hash");
-                        e.addErrorLine(kwParams.front()->loc,
-                                       "Keyword parameters of `{}` begin here:", method.show(gs));
-                        e.addErrorSection(kwSplatTPO.explainGot(gs, args.originForUninitialized));
-                        e.addErrorNote("Note that Sorbet does not yet handle mixing explicitly-passed keyword args "
-                                       "with splats.\n"
-                                       "    To ignore this and pass the splat anyways, use `{}`",
-                                       "T.unsafe");
-                        maybeSuggestUnsafeKwsplat(gs, e, kwSplatArgLoc);
-                        result.main.errors.emplace_back(e.build());
+                    if (kwErrors.count(kwSplatArgLoc) == 0 &&
+                        !absl::StartsWith(kwSplatArgLoc.source(gs).value(), "**")) {
+                        if (auto e = gs.beginError(kwSplatArgLoc, errors::Infer::UntypedSplat)) {
+                            // Unfortunately, this prevents even valid splats:
+                            //     def f(x:, y: 0); end
+                            //     f(x: 0, **opts)
+                            // This should work, but we currently handle kwsplat even before we check
+                            // which keyword args have already been consumed (see below for that).
+                            // This is harder to support, but maybe also less likely:
+                            //     f(**opts, x: 0)
+                            e.setHeader("Keyword argument hash without `{}` is deprecated", "**");
+                            e.addErrorLine(kwSplatArgLoc, "This produces a runtime warning in Ruby 2.7, "
+                                                          "and will be an error in Ruby 3.0");
+                            maybeSuggestDoubleSplat(gs, e, kwSplatArgLoc);
+                            result.main.errors.emplace_back(e.build());
+                            kwErrors.insert(kwSplatArgLoc);
+                        }
                     }
                 } else if (!Types::isSubTypeUnderConstraint(gs, *constr, kwSplatKeyType, Types::Symbol(),
                                                             UntypedMode::AlwaysCompatible)) {

--- a/test/testdata/infer/ruby3_keyword_args.rb
+++ b/test/testdata/infer/ruby3_keyword_args.rb
@@ -8,7 +8,8 @@ def takes_kwargs(x, y:)
 end
 
 arghash = {y: 42}
-takes_kwargs(99, arghash) # error: Keyword argument hash without `**` is deprecated
+takes_kwargs(99, arghash)
+               # ^^^^^^^ error: Keyword argument hash without `**` is deprecated
 
 takes_kwargs(99, **arghash)
 
@@ -27,3 +28,189 @@ end
 
 blk = Proc.new
 foo("", tags: {}, x: 1, &blk)
+
+def with_base_dir(*segments)
+end
+
+# Alerting, but shouldn't
+Dir[with_base_dir("")].each do |file_path|
+  p file_path
+end
+
+
+# Carried over from test/cli/autocorrect-kwsplat/test.rb
+# For more details see https://github.com/sorbet/sorbet/pull/6771
+sig {params(pos: Integer, x: Integer).void}
+def requires_x(*pos, x:)
+end
+
+sig {params(pos: Integer, x: String).void}
+def optional_x(*pos, x: '')
+end
+
+opts = T::Hash[Symbol, Integer].new
+string_keys = T::Hash[String, Integer].new
+nilble_opts = T::Hash[Symbol, T.nilable(Integer)].new
+x = T.let(:x, Symbol)
+
+# wrong error reported
+requires_x(0, 1, 2, opts)
+                  # ^^^^ error: Keyword argument hash without `**` is deprecated
+requires_x(0, 1, 2, **opts)
+
+requires_x(0, 1, 2, **opts, x: 0)
+
+requires_x(0, 1, 2, x: 0, **opts)
+                  # ^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+requires_x(0, 1, 2, **{x => 0})
+
+optional_x(0, 1, 2, **string_keys)
+                  # ^^^^^^^^^^^^^ error: Expected `Symbol` but found `String` for keyword splat keys type
+
+optional_x(0, 1, 2, **nilble_opts)
+                  # ^^^^^^^^^^^^^ error: Expected `String` for keyword parameter `x` but found `T.nilable(Integer)` from keyword splat
+
+def bar(x:, y: 10)
+  p x
+  p y
+end
+
+bar(x: 10)
+bar(x: 10, y: 20)
+
+args = {x: 10}
+bar(**args)
+bar(x: 20, **args)
+
+other3 = T.let(:bar, Symbol)
+bar(other3 => 10)
+  # ^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+bar(**{other3 => 10})
+
+
+sig {params(x: Integer, y: Integer, z: String).void}
+def f(x, y:, z:)
+  puts x
+  puts y
+  puts z
+end
+
+sig {params(x: Integer, y: Integer, z: String, w: Float).void}
+def g(x, y:, z:, w:)
+  puts x
+  puts y
+  puts z
+  puts w
+end
+
+shaped_hash = {y: 3, z: "hi mom"}
+f(3, shaped_hash)
+   # ^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+f(3, **shaped_hash)
+g(3, **shaped_hash, w: 2.0)
+
+untyped_hash = T.let(shaped_hash, T.untyped)
+f(3, untyped_hash)
+   # ^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+f(3, **untyped_hash)
+g(3, **untyped_hash, w: 2.0)
+
+untyped_values_hash = T.let(shaped_hash, T::Hash[Symbol, T.untyped])
+f(3, untyped_values_hash)
+   # ^^^^^^^^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+f(3, **untyped_values_hash)
+g(3, **untyped_values_hash, w: 2.0)
+
+sig {params(x: Integer, y: Integer, kw_splat: BasicObject).void}
+def h(x, y:, **kw_splat)
+  puts x
+  puts y
+  puts kw_splat
+end
+
+untyped_values_hash = T.let({}, T::Hash[Symbol, T.untyped])
+h(1, y: 2, **untyped_values_hash)
+   # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+
+sig {returns(T.untyped)}
+def make_untyped; T.unsafe("hello"); end
+class Tempfile_
+  extend T::Sig
+  sig do
+    params(
+      basename: T.any(String, [String, String]),
+      tmpdir: T.nilable(String),
+      mode: Integer,
+      options: T.untyped,
+    )
+    .void
+  end
+  def initialize(basename='', tmpdir=nil, mode: 0, **options); end
+end
+
+Tempfile_.new(make_untyped)
+
+module B
+  def self.inner_foo(arg0 = [], arg1: true)
+    p [arg0, arg1]
+
+  end
+  def self.outer_foo(arg0)
+    # probably shouldn't
+    B.inner_foo(arg0)
+  end
+end
+
+
+
+# Ruby 2.7: [[], []] and also a warning
+# Ruby 3.0: [{:arg1=>[]}, true]
+B.inner_foo({:arg1 => []})
+          # ^^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+
+
+hash_args = {}
+hash_args[:arg1] = false
+# Ruby 2.7: [[], false] 
+# Ruby 3.0: [{:arg1=>false}, true] 
+B.inner_foo(hash_args)
+          # ^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+
+B.inner_foo([123])
+array_arg = [123]
+B.inner_foo(array_arg)
+
+# Ruby 2.7: [{"foo"=>"bar"}, {"cred1"=>true, "cred2"=>false, "cred3"=>false, "cred4"=>true}, false, "x"]
+# Ruby 3.0: [{"foo"=>"bar"}, {"cred1"=>true, "cred2"=>false, "cred3"=>false, "cred4"=>true}, false, "x"]
+def takes_default_hash(arg0, arg1 = {}, arg2: false, arg3: "x"); end
+takes_default_hash(
+  {"foo" => "bar"},
+  {"cred1" => true, "cred2" => false, "cred3" => false, "cred4" => true}
+  # The second param here is usually dispatched as a keyword args hash
+  # That's incorrect, but it's impossible to model it correctly rn.
+  # We special cased this use case in calls.cc
+)
+
+# Ruby 2.7: [{"foo"=>"bar"}, {}, true, "y"] 
+# Ruby 3.0: [{"foo"=>"bar"}, {:arg2=>true, :arg3=>"y"}, false, "x"]
+arg1 = {:arg2 => true, :arg3 => "y"}
+takes_default_hash(
+  {"foo" => "bar"},
+  arg1
+# ^^^^ error: Keyword argument hash without `**` is deprecated
+)
+
+# Ruby 2.7: [{"foo"=>"bar"}, {"arg2"=>true, "arg3"=>"y"}, false, "x"]
+# Ruby 3.0: [{"foo"=>"bar"}, {"arg2"=>true, "arg3"=>"y"}, false, "x"]
+takes_default_hash(
+  {"foo" => "bar"},
+  {"arg2" => true, "arg3" => "y"}
+)
+
+# Ruby 2.7: [{"foo"=>"bar"}, {}, true, "y"] 
+# Ruby 3.0: [{"foo"=>"bar"}, {:arg2=>true, :arg3=>"y"}, false, "x"]
+takes_default_hash(
+  {"foo" => "bar"},
+  {arg2: true, arg3: "y"}
+# ^^^^^^^^^^^^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR consolidates all my previous effort on modeling Ruby 3 warnings about implicit hash to keyword conversion.
The code doesn't model Ruby's behavior 100% accurately, see examples in the test. But also the code doesn't produce auto-corrects which generate incorrect syntax.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Ruby 3

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
