### PR TITLE
Create applied types for type in sealed_subclasses

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -550,6 +550,8 @@ public:
     // Returns the locations that are allowed to subclass the sealed class.
     const SymbolRef::LOC_store &sealedLocs(const GlobalState &gs) const;
 
+    void sealedSubclassesToApplied(GlobalState &gs);
+
     TypePtr sealedSubclassesToUnion(const GlobalState &ctx) const;
 
     bool hasSingleSealedSubclass(const GlobalState &ctx) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -155,6 +155,7 @@ public:
     static TypePtr arrayOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr rangeOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr hashOf(const GlobalState &gs, const TypePtr &elem);
+    static TypePtr setOf(const TypePtr &elem);
     static TypePtr tClass(const TypePtr &attachedClass);
     static TypePtr dropNil(const GlobalState &gs, const TypePtr &from);
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -294,6 +294,11 @@ TypePtr Types::hashOf(const GlobalState &gs, const TypePtr &elem) {
     return make_type<AppliedType>(Symbols::Hash(), move(targs));
 }
 
+TypePtr Types::setOf(const TypePtr &elem) {
+    vector<TypePtr> targs{elem};
+    return make_type<AppliedType>(Symbols::Set(), move(targs));
+}
+
 TypePtr Types::tClass(const TypePtr &attachedClass) {
     vector<TypePtr> targs;
     targs.emplace_back(attachedClass);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1269,9 +1269,7 @@ private:
 
             // T.noreturn here represents the zero-length list of subclasses of this sealed class.
             // We will use T.any to record subclasses when they're resolved.
-            vector<core::TypePtr> targs{core::Types::bottom()};
-            sealedSubclasses.data(ctx)->resultType =
-                core::make_type<core::AppliedType>(core::Symbols::Set(), move(targs));
+            sealedSubclasses.data(ctx)->resultType = core::Types::setOf(core::Types::bottom());
         }
         if (fun == core::Names::declareInterface() || fun == core::Names::declareAbstract()) {
             symbolData->flags.isAbstract = true;

--- a/test/testdata/resolver/sealed_class.rb
+++ b/test/testdata/resolver/sealed_class.rb
@@ -22,7 +22,7 @@ def foo(x)
   end
 end
 
-T.reveal_type(AbstractParent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child1), T.class_of(Child2), T.class_of(Child3))]`
+T.reveal_type(AbstractParent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child2), T.class_of(Child3), T.class_of(Child1))]`
 
 
 class EmptyParent

--- a/test/testdata/resolver/sealed_concrete_parent_class.rb
+++ b/test/testdata/resolver/sealed_concrete_parent_class.rb
@@ -23,4 +23,4 @@ def foo(x)
   end
 end
 
-T.reveal_type(ConcreteParent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child1), T.class_of(Child2), T.class_of(Child3))]`
+T.reveal_type(ConcreteParent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child2), T.class_of(Child3), T.class_of(Child1))]`

--- a/test/testdata/resolver/sealed_module.rb
+++ b/test/testdata/resolver/sealed_module.rb
@@ -21,4 +21,4 @@ def foo(x)
   end
 end
 
-T.reveal_type(Parent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child1), T.class_of(Child2), T.class_of(Child3))]`
+T.reveal_type(Parent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child2), T.class_of(Child3), T.class_of(Child1))]`

--- a/test/testdata/resolver/sealed_subclasses.rb
+++ b/test/testdata/resolver/sealed_subclasses.rb
@@ -1,0 +1,34 @@
+# typed: true
+extend T::Sig
+
+# A previous version of Sorbet's support for sealed_subclasses manually created
+# `ClassType`'s for the elements of the sealed subclasses, instead of
+# AppliedTypes, like will normally be created if someone writes a
+# `T.class_of(...)` type directly. That meant that once upon a time, the final
+# `T.let` below failed to check.
+#
+# This was particularly pernicious to diagnose, because we print ClassTypes and
+# AppliedTypes the same way for singleton classes, so it wasn't obvious why the
+# two cases were different. This also means that it's important to use `T.let`
+# in this test, because using `T.reveal_type` would show the same type in both
+# cases.
+
+class Parent
+  extend T::Helpers
+  abstract!
+  sealed!
+end
+
+class Child1 < Parent
+end
+
+class Child2 < Parent
+end
+
+sig {params(x: T.any(T.class_of(Child1), T.class_of(Child2))).void}
+def foo(x)
+  T.let(x, T.class_of(Parent))
+end
+
+y = T.must(Parent.sealed_subclasses.first)
+T.let(y, T.class_of(Parent))


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #3618.

In recordSealedSubclass, we use `make_type<ClassType>(sym)` instead of
`sym.data(ctx)->externalType(ctx)` because we call recordSealedSubclass
from ResolveCosntantsWalk, before we've created `<AttachedClass>` type
members for all classes.

But that's weird, because all singleton classes are supposed to be generic
classes and are thus supposed to be applied types.

Luckily, there's no way to notice that we're using ClassTypes here, so we
can record the sealed subclasses during ResolveConstantsWalk and then fix
up the type later ResolveTypeMembersAndFieldsWalk (in the portion of it
that runs after we've computed all the type members).

This is a little annoying, because it adds code to the single-threaded
portion of resolver, but I think this is worth it for correctness.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.