### PR TITLE
Remove `bind` from `T.proc` when in Initializer rewriter

### DIFF
--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -29,31 +29,8 @@ bool isCopyableType(const ast::ExpressionPtr &typeExpr) {
     return true;
 }
 
-// copied from rewriter/Prop.cc
-bool isT(const ast::ExpressionPtr &expr) {
-    auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
-    return t != nullptr && t->cnst == core::Names::Constants::T() && ast::MK::isRootScope(t->scope);
-}
-
-// partially copied from resolver/type_syntax/type_syntax.cc
-bool isTProc(core::Context ctx, const ast::Send *send) {
-    while (send != nullptr) {
-        if (send->fun == core::Names::proc()) {
-            if (isT(send->recv)) {
-                return true;
-            }
-        }
-        send = ast::cast_tree<ast::Send>(send->recv);
-    }
-    return false;
-}
-
 // Not checking for being T.proc, it's expected to be checked
 void maybeRemoveBind(core::Context ctx, ast::Send *send) {
-    if (!isTProc(ctx, send)) {
-        return;
-    }
-
     auto lastSend = send;
     while (send != nullptr) {
         if (send->fun == core::Names::bind()) {

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -29,6 +29,53 @@ bool isCopyableType(const ast::ExpressionPtr &typeExpr) {
     return true;
 }
 
+// copied from rewriter/Prop.cc
+bool isT(const ast::ExpressionPtr &expr) {
+    auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+    return t != nullptr && t->cnst == core::Names::Constants::T() && ast::MK::isRootScope(t->scope);
+}
+
+// partially copied from resolver/type_syntax/type_syntax.cc
+bool isTProc(core::Context ctx, const ast::Send *send) {
+    while (send != nullptr) {
+        if (send->fun == core::Names::proc()) {
+            if (isT(send->recv)) {
+                return true;
+            }
+        }
+        send = ast::cast_tree<ast::Send>(send->recv);
+    }
+    return false;
+}
+
+// Not checking for being T.proc, it's expected to be checked
+void maybeRemoveBind(core::Context ctx, ast::Send *send) {
+    if (!isTProc(ctx, send)) {
+        return;
+    }
+
+    auto lastSend = send;
+    while (send != nullptr) {
+        if (send->fun == core::Names::bind()) {
+            // `bind` is the last send in the chain of sends.
+            // This is incorrect syntax which is covered by the resolver.
+            // Safe to ignore.
+            if (send == lastSend) {
+                return;
+            }
+            auto recvSend = ast::cast_tree<ast::Send>(send->recv);
+            if (recvSend != nullptr) {
+                lastSend->recv = move(send->recv);
+                return;
+            }
+            // We handle only one `.bind` call in the whole chain,
+            // no need to traverse the rest of the tree.
+            return;
+        }
+        send = ast::cast_tree<ast::Send>(send->recv);
+    }
+}
+
 // if expr is of the form `@var = local`, and `local` is typed, then replace it with with `@var = T.let(local,
 // type_of_local)`
 void maybeAddLet(core::MutableContext ctx, ast::ExpressionPtr &expr,
@@ -75,6 +122,11 @@ void maybeAddLet(core::MutableContext ctx, ast::ExpressionPtr &expr,
                                    zloc, ast::MK::Constant(zloc, core::Symbols::Symbol()), move(type));
                 break;
             }
+        }
+
+        auto send = ast::cast_tree<ast::Send>(type);
+        if (send != nullptr) {
+            maybeRemoveBind(ctx, send);
         }
 
         auto newLet = ast::MK::Let(loc, move(assn->rhs), move(type));

--- a/test/testdata/rewriter/initializer.rb
+++ b/test/testdata/rewriter/initializer.rb
@@ -174,3 +174,21 @@ class BadSigReturnNotLastStatement
     @x = x
   end
 end
+
+class TProcBindInInitializerLet
+  extend T::Sig
+
+  sig {params(blk: T.proc.bind(String).void).void }
+  def initialize(&blk)
+    @blk = blk
+  end
+end
+
+class NoBindInTProcInitializerLet
+  extend T::Sig
+
+  sig {params(blk: T.proc.void).void }
+  def initialize(&blk)
+    @blk = blk
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This little patch simply removes `.bind(…)` from the chain of `Send`s when copying the block argument type definition to the `initialize` method body where `.bind(…)` is not allowed.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes https://github.com/sorbet/sorbet/issues/6848.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
