### PR TITLE
Widen type of `Array#+`

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -444,16 +444,10 @@ class Array < Object
   # See also
   # [`Array#concat`](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-concat).
   sig do
-    params(
-        arg0: T::Enumerable[Elem],
+    type_parameters(:T).params(
+        arg0: T::Enumerable[T.type_parameter(:T)],
     )
-    .returns(T::Array[Elem])
-  end
-  sig do
-    params(
-        arg0: T::Array[Elem],
-    )
-    .returns(T::Array[Elem])
+    .returns(T::Array[T.any(Elem, T.type_parameter(:T))])
   end
   def +(arg0); end
 

--- a/test/cli/autocorrect_array_plus/autocorrect_array_plus.rb
+++ b/test/cli/autocorrect_array_plus/autocorrect_array_plus.rb
@@ -3,7 +3,8 @@
 ints = T::Array[Integer].new
 strings = T::Array[String].new
 
-ints + strings
+x = ints + strings
+T.reveal_type(x)
 
 ints + (strings)
 ints + ((strings))

--- a/test/cli/autocorrect_array_plus/test.out
+++ b/test/cli/autocorrect_array_plus/test.out
@@ -1,135 +1,15 @@
-autocorrect_array_plus.rb:6: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-     6 |ints + strings
-               ^^^^^^^
-  Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `T::Array[String]` originating from:
-    autocorrect_array_plus.rb:4:
-     4 |strings = T::Array[String].new
-                  ^^^^^^^^^^^^^^^^^^^^
-
-autocorrect_array_plus.rb:8: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-     8 |ints + (strings)
-                ^^^^^^^
-  Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `T::Array[String]` originating from:
-    autocorrect_array_plus.rb:4:
-     4 |strings = T::Array[String].new
-                  ^^^^^^^^^^^^^^^^^^^^
-
-autocorrect_array_plus.rb:9: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-     9 |ints + ((strings))
-                 ^^^^^^^
-  Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `T::Array[String]` originating from:
-    autocorrect_array_plus.rb:4:
-     4 |strings = T::Array[String].new
-                  ^^^^^^^^^^^^^^^^^^^^
-
-autocorrect_array_plus.rb:10: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-    10 |ints.+(strings)
-               ^^^^^^^
-  Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `T::Array[String]` originating from:
-    autocorrect_array_plus.rb:4:
-     4 |strings = T::Array[String].new
-                  ^^^^^^^^^^^^^^^^^^^^
-
-autocorrect_array_plus.rb:13: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-    13 |  strings
-          ^^^^^^^
-  Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `T::Array[String]` originating from:
-    autocorrect_array_plus.rb:4:
-     4 |strings = T::Array[String].new
-                  ^^^^^^^^^^^^^^^^^^^^
-
-autocorrect_array_plus.rb:16: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-    16 |ints + strings
-               ^^^^^^^
-  Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `T::Array[String]` originating from:
-    autocorrect_array_plus.rb:4:
-     4 |strings = T::Array[String].new
-                  ^^^^^^^^^^^^^^^^^^^^
-
-autocorrect_array_plus.rb:18: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-    18 |ints += strings
-                ^^^^^^^
-  Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `T::Array[String]` originating from:
-    autocorrect_array_plus.rb:4:
-     4 |strings = T::Array[String].new
-                  ^^^^^^^^^^^^^^^^^^^^
-
-autocorrect_array_plus.rb:19: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-    19 |ints += strings
-                ^^^^^^^
-  Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `T::Array[String]` originating from:
-    autocorrect_array_plus.rb:4:
-     4 |strings = T::Array[String].new
-                  ^^^^^^^^^^^^^^^^^^^^
-
-autocorrect_array_plus.rb:20: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-    20 |ints += strings
-                ^^^^^^^
-  Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `T::Array[String]` originating from:
-    autocorrect_array_plus.rb:4:
-     4 |strings = T::Array[String].new
-                  ^^^^^^^^^^^^^^^^^^^^
-
-autocorrect_array_plus.rb:22: Expected `T::Enumerable[{String("foo") => String("bar")}]` but found `[{}]` for argument `arg0` https://srb.help/7002
-    22 |[{"foo" => "bar"}] + [{}]
-                             ^^^^
-  Expected `T::Enumerable[{String("foo") => String("bar")}]` for argument `arg0` of method `Array#+`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
-                  ^^^^
-  Got `[{}] (1-tuple)` originating from:
-    autocorrect_array_plus.rb:22:
-    22 |[{"foo" => "bar"}] + [{}]
-                             ^^^^
-
-autocorrect_array_plus.rb:24: Expected `T::Enumerable[String]` but found `String("")` for argument `arg0` https://srb.help/7002
+autocorrect_array_plus.rb:24: Expected `T::Enumerable[T.type_parameter(:T)]` but found `String("")` for argument `arg0` https://srb.help/7002
     24 |strings + ""
                   ^^
-  Expected `T::Enumerable[String]` for argument `arg0` of method `Array#+`:
+  Expected `T::Enumerable[T.type_parameter(:T)]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
-      NN |        arg0: T::Enumerable[Elem],
+      NN |        arg0: T::Enumerable[T.type_parameter(:T)],
                   ^^^^
   Got `String("")` originating from:
     autocorrect_array_plus.rb:24:
     24 |strings + ""
                   ^^
-Errors: 11
+Errors: 1
 
 --------------------------------------------------------------------------
 

--- a/test/cli/autocorrect_array_plus/test.out
+++ b/test/cli/autocorrect_array_plus/test.out
@@ -1,15 +1,23 @@
-autocorrect_array_plus.rb:24: Expected `T::Enumerable[T.type_parameter(:T)]` but found `String("")` for argument `arg0` https://srb.help/7002
-    24 |strings + ""
+autocorrect_array_plus.rb:7: Revealed type: `T::Array[T.any(Integer, String)]` https://srb.help/7014
+     7 |T.reveal_type(x)
+        ^^^^^^^^^^^^^^^^
+  Got `T::Array[T.any(Integer, String)]` originating from:
+    autocorrect_array_plus.rb:6:
+     6 |x = ints + strings
+            ^^^^^^^^^^^^^^
+
+autocorrect_array_plus.rb:25: Expected `T::Enumerable[T.type_parameter(:T)]` but found `String("")` for argument `arg0` https://srb.help/7002
+    25 |strings + ""
                   ^^
   Expected `T::Enumerable[T.type_parameter(:T)]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#LCENSORED:
       NN |        arg0: T::Enumerable[T.type_parameter(:T)],
                   ^^^^
   Got `String("")` originating from:
-    autocorrect_array_plus.rb:24:
-    24 |strings + ""
+    autocorrect_array_plus.rb:25:
+    25 |strings + ""
                   ^^
-Errors: 1
+Errors: 2
 
 --------------------------------------------------------------------------
 
@@ -18,7 +26,8 @@ Errors: 1
 ints = T::Array[Integer].new
 strings = T::Array[String].new
 
-ints + strings
+x = ints + strings
+T.reveal_type(x)
 
 ints + (strings)
 ints + ((strings))

--- a/test/cli/suggest-sig-literal/test.out
+++ b/test/cli/suggest-sig-literal/test.out
@@ -3,7 +3,7 @@ suggest-sig-literal.rb:2: The method `index_for_live` does not have a `sig` http
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     suggest-sig-literal.rb:2: Inserted `extend T::Sig
-    sig { params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]]) }`
+    sig { params(fields: T.untyped).returns(T::Array[T.untyped]) }`
      2 |def index_for_live(fields)
         ^
 Errors: 1
@@ -12,7 +12,7 @@ Errors: 1
 
 # typed: strict
 extend T::Sig
-sig { params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]]) }
+sig { params(fields: T.untyped).returns(T::Array[T.untyped]) }
 def index_for_live(fields)
   [[:deleted_at, 1]] + fields
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Historically we held this type artificially narrow because we thought the
error messages would be more direct if we rejected this code. More context
in this change: #4747

But the workarounds are annoying, and the error messages are not actually
that bad. (In particular, the workaround involved mutating the receiver,
something that `Array#+` doesn't do.)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.