### PR TITLE
add some more exception-handling test cases

### DIFF
--- a/test/testdata/cfg/rescue_complex.rb
+++ b/test/testdata/cfg/rescue_complex.rb
@@ -71,6 +71,7 @@ class TestRescue
     rescue *typed_exceptions => e
       T.reveal_type(e) # error: Revealed type: `T.untyped`
     end
+  end
 
   def parse_rescue_ensure()
     begin; meth; rescue; baz; ensure; bar; end

--- a/test/testdata/cfg/rescue_complex.rb
+++ b/test/testdata/cfg/rescue_complex.rb
@@ -35,6 +35,16 @@ class TestRescue
     end
   end
 
+  def multiple_rescue_classes_varuse()
+    begin
+      meth
+    rescue LoadError, SocketError => baz
+      baz
+    end
+
+    T.reveal_type(baz) # error: Revealed type: `T.untyped`
+  end
+
   def rescue_loop()
     ex = T.let(nil, T.nilable(StandardError))
 
@@ -61,7 +71,6 @@ class TestRescue
     rescue *typed_exceptions => e
       T.reveal_type(e) # error: Revealed type: `T.untyped`
     end
-  end
 
   def parse_rescue_ensure()
     begin; meth; rescue; baz; ensure; bar; end

--- a/test/testdata/cfg/rescue_complex.rb
+++ b/test/testdata/cfg/rescue_complex.rb
@@ -1,10 +1,15 @@
 # typed: true
 class TestRescue
+  extend T::Sig
+
   def meth; 0; end
   def foo; 1; end
   def bar; 2; end
   def baz; 3; end
   def take_arg(x); x; end
+  def untyped_exceptions(); [Exception]; end
+  sig {returns(T::Array[T.class_of(Exception)])}
+  def typed_exceptions(); [Exception]; end
 
   def initialize
     @ex = T.let(nil, T.nilable(StandardError))
@@ -27,6 +32,34 @@ class TestRescue
          # ^^^ error: Unable to resolve constant `Foo`
               # ^^^ error: Unable to resolve constant `Bar`
       baz
+    end
+  end
+
+  def rescue_loop()
+    ex = T.let(nil, T.nilable(StandardError))
+
+    loop do
+      ex = nil
+      begin
+        meth
+      rescue => ex
+      end
+    end
+  end
+
+  def rescue_untyped_splat()
+    begin
+      meth
+    rescue *untyped_exceptions => e
+      T.reveal_type(e) # error: Revealed type: `T.untyped`
+    end
+  end
+
+  def rescue_typed_splat()
+    begin
+      meth
+    rescue *typed_exceptions => e
+      T.reveal_type(e) # error: Revealed type: `T.untyped`
     end
   end
 

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -91,6 +91,40 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 }
 
+method ::TestRescue#untyped_exceptions {
+
+bb0[rubyRegionId=0, firstDead=5]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <cfgAlias>$4: T.class_of(Exception) = alias <C Exception>
+    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
+    <returnMethodTemp>$2: [T.class_of(Exception)] = <magic>$5: T.class_of(<Magic>).<build-array>(<cfgAlias>$4: T.class_of(Exception))
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: [T.class_of(Exception)]
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+
+method ::TestRescue#typed_exceptions {
+
+bb0[rubyRegionId=0, firstDead=5]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <cfgAlias>$4: T.class_of(Exception) = alias <C Exception>
+    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
+    <returnMethodTemp>$2: [T.class_of(Exception)] = <magic>$5: T.class_of(<Magic>).<build-array>(<cfgAlias>$4: T.class_of(Exception))
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: [T.class_of(Exception)]
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+
 method ::TestRescue#initialize {
 
 bb0[rubyRegionId=0, firstDead=10]():
@@ -259,6 +293,240 @@ bb9[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
 # backedges
 # - bb6(rubyRegionId=3)
 bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
+    <unconditional> -> bb1
+
+}
+
+method ::TestRescue#rescue_loop {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <cfgAlias>$6: T.class_of(T) = alias <C T>
+    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
+    keep_for_ide$4: Runtime object representing type: T.nilable(StandardError) = <cfgAlias>$6: T.class_of(T).nilable(<cfgAlias>$8: T.class_of(StandardError))
+    keep_for_ide$4: T.untyped = <keep-alive> keep_for_ide$4
+    <castTemp>$9: NilClass = nil
+    ex: T.nilable(StandardError) = cast(<castTemp>$9: NilClass, T.nilable(StandardError));
+    <block-pre-call-temp>$11: Sorbet::Private::Static::Void = <self>: TestRescue.loop()
+    <selfRestore>$12: TestRescue = <self>
+    <unconditional> -> bb2
+
+# backedges
+# - bb3(rubyRegionId=0)
+# - bb10(rubyRegionId=4)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb13(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$22: NilClass):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb5 : bb3)
+
+# backedges
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=1](<block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue):
+    <returnMethodTemp>$2: T.noreturn = Solve<<block-pre-call-temp>$11, loop>
+    <finalReturn> = return <returnMethodTemp>$2
+    <unconditional> -> bb1
+
+# backedges
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$22: NilClass):
+    # outerLoops: 1
+    <self>: TestRescue = loadSelf(loop)
+    ex: NilClass = nil
+    <magic>$17: T.class_of(<Magic>) = alias <C <Magic>>
+    <exceptionValue>$15: T.untyped = <get-current-exception>
+    <exceptionValue>$15 -> (T.untyped ? bb7 : bb8)
+
+# backedges
+# - bb5(rubyRegionId=1)
+# - bb8(rubyRegionId=2)
+bb7[rubyRegionId=3, firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: T.untyped, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
+    # outerLoops: 1
+    ex: T.untyped = <exceptionValue>$15
+    <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(ex: T.untyped)
+    <isaCheckTemp>$21 -> (T::Boolean ? bb11 : bb12)
+
+# backedges
+# - bb5(rubyRegionId=1)
+bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
+    # outerLoops: 1
+    <blockReturnTemp>$13: T.untyped = <self>: TestRescue.meth()
+    <exceptionValue>$15: T.untyped = <get-current-exception>
+    <exceptionValue>$15 -> (T.untyped ? bb7 : bb9)
+
+# backedges
+# - bb8(rubyRegionId=2)
+bb9[rubyRegionId=5, firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
+    # outerLoops: 1
+    <unconditional> -> bb10
+
+# backedges
+# - bb9(rubyRegionId=5)
+# - bb11(rubyRegionId=3)
+# - bb12(rubyRegionId=3)
+bb10[rubyRegionId=4, firstDead=-1](<self>: TestRescue, ex: T.untyped, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: T.nilable(TrueClass)):
+    # outerLoops: 1
+    <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb13)
+
+# backedges
+# - bb7(rubyRegionId=3)
+bb11[rubyRegionId=3, firstDead=-1](<self>: TestRescue, ex: StandardError, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
+    # outerLoops: 1
+    <exceptionValue>$15: NilClass = nil
+    <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$15: NilClass)
+    <unconditional> -> bb10
+
+# backedges
+# - bb7(rubyRegionId=3)
+bb12[rubyRegionId=3, firstDead=-1](<self>: TestRescue, ex: T.untyped, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped):
+    # outerLoops: 1
+    <gotoDeadTemp>$22: TrueClass = true
+    <unconditional> -> bb10
+
+# backedges
+# - bb10(rubyRegionId=4)
+bb13[rubyRegionId=1, firstDead=1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
+    # outerLoops: 1
+    <blockReturnTemp>$24: T.noreturn = blockreturn<loop> <blockReturnTemp>$13: T.untyped
+    <unconditional> -> bb2
+
+}
+
+method ::TestRescue#rescue_untyped_splat {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
+    <exceptionValue>$3: T.untyped = <get-current-exception>
+    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+
+# backedges
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+    e: T.untyped = <exceptionValue>$3
+    <cfgAlias>$9: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$10: T.untyped = <self>: TestRescue.untyped_exceptions()
+    <exceptionClassTemp>$7: T.untyped = <cfgAlias>$9: T.class_of(<Magic>).<splat>(<statTemp>$10: T.untyped)
+    <isaCheckTemp>$12: T.untyped = <exceptionClassTemp>$7: T.untyped.===(e: T.untyped)
+    <isaCheckTemp>$12 -> (T.untyped ? bb7 : bb8)
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
+    <exceptionValue>$3: T.untyped = <get-current-exception>
+    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+
+# backedges
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+    <unconditional> -> bb6
+
+# backedges
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
+    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>), e: T.untyped):
+    <exceptionValue>$3: NilClass = nil
+    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <cfgAlias>$14: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: T.untyped = <cfgAlias>$14: T.class_of(T).reveal_type(e: T.untyped)
+    <unconditional> -> bb6
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+    <gotoDeadTemp>$16: TrueClass = true
+    <unconditional> -> bb6
+
+# backedges
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
+    <unconditional> -> bb1
+
+}
+
+method ::TestRescue#rescue_typed_splat {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
+    <exceptionValue>$3: T.untyped = <get-current-exception>
+    <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
+
+# backedges
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+    e: T.untyped = <exceptionValue>$3
+    <cfgAlias>$9: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$10: T::Array[T.class_of(Exception)] = <self>: TestRescue.typed_exceptions()
+    <exceptionClassTemp>$7: T::Array[T.class_of(Exception)] = <cfgAlias>$9: T.class_of(<Magic>).<splat>(<statTemp>$10: T::Array[T.class_of(Exception)])
+    <isaCheckTemp>$12: T::Boolean = <exceptionClassTemp>$7: T::Array[T.class_of(Exception)].===(e: T.untyped)
+    <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
+    <exceptionValue>$3: T.untyped = <get-current-exception>
+    <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
+
+# backedges
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+    <unconditional> -> bb6
+
+# backedges
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
+    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>), e: T.untyped):
+    <exceptionValue>$3: NilClass = nil
+    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <cfgAlias>$14: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: T.untyped = <cfgAlias>$14: T.class_of(T).reveal_type(e: T.untyped)
+    <unconditional> -> bb6
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+    <gotoDeadTemp>$16: TrueClass = true
+    <unconditional> -> bb6
+
+# backedges
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -1107,15 +1375,50 @@ bb9[rubyRegionId=0, firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9
 
 method ::<Class:TestRescue>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(TestRescue) = cast(<self>: NilClass, T.class_of(TestRescue));
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(TestRescue))
+    <selfRestore>$8: T.class_of(TestRescue) = <self>
+    <unconditional> -> bb2
+
+# backedges
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
 # - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(TestRescue), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestRescue)):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb5 : bb3)
+
+# backedges
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestRescue)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
+    <self>: T.class_of(TestRescue) = <selfRestore>$8
+    <cfgAlias>$25: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$27: T.class_of(T) = alias <C T>
+    <statTemp>$22: T.class_of(TestRescue) = <self>: T.class_of(TestRescue).extend(<cfgAlias>$25: T.class_of(T::Sig))
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
+
+# backedges
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(TestRescue), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestRescue)):
+    # outerLoops: 1
+    <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
+    <cfgAlias>$13: T.class_of(T::Array) = alias <C Array>
+    <cfgAlias>$15: T.class_of(T) = alias <C T>
+    <cfgAlias>$18: T.class_of(T) = alias <C T>
+    <cfgAlias>$20: T.class_of(Exception) = alias <C Exception>
+    <statTemp>$16: Runtime object representing type: T.class_of(Exception) = <cfgAlias>$18: T.class_of(T).class_of(<cfgAlias>$20: T.class_of(Exception))
+    <statTemp>$11: Runtime object representing type: T::Array[T.class_of(Exception)] = <cfgAlias>$13: T.class_of(T::Array).[](<statTemp>$16: Runtime object representing type: T.class_of(Exception))
+    <blockReturnTemp>$9: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$11: Runtime object representing type: T::Array[T.class_of(Exception)])
+    <blockReturnTemp>$21: T.noreturn = blockreturn<sig> <blockReturnTemp>$9: T::Private::Methods::DeclBuilder
+    <unconditional> -> bb2
 
 }
 

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -298,6 +298,79 @@ bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 }
 
+method ::TestRescue#multiple_rescue_classes_varuse {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
+    <exceptionValue>$4: T.untyped = <get-current-exception>
+    <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
+
+# backedges
+# - bb6(rubyRegionId=3)
+# - bb10(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: T.untyped, <magic>$6: T.class_of(<Magic>)):
+    baz: T.untyped = <exceptionValue>$4
+    <cfgAlias>$9: T.class_of(LoadError) = alias <C LoadError>
+    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(LoadError).===(baz: T.untyped)
+    <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
+    <statTemp>$3: T.untyped = <self>: TestRescue.meth()
+    <exceptionValue>$4: T.untyped = <get-current-exception>
+    <exceptionValue>$4 -> (T.untyped ? bb3 : bb5)
+
+# backedges
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1]():
+    <unconditional> -> bb6
+
+# backedges
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](baz: T.untyped, <gotoDeadTemp>$14: T.nilable(TrueClass)):
+    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb10)
+
+# backedges
+# - bb3(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>), baz: T.any(LoadError, SocketError)):
+    <exceptionValue>$4: NilClass = nil
+    <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
+    <unconditional> -> bb6
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>), baz: T.untyped):
+    <cfgAlias>$12: T.class_of(SocketError) = alias <C SocketError>
+    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(SocketError).===(baz: T.untyped)
+    <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb9)
+
+# backedges
+# - bb8(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=-1](baz: T.untyped):
+    <gotoDeadTemp>$14: TrueClass = true
+    <unconditional> -> bb6
+
+# backedges
+# - bb6(rubyRegionId=3)
+bb10[rubyRegionId=0, firstDead=3](baz: T.untyped):
+    <cfgAlias>$17: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: T.untyped = <cfgAlias>$17: T.class_of(T).reveal_type(baz: T.untyped)
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
+    <unconditional> -> bb1
+
+}
+
 method ::TestRescue#rescue_loop {
 
 bb0[rubyRegionId=0, firstDead=-1]():

--- a/test/testdata/cfg/rescue_complex.rb.desugar-tree.exp
+++ b/test/testdata/cfg/rescue_complex.rb.desugar-tree.exp
@@ -1,5 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C TestRescue><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
     def meth<<todo method>>(&<blk>)
       0
     end
@@ -20,6 +22,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       x
     end
 
+    def untyped_exceptions<<todo method>>(&<blk>)
+      [<emptyTree>::<C Exception>]
+    end
+
+    <self>.sig() do ||
+      <self>.returns(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C T>.class_of(<emptyTree>::<C Exception>)))
+    end
+
+    def typed_exceptions<<todo method>>(&<blk>)
+      [<emptyTree>::<C Exception>]
+    end
+
     def initialize<<todo method>>(&<blk>)
       @ex = <emptyTree>::<C T>.let(nil, <emptyTree>::<C T>.nilable(<emptyTree>::<C StandardError>))
     end
@@ -36,6 +50,32 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.meth()
     rescue <emptyTree>::<C Foo>, <emptyTree>::<C Bar> => baz
       baz
+    end
+
+    def rescue_loop<<todo method>>(&<blk>)
+      begin
+        ex = <emptyTree>::<C T>.let(nil, <emptyTree>::<C T>.nilable(<emptyTree>::<C StandardError>))
+        <self>.loop() do ||
+          begin
+            ex = nil
+            <self>.meth()
+          rescue => ex
+            <emptyTree>
+          end
+        end
+      end
+    end
+
+    def rescue_untyped_splat<<todo method>>(&<blk>)
+      <self>.meth()
+    rescue ::<Magic>.<splat>(<self>.untyped_exceptions()) => e
+      <emptyTree>::<C T>.reveal_type(e)
+    end
+
+    def rescue_typed_splat<<todo method>>(&<blk>)
+      <self>.meth()
+    rescue ::<Magic>.<splat>(<self>.typed_exceptions()) => e
+      <emptyTree>::<C T>.reveal_type(e)
     end
 
     def parse_rescue_ensure<<todo method>>(&<blk>)

--- a/test/testdata/cfg/rescue_complex.rb.desugar-tree.exp
+++ b/test/testdata/cfg/rescue_complex.rb.desugar-tree.exp
@@ -52,6 +52,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       baz
     end
 
+    def multiple_rescue_classes_varuse<<todo method>>(&<blk>)
+      begin
+        <self>.meth()
+      rescue <emptyTree>::<C LoadError>, <emptyTree>::<C SocketError> => baz
+        baz
+        <emptyTree>::<C T>.reveal_type(baz)
+      end
+    end
+
     def rescue_loop<<todo method>>(&<blk>)
       begin
         ex = <emptyTree>::<C T>.let(nil, <emptyTree>::<C T>.nilable(<emptyTree>::<C StandardError>))

--- a/test/testdata/infer/strong_rescue.rb
+++ b/test/testdata/infer/strong_rescue.rb
@@ -53,3 +53,15 @@ def example4
   end
 end
 
+sig {void}
+def example5
+  begin
+  rescue Exception => e
+# ^^^^^^ error: Conditional branch on `T.untyped`
+# ^^^^^^ error: Conditional branch on `T.untyped`
+    #    ^^^^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
+    T.reveal_type(e) # error: `Exception`
+  else
+  ensure
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This cherry-picks a testcase change from #6928.  It also adds a testcase around loops, inspired by some Stripe code.

I also added some splat testcases; Sorbet doesn't really handle these, thanks to untyped and various other things, but I think we *should* be able to if we rewrote how we represent `rescue`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
