### PR TITLE
cache `T.type_parameter` return values for the same typename

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -123,7 +123,7 @@ module T
   #  .returns(T::Array[T.type_parameter(:U)])
   #  def map(&blk); end
   def self.type_parameter(name)
-    T::Types::TypeParameter.new(name)
+    T::Types::TypeParameter.make(name)
   end
 
   # Tells the typechecker that `value` is of type `type`. Use this to get additional checking after

--- a/gems/sorbet-runtime/lib/types/types/type_parameter.rb
+++ b/gems/sorbet-runtime/lib/types/types/type_parameter.rb
@@ -3,9 +3,28 @@
 
 module T::Types
   class TypeParameter < Base
+    module Private
+      @pool = {}
+
+      def self.cached_entry(name)
+        @pool[name]
+      end
+
+      def self.set_entry_for(name, type)
+        @pool[name] = type
+      end
+    end
+
     def initialize(name)
       raise ArgumentError.new("not a symbol: #{name}") unless name.is_a?(Symbol)
       @name = name
+    end
+
+    def self.make(name)
+      cached = Private.cached_entry(name)
+      return cached if cached
+
+      Private.set_entry_for(name, new(name))
     end
 
     def valid?(obj)

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1582,6 +1582,12 @@ module Opus::Types::Test
           assert_subtype(T::Types::TypeParameter.new(:T),
                          T::Types::TypeParameter.new(:V))
         end
+
+        it 'pools' do
+          assert_equal(T.type_parameter(:T).object_id, T.type_parameter(:T).object_id)
+          refute_equal(T.type_parameter(:T).object_id, T.type_parameter(:U).object_id)
+          refute_equal(T::Types::TypeParameter.new(:T).object_id, T::Types::TypeParameter.new(:T).object_id)
+        end
       end
 
       describe 'untyped containers' do

--- a/rbi/sorbet/ttypes.rbi
+++ b/rbi/sorbet/ttypes.rbi
@@ -130,6 +130,7 @@ class T::Types::TypeParameter < T::Types::Base
   def valid?(obj); end
   def subtype_of_single?(type); end
   def name; end
+  def self.make(name); end
 end
 
 # --- stdlib generics ---


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We came across some use cases for generic code that also exist inside hot code paths where allocations are undesirable.  We might as well make `T.type_parameter` as cheap as we can.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I thought about making `new` a `private_class_method`, but since `T::Types::TypeParameter` is technically a private API, something along the lines of this PR seems better.
