### PR TITLE
Revert "Bump bundler version in sorbet_ruby"

### DIFF
--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -151,6 +151,11 @@ cp "$out_dir/bin/bundle" "$out_dir/bin/bundler"
 
 {install_gems}
 
+# Since we get our version of bundler from update_rubygems, we have to apply
+# this patch after everything is built. This is a bit of a hack, but the need
+# for the patch should go away once we upgrade Ruby and/or bundler anyway.
+{post_build_patch_command}
+
 popd > /dev/null
 
 rm -rf "$build_dir"

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -10,8 +10,8 @@ def register_ruby_dependencies():
 
     http_file(
         name = "rubygems_update_stripe",
-        urls = _rubygems_urls("rubygems-update-3.2.33.gem"),
-        sha256 = "46862bd39dd078789d1cc7e2359772e50b33880a28b3eb83f80d42eec7e5a7e2",
+        urls = _rubygems_urls("rubygems-update-3.1.2.gem"),
+        sha256 = "7bfe4e5e274191e56da8d127c79df10d9120feb8650e4bad29238f4b2773a661",
     )
 
     ruby_build = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD"


### PR DESCRIPTION
Reverts sorbet/sorbet#6900

No problem with the change but it's to take a bit longer to get this change into master, so temporarily reverting this until we're in a spot to re-land.