### PR TITLE
Hide `<AttachedClass>` constants from autogen

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -199,6 +199,11 @@ public:
         if (original.original == nullptr) {
             return;
         }
+        if (original.symbol.name(ctx) == core::Names::Constants::AttachedClass()) {
+            // This is a reference to a constant like <AttachedClass> that came from the `has_attached_class!` DSL
+            // These are not real constant references.
+            return;
+        }
 
         // Create a new `Reference`
         auto &ref = refs.emplace_back();
@@ -244,6 +249,12 @@ public:
         // autogen only cares about constant assignments/definitions, so bail otherwise
         auto *lhs = ast::cast_tree<ast::ConstantLit>(original.lhs);
         if (lhs == nullptr || lhs->original == nullptr) {
+            return;
+        }
+
+        if (lhs->symbol.name(ctx) == core::Names::Constants::AttachedClass()) {
+            // has_attached_class! create constant assignments that look like `<AttachedClass> = type_member`
+            // which do not actually exist at runtime.
             return;
         }
 

--- a/test/testdata/autogen/has_attached_class.rb
+++ b/test/testdata/autogen/has_attached_class.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+module HasAttachedClassExample
+  extend T::Sig
+  extend T::Generic
+
+  abstract!
+  has_attached_class!
+
+  sig {abstract.returns(T.attached_class)}
+  def example; end
+end

--- a/test/testdata/autogen/has_attached_class.rb.autogen.exp
+++ b/test/testdata/autogen/has_attached_class.rb.autogen.exp
@@ -10,11 +10,6 @@ requires: []
  defines_behavior=1
  is_empty=0
  defining_ref=[HasAttachedClassExample]
-[def id=2]
- type=casgn
- defines_behavior=1
- is_empty=0
- defining_ref=[<AttachedClass>]
 ## refs:
 [ref id=0]
  scope=[]
@@ -44,10 +39,3 @@ requires: []
  resolved=[T]
  loc=test/testdata/autogen/has_attached_class.rb:10
  is_defining_ref=0
-[ref id=4]
- scope=[HasAttachedClassExample]
- name=[<AttachedClass>]
- nesting=[[HasAttachedClassExample]]
- resolved=[HasAttachedClassExample <AttachedClass>]
- loc=test/testdata/autogen/has_attached_class.rb:8
- is_defining_ref=1

--- a/test/testdata/autogen/has_attached_class.rb.autogen.exp
+++ b/test/testdata/autogen/has_attached_class.rb.autogen.exp
@@ -1,0 +1,53 @@
+# ParsedFile: test/testdata/autogen/has_attached_class.rb
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+[def id=1]
+ type=module
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[HasAttachedClassExample]
+[def id=2]
+ type=casgn
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[<AttachedClass>]
+## refs:
+[ref id=0]
+ scope=[]
+ name=[HasAttachedClassExample]
+ nesting=[]
+ resolved=[HasAttachedClassExample]
+ loc=test/testdata/autogen/has_attached_class.rb:3
+ is_defining_ref=1
+[ref id=1]
+ scope=[HasAttachedClassExample]
+ name=[T Sig]
+ nesting=[[HasAttachedClassExample]]
+ resolved=[T Sig]
+ loc=test/testdata/autogen/has_attached_class.rb:4
+ is_defining_ref=0
+[ref id=2]
+ scope=[HasAttachedClassExample]
+ name=[T Generic]
+ nesting=[[HasAttachedClassExample]]
+ resolved=[T Generic]
+ loc=test/testdata/autogen/has_attached_class.rb:5
+ is_defining_ref=0
+[ref id=3]
+ scope=[HasAttachedClassExample]
+ name=[T]
+ nesting=[[HasAttachedClassExample]]
+ resolved=[T]
+ loc=test/testdata/autogen/has_attached_class.rb:10
+ is_defining_ref=0
+[ref id=4]
+ scope=[HasAttachedClassExample]
+ name=[<AttachedClass>]
+ nesting=[[HasAttachedClassExample]]
+ resolved=[HasAttachedClassExample <AttachedClass>]
+ loc=test/testdata/autogen/has_attached_class.rb:8
+ is_defining_ref=1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This feature caused some problems with our preloader, because it made it look
like certain constants were defined when they actually weren't.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Review by commit to see the test before+after.