### PR TITLE
add rudimentary sig benchmark

### DIFF
--- a/gems/sorbet-runtime/bench/sigs.rb
+++ b/gems/sorbet-runtime/bench/sigs.rb
@@ -15,7 +15,7 @@ module SorbetBenchmarks
 
       t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
       begin_allocs = GC.stat(:total_allocated_objects)
-      T::Utils::run_all_sig_blocks
+      T::Utils.run_all_sig_blocks
       duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - t0
       end_allocs = GC.stat(:total_allocated_objects) - 1
 

--- a/gems/sorbet-runtime/bench/sigs.rb
+++ b/gems/sorbet-runtime/bench/sigs.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module Sigs
+    extend T::Sig
+
+    def self.run
+      GC.start
+      GC.disable
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+      begin_allocs = GC.stat(:total_allocated_objects)
+      T::Utils::run_all_sig_blocks
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - t0
+      end_allocs = GC.stat(:total_allocated_objects) - 1
+
+      str = duration_s >= 1000 ? "#{(duration_s / 1000).round(3)} μs" : "#{duration_s.round(3)} ns"
+      puts "run_all_sigs: #{str} #{end_allocs - begin_allocs}"
+    end
+  end
+end

--- a/gems/sorbet-runtime/bench/tasks.rb
+++ b/gems/sorbet-runtime/bench/tasks.rb
@@ -8,6 +8,7 @@ require_relative 'deserialize'
 require_relative 'prop_definition'
 require_relative 'prop_validation'
 require_relative 'serialize_custom_type'
+require_relative 'sigs'
 require_relative 'tutils'
 require_relative 'typecheck'
 require_relative 'typecheck_kwargs_splat'
@@ -41,6 +42,10 @@ namespace :bench do
     SorbetBenchmarks::SerializeCustomType.run
   end
 
+  task :sigs do
+    SorbetBenchmarks::Sigs.run
+  end
+
   task :typecheck do
     SorbetBenchmarks::Typecheck.run
   end
@@ -53,5 +58,5 @@ namespace :bench do
     SorbetBenchmarks::TUtils.run
   end
 
-  task all: %i[getters setters constructor deserialize prop_definition serialize_custom_type tuils typecheck]
+  task all: %i[getters setters constructor deserialize prop_definition serialize_custom_type sigs tutils typecheck]
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We've been doing some PRs that change how performant signature running should be.  Let's add a small benchmark that sees how expensive it is to run all of sorbet-runtime's signatures (admittedly not the greatest benchmark, but there's a reason this says "rudimentary" on the tin).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
