### PR TITLE
Force the first argument to `Time.new` to be `Integer`

### DIFF
--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -689,12 +689,12 @@ class Time < Object
 
   sig do
     params(
-      year: T.any(Integer, String),
+      year: Integer,
       month: T.any(Integer, String),
-      day: T.any(Integer, String),
-      hour: T.any(Integer, String),
-      min: T.any(Integer, String),
-      sec: T.any(Numeric, String),
+      day: Integer,
+      hour: Integer,
+      min: Integer,
+      sec: Numeric,
       tz: T.any(Numeric, String),
     )
     .void

--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -691,10 +691,10 @@ class Time < Object
     params(
       year: Integer,
       month: T.any(Integer, String),
-      day: Integer,
-      hour: Integer,
-      min: Integer,
-      sec: Numeric,
+      day: T.any(Integer, String),
+      hour: T.any(Integer, String),
+      min: T.any(Integer, String),
+      sec: T.any(Numeric, String),
       tz: T.any(Numeric, String),
     )
     .void


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
It's _very_ easy to do the wrong thing with `Time.new` when passing a string, because `Time.new("2023-05-24")` does not do what someone might at first glance expect: since it gives you a date corresponding to `2023-01-01`. Technically, a string is fine as argument as long as it's fully numeric. However, to prevent this specific problem of people trying to use `Time.new` instead of e.g. `Time.parse`, this limits the first argument to be just an `Integer`. You can recapture the previous behavior with an explicit `#to_i` call.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
