### PR TITLE
Fix fast path behavior when changing type_member variance

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2413,7 +2413,11 @@ uint32_t ClassOrModule::hash(const GlobalState &gs, bool skipTypeMemberNames) co
         }
         fast_sort(membersToHash, [](const auto &a, const auto &b) -> bool { return a.rawId() < b.rawId(); });
         for (auto member : membersToHash) {
-            result = mix(result, _hash(member.name(gs).shortName(gs)));
+            if (member.isTypeMember()) {
+                result = mix(result, member.asTypeMemberRef().data(gs)->hash(gs));
+            } else {
+                result = mix(result, _hash(member.name(gs).shortName(gs)));
+            }
         }
     }
     for (const auto &e : mixins_) {

--- a/test/testdata/lsp/fast_path/change_variance__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/change_variance__1.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: true
+# assert-fast-path: change_variance__1.rb,change_variance__2.rb
+
+class Box
+  extend T::Generic
+  Elem = type_member(:out)
+end

--- a/test/testdata/lsp/fast_path/change_variance__1.rb
+++ b/test/testdata/lsp/fast_path/change_variance__1.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+class Box
+  extend T::Generic
+  Elem = type_member
+end

--- a/test/testdata/lsp/fast_path/change_variance__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/change_variance__2.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: true
+# exclude-from-file-update: true
+
+class Parent; end
+class Child < Parent; end
+
+T.let(Box[Child].new, Box[Parent])

--- a/test/testdata/lsp/fast_path/change_variance__2.rb
+++ b/test/testdata/lsp/fast_path/change_variance__2.rb
@@ -1,0 +1,7 @@
+# typed: true
+# spacer for exclude-from-file-update
+
+class Parent; end
+class Child < Parent; end
+
+T.let(Box[Child].new, Box[Parent]) # error: does not have asserted type

--- a/test/testdata/lsp/fast_path/has_attached_class__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/has_attached_class__1.1.rbupdate
@@ -1,0 +1,13 @@
+# typed: true
+# assert-fast-path: has_attached_class__1.rb,has_attached_class__2.rb
+extend T::Sig
+
+module Inheritable
+  extend T::Helpers
+
+  module ClassMethods
+    extend T::Generic
+    has_attached_class!(:out)
+  end
+  mixes_in_class_methods(ClassMethods)
+end

--- a/test/testdata/lsp/fast_path/has_attached_class__1.rb
+++ b/test/testdata/lsp/fast_path/has_attached_class__1.rb
@@ -1,0 +1,12 @@
+# typed: true
+extend T::Sig
+
+module Inheritable
+  extend T::Helpers
+
+  module ClassMethods
+    extend T::Generic
+    has_attached_class!
+  end
+  mixes_in_class_methods(ClassMethods)
+end

--- a/test/testdata/lsp/fast_path/has_attached_class__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/has_attached_class__2.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# exclude-from-file-update: true
+
+class AbstractModel; end
+class Parent < AbstractModel
+  include Inheritable
+end
+
+T.let(Parent, Inheritable::ClassMethods[AbstractModel])

--- a/test/testdata/lsp/fast_path/has_attached_class__2.rb
+++ b/test/testdata/lsp/fast_path/has_attached_class__2.rb
@@ -1,0 +1,9 @@
+# typed: true
+# spacer for exclude-from-file-update
+
+class AbstractModel; end
+class Parent < AbstractModel
+  include Inheritable
+end
+
+T.let(Parent, Inheritable::ClassMethods[AbstractModel]) # error: does not have asserted type


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Changing the variance of a type member can be handled on the fast path, but needs to correctly figure out which files downstream get retypechecked.

Previously, the set of files only included files that verbatim mentioned the type member. But in fact, there's more files that you might need to typecheck: any file that mentions the name of the class containing the type member.

This fixes that bug.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.