### PR TITLE
Add the self parameter for `instance_eval` on `BasicObject`

### DIFF
--- a/rbi/core/basic_object.rbi
+++ b/rbi/core/basic_object.rbi
@@ -261,7 +261,7 @@ class BasicObject
   sig do
     type_parameters(:U)
     .params(
-        blk: T.proc.bind(T.untyped).returns(T.type_parameter(:U)),
+        blk: T.proc.bind(T.untyped).params(arg0: T.untyped).returns(T.type_parameter(:U)),
     )
     .returns(T.type_parameter(:U))
   end

--- a/test/testdata/rbi/basicobject_instance_eval.rb
+++ b/test/testdata/rbi/basicobject_instance_eval.rb
@@ -4,7 +4,7 @@ class A
   sig do
     type_parameters(:U)
     .params(
-        blk: T.proc.bind(T.untyped).param(arg0: T.untyped).returns(T.type_parameter(:U)),
+        blk: T.proc.bind(T.untyped).params(arg0: T.untyped).returns(T.type_parameter(:U)),
     )
     .returns(T.type_parameter(:U))
   end

--- a/test/testdata/rbi/basicobject_instance_eval.rb
+++ b/test/testdata/rbi/basicobject_instance_eval.rb
@@ -9,10 +9,10 @@ class A
     .returns(T.type_parameter(:U))
   end
   def instance_eval(&blk)
-    blk.call
+    blk.call(self)
   end
 end
 
 T.reveal_type(A.new.instance_eval {4}) # error: Revealed type: `Integer`
 A.new.instance_eval {T.reveal_type(self)} # error: Revealed type: `T.untyped`
-A.new.instance_eval {|x| T.reval_type(x)} # error: Revealed type: `T.untyped`
+A.new.instance_eval {|x| T.reveal_type(x)} # error: Revealed type: `T.untyped`

--- a/test/testdata/rbi/basicobject_instance_eval.rb
+++ b/test/testdata/rbi/basicobject_instance_eval.rb
@@ -4,7 +4,7 @@ class A
   sig do
     type_parameters(:U)
     .params(
-        blk: T.proc.bind(T.untyped).returns(T.type_parameter(:U)),
+        blk: T.proc.bind(T.untyped).param(arg0: T.untyped).returns(T.type_parameter(:U)),
     )
     .returns(T.type_parameter(:U))
   end
@@ -15,3 +15,4 @@ end
 
 T.reveal_type(A.new.instance_eval {4}) # error: Revealed type: `Integer`
 A.new.instance_eval {T.reveal_type(self)} # error: Revealed type: `T.untyped`
+A.new.instance_eval {|x| T.reval_type(x)} # error: Revealed type: `T.untyped`

--- a/test/testdata/rbi/basicobject_instance_eval.rb
+++ b/test/testdata/rbi/basicobject_instance_eval.rb
@@ -1,18 +1,5 @@
 # typed: true
-class A
-  extend T::Sig
-  sig do
-    type_parameters(:U)
-    .params(
-        blk: T.proc.bind(T.untyped).params(arg0: T.untyped).returns(T.type_parameter(:U)),
-    )
-    .returns(T.type_parameter(:U))
-  end
-  def instance_eval(&blk)
-    blk.call(self)
-  end
-end
 
-T.reveal_type(A.new.instance_eval {4}) # error: Revealed type: `Integer`
-A.new.instance_eval {T.reveal_type(self)} # error: Revealed type: `T.untyped`
-A.new.instance_eval {|x| T.reveal_type(x)} # error: Revealed type: `T.untyped`
+T.reveal_type(4.instance_eval {4}) # error: Revealed type: `Integer`
+4.instance_eval {T.reveal_type(self)} # error: Revealed type: `T.untyped`
+4.instance_eval {|x| T.reveal_type(x)} # error: Revealed type: `T.untyped`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Before this change needed an escape hatch to use the `obj` parameter in the block version of `instance_eval`

```ruby
# typed: true
extend T::Sig

5.instance_eval {|x| T.reveal_type(x) }
```

current output
```
Revealed type: NilClass https://srb.help/7014
     4 |5.instance_eval {|x| T.reveal_type(x) }
                             ^^^^^^^^^^^^^^^^
  Got NilClass originating from:
    editor.rb:4:
     4 |5.instance_eval {|x| T.reveal_type(x) }
                          ^
Errors: 1
```

Ideally the revealed type should be the type of the receiver (~`T.self_type`) but in this change we settle for `T.untyped`

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
