### PR TITLE
noop: Compute file table after typecheck, not after resolve

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -960,8 +960,6 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
         opts.print.SymbolTableFullRaw.fmt("{}\n", gs->showRawFull());
     }
 
-    pipeline::printFileTable(gs, opts);
-
     if (opts.print.MissingConstants.enabled) {
         what = printMissingConstants(*gs, opts, move(what));
     }

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -54,6 +54,8 @@ void typecheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> what, c
                std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
                bool presorted = false, bool intentionallyLeakASTs = false);
 
+void printFileTable(std::unique_ptr<core::GlobalState> &gs, const options::Options &opts);
+
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -785,6 +785,8 @@ int realmain(int argc, char *argv[]) {
             }
         }
 
+        pipeline::printFileTable(gs, opts);
+
         if (!opts.minimizeRBI.empty()) {
 #ifdef SORBET_REALMAIN_MIN
             logger->warn("--minimize-rbi is disabled in sorbet-orig for faster builds");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This paves the way for us to get some information from infer into the file table
output.

Note that people who wish to get the old behavior back can simply pass `--stop-after=resolver`, and infer will not run + the file table output will still be generated.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests