### PR TITLE
Add environment variable to opt into recursive type checks 

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -148,8 +148,11 @@ module T
   # doesn't match the type.
   def self.let(value, type, checked: true)
     return value unless checked
-
-    Private::Casts.cast(value, type, "T.let")
+    if Configuration.recursively_check_in_tests?
+      Private::Casts.cast_recursive(value, type, "T.let")
+    else
+      Private::Casts.cast(value, type, "T.let")
+    end
   end
 
   # Tells the type checker to treat `self` in the current block as `type`.

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -20,6 +20,10 @@ module T::Configuration
     T::Private::RuntimeLevels.enable_checking_in_tests
   end
 
+  def self.recursively_check_in_tests?
+    T::Private::RuntimeLevels.recursively_check_in_tests?
+  end
+
   # Announce to Sorbet that we would like the final checks to be enabled when
   # including and extending modules. Iff this is not called, then the following
   # example will not raise an error.

--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
@@ -22,6 +22,7 @@ module T::Private::RuntimeLevels
 
   @has_read_default_checked_level = false
   @default_checked_level = :always
+  @recursively_check_in_tests = false
 
   def self.check_tests?
     # Assume that this code path means that some `sig.checked(:tests)`
@@ -30,6 +31,10 @@ module T::Private::RuntimeLevels
     @wrapped_tests_with_validation = true
 
     @check_tests
+  end
+
+  def self.recursively_check_in_tests?
+    @recursively_check_in_tests
   end
 
   def self.enable_checking_in_tests
@@ -78,4 +83,12 @@ module T::Private::RuntimeLevels
     end
   end
   set_default_checked_level_from_environment
+
+  private_class_method def self.set_enable_recursive_checking_in_tests_from_environment
+    recursively_check_in_tests = ENV['SORBET_RUNTIME_ENABLE_RECURSIVE_CHECKING_IN_TESTS']
+    if recursively_check_in_tests
+      @recursively_check_in_tests = true
+    end
+  end
+  set_enable_recursive_checking_in_tests_from_environment
 end

--- a/gems/sorbet-runtime/test/types/runtime_levels.rb
+++ b/gems/sorbet-runtime/test/types/runtime_levels.rb
@@ -90,5 +90,52 @@ module Opus::Types::Test
         end
       end
     end
+
+    describe 'set_enable_recursive_checking_in_tests_from_environment' do
+      before do
+        @orig_wrapped_tests_with_validation = T::Private::RuntimeLevels.instance_variable_get(:@wrapped_tests_with_validation)
+        @orig_check_tests = T::Private::RuntimeLevels.instance_variable_get(:@check_tests)
+        @orig_recursively_check_in_tests = T::Private::RuntimeLevels.instance_variable_get(:@recursively_check_in_tests)
+        @orig_env_recursively_check_in_tests = ENV['SORBET_RUNTIME_ENABLE_RECURSIVE_CHECKING_IN_TESTS']
+
+        # Within these specs pretend we haven't yet read this value and checked_tests is false
+        T::Private::RuntimeLevels.instance_variable_set(:@wrapped_tests_with_validation, false)
+        T::Private::RuntimeLevels.instance_variable_set(:@check_tests, false)
+        T::Private::RuntimeLevels.instance_variable_set(:@recursively_check_in_tests, false)
+      end
+
+      after do
+        T::Private::RuntimeLevels.instance_variable_set(:@check_tests, @orig_check_tests)
+        T::Private::RuntimeLevels.instance_variable_set(:@wrapped_tests_with_validation, @orig_wrapped_tests_with_validation)
+        T::Private::RuntimeLevels.instance_variable_set(:@recursively_check_in_tests, @orig_recursively_check_in_tests)
+        ENV['SORBET_RUNTIME_ENABLE_RECURSIVE_CHECKING_IN_TESTS'] = @orig_env_recursively_check_in_tests
+      end
+
+      describe 'when SORBET_RUNTIME_ENABLE_RECURSIVE_CHECKING_IN_TESTS env variable is not set' do
+        before do
+          ENV['SORBET_RUNTIME_ENABLE_RECURSIVE_CHECKING_IN_TESTS'] = nil
+        end
+
+        it 'does not change check_tests' do
+          # Reaching into a private method for testing purposes
+          T::Private::RuntimeLevels.send(:set_enable_recursive_checking_in_tests_from_environment)
+
+          assert_equal(false, T::Private::RuntimeLevels.recursively_check_in_tests?)
+        end
+      end
+
+      describe 'when SORBET_RUNTIME_ENABLE_RECURSIVE_CHECKING_IN_TESTS env variable is set' do
+        before do
+          ENV['SORBET_RUNTIME_ENABLE_RECURSIVE_CHECKING_IN_TESTS'] = '1'
+        end
+
+        it 'updates check_tests' do
+          # Reaching into a private method for testing purposes
+          T::Private::RuntimeLevels.send(:set_enable_recursive_checking_in_tests_from_environment)
+
+          assert_equal(true, T::Private::RuntimeLevels.recursively_check_in_tests?)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
TODO:
1. I'm not sure how to enforce this is only enabled for tests
2. Add more tests to check recursive type checking is enabled

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Recursive type checking was disabled due to its performance cost. But it can still be useful to let users opt into it while running tests locally to identify errors that would otherwise not be caught eg `T.let([nil], T::Array[Integer])`

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
