### PR TITLE
Add serialization support to unions of serializables

### DIFF
--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -598,12 +598,25 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
   end
 
   describe 'unions of two different serializables' do
-    it 'are just cloned on serde' do
+    it 'are serialized' do
       obj = MyNilableSerializable.new
-      T::Props::Utils.expects(:deep_clone_object).with(obj).at_least_once.returns(obj)
+      obj.name = "test"
+      T::Props::Utils.expects(:deep_clone_object).never
 
       s = MultipleStructUnionStruct.new(prop: obj)
-      assert_equal(obj, MultipleStructUnionStruct.from_hash(s.serialize).prop)
+      deserialized = MultipleStructUnionStruct.from_hash(s.serialize).prop
+
+      assert_instance_of(MyNilableSerializable, deserialized)
+      assert_equal(obj.address, deserialized.address)
+      assert_equal(obj.name, deserialized.name)
+    end
+
+    it 'can deserialize when a __class__ magic prop does not exist' do
+      deserialized = MultipleStructUnionStruct.from_hash({"prop" => {"name" => "foo", "address" => "bar"}}).prop
+
+      assert_instance_of(MyNilableSerializable, deserialized)
+      assert_equal("bar", deserialized.address)
+      assert_equal("foo", deserialized.name)
     end
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
It was somewhat surprising to me that [this example](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Aclass%20B%20%3C%20T%3A%3AStruct%0A%20%20prop%20%3Aname%2C%20String%0Aend%0A%0Aclass%20C%20%3C%20T%3A%3AStruct%0A%20%20prop%20%3Aage%2C%20Integer%0Aend%0A%0Aclass%20A%20%3C%20T%3A%3AStruct%0A%20%20prop%20%3Afoos%2C%20T%3A%3AArray%5BT.any%28B%2C%20C%29%5D%0Aend%0A%0AA.new%28foos%3A%20%5BB.new%28name%3A%20%22asdf%22%29%2C%20C.new%28age%3A%2010%29%5D%29.serialize%0A%23%20%5E%20B%20and%20C%20are%20not%20serialized%20right%20now) did not work: 


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
