### PR TITLE
Descend further to find include and extend

### DIFF
--- a/test/cli/print_to_file_v2/test.out
+++ b/test/cli/print_to_file_v2/test.out
@@ -136,28 +136,43 @@ requires: []
  resolved=[]
  loc=test/cli/print_to_file_v2/c.rb:9
  is_defining_ref=0
+ parent_of=[C BarChild]
 [ref id=6]
+ scope=[]
+ name=[InMethodX]
+ nesting=[]
+ resolved=[]
+ loc=test/cli/print_to_file_v2/c.rb:9
+ is_defining_ref=0
+[ref id=7]
  scope=[C]
  name=[TestExtend]
  nesting=[[C]]
  resolved=[C TestExtend]
  loc=test/cli/print_to_file_v2/c.rb:13
  is_defining_ref=1
-[ref id=7]
+[ref id=8]
  scope=[]
  name=[Y]
  nesting=[]
  resolved=[]
  loc=test/cli/print_to_file_v2/c.rb:14
  is_defining_ref=0
-[ref id=8]
+[ref id=9]
  scope=[]
  name=[InMethodY]
  nesting=[]
  resolved=[]
  loc=test/cli/print_to_file_v2/c.rb:16
  is_defining_ref=0
-[ref id=9]
+[ref id=10]
+ scope=[]
+ name=[InMethodY]
+ nesting=[]
+ resolved=[]
+ loc=test/cli/print_to_file_v2/c.rb:16
+ is_defining_ref=0
+[ref id=11]
  scope=[]
  name=[ViaMethod]
  nesting=[]
@@ -252,6 +267,6 @@ requires: []
  is_defining_ref=0
 --- autogen.txt end ---
 
-bebe1bec5a305f6c01a56ce81b2dbbab7fd1b194  autogen.msgpack
+7bb5ed76124dfb3066e505a9bf96b1f5b0108aa7  autogen.msgpack
 
 --print=cfg specified multiple times with inconsistent output options

--- a/test/cli/print_to_file_v3/test.out
+++ b/test/cli/print_to_file_v3/test.out
@@ -136,28 +136,43 @@ requires: []
  resolved=[]
  loc=test/cli/print_to_file_v3/c.rb:9
  is_defining_ref=0
+ parent_of=[C BarChild]
 [ref id=6]
+ scope=[]
+ name=[InMethodX]
+ nesting=[]
+ resolved=[]
+ loc=test/cli/print_to_file_v3/c.rb:9
+ is_defining_ref=0
+[ref id=7]
  scope=[C]
  name=[TestExtend]
  nesting=[[C]]
  resolved=[C TestExtend]
  loc=test/cli/print_to_file_v3/c.rb:13
  is_defining_ref=1
-[ref id=7]
+[ref id=8]
  scope=[]
  name=[Y]
  nesting=[]
  resolved=[]
  loc=test/cli/print_to_file_v3/c.rb:14
  is_defining_ref=0
-[ref id=8]
+[ref id=9]
  scope=[]
  name=[InMethodY]
  nesting=[]
  resolved=[]
  loc=test/cli/print_to_file_v3/c.rb:16
  is_defining_ref=0
-[ref id=9]
+[ref id=10]
+ scope=[]
+ name=[InMethodY]
+ nesting=[]
+ resolved=[]
+ loc=test/cli/print_to_file_v3/c.rb:16
+ is_defining_ref=0
+[ref id=11]
  scope=[]
  name=[ViaMethod]
  nesting=[]
@@ -252,6 +267,6 @@ requires: []
  is_defining_ref=0
 --- autogen.txt end ---
 
-ef1f9c175a81b441fabaf42a3fc947b94ff3f0de  autogen.msgpack
+c750bdf9139be78a2904477f1cdb6c8e2ed4b721  autogen.msgpack
 
 --print=cfg specified multiple times with inconsistent output options


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are a bunch of `include` and `extend` lines that sit behind an `if`
condition at a class top level.

Right now, those are just getting written out into RBI files, so it shouldn't
cause any new type check errors because of this, unless the value of the `if`
condition matters.

It looks like autogen had a test that explicitly tested that we _didn't_ find
the `include` in side block calls. So maybe that means this is intentional, and
we'll have to find another way to solve the RBI problem. Only one way to find
out.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.