### PR TITLE
[Ruby 3] Autocorrects for all kwarg issues

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -49,7 +49,8 @@ constexpr ErrorClass UntypedFieldSuggestion{7043, StrictLevel::Strict};
 constexpr ErrorClass DigExtraArgs{7044, StrictLevel::True};
 constexpr ErrorClass IncorrectlyAssumedType{7045, StrictLevel::True};
 constexpr ErrorClass NonOverlappingEqual{7046, StrictLevel::True};
-constexpr ErrorClass UntypedValueInformation{7047, StrictLevel::True};
+constexpr ErrorClass NoKeywordArgAsLastHashArg{7047, StrictLevel::True};
+constexpr ErrorClass UntypedValueInformation{7048, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 
 ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -40,7 +40,7 @@ bool allComponentsPresent(DispatchResult &res) {
 }
 
 inline bool isTyped(const TypePtr type) {
-    return type && !type.isUntyped();
+    return !type.isUntyped();
 }
 
 inline bool isHash(const GlobalState &gs, const TypePtr type) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -566,6 +566,35 @@ optional<core::AutocorrectSuggestion> maybeSuggestExtendModule(const GlobalState
         {core::AutocorrectSuggestion::Edit{nextLineLoc.value(), fmt::format("{}extend {}\n", prefix, modStr)}}};
 }
 
+void maybeSuggestDoubleSplat(const core::GlobalState &gs, core::ErrorBuilder &e, core::Loc kwSplatArgLoc) {
+    if (!kwSplatArgLoc.exists()) {
+        return;
+    }
+
+    auto replaceLoc = kwSplatArgLoc;
+    string maybeStarStar = "**";
+    if (kwSplatArgLoc.adjustLen(gs, 0, 2).source(gs) == "**") {
+        replaceLoc = kwSplatArgLoc.adjust(gs, 2, 0);
+        maybeStarStar = "";
+    }
+
+    auto title = fmt::format("Use `{}` for the keyword argument hash", "**");
+    auto replaceValue = replaceLoc.source(gs).value();
+    if (absl::c_all_of(replaceValue, [](char c) { return absl::ascii_isalnum(c) || c == '_'; }) ||
+        (absl::StartsWith(replaceValue, "{") && absl::EndsWith(replaceValue, "}"))) {
+        e.replaceWith(title, replaceLoc, "{}{}", maybeStarStar, replaceValue);
+    } else {
+        e.replaceWith(title, replaceLoc, "{}{{{}}}", maybeStarStar, replaceValue);
+    }
+}
+
+inline bool checkHashKeys(TypePtr argType) {
+    return absl::c_any_of((cast_type<ShapeType>(argType))->keys, [](const TypePtr keyType) {
+        return !isa_type<NamedLiteralType>(keyType) ||
+               cast_type_nonnull<NamedLiteralType>(keyType).literalKind != NamedLiteralType::LiteralTypeKind::Symbol;
+    });
+}
+
 void maybeSuggestUnsafeKwsplat(const core::GlobalState &gs, core::ErrorBuilder &e, core::Loc kwSplatArgLoc) {
     if (!kwSplatArgLoc.exists()) {
         return;
@@ -891,15 +920,23 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         if (spec.flags.isKeyword) {
             break;
         }
-        if (ait + 1 == aend && hasKwargs && (spec.flags.isDefault || spec.flags.isRepeated) &&
-            Types::approximate(gs, arg->type, *constr).derivesFrom(gs, Symbols::Hash())) {
-            break;
-        }
 
         auto offset = ait - args.args.begin();
-        if (auto e = matchArgType(gs, *constr, args.receiverLoc(), symbol, method, *arg, spec, args.selfType, targs,
-                                  args.argLoc(offset), args.originForUninitialized, args.args.size() == 1)) {
-            result.main.errors.emplace_back(std::move(e));
+        auto argType = Types::approximate(gs, arg->type, *constr);
+
+        auto argTypeMatchErr =
+            matchArgType(gs, *constr, args.receiverLoc(), symbol, method, *arg, spec, args.selfType, targs,
+                         args.argLoc(offset), args.originForUninitialized, args.args.size() == 1);
+
+        if (ait + 1 == aend && hasKwargs && (spec.flags.isDefault || spec.flags.isRepeated) && !argType.isUntyped() &&
+            argType.derivesFrom(gs, Symbols::Hash())) {
+            if (!(!argTypeMatchErr && isa_type<ShapeType>(argType) && pit->flags.isDefault && checkHashKeys(argType))) {
+                break;
+            }
+        }
+
+        if (argTypeMatchErr) {
+            result.main.errors.emplace_back(std::move(argTypeMatchErr));
         }
 
         if (!spec.flags.isRepeated) {
@@ -911,11 +948,12 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     // If positional arguments remain, the method accepts keyword arguments, and no keyword arguments were provided in
     // the send, assume that the last argument is an implicit keyword args hash.
     bool implicitKwsplat = false;
+    UnorderedSet<Loc> kwErrors;
     if (ait != aPosEnd && hasKwargs && args.args.size() == args.numPosArgs) {
         auto splatLoc = args.argLoc(args.args.size() - 1);
 
         // If --experimental-ruby3-keyword-args is set, we will treat "**-less" keyword hash argument as an error.
-        if (gs.ruby3KeywordArgs) {
+        if (gs.ruby3KeywordArgs && kwErrors.count(splatLoc) == 0) {
             if (auto e = gs.beginError(splatLoc, errors::Infer::KeywordArgHashWithoutSplat)) {
                 e.setHeader("Keyword argument hash without `{}` is deprecated", "**");
                 e.addErrorLine(splatLoc, "This produces a runtime warning in Ruby 2.7, "
@@ -924,6 +962,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     e.replaceWith(fmt::format("Use `{}` for the keyword argument hash", "**"), splatLoc, "**{}",
                                   source.value());
                 }
+                kwErrors.insert(splatLoc);
             }
         }
         hasKwsplat = true;
@@ -1078,26 +1117,23 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 auto kwSplatValueType = appliedType.targs[1];
 
                 if (hasRequiredKwParam) {
-                    if (auto e = gs.beginError(kwSplatArgLoc, errors::Infer::UntypedSplat)) {
-                        // Unfortunately, this prevents even valid splats:
-                        //     def f(x:, y: 0); end
-                        //     f(x: 0, **opts)
-                        // This should work, but we currently handle kwsplat even before we check
-                        // which keyword args have already been consumed (see below for that).
-                        // This is harder to support, but maybe also less likely:
-                        //     f(**opts, x: 0)
-                        e.setHeader("Cannot call `{}` with a `{}` keyword splat because the method has required "
-                                    "keyword parameters",
-                                    method.show(gs), "Hash");
-                        e.addErrorLine(kwParams.front()->loc,
-                                       "Keyword parameters of `{}` begin here:", method.show(gs));
-                        e.addErrorSection(kwSplatTPO.explainGot(gs, args.originForUninitialized));
-                        e.addErrorNote("Note that Sorbet does not yet handle mixing explicitly-passed keyword args "
-                                       "with splats.\n"
-                                       "    To ignore this and pass the splat anyways, use `{}`",
-                                       "T.unsafe");
-                        maybeSuggestUnsafeKwsplat(gs, e, kwSplatArgLoc);
-                        result.main.errors.emplace_back(e.build());
+                    if (kwErrors.count(kwSplatArgLoc) == 0 &&
+                        !absl::StartsWith(kwSplatArgLoc.source(gs).value(), "**")) {
+                        if (auto e = gs.beginError(kwSplatArgLoc, errors::Infer::UntypedSplat)) {
+                            // Unfortunately, this prevents even valid splats:
+                            //     def f(x:, y: 0); end
+                            //     f(x: 0, **opts)
+                            // This should work, but we currently handle kwsplat even before we check
+                            // which keyword args have already been consumed (see below for that).
+                            // This is harder to support, but maybe also less likely:
+                            //     f(**opts, x: 0)
+                            e.setHeader("Keyword argument hash without `{}` is deprecated", "**");
+                            e.addErrorLine(kwSplatArgLoc, "This produces a runtime warning in Ruby 2.7, "
+                                                          "and will be an error in Ruby 3.0");
+                            maybeSuggestDoubleSplat(gs, e, kwSplatArgLoc);
+                            result.main.errors.emplace_back(e.build());
+                            kwErrors.insert(kwSplatArgLoc);
+                        }
                     }
                 } else if (!Types::isSubTypeUnderConstraint(gs, *constr, kwSplatKeyType, Types::Symbol(),
                                                             UntypedMode::AlwaysCompatible)) {

--- a/test/testdata/infer/ruby3_keyword_args.rb
+++ b/test/testdata/infer/ruby3_keyword_args.rb
@@ -8,7 +8,8 @@ def takes_kwargs(x, y:)
 end
 
 arghash = {y: 42}
-takes_kwargs(99, arghash) # error: Keyword argument hash without `**` is deprecated
+takes_kwargs(99, arghash)
+               # ^^^^^^^ error: Keyword argument hash without `**` is deprecated
 
 takes_kwargs(99, **arghash)
 
@@ -27,3 +28,189 @@ end
 
 blk = Proc.new
 foo("", tags: {}, x: 1, &blk)
+
+def with_base_dir(*segments)
+end
+
+# Alerting, but shouldn't
+Dir[with_base_dir("")].each do |file_path|
+  p file_path
+end
+
+
+# Carried over from test/cli/autocorrect-kwsplat/test.rb
+# For more details see https://github.com/sorbet/sorbet/pull/6771
+sig {params(pos: Integer, x: Integer).void}
+def requires_x(*pos, x:)
+end
+
+sig {params(pos: Integer, x: String).void}
+def optional_x(*pos, x: '')
+end
+
+opts = T::Hash[Symbol, Integer].new
+string_keys = T::Hash[String, Integer].new
+nilble_opts = T::Hash[Symbol, T.nilable(Integer)].new
+x = T.let(:x, Symbol)
+
+# wrong error reported
+requires_x(0, 1, 2, opts)
+                  # ^^^^ error: Keyword argument hash without `**` is deprecated
+requires_x(0, 1, 2, **opts)
+
+requires_x(0, 1, 2, **opts, x: 0)
+
+requires_x(0, 1, 2, x: 0, **opts)
+                  # ^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+requires_x(0, 1, 2, **{x => 0})
+
+optional_x(0, 1, 2, **string_keys)
+                  # ^^^^^^^^^^^^^ error: Expected `Symbol` but found `String` for keyword splat keys type
+
+optional_x(0, 1, 2, **nilble_opts)
+                  # ^^^^^^^^^^^^^ error: Expected `String` for keyword parameter `x` but found `T.nilable(Integer)` from keyword splat
+
+def bar(x:, y: 10)
+  p x
+  p y
+end
+
+bar(x: 10)
+bar(x: 10, y: 20)
+
+args = {x: 10}
+bar(**args)
+bar(x: 20, **args)
+
+other3 = T.let(:bar, Symbol)
+bar(other3 => 10)
+  # ^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+bar(**{other3 => 10})
+
+
+sig {params(x: Integer, y: Integer, z: String).void}
+def f(x, y:, z:)
+  puts x
+  puts y
+  puts z
+end
+
+sig {params(x: Integer, y: Integer, z: String, w: Float).void}
+def g(x, y:, z:, w:)
+  puts x
+  puts y
+  puts z
+  puts w
+end
+
+shaped_hash = {y: 3, z: "hi mom"}
+f(3, shaped_hash)
+   # ^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+f(3, **shaped_hash)
+g(3, **shaped_hash, w: 2.0)
+
+untyped_hash = T.let(shaped_hash, T.untyped)
+f(3, untyped_hash)
+   # ^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+f(3, **untyped_hash)
+g(3, **untyped_hash, w: 2.0)
+
+untyped_values_hash = T.let(shaped_hash, T::Hash[Symbol, T.untyped])
+f(3, untyped_values_hash)
+   # ^^^^^^^^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+f(3, **untyped_values_hash)
+g(3, **untyped_values_hash, w: 2.0)
+
+sig {params(x: Integer, y: Integer, kw_splat: BasicObject).void}
+def h(x, y:, **kw_splat)
+  puts x
+  puts y
+  puts kw_splat
+end
+
+untyped_values_hash = T.let({}, T::Hash[Symbol, T.untyped])
+h(1, y: 2, **untyped_values_hash)
+   # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+
+sig {returns(T.untyped)}
+def make_untyped; T.unsafe("hello"); end
+class Tempfile_
+  extend T::Sig
+  sig do
+    params(
+      basename: T.any(String, [String, String]),
+      tmpdir: T.nilable(String),
+      mode: Integer,
+      options: T.untyped,
+    )
+    .void
+  end
+  def initialize(basename='', tmpdir=nil, mode: 0, **options); end
+end
+
+Tempfile_.new(make_untyped)
+
+module B
+  def self.inner_foo(arg0 = [], arg1: true)
+    p [arg0, arg1]
+
+  end
+  def self.outer_foo(arg0)
+    # probably shouldn't
+    B.inner_foo(arg0)
+  end
+end
+
+
+
+# Ruby 2.7: [[], []] and also a warning
+# Ruby 3.0: [{:arg1=>[]}, true]
+B.inner_foo({:arg1 => []})
+          # ^^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+
+
+hash_args = {}
+hash_args[:arg1] = false
+# Ruby 2.7: [[], false] 
+# Ruby 3.0: [{:arg1=>false}, true] 
+B.inner_foo(hash_args)
+          # ^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+
+B.inner_foo([123])
+array_arg = [123]
+B.inner_foo(array_arg)
+
+# Ruby 2.7: [{"foo"=>"bar"}, {"cred1"=>true, "cred2"=>false, "cred3"=>false, "cred4"=>true}, false, "x"]
+# Ruby 3.0: [{"foo"=>"bar"}, {"cred1"=>true, "cred2"=>false, "cred3"=>false, "cred4"=>true}, false, "x"]
+def takes_default_hash(arg0, arg1 = {}, arg2: false, arg3: "x"); end
+takes_default_hash(
+  {"foo" => "bar"},
+  {"cred1" => true, "cred2" => false, "cred3" => false, "cred4" => true}
+  # The second param here is usually dispatched as a keyword args hash
+  # That's incorrect, but it's impossible to model it correctly rn.
+  # We special cased this use case in calls.cc
+)
+
+# Ruby 2.7: [{"foo"=>"bar"}, {}, true, "y"] 
+# Ruby 3.0: [{"foo"=>"bar"}, {:arg2=>true, :arg3=>"y"}, false, "x"]
+arg1 = {:arg2 => true, :arg3 => "y"}
+takes_default_hash(
+  {"foo" => "bar"},
+  arg1
+# ^^^^ error: Keyword argument hash without `**` is deprecated
+)
+
+# Ruby 2.7: [{"foo"=>"bar"}, {"arg2"=>true, "arg3"=>"y"}, false, "x"]
+# Ruby 3.0: [{"foo"=>"bar"}, {"arg2"=>true, "arg3"=>"y"}, false, "x"]
+takes_default_hash(
+  {"foo" => "bar"},
+  {"arg2" => true, "arg3" => "y"}
+)
+
+# Ruby 2.7: [{"foo"=>"bar"}, {}, true, "y"] 
+# Ruby 3.0: [{"foo"=>"bar"}, {:arg2=>true, :arg3=>"y"}, false, "x"]
+takes_default_hash(
+  {"foo" => "bar"},
+  {arg2: true, arg3: "y"}
+# ^^^^^^^^^^^^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
+)

--- a/test/testdata/infer/ruby3_keyword_args.rb
+++ b/test/testdata/infer/ruby3_keyword_args.rb
@@ -214,3 +214,223 @@ takes_default_hash(
   {arg2: true, arg3: "y"}
 # ^^^^^^^^^^^^^^^^^^^^^^^ error: Keyword argument hash without `**` is deprecated
 )
+sig {params(h: T::Hash[T.untyped, T.untyped], kw: T::Hash[T.untyped, T.untyped]).void}
+def takes_only_hash_and_kwargs(h, **kw); end
+
+takes_only_hash_and_kwargs(a: "x")
+                        #  ^^^^^^ error: Passing the keyword argument as the last hash parameter is deprecated
+takes_only_hash_and_kwargs({a: "x"}) # => OK
+
+sig {params(h: T::Hash[T.untyped, T.untyped]).void}
+def takes_only_hash(h); end
+
+takes_only_hash(a: "x") # => OK
+takes_only_hash({a: "x"}) # => OK
+
+sig {params(k: Integer).void}
+def takes_only_kwargs(k:) end
+
+takes_only_kwargs(k: 42) # => OK
+takes_only_kwargs({k: 42})
+                # ^^^^^^^ error: Keyword argument hash without `**` is deprecated
+
+
+module A
+  extend T::Sig
+  sig {params(a: String, b: String, h: T::Hash[String, Integer], kw: T::Hash[String, Integer]).void}
+  def self.takes_hash(a, b, h, **kw); end
+end
+
+A.takes_hash("", "", h: 42)
+                   # ^^^^^ error: Passing the keyword argument as the last hash parameter is deprecated
+A.takes_hash("", "", {h: 42}) # => OK
+
+
+sig {params(a: Integer, b: String).void}
+def needs_double_splats(a, b:); end
+
+options = { b: "str" }
+
+needs_double_splats(42, options)
+                      # ^^^^^^^ error: Keyword argument hash without `**` is deprecated
+needs_double_splats(42, **options) # => OK
+
+
+
+sig {params(arg: T::Hash[T.untyped, T.untyped], arg_with_default: String ).void}
+def last_arg_with_default(arg, arg_with_default: "something"); end
+
+last_arg_with_default(item: "42")
+                    # ^^^^^^^^^^ error: Passing the keyword argument as the last hash parameter is deprecated
+last_arg_with_default({ item: "42" }) # => OK
+
+
+sig {params(arg0: Integer, arg: T::Hash[T.untyped, T.untyped], arg_with_default: String ).void}
+def last_arg_with_default2(arg0, arg, arg_with_default: "something"); end
+
+last_arg_with_default2(1, item: 42)
+                        # ^^^^^^^^ error: Passing the keyword argument as the last hash parameter is deprecated
+sig {params(kwargs: T::Hash[T.untyped, T.untyped]).void}
+def kwargs_with_default(kwargs = {}); end
+
+kwargs_with_default(k: 1) # => OK
+kwargs_with_default({k: 1}) # => OK
+
+sig {params(a: Integer, h: T::Hash[T.untyped, T.untyped]).void}
+def takes_empty_hash(a, h); end
+
+empty_hash = {}
+takes_empty_hash(1, **empty_hash)
+                  # ^^^^^^^^^^^^ error: Passing the keyword argument as the last hash parameter is deprecated
+
+takes_empty_hash(1, empty_hash) # => OK
+
+[{a: 42, b: "something"}].each do |a:, b:|
+                                #  ^^^^^^ We don't report this usage as an error yet
+  p [a, b]
+end
+
+# Examples below are similar to the real world cases
+# which gave me false-positive or false-negative result.
+# Keeping them to catch regressions
+
+sig {params(url: String, key: T.nilable(String), params: T::Hash[T.untyped, T.untyped], env: T::Hash[T.untyped, T.untyped]).void}
+def get_live(url, key = nil, params: {}, env: {}); end
+
+get_live("some url") # => OK
+
+
+sig do
+  params(
+    id: T.nilable(T.any(String, Integer)),
+    extra: T::Hash[T.untyped, T.untyped],
+    opts: T::Hash[T.untyped, T.untyped]
+  )
+    .void
+end
+def load!(id, extra = {}, opts = {}); end
+
+
+load!("some_id") # => OK
+
+
+def assert_match(matcher, obj, msg = nil); end
+
+sig {returns(T.untyped)}
+def returns_untyped; end;
+
+assert_match(/some regex/, returns_untyped) # => OK
+
+
+class LoadAll
+  extend T::Sig
+
+  sig do
+    params(
+      query: T::Hash[T.untyped, T.untyped],
+      opts: T::Hash[T.untyped, T.untyped],
+      opts2: T::Hash[T.untyped, T.untyped],
+      blk: T.untyped
+      ).returns(T.attached_class)
+  end
+  def self.load_all(query = {}, opts = {}, opts2 = {}, &blk); new end
+
+
+
+  sig do
+    params(
+      query: T::Hash[T.untyped, T.untyped],
+      opts: T::Hash[T.untyped, T.untyped],
+      blk: T.untyped
+      ).returns(T.attached_class)
+  end
+  def self.load_one(query = {}, opts = {}, &blk); new end
+end
+
+LoadAll.load_all({m: "m_42", payment_intent: "pi_43"}) # => OK
+LoadAll.load_one({m: "m_42", payment_intent: "pi_43"}) # => OK
+
+class GQLObject
+  extend T::Sig
+  sig do
+    params(
+      field_name: Symbol,
+      type: T.untyped,
+      desc: T.nilable(::String),
+      null: T.nilable(T::Boolean),
+      unnamed_kwargs: T.untyped,
+      block: T.nilable(T.proc.void)
+    )
+      .void
+  end
+  def self.field(
+    field_name,
+    type,
+    desc = nil,
+    null: nil,
+    **unnamed_kwargs,
+    &block
+  )
+  end
+
+end
+
+class Obj < GQLObject
+  field :transaction_id, String
+end
+
+
+# `prop` methods receive an additional keyword arg, because of the rewriter step
+class MyProp
+  extend T::Sig
+
+  sig do
+    params(
+      name: Symbol,
+      prop_type: T.untyped,
+      rules: T::Hash[Symbol, T.untyped],
+      arg0: T.untyped,
+      arg1: T.nilable(String),
+      arg2: T.untyped,
+      arg3: T.nilable(String),
+      arg4: T.nilable(String),
+      arg5: T.nilable(String),
+      arg6: T.untyped,
+      arg7: T.nilable(T.proc.returns(T.untyped)),
+      arg8: T.nilable(T::Array[String]),
+      arg9: T.nilable(T.proc.returns(T.nilable(T::Array[String]))),
+      arg10: T.nilable(T.proc.returns(T.untyped)),
+      arg11: T::Boolean,
+      kwargs: T.untyped
+    )
+      .returns(T.untyped)
+  end
+  def self.prop(
+    name,
+    prop_type,
+    rules = {},
+    arg0: nil,
+    arg1: nil,
+    arg2: nil,
+    arg3: nil,
+    arg4: nil,
+    arg5: nil,
+    arg6: nil,
+    arg7: nil,
+    arg8: nil,
+    arg9: nil,
+    arg10: nil,
+    arg11: false,
+    **kwargs
+  )
+  end
+end
+
+class Abacaba < MyProp
+    prop :_id, String, arg2: "e.g., _id"
+    prop :a, T::Array[String]
+    prop :b, T::Array[String], arg2: "bbbb"
+    prop :d, Integer, arg1: "Amount in cents", arg2: "e.g. 1000"
+end
+
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR joins two other PRs:
1. [Autocorrects for the implicit hash to keyword arguments conversions](https://github.com/sorbet/sorbet/pull/6898)
2. [Autocorrects for the implicit keyword to hash arguments conversions](https://github.com/sorbet/sorbet/pull/6695)

I've manually cherry-picked valuable commits into this branch. The only meaningful difference is [the last commit](https://github.com/sorbet/sorbet/commit/ad13791c9ff9f86f801edc79165bfbdedd98315a). It opt-outs from handling untyped code for implicit keyword to hash conversions.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Ruby 3
### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
