### PR TITLE
Remove Array#+ -> Array#concat autocorrect

### DIFF
--- a/test/cli/autocorrect_array_plus/test.out
+++ b/test/cli/autocorrect_array_plus/test.out
@@ -9,12 +9,6 @@ autocorrect_array_plus.rb:6: Expected `T::Enumerable[Integer]` but found `T::Arr
     autocorrect_array_plus.rb:4:
      4 |strings = T::Array[String].new
                   ^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:6: Replaced with `.concat(strings)`
-     6 |ints + strings
-            ^^^^^^^^^^
 
 autocorrect_array_plus.rb:8: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
      8 |ints + (strings)
@@ -27,12 +21,6 @@ autocorrect_array_plus.rb:8: Expected `T::Enumerable[Integer]` but found `T::Arr
     autocorrect_array_plus.rb:4:
      4 |strings = T::Array[String].new
                   ^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:8: Replaced with `.concat(strings)`
-     8 |ints + (strings)
-            ^^^^^^^^^^^^
 
 autocorrect_array_plus.rb:9: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
      9 |ints + ((strings))
@@ -45,12 +33,6 @@ autocorrect_array_plus.rb:9: Expected `T::Enumerable[Integer]` but found `T::Arr
     autocorrect_array_plus.rb:4:
      4 |strings = T::Array[String].new
                   ^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:9: Replaced with `.concat(strings)`
-     9 |ints + ((strings))
-            ^^^^^^^^^^^^^^
 
 autocorrect_array_plus.rb:10: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     10 |ints.+(strings)
@@ -63,12 +45,6 @@ autocorrect_array_plus.rb:10: Expected `T::Enumerable[Integer]` but found `T::Ar
     autocorrect_array_plus.rb:4:
      4 |strings = T::Array[String].new
                   ^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:10: Replaced with `.concat(strings)`
-    10 |ints.+(strings)
-            ^^^^^^^^^^^
 
 autocorrect_array_plus.rb:13: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     13 |  strings
@@ -81,13 +57,6 @@ autocorrect_array_plus.rb:13: Expected `T::Enumerable[Integer]` but found `T::Ar
     autocorrect_array_plus.rb:4:
      4 |strings = T::Array[String].new
                   ^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:12: Replaced with `.concat(strings)`
-    12 |ints.+(
-    13 |  strings
-    14 |)
 
 autocorrect_array_plus.rb:16: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     16 |ints + strings
@@ -100,12 +69,6 @@ autocorrect_array_plus.rb:16: Expected `T::Enumerable[Integer]` but found `T::Ar
     autocorrect_array_plus.rb:4:
      4 |strings = T::Array[String].new
                   ^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:16: Replaced with `.concat(strings)`
-    16 |ints + strings
-            ^^^^^^^^^^
 
 autocorrect_array_plus.rb:18: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     18 |ints += strings
@@ -118,12 +81,6 @@ autocorrect_array_plus.rb:18: Expected `T::Enumerable[Integer]` but found `T::Ar
     autocorrect_array_plus.rb:4:
      4 |strings = T::Array[String].new
                   ^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:18: Replaced with `= ints.concat(strings)`
-    18 |ints += strings
-            ^^^^^^^^^^^
 
 autocorrect_array_plus.rb:19: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     19 |ints += strings
@@ -136,12 +93,6 @@ autocorrect_array_plus.rb:19: Expected `T::Enumerable[Integer]` but found `T::Ar
     autocorrect_array_plus.rb:4:
      4 |strings = T::Array[String].new
                   ^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:19: Replaced with `= ints.concat(strings)`
-    19 |ints += strings
-            ^^^^^^^^^^^
 
 autocorrect_array_plus.rb:20: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     20 |ints += strings
@@ -154,12 +105,6 @@ autocorrect_array_plus.rb:20: Expected `T::Enumerable[Integer]` but found `T::Ar
     autocorrect_array_plus.rb:4:
      4 |strings = T::Array[String].new
                   ^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:20: Replaced with `= ints.concat(strings)`
-    20 |ints += strings
-            ^^^^^^^^^^^
 
 autocorrect_array_plus.rb:22: Expected `T::Enumerable[{String("foo") => String("bar")}]` but found `[{}]` for argument `arg0` https://srb.help/7002
     22 |[{"foo" => "bar"}] + [{}]
@@ -172,12 +117,6 @@ autocorrect_array_plus.rb:22: Expected `T::Enumerable[{String("foo") => String("
     autocorrect_array_plus.rb:22:
     22 |[{"foo" => "bar"}] + [{}]
                              ^^^^
-  Note:
-    If the desired behavior is to widen the type to `[{String("foo") => String("bar")}, {}]`, use `Array#concat` instead
-  Autocorrect: Done
-    autocorrect_array_plus.rb:22: Replaced with `.concat([{}])`
-    22 |[{"foo" => "bar"}] + [{}]
-                          ^^^^^^^
 
 autocorrect_array_plus.rb:24: Expected `T::Enumerable[String]` but found `String("")` for argument `arg0` https://srb.help/7002
     24 |strings + ""
@@ -199,20 +138,22 @@ Errors: 11
 ints = T::Array[Integer].new
 strings = T::Array[String].new
 
-ints.concat(strings)
+ints + strings
 
-ints.concat(strings)
-ints.concat(strings)
-ints.concat(strings)
+ints + (strings)
+ints + ((strings))
+ints.+(strings)
 
-ints.concat(strings)
+ints.+(
+  strings
+)
 
-ints.concat(strings)
+ints + strings
 
-ints = ints.concat(strings)
-ints = ints.concat(strings)
-ints = ints.concat(strings)
+ints += strings
+ints += strings
+ints += strings
 
-[{"foo" => "bar"}].concat([{}])
+[{"foo" => "bar"}] + [{}]
 
 strings + ""


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was not great because it suggests people to use a method that
mutates the underlying array when `+` wouldn't do that.

We might want to revive the changes we're removing here and bring them
back suggesting changing `Array#concat` to `Array#+` but people use
`concat` way less as it is, so it's possible that it'll be so rare that
we don't want to justify all this custom code.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.