### PR TITLE
Only handle sensitivity annotations in prop DSL when necessary

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -338,20 +338,23 @@ class T::Props::Decorator
     # Retrive the possible underlying object with T.nilable.
     type = T::Utils::Nilable.get_underlying_type(type)
 
-    sensitivity_and_pii = {sensitivity: rules[:sensitivity]}
-    normalize = T::Configuration.normalize_sensitivity_and_pii_handler
-    if normalize
-      sensitivity_and_pii = normalize.call(sensitivity_and_pii)
+    rules_sensitivity = rules[:sensitivity]
+    sensitivity_and_pii = {sensitivity: rules_sensitivity}
+    if !rules_sensitivity.nil?
+      normalize = T::Configuration.normalize_sensitivity_and_pii_handler
+      if normalize
+        sensitivity_and_pii = normalize.call(sensitivity_and_pii)
 
-      # We check for Class so this is only applied on concrete
-      # documents/models; We allow mixins containing props to not
-      # specify their PII nature, as long as every class into which they
-      # are ultimately included does.
-      #
-      if sensitivity_and_pii[:pii] && @class.is_a?(Class) && !T.unsafe(@class).contains_pii?
-        raise ArgumentError.new(
-          'Cannot include a pii prop in a class that declares `contains_no_pii`'
-        )
+        # We check for Class so this is only applied on concrete
+        # documents/models; We allow mixins containing props to not
+        # specify their PII nature, as long as every class into which they
+        # are ultimately included does.
+        #
+        if sensitivity_and_pii[:pii] && @class.is_a?(Class) && !T.unsafe(@class).contains_pii?
+          raise ArgumentError.new(
+            'Cannot include a pii prop in a class that declares `contains_no_pii`'
+          )
+        end
       end
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The `prop` DSL always calls into the `normalize_sensitivity_and_pii_handler`, even when the `sensitivity` rule isn't declared. In those cases, the call is unnecessary and allocates memory. Fixing this issue reduces the object allocations of loading all model classes at Stripe by **0.3%**.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Tested on Stripe codebase.
https://go/builds/bui_No8ZOgvDw9hKgn
