### PR TITLE
More disabling sig-checking in props, and other fixes

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -79,7 +79,7 @@ class T::Props::Decorator
     extra
     setter_validate
     _tnilable
-  ].map {|k| [k, true]}.to_h.freeze, T::Hash[Symbol, T::Boolean], checked: false)
+  ].to_h {|k| [k, true]}.freeze, T::Hash[Symbol, T::Boolean], checked: false)
   private_constant :VALID_RULE_KEYS
 
   sig {params(key: Symbol).returns(T::Boolean).checked(:never)}
@@ -358,16 +358,12 @@ class T::Props::Decorator
       end
     end
 
-    rules.merge!(
-      # TODO: The type of this element is confusing. We should refactor so that
-      # it can be always `type_object` (a PropType) or always `cls` (a Module)
-      type: type,
-      type_object: type_object,
-      accessor_key: "@#{name}".to_sym,
-      sensitivity: sensitivity_and_pii[:sensitivity],
-      pii: sensitivity_and_pii[:pii],
-      extra: rules[:extra]&.freeze,
-    )
+    rules[:type] = type
+    rules[:type_object] = type_object
+    rules[:accessor_key] = "@#{name}".to_sym
+    rules[:sensitivity] = sensitivity_and_pii[:sensitivity]
+    rules[:pii] = sensitivity_and_pii[:pii]
+    rules[:extra] = rules[:extra]&.freeze
 
     # extra arbitrary metadata attached by the code defining this property
 
@@ -530,8 +526,8 @@ class T::Props::Decorator
     # here, but we're baking in `allow_direct_mutation` since we
     # *haven't* allowed additional options in the past and want to
     # default to keeping this interface narrow.
+    foreign = T.let(foreign, T.untyped, checked: false)
     @class.send(:define_method, fk_method) do |allow_direct_mutation: nil|
-      foreign = T.let(foreign, T.untyped, checked: false)
       if foreign.is_a?(Proc)
         resolved_foreign = foreign.call
         if !resolved_foreign.respond_to?(:load)

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -17,7 +17,7 @@ class T::Props::Decorator
 
   class NoRulesError < StandardError; end
 
-  EMPTY_PROPS = T.let({}.freeze, T::Hash[Symbol, Rules])
+  EMPTY_PROPS = T.let({}.freeze, T::Hash[Symbol, Rules], checked: false)
   private_constant :EMPTY_PROPS
 
   sig {params(klass: T.untyped).void.checked(:never)}
@@ -26,7 +26,7 @@ class T::Props::Decorator
     @class.plugins.each do |mod|
       T::Props::Plugin::Private.apply_decorator_methods(mod, self)
     end
-    @props = T.let(EMPTY_PROPS, T::Hash[Symbol, Rules])
+    @props = T.let(EMPTY_PROPS, T::Hash[Symbol, Rules], checked: false)
   end
 
   # checked(:never) - O(prop accesses)
@@ -79,7 +79,7 @@ class T::Props::Decorator
     extra
     setter_validate
     _tnilable
-  ].map {|k| [k, true]}.to_h.freeze, T::Hash[Symbol, T::Boolean])
+  ].map {|k| [k, true]}.to_h.freeze, T::Hash[Symbol, T::Boolean], checked: false)
   private_constant :VALID_RULE_KEYS
 
   sig {params(key: Symbol).returns(T::Boolean).checked(:never)}
@@ -205,7 +205,7 @@ class T::Props::Decorator
   end
 
   # TODO: we should really be checking all the methods on `cls`, not just Object
-  BANNED_METHOD_NAMES = T.let(Object.instance_methods.each_with_object({}) {|x, acc| acc[x] = true}.freeze, T::Hash[Symbol, TrueClass])
+  BANNED_METHOD_NAMES = T.let(Object.instance_methods.each_with_object({}) {|x, acc| acc[x] = true}.freeze, T::Hash[Symbol, TrueClass], checked: false)
 
   # checked(:never) - Rules hash is expensive to check
   sig do
@@ -247,10 +247,10 @@ class T::Props::Decorator
     nil
   end
 
-  SAFE_NAME = T.let(/\A[A-Za-z_][A-Za-z0-9_-]*\z/.freeze, Regexp)
+  SAFE_NAME = T.let(/\A[A-Za-z_][A-Za-z0-9_-]*\z/.freeze, Regexp, checked: false)
 
   # Used to validate both prop names and serialized forms
-  sig {params(name: T.any(Symbol, String)).void}
+  sig {params(name: T.any(Symbol, String)).void.checked(:never)}
   private def validate_prop_name(name)
     if !name.match?(SAFE_NAME)
       raise ArgumentError.new("Invalid prop name in #{@class.name}: #{name}")
@@ -258,7 +258,7 @@ class T::Props::Decorator
   end
 
   # This converts the type from a T::Type to a regular old ruby class.
-  sig {params(type: T::Types::Base).returns(Module)}
+  sig {params(type: T::Types::Base).returns(Module).checked(:never)}
   private def convert_type_to_class(type)
     case type
     when T::Types::TypedArray, T::Types::FixedArray
@@ -358,7 +358,7 @@ class T::Props::Decorator
       end
     end
 
-    rules = rules.merge(
+    rules.merge!(
       # TODO: The type of this element is confusing. We should refactor so that
       # it can be always `type_object` (a PropType) or always `cls` (a Module)
       type: type,
@@ -366,9 +366,10 @@ class T::Props::Decorator
       accessor_key: "@#{name}".to_sym,
       sensitivity: sensitivity_and_pii[:sensitivity],
       pii: sensitivity_and_pii[:pii],
-      # extra arbitrary metadata attached by the code defining this property
       extra: rules[:extra]&.freeze,
     )
+
+    # extra arbitrary metadata attached by the code defining this property
 
     validate_not_missing_sensitivity(name, rules)
 
@@ -422,6 +423,7 @@ class T::Props::Decorator
   sig do
     params(type: PropTypeOrClass, enum: T.untyped)
     .returns(T::Types::Base)
+    .checked(:never)
   end
   private def smart_coerce(type, enum:)
     # Backwards compatibility for pre-T::Types style
@@ -474,6 +476,7 @@ class T::Props::Decorator
       redaction: T.untyped,
     )
     .void
+    .checked(:never)
   end
   private def handle_redaction_option(prop_name, redaction)
     redacted_method = "#{prop_name}_redacted"
@@ -495,6 +498,7 @@ class T::Props::Decorator
       valid_type_msg: String,
     )
     .void
+    .checked(:never)
   end
   private def validate_foreign_option(option_sym, foreign, valid_type_msg:)
     if foreign.is_a?(Symbol) || foreign.is_a?(String)
@@ -527,7 +531,7 @@ class T::Props::Decorator
     # *haven't* allowed additional options in the past and want to
     # default to keeping this interface narrow.
     @class.send(:define_method, fk_method) do |allow_direct_mutation: nil|
-      foreign = T.let(foreign, T.untyped)
+      foreign = T.let(foreign, T.untyped, checked: false)
       if foreign.is_a?(Proc)
         resolved_foreign = foreign.call
         if !resolved_foreign.respond_to?(:load)

--- a/gems/sorbet-runtime/lib/types/props/type_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/type_validation.rb
@@ -16,6 +16,7 @@ module T::Props::TypeValidation
       super || key == :DEPRECATED_underspecified_type
     end
 
+    # checked(:never) - Rules hash is expensive to check
     sig do
       params(
         name: T.any(Symbol, String),
@@ -24,6 +25,7 @@ module T::Props::TypeValidation
         type: T.any(T::Types::Base, Module)
       )
       .void
+      .checked(:never)
     end
     def prop_validate_definition!(name, _cls, rules, type)
       super


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

cc @georg-stripe @jez 

This is a follow up to my earlier PRs
https://github.com/sorbet/sorbet/pull/6967
https://github.com/sorbet/sorbet/pull/6968
https://github.com/sorbet/sorbet/pull/6969

Further improve the performance of `prop` declaration by dropping unnecessary sig checking on inner helper methods. Also fix an inefficient use of `merge`.

From a safety standpoint, the `sig` checks on inner helper methods were not adding further type safety than what is already available via the wrapper `prop` method up the stack. The `rules` hash is expensive to sig-check, and we've already turned off sig-checking for it in one place, and this ports over that change to other places.

Drops number of allocations on loading all model classes at Stripe by up to 2%.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improve code loading performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests + tested on Stripe codebase.
https://go/builds/bui_NpnHlBX9OIZN69