### PR TITLE
Make bare `Class` an error

### DIFF
--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -92,8 +92,8 @@ void TypeErrorDiagnostics::maybeAutocorrect(const GlobalState &gs, ErrorBuilder 
     }
 }
 
-void TypeErrorDiagnostics::insertUntypedTypeArguments(const GlobalState &gs, ErrorBuilder &e, ClassOrModuleRef klass,
-                                                      core::Loc replaceLoc) {
+void TypeErrorDiagnostics::insertTypeArguments(const GlobalState &gs, ErrorBuilder &e, ClassOrModuleRef klass,
+                                               core::Loc replaceLoc) {
     // if we're looking at `Array`, we want the autocorrect to include `T::`, but we don't need to
     // if we're already looking at `T::Array` instead.
     klass = klass.maybeUnwrapBuiltinGenericForwarder();
@@ -109,9 +109,10 @@ void TypeErrorDiagnostics::insertUntypedTypeArguments(const GlobalState &gs, Err
             e.replaceWith("Add type arguments", loc, "{}[T.untyped, T.untyped]", typePrefixSym.show(gs));
         } else {
             auto numTypeArgs = klass.data(gs)->typeArity(gs);
+            auto arg = (klass == Symbols::Class() || klass == Symbols::T_Class()) ? "T.anything" : "T.untyped";
             vector<string> untypeds;
             for (int i = 0; i < numTypeArgs; i++) {
-                untypeds.emplace_back("T.untyped");
+                untypeds.emplace_back(arg);
             }
             e.replaceWith("Add type arguments", loc, "{}[{}]", typePrefixSym.show(gs), absl::StrJoin(untypeds, ", "));
         }

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -23,8 +23,8 @@ public:
     static void explainTypeMismatch(const GlobalState &gs, ErrorBuilder &e, const TypePtr &expected,
                                     const TypePtr &got);
 
-    static void insertUntypedTypeArguments(const GlobalState &gs, ErrorBuilder &e, ClassOrModuleRef klass,
-                                           core::Loc replaceLoc);
+    static void insertTypeArguments(const GlobalState &gs, ErrorBuilder &e, ClassOrModuleRef klass,
+                                    core::Loc replaceLoc);
 
     static void explainUntyped(const GlobalState &gs, ErrorBuilder &e, ErrorClass what, const TypeAndOrigins &untyped,
                                Loc originForUninitialized);

--- a/rbi/core/class.rbi
+++ b/rbi/core/class.rbi
@@ -167,7 +167,7 @@ class Class < Module
   # ```
   sig do
     params(
-        arg0: Class,
+        arg0: T::Class[T.anything],
     )
     .returns(T.untyped)
   end
@@ -198,7 +198,7 @@ class Class < Module
   # B.subclasses        #=> [C]
   # C.subclasses        #=> []
   # ```
-  sig { returns(T::Array[Class]) }
+  sig { returns(T::Array[T::Class[T.anything]]) }
   def subclasses(); end
 
   # Returns the superclass of *class*, or `nil`.
@@ -217,26 +217,26 @@ class Class < Module
   # ```ruby
   # BasicObject.superclass   #=> nil
   # ```
-  sig {returns(T.nilable(Class))}
+  sig {returns(T.nilable(T::Class[T.anything]))}
   def superclass(); end
 
   sig {void}
   sig do
     params(
-        superclass: Class,
+        superclass: T::Class[T.anything],
     )
     .void
   end
   sig do
     params(
-        blk: T.proc.params(arg0: Class).returns(BasicObject),
+        blk: T.proc.params(arg0: T::Class[T.anything]).returns(BasicObject),
     )
     .void
   end
   sig do
     params(
-        superclass: Class,
-        blk: T.proc.params(arg0: Class).returns(BasicObject),
+        superclass: T::Class[T.anything],
+        blk: T.proc.params(arg0: T::Class[T.anything]).returns(BasicObject),
     )
     .void
   end

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -493,7 +493,7 @@ module Kernel
 
   sig do
     params(
-        arg0: Class,
+        arg0: T::Class[T.anything],
     )
     .returns(T::Boolean)
   end
@@ -638,7 +638,7 @@ module Kernel
   end
   def send(arg0, *arg1, &blk); end
 
-  sig {returns(Class)}
+  sig {returns(T::Class[T.anything])}
   def singleton_class(); end
 
   sig do
@@ -1272,7 +1272,7 @@ module Kernel
   end
   sig do
     params(
-        arg0: Class,
+        arg0: T::Class[T.anything],
         arg1: T.any(String, T::Array[String]),
     )
     .returns(T.noreturn)
@@ -2910,13 +2910,13 @@ module Kernel
   sig {returns(T.noreturn)}
   sig do
     params(
-        arg0: T.any(Class, Exception, String),
+        arg0: T.any(T::Class[T.anything], Exception, String),
     )
     .returns(T.noreturn)
   end
   sig do
     params(
-        arg0: T.any(Class, Exception),
+        arg0: T.any(T::Class[T.anything], Exception),
         arg1: T.untyped,
         arg2: T.nilable(T::Array[String]),
     )

--- a/rbi/core/method.rbi
+++ b/rbi/core/method.rbi
@@ -259,7 +259,7 @@ class Method < Object
   # ```ruby
   # (1..3).method(:map).owner #=> Enumerable
   # ```
-  sig {returns(T.any(Class, Module))}
+  sig {returns(Module)}
   def owner; end
 
   # Returns the parameter information of this method.

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -1634,7 +1634,7 @@ class Module < Object
   # Returns a module, where refined methods are defined.
   sig do
     params(
-        arg0: Class,
+        arg0: T::Class[T.anything],
         blk: T.proc.params(arg0: T.untyped).returns(BasicObject),
     )
     .returns(T.self_type)

--- a/rbi/stdlib/e2mmap.rbi
+++ b/rbi/stdlib/e2mmap.rbi
@@ -84,7 +84,7 @@ module Exception2MessageMapper
   #     m:  message_form
   # define exception c with message m.
   # ```
-  sig {params(c: Class, m: String).void}
+  sig {params(c: T::Class[T.anything], m: String).void}
   def def_e2message(c, m); end
 
   # [`def_exception`](https://docs.ruby-lang.org/en/2.6.0/Exception2MessageMapper.html#method-i-def_exception)(n,
@@ -96,6 +96,6 @@ module Exception2MessageMapper
   #     s:  superclass(default: StandardError)
   # define exception named ``c'' with message m.
   # ```
-  sig {params(n: Symbol, m: String, s: Class).void}
+  sig {params(n: Symbol, m: String, s: T::Class[T.anything]).void}
   def def_exception(n, m, s = StandardError); end
 end

--- a/rbi/stdlib/psych.rbi
+++ b/rbi/stdlib/psych.rbi
@@ -319,7 +319,7 @@ module Psych
     params(
       yaml: T.any(String, StringIO, IO),
       legacy_filename: Object,
-      permitted_classes: T::Array[Class],
+      permitted_classes: T::Array[T::Class[T.anything]],
       permitted_symbols: T::Array[Symbol],
       aliases: T::Boolean,
       filename: T.nilable(String),
@@ -396,7 +396,7 @@ module Psych
       legacy_permitted_symbols: Object,
       legacy_aliases: Object,
       legacy_filename: Object,
-      permitted_classes: T::Array[Class],
+      permitted_classes: T::Array[T::Class[T.anything]],
       permitted_symbols: T::Array[Symbol],
       aliases: T::Boolean,
       filename: T.nilable(String),

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -452,7 +452,7 @@ module URI
 
   # Returns a [`Hash`](https://docs.ruby-lang.org/en/2.7.0/Hash.html) of the
   # defined schemes.
-  sig {returns(T::Hash[String, Class])}
+  sig {returns(T::Hash[String, T::Class[T.anything]])}
   def self.scheme_list(); end
 
   # ## Synopsis

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1019,12 +1019,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
             auto klass = sym.asClassOrModuleRef();
             // the T::Type generics internally have a typeArity of 0, so this allows us to check against them in the
             // same way that we check against types like `Array`
-            //
-            // TODO(jez) After T::Class change: fix the payload, fix all the codebases, and remove this check.
-            // (Leaving at least one version in between, so that there is a published version that
-            // supports both `Class` and `T::Class` as valid syntax.)
-            if (klass != core::Symbols::Class() &&
-                (klass.isBuiltinGenericForwarder() || klass.data(ctx)->typeArity(ctx) > 0)) {
+            if (klass.isBuiltinGenericForwarder() || klass.data(ctx)->typeArity(ctx) > 0) {
                 // Class is not isLegacyStdlibGeneric (because its type members don't default to T.untyped),
                 // but we want to report this syntax error at `# typed: strict` like other stdlib classes.
                 auto level = klass.isLegacyStdlibGeneric() || klass == core::Symbols::Class()
@@ -1033,7 +1028,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
                 if (auto e = ctx.beginError(i.loc, level)) {
                     e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",
                                 klass.show(ctx));
-                    core::TypeErrorDiagnostics::insertUntypedTypeArguments(ctx, e, klass, ctx.locAt(i.loc));
+                    core::TypeErrorDiagnostics::insertTypeArguments(ctx, e, klass, ctx.locAt(i.loc));
                 }
             }
             if (klass == core::Symbols::StubModule()) {

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -125,7 +125,10 @@ bool ClassNew::run(core::MutableContext ctx, ast::Send *send) {
     ast::ExpressionPtr type;
 
     if (argc == 0) {
-        type = ast::MK::Constant(send->loc, core::Symbols::Class());
+        auto zeroLoc = send->loc.copyWithZeroLength();
+        type =
+            ast::MK::Send1(send->loc, ast::MK::Constant(send->recv.loc(), core::Symbols::T_Class()),
+                           core::Names::squareBrackets(), zeroLoc, ast::MK::Constant(zeroLoc, core::Symbols::Object()));
     } else {
         auto target = send->getPosArg(0).deepCopy();
         type = ast::MK::ClassOf(send->loc, std::move(target));

--- a/test/cli/errors/test.out
+++ b/test/cli/errors/test.out
@@ -14,7 +14,7 @@ test/cli/errors/errors.rb:15: Expected `T.any(T::Class[T.anything], Exception, S
                   ^^^
   Expected `T.any(T::Class[T.anything], Exception, String)` for argument `arg0` of method `Kernel#raise (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
-      NN |        arg0: T.any(Class, Exception, String),
+      NN |        arg0: T.any(T::Class[T.anything], Exception, String),
                   ^^^^
   Got `Integer` originating from:
     test/cli/errors/errors.rb:13:
@@ -71,7 +71,7 @@ test/cli/errors/errors.rb:15: Expected `T.any(T::Class[T.anything], Exception, S
                   ^^^
   Expected `T.any(T::Class[T.anything], Exception, String)` for argument `arg0` of method `Kernel#raise (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
-      NN |        arg0: T.any(Class, Exception, String),
+      NN |        arg0: T.any(T::Class[T.anything], Exception, String),
                   ^^^^
   Got `Integer` originating from:
     test/cli/errors/errors.rb:13:
@@ -128,7 +128,7 @@ test/cli/errors/errors.rb:15: Expected `T.any(T::Class[T.anything], Exception, S
                   ^^^
   Expected `T.any(T::Class[T.anything], Exception, String)` for argument `arg0` of method `Kernel#raise (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
-      NN |        arg0: T.any(Class, Exception, String),
+      NN |        arg0: T.any(T::Class[T.anything], Exception, String),
                   ^^^^
   Got `Integer` originating from:
     test/cli/errors/errors.rb:13:

--- a/test/testdata/rbi/uri.rb
+++ b/test/testdata/rbi/uri.rb
@@ -9,7 +9,7 @@ def validate_http(uri_string)
   uri
 end
 
-sig {returns(Class)}
+sig {returns(T::Class[T.anything])}
 def uri_parser
   URI::Parser
 end

--- a/test/testdata/resolver/t_class.rb
+++ b/test/testdata/resolver/t_class.rb
@@ -2,6 +2,7 @@
 extend T::Sig
 
 sig {returns(Class)}
+#            ^^^^^ error: Generic class without type arguments `Class`
 def example
   Integer
 end

--- a/test/testdata/resolver/t_class.rb
+++ b/test/testdata/resolver/t_class.rb
@@ -1,0 +1,7 @@
+# typed: strict
+extend T::Sig
+
+sig {returns(Class)}
+def example
+  Integer
+end

--- a/test/testdata/resolver/t_class.rb.autocorrects.exp
+++ b/test/testdata/resolver/t_class.rb.autocorrects.exp
@@ -2,7 +2,8 @@
 # typed: strict
 extend T::Sig
 
-sig {returns(Class)}
+sig {returns(T::Class[T.anything])}
+#            ^^^^^ error: Generic class without type arguments `Class`
 def example
   Integer
 end

--- a/test/testdata/resolver/t_class.rb.autocorrects.exp
+++ b/test/testdata/resolver/t_class.rb.autocorrects.exp
@@ -1,0 +1,9 @@
+# -- test/testdata/resolver/t_class.rb --
+# typed: strict
+extend T::Sig
+
+sig {returns(Class)}
+def example
+  Integer
+end
+# ------------------------------

--- a/test/testdata/rewriter/class_new.rb
+++ b/test/testdata/rewriter/class_new.rb
@@ -56,7 +56,7 @@ C2 = Class.new(Foo) do
 end
 
 c1 = Class.new do
-  T.reveal_type self # error: Revealed type: `T::Class[T.anything]`
+  T.reveal_type self # error: Revealed type: `T::Class[Object]`
 end
 
 c2 = Class.new(Foo) do
@@ -65,7 +65,7 @@ c2 = Class.new(Foo) do
 end
 
 Class.new do
-  T.reveal_type(self) # error: Revealed type: `T::Class[T.anything]`
+  T.reveal_type(self) # error: Revealed type: `T::Class[Object]`
 end
 
 Class.new(Foo) do

--- a/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
@@ -80,7 +80,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   c1 = <emptyTree>::<C Class>.new() do ||
     begin
-      <cast:<synthetic bind>>(<self>, <todo sym>, ::Class)
+      <cast:<synthetic bind>>(<self>, <todo sym>, ::T::Class.[](::Object))
       <emptyTree>::<C T>.reveal_type(<self>)
     end
   end
@@ -95,7 +95,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <emptyTree>::<C Class>.new() do ||
     begin
-      <cast:<synthetic bind>>(<self>, <todo sym>, ::Class)
+      <cast:<synthetic bind>>(<self>, <todo sym>, ::T::Class.[](::Object))
       <emptyTree>::<C T>.reveal_type(<self>)
     end
   end

--- a/test/testdata/rewriter/class_new_strict.rb
+++ b/test/testdata/rewriter/class_new_strict.rb
@@ -3,7 +3,10 @@ class A
   extend T::Sig
   sig {void}
   def self.make
-    cls = Class.new(A) do
+    _cls = Class.new do
+    end
+
+    _cls = Class.new(A) do
     end
   end
 end

--- a/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
@@ -19,45 +19,76 @@ method ::<Class:A>#make {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
-    <cfgAlias>$4: T.class_of(Class) = alias <C Class>
-    <cfgAlias>$6: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$4: T.class_of(Class).new(<cfgAlias>$6: T.class_of(A))
-    <selfRestore>$8: T.class_of(A) = <self>
+    <cfgAlias>$5: T.class_of(Class) = alias <C Class>
+    <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Class).new()
+    <selfRestore>$7: T.class_of(A) = <self>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
+# - bb7(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=3](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
-    cls: T.class_of(A) = Solve<<block-pre-call-temp>$7, new>
-    <returnMethodTemp>$2: T.class_of(A) = cls
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
+    _cls: T::Class[Object] = Solve<<block-pre-call-temp>$6, new>
+    <self>: T.class_of(A) = <selfRestore>$7
+    <cfgAlias>$18: T.class_of(Class) = alias <C Class>
+    <cfgAlias>$20: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$21: Sorbet::Private::Static::Void = <cfgAlias>$18: T.class_of(Class).new(<cfgAlias>$20: T.class_of(A))
+    <selfRestore>$22: T.class_of(A) = <self>
+    <unconditional> -> bb6
+
+# backedges
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
+    # outerLoops: 1
+    <self>: T.class_of(A) = loadSelf(new)
+    <cfgAlias>$12: T.class_of(T::Class) = alias <C Class>
+    <cfgAlias>$14: T.class_of(Object) = alias <C Object>
+    keep_for_ide$10: Runtime object representing type: T::Class[Object] = <cfgAlias>$12: T.class_of(T::Class).[](<cfgAlias>$14: T.class_of(Object))
+    keep_for_ide$10: T.untyped = <keep-alive> keep_for_ide$10
+    <castTemp>$15: T.class_of(A) = <self>
+    <self>: T::Class[Object] = cast(<castTemp>$15: T.class_of(A), T::Class[Object]);
+    <blockReturnTemp>$16: T.noreturn = blockreturn<new> <blockReturnTemp>$8: NilClass
+    <unconditional> -> bb2
+
+# backedges
+# - bb3(rubyRegionId=0)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb9 : bb7)
+
+# backedges
+# - bb6(rubyRegionId=2)
+bb7[rubyRegionId=0, firstDead=3](<block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
+    _cls: T.class_of(A) = Solve<<block-pre-call-temp>$21, new>
+    <returnMethodTemp>$2: T.class_of(A) = _cls
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.class_of(A)
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb6(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
     # outerLoops: 1
     <self>: T.class_of(A) = loadSelf(new)
-    <cfgAlias>$13: T.class_of(T) = alias <C T>
-    <cfgAlias>$15: T.class_of(A) = alias <C A>
-    keep_for_ide$11: Runtime object representing type: T.class_of(A) = <cfgAlias>$13: T.class_of(T).class_of(<cfgAlias>$15: T.class_of(A))
-    keep_for_ide$11: T.untyped = <keep-alive> keep_for_ide$11
-    <castTemp>$16: T.class_of(A) = <self>
-    <self>: T.class_of(A) = cast(<castTemp>$16: T.class_of(A), T.class_of(A));
-    <blockReturnTemp>$17: T.noreturn = blockreturn<new> <blockReturnTemp>$9: NilClass
-    <unconditional> -> bb2
+    <cfgAlias>$27: T.class_of(T) = alias <C T>
+    <cfgAlias>$29: T.class_of(A) = alias <C A>
+    keep_for_ide$25: Runtime object representing type: T.class_of(A) = <cfgAlias>$27: T.class_of(T).class_of(<cfgAlias>$29: T.class_of(A))
+    keep_for_ide$25: T.untyped = <keep-alive> keep_for_ide$25
+    <castTemp>$30: T.class_of(A) = <self>
+    <self>: T.class_of(A) = cast(<castTemp>$30: T.class_of(A), T.class_of(A));
+    <blockReturnTemp>$31: T.noreturn = blockreturn<new> <blockReturnTemp>$23: NilClass
+    <unconditional> -> bb6
 
 }
 

--- a/test/testdata/rewriter/class_new_strict.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.flatten-tree.exp
@@ -11,15 +11,28 @@ begin
   end
   class ::A<<C A>> < (::<todo sym>)
     def self.make(<blk>)
-      cls = ::Class.new(::A) do ||
-        begin
-          <cast:<synthetic bind>>(<self>, AppliedType {
-            klass = <S <C <U A>> $1>
-            targs = [
-              <C <U <AttachedClass>>> = A
-            ]
-          }, ::T.class_of(::A))
-          <emptyTree>
+      begin
+        _cls = ::Class.new() do ||
+          begin
+            <cast:<synthetic bind>>(<self>, AppliedType {
+              klass = <C <U Class>>
+              targs = [
+                <C <U <AttachedClass>>> = Object
+              ]
+            }, ::T::Class.[](::Object))
+            <emptyTree>
+          end
+        end
+        _cls = ::Class.new(::A) do ||
+          begin
+            <cast:<synthetic bind>>(<self>, AppliedType {
+              klass = <S <C <U A>> $1>
+              targs = [
+                <C <U <AttachedClass>>> = A
+              ]
+            }, ::T.class_of(::A))
+            <emptyTree>
+          end
         end
       end
     end

--- a/test/testdata/rewriter/class_new_strict.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.rewrite-tree.exp
@@ -5,10 +5,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def self.make<<todo method>>(&<blk>)
-      cls = <emptyTree>::<C Class>.new(<emptyTree>::<C A>) do ||
-        begin
-          <cast:<synthetic bind>>(<self>, <todo sym>, ::T.class_of(<emptyTree>::<C A>))
-          <emptyTree>
+      begin
+        _cls = <emptyTree>::<C Class>.new() do ||
+          begin
+            <cast:<synthetic bind>>(<self>, <todo sym>, ::T::Class.[](::Object))
+            <emptyTree>
+          end
+        end
+        _cls = <emptyTree>::<C Class>.new(<emptyTree>::<C A>) do ||
+          begin
+            <cast:<synthetic bind>>(<self>, <todo sym>, ::T.class_of(<emptyTree>::<C A>))
+            <emptyTree>
+          end
         end
       end
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Note to users

If you need to silence this error temporarily for a migration or
compatibility reasons, you can pass this command line flag:

    --suppress-error-code=5046

This will suppress *all* bare stdlib generic errors, so things like
`Array` and `Hash` will also not be reported as an error. Thus using
this flag should be considered only a temporary migration mechanism.

Other temporary migration techniques:

- Downgrade any files with these errors to `# typed: true`, and
  re-upgrade them to `# typed: strict` once all bare `Class` errors have
  been fixed in the file.

- Downgrade Sorbet back to the version before this error started to be
  reported. That version treats `T::Class` as valid type syntax, but
  does not report an error for bare `Class` usage.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This closes a follow-up action item from #6781.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Review by commit to see the changes to the tests.
