### PR TITLE
Settings should use `mardownDescription` when using markdown.

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -97,11 +97,11 @@
           "type": "boolean"
         },
         "sorbet.selectedLspConfigId": {
-          "description": "The default configuration to use from `sorbet.userLspConfigs` or `sorbet.lspConfigs`.  If unset, defaults to the first item in `sorbet.userLspConfigs` or `sorbet.lspConfigs`.",
+          "markdownDescription": "The default configuration to use from `sorbet.userLspConfigs` or `sorbet.lspConfigs`.  If unset, defaults to the first item in `sorbet.userLspConfigs` or `sorbet.lspConfigs`.",
           "type": "string"
         },
         "sorbet.lspConfigs": {
-          "description": "Standard Ruby LSP configurations.  If you commit your VSCode settings to source control, you probably want to commit *this* setting, not `sorbet.userLspConfigs`.",
+          "markdownDescription": "Standard Ruby LSP configurations.  If you commit your VSCode settings to source control, you probably want to commit *this* setting, not `sorbet.userLspConfigs`.",
           "type": "array",
           "default": [
             {
@@ -184,7 +184,7 @@
           }
         },
         "sorbet.userLspConfigs": {
-          "description": "Custom user LSP configurations that supplement `sorbet.lspConfigs` (and override configurations with the same id).  If you commit your VSCode settings to source control, you probably want to commit `sorbet.lspConfigs`, not this value.",
+          "markdownDescription": "Custom user LSP configurations that supplement `sorbet.lspConfigs` (and override configurations with the same id).  If you commit your VSCode settings to source control, you probably want to commit `sorbet.lspConfigs`, not this value.",
           "type": "array",
           "default": [],
           "items": {


### PR DESCRIPTION
Settings should use the `mardownDescription` property when using markdown text (package.json), instead of `description`, otherwise text is not formatted.

**After**
<p align="center">
<img width="640" alt="image" src="https://github.com/sorbet/sorbet/assets/46902661/ee20d541-f3b1-4146-84f3-68faeb47608f">
</p>

**Before**
<p align="center">
<img width="640" alt="image" src="https://github.com/sorbet/sorbet/assets/46902661/186dee8d-628d-43e0-b555-1729fca0a833">
</p>

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
