### PR TITLE
Remove runtime lodash dependency

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -298,14 +298,12 @@
   "dependencies": {
     "async": "^2.6.4",
     "elegant-spinner": "^2.0.0",
-    "lodash": "^4.17.21",
     "minimatch": "^3.0.5",
     "vscode-languageclient": "7.0.0"
   },
   "devDependencies": {
     "@types/elegant-spinner": "^1.0.0",
     "@types/glob": "^7.1.1",
-    "@types/lodash": "^4.14.144",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.11.7",
     "@types/sinon": "^7.5.0",

--- a/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
+++ b/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
@@ -1,5 +1,4 @@
 import { QuickPickItem, window } from "vscode";
-import { isEqual } from "lodash";
 import { SorbetExtensionConfig, SorbetLspConfig } from "../config";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
 
@@ -20,7 +19,7 @@ export default class ShowSorbetConfigurationPicker {
   public async execute(): Promise<void> {
     const { activeLspConfig, lspConfigs } = this._extensionConfig;
     const items: SorbetQuickPickItem[] = lspConfigs.map((config) => ({
-      label: `${isEqual(activeLspConfig, config) ? "• " : ""}${config.name}`,
+      label: `${config.isEqualTo(activeLspConfig) ? "• " : ""}${config.name}`,
       description: config.description,
       detail: config.command.join(" "),
       lspConfig: config,

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -1,17 +1,23 @@
-import { isEqual } from "lodash";
 import {
-  workspace,
-  Event,
-  EventEmitter,
   ConfigurationChangeEvent,
   Disposable,
+  Event,
+  EventEmitter,
   ExtensionContext,
-  Memento,
   FileSystemWatcher,
+  Memento,
   Uri,
+  workspace,
   WorkspaceFolder,
 } from "vscode";
 import * as fs from "fs";
+
+/**
+ * Compare two `string` arrays for deep, in-order equality.
+ */
+export function deepEqual(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
+  return a.length === b.length && a.every((itemA, index) => itemA === b[index]);
+}
 
 interface ISorbetLspConfig {
   readonly id: string;
@@ -74,7 +80,7 @@ export class SorbetLspConfig {
     if (this.cwd !== other.cwd) {
       return false;
     }
-    if (!isEqual(this.command, other.command)) {
+    if (!deepEqual(this.command, other.command)) {
       return false;
     }
     return true;
@@ -294,7 +300,7 @@ export class SorbetExtensionConfig implements Disposable {
     const newLspConfig = this.activeLspConfig;
     if (
       !SorbetLspConfig.areEqual(oldLspConfig, newLspConfig) ||
-      !isEqual(oldConfigFilePatterns, this._configFilePatterns)
+      !deepEqual(oldConfigFilePatterns, this._configFilePatterns)
     ) {
       this._onLspConfigChangeEmitter.fire({
         oldLspConfig,

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -1,5 +1,4 @@
 import * as assert from "assert";
-import { isEqual } from "lodash";
 import * as sinon from "sinon";
 import {
   EventEmitter,
@@ -224,16 +223,6 @@ suite("SorbetLspConfig", () => {
           !SorbetLspConfig.areEqual(config1, c),
           `Should not equal: ${c}`,
         );
-      });
-    });
-    test("using lodash.isEqual()", () => {
-      assert.notEqual(config1, config2, "Should not be identical");
-      assert.ok(
-        isEqual(config1, config2),
-        `Should be deeply equal to ${config2}`,
-      );
-      differentConfigs.forEach((c) => {
-        assert.ok(!isEqual(c, config1), `Should not be deeply equal to ${c}`);
       });
     });
   });

--- a/vscode_extension/yarn.lock
+++ b/vscode_extension/yarn.lock
@@ -141,11 +141,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/lodash@^4.14.144":
-  version "4.14.149"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
-  integrity "sha1-E0LWPZSMYGKDj7+WEBL3TU5jhEA= sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1597,7 +1592,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Remove runtime `lodash` dependency as it was brought in to perform a simple `string[]` deep-equality comparison.
- Removing this dependency reduces the size of the extension .VSIX package from **3.62MB to 2.59MB**.
  - Note that `sinon` (used in tests) still depends on `lodash`, so the `yarn.lock` file does not change significantly.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. --> The cost-benefit of the library does not add up: 40% increase on the VSIX file to use a single method that is easily implemented with stock JS.  Additionally, its presence causes confusion as at least one callsite being removed on this PR used `lodash`'s `isEqual` directly instead of using the more correct class method (that was implemented wiht it!).

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call 
### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
