### PR TITLE
Add the class name to prop definition error

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -50,9 +50,9 @@ class T::Props::Decorator
     override = rules.delete(:override)
 
     if props.include?(prop) && !override
-      raise ArgumentError.new("Attempted to redefine prop #{prop.inspect} on class #{@class.inspect} that's already defined without specifying :override => true: #{prop_rules(prop)}")
+      raise ArgumentError.new("Attempted to redefine prop #{prop.inspect} on class #{@class} that's already defined without specifying :override => true: #{prop_rules(prop)}")
     elsif !props.include?(prop) && override
-      raise ArgumentError.new("Attempted to override a prop #{prop.inspect} on class #{@class.inspect} that doesn't already exist")
+      raise ArgumentError.new("Attempted to override a prop #{prop.inspect} on class #{@class} that doesn't already exist")
     end
 
     @props = @props.merge(prop => rules.freeze).freeze

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -50,9 +50,9 @@ class T::Props::Decorator
     override = rules.delete(:override)
 
     if props.include?(prop) && !override
-      raise ArgumentError.new("Attempted to redefine prop #{prop.inspect} that's already defined without specifying :override => true: #{prop_rules(prop)}")
+      raise ArgumentError.new("Attempted to redefine prop #{prop.inspect} on class #{@class.inspect} that's already defined without specifying :override => true: #{prop_rules(prop)}")
     elsif !props.include?(prop) && override
-      raise ArgumentError.new("Attempted to override a prop #{prop.inspect} that doesn't already exist")
+      raise ArgumentError.new("Attempted to override a prop #{prop.inspect} on class #{@class.inspect} that doesn't already exist")
     end
 
     @props = @props.merge(prop => rules.freeze).freeze

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -379,4 +379,36 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
     end
   end
 
+  describe 'override checking' do
+    class OverrideProps
+      include T::Props
+      prop :a, String
+    end
+
+    it 'errors if a prop is overriden without override => true' do
+      error = assert_raises(ArgumentError) do
+        class OverrideProps1 < OverrideProps
+          prop :a, Integer
+        end
+      end
+
+      assert(error.message.include?("Attempted to redefine prop :a on class Opus::Types::Test::Props::PropsTest::OverrideProps1 that's already defined without specifying :override => true"))
+    end
+
+    it 'allows overriding with override => true' do
+      class OverrideProps2 < OverrideProps
+        prop :a, Integer, override: true
+      end
+    end
+
+    it 'errors if a prop has override => true but does not exist' do
+      error = assert_raises(ArgumentError) do
+        class OverrideProps3 < OverrideProps
+          prop :b, Integer, override: true
+        end
+      end
+
+      assert(error.message.include?("Attempted to override a prop :b on class Opus::Types::Test::Props::PropsTest::OverrideProps3 that doesn't already exist"))
+    end
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The previous error message only mentioned the prop, and not the class name, so for commonly used prop names, it would be difficult to find the offending code (especially if the stack trace was not available).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
