### PR TITLE
Update `Enumerable#tally` sig for Ruby 3.1

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1744,8 +1744,12 @@ module Enumerable
   # ```ruby
   # ["a", "b", "c", "b"].tally  #=> {"a"=>1, "b"=>2, "c"=>1}
   # ```
-  sig {returns(T::Hash[Elem, Integer])}
-  def tally(); end
+  #
+  # If a hash is given, the number of occurrences is added to each value
+  # in the hash, and the hash is returned. The value corresponding to
+  # each element must be an integer.
+  sig {params(hash: T::Hash[Elem, Integer]).returns(T::Hash[Elem, Integer])}
+  def tally(hash = {}); end
 
   ### Implemented in C++
 

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -21,7 +21,10 @@ extend T::Sig
 
 T.assert_type!([1].lazy, T::Enumerator::Lazy[Integer])
 T.assert_type!([1, 2].filter_map { |x| x.odd? ? x.to_f : x.to_s }, T::Array[T.any(Float, String)])
+
 T.assert_type!([1, 2, "3", nil].tally, T::Hash[T.nilable(T.any(Integer, String)), Integer])
+T.assert_type!([1, 2, "3", nil].tally(T::Hash[T.nilable(T.any(Integer, String)), Integer].new),
+               T::Hash[T.nilable(T.any(Integer, String)), Integer])
 
 # There are 3 different ways to call all?, any? and none?
 a = [1, 3, 20]


### PR DESCRIPTION
### Motivation

As of Ruby 3.1, `Enumerable#tally` takes an optional hash that it will accumulate into (instead of allocating a new Hash).

Requested in https://bugs.ruby-lang.org/issues/17744
Implemented in https://github.com/ruby/ruby/pull/4318