### PR TITLE
Change highlight loc of untyped call site

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -563,7 +563,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
     if (symbol == core::Symbols::untyped()) {
         auto what = core::errors::Infer::errorClassForUntyped(gs, args.locs.file, args.thisType);
-        if (auto e = gs.beginError(args.receiverLoc(), what)) {
+        if (auto e = gs.beginError(errLoc, what)) {
             e.setHeader("Call to method `{}` on `{}`", args.name.show(gs), "T.untyped");
             TypeErrorDiagnostics::explainUntyped(gs, e, what, args.fullType, args.originForUninitialized);
         }

--- a/test/cli/track-untyped/test.out
+++ b/test/cli/track-untyped/test.out
@@ -1,6 +1,6 @@
 a.rb:6: Call to method `foo` on `T.untyped` https://srb.help/7018
      6 |  result = arg0.foo
-                   ^^^^
+                        ^^^
   Got `T.untyped` originating from:
     a.rb:5:
      5 |def example_untyped(arg0)
@@ -50,7 +50,7 @@ a.rb:12: Value returned from method is `T.untyped` https://srb.help/7018
 
 b.rb:4: Call to method `foo` on `T.untyped` https://srb.help/7018
      4 |T.unsafe(nil).foo
-        ^^^^^^^^^^^^^
+                      ^^^
   Got `T.untyped` originating from:
     b.rb:4:
      4 |T.unsafe(nil).foo

--- a/test/testdata/infer/untyped.rb
+++ b/test/testdata/infer/untyped.rb
@@ -22,8 +22,8 @@ else
   x = 0
 end
 
-  x.foo
-# ^ error: Call to method `foo` on `T.untyped`
+x.foo
+# ^^^ error: Call to method `foo` on `T.untyped`
 
 y = T.let(x, A)
 y.foo

--- a/test/testdata/lsp/highlight_untyped.rb
+++ b/test/testdata/lsp/highlight_untyped.rb
@@ -29,13 +29,13 @@ end
 b = baz
 
 # use an untyped variable
-  b.length
-# ^ untyped: Call to method `length` on `T.untyped`
+b.length
+# ^^^^^^ untyped: Call to method `length` on `T.untyped`
 
-  b.foo(0).bar(1).baz(2)
-# ^ untyped: Call to method `foo` on `T.untyped`
-# ^^^^^^^^ untyped: Call to method `bar` on `T.untyped`
-# ^^^^^^^^^^^^^^^ untyped: Call to method `baz` on `T.untyped`
+b.foo(0).bar(1).baz(2)
+# ^^^ untyped: Call to method `foo` on `T.untyped`
+#        ^^^ untyped: Call to method `bar` on `T.untyped`
+#               ^^^ untyped: Call to method `baz` on `T.untyped`
 
 T.let(b, Integer) == 6
 

--- a/test/testdata/lsp/highlight_untyped_typed_strong.rb
+++ b/test/testdata/lsp/highlight_untyped_typed_strong.rb
@@ -29,8 +29,8 @@ end
 b = baz
 
 # use an untyped variable
-  b.length
-# ^ error: Call to method `length` on `T.untyped`
+b.length
+# ^^^^^^ error: Call to method `length` on `T.untyped`
 T.let(b, Integer) == 6
 
 

--- a/test/testdata/lsp/hover_untyped_lambda.rb
+++ b/test/testdata/lsp/hover_untyped_lambda.rb
@@ -5,5 +5,5 @@
 
 ->(arg0) do
   arg0.foo
-# ^^^^ error: Call to method `foo` on `T.untyped`
+  #    ^^^ error: Call to method `foo` on `T.untyped`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's getting pretty noisy to have a huge chain of well-typed code, and then have
a single call at the end that's untyped suddenly highlight the entire receiver.

This visualization should hopefully be less noisy.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.