### PR TITLE
Allow --suggest-unsafe to suggest all-untyped sigs

### DIFF
--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -474,7 +474,11 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
         }
         fmt::format_to(std::back_inserter(ss), ").");
     }
-    if (!guessedSomethingUseful) {
+    if (!guessedSomethingUseful && !ctx.state.suggestUnsafe.has_value()) {
+        // We don't want to condition people to start inserting a bunch of useless signatures filled
+        // with `T.untyped`, unless they've explicitly opted into the behavior with
+        // `--suggest-unsafe` (which usually suggests that they're doing some sort of codemod and
+        // they know what they're asking for).
         return nullopt;
     }
 

--- a/test/testdata/infer/suggest_useless_sig.rb
+++ b/test/testdata/infer/suggest_useless_sig.rb
@@ -1,6 +1,6 @@
 # typed: strict
 # enable-suggest-unsafe: true
 
-def foo(x)
+def foo(x) # error: does not have a `sig`
   T.unsafe(nil)
 end

--- a/test/testdata/infer/suggest_useless_sig.rb
+++ b/test/testdata/infer/suggest_useless_sig.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-suggest-unsafe: true
+
+def foo(x)
+  T.unsafe(nil)
+end

--- a/test/testdata/infer/suggest_useless_sig.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_useless_sig.rb.autocorrects.exp
@@ -3,7 +3,7 @@
 # enable-suggest-unsafe: true
 
 sig { params(x: T.untyped).returns(T.untyped) }
-def foo(x)
+def foo(x) # error: does not have a `sig`
   T.unsafe(nil)
 end
 # ------------------------------

--- a/test/testdata/infer/suggest_useless_sig.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_useless_sig.rb.autocorrects.exp
@@ -1,0 +1,9 @@
+# -- test/testdata/infer/suggest_useless_sig.rb --
+# typed: strict
+# enable-suggest-unsafe: true
+
+sig { params(x: T.untyped).returns(T.untyped) }
+def foo(x)
+  T.unsafe(nil)
+end
+# ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I can imagine that this helps people who want to codemod files up to
`# typed: strict`.

I can also imagine this being useful in a future where it's possible to
toggle the `suggestUnsafe` boolean on and off inside an editor, which would then
allow applying these autocorrects as quickfixes.

(Once we build support for toggling untyped highlighting, we can likely extend
that feature to support `suggestUnsafe` and other GlobalState booleans too)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.