### PR TITLE
Work around rubygems.org being flaky

### DIFF
--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -46,26 +46,23 @@ for gem_archive in "_out_/gems/sorbet-static-$release_version"-*.gem; do
   fi
 done
 
-gem_archive="_out_/gems/sorbet-runtime-$release_version.gem"
-echo "Attempting to publish $gem_archive"
-if ! gem list --remote rubygems.org --exact 'sorbet-runtime' | grep -q "$release_version"; then
-  with_backoff gem push --verbose "$gem_archive"
-else
-  echo "$gem_archive already published."
-fi
+# Sometimes the 'gem push' times out, but after the connection dies, the server
+# decides to finish publishing the gem. So we have to interleave 'gem list' and
+# 'gem push' calls--it's not enough to just check whether it exists once.
+publish_gem() {
+  gem_name=$1
+  gem_archive="_out_/gems/$gem_name-$release_version.gem"
 
-gem_archive="_out_/gems/sorbet-$release_version.gem"
-echo "Attempting to publish $gem_archive"
-if ! gem list --remote rubygems.org --exact 'sorbet' | grep -q "$release_version"; then
-  with_backoff gem push --verbose "$gem_archive"
-else
-  echo "$gem_archive already published."
-fi
+  echo "Attempting to publish $gem_archive"
+  if gem list --remote rubygems.org --exact "$gem_name" | grep -q "$release_version"; then
+    echo "$gem_archive already published."
+    return
+  fi
 
-gem_archive="_out_/gems/sorbet-static-and-runtime-$release_version.gem"
-echo "Attempting to publish $gem_archive"
-if ! gem list --remote rubygems.org --exact 'sorbet-static-and-runtime' | grep -q "$release_version"; then
-  with_backoff gem push --verbose "$gem_archive"
-else
-  echo "$gem_archive already published."
-fi
+  # This is last so the exit code is used as the status code for with_backoff
+  gem push --verbose "$gem_archive"
+}
+
+with_backoff publish_gem "sorbet-runtime"
+with_backoff publish_gem "sorbet"
+with_backoff publish_gem "sorbet-static-and-runtime"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Our nightly rubygems.org publish has failed ~every day for weeks.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Some failing builds:

https://buildkite.com/sorbet/sorbet/builds/26828#01873618-47b5-4845-9458-54102c8c661a

https://buildkite.com/sorbet/sorbet/builds/26905#018754fd-e88d-485a-93e6-b46794bd927d

We see that the problem appears to be that there is a "timeout waiting for first byte" and then on retry, we get an error saying "this version already published"

I plan to test that these changes work by manually kicking off a gem publish build when this lands on master.