### PR TITLE
Annotate `Ripper::PARSER_EVENT_TABLE` and `Ripper::SCANNER_EVENT_TABLE`

### DIFF
--- a/rbi/stdlib/ripper.rbi
+++ b/rbi/stdlib/ripper.rbi
@@ -76,6 +76,12 @@
 # *   aamine@loveruby.net
 # *   http://i.loveruby.net
 class Ripper
+  # This hash contains parser event names and arity to handle them.
+  PARSER_EVENT_TABLE = T.let(T.unsafe(nil), T::Hash[Symbol, Integer])
+
+  # This hash contains scanner event names and arity to handle them.
+  SCANNER_EVENT_TABLE = T.let(T.unsafe(nil), T::Hash[Symbol, Integer])
+
   # This array contains name of all ripper events.
   EVENTS = T.let(T.unsafe(nil), T::Array[Symbol])
 


### PR DESCRIPTION
### Motivation

`Ripper` uses 2 base constants: 
- PARSER_EVENT_TABLE
- SCANNER_EVENT_TABLE

Based on those it defines a few more constant that are well annotated in `sorbet`

```rb
  # This array contains name of parser events.
  PARSER_EVENTS = PARSER_EVENT_TABLE.keys

  # This array contains name of scanner events.
  SCANNER_EVENTS = SCANNER_EVENT_TABLE.keys

  # This array contains name of all ripper events.
  EVENTS = PARSER_EVENTS + SCANNER_EVENTS
```
[source](https://github.com/ruby/ruby/blob/38d255d023373a665ce0d2622ed6e25462653a2a/ext/ripper/lib/ripper/core.rb#L22-L29)

The suggestion is just to add proper annotations for those 2.

### Test plan
I'd appreciate a tip on how to write a proper test for it in the current repo. 

Tested manually by creating a file:

```rb
#typed:strict
Ripper::PARSER_EVENT_TABLE
```

#### Before 

```
manual_test.rb:2: Unable to resolve constant PARSER_EVENT_TABLE https://srb.help/5002
     2 |Ripper::PARSER_EVENT_TABLE
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  Did you mean Ripper::PARSER_EVENTS? Use `-a` to autocorrect
    manual_test.rb:2: Replace with Ripper::PARSER_EVENTS
     2 |Ripper::PARSER_EVENT_TABLE
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/5a46d2b33cca64f18f6d914e94c98470fa4399dc/rbi/stdlib/ripper.rbi#L83: Ripper::PARSER_EVENTS defined here
    83 |  PARSER_EVENTS = T.let(T.unsafe(nil), T::Array[Symbol])
          ^^^^^^^^^^^^^
Errors: 1

```

#### After

Adding an annotation to the `ripper.rbi` turns `srb` check green.