### PR TITLE
Migrate a prop type validation helper from kwarg -> arg so that it can be sig-checked faster

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/type_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/type_validation.rb
@@ -29,7 +29,7 @@ module T::Props::TypeValidation
       super
 
       if !rules[:DEPRECATED_underspecified_type]
-        validate_type(type, field_name: name)
+        validate_type(type, name)
       elsif rules[:DEPRECATED_underspecified_type] && find_invalid_subtype(type).nil?
         raise ArgumentError.new("DEPRECATED_underspecified_type set unnecessarily for #{@class.name}.#{name} - #{type} is a valid type")
       end
@@ -42,7 +42,7 @@ module T::Props::TypeValidation
       )
       .void
     end
-    private def validate_type(type, field_name:)
+    private def validate_type(type, field_name)
       if (invalid_subtype = find_invalid_subtype(type))
         raise UnderspecifiedType.new(type_error_message(invalid_subtype, field_name, type))
       end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Every `prop` declaration is validated at runtime for its type declarations. This is a critical path in class loading at Stripe. There is a `validate_type` method that is called during prop declarations, which uses kwargs. Unfortunately, kwarg validation is slower in Sorbet runtime. Converting arity to simple args so that the method can take the "fast path".

Fixing this issue reduces the object allocations of loading all model classes at Stripe by **0.7%**. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on Stripe codebase.
