### PR TITLE
Change how we print T.class_of types

### DIFF
--- a/test/cli/suggest-class-new-not-singleton/test.out
+++ b/test/cli/suggest-class-new-not-singleton/test.out
@@ -18,7 +18,7 @@ suggest-class-new-not-singleton.rb:5: Call to method `new` on `T.class_of(T::Arr
      5 |T.class_of(T::Array).new
                              ^^^
 
-suggest-class-new-not-singleton.rb:6: Call to method `new` on `T.class_of(Array)` mistakes a type for a value https://srb.help/7030
+suggest-class-new-not-singleton.rb:6: Call to method `new` on `T.class_of(Array)[T::Array[T.untyped]]` mistakes a type for a value https://srb.help/7030
      6 |T.class_of(T::Array[String]).new
                                      ^^^
   Autocorrect: Done

--- a/test/testdata/infer/class_of_printing.rb
+++ b/test/testdata/infer/class_of_printing.rb
@@ -1,0 +1,18 @@
+# typed: true
+extend T::Sig
+
+module Left; end
+module Right; end
+class Parent; end
+
+sig {params(x: T.all(T.class_of(Parent), T::Class[Left])).void}
+def example1(x)
+  T.reveal_type(x) # error: `T.class_of(Parent)`
+end
+
+sig {params(x: T.all(T.class_of(Parent), T::Class[Right])).void}
+def example2(x)
+  T.reveal_type(x) # error: `T.class_of(Parent)`
+  example1(x)
+  #        ^ error: `T.class_of(Parent)` but found `T.class_of(Parent)` for argument `x`
+end

--- a/test/testdata/infer/class_of_printing.rb
+++ b/test/testdata/infer/class_of_printing.rb
@@ -7,12 +7,12 @@ class Parent; end
 
 sig {params(x: T.all(T.class_of(Parent), T::Class[Left])).void}
 def example1(x)
-  T.reveal_type(x) # error: `T.class_of(Parent)`
+  T.reveal_type(x) # error: `T.class_of(Parent)[T.all(Parent, Left)]`
 end
 
 sig {params(x: T.all(T.class_of(Parent), T::Class[Right])).void}
 def example2(x)
-  T.reveal_type(x) # error: `T.class_of(Parent)`
+  T.reveal_type(x) # error: `T.class_of(Parent)[T.all(Parent, Right)]`
   example1(x)
-  #        ^ error: `T.class_of(Parent)` but found `T.class_of(Parent)` for argument `x`
+  #        ^ error: `T.class_of(Parent)[T.all(Parent, Left)]` but found `T.class_of(Parent)[T.all(Parent, Right)]` for argument `x`
 end

--- a/test/testdata/infer/control_flow/normalize_params.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/normalize_params.rb.cfg-text.exp
@@ -20,8 +20,8 @@ method ::Test#normalize_params {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Test = cast(<self>: NilClass, Test);
     v: T.untyped = load_arg(v)
-    <cfgAlias>$6: T.class_of(Hash) = alias <C Hash>
-    <ifTemp>$3: T.untyped = v: T.untyped.is_a?(<cfgAlias>$6: T.class_of(Hash))
+    <cfgAlias>$6: T.class_of(Hash)[T::Hash[T.untyped, T.untyped]] = alias <C Hash>
+    <ifTemp>$3: T.untyped = v: T.untyped.is_a?(<cfgAlias>$6: T.class_of(Hash)[T::Hash[T.untyped, T.untyped]])
     <ifTemp>$3 -> (T.untyped ? bb2 : bb3)
 
 # backedges
@@ -40,8 +40,8 @@ bb2[rubyRegionId=0, firstDead=-1](<self>: Test, v: T::Hash[T.untyped, T.untyped]
 # backedges
 # - bb0(rubyRegionId=0)
 bb3[rubyRegionId=0, firstDead=-1](<self>: Test, v: T.untyped):
-    <cfgAlias>$14: T.class_of(Array) = alias <C Array>
-    <ifTemp>$11: T.untyped = v: T.untyped.is_a?(<cfgAlias>$14: T.class_of(Array))
+    <cfgAlias>$14: T.class_of(Array)[T::Array[T.untyped]] = alias <C Array>
+    <ifTemp>$11: T.untyped = v: T.untyped.is_a?(<cfgAlias>$14: T.class_of(Array)[T::Array[T.untyped]])
     <ifTemp>$11 -> (T.untyped ? bb4 : bb5)
 
 # backedges

--- a/test/testdata/infer/generics/box_class_of.rb
+++ b/test/testdata/infer/generics/box_class_of.rb
@@ -1,0 +1,71 @@
+# typed: true
+extend T::Sig
+
+class Box
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member(:out)
+
+  sig {params(val: Elem).void}
+  def initialize(val)
+    @val = val
+  end
+end
+
+class BoxA < Box
+  Elem = type_member(:out) {{upper: A}}
+end
+
+sig {params(klass: T.class_of(Box)).void}
+def example1(klass)
+  T.reveal_type(klass) # error: `T.class_of(Box)[Box[T.anything]]`
+  instance = klass.new(0)
+  T.reveal_type(instance) # error: `Box[T.anything]`
+
+  T.reveal_type(klass[Integer]) # error: `Runtime object representing type: Box[Integer]`
+  instance = klass[Integer].new(0)
+  T.reveal_type(instance) # error: `Box[Integer]`
+
+  klass[Integer].new('')
+  #                  ^^ error: Expected `Integer` but found `String("")` for argument `val`
+end
+
+module M; end
+class A; end
+
+class ChildA < A
+  include M
+end
+
+class BoxChildA < Box
+  Elem = type_member(:out) {{upper: ChildA}}
+end
+
+sig {params(klass: T.all(T.class_of(Box), T::Class[Box[T.all(A, M)]])).void}
+def example2(klass)
+  T.reveal_type(klass) # error: `T.class_of(Box)[Box[T.all(A, M)]]`
+  instance = klass.new(ChildA.new)
+  T.reveal_type(instance) # error: `Box[T.all(A, M)]`
+
+  klass.new # error: Not enough arguments provided for method `Box#initialize`
+
+  # These two are bugs in our Class_new intrinsic. We dispatch on
+  # attachedClass->externalType() instead of on the attached class type
+  # argument. This doesn't happen for the klass[Integer].new calls because the
+  # [] call creates a MetaType, and then the `new` dispatchCall goes to
+  # `initialize` on the the MetaType's wrapped type.
+  klass.new(A.new)
+  klass.new(0)
+
+  # But I guess this still works, where you can just apply it to another type?
+
+  T.reveal_type(klass[Integer]) # error: `Runtime object representing type: Box[Integer]`
+  instance = klass[Integer].new # error: Not enough arguments
+  T.reveal_type(instance) # error: `Box[Integer]`
+end
+
+example2(Box)
+#        ^^^ error: Expected `T.class_of(Box)[Box[T.all(A, M)]]` but found `T.class_of(Box)`
+example2(BoxA)
+#        ^^^^ error: Expected `T.class_of(Box)[Box[T.all(A, M)]]` but found `T.class_of(BoxA)`
+example2(BoxChildA)

--- a/test/testdata/infer/generics/object_class.rb
+++ b/test/testdata/infer/generics/object_class.rb
@@ -17,7 +17,7 @@ class Get
   sig {params(instance: ModelType).returns(ModelType)}
   def get(instance)
     T.reveal_type(instance) # error: `Get::ModelType`
-    T.reveal_type(instance.class) # error: `T.class_of(Model)`
+    T.reveal_type(instance.class) # error: `T.class_of(Model)[T.all(Model, Get::ModelType)]`
     x = instance.class.load_one
     T.reveal_type(x) # error: `T.all(Model, Get::ModelType)`
     x

--- a/test/testdata/infer/generics/object_class.rb
+++ b/test/testdata/infer/generics/object_class.rb
@@ -34,6 +34,6 @@ extend T::Sig
 
 sig {params(x: T.all(A, M)).void}
 def example(x)
-  T.reveal_type(x.class) # error: `T.class_of(A)`
+  T.reveal_type(x.class) # error: `T.class_of(A)[T.all(A, M)]`
   T.reveal_type(x.class.new) # error: `T.all(A, M)`
 end

--- a/test/testdata/infer/generics/self_class_elem.rb
+++ b/test/testdata/infer/generics/self_class_elem.rb
@@ -15,7 +15,7 @@ class Box
   sig {params(new_val: Elem).returns(T.self_type)}
   def copy_with(new_val)
     klass = self.class
-    T.reveal_type(klass) # error: `T.class_of(Box)`
+    T.reveal_type(klass) # error: `T.class_of(Box)[Box[Box::Elem]]`
     new_box = self.class.new(new_val)
     T.reveal_type(new_box) # error: `Box[Box::Elem]`
 

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -83,8 +83,8 @@ bb2[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), a: T.all(Generic[S
 # - bb2(rubyRegionId=0)
 bb4[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     <cfgAlias>$88: T.class_of(Sorbet::Private::Static) = alias <C Static>
-    <cfgAlias>$90: T.class_of(Array) = alias <C Array>
-    <statTemp>$86: Sorbet::Private::Static::Void = <cfgAlias>$88: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$90: T.class_of(Array))
+    <cfgAlias>$90: T.class_of(Array)[T::Array[T.untyped]] = alias <C Array>
+    <statTemp>$86: Sorbet::Private::Static::Void = <cfgAlias>$88: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$90: T.class_of(Array)[T::Array[T.untyped]])
     <cfgAlias>$94: T.class_of(Integer) = alias <C Integer>
     <cfgAlias>$96: T.class_of(Integer) = alias <C Integer>
     <magic>$97: T.class_of(<Magic>) = alias <C <Magic>>

--- a/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
@@ -19,8 +19,8 @@ method ::<Class:A>#make {
 
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
-    <cfgAlias>$5: T.class_of(Class) = alias <C Class>
-    <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Class).new()
+    <cfgAlias>$5: T.class_of(Class)[T::Class[T.anything]] = alias <C Class>
+    <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Class)[T::Class[T.anything]].new()
     <selfRestore>$7: T.class_of(A) = <self>
     <unconditional> -> bb2
 
@@ -41,9 +41,9 @@ bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$6
 bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
     _cls: T::Class[Object] = Solve<<block-pre-call-temp>$6, new>
     <self>: T.class_of(A) = <selfRestore>$7
-    <cfgAlias>$18: T.class_of(Class) = alias <C Class>
+    <cfgAlias>$18: T.class_of(Class)[T::Class[T.anything]] = alias <C Class>
     <cfgAlias>$20: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$21: Sorbet::Private::Static::Void = <cfgAlias>$18: T.class_of(Class).new(<cfgAlias>$20: T.class_of(A))
+    <block-pre-call-temp>$21: Sorbet::Private::Static::Void = <cfgAlias>$18: T.class_of(Class)[T::Class[T.anything]].new(<cfgAlias>$20: T.class_of(A))
     <selfRestore>$22: T.class_of(A) = <self>
     <unconditional> -> bb6
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Now that `T::Class` exists, it's possible to do something wild like
`T.all(T.class_of(...), T::Class[...])` which has the effect of
"applying" a type to the `T.class_of`'s `<AttachedClass>` type argument,
printing `T.class_of` types as simply `T.class_of(A)` can be misleading.
Sorbet will be able to collapse the `T.all` to just a `T.class_of`
applied type, which means that you can have two types that are printed
like `T.class_of(A)` but they're actually applied to differen types and
thus incompatible with each other.

This changes detects those cases where it's ambiguous what the
`T.class_of`'s `<AttachedClass>` type argument is, because it wasn't the
default value, and prints it explicitly.

It's still weird, because `T.class_of(A)[...]` is still not valid type
syntax, but that's not a new problem--Sorbet would already sometimes
print `T.class_of(A)[...]` when the singleton class had other type
templates.

We can revisit this printing if/when we make `T.class_of(...)[...]`
syntax valid.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.