### PR TITLE
Use reveal_type in `self.class` test

### DIFF
--- a/test/testdata/infer/class.rb
+++ b/test/testdata/infer/class.rb
@@ -10,9 +10,8 @@ class TestCase
     # Test that Class's methods work
     self.class.allocate
 
-    T.assert_type!(self.class.new, TestCase)
-    T.assert_type!(self.class, T.class_of(TestCase))
-    T.assert_type!(self.class, Class)
-    T.assert_type!(self.class.class, Class)
+    T.reveal_type(self.class.new) # error: `TestCase`
+    T.reveal_type(self.class) # error: `T.class_of(TestCase)`
+    T.reveal_type(self.class.class) # error: `Class`
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm planning on making some changes to the intrinsic we have for `Object_class`.
It's easier to see how that change works when this test is rewritten to use
`reveal_type` instead of `assert_type!`, because the type will get narrower. As
written, the test would still pass. Now, the test would fail if some change
improved the way that this intrinsic works, which is better.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change