### PR TITLE
more signature allocation optimizations

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -12,8 +12,8 @@ class T::Private::Methods::Signature
   UNNAMED_REQUIRED_PARAMETERS = [[:req]].freeze
 
   def self.new_untyped(method:, mode: T::Private::Methods::Modes.untyped, parameters: method.parameters)
-    # Using `Untyped` ensures we'll get an error if we ever try validation on these.
-    not_typed = T::Private::Types::NotTyped.new
+    # Using `NotTyped` ensures we'll get an error if we ever try validation on these.
+    not_typed = T::Private::Types::NotTyped::INSTANCE
     raw_return_type = not_typed
     # Map missing parameter names to "argN" positionally
     parameters = parameters.each_with_index.map do |(param_kind, param_name), index|

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -19,8 +19,9 @@ class T::Private::Methods::Signature
     parameters = parameters.each_with_index.map do |(param_kind, param_name), index|
       [param_kind, param_name || "arg#{index}"]
     end
-    raw_arg_types = parameters.to_h do |_param_kind, param_name|
-      [param_name, not_typed]
+    raw_arg_types = {}
+    parameters.each do |_, param_name|
+      raw_arg_types[param_name] = not_typed
     end
 
     self.new(

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -83,8 +83,13 @@ class T::Private::Methods::Signature
     if parameters.size != raw_arg_types.size
       raise "The declaration for `#{method.name}` has arguments with duplicate names"
     end
+    params_size = parameters.size
+    i = 0
+    while i < params_size
+      param_kind, param_name = parameters[i]
+      type_name = declared_param_names[i]
+      raw_type = raw_arg_types[type_name]
 
-    parameters.zip(raw_arg_types) do |(param_kind, param_name), (type_name, raw_type)|
       if type_name != param_name
         hint = ""
         # Ruby reorders params so that required keyword arguments
@@ -140,6 +145,8 @@ class T::Private::Methods::Signature
       else
         raise "Unexpected param_kind: `#{param_kind}`. Method: #{method_desc}"
       end
+
+      i += 1
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/types/not_typed.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/not_typed.rb
@@ -20,4 +20,6 @@ class T::Private::Types::NotTyped < T::Types::Base
   private def subtype_of_single?(other)
     raise ERROR_MESSAGE
   end
+
+  INSTANCE = ::T::Private::Types::NotTyped.new.freeze
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
cc @zanker-stripe 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Follow on from #6991 with suggestions from the team at Stripe.  We can't modify the `parameters` array in-place in `new_untyped`, unfortunately, because it's coming from Ruby itself, which freezes the array.

I was too lazy to merge the loops in `new_untyped`.  Maybe another day.

This is probably going to conflict with #6993 cc @maruth-stripe .

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
