### PR TITLE
Remove unnecessary allocations when checking splat arguments

### DIFF
--- a/gems/sorbet-runtime/.rubocop_todo.yml
+++ b/gems/sorbet-runtime/.rubocop_todo.yml
@@ -220,6 +220,7 @@ Naming/MemoizedInstanceVariableName:
 Naming/MethodParameterName:
   Exclude:
     - 'bench/typecheck.rb'
+    - 'bench/typecheck_kwargs_splat.rb'
     - 'lib/types/types/base.rb'
     - 'test/types/abstract_validation.rb'
     - 'test/types/builder_syntax.rb'

--- a/gems/sorbet-runtime/bench/tasks.rb
+++ b/gems/sorbet-runtime/bench/tasks.rb
@@ -10,6 +10,7 @@ require_relative 'prop_validation'
 require_relative 'serialize_custom_type'
 require_relative 'tutils'
 require_relative 'typecheck'
+require_relative 'typecheck_kwargs_splat'
 
 namespace :bench do
   task :getters do
@@ -42,6 +43,10 @@ namespace :bench do
 
   task :typecheck do
     SorbetBenchmarks::Typecheck.run
+  end
+
+  task :typecheck_kwargs_splat do
+    SorbetBenchmarks::TypecheckKwargsSplat.run
   end
 
   task :tutils do

--- a/gems/sorbet-runtime/bench/typecheck_kwargs_splat.rb
+++ b/gems/sorbet-runtime/bench/typecheck_kwargs_splat.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module TypecheckKwargsSplat
+    extend T::Sig
+
+    class Example; end
+
+    def self.time_block(name, iterations_of_block: 1_000_000, iterations_in_block: 2, &blk)
+      10_000.times(&blk) # warmup
+
+      GC.start
+      GC.disable
+      before_alloc = GC.stat(:total_allocated_objects)
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      iterations_of_block.times(&blk)
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+
+      after_alloc = GC.stat(:total_allocated_objects)
+      GC.enable
+
+      ns_per_iter = duration_s * 1_000_000_000 / (iterations_of_block * iterations_in_block)
+      duration_str = ns_per_iter >= 1000 ? "#{(ns_per_iter / 1000).round(3)} μs" : "#{ns_per_iter.round(3)} ns"
+      puts "#{name}: #{duration_str}"
+      puts "Allocations for #{name}: #{after_alloc - before_alloc}"
+    end
+
+    def self.run
+      example = Example.new
+
+      time_block("sig {params(s: Symbol, rest: String, x: Integer, y: Integer).void} (with kwargs plus splat)") do
+        arg_plus_kwargs(:foo, "foo", "bar", "baz", x: 1, y: 2)
+        arg_plus_kwargs(:bar, "foo", "bar", "baz", x: 1)
+      end
+    end
+
+    sig {params(s: Symbol, rest: String, x: Integer, y: Integer).void}
+    def self.arg_plus_kwargs(s, *rest, x:, y: 0); end
+  end
+end
+

--- a/gems/sorbet-runtime/bench/typecheck_kwargs_splat.rb
+++ b/gems/sorbet-runtime/bench/typecheck_kwargs_splat.rb
@@ -32,8 +32,6 @@ module SorbetBenchmarks
     end
 
     def self.run
-      example = Example.new
-
       time_block("sig {params(s: Symbol, rest: String, x: Integer, y: Integer).void} (with kwargs plus splat)") do
         arg_plus_kwargs(:foo, "foo", "bar", "baz", x: 1, y: 2)
         arg_plus_kwargs(:bar, "foo", "bar", "baz", x: 1)
@@ -44,4 +42,3 @@ module SorbetBenchmarks
     def self.arg_plus_kwargs(s, *rest, x:, y: 0); end
   end
 end
-

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -192,7 +192,7 @@ class T::Private::Methods::Signature
 
       # Process given pre-rest args. When there are no rest args,
       # this is just the given number of args.
-      while it < [args_length, @arg_types.length].min
+      while it < args_length && it < @arg_types.length
         yield @arg_types[it][0], args[it], @arg_types[it][1]
         it += 1
       end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Drops **1%** of allocations when loading all model classes at Stripe. Will potentially have a further impact for all method calls with splats, beyond just class loading.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improve performance of runtime typechecking.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Build: https://go/builds/bui_NoJwP5CetUPaMi