### PR TITLE
give `rescue` better types

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -862,10 +862,10 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                         args.emplace_back(localVar);
 
                         auto isPrivateOk = false;
-                        rescueHandlersBlock->exprs.emplace_back(
-                            isaCheck, loc,
-                            make_insn<Send>(exceptionClass, loc, core::Names::tripleEq(), loc.copyWithZeroLength(),
-                                            args.size(), args, std::move(argLocs), isPrivateOk));
+                        synthesizeExpr(rescueHandlersBlock, isaCheck, loc,
+                                       make_insn<Send>(exceptionClass, loc, core::Names::tripleEq(),
+                                                       loc.copyWithZeroLength(), args.size(), args, std::move(argLocs),
+                                                       isPrivateOk));
 
                         auto otherHandlerBlock = cctx.inWhat.freshBlock(cctx.loops, handlersRubyRegionId);
                         conditionalJump(rescueHandlersBlock, isaCheck, caseBody, otherHandlerBlock, cctx.inWhat, loc);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1491,7 +1491,8 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::GetCurrentException &i) {
-                tp.type = core::Types::untypedUntracked();
+                tp.type = core::Types::any(ctx, core::make_type<core::ClassType>(core::Symbols::Exception()),
+                                           core::Types::nilClass());
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::LoadSelf &l) {

--- a/test/cli/dedup_loc/test.out
+++ b/test/cli/dedup_loc/test.out
@@ -5,7 +5,4 @@ test/cli/dedup_loc/dedup_loc.rb:5: Argument does not have asserted type `NilClas
     test/cli/dedup_loc/dedup_loc.rb:4:
      4 |rescue Exception => e
         ^^^^^^
-    test/cli/dedup_loc/dedup_loc.rb:4:
-     4 |rescue Exception => e
-               ^^^^^^^^^
 Errors: 1

--- a/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
@@ -3,8 +3,8 @@ method ::Object#a {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -16,9 +16,9 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb0(rubyRegionId=0)
-bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: T.untyped, <magic>$6: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: T.untyped)
+    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
@@ -17,8 +17,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$4
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
+    <exceptionClassTemp>$8: T.class_of(StandardError) = <cfgAlias>$9
+    <isaCheckTemp>$10: T::Boolean = <exceptionClassTemp>$8: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/rescue.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue.rb.cfg-text.exp
@@ -16,8 +16,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$8: T.class_of(StandardError) = <cfgAlias>$9
+    <isaCheckTemp>$10: T::Boolean = <exceptionClassTemp>$8: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/rescue.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue.rb.cfg-text.exp
@@ -3,8 +3,8 @@ method ::Object#main {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -15,17 +15,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <magic>$6: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -118,8 +118,8 @@ method ::TestRescue#multiple_rescue {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -130,17 +130,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -165,9 +165,9 @@ bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Mag
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$13: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$14: T::Boolean = <cfgAlias>$13: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$14: T::Boolean = <cfgAlias>$13: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$14 -> (T::Boolean ? bb9 : bb10)
 
 # backedges
@@ -197,8 +197,8 @@ method ::TestRescue#multiple_rescue_classes {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -209,18 +209,18 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
-    baz: T.untyped = <exceptionValue>$3
+bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    baz: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.untyped = alias <C T.untyped>
-    <isaCheckTemp>$9: T.untyped = <cfgAlias>$8: T.untyped.===(baz: T.untyped)
+    <isaCheckTemp>$9: T.untyped = <cfgAlias>$8: T.untyped.===(baz: Exception)
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -237,17 +237,17 @@ bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp
 # backedges
 # - bb3(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>), baz: T.untyped):
+bb7[rubyRegionId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>), baz: Exception):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = baz
+    <returnMethodTemp>$2: Exception = baz
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <magic>$5: T.class_of(<Magic>), baz: T.untyped):
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <magic>$5: T.class_of(<Magic>), baz: Exception):
     <cfgAlias>$11: T.untyped = alias <C T.untyped>
-    <isaCheckTemp>$12: T.untyped = <cfgAlias>$11: T.untyped.===(baz: T.untyped)
+    <isaCheckTemp>$12: T.untyped = <cfgAlias>$11: T.untyped.===(baz: Exception)
     <isaCheckTemp>$12 -> (T.untyped ? bb7 : bb9)
 
 # backedges
@@ -269,8 +269,8 @@ method ::TestRescue#parse_rescue_ensure {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -281,17 +281,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -333,8 +333,8 @@ method ::TestRescue#parse_bug_rescue_empty_else {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$4: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -345,16 +345,16 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: T.untyped, <magic>$4: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$4: T.class_of(<Magic>)):
     <cfgAlias>$7: T.class_of(LoadError) = alias <C LoadError>
-    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(LoadError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(LoadError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<magic>$4: T.class_of(<Magic>)):
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -394,8 +394,8 @@ method ::TestRescue#parse_ruby_bug_12686 {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$5: T.untyped = <get-current-exception>
-    <exceptionValue>$5 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -406,17 +406,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: T.untyped, <magic>$7: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: T.untyped)
+    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
-    <exceptionValue>$5: T.untyped = <get-current-exception>
-    <exceptionValue>$5 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -458,8 +458,8 @@ method ::TestRescue#parse_rescue_mod {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -470,17 +470,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -521,8 +521,8 @@ method ::TestRescue#parse_resbody_list_var {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -533,18 +533,18 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
-    ex: T.untyped = <exceptionValue>$3
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    ex: Exception = <exceptionValue>$3
     <exceptionClassTemp>$7: T.untyped = <self>: TestRescue.foo()
-    <isaCheckTemp>$9: T.untyped = <exceptionClassTemp>$7: T.untyped.===(ex: T.untyped)
+    <isaCheckTemp>$9: T.untyped = <exceptionClassTemp>$7: T.untyped.===(ex: Exception)
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -585,8 +585,8 @@ method ::TestRescue#parse_rescue_else_ensure {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -597,17 +597,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -650,8 +650,8 @@ method ::TestRescue#parse_rescue {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -662,17 +662,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -713,8 +713,8 @@ method ::TestRescue#parse_resbody_var {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -725,18 +725,18 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
-    ex: T.untyped = <exceptionValue>$3
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    ex: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(ex: T.untyped)
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(ex: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -778,8 +778,8 @@ bb0[rubyRegionId=0, firstDead=-1]():
     @ex$11: T.nilable(StandardError) = alias @ex
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -790,18 +790,18 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
-    <rescueTemp>$2: T.untyped = <exceptionValue>$3
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -817,10 +817,10 @@ bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: T.untyped, @ex$11: T.nilable(StandardError)):
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: Exception, @ex$11: T.nilable(StandardError)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    @ex$11: T.untyped = <rescueTemp>$2
+    @ex$11: T.nilable(StandardError) = <rescueTemp>$2
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
@@ -844,8 +844,8 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <statTemp>$3: NilClass = foo
     <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$5: T.untyped = <get-current-exception>
-    <exceptionValue>$5 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -856,17 +856,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: T.untyped, <magic>$7: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: T.untyped)
+    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$4: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$5: T.untyped = <get-current-exception>
-    <exceptionValue>$5 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -909,8 +909,8 @@ method ::TestRescue#parse_ruby_bug_12402 {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -921,9 +921,9 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](foo: NilClass, <exceptionValue>$3: T.untyped, <magic>$7: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](foo: NilClass, <exceptionValue>$3: Exception, <magic>$7: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -975,8 +975,8 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <statTemp>$3: NilClass = foo
     <magic>$9: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$5: T.untyped = <get-current-exception>
-    <exceptionValue>$5 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -987,9 +987,9 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: T.untyped, <magic>$9: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: Exception, <magic>$9: T.class_of(<Magic>)):
     <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$5: T.untyped)
+    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
     <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -1044,8 +1044,8 @@ bb0[rubyRegionId=0, firstDead=-1]():
     []$4: Integer(0) = 0
     <statTemp>$9: T.untyped = []$3: T.untyped.[]([]$4: Integer(0))
     <magic>$17: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$13: T.untyped = <get-current-exception>
-    <exceptionValue>$13 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$13: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$13 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -1056,9 +1056,9 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: T.untyped, <magic>$17: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: Exception, <magic>$17: T.class_of(<Magic>)):
     <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$13: T.untyped)
+    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$13: Exception)
     <isaCheckTemp>$21 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -131,8 +131,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$7: T.class_of(StandardError) = <cfgAlias>$8
+    <isaCheckTemp>$9: T::Boolean = <exceptionClassTemp>$7: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -166,8 +168,10 @@ bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Mag
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    <rescueTemp>$3: Exception = <exceptionValue>$3
     <cfgAlias>$13: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$14: T::Boolean = <cfgAlias>$13: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$12: T.class_of(StandardError) = <cfgAlias>$13
+    <isaCheckTemp>$14: T::Boolean = <exceptionClassTemp>$12: T.class_of(StandardError).===(<rescueTemp>$3: Exception)
     <isaCheckTemp>$14 -> (T::Boolean ? bb9 : bb10)
 
 # backedges
@@ -212,7 +216,8 @@ bb1[rubyRegionId=0, firstDead=-1]():
 bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     baz: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.untyped = alias <C T.untyped>
-    <isaCheckTemp>$9: T.untyped = <cfgAlias>$8: T.untyped.===(baz: Exception)
+    <exceptionClassTemp>$7: T.untyped = <cfgAlias>$8
+    <isaCheckTemp>$9: T.untyped = <exceptionClassTemp>$7: T.untyped.===(baz: Exception)
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
@@ -247,7 +252,8 @@ bb7[rubyRegionId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>), baz: Exception
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <magic>$5: T.class_of(<Magic>), baz: Exception):
     <cfgAlias>$11: T.untyped = alias <C T.untyped>
-    <isaCheckTemp>$12: T.untyped = <cfgAlias>$11: T.untyped.===(baz: Exception)
+    <exceptionClassTemp>$10: T.untyped = <cfgAlias>$11
+    <isaCheckTemp>$12: T.untyped = <exceptionClassTemp>$10: T.untyped.===(baz: Exception)
     <isaCheckTemp>$12 -> (T.untyped ? bb7 : bb9)
 
 # backedges
@@ -282,8 +288,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$7: T.class_of(StandardError) = <cfgAlias>$8
+    <isaCheckTemp>$9: T::Boolean = <exceptionClassTemp>$7: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -346,8 +354,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$4: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$7: T.class_of(LoadError) = alias <C LoadError>
-    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(LoadError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$6: T.class_of(LoadError) = <cfgAlias>$7
+    <isaCheckTemp>$8: T::Boolean = <exceptionClassTemp>$6: T.class_of(LoadError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -407,8 +417,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$5
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
+    <exceptionClassTemp>$9: T.class_of(StandardError) = <cfgAlias>$10
+    <isaCheckTemp>$11: T::Boolean = <exceptionClassTemp>$9: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -471,8 +483,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$7: T.class_of(StandardError) = <cfgAlias>$8
+    <isaCheckTemp>$9: T::Boolean = <exceptionClassTemp>$7: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -598,8 +612,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$8: T.class_of(StandardError) = <cfgAlias>$9
+    <isaCheckTemp>$10: T::Boolean = <exceptionClassTemp>$8: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -663,8 +679,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$7: T.class_of(StandardError) = <cfgAlias>$8
+    <isaCheckTemp>$9: T::Boolean = <exceptionClassTemp>$7: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -728,7 +746,8 @@ bb1[rubyRegionId=0, firstDead=-1]():
 bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     ex: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(ex: Exception)
+    <exceptionClassTemp>$7: T.class_of(StandardError) = <cfgAlias>$8
+    <isaCheckTemp>$9: T::Boolean = <exceptionClassTemp>$7: T.class_of(StandardError).===(ex: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -793,7 +812,8 @@ bb1[rubyRegionId=0, firstDead=-1]():
 bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
     <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$7: T.class_of(StandardError) = <cfgAlias>$8
+    <isaCheckTemp>$9: T::Boolean = <exceptionClassTemp>$7: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -817,10 +837,10 @@ bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: Exception, @ex$11: T.nilable(StandardError)):
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: StandardError, @ex$11: T.nilable(StandardError)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    @ex$11: T.nilable(StandardError) = <rescueTemp>$2
+    @ex$11: StandardError = <rescueTemp>$2
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
@@ -857,8 +877,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$5
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
+    <exceptionClassTemp>$9: T.class_of(StandardError) = <cfgAlias>$10
+    <isaCheckTemp>$11: T::Boolean = <exceptionClassTemp>$9: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -922,8 +944,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](foo: NilClass, <exceptionValue>$3: Exception, <magic>$7: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$9: T.class_of(StandardError) = <cfgAlias>$10
+    <isaCheckTemp>$11: T::Boolean = <exceptionClassTemp>$9: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -988,8 +1012,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: Exception, <magic>$9: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$5
     <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
+    <exceptionClassTemp>$11: T.class_of(StandardError) = <cfgAlias>$12
+    <isaCheckTemp>$13: T::Boolean = <exceptionClassTemp>$11: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -1057,8 +1083,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: Exception, <magic>$17: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$13
     <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$13: Exception)
+    <exceptionClassTemp>$19: T.class_of(StandardError) = <cfgAlias>$20
+    <isaCheckTemp>$21: T::Boolean = <exceptionClassTemp>$19: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$21 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -3,8 +3,8 @@ method ::Object#foo {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb9(rubyRegionId=3)
@@ -15,17 +15,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: Integer(1) = 1
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -16,8 +16,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$7: T.class_of(StandardError) = <cfgAlias>$8
+    <isaCheckTemp>$9: T::Boolean = <exceptionClassTemp>$7: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb10 : bb11)
 
 # backedges

--- a/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
@@ -3,8 +3,8 @@ method ::Object#foo {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$8: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -15,12 +15,12 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped, <magic>$8: T.class_of(<Magic>)):
-    e: T.untyped = <exceptionValue>$3
+bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception, <magic>$8: T.class_of(<Magic>)):
+    e: Exception = <exceptionValue>$3
     <cfgAlias>$13: T.class_of(MyException) = alias <C MyException>
     <statTemp>$11: MyException = <cfgAlias>$13: T.class_of(MyException).new()
     <exceptionClassTemp>$10: T.class_of(MyException) = <statTemp>$11: MyException.class()
-    <isaCheckTemp>$14: T::Boolean = <exceptionClassTemp>$10: T.class_of(MyException).===(e: T.untyped)
+    <isaCheckTemp>$14: T::Boolean = <exceptionClassTemp>$10: T.class_of(MyException).===(e: Exception)
     <isaCheckTemp>$14 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
@@ -18,8 +18,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$4
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
+    <exceptionClassTemp>$8: T.class_of(StandardError) = <cfgAlias>$9
+    <isaCheckTemp>$10: T::Boolean = <exceptionClassTemp>$8: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
@@ -3,8 +3,8 @@ method ::Object#foo {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -17,9 +17,9 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb0(rubyRegionId=0)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <exceptionValue>$4: T.untyped, <magic>$6: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: T.untyped)
+    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
@@ -18,7 +18,8 @@ bb1[rubyRegionId=0, firstDead=-1]():
 bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
     <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$9: T.class_of(Exception) = alias <C Exception>
-    <isaCheckTemp>$10: TrueClass = <cfgAlias>$9: T.class_of(Exception).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$8: T.class_of(Exception) = <cfgAlias>$9
+    <isaCheckTemp>$10: TrueClass = <exceptionClassTemp>$8: T.class_of(Exception).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$10 -> (TrueClass ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
@@ -3,8 +3,8 @@ method ::Object#foo {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -15,11 +15,11 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>)):
-    <rescueTemp>$2: T.untyped = <exceptionValue>$3
+bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$9: T.class_of(Exception) = alias <C Exception>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(Exception).===(<exceptionValue>$3: T.untyped)
-    <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
+    <isaCheckTemp>$10: TrueClass = <cfgAlias>$9: T.class_of(Exception).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$10 -> (TrueClass ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
@@ -38,24 +38,24 @@ bb5[rubyRegionId=4, firstDead=0](<returnMethodTemp>$2: NilClass):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$16: T.nilable(TrueClass)):
-    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: Integer(3), <gotoDeadTemp>$16: NilClass):
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>), <rescueTemp>$2: T.untyped):
+bb7[rubyRegionId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>), <rescueTemp>$2: Exception):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <cfgAlias>$14: T.class_of(MyClass) = alias <C MyClass>
     <statTemp>$12: MyClass = <cfgAlias>$14: T.class_of(MyClass).new()
-    <statTemp>$11: T.untyped = <statTemp>$12: MyClass.foo=(<rescueTemp>$2: T.untyped)
+    <statTemp>$11: Exception = <statTemp>$12: MyClass.foo=(<rescueTemp>$2: Exception)
     <returnMethodTemp>$2: Integer(3) = 3
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$16: TrueClass = true
+bb8[rubyRegionId=2, firstDead=0](<returnMethodTemp>$2: NilClass):
+    <gotoDeadTemp>$16 = true
     <unconditional> -> bb6
 
 # backedges

--- a/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
@@ -17,8 +17,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$7: T.class_of(StandardError) = <cfgAlias>$8
+    <isaCheckTemp>$9: T::Boolean = <exceptionClassTemp>$7: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
@@ -3,8 +3,8 @@ method ::Object#a {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -16,9 +16,9 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb0(rubyRegionId=0)
-bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/retry.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry.rb.cfg-text.exp
@@ -16,15 +16,15 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb10(rubyRegionId=2)
 bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb2(rubyRegionId=0)
 # - bb7(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$13: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$13: T.class_of(<Magic>)):
     <cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$17: T::Boolean = <cfgAlias>$16: T.class_of(StandardError).===(<exceptionValue>$4: T.untyped)
+    <isaCheckTemp>$17: T::Boolean = <cfgAlias>$16: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$17 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
@@ -48,8 +48,8 @@ bb5[rubyRegionId=1, firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.
 # - bb4(rubyRegionId=1)
 # - bb5(rubyRegionId=1)
 bb7[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb8)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb8)
 
 # backedges
 # - bb7(rubyRegionId=1)

--- a/test/testdata/cfg/retry.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry.rb.cfg-text.exp
@@ -23,8 +23,10 @@ bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
 # - bb2(rubyRegionId=0)
 # - bb7(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$13: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$4
     <cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$17: T::Boolean = <cfgAlias>$16: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
+    <exceptionClassTemp>$15: T.class_of(StandardError) = <cfgAlias>$16
+    <isaCheckTemp>$17: T::Boolean = <exceptionClassTemp>$15: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$17 -> (T::Boolean ? bb10 : bb11)
 
 # backedges

--- a/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
@@ -17,15 +17,15 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb13(rubyRegionId=2)
 # - bb15(rubyRegionId=2)
 bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb2(rubyRegionId=0)
 # - bb10(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$25: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
     <cfgAlias>$28: T.class_of(A) = alias <C A>
-    <isaCheckTemp>$29: T::Boolean = <cfgAlias>$28: T.class_of(A).===(<exceptionValue>$4: T.untyped)
+    <isaCheckTemp>$29: T::Boolean = <cfgAlias>$28: T.class_of(A).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$29 -> (T::Boolean ? bb13 : bb14)
 
 # backedges
@@ -69,8 +69,8 @@ bb7[rubyRegionId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.
 # - bb6(rubyRegionId=1)
 # - bb7(rubyRegionId=1)
 bb10[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb11)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb11)
 
 # backedges
 # - bb10(rubyRegionId=1)
@@ -96,9 +96,9 @@ bb13[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClas
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb14[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$25: T.class_of(<Magic>)):
+bb14[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
     <cfgAlias>$38: T.class_of(B) = alias <C B>
-    <isaCheckTemp>$39: T::Boolean = <cfgAlias>$38: T.class_of(B).===(<exceptionValue>$4: T.untyped)
+    <isaCheckTemp>$39: T::Boolean = <cfgAlias>$38: T.class_of(B).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$39 -> (T::Boolean ? bb15 : bb16)
 
 # backedges

--- a/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
@@ -24,8 +24,10 @@ bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
 # - bb2(rubyRegionId=0)
 # - bb10(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$4
     <cfgAlias>$28: T.class_of(A) = alias <C A>
-    <isaCheckTemp>$29: T::Boolean = <cfgAlias>$28: T.class_of(A).===(<exceptionValue>$4: Exception)
+    <exceptionClassTemp>$27: T.class_of(A) = <cfgAlias>$28
+    <isaCheckTemp>$29: T::Boolean = <exceptionClassTemp>$27: T.class_of(A).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$29 -> (T::Boolean ? bb13 : bb14)
 
 # backedges
@@ -97,8 +99,10 @@ bb13[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClas
 # backedges
 # - bb3(rubyRegionId=2)
 bb14[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
+    <rescueTemp>$3: Exception = <exceptionValue>$4
     <cfgAlias>$38: T.class_of(B) = alias <C B>
-    <isaCheckTemp>$39: T::Boolean = <cfgAlias>$38: T.class_of(B).===(<exceptionValue>$4: Exception)
+    <exceptionClassTemp>$37: T.class_of(B) = <cfgAlias>$38
+    <isaCheckTemp>$39: T::Boolean = <exceptionClassTemp>$37: T.class_of(B).===(<rescueTemp>$3: Exception)
     <isaCheckTemp>$39 -> (T::Boolean ? bb15 : bb16)
 
 # backedges

--- a/test/testdata/cfg/retry_nested.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg-text.exp
@@ -17,15 +17,15 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb21(rubyRegionId=2)
 bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb2(rubyRegionId=0)
 # - bb18(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <cfgAlias>$45: T.class_of(B) = alias <C B>
-    <isaCheckTemp>$46: T::Boolean = <cfgAlias>$45: T.class_of(B).===(<exceptionValue>$4: T.untyped)
+    <isaCheckTemp>$46: T::Boolean = <cfgAlias>$45: T.class_of(B).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$46 -> (T::Boolean ? bb21 : bb22)
 
 # backedges
@@ -40,15 +40,15 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
 # - bb4(rubyRegionId=1)
 # - bb16(rubyRegionId=6)
 bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
-    <exceptionValue>$8: T.untyped = <get-current-exception>
-    <exceptionValue>$8 -> (T.untyped ? bb6 : bb7)
+    <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$8 -> (T.nilable(Exception) ? bb6 : bb7)
 
 # backedges
 # - bb5(rubyRegionId=1)
 # - bb13(rubyRegionId=5)
-bb6[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: T.untyped, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb6[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: Exception, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <cfgAlias>$32: T.class_of(A) = alias <C A>
-    <isaCheckTemp>$33: T::Boolean = <cfgAlias>$32: T.class_of(A).===(<exceptionValue>$8: T.untyped)
+    <isaCheckTemp>$33: T::Boolean = <cfgAlias>$32: T.class_of(A).===(<exceptionValue>$8: Exception)
     <isaCheckTemp>$33 -> (T::Boolean ? bb16 : bb17)
 
 # backedges
@@ -92,8 +92,8 @@ bb10[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T
 # - bb9(rubyRegionId=5)
 # - bb10(rubyRegionId=5)
 bb13[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
-    <exceptionValue>$8: T.untyped = <get-current-exception>
-    <exceptionValue>$8 -> (T.untyped ? bb6 : bb14)
+    <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$8 -> (T.nilable(Exception) ? bb6 : bb14)
 
 # backedges
 # - bb13(rubyRegionId=5)
@@ -126,8 +126,8 @@ bb17[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClas
 # backedges
 # - bb15(rubyRegionId=7)
 bb18[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb19)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb19)
 
 # backedges
 # - bb18(rubyRegionId=1)

--- a/test/testdata/cfg/retry_nested.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg-text.exp
@@ -24,8 +24,10 @@ bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
 # - bb2(rubyRegionId=0)
 # - bb18(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$4
     <cfgAlias>$45: T.class_of(B) = alias <C B>
-    <isaCheckTemp>$46: T::Boolean = <cfgAlias>$45: T.class_of(B).===(<exceptionValue>$4: Exception)
+    <exceptionClassTemp>$44: T.class_of(B) = <cfgAlias>$45
+    <isaCheckTemp>$46: T::Boolean = <exceptionClassTemp>$44: T.class_of(B).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$46 -> (T::Boolean ? bb21 : bb22)
 
 # backedges
@@ -47,8 +49,10 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
 # - bb5(rubyRegionId=1)
 # - bb13(rubyRegionId=5)
 bb6[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: Exception, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+    <rescueTemp>$3: Exception = <exceptionValue>$8
     <cfgAlias>$32: T.class_of(A) = alias <C A>
-    <isaCheckTemp>$33: T::Boolean = <cfgAlias>$32: T.class_of(A).===(<exceptionValue>$8: Exception)
+    <exceptionClassTemp>$31: T.class_of(A) = <cfgAlias>$32
+    <isaCheckTemp>$33: T::Boolean = <exceptionClassTemp>$31: T.class_of(A).===(<rescueTemp>$3: Exception)
     <isaCheckTemp>$33 -> (T::Boolean ? bb16 : bb17)
 
 # backedges

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -21,7 +21,8 @@ bb1[rubyRegionId=0, firstDead=-1]():
 bb3[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$11: Exception, <magic>$22: T.class_of(<Magic>)):
     e: Exception = <exceptionValue>$11
     <cfgAlias>$25: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$26: T::Boolean = <cfgAlias>$25: T.class_of(StandardError).===(e: Exception)
+    <exceptionClassTemp>$24: T.class_of(StandardError) = <cfgAlias>$25
+    <isaCheckTemp>$26: T::Boolean = <exceptionClassTemp>$24: T.class_of(StandardError).===(e: Exception)
     <isaCheckTemp>$26 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -6,8 +6,8 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$9: T.class_of(A) = alias <C A>
     <statTemp>$5: Sorbet::Private::Static::Void = <cfgAlias>$7: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$9: T.class_of(A))
     <magic>$22: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$11: T.untyped = <get-current-exception>
-    <exceptionValue>$11 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$11: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$11 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -18,10 +18,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$11: T.untyped, <magic>$22: T.class_of(<Magic>)):
-    e: T.untyped = <exceptionValue>$11
+bb3[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$11: Exception, <magic>$22: T.class_of(<Magic>)):
+    e: Exception = <exceptionValue>$11
     <cfgAlias>$25: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$26: T::Boolean = <cfgAlias>$25: T.class_of(StandardError).===(e: T.untyped)
+    <isaCheckTemp>$26: T::Boolean = <cfgAlias>$25: T.class_of(StandardError).===(e: Exception)
     <isaCheckTemp>$26 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -37,8 +37,8 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$22: T.clas
     <statTemp>$15: {z: Integer(3), w: String("string")} = <magic>$20: T.class_of(<Magic>).<build-hash>(<hashTemp>$16: Symbol(:z), <hashTemp>$17: Integer(3), <hashTemp>$18: Symbol(:w), <hashTemp>$19: String("string"))
     <statTemp>$21: TrueClass = true
     <statTemp>$10: T.untyped = <statTemp>$12: A.f(<statTemp>$15: {z: Integer(3), w: String("string")}, <statTemp>$21: TrueClass)
-    <exceptionValue>$11: T.untyped = <get-current-exception>
-    <exceptionValue>$11 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$11: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$11 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)

--- a/test/testdata/cfg/uaf1.rb.cfg-text.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg-text.exp
@@ -60,7 +60,8 @@ bb7[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
     # outerLoops: 1
     se$1: Exception = <exceptionValue>$8
     <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(se$1: Exception)
+    <exceptionClassTemp>$11: T.class_of(StandardError) = <cfgAlias>$12
+    <isaCheckTemp>$13: T::Boolean = <exceptionClassTemp>$11: T.class_of(StandardError).===(se$1: Exception)
     <isaCheckTemp>$13 -> (T::Boolean ? bb11 : bb12)
 
 # backedges

--- a/test/testdata/cfg/uaf1.rb.cfg-text.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg-text.exp
@@ -50,17 +50,17 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
     # outerLoops: 1
     <self>: A = loadSelf(map)
     <magic>$9: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$8: T.untyped = <get-current-exception>
-    <exceptionValue>$8 -> (T.untyped ? bb7 : bb8)
+    <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$8 -> (T.nilable(Exception) ? bb7 : bb8)
 
 # backedges
 # - bb5(rubyRegionId=1)
 # - bb8(rubyRegionId=2)
-bb7[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <exceptionValue>$8: T.untyped, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
+bb7[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <exceptionValue>$8: Exception, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
-    se$1: T.untyped = <exceptionValue>$8
+    se$1: Exception = <exceptionValue>$8
     <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(se$1: T.untyped)
+    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(se$1: Exception)
     <isaCheckTemp>$13 -> (T::Boolean ? bb11 : bb12)
 
 # backedges
@@ -68,8 +68,8 @@ bb7[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
 bb8[rubyRegionId=2, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$7: Integer(1) = 1
-    <exceptionValue>$8: T.untyped = <get-current-exception>
-    <exceptionValue>$8 -> (T.untyped ? bb7 : bb9)
+    <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$8 -> (T.nilable(Exception) ? bb7 : bb9)
 
 # backedges
 # - bb8(rubyRegionId=2)

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
@@ -3,8 +3,8 @@ method ::Object#main {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -23,8 +23,8 @@ bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untype
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](<self>: Object):
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -779,9 +779,9 @@ method ::Rescues#foo {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
     <magic>$11: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <self>: String = cast(<castTemp>$7: NilClass, String);
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -792,9 +792,9 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.untyped, <magic>$11: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
     <cfgAlias>$14: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$15: T::Boolean = <cfgAlias>$14: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$15: T::Boolean = <cfgAlias>$14: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$15 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -807,8 +807,8 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: String, <magic>$11: T.class_of(<Magic>
     <self>: String = cast(<castTemp>$7: String, String);
     <cfgAlias>$9: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: String = <cfgAlias>$9: T.class_of(T).reveal_type(<self>: String)
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -852,11 +852,11 @@ method ::Rescues#bar {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
     <magic>$11: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.untyped = <get-current-exception>
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <self>: String = cast(<castTemp>$7: NilClass, String);
     <self>: Integer = cast(<castTemp>$19: NilClass, Integer);
     <self>: Float = cast(<castTemp>$28: NilClass, Float);
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -867,9 +867,9 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.untyped, <magic>$11: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
     <cfgAlias>$14: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$15: T::Boolean = <cfgAlias>$14: T.class_of(StandardError).===(<exceptionValue>$3: T.untyped)
+    <isaCheckTemp>$15: T::Boolean = <cfgAlias>$14: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$15 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -882,8 +882,8 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: Float, <magic>$11: T.class_of(<Magic>)
     <self>: String = cast(<castTemp>$7: Float, String);
     <cfgAlias>$9: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: String = <cfgAlias>$9: T.class_of(T).reveal_type(<self>: String)
-    <exceptionValue>$3: T.untyped = <get-current-exception>
-    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -939,9 +939,9 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$5: T.class_of(T) = alias <C T>
     <statTemp>$3: Rescues = <cfgAlias>$5: T.class_of(T).reveal_type(<self>: Rescues)
     <magic>$15: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$7: T.untyped = <get-current-exception>
+    <exceptionValue>$7: T.nilable(Exception) = <get-current-exception>
     <self>: String = cast(<castTemp>$11: NilClass, String);
-    <exceptionValue>$7 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$7 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -952,9 +952,9 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: T.untyped, <magic>$15: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: Exception, <magic>$15: T.class_of(<Magic>)):
     <cfgAlias>$18: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$19: T::Boolean = <cfgAlias>$18: T.class_of(StandardError).===(<exceptionValue>$7: T.untyped)
+    <isaCheckTemp>$19: T::Boolean = <cfgAlias>$18: T.class_of(StandardError).===(<exceptionValue>$7: Exception)
     <isaCheckTemp>$19 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -967,8 +967,8 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: String, <magic>$15: T.class_of(<Magic>
     <self>: String = cast(<castTemp>$11: String, String);
     <cfgAlias>$13: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: String = <cfgAlias>$13: T.class_of(T).reveal_type(<self>: String)
-    <exceptionValue>$7: T.untyped = <get-current-exception>
-    <exceptionValue>$7 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$7: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$7 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)
@@ -1039,17 +1039,17 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-t
     # outerLoops: 1
     <self>: T.class_of(Rescues) = loadSelf(takes_block)
     <magic>$17: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$9: T.untyped = <get-current-exception>
+    <exceptionValue>$9: T.nilable(Exception) = <get-current-exception>
     <self>: Integer = cast(<castTemp>$13: NilClass, Integer);
-    <exceptionValue>$9 -> (T.untyped ? bb7 : bb8)
+    <exceptionValue>$9 -> (T.nilable(Exception) ? bb7 : bb8)
 
 # backedges
 # - bb5(rubyRegionId=1)
 # - bb8(rubyRegionId=2)
-bb7[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: T.untyped, <castTemp>$13: T.nilable(Integer), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
+bb7[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: Exception, <castTemp>$13: T.nilable(Integer), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
     <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$9: T.untyped)
+    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$9: Exception)
     <isaCheckTemp>$21 -> (T::Boolean ? bb11 : bb12)
 
 # backedges
@@ -1063,8 +1063,8 @@ bb8[rubyRegionId=2, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorb
     <self>: Integer = cast(<castTemp>$13: Integer, Integer);
     <cfgAlias>$15: T.class_of(T) = alias <C T>
     <blockReturnTemp>$8: Integer = <cfgAlias>$15: T.class_of(T).reveal_type(<self>: Integer)
-    <exceptionValue>$9: T.untyped = <get-current-exception>
-    <exceptionValue>$9 -> (T.untyped ? bb7 : bb9)
+    <exceptionValue>$9: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$9 -> (T.nilable(Exception) ? bb7 : bb9)
 
 # backedges
 # - bb8(rubyRegionId=2)

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -793,8 +793,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$14: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$15: T::Boolean = <cfgAlias>$14: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$13: T.class_of(StandardError) = <cfgAlias>$14
+    <isaCheckTemp>$15: T::Boolean = <exceptionClassTemp>$13: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$15 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -868,8 +870,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$3
     <cfgAlias>$14: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$15: T::Boolean = <cfgAlias>$14: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <exceptionClassTemp>$13: T.class_of(StandardError) = <cfgAlias>$14
+    <isaCheckTemp>$15: T::Boolean = <exceptionClassTemp>$13: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$15 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -953,8 +957,10 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
 bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: Exception, <magic>$15: T.class_of(<Magic>)):
+    <rescueTemp>$2: Exception = <exceptionValue>$7
     <cfgAlias>$18: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$19: T::Boolean = <cfgAlias>$18: T.class_of(StandardError).===(<exceptionValue>$7: Exception)
+    <exceptionClassTemp>$17: T.class_of(StandardError) = <cfgAlias>$18
+    <isaCheckTemp>$19: T::Boolean = <exceptionClassTemp>$17: T.class_of(StandardError).===(<rescueTemp>$2: Exception)
     <isaCheckTemp>$19 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
@@ -1048,8 +1054,10 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-t
 # - bb8(rubyRegionId=2)
 bb7[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: Exception, <castTemp>$13: T.nilable(Integer), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
+    <rescueTemp>$2$1: Exception = <exceptionValue>$9
     <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$9: Exception)
+    <exceptionClassTemp>$19: T.class_of(StandardError) = <cfgAlias>$20
+    <isaCheckTemp>$21: T::Boolean = <exceptionClassTemp>$19: T.class_of(StandardError).===(<rescueTemp>$2$1: Exception)
     <isaCheckTemp>$21 -> (T::Boolean ? bb11 : bb12)
 
 # backedges

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -22,8 +22,8 @@ bb0[rubyRegionId=0, firstDead=-1]():
     final_attempt: T.untyped = load_arg(final_attempt)
     foo: T.untyped = load_arg(foo)
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb6(rubyRegionId=3)
@@ -34,17 +34,17 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: T.untyped, <magic>$5: T.class_of(<Magic>)):
-    e: T.untyped = <exceptionValue>$4
+bb3[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: Exception, <magic>$5: T.class_of(<Magic>)):
+    e: Exception = <exceptionValue>$4
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(e: T.untyped)
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(e: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb4[rubyRegionId=1, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>)):
-    <exceptionValue>$4: T.untyped = <get-current-exception>
-    <exceptionValue>$4 -> (T.untyped ? bb3 : bb5)
+    <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
 # - bb4(rubyRegionId=1)

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -37,7 +37,8 @@ bb1[rubyRegionId=0, firstDead=-1]():
 bb3[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: Exception, <magic>$5: T.class_of(<Magic>)):
     e: Exception = <exceptionValue>$4
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(e: Exception)
+    <exceptionClassTemp>$7: T.class_of(StandardError) = <cfgAlias>$8
+    <isaCheckTemp>$9: T::Boolean = <exceptionClassTemp>$7: T.class_of(StandardError).===(e: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges

--- a/test/testdata/infer/strong_rescue.rb
+++ b/test/testdata/infer/strong_rescue.rb
@@ -1,17 +1,10 @@
 # typed: strong
 extend T::Sig
 
-# Sorbet's implementation of exceptions currently heavily relies on T.untyped
-# Fixing that involves more work than I have time for, so let's at least just
-# not spam an entire method with untyped squiggles.
-
 sig {void}
 def example1
   begin
   rescue TypeError => e
-# ^^^^^^ error: Conditional branch on `T.untyped`
-# ^^^^^^ error: Conditional branch on `T.untyped`
-    #    ^^^^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
     T.reveal_type(e) # error: `TypeError`
   else
   ensure
@@ -22,9 +15,6 @@ sig {void}
 def example2
   begin
   rescue; puts("")
-# ^^^^^^ error: Conditional branch on `T.untyped`
-# ^^^^^^ error: Conditional branch on `T.untyped`
-# ^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
   ensure
   end
 end
@@ -33,9 +23,6 @@ sig {void}
 def example3
   begin
   rescue => e; T.reveal_type(e)
-# ^^^^^^ error: Conditional branch on `T.untyped`
-# ^^^^^^ error: Conditional branch on `T.untyped`
-    #       ^ error: Argument passed to parameter `other` is `T.untyped`
     #          ^^^^^^^^^^^^^^^^ error: `StandardError`
   ensure
   end
@@ -46,9 +33,6 @@ def example4
   begin
     puts("here we are")
   rescue; puts("")
-# ^^^^^^ error: Conditional branch on `T.untyped`
-# ^^^^^^ error: Conditional branch on `T.untyped`
-# ^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
   ensure
   end
 end
@@ -57,9 +41,6 @@ sig {void}
 def example5
   begin
   rescue Exception => e
-# ^^^^^^ error: Conditional branch on `T.untyped`
-# ^^^^^^ error: Conditional branch on `T.untyped`
-    #    ^^^^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
     T.reveal_type(e) # error: `Exception`
   else
   ensure

--- a/test/testdata/infer/strong_rescue.rb
+++ b/test/testdata/infer/strong_rescue.rb
@@ -53,3 +53,15 @@ def example4
   end
 end
 
+sig {void}
+def example5
+  begin
+  rescue Exception => e
+# ^^^^^^ error: Conditional branch on `T.untyped`
+# ^^^^^^ error: Conditional branch on `T.untyped`
+    #    ^^^^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
+    T.reveal_type(e) # error: `Exception`
+  else
+  ensure
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less noisy squiggles in vscode when you use exception handling in typed files and are highlighting untyped code.

The obvious thing in this PR is giving `GetCurrentException` a real type.  This works for _almost_ everything, except for:

```ruby
# test/testdata/cfg/rescue_complex.rb
class TestRescue
  def meth; 0; end
  def bar; 2; end

  def initialize
    @ex = T.let(nil, T.nilable(StandardError))
  end

  def parse_resbody_var_1()
    begin; meth; rescue => @ex; bar; end
  end
end
```

Because we wind up with control flow that looks like:

```
# backedges
# - bb0(rubyRegionId=0)
# - bb4(rubyRegionId=1)
bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
    <rescueTemp>$2: Exception = <exceptionValue>$3
    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)

# backedges
# - bb3(rubyRegionId=2)
bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: Exception, @ex$11: T.nilable(StandardError)):
    <exceptionValue>$3: NilClass = nil
    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
    @ex$11: T.nilable(StandardError) = <rescueTemp>$2
    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
    <unconditional> -> bb6
```

bb3 is testing whether the current exception is an instance of `StandardError`; bb7 is doing the actual assignment to `@ex`.  Except that bb3 is using the moral equivalent of:

```ruby
StandardError.===(<exceptionValue>)
```

to do the test, and bb7 is using `<rescueTemp>` to do the assignment to `@ex`.  So the information about `StandardError`-ness is stored for `<exceptionValue>`, which we don't care about.  We should have known in bb7 that `<rescueTemp>` is a `StandardError`, and we actually constructed the CFG as:

```ruby
StandardError.===(<rescueTemp>)
```

but we were defeated by dealiasing hereabouts:

https://github.com/sorbet/sorbet/blob/9864768a0854ab8a511f30ce9665a030ce53e0d7/cfg/builder/builder_finalize.cc#L191-L229

because we noticed that `<rescueTemp>` and `<exceptionValue>` are the same thing, thanks to the assignment at the start of bb3.  So we had propagated `<exceptionValue>` into the send, and inhibited Sorbet's inference pass from doing its thing.

The fix is to mark that send as a synthesized expression, so we won't propagate aliases into it.

The CLI test change is...not the greatest, but I think it is acceptable in light of the other changes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
