### PR TITLE
Alias method

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2581,6 +2581,11 @@ class ResolveTypeMembersAndFieldsWalk {
         core::MethodRef toMethod = ctx.owner.asClassOrModuleRef().data(ctx)->findMethodNoDealias(ctx, job.toName);
         if (toMethod.exists()) {
             toMethod = toMethod.data(ctx)->dealiasMethod(ctx);
+        } else {
+            auto member = ctx.owner.asClassOrModuleRef().data(ctx)->findMemberTransitive(ctx, job.toName);
+            if (member.isMethod()) {
+                toMethod = member.asMethodRef();
+            }
         }
 
         if (!toMethod.exists()) {

--- a/test/testdata/namer/alias_method_superclass.rb
+++ b/test/testdata/namer/alias_method_superclass.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+class Super
+  extend T::Sig
+  sig {params(x: Integer).returns(String)}
+  def parent_method(x)
+    x.to_s
+  end
+end
+
+class A < Super
+  alias_method(:bar, :parent_method)
+end
+
+A.new.parent_method(1)
+A.new.bar(1)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Cover more use cases of `alias_method`.

Sorbet currently doesn't support aliasing methods from superclasses and includes:

* https://github.com/sorbet/sorbet/issues/365
* https://github.com/sorbet/sorbet/issues/2378
* https://github.com/sorbet/sorbet/issues/3888


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
