### PR TITLE
explicitly use one thread per core when using thinlto

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -170,6 +170,9 @@ build:lto --config=static-libs
 
 ## flags that substantially increase Clang&LLVMs ability to devirtualize calls
 build:lto-linux --linkopt=-Wl,--icf=all
+
+# Improves linking time on arm64 hosts
+build:lto-linux --linkopt=-Wl,--thinlto-jobs=all
 build:lto-linux --config=lto
 
 # By default, we make static builds, but we can also use dynamic linking if asked to.

--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -29,7 +29,7 @@ JEMALLOC_BUILD_COMMAND = """
   export OBJCOPY=$$(absolutize $(OBJCOPY))
   export CFLAGS=$(CC_FLAGS)
   export CXXFLAGS=$(CC_FLAGS)
-  export LTOFLAGS="$$([ "$$(uname)" = "Linux" ] && echo "-flto=thin")" # todo: on next clang toolchain upgrade, check if it's fixed and we can re-enable thinlto on mac
+  export LTOFLAGS="$$([ "$$(uname)" = "Linux" ] && echo "-flto=thin -Wl,--thinlto-jobs=all")" # todo: on next clang toolchain upgrade, check if it's fixed and we can re-enable thinlto on mac
   export EXTRA_CFLAGS="$${LTOFLAGS}"
   export EXTRA_CXXFLAGS="-stdlib=libc++ $${EXTRA_CFLAGS}"
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Applies the option `--thinlto-jobs=all` to building the main sorbet target and jemalloc

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Improves build times on graviton / arm64 machines

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
