### PR TITLE
Add `pkg` to file-table-export

### DIFF
--- a/core/errors/infer.cc
+++ b/core/errors/infer.cc
@@ -12,9 +12,9 @@ ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file) {
     if (gs.printingFileTable) {
         // Note: this metric, despite being a prod metric, will not get reported in the normal way
         // to the metrics file, the web trace file, nor statsd. We call getAndClearHistogram BEFORE
-        // calling getAndClearThreadCounters, which means that the metric will have been deleted
-        // before reporting to SignalFX, and we don't even compute this if we are not running that
-        // code path (i.e. printing in realmain), because:
+        // calling getAndClearThreadCounters on the main thread, which means that the metric will
+        // have been deleted before reporting to SignalFX. We don't even compute this if we are
+        // not running that code path (i.e. printing in realmain), because:
         //
         // - Tracking this metric causes a noticeable slowdown (it involves growing and merging
         //   large UnorderedMap's), and

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -390,6 +390,8 @@ com::stripe::rubytyper::File::CompiledLevel compiledToProto(core::CompiledLevel 
 com::stripe::rubytyper::FileTable Proto::filesToProto(const GlobalState &gs,
                                                       const UnorderedMap<long, long> &untypedUsages, bool showFull) {
     com::stripe::rubytyper::FileTable files;
+    const auto &packageDB = gs.packageDB();
+    auto stripePackages = !packageDB.empty();
     for (int i = 1; i < gs.filesUsed(); ++i) {
         core::FileRef file(i);
         if (file.data(gs).isPayload()) {
@@ -413,6 +415,13 @@ com::stripe::rubytyper::FileTable Proto::filesToProto(const GlobalState &gs,
         auto frefIdIt = untypedUsages.find(i);
         if (frefIdIt != untypedUsages.end()) {
             entry->set_untyped_usages(frefIdIt->second);
+        }
+
+        if (stripePackages) {
+            const auto &packageInfo = packageDB.getPackageForFile(gs, file);
+            if (packageInfo.exists()) {
+                entry->set_pkg(packageInfo.show(gs));
+            }
         }
     }
     return files;

--- a/proto/File.proto
+++ b/proto/File.proto
@@ -32,6 +32,7 @@ message File {
     CompiledLevel compiled = 5;
     // Note: a value of zero and an unset field look the same.
     int32 untyped_usages = 6;
+    string pkg = 7;
 }
 
 message FileTable {

--- a/test/cli/package-file-table/bar/__package.rb
+++ b/test/cli/package-file-table/bar/__package.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Project::Bar < PackageSpec
+  import Project::Foo
+
+  export Project::Bar::BarClass
+  export Project::Bar::BarMethods
+end

--- a/test/cli/package-file-table/bar/bar.rb
+++ b/test/cli/package-file-table/bar/bar.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+module Project::Bar
+  class BarClass
+    extend T::Sig
+    sig { params(value: Integer).void }
+    def initialize(value)
+      @value = T.let(value, Integer)
+    end
+  end
+
+  class UnexportedClass; end
+end

--- a/test/cli/package-file-table/bar/bar_methods.rb
+++ b/test/cli/package-file-table/bar/bar_methods.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Project::Bar
+  module BarMethods
+    extend T::Sig
+
+    sig {returns(Project::Foo::FooClass)}
+    def self.build_foo
+      # Construct an imported class.
+      Project::Foo::FooClass.new(10)
+    end
+
+    sig {returns(BarClass)}
+    def self.build_bar
+      # Call an imported method.
+      Project::Foo::FooMethods.build_bar
+    end
+  end
+end

--- a/test/cli/package-file-table/foo/__package.rb
+++ b/test/cli/package-file-table/foo/__package.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::Foo < PackageSpec
+  import Project::Bar
+
+  export Project::Foo::FooClass
+  export Project::Foo::FooMethods
+end

--- a/test/cli/package-file-table/foo/foo.rb
+++ b/test/cli/package-file-table/foo/foo.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+module Project::Foo
+  class FooClass
+    extend T::Sig
+    sig { params(value: Integer).void }
+    def initialize(value)
+      @value = T.let(value, Integer)
+    end
+
+    Project::Bar::BardClass
+    Project::Bar::UnexportedClass
+  end
+end

--- a/test/cli/package-file-table/foo/foo_methods.rb
+++ b/test/cli/package-file-table/foo/foo_methods.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Project::Foo
+  module FooMethods
+    extend T::Sig
+
+    sig {returns(Project::Bar::BarClass)}
+    def self.build_bar
+      # Construct an imported class.
+      Project::Bar::BarClass.new(10)
+    end
+
+    sig {returns(FooClass)}
+    def self.build_foo
+      # Call an imported method.
+      Project::Bar::BarMethods.build_foo
+    end
+  end
+end

--- a/test/cli/package-file-table/test.out
+++ b/test/cli/package-file-table/test.out
@@ -27,42 +27,42 @@ Errors: 2
    "sigil": "Strict",
    "strict": "Strict",
    "min_error_level": "Max",
-   "enclosing_package": "Project::Bar"
+   "pkg": "Project::Bar"
   },
   {
    "path": "./bar/bar.rb",
    "sigil": "Strict",
    "strict": "Strict",
    "min_error_level": "Max",
-   "enclosing_package": "Project::Bar"
+   "pkg": "Project::Bar"
   },
   {
    "path": "./bar/bar_methods.rb",
    "sigil": "Strict",
    "strict": "Strict",
    "min_error_level": "Max",
-   "enclosing_package": "Project::Bar"
+   "pkg": "Project::Bar"
   },
   {
    "path": "./foo/__package.rb",
    "sigil": "Strict",
    "strict": "Strict",
    "min_error_level": "Max",
-   "enclosing_package": "Project::Foo"
+   "pkg": "Project::Foo"
   },
   {
    "path": "./foo/foo.rb",
    "sigil": "Strict",
    "strict": "Strict",
    "min_error_level": "False",
-   "enclosing_package": "Project::Foo"
+   "pkg": "Project::Foo"
   },
   {
    "path": "./foo/foo_methods.rb",
    "sigil": "Strict",
    "strict": "Strict",
    "min_error_level": "Max",
-   "enclosing_package": "Project::Foo"
+   "pkg": "Project::Foo"
   }
  ]
 }

--- a/test/cli/package-file-table/test.out
+++ b/test/cli/package-file-table/test.out
@@ -1,0 +1,68 @@
+foo/foo.rb:13: Unable to resolve constant `BardClass` https://srb.help/5002
+    13 |    Project::Bar::BardClass
+            ^^^^^^^^^^^^^^^^^^^^^^^
+  Did you mean `Project::Bar::BarClass`? Use `-a` to autocorrect
+    foo/foo.rb:13: Replace with `Project::Bar::BarClass`
+    13 |    Project::Bar::BardClass
+            ^^^^^^^^^^^^^^^^^^^^^^^
+    bar/bar.rb:6: `Project::Bar::BarClass` defined here
+     6 |  class BarClass
+          ^^^^^^^^^^^^^^
+
+foo/foo.rb:14: `Project::Bar::UnexportedClass` resolves but is not exported from `Project::Bar` https://srb.help/3717
+    14 |    Project::Bar::UnexportedClass
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    bar/bar.rb:14: Defined here
+    14 |  class UnexportedClass; end
+          ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    bar/__package.rb:9: Insert `export Project::Bar::UnexportedClass`
+     9 |  export Project::Bar::BarMethods
+                                         ^
+Errors: 2
+{
+ "files": [
+  {
+   "path": "./bar/__package.rb",
+   "sigil": "Strict",
+   "strict": "Strict",
+   "min_error_level": "Max",
+   "enclosing_package": "Project::Bar"
+  },
+  {
+   "path": "./bar/bar.rb",
+   "sigil": "Strict",
+   "strict": "Strict",
+   "min_error_level": "Max",
+   "enclosing_package": "Project::Bar"
+  },
+  {
+   "path": "./bar/bar_methods.rb",
+   "sigil": "Strict",
+   "strict": "Strict",
+   "min_error_level": "Max",
+   "enclosing_package": "Project::Bar"
+  },
+  {
+   "path": "./foo/__package.rb",
+   "sigil": "Strict",
+   "strict": "Strict",
+   "min_error_level": "Max",
+   "enclosing_package": "Project::Foo"
+  },
+  {
+   "path": "./foo/foo.rb",
+   "sigil": "Strict",
+   "strict": "Strict",
+   "min_error_level": "False",
+   "enclosing_package": "Project::Foo"
+  },
+  {
+   "path": "./foo/foo_methods.rb",
+   "sigil": "Strict",
+   "strict": "Strict",
+   "min_error_level": "Max",
+   "enclosing_package": "Project::Foo"
+  }
+ ]
+}

--- a/test/cli/package-file-table/test.sh
+++ b/test/cli/package-file-table/test.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-file-table || exit 1
+
+../../../main/sorbet --print=file-table-json --silence-dev-message --stripe-packages --max-threads=0 . 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think it will come in useful to have the package information in
Sorbet's file table export. The export is already pretty small, so it's
not that much extra data to export.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
