### PR TITLE
Kernel#send: BasicObject -> T.anything

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -624,14 +624,14 @@ module Kernel
   sig do
     params(
         arg0: T.any(String, Symbol),
-        arg1: BasicObject,
+        arg1: T.anything,
     )
     .returns(T.untyped)
   end
   sig do
     params(
         arg0: T.any(String, Symbol),
-        arg1: BasicObject,
+        arg1: T.anything,
         blk: T.untyped,
     )
     .returns(T.untyped)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If you have a type member or a module in `y` and you want to call `x.send(:foo,
y)`, that should be fine. There's already no type safety for this.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.