### PR TITLE
Fix Opus::Command in `# typed: strong`

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -459,7 +459,6 @@ public:
     static ExpressionPtr RaiseTypedUnimplemented(core::LocOffsets loc) {
         auto kernel = Constant(loc, core::Symbols::Kernel());
         auto msg = String(loc, core::Names::rewriterRaiseUnimplemented());
-        // T.unsafe so that Sorbet doesn't know this unconditionally raises (avoids introducing dead code errors)
         auto ret = Send1(loc, std::move(kernel), core::Names::raise(), loc, std::move(msg));
         cast_tree<ast::Send>(ret)->flags.isRewriterSynthesized = true;
         return ret;

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -456,6 +456,15 @@ public:
         return ret;
     }
 
+    static ExpressionPtr RaiseTypedUnimplemented(core::LocOffsets loc) {
+        auto kernel = Constant(loc, core::Symbols::Kernel());
+        auto msg = String(loc, core::Names::rewriterRaiseUnimplemented());
+        // T.unsafe so that Sorbet doesn't know this unconditionally raises (avoids introducing dead code errors)
+        auto ret = Send1(loc, std::move(kernel), core::Names::raise(), loc, std::move(msg));
+        cast_tree<ast::Send>(ret)->flags.isRewriterSynthesized = true;
+        return ret;
+    }
+
     static bool isRootScope(const ast::ExpressionPtr &scope) {
         if (ast::isa_tree<ast::EmptyTree>(scope)) {
             return true;

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -85,7 +85,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     flags.isSelfMethod = true;
     flags.discardDef = true;
     auto selfCall = ast::MK::SyntheticMethod(call->loc, call->loc, call->name, std::move(newArgs),
-                                             ast::MK::UntypedNil(call->loc), flags);
+                                             ast::MK::RaiseTypedUnimplemented(call->declLoc), flags);
 
     klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());
     klass->rhs.insert(klass->rhs.begin() + i + 2, std::move(selfCall));

--- a/test/testdata/rewriter/command.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/command.rb.rewrite-tree.exp
@@ -17,7 +17,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.call<<todo method>>(x, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     <runtime method definition of call>
@@ -39,7 +39,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.call<<todo method>>(x, &<blk>)
-      ::T.unsafe(nil)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
     end
 
     <runtime method definition of call>

--- a/test/testdata/rewriter/strong_command.rb
+++ b/test/testdata/rewriter/strong_command.rb
@@ -1,0 +1,15 @@
+# typed: strong
+
+module Opus
+  class Command
+  end
+end
+
+class MyCommand < Opus::Command
+  extend T::Sig
+
+  sig {void}
+  def call
+    nil
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less untyped


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.