### PR TITLE
Support Ruby 3.2 forwarded rest and keyword rest args

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -735,7 +735,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     // synthesize a call to
                     //   Magic.callWithSplat(receiver, method, argArray, [&blk])
                     // The callWithSplat implementation (in C++) will unpack a
-                    // tuple type and call into the normal call merchanism.
+                    // tuple type and call into the normal call mechanism.
                     unique_ptr<parser::Node> block;
                     auto argnodes = std::move(send->args);
                     bool anonymousBlockPass = false;

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -986,6 +986,14 @@ public:
         return make_unique<ForwardedArgs>(tokLoc(dots));
     }
 
+    unique_ptr<Node> forwarded_restarg(const token *star) {
+        return make_unique<ForwardedRestArg>(tokLoc(star));
+    }
+
+    unique_ptr<Node> forwarded_kwrestarg(const token *dstar) {
+        return make_unique<ForwardedKwrestArg>(tokLoc(dstar));
+    }
+
     unique_ptr<Node> gvar(const token *tok) {
         return make_unique<GVar>(tokLoc(tok), gs_.enterNameUTF8(tok->view()));
     }
@@ -2200,6 +2208,16 @@ ForeignPtr forwarded_args(SelfPtr builder, const token *dots) {
     return build->toForeign(build->forwarded_args(dots));
 }
 
+ForeignPtr forwarded_restarg(SelfPtr builder, const token *star) {
+    auto build = cast_builder(builder);
+    return build->toForeign(build->forwarded_restarg(star));
+}
+
+ForeignPtr forwarded_kwrestarg(SelfPtr builder, const token *dstar) {
+    auto build = cast_builder(builder);
+    return build->toForeign(build->forwarded_kwrestarg(dstar));
+}
+
 ForeignPtr gvar(SelfPtr builder, const token *tok) {
     auto build = cast_builder(builder);
     return build->toForeign(build->gvar(tok));
@@ -2734,6 +2752,8 @@ struct ruby_parser::builder Builder::interface = {
     for_,
     forward_arg,
     forwarded_args,
+    forwarded_restarg,
+    forwarded_kwrestarg,
     gvar,
     hash_pattern,
     ident,

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -377,6 +377,10 @@ public:
             return true;
         }
 
+        if (parser::isa_node<ForwardedKwrestArg>(nd)) {
+            return true;
+        }
+
         if (auto *pair = parser::cast_node<Pair>(nd)) {
             return parser::isa_node<Symbol>(pair->key.get());
         }

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1958,6 +1958,16 @@ lbrace_cmd_block_start:
                       list->emplace_back(driver.build.splat(self, $3, $4));
                       $$ = list;
                     }
+                | args tCOMMA tSTAR
+                    {
+                      if (!driver.lex.is_declared_anonymous_restarg()) {
+                        driver.diagnostics.emplace_back(dlevel::ERROR, dclass::NoAnonymousRestArg, $3);
+                      }
+
+                      auto &list = $1;
+                      list->emplace_back(driver.build.forwarded_restarg(self, $3));
+                      $$ = list;
+                    }
 
         mrhs_arg: mrhs
                     {

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1931,6 +1931,14 @@ lbrace_cmd_block_start:
                     {
                       $$ = driver.alloc.node_list(driver.build.splat(self, $1, $2));
                     }
+                | tSTAR
+                  {
+                    if (!driver.lex.is_declared_anonymous_restarg()) {
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::NoAnonymousRestArg, $1);
+                    }
+
+                    $$ = driver.alloc.node_list(driver.build.forwarded_restarg(self, $1));
+                  }
                 | args tCOMMA arg_value
                     {
                       auto &list = $1;
@@ -4185,6 +4193,8 @@ f_opt_paren_args: f_paren_args
                     }
                 | kwrest_mark
                     {
+                      driver.lex.declare_anonymous_kwrestarg();
+
                       auto kwrestarg = driver.build.kwrestarg(self, $1, nullptr);
 
                       $$ = driver.alloc.node_list(kwrestarg);
@@ -4240,6 +4250,8 @@ f_opt_paren_args: f_paren_args
                     }
                 | restarg_mark
                     {
+                      driver.lex.declare_anonymous_restarg();
+
                       auto restarg = driver.build.restarg(self, $1, nullptr);
 
                       $$ = driver.alloc.node_list(restarg);
@@ -4377,6 +4389,14 @@ f_opt_paren_args: f_paren_args
                 | tDSTAR arg_value
                     {
                       $$ = driver.build.kwsplat(self, $1, $2);
+                    }
+                | tDSTAR
+                    {
+                      if (!driver.lex.is_declared_anonymous_kwrestarg()) {
+                        driver.diagnostics.emplace_back(dlevel::ERROR, dclass::NoAnonymousKwrestArg, $1);
+                      }
+
+                      $$ = driver.build.forwarded_kwrestarg(self, $1);
                     }
 
        operation: tIDENTIFIER | tCONSTANT | tFID

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -3101,6 +3101,22 @@ bool lexer::is_declared_anonymous_args() {
   return is_declared(ANONYMOUS_BLOCKARG);
 }
 
+void lexer::declare_anonymous_restarg() {
+  declare(ANONYMOUS_RESTARG);
+}
+
+bool lexer::is_declared_anonymous_restarg() {
+  return is_declared(ANONYMOUS_RESTARG);
+}
+
+void lexer::declare_anonymous_kwrestarg() {
+  declare(ANONYMOUS_KWRESTARG);
+}
+
+bool lexer::is_declared_anonymous_kwrestarg() {
+  return is_declared(ANONYMOUS_KWRESTARG);
+}
+
 optional_size lexer::dedentLevel() {
   // We erase @dedentLevel as a precaution to avoid accidentally
   // using a stale value.

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -76,6 +76,8 @@ tuple<string, string> MESSAGES[] = {
     {"ForwardArgAfterRestArg", "... after rest argument"},
     {"InvalidIdToGet", "identifier {} is not valid to get"},
     {"NoAnonymousBlockArg", "no anonymous block parameter"},
+    {"NoAnonymousRestArg", "no anonymous rest parameter"},
+    {"NoAnonymousKwrestArg", "no anonymous keyword rest parameter"},
 
     // Error recovery hints
     {"DedentedEnd", "Hint: this {} token might not be properly closed"},

--- a/parser/parser/include/ruby_parser/builder.hh
+++ b/parser/parser/include/ruby_parser/builder.hh
@@ -86,6 +86,8 @@ struct builder {
                        const token *do_, ForeignPtr body, const token *end);
     ForeignPtr (*forward_arg)(SelfPtr builder, const token *begin, const token *dots, const token *end);
     ForeignPtr (*forwarded_args)(SelfPtr builder, const token *dots);
+    ForeignPtr (*forwarded_restarg)(SelfPtr builder, const token *star);
+    ForeignPtr (*forwarded_kwrestarg)(SelfPtr builder, const token *dstar);
     ForeignPtr (*gvar)(SelfPtr builder, const token *tok);
     ForeignPtr (*hash_pattern)(SelfPtr builder, const token *begin, const node_list *kwargs, const token *end);
     ForeignPtr (*ident)(SelfPtr builder, const token *tok);

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -97,6 +97,8 @@ private:
 
     const std::string FORWARD_ARGS = "FORWARD_ARGS";
     const std::string ANONYMOUS_BLOCKARG = "ANONYMOUS_BLOCKARG";
+    const std::string ANONYMOUS_RESTARG = "ANONYMOUS_RESTARG";
+    const std::string ANONYMOUS_KWRESTARG = "ANONYMOUS_KWRESTARG";
 
     // State before =begin / =end block comment
     int cs_before_block_comment;
@@ -234,6 +236,10 @@ public:
     bool is_declared_forward_args();
     void declare_anonymous_args();
     bool is_declared_anonymous_args();
+    void declare_anonymous_restarg();
+    bool is_declared_anonymous_restarg();
+    void declare_anonymous_kwrestarg();
+    bool is_declared_anonymous_kwrestarg();
 
     optional_size dedentLevel();
 };

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -303,6 +303,18 @@ NodeDef nodes[] = {
         "forwarded_args",
         vector<FieldDef>(),
     },
+    // "*" argument forwarding in call site
+    {
+        "ForwardedRestArg",
+        "forwarded_restarg",
+        vector<FieldDef>(),
+    },
+    // "**" argument forwarding in call site
+    {
+        "ForwardedKwrestArg",
+        "forwarded_kwrestarg",
+        vector<FieldDef>(),
+    },
     // float literal like "1.2"
     {
         "Float",

--- a/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb
+++ b/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb
@@ -1,6 +1,8 @@
 # typed: true
 
 def bar(a, b, c); end
+def baz(a:, b:, c:)
+end
 
 def foo(*)
   bar(*)
@@ -9,4 +11,8 @@ def foo(*)
   T.unsafe(self).bar(*)
   T.unsafe(self).bar(1, *)
   T.unsafe(self).bar(1, 2, *)
+end
+
+def buzz(**)
+  baz(**)
 end

--- a/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb
+++ b/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+def bar(a, b, c); end
+
+def foo(*)
+  bar(*)
+# ^^^^^^ error: Splats are only supported where the size of the array is known statically
+
+  T.unsafe(self).bar(*)
+  T.unsafe(self).bar(1, *)
+  T.unsafe(self).bar(1, 2, *)
+end

--- a/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb
+++ b/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb
@@ -1,18 +1,35 @@
 # typed: true
 
-def bar(a, b, c); end
-def baz(a:, b:, c:)
-end
+def pos_args(a, b, c); end
+def req_kwargs(a:, b:, c:); end
+def opt_kwargs(a: 1, b: 2, c: 3); end
+def all_the_args(a, b: 2, &blk); end
 
 def foo(*)
-  bar(*)
-# ^^^^^^ error: Splats are only supported where the size of the array is known statically
+  pos_args(*)
+# ^^^^^^^^^^^ error: Splats are only supported where the size of the array is known statically
 
-  T.unsafe(self).bar(*)
-  T.unsafe(self).bar(1, *)
-  T.unsafe(self).bar(1, 2, *)
+  T.unsafe(self).pos_args(*)
+  T.unsafe(self).pos_args(1, *)
+  T.unsafe(self).pos_args(1, 2, *)
 end
 
-def buzz(**)
-  baz(**)
+def bar(**)
+  req_kwargs(**)
+  req_kwargs(a: 1, **)
+#            ^^^^^^^^ error: Cannot call `Object#req_kwargs` with a `Hash` keyword splat because the method has required keyword parameters
+  req_kwargs(a: 1, b: 2, **)
+#            ^^^^^^^^^^^^^^ error: Cannot call `Object#req_kwargs` with a `Hash` keyword splat because the method has required keyword parameters
+
+  opt_kwargs(**)
+  opt_kwargs(a: 1, **)
+  opt_kwargs(a: 1, b: 2, **)
+end
+
+def baz(*, **, &)
+  all_the_args(*, **, &)
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Splats are only supported where the size of the array is known statically
+  T.unsafe(self).all_the_args(*, **, &)
+  all_the_args(1, **, &)
+  all_the_args(1, b: 3, &)
 end

--- a/test/whitequark/test_forwarded_argument_with_kwrestarg_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forwarded_argument_with_kwrestarg_0.parse-tree-whitequark.exp
@@ -1,0 +1,8 @@
+s(:def, :foo,
+  s(:args,
+    s(:arg, :argument),
+    s(:kwrestarg, :**)),
+  s(:send, nil, :bar,
+    s(:lvar, :argument),
+    s(:hash,
+      s(:forwarded_kwrestarg))))

--- a/test/whitequark/test_forwarded_argument_with_kwrestarg_0.rb
+++ b/test/whitequark/test_forwarded_argument_with_kwrestarg_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(argument, **); bar(argument, **); end

--- a/test/whitequark/test_forwarded_argument_with_kwrestarg_1.rb
+++ b/test/whitequark/test_forwarded_argument_with_kwrestarg_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo; bar(argument, **); end # error: no anonymous keyword rest parameter

--- a/test/whitequark/test_forwarded_argument_with_restarg_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forwarded_argument_with_restarg_0.parse-tree-whitequark.exp
@@ -1,0 +1,7 @@
+s(:def, :foo,
+  s(:args,
+    s(:arg, :argument),
+    s(:restarg, :*)),
+  s(:send, nil, :bar,
+    s(:lvar, :argument),
+    s(:forwarded_restarg)))

--- a/test/whitequark/test_forwarded_argument_with_restarg_0.rb
+++ b/test/whitequark/test_forwarded_argument_with_restarg_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(argument, *); bar(argument, *); end

--- a/test/whitequark/test_forwarded_argument_with_restarg_1.rb
+++ b/test/whitequark/test_forwarded_argument_with_restarg_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo; bar(argument, *); end # error: no anonymous rest parameter

--- a/test/whitequark/test_forwarded_kwrestarg_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forwarded_kwrestarg_0.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:def, :foo,
+  s(:args,
+    s(:kwrestarg, :**)),
+  s(:send, nil, :bar,
+    s(:hash,
+      s(:forwarded_kwrestarg))))

--- a/test/whitequark/test_forwarded_kwrestarg_0.rb
+++ b/test/whitequark/test_forwarded_kwrestarg_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(**); bar(**); end

--- a/test/whitequark/test_forwarded_kwrestarg_1.rb
+++ b/test/whitequark/test_forwarded_kwrestarg_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo; bar(**); end # error: no anonymous keyword rest parameter

--- a/test/whitequark/test_forwarded_restarg_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forwarded_restarg_0.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:def, :foo,
+  s(:args,
+    s(:restarg, :*)),
+  s(:send, nil, :bar,
+    s(:forwarded_restarg)))

--- a/test/whitequark/test_forwarded_restarg_0.rb
+++ b/test/whitequark/test_forwarded_restarg_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(*); bar(*); end

--- a/test/whitequark/test_forwarded_restarg_1.rb
+++ b/test/whitequark/test_forwarded_restarg_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo; bar(*); end # error: no anonymous rest parameter


### PR DESCRIPTION
### Motivation
This PR adds Sorbet support for forwarded rest and keyword rest args, which were [introduced in Ruby 3.2](https://bugs.ruby-lang.org/issues/18351).

For example:
```
def foo(*)
  bar(*)
end

def baz(**)
  quux(**)
end
```

This PR can be read commit-by-commit. The first few commits add parsing for `ForwardedRestArg` and `ForwardedKwrestArg` nodes and have corresponding commits in the whitequark parser. The remaining commits add support for these nodes in `Desugar.cc`. I heavily based the implementation there on the implementation of forwarded args (`def foo(...); bar(...); end`).

### Test plan
See included automated tests.
