### PR TITLE
Add editForDSLMethod helper

### DIFF
--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -136,6 +136,7 @@ void TypeErrorDiagnostics::explainUntyped(const GlobalState &gs, ErrorBuilder &e
 }
 
 // dslOwner can be noClassOrModule() to simply unconditionally insert the `dsl` string
+// dsl can be `""` to simply insert `extend {dslOwner}` if dslOwner is not already an ancestor
 optional<core::AutocorrectSuggestion::Edit> TypeErrorDiagnostics::editForDSLMethod(const Context &ctx,
                                                                                    ClassOrModuleRef inWhatRef,
                                                                                    ClassOrModuleRef dslOwner,
@@ -178,10 +179,12 @@ optional<core::AutocorrectSuggestion::Edit> TypeErrorDiagnostics::editForDSLMeth
     if (needsDslOwner) {
         return core::AutocorrectSuggestion::Edit{
             nextLineLoc.value(),
-            fmt::format("{}extend {}\n{}{}\n", prefix, dslOwner.show(ctx), prefix, dsl),
+            fmt::format("{}extend {}\n{}{}\n", prefix, dslOwner.show(ctx), dsl != "" ? prefix : "", dsl),
         };
-    } else {
+    } else if (dsl != "") {
         return core::AutocorrectSuggestion::Edit{nextLineLoc.value(), fmt::format("{}{}\n", prefix, dsl)};
+    } else {
+        return nullopt;
     }
 }
 

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -207,4 +207,17 @@ TypeErrorDiagnostics::editForDSLMethod(const GlobalState &gs, FileRef fileToEdit
     return autocorrectEditForDSLMethod(gs, nextLineLoc.value(), prefix, dslOwner, dsl, needsDslOwner);
 }
 
+void TypeErrorDiagnostics::maybeInsertDSLMethod(const GlobalState &gs, ErrorBuilder &e, FileRef fileToEdit,
+                                                Loc defaultInsertLoc, ClassOrModuleRef inWhatRef,
+                                                ClassOrModuleRef dslOwner, string_view dsl) {
+    auto edit = editForDSLMethod(gs, fileToEdit, defaultInsertLoc, inWhatRef, dslOwner, dsl);
+    if (!edit.has_value()) {
+        return;
+    }
+
+    auto label = dsl == "" ? fmt::format("Add `extend {}`", dslOwner.show(gs)) : fmt::format("Insert `{}`", dsl);
+
+    e.addAutocorrect(core::AutocorrectSuggestion{move(label), {move(edit.value())}});
+}
+
 } // namespace sorbet::core

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -140,12 +140,22 @@ optional<core::AutocorrectSuggestion::Edit> autocorrectEditForDSLMethod(const Gl
                                                                         string_view prefix, ClassOrModuleRef dslOwner,
                                                                         string_view dsl, bool needsDslOwner) {
     if (needsDslOwner) {
+        if (dsl == "") {
+            return core::AutocorrectSuggestion::Edit{
+                insertLoc,
+                fmt::format("{}extend {}\n", prefix, dslOwner.show(gs)),
+            };
+        } else {
+            return core::AutocorrectSuggestion::Edit{
+                insertLoc,
+                fmt::format("{}extend {}\n{}{}\n", prefix, dslOwner.show(gs), prefix, dsl),
+            };
+        }
+    } else if (dsl != "") {
         return core::AutocorrectSuggestion::Edit{
             insertLoc,
-            fmt::format("{}extend {}\n{}{}\n", prefix, dslOwner.show(gs), dsl != "" ? prefix : "", dsl),
+            fmt::format("{}{}\n", prefix, dsl),
         };
-    } else if (dsl != "") {
-        return core::AutocorrectSuggestion::Edit{insertLoc, fmt::format("{}{}\n", prefix, dsl)};
     } else {
         return nullopt;
     }

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -35,6 +35,9 @@ public:
     static std::optional<core::AutocorrectSuggestion::Edit>
     editForDSLMethod(const GlobalState &gs, FileRef fileToEdit, Loc defaultInsertLoc, ClassOrModuleRef inWhat,
                      ClassOrModuleRef dslOwner, std::string_view dsl);
+
+    static void maybeInsertDSLMethod(const GlobalState &gs, ErrorBuilder &e, FileRef fileToEdit, Loc defaultInsertLoc,
+                                     ClassOrModuleRef inWhat, ClassOrModuleRef dslOwner, std::string_view dsl);
 };
 
 } // namespace sorbet::core

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -32,10 +32,9 @@ public:
     static void explainUntyped(const GlobalState &gs, ErrorBuilder &e, ErrorClass what, TypePtr untyped, Loc origin,
                                Loc originForUninitialized);
 
-    static std::optional<core::AutocorrectSuggestion::Edit> editForDSLMethod(const GlobalState &gs, FileRef fileToEdit,
-                                                                             ClassOrModuleRef inWhat,
-                                                                             ClassOrModuleRef dslOwner,
-                                                                             std::string_view dsl);
+    static std::optional<core::AutocorrectSuggestion::Edit>
+    editForDSLMethod(const GlobalState &gs, FileRef fileToEdit, Loc defaultInsertLoc, ClassOrModuleRef inWhat,
+                     ClassOrModuleRef dslOwner, std::string_view dsl);
 };
 
 } // namespace sorbet::core

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -1,6 +1,7 @@
 #ifndef SORBET_TYPE_ERROR_DIAGNOSTICS_H
 #define SORBET_TYPE_ERROR_DIAGNOSTICS_H
 
+#include "core/Context.h"
 #include "core/Error.h"
 #include "core/GlobalState.h"
 #include "core/TypeConstraint.h"
@@ -30,6 +31,9 @@ public:
 
     static void explainUntyped(const GlobalState &gs, ErrorBuilder &e, ErrorClass what, TypePtr untyped, Loc origin,
                                Loc originForUninitialized);
+
+    static std::optional<core::AutocorrectSuggestion::Edit>
+    editForDSLMethod(const Context &ctx, ClassOrModuleRef inWhat, ClassOrModuleRef dslOwner, std::string_view dsl);
 };
 
 } // namespace sorbet::core

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -32,8 +32,10 @@ public:
     static void explainUntyped(const GlobalState &gs, ErrorBuilder &e, ErrorClass what, TypePtr untyped, Loc origin,
                                Loc originForUninitialized);
 
-    static std::optional<core::AutocorrectSuggestion::Edit>
-    editForDSLMethod(const Context &ctx, ClassOrModuleRef inWhat, ClassOrModuleRef dslOwner, std::string_view dsl);
+    static std::optional<core::AutocorrectSuggestion::Edit> editForDSLMethod(const GlobalState &gs, FileRef fileToEdit,
+                                                                             ClassOrModuleRef inWhat,
+                                                                             ClassOrModuleRef dslOwner,
+                                                                             std::string_view dsl);
 };
 
 } // namespace sorbet::core

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -472,11 +472,8 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     }
 
     auto topAttachedClass = enclosingClass.data(ctx)->topAttachedClass(ctx);
-    if (!topAttachedClass.data(ctx)->lookupSingletonClass(ctx).data(ctx)->derivesFrom(ctx, core::Symbols::T_Sig())) {
-        if (auto edit = core::TypeErrorDiagnostics::editForDSLMethod(
-                ctx, topAttachedClass, core::Symbols::noClassOrModule(), "extend T::Sig")) {
-            edits.emplace_back(edit.value());
-        }
+    if (auto edit = core::TypeErrorDiagnostics::editForDSLMethod(ctx, topAttachedClass, core::Symbols::T_Sig(), "")) {
+        edits.emplace_back(edit.value());
     }
 
     return core::AutocorrectSuggestion{fmt::format("Add `{}`", sig), edits};

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -472,7 +472,8 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     }
 
     auto topAttachedClass = enclosingClass.data(ctx)->topAttachedClass(ctx);
-    if (auto edit = core::TypeErrorDiagnostics::editForDSLMethod(ctx, topAttachedClass, core::Symbols::T_Sig(), "")) {
+    if (auto edit =
+            core::TypeErrorDiagnostics::editForDSLMethod(ctx, ctx.file, topAttachedClass, core::Symbols::T_Sig(), "")) {
         edits.emplace_back(edit.value());
     }
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -19,15 +19,13 @@ bool extendsTSig(core::Context ctx, core::ClassOrModuleRef enclosingClass) {
 }
 
 optional<core::AutocorrectSuggestion::Edit> maybeSuggestExtendTSig(core::Context ctx, core::MethodRef methodSymbol) {
-    auto method = methodSymbol.data(ctx);
-
     auto enclosingClass = methodSymbol.enclosingClass(ctx).data(ctx)->topAttachedClass(ctx);
     if (extendsTSig(ctx, enclosingClass)) {
         // No need to suggest here, because it already has 'extend T::Sig'
         return nullopt;
     }
 
-    auto inFileOfMethod = [&](const auto &loc) { return loc.file() == method->loc().file(); };
+    auto inFileOfMethod = [&](const auto &loc) { return loc.file() == ctx.file; };
     auto &classLocs = enclosingClass.data(ctx)->locs();
     auto classLoc = absl::c_find_if(classLocs, inFileOfMethod);
 

--- a/test/cli/autocorrect-extend/autocorrect-extend.rb
+++ b/test/cli/autocorrect-extend/autocorrect-extend.rb
@@ -1,6 +1,5 @@
 # typed: strict
 
-# Don't extend T::Sig for this one, because the class wasn't defined here.
 def top_level; end
 
 # Should only add one extend

--- a/test/cli/autocorrect-extend/test.out
+++ b/test/cli/autocorrect-extend/test.out
@@ -1,6 +1,6 @@
 # typed: strict
 
-# Don't extend T::Sig for this one, because the class wasn't defined here.
+extend T::Sig
 sig { returns(NilClass) }
 def top_level; end
 

--- a/test/cli/autocorrect/test.out
+++ b/test/cli/autocorrect/test.out
@@ -285,7 +285,6 @@ T.must(foo)[0]
 "hi" + T.must(foo)
 
 extend T::Sig
-
 sig {params(a: String).void}
 def int(a:); end
 int(a: T.must(foo))
@@ -298,7 +297,6 @@ T.must(foo.bar) &= "a"
 T.must([1].max_by {|l,r| 1})[2]
 
 extend T::Sig
-
 sig {params(a: T.nilable(Integer)).void}
 def foo(a:)
 end

--- a/test/cli/dash-e/test.out
+++ b/test/cli/dash-e/test.out
@@ -13,7 +13,8 @@ class ::<root> < ::Object ()
      2 |def foo; end
         ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    -e:2: Insert `sig { returns(NilClass) }`
+    -e:2: Insert `extend T::Sig
+    sig { returns(NilClass) }`
      2 |def foo; end
         ^
 Errors: 1

--- a/test/cli/print_generics/test.out
+++ b/test/cli/print_generics/test.out
@@ -2,7 +2,8 @@ test/cli/print_generics/print_generics.rb:5: The method `foo` does not have a `s
      5 |def foo(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:5: Insert `sig { params(x: T.untyped).returns(T::Array[Integer]) }`
+    test/cli/print_generics/print_generics.rb:5: Insert `extend T::Sig
+    sig { params(x: T.untyped).returns(T::Array[Integer]) }`
      5 |def foo(x)
         ^
 
@@ -10,7 +11,8 @@ test/cli/print_generics/print_generics.rb:9: The method `bar` does not have a `s
      9 |def bar(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:9: Insert `sig { params(x: T.untyped).returns(T::Hash[Symbol, Integer]) }`
+    test/cli/print_generics/print_generics.rb:9: Insert `extend T::Sig
+    sig { params(x: T.untyped).returns(T::Hash[Symbol, Integer]) }`
      9 |def bar(x)
         ^
 
@@ -18,7 +20,8 @@ test/cli/print_generics/print_generics.rb:13: The method `qux` does not have a `
     13 |def qux(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:13: Insert `sig { params(x: T.untyped).returns(T::Enumerable[Integer]) }`
+    test/cli/print_generics/print_generics.rb:13: Insert `extend T::Sig
+    sig { params(x: T.untyped).returns(T::Enumerable[Integer]) }`
     13 |def qux(x)
         ^
 
@@ -26,7 +29,8 @@ test/cli/print_generics/print_generics.rb:17: The method `wub` does not have a `
     17 |def wub(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:17: Insert `sig { params(x: T.untyped).returns(T::Range[Integer]) }`
+    test/cli/print_generics/print_generics.rb:17: Insert `extend T::Sig
+    sig { params(x: T.untyped).returns(T::Range[Integer]) }`
     17 |def wub(x)
         ^
 
@@ -34,7 +38,8 @@ test/cli/print_generics/print_generics.rb:21: The method `zan` does not have a `
     21 |def zan(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:21: Insert `sig { params(x: T.untyped).returns(T::Set[Integer]) }`
+    test/cli/print_generics/print_generics.rb:21: Insert `extend T::Sig
+    sig { params(x: T.untyped).returns(T::Set[Integer]) }`
     21 |def zan(x)
         ^
 
@@ -42,7 +47,8 @@ test/cli/print_generics/print_generics.rb:25: The method `gaz` does not have a `
     25 |def gaz(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:25: Insert `sig { params(x: T.untyped).returns(T::Enumerator[Integer]) }`
+    test/cli/print_generics/print_generics.rb:25: Insert `extend T::Sig
+    sig { params(x: T.untyped).returns(T::Enumerator[Integer]) }`
     25 |def gaz(x)
         ^
 Errors: 6

--- a/test/cli/suggest-sig-literal/test.out
+++ b/test/cli/suggest-sig-literal/test.out
@@ -2,7 +2,8 @@ suggest-sig-literal.rb:2: The method `index_for_live` does not have a `sig` http
      2 |def index_for_live(fields)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig-literal.rb:2: Inserted `sig { params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]]) }`
+    suggest-sig-literal.rb:2: Inserted `extend T::Sig
+    sig { params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]]) }`
      2 |def index_for_live(fields)
         ^
 Errors: 1
@@ -10,6 +11,7 @@ Errors: 1
 --------------------------------------------------------------------------
 
 # typed: strict
+extend T::Sig
 sig { params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]]) }
 def index_for_live(fields)
   [[:deleted_at, 1]] + fields

--- a/test/cli/suggest-sig/test.out
+++ b/test/cli/suggest-sig/test.out
@@ -36,7 +36,9 @@ suggest-sig.rb:5: The method `hazTwoArgs` does not have a `sig` https://srb.help
      5 |def hazTwoArgs(a, b); 1; end;
         ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:5: Inserted `sig { params(a: T.untyped, b: T.untyped).returns(Integer) }`
+    suggest-sig.rb:5: Inserted `extend T::Sig
+    
+    sig { params(a: T.untyped, b: T.untyped).returns(Integer) }`
      5 |def hazTwoArgs(a, b); 1; end;
         ^
 
@@ -48,7 +50,9 @@ suggest-sig.rb:7: The method `baz` does not have a `sig` https://srb.help/7017
      7 |def baz
         ^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:7: Inserted `sig { returns(T.any(T::Array[T.untyped], String)) }`
+    suggest-sig.rb:7: Inserted `extend T::Sig
+    
+    sig { returns(T.any(T::Array[T.untyped], String)) }`
      7 |def baz
         ^
 
@@ -56,7 +60,9 @@ suggest-sig.rb:18: The method `bla` does not have a `sig` https://srb.help/7017
     18 |def bla; give_me_void; end
         ^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:18: Inserted `sig { void }`
+    suggest-sig.rb:18: Inserted `extend T::Sig
+    
+    sig { void }`
     18 |def bla; give_me_void; end
         ^
 
@@ -68,7 +74,9 @@ suggest-sig.rb:20: The method `bbq` does not have a `sig` https://srb.help/7017
     20 |def bbq
         ^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:20: Inserted `sig { void }`
+    suggest-sig.rb:20: Inserted `extend T::Sig
+    
+    sig { void }`
     20 |def bbq
         ^
 
@@ -80,7 +88,9 @@ suggest-sig.rb:30: The method `give_me_literal` does not have a `sig` https://sr
     30 |def give_me_literal; 1; end;
         ^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:30: Inserted `sig { returns(Integer) }`
+    suggest-sig.rb:30: Inserted `extend T::Sig
+    
+    sig { returns(Integer) }`
     30 |def give_me_literal; 1; end;
         ^
 
@@ -88,7 +98,9 @@ suggest-sig.rb:32: The method `give_me_literal_nested` does not have a `sig` htt
     32 |def give_me_literal_nested; [[1]]; end;
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:32: Inserted `sig { returns(T::Array[T::Array[Integer]]) }`
+    suggest-sig.rb:32: Inserted `extend T::Sig
+    
+    sig { returns(T::Array[T::Array[Integer]]) }`
     32 |def give_me_literal_nested; [[1]]; end;
         ^
 
@@ -96,7 +108,9 @@ suggest-sig.rb:34: The method `root_private` does not have a `sig` https://srb.h
     34 |private def root_private; end
                 ^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:34: Inserted `sig { returns(NilClass) }`
+    suggest-sig.rb:34: Inserted `extend T::Sig
+    
+    sig { returns(NilClass) }`
     34 |private def root_private; end
         ^
 
@@ -104,7 +118,9 @@ suggest-sig.rb:36: The method `root_protected` does not have a `sig` https://srb
     36 |protected def root_protected; end
                   ^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:36: Inserted `sig { returns(NilClass) }`
+    suggest-sig.rb:36: Inserted `extend T::Sig
+    
+    sig { returns(NilClass) }`
     36 |protected def root_protected; end
         ^
 
@@ -112,7 +128,9 @@ suggest-sig.rb:46: The method `foo` does not have a `sig` https://srb.help/7017
     46 |def foo(a)
         ^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:46: Inserted `sig { params(a: Integer).returns(Integer) }`
+    suggest-sig.rb:46: Inserted `extend T::Sig
+    
+    sig { params(a: Integer).returns(Integer) }`
     46 |def foo(a)
         ^
 
@@ -120,7 +138,9 @@ suggest-sig.rb:56: The method `fooCond` does not have a `sig` https://srb.help/7
     56 |def fooCond(a, cond)
         ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:56: Inserted `sig { params(a: T.any(Integer, String), cond: T.untyped).void }`
+    suggest-sig.rb:56: Inserted `extend T::Sig
+    
+    sig { params(a: T.any(Integer, String), cond: T.untyped).void }`
     56 |def fooCond(a, cond)
         ^
 
@@ -128,7 +148,9 @@ suggest-sig.rb:64: The method `fooWhile` does not have a `sig` https://srb.help/
     64 |def fooWhile(a, cond1, cond2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:64: Inserted `sig { params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass) }`
+    suggest-sig.rb:64: Inserted `extend T::Sig
+    
+    sig { params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass) }`
     64 |def fooWhile(a, cond1, cond2)
         ^
 
@@ -136,7 +158,9 @@ suggest-sig.rb:74: The method `takesBlock` does not have a `sig` https://srb.hel
     74 |def takesBlock
         ^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:74: Inserted `sig { returns(Integer) }`
+    suggest-sig.rb:74: Inserted `extend T::Sig
+    
+    sig { returns(Integer) }`
     74 |def takesBlock
         ^
 
@@ -144,7 +168,9 @@ suggest-sig.rb:79: The method `list_ints_or_empty_list` does not have a `sig` ht
     79 |def list_ints_or_empty_list
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:79: Inserted `sig { returns(T::Array[T.untyped]) }`
+    suggest-sig.rb:79: Inserted `extend T::Sig
+    
+    sig { returns(T::Array[T.untyped]) }`
     79 |def list_ints_or_empty_list
         ^
 
@@ -188,7 +214,9 @@ suggest-sig.rb:84: The method `dead` does not have a `sig` https://srb.help/7017
     84 |def dead(x)
         ^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:84: Inserted `sig { params(x: Integer).void }`
+    suggest-sig.rb:84: Inserted `extend T::Sig
+    
+    sig { params(x: Integer).void }`
     84 |def dead(x)
         ^
 
@@ -196,7 +224,9 @@ suggest-sig.rb:92: The method `with_block` does not have a `sig` https://srb.hel
     92 |def with_block
         ^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:92: Inserted `sig { returns(NilClass) }`
+    suggest-sig.rb:92: Inserted `extend T::Sig
+    
+    sig { returns(NilClass) }`
     92 |def with_block
         ^
 
@@ -212,7 +242,9 @@ suggest-sig.rb:118: The method `cantRun` does not have a `sig` https://srb.help/
      118 |def cantRun(a)
           ^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:118: Inserted `sig { params(a: T.untyped).returns(Integer) }`
+    suggest-sig.rb:118: Inserted `extend T::Sig
+    
+    sig { params(a: T.untyped).returns(Integer) }`
      118 |def cantRun(a)
           ^
 
@@ -220,7 +252,9 @@ suggest-sig.rb:155: The method `explicitly_named_block_parameter` does not have 
      155 |def explicitly_named_block_parameter(&blk)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:155: Inserted `sig { params(blk: T.untyped).returns(Integer) }`
+    suggest-sig.rb:155: Inserted `extend T::Sig
+    
+    sig { params(blk: T.untyped).returns(Integer) }`
      155 |def explicitly_named_block_parameter(&blk)
           ^
 
@@ -376,8 +410,12 @@ Errors: 47
 
 extend T::Sig
 
+extend T::Sig
+
 sig { params(a: T.untyped, b: T.untyped).returns(Integer) }
 def hazTwoArgs(a, b); 1; end;
+
+extend T::Sig
 
 sig { returns(T.any(T::Array[T.untyped], String)) }
 def baz
@@ -391,8 +429,12 @@ end
 sig {void}
 def give_me_void; end
 
+extend T::Sig
+
 sig { void }
 def bla; give_me_void; end
+
+extend T::Sig
 
 sig { void }
 def bbq
@@ -405,14 +447,22 @@ end
 
 def idk(a); a / a + a * a; end
 
+extend T::Sig
+
 sig { returns(Integer) }
 def give_me_literal; 1; end;
+
+extend T::Sig
 
 sig { returns(T::Array[T::Array[Integer]]) }
 def give_me_literal_nested; [[1]]; end;
 
+extend T::Sig
+
 sig { returns(NilClass) }
 private def root_private; end
+
+extend T::Sig
 
 sig { returns(NilClass) }
 protected def root_protected; end
@@ -427,6 +477,8 @@ class A
   protected def a_protected; end
 end
 
+extend T::Sig
+
 sig { params(a: Integer).returns(Integer) }
 def foo(a)
  1 + a
@@ -438,6 +490,8 @@ def takesInt(a); end;
 sig {params(a: String).void}
 def takesString(a); end;
 
+extend T::Sig
+
 sig { params(a: T.any(Integer, String), cond: T.untyped).void }
 def fooCond(a, cond)
   if cond
@@ -446,6 +500,8 @@ def fooCond(a, cond)
     takesString(a)
   end
 end
+
+extend T::Sig
 
 sig { params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass) }
 def fooWhile(a, cond1, cond2)
@@ -458,17 +514,23 @@ def fooWhile(a, cond1, cond2)
   end
 end
 
+extend T::Sig
+
 sig { returns(Integer) }
 def takesBlock
   yield 1
   2
 end
 
+extend T::Sig
+
 sig { returns(T::Array[T.untyped]) }
 def list_ints_or_empty_list
   x = T.let(1, T.nilable(Integer))
   x.nil? ? [x] : []
 end
+
+extend T::Sig
 
 sig { params(x: Integer).void }
 def dead(x)
@@ -478,6 +540,8 @@ def dead(x)
     takesString(x)
   end
 end
+
+extend T::Sig
 
 sig { returns(NilClass) }
 def with_block
@@ -494,6 +558,7 @@ Foo = Struct.new(:a, :b)
 
 class TestCarash
   extend T::Sig
+
   class Merchant
   end
 
@@ -507,6 +572,8 @@ class TestCarash
     1
   end
 end
+
+extend T::Sig
 
 sig { params(a: T.untyped).returns(Integer) }
 def cantRun(a)
@@ -545,6 +612,8 @@ class Abstract
   sig {abstract.params(a: T.untyped).void}
   def abstract_foo(a); end
 end
+
+extend T::Sig
 
 sig { params(blk: T.untyped).returns(Integer) }
 def explicitly_named_block_parameter(&blk)

--- a/test/cli/suggest-sig/test.out
+++ b/test/cli/suggest-sig/test.out
@@ -37,7 +37,6 @@ suggest-sig.rb:5: The method `hazTwoArgs` does not have a `sig` https://srb.help
         ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:5: Inserted `extend T::Sig
-    
     sig { params(a: T.untyped, b: T.untyped).returns(Integer) }`
      5 |def hazTwoArgs(a, b); 1; end;
         ^
@@ -51,7 +50,6 @@ suggest-sig.rb:7: The method `baz` does not have a `sig` https://srb.help/7017
         ^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:7: Inserted `extend T::Sig
-    
     sig { returns(T.any(T::Array[T.untyped], String)) }`
      7 |def baz
         ^
@@ -61,7 +59,6 @@ suggest-sig.rb:18: The method `bla` does not have a `sig` https://srb.help/7017
         ^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:18: Inserted `extend T::Sig
-    
     sig { void }`
     18 |def bla; give_me_void; end
         ^
@@ -75,7 +72,6 @@ suggest-sig.rb:20: The method `bbq` does not have a `sig` https://srb.help/7017
         ^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:20: Inserted `extend T::Sig
-    
     sig { void }`
     20 |def bbq
         ^
@@ -89,7 +85,6 @@ suggest-sig.rb:30: The method `give_me_literal` does not have a `sig` https://sr
         ^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:30: Inserted `extend T::Sig
-    
     sig { returns(Integer) }`
     30 |def give_me_literal; 1; end;
         ^
@@ -99,7 +94,6 @@ suggest-sig.rb:32: The method `give_me_literal_nested` does not have a `sig` htt
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:32: Inserted `extend T::Sig
-    
     sig { returns(T::Array[T::Array[Integer]]) }`
     32 |def give_me_literal_nested; [[1]]; end;
         ^
@@ -109,7 +103,6 @@ suggest-sig.rb:34: The method `root_private` does not have a `sig` https://srb.h
                 ^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:34: Inserted `extend T::Sig
-    
     sig { returns(NilClass) }`
     34 |private def root_private; end
         ^
@@ -119,7 +112,6 @@ suggest-sig.rb:36: The method `root_protected` does not have a `sig` https://srb
                   ^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:36: Inserted `extend T::Sig
-    
     sig { returns(NilClass) }`
     36 |protected def root_protected; end
         ^
@@ -129,7 +121,6 @@ suggest-sig.rb:46: The method `foo` does not have a `sig` https://srb.help/7017
         ^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:46: Inserted `extend T::Sig
-    
     sig { params(a: Integer).returns(Integer) }`
     46 |def foo(a)
         ^
@@ -139,7 +130,6 @@ suggest-sig.rb:56: The method `fooCond` does not have a `sig` https://srb.help/7
         ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:56: Inserted `extend T::Sig
-    
     sig { params(a: T.any(Integer, String), cond: T.untyped).void }`
     56 |def fooCond(a, cond)
         ^
@@ -149,7 +139,6 @@ suggest-sig.rb:64: The method `fooWhile` does not have a `sig` https://srb.help/
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:64: Inserted `extend T::Sig
-    
     sig { params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass) }`
     64 |def fooWhile(a, cond1, cond2)
         ^
@@ -159,7 +148,6 @@ suggest-sig.rb:74: The method `takesBlock` does not have a `sig` https://srb.hel
         ^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:74: Inserted `extend T::Sig
-    
     sig { returns(Integer) }`
     74 |def takesBlock
         ^
@@ -169,7 +157,6 @@ suggest-sig.rb:79: The method `list_ints_or_empty_list` does not have a `sig` ht
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:79: Inserted `extend T::Sig
-    
     sig { returns(T::Array[T.untyped]) }`
     79 |def list_ints_or_empty_list
         ^
@@ -215,7 +202,6 @@ suggest-sig.rb:84: The method `dead` does not have a `sig` https://srb.help/7017
         ^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:84: Inserted `extend T::Sig
-    
     sig { params(x: Integer).void }`
     84 |def dead(x)
         ^
@@ -225,7 +211,6 @@ suggest-sig.rb:92: The method `with_block` does not have a `sig` https://srb.hel
         ^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:92: Inserted `extend T::Sig
-    
     sig { returns(NilClass) }`
     92 |def with_block
         ^
@@ -243,7 +228,6 @@ suggest-sig.rb:118: The method `cantRun` does not have a `sig` https://srb.help/
           ^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:118: Inserted `extend T::Sig
-    
     sig { params(a: T.untyped).returns(Integer) }`
      118 |def cantRun(a)
           ^
@@ -253,7 +237,6 @@ suggest-sig.rb:155: The method `explicitly_named_block_parameter` does not have 
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig.rb:155: Inserted `extend T::Sig
-    
     sig { params(blk: T.untyped).returns(Integer) }`
      155 |def explicitly_named_block_parameter(&blk)
           ^
@@ -411,12 +394,10 @@ Errors: 47
 extend T::Sig
 
 extend T::Sig
-
 sig { params(a: T.untyped, b: T.untyped).returns(Integer) }
 def hazTwoArgs(a, b); 1; end;
 
 extend T::Sig
-
 sig { returns(T.any(T::Array[T.untyped], String)) }
 def baz
   if someCondition
@@ -430,12 +411,10 @@ sig {void}
 def give_me_void; end
 
 extend T::Sig
-
 sig { void }
 def bla; give_me_void; end
 
 extend T::Sig
-
 sig { void }
 def bbq
   if someCondition
@@ -448,22 +427,18 @@ end
 def idk(a); a / a + a * a; end
 
 extend T::Sig
-
 sig { returns(Integer) }
 def give_me_literal; 1; end;
 
 extend T::Sig
-
 sig { returns(T::Array[T::Array[Integer]]) }
 def give_me_literal_nested; [[1]]; end;
 
 extend T::Sig
-
 sig { returns(NilClass) }
 private def root_private; end
 
 extend T::Sig
-
 sig { returns(NilClass) }
 protected def root_protected; end
 
@@ -478,7 +453,6 @@ class A
 end
 
 extend T::Sig
-
 sig { params(a: Integer).returns(Integer) }
 def foo(a)
  1 + a
@@ -491,7 +465,6 @@ sig {params(a: String).void}
 def takesString(a); end;
 
 extend T::Sig
-
 sig { params(a: T.any(Integer, String), cond: T.untyped).void }
 def fooCond(a, cond)
   if cond
@@ -502,7 +475,6 @@ def fooCond(a, cond)
 end
 
 extend T::Sig
-
 sig { params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass) }
 def fooWhile(a, cond1, cond2)
   while cond2
@@ -515,7 +487,6 @@ def fooWhile(a, cond1, cond2)
 end
 
 extend T::Sig
-
 sig { returns(Integer) }
 def takesBlock
   yield 1
@@ -523,7 +494,6 @@ def takesBlock
 end
 
 extend T::Sig
-
 sig { returns(T::Array[T.untyped]) }
 def list_ints_or_empty_list
   x = T.let(1, T.nilable(Integer))
@@ -531,7 +501,6 @@ def list_ints_or_empty_list
 end
 
 extend T::Sig
-
 sig { params(x: Integer).void }
 def dead(x)
   if true || qux || blah
@@ -542,7 +511,6 @@ def dead(x)
 end
 
 extend T::Sig
-
 sig { returns(NilClass) }
 def with_block
   yield
@@ -558,7 +526,6 @@ Foo = Struct.new(:a, :b)
 
 class TestCarash
   extend T::Sig
-
   class Merchant
   end
 
@@ -574,7 +541,6 @@ class TestCarash
 end
 
 extend T::Sig
-
 sig { params(a: T.untyped).returns(Integer) }
 def cantRun(a)
   takesInt(a)
@@ -614,7 +580,6 @@ class Abstract
 end
 
 extend T::Sig
-
 sig { params(blk: T.untyped).returns(Integer) }
 def explicitly_named_block_parameter(&blk)
   42

--- a/test/testdata/infer/autocorrect_extend_t_sig.rb.autocorrects.exp
+++ b/test/testdata/infer/autocorrect_extend_t_sig.rb.autocorrects.exp
@@ -19,7 +19,6 @@ class HasSig
 end
 
   extend T::Sig
-
   sig do
 # ^^^ error: Method `sig` does not exist
     load

--- a/test/testdata/infer/kwsplat_is_sometimes_okay.rb.autocorrects.exp
+++ b/test/testdata/infer/kwsplat_is_sometimes_okay.rb.autocorrects.exp
@@ -23,10 +23,13 @@ def takes_some_required_untyped(x:, y: ''); end
 sig {params(x: String, y: String).void}
 def takes_all_optional_untyped(x: '', y: ''); end
 
+extend T::Sig
 sig { params(x: T.untyped, y: T.untyped).returns(NilClass) }
 def takes_all_required_unsigged(x:, y:); end # error: does not have a `sig`
+extend T::Sig
 sig { params(x: T.untyped, y: T.untyped).returns(NilClass) }
 def takes_some_required_unsigged(x:, y: ''); end # error: does not have a `sig`
+extend T::Sig
 sig { params(x: T.untyped, y: T.untyped).returns(NilClass) }
 def takes_all_optional_unsigged(x: '', y: ''); end # error: does not have a `sig`
 

--- a/test/testdata/infer/suggest_useless_sig.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_useless_sig.rb.autocorrects.exp
@@ -2,6 +2,7 @@
 # typed: strict
 # enable-suggest-unsafe: true
 
+extend T::Sig
 sig { params(x: T.untyped).returns(T.untyped) }
 def foo(x) # error: does not have a `sig`
   T.unsafe(nil)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's a bunch of autocorrects I want to build of the form "insert some DSL
method into the class"

- add `abstract!`
- add `X = type_member`

etc.

It's convenient if we don't have to keep duplicating this logic into every
specific autocorrect where we want this.

### Caveats

An extended note about the root logic: this is kind of a tradeoff.

For the SigSuggestion autocorrect, this has the unfortunate side effect of
inserting `extend T::Sig` multiple times in the file. But IMO, that's kind
of find, because that would only apply if there were multiple methods
without a sig in the file, and either

- You used "apply all fixes for file", or
- You used `-a` at the command line

There will be many cases where neither of those is true, which means that
the new behavior is a strict improvement.

In the cases where it does add duplicate, the redundant calls to
`extend T::Sig` are a no-op, so it's not _incorrect_ to have them, it's
just maybe bad style. I think I'd prefer having something that is really
good at fixing type errors.

It's hard to do better here. If it were possible to always insert the
`extend T::Sig` somewhere like "at the top of the file, but after all
requires and comments," then all the autocorrect edits would share the same
location, causing only one of them to get applied (we only apply the first
edit that happens at a given place).

The real goal is to get this in so that other call sites that _are_ fine
with this logic can use this one new helper.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests