### PR TITLE
Fix signature for Kernel.raise

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -2910,22 +2910,14 @@ module Kernel
   sig {returns(T.noreturn)}
   sig do
     params(
-        arg0: String,
+        arg0: T.any(Class, Exception, String),
     )
     .returns(T.noreturn)
   end
   sig do
     params(
-        arg0: Class,
-        arg1: T.nilable(T.untyped),
-        arg2: T.nilable(T::Array[String]),
-    )
-    .returns(T.noreturn)
-  end
-  sig do
-    params(
-        arg0: Exception,
-        arg1: T.nilable(T.untyped),
+        arg0: T.any(Class, Exception),
+        arg1: T.untyped,
         arg2: T.nilable(T::Array[String]),
     )
     .returns(T.noreturn)

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -2917,7 +2917,7 @@ module Kernel
   sig do
     params(
         arg0: Class,
-        arg1: T.untyped,
+        arg1: T.nilable(T.untyped),
         arg2: T.nilable(T::Array[String]),
     )
     .returns(T.noreturn)
@@ -2925,7 +2925,7 @@ module Kernel
   sig do
     params(
         arg0: Exception,
-        arg1: T.untyped,
+        arg1: T.nilable(T.untyped),
         arg2: T.nilable(T::Array[String]),
     )
     .returns(T.noreturn)

--- a/test/cli/errors/test.out
+++ b/test/cli/errors/test.out
@@ -9,12 +9,12 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
      .. |  MyConstantWithNoTypo = nil
           ^^^^^^^^^^^^^^^^^^^^
 
-test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
+test/cli/errors/errors.rb:15: Expected `T.any(Class, Exception, String)` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
                   ^^^
-  Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
+  Expected `T.any(Class, Exception, String)` for argument `arg0` of method `Kernel#raise (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
-      NN |        arg0: String,
+      NN |        arg0: T.any(Class, Exception, String),
                   ^^^^
   Got `Integer` originating from:
     test/cli/errors/errors.rb:13:
@@ -66,12 +66,12 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
      .. |  MyConstantWithNoTypo = nil
           ^^^^^^^^^^^^^^^^^^^^
 
-test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
+test/cli/errors/errors.rb:15: Expected `T.any(Class, Exception, String)` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
                   ^^^
-  Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
+  Expected `T.any(Class, Exception, String)` for argument `arg0` of method `Kernel#raise (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
-      NN |        arg0: String,
+      NN |        arg0: T.any(Class, Exception, String),
                   ^^^^
   Got `Integer` originating from:
     test/cli/errors/errors.rb:13:
@@ -123,12 +123,12 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
      .. |  MyConstantWithNoTypo = nil
           ^^^^^^^^^^^^^^^^^^^^
 
-test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
+test/cli/errors/errors.rb:15: Expected `T.any(Class, Exception, String)` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
                   ^^^
-  Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
+  Expected `T.any(Class, Exception, String)` for argument `arg0` of method `Kernel#raise (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
-      NN |        arg0: String,
+      NN |        arg0: T.any(Class, Exception, String),
                   ^^^^
   Got `Integer` originating from:
     test/cli/errors/errors.rb:13:

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -105,9 +105,9 @@ def main
   # Test primitive types
   n = nil
 # ^ hover: NilClass
-  t = true 
+  t = true
 # ^ hover: TrueClass
-  f = false 
+  f = false
 # ^ hover: FalseClass
   r = //
 # ^ hover: Regexp
@@ -144,5 +144,5 @@ def main
   hoo = BigFoo::LittleFoo1.new
                          # ^^^ hover: sig {returns(BigFoo::LittleFoo1)}
   raise "error message"
-# ^ hover: sig {params(arg0: String).returns(T.noreturn)}
+# ^ hover: sig {params(arg0: T.any(Class, Exception, String)).returns(T.noreturn)}
 end

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -1,5 +1,7 @@
 # typed: true
 
+extend T::Sig
+
 T.assert_type!(caller, T::Array[String])
 T.assert_type!(caller(10), T.nilable(T::Array[String]))
 
@@ -33,7 +35,7 @@ def raise_test
   raise ArgumentError, 'bad argument', nil
 end
 
-sig { params(obj_or_str: T.any(Exception, String)) }
+sig { params(obj_or_str: T.any(Exception, String)).void }
 def raise_obj_or_string(obj_or_str)
   raise obj_or_str
 end

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -33,6 +33,11 @@ def raise_test
   raise ArgumentError, 'bad argument', nil
 end
 
+sig { params(obj_or_str: T.any(Exception, String)) }
+def raise_obj_or_string(obj_or_str)
+  raise obj_or_str
+end
+
 # make sure we don't regress and mark these as errors
 env = {'VAR' => 'VAL'}
 system('echo')


### PR DESCRIPTION
Related: #1483 

### Motivation
~`Kernel.raise` second parameter is always optional, as described in the documentation:~
~The optional second parameter sets the message associated with the exception~
UPDATE: This is not an issue with optionality as I originally thought. The PR changes have been updated.

`Kernel.raise` overloaded signatures are currently defined for individual classes: `String`, `Class` and `Exception`.
This makes it impossible to type-check a call to `raise` with a `T.any` type like `T.any(Exception, String)`.

I encountered this issue while trying to define a method similar to [the following](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Asig%20%7B%20params%28obj_or_str%3A%20T.any%28Exception%2C%20String%29%29.returns%28T.noreturn%29%20%7D%0Adef%20raise_obj_or_string%28obj_or_str%29%0A%20%20raise%20obj_or_str%0Aend) in my code: 
```ruby
sig { params(obj_or_str: T.any(Exception, String)).returns(T.noreturn) }
def raise_obj_or_string(obj_or_str)
  raise obj_or_str
end

# Expected String but found T.any(Exception, String) for argument arg0 https://srb.help/7002
#      6 |  raise obj_or_str
#                 ^^^^^^^^^^
#   Expected String for argument arg0 of method Kernel#raise (overload.1):
#     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2913:
#     2913 |        arg0: String,
#                   ^^^^
#   Got T.any(Exception, String) originating from:
#     editor.rb:5:
#      5 |def raise_obj_or_string(obj_or_str)
#                                 ^^^^^^^^^^
# Errors: 1
```

This change fixes that and adds an additional test for this specific use case.


### Test plan
See included automated tests.
