### PR TITLE
Restore performance of recording sealed subclasses

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1820,12 +1820,12 @@ ClassOrModuleRef ClassOrModule::topAttachedClass(const GlobalState &gs) const {
     return classSymbol;
 }
 
-void ClassOrModule::recordSealedSubclass(MutableContext ctx, ClassOrModuleRef subclass) {
-    ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(ctx).show(ctx));
-    ENFORCE(subclass.exists(), "Can't record sealed subclass for {} when subclass doesn't exist", ref(ctx).show(ctx));
+void ClassOrModule::recordSealedSubclass(GlobalState &gs, ClassOrModuleRef subclass) {
+    ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(gs).show(gs));
+    ENFORCE(subclass.exists(), "Can't record sealed subclass for {} when subclass doesn't exist", ref(gs).show(gs));
 
     // Avoid using a clobbered `this` pointer, as `singletonClass` can cause the symbol table to move.
-    ClassOrModuleRef selfRef = this->ref(ctx);
+    ClassOrModuleRef selfRef = this->ref(gs);
 
     // We record sealed subclasses on the method called core::Names::sealedSubclasses().
     //
@@ -1833,11 +1833,11 @@ void ClassOrModule::recordSealedSubclass(MutableContext ctx, ClassOrModuleRef su
     // classes will never use.
     //
     // Note: this method actually exists at runtime as well--the name is not magic.
-    auto classOfSubclass = subclass.data(ctx)->singletonClass(ctx);
+    auto classOfSubclass = subclass.data(gs)->singletonClass(gs);
     auto sealedSubclasses =
-        selfRef.data(ctx)->lookupSingletonClass(ctx).data(ctx)->findMethod(ctx, core::Names::sealedSubclasses());
+        selfRef.data(gs)->lookupSingletonClass(gs).data(gs)->findMethod(gs, core::Names::sealedSubclasses());
 
-    auto data = sealedSubclasses.data(ctx);
+    auto data = sealedSubclasses.data(gs);
     ENFORCE(data->resultType != nullptr, "Should have been populated in namer");
     auto appliedType = cast_type<AppliedType>(data->resultType);
     ENFORCE(appliedType != nullptr, "sealedSubclasses should always be AppliedType");

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -550,8 +550,6 @@ public:
     // Returns the locations that are allowed to subclass the sealed class.
     const SymbolRef::LOC_store &sealedLocs(const GlobalState &gs) const;
 
-    void sealedSubclassesToApplied(GlobalState &gs);
-
     TypePtr sealedSubclassesToUnion(const GlobalState &ctx) const;
 
     bool hasSingleSealedSubclass(const GlobalState &ctx) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -545,7 +545,7 @@ public:
 
     ClassOrModuleRef topAttachedClass(const GlobalState &gs) const;
 
-    void recordSealedSubclass(MutableContext ctx, ClassOrModuleRef subclass);
+    void recordSealedSubclass(GlobalState &gs, ClassOrModuleRef subclass);
 
     // Returns the locations that are allowed to subclass the sealed class.
     const SymbolRef::LOC_store &sealedLocs(const GlobalState &gs) const;

--- a/test/testdata/resolver/sealed_class.rb
+++ b/test/testdata/resolver/sealed_class.rb
@@ -22,7 +22,7 @@ def foo(x)
   end
 end
 
-T.reveal_type(AbstractParent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child2), T.class_of(Child3), T.class_of(Child1))]`
+T.reveal_type(AbstractParent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child1), T.class_of(Child2), T.class_of(Child3))]`
 
 
 class EmptyParent

--- a/test/testdata/resolver/sealed_concrete_parent_class.rb
+++ b/test/testdata/resolver/sealed_concrete_parent_class.rb
@@ -23,4 +23,4 @@ def foo(x)
   end
 end
 
-T.reveal_type(ConcreteParent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child2), T.class_of(Child3), T.class_of(Child1))]`
+T.reveal_type(ConcreteParent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child1), T.class_of(Child2), T.class_of(Child3))]`

--- a/test/testdata/resolver/sealed_module.rb
+++ b/test/testdata/resolver/sealed_module.rb
@@ -21,4 +21,4 @@ def foo(x)
   end
 end
 
-T.reveal_type(Parent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child2), T.class_of(Child3), T.class_of(Child1))]`
+T.reveal_type(Parent.sealed_subclasses) # error: Revealed type: `T::Set[T.any(T.class_of(Child1), T.class_of(Child2), T.class_of(Child3))]`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The changes in #7020 caused a large regression in the time it takes us to run
the sealed_registraion_perf.rb test.

Previously, it took 2.3s on my laptop in debug builds to finish. After that PR,
it took upwards of 60s, causing it to get killed with a timeout.

Those changes _did_ also cause a regression in CI, but just not enough to push
it over the 60s threshold. Before #7020, the sealed registration test ran in 5s
in CI. After, it takes 23s. (The configuration we run tests with in CI uses a
higher optimization level than what I use by default on my development machine.)

### Summary

The idea is that we can use the ancestors stored on a ClassDef tree node to
figure out whether a class was directly a subclass of a sealed class.

I had previously thought we wouldn't be able to do this, becuase I thought
that since we'd have to run in ResolveTypeMembersAndFieldsWalk that would
have meant we'd be after ancestor linearization, which would have made it
hard to see whether a sealed class was a direct parent or a transitive
parent. But by looking at the ancestors node on the ClassDef we still have
that information on hand to disambiguate.

This approach means we can simply remove all the sealed class registration
from ResolveConstantsWalk and defer it to ResolveTypeMembersAndFieldsWalk,
which means we don't have to do an expensive walk tearing down and building
back up large union types--we can simply use externalType directly in
recordSealedSubclass.

The fact that we see ClassType and AppliedType here is subtle, but it's
because `T.class_of(MyModule)` is a ClassType while for something like
`T.class_of(MyClass)`, that would be an applied type (module singleton
classes don't currently have `<AttachedClass>` type members).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Also, I tested the sealed_registration_perf.rb test on my development machine
and it's back down to 1.6s.