### PR TITLE
don't call `instance_variable_defined` when it's unnecessary

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -174,7 +174,9 @@ class T::Props::Decorator
     .checked(:never)
   end
   def prop_get(instance, prop, rules=prop_rules(prop))
-    val = instance.instance_variable_get(rules[:accessor_key]) if instance.instance_variable_defined?(rules[:accessor_key])
+    # `instance_variable_get` will return nil if the variable doesn't exist
+    # which is what we want to have happen for the logic below.
+    val = instance.instance_variable_get(rules[:accessor_key])
     if !val.nil?
       val
     elsif (d = rules[:ifunset])
@@ -194,7 +196,9 @@ class T::Props::Decorator
     .checked(:never)
   end
   def prop_get_if_set(instance, prop, rules=prop_rules(prop))
-    instance.instance_variable_get(rules[:accessor_key]) if instance.instance_variable_defined?(rules[:accessor_key])
+    # `instance_variable_get` will return nil if the variable doesn't exist
+    # which is what we want to have happen for the return value here.
+    instance.instance_variable_get(rules[:accessor_key])
   end
   alias_method :get, :prop_get_if_set # Alias for backwards compatibility
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Our props code has some patterns of:

```
val = x.instance_variable_get(var) if x.instance_variable_defined?(var)
```

expecting that `val` will be `nil` if the instance variable is defined and the value of the instance variable otherwise.

But this pattern is just wasting work: `instance_variable_get` will already return `nil` if the instance variable does not exist.  `instance_variable_get` will also return nil if `var` is not a valid instance variable name, but since we control the name in this case, we should be able to ensure that `var` always follows the proper format.

(Class variables are different in this respect, and we would absolutely need to check for the existence of class-level variables before access.)

`instance_variable_get` does not cause the variable to spring into existence on the requisite object, so there is no danger of behavior change there.

I realize this is not much of a proof, but if you look in the VM, the codepaths for `instance_variable_get` and `instance_variable_defined?` are practically identical.

This PR, therefore, ditches the `instance_variable_defined?` check.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I will run testing on Stripe's codebase before thinking about committing this.
