### PR TITLE
Add RBI sigs for `JSON.load_file` & `JSON.load_file!`

### DIFF
--- a/rbi/stdlib/json.rbi
+++ b/rbi/stdlib/json.rbi
@@ -235,6 +235,26 @@ module JSON
   end
   def self.load(source, proc=T.unsafe(nil), options=T.unsafe(nil)); end
 
+  # https://docs.ruby-lang.org/en/master/JSON.html#method-i-load_file
+  sig do
+    params(
+      path: ::T.untyped,
+      opts: ::T.untyped,
+    )
+    .returns(::T.untyped)
+  end
+  def self.load_file(path, opts=T.unsafe({})); end
+
+  # https://docs.ruby-lang.org/en/master/JSON.html#method-i-load_file-21
+  sig do
+    params(
+      path: ::T.untyped,
+      opts: ::T.untyped,
+    )
+    .returns(::T.untyped)
+  end
+  def self.load_file!(path, opts=T.unsafe({})); end
+
   # The global default options for the
   # [`JSON.load`](https://docs.ruby-lang.org/en/2.7.0/JSON.html#method-i-load)
   # method:


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This adds RBI sigs for [`JSON.load_file`](https://docs.ruby-lang.org/en/master/JSON.html#method-i-load_file) & [`JSON.load_file!`](https://docs.ruby-lang.org/en/master/JSON.html#method-i-load_file-21), introduced in https://github.com/flori/json/pull/387 and [released in Ruby 3](https://github.com/ruby/ruby/commit/0aac138e0b507c8a361f7cf2f30c276e7110ea33).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Because the current RBI is missing them, even though they exist.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests for these RBIs AFAIK.
