### PR TITLE
Autocorrect e -> T.must(e) for T.let(e, U) where e: S with S = T.nilable(U)

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1593,8 +1593,8 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                             if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                                 e.setHeader("Argument does not have asserted type `{}`", castType.show(ctx));
                                 e.addErrorSection(ty.explainGot(ctx, ownerLoc));
-                                core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, ownerLoc, constr, castType,
-                                                                             ty.type);
+                                core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, ctx.locAt(c.valueLoc), constr,
+                                                                             castType, ty.type);
                             }
                         }
                     }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1593,6 +1593,8 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                             if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                                 e.setHeader("Argument does not have asserted type `{}`", castType.show(ctx));
                                 e.addErrorSection(ty.explainGot(ctx, ownerLoc));
+                                core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, ownerLoc, constr, castType,
+                                                                             ty.type);
                             }
                         }
                     }

--- a/test/testdata/infer/autocorrect_t_let_nilable.rb
+++ b/test/testdata/infer/autocorrect_t_let_nilable.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+T.let(T.let(5, T.nilable(Integer)), Integer)

--- a/test/testdata/infer/autocorrect_t_let_nilable.rb.autocorrects.exp
+++ b/test/testdata/infer/autocorrect_t_let_nilable.rb.autocorrects.exp
@@ -1,5 +1,7 @@
+# -- test/testdata/infer/autocorrect_t_let_nilable.rb --
 # typed: true
 
 x = T.let(5, T.nilable(Integer))
-  T.let(x, Integer)
+  T.let(T.must(x), Integer)
 # ^^^^^^^^^^^^^^^^^ error: Argument does not have asserted type `Integer`
+# ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Better autocorrects

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
