### PR TITLE
Don't build sorbet_ruby on test-static-sanitized

### DIFF
--- a/.buildkite/test-compiler.sh
+++ b/.buildkite/test-compiler.sh
@@ -39,6 +39,10 @@ mkdir -p _out_
 test_args=(
   "//test:compiler"
   "//test/cli/compiler"
+  # These are two tests that depend on sorbet_ruby, and it's annoying to have
+  # to build sorbet_ruby on the static sanitized job (delays test start time)
+  "//test:end_to_end_rbi_test"
+  "//test:single_package_runner"
   "-c"
   "opt"
   "--config=forcedebug"

--- a/test/BUILD
+++ b/test/BUILD
@@ -371,13 +371,13 @@ sh_binary(
         "//main:sorbet",
         "@sorbet_ruby_2_7//:ruby",
     ],
+    # This is to get the test to run on the compiler build job,
+    # so we can avoid building ruby on the test-static-sanitized job.
+    tags = ["compiler"],
     deps = [
         ":logging",
         "@bazel_tools//tools/bash/runfiles",
     ],
-    # This is to get the test to run on the compiler build job,
-    # so we can avoid building ruby on the test-static-sanitized job.
-    tags = ["compiler"],
 )
 
 sh_binary(

--- a/test/BUILD
+++ b/test/BUILD
@@ -375,6 +375,9 @@ sh_binary(
         ":logging",
         "@bazel_tools//tools/bash/runfiles",
     ],
+    # This is to get the test to run on the compiler build job,
+    # so we can avoid building ruby on the test-static-sanitized job.
+    tags = ["compiler"],
 )
 
 sh_binary(

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -100,6 +100,9 @@ def single_package_rbi_test(name, rb_files):
         name = name,
         rb_files = rb_files,
         size = "small",
+        # This is to get the test to run on the compiler build job,
+        # so we can avoid building ruby on the test-static-sanitized job.
+        tags = ["compiler"],
     )
 
 _TEST_RUNNERS = {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes test-static-sanitized start running pipeline and LSP tests faster,
because it doesn't wait for ruby to build.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.