### PR TITLE
Fix: Restore "sorbet.configure" command Id

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Version history
+## 0.3.20
+- `Sorbet` status bar item shows a quick-pick drop down instead of a notification dialog when clicked.
 
 ## 0.3.7
 

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -271,21 +271,6 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "sorbet.configure"
-        },
-        {
-          "command": "sorbet.disable"
-        },
-        {
-          "command": "sorbet.enable"
-        },
-        {
-          "command": "sorbet.restart"
-        },
-        {
-          "command": "sorbet.toggleHighlightUntyped"
-        },
-        {
           "command": "sorbet.showOutput",
           "when": "editorLangId == ruby"
         }

--- a/vscode_extension/src/commandIds.ts
+++ b/vscode_extension/src/commandIds.ts
@@ -6,7 +6,7 @@ export const SHOW_ACTIONS_COMMAND_ID = "sorbet.showAvailableActions";
 /**
  * Show Configuration picker. See {@link ShowSorbetConfigurationPicker}.
  */
-export const SHOW_CONFIG_PICKER_COMMAND_ID = "sorbet.showConfigPicker";
+export const SHOW_CONFIG_PICKER_COMMAND_ID = "sorbet.configure";
 
 /**
  * Show Sorbet Output panel. See {@link ShowSorbetOutput}.


### PR DESCRIPTION
*Issue*: `sorbet.configure` was unmapped in https://github.com/sorbet/sorbet/pull/7042 when the matching command Id was replaced by `sorbet.showConfigPicker`.
- Missing CommandId error only manifests when trying to use the `Sorbet: Configure` command as the status bar called the command using `sorbet.showConfigPicker`.

*Fix*: Map `sorbet.configure` only.

Misc:
- Remove unused command-id entries from the `commandPalette` section package.json (all commands are available by default there).
- Update CHANGELOG.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Manually tests all commands from Command Palette and Status Bar Item's actions.
