### PR TITLE
Raise deserialize errors if an enum value is invalid

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -56,6 +56,13 @@ module T::Props
             <<~RUBY
               begin
                 #{transformation}
+              rescue KeyError => e
+                raise_deserialization_error(
+                  #{prop.inspect},
+                  val,
+                  e,
+                )
+                val
               rescue NoMethodError => e
                 raise_deserialization_error(
                   #{prop.inspect},

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -1014,6 +1014,25 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(MyEnum::BAR, roundtripped.deprecated_enum_of_enums)
     end
 
+    it 'raises deserialize errors if the enum value is invalid' do
+      msg_string = nil
+      extra_hash = nil
+      T::Configuration.soft_assert_handler = proc do |msg, extra|
+        msg_string = msg
+        extra_hash = extra
+      end
+
+      EnumStruct.from_hash({'enum' => 'invalid'})
+
+      refute_nil(msg_string)
+      refute_nil(extra_hash)
+      storytime = extra_hash[:storytime]
+      assert_equal(EnumStruct, storytime[:klass])
+      assert_equal(:enum, storytime[:prop])
+      assert_equal('invalid', storytime[:value])
+      assert_includes(storytime[:error], "key not found")
+    end
+
     it 'does not break during serde when used redundantly with legacy T.deprecated_enum' do
       s = RedundantEnumStruct.new(deprecated_enum: MyEnum::FOO)
       serialized = s.serialize


### PR DESCRIPTION
This allows to receive a more useful error when deserializing an invalid value for an enum type. This is a fairly broad fix, but hopefully we shouldn't encounter `KeyError` in deserialization normal process?

### Motivation

If you deserialize a `Struct` with an Enum type today, you get a `KeyError` with no useful information has to what property is invalid nor which value was used for said property. 

### Test plan

See included automated tests.
