### PR TITLE
Revert "Add the self parameter for `instance_eval` on `BasicObject`"

### DIFF
--- a/rbi/core/basic_object.rbi
+++ b/rbi/core/basic_object.rbi
@@ -261,7 +261,7 @@ class BasicObject
   sig do
     type_parameters(:U)
     .params(
-        blk: T.proc.bind(T.untyped).params(arg0: T.untyped).returns(T.type_parameter(:U)),
+        blk: T.proc.bind(T.untyped).returns(T.type_parameter(:U)),
     )
     .returns(T.type_parameter(:U))
   end

--- a/test/testdata/rbi/basicobject_instance_eval.rb
+++ b/test/testdata/rbi/basicobject_instance_eval.rb
@@ -1,5 +1,17 @@
 # typed: true
+class A
+  extend T::Sig
+  sig do
+    type_parameters(:U)
+    .params(
+        blk: T.proc.bind(T.untyped).returns(T.type_parameter(:U)),
+    )
+    .returns(T.type_parameter(:U))
+  end
+  def instance_eval(&blk)
+    blk.call
+  end
+end
 
-T.reveal_type(4.instance_eval {4}) # error: Revealed type: `Integer`
-4.instance_eval {T.reveal_type(self)} # error: Revealed type: `T.untyped`
-4.instance_eval {|x| T.reveal_type(x)} # error: Revealed type: `T.untyped`
+T.reveal_type(A.new.instance_eval {4}) # error: Revealed type: `Integer`
+A.new.instance_eval {T.reveal_type(self)} # error: Revealed type: `T.untyped`


### PR DESCRIPTION
Reverts sorbet/sorbet#6914

This caused type errors on Stripe's codebase that were not first fixed.

We will have to fix those errors first, and then re-open this PR.