### PR TITLE
Register `class` intrinsic on `Kernel`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1919,18 +1919,15 @@ public:
     }
 } DeclBuilderForProcs_bind;
 
-class Object_class : public IntrinsicMethod {
+class Kernel_class : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         auto mustExist = true;
         ClassOrModuleRef self = unwrapSymbol(gs, args.thisType, mustExist);
         auto tClassSelfType = Types::tClass(args.selfType);
         if (self.data(gs)->isModule()) {
-            ENFORCE(gs.requiresAncestorEnabled, "Congrats, you've found a test case. Please add it, then delete this.");
-            // This normally can't happen, because `Object` is not an ancestor of any module
-            // instance by default. But Sorbet supports requires ancestor in a really weird way (by
-            // simply dispatching to a completely unrelated method) which means that sometimes we
-            // can actually get a call to this on a module.
+            // This means either: self is Kernel, or self includes Kernel, or self is some module
+            // which has requires_ancestor of Kernel.
             //
             // In the case where the receiver is a module, `singleton` will be `T.class_of(MyModule)`
             // which will not actually reflect how `.class` in a module instance method works at runtime.
@@ -1957,7 +1954,7 @@ public:
         // (This matters, btw, in case the receiver is something like a generic.)
         res.returnType = Types::all(gs, tClassSelfType, singleton.data(gs)->externalType());
     }
-} Object_class;
+} Kernel_class;
 
 class Class_new : public IntrinsicMethod {
 public:
@@ -4165,9 +4162,6 @@ const vector<Intrinsic> intrinsics{
     {Symbols::T_Set(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},
     {Symbols::T_Class(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},
 
-    {Symbols::Object(), Intrinsic::Kind::Instance, Names::class_(), &Object_class},
-    {Symbols::Object(), Intrinsic::Kind::Instance, Names::singletonClass(), &Object_class},
-
     {Symbols::Class(), Intrinsic::Kind::Instance, Names::new_(), &Class_new},
     {Symbols::Class(), Intrinsic::Kind::Instance, Names::subclasses(), &Class_subclasses},
 
@@ -4218,6 +4212,8 @@ const vector<Intrinsic> intrinsics{
     {Symbols::Symbol(), Intrinsic::Kind::Instance, Names::eqeq(), &Symbol_eqeq},
     {Symbols::String(), Intrinsic::Kind::Instance, Names::eqeq(), &String_eqeq},
 
+    {Symbols::Kernel(), Intrinsic::Kind::Instance, Names::class_(), &Kernel_class},
+    {Symbols::Kernel(), Intrinsic::Kind::Instance, Names::singletonClass(), &Kernel_class},
     {Symbols::Kernel(), Intrinsic::Kind::Instance, Names::proc(), &Kernel_proc},
     {Symbols::Kernel(), Intrinsic::Kind::Instance, Names::lambda(), &Kernel_proc},
     {Symbols::Kernel(), Intrinsic::Kind::Instance, Names::raise(), &Kernel_raise},

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -67,7 +67,9 @@ TEST_CASE("namer tests") {
         const auto &objectScope = core::Symbols::Object().data(gs);
         REQUIRE_EQ(core::Symbols::root(), objectScope->owner);
 
-        REQUIRE_EQ(4, objectScope->members().size());
+        // 2 members: the `hello_world` method (defined by the test), and the magic
+        // "<singleton class>" method that Sorbet uses to link a class with its singleton class.
+        REQUIRE_EQ(2, objectScope->members().size());
         auto methodSym = objectScope->members().at(gs.enterNameUTF8("hello_world")).asMethodRef();
         const auto &symbol = methodSym.data(gs);
         REQUIRE_EQ(core::Symbols::Object(), symbol->owner);

--- a/test/cli/suggest-object/test.out
+++ b/test/cli/suggest-object/test.out
@@ -1,4 +1,6 @@
 test/cli/suggest-object/suggest-object.rb:4: Method `class` does not exist on `M` https://srb.help/7003
      4 |    self.class
                  ^^^^^
+  Note:
+    Did you mean to `include Kernel` in this module?
 Errors: 1

--- a/test/testdata/infer/method_result_type_locs.rb
+++ b/test/testdata/infer/method_result_type_locs.rb
@@ -46,6 +46,7 @@ module M
     # ^^^^^^^^^^^^^^^^ error: Expected `String` but found `T.nilable(String)` for method result type
     else
       return self.class.name
+    # ^^^^^^^^^^^^^^^^^^^^^^ error: Expected `String` but found `T.nilable(String)` for method result type
     end
   end
 end


### PR DESCRIPTION
Second chance at https://github.com/sorbet/sorbet/pull/7030, after it was reverted once.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This works around a bug where jump to def would not work on calls to
`.class`.

What was happening is that any time we register an intrinsic, if there
is not a method already defined for that intrinsic, we create a new one
on the fly. What usually happens is that later we see an RBI definition
for the intrinsic method too, which fills in things like arity,
location, etc.

But in this case, Object#class doesn't exist in our RBIs, only
Kernel#class does. So there was never a method that would come along and
define things like location information, so jump to definition wouldn't
work.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

It's hard to write a test for this, because the problem is that we don't have location information for something in the payload. Showing that there's jump-to-def results for something in the payload doesn't work with our current test suite.

I verified that this fixes it when using jump to def on `.class` in Vim with Sorbet's LSP.