### PR TITLE
Make T::Private::Types::Void a singleton

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -79,7 +79,7 @@ module T::Private::Methods
         raise BuilderError.new("You can't call .void after calling .returns.")
       end
 
-      decl.returns = T::Private::Types::Void.new
+      decl.returns = T::Private::Types::Void::Private::INSTANCE
 
       self
     end

--- a/gems/sorbet-runtime/lib/types/private/types/void.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/void.rb
@@ -3,32 +3,38 @@
 
 # A marking class for when methods return void.
 # Should never appear in types directly.
-class T::Private::Types::Void < T::Types::Base
-  ERROR_MESSAGE = "Validation is being done on an `Void`. Please report this bug at https://github.com/sorbet/sorbet/issues"
+module T::Private::Types
+  class Void < T::Types::Base
+    ERROR_MESSAGE = "Validation is being done on an `Void`. Please report this bug at https://github.com/sorbet/sorbet/issues"
 
-  # The actual return value of `.void` methods.
-  #
-  # Uses `module VOID` because this gives it a readable name when someone
-  # examines it in Pry or with `#inspect` like:
-  #
-  #     T::Private::Types::Void::VOID
-  #
-  module VOID
-    freeze
-  end
+    # The actual return value of `.void` methods.
+    #
+    # Uses `module VOID` because this gives it a readable name when someone
+    # examines it in Pry or with `#inspect` like:
+    #
+    #     T::Private::Types::Void::VOID
+    #
+    module VOID
+      freeze
+    end
 
-  # overrides Base
-  def name
-    "<VOID>"
-  end
+    # overrides Base
+    def name
+      "<VOID>"
+    end
 
-  # overrides Base
-  def valid?(obj)
-    raise ERROR_MESSAGE
-  end
+    # overrides Base
+    def valid?(obj)
+      raise ERROR_MESSAGE
+    end
 
-  # overrides Base
-  private def subtype_of_single?(other)
-    raise ERROR_MESSAGE
+    # overrides Base
+    private def subtype_of_single?(other)
+      raise ERROR_MESSAGE
+    end
+
+    module Private
+      INSTANCE = Void.new.freeze
+    end
   end
 end


### PR DESCRIPTION
From heap-profiler:

```
retained objects by class
-----------------------------------
     13906  T::Private::Types::Void
```

But all these instances are purely identical, so we can save a bit of memory and make it easier on the GC by making it a singleton.

cc @paracycle @jez 