### PR TITLE
Add missing RBI for `URI.encode_uri_component`

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -263,6 +263,16 @@ module URI
   end
   def self.encode_www_form_component(str, enc=nil); end
 
+  # Like URI.encode_www_form_component, except that <tt>' '</tt> (space)
+  # is encoded as <tt>'%20'</tt> (instead of <tt>'+'</tt>).
+  sig do
+    params(
+      str: Object,
+      enc: T.nilable(Encoding)
+    ).returns(String)
+  end
+  def self.encode_uri_component(str, enc=nil);end
+
   # ## Synopsis
   #
   # ```


### PR DESCRIPTION
### Motivation

This adds the missing sig for [`URI.encode_uri_component`](https://github.com/ruby/uri/blob/f4f20bd736245ec68ebb2332cd5cb0d3b4181f7d/lib/uri/common.rb#L372-L376).

### Test plan

I don't believe RBIs are tested.