### PR TITLE
Fix Command Enablement Rules

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -54,6 +54,12 @@
         "category": "Sorbet"
       },
       {
+        "command": "sorbet.copySymbolToClipboard",
+        "title": "Copy Symbol to Clipboard",
+        "category": "Sorbet",
+        "enablement": "editorLangId == ruby"
+      },
+      {
         "command": "sorbet.disable",
         "title": "Disable",
         "category": "Sorbet"
@@ -64,13 +70,14 @@
         "category": "Sorbet"
       },
       {
-        "command": "sorbet.restart",
-        "title": "Restart",
-        "category": "Sorbet"
+        "command": "sorbet.rename",
+        "title": "Rename Symbol",
+        "category": "Sorbet",
+        "enablement": "editorLangId == ruby"
       },
       {
-        "command": "sorbet.toggleHighlightUntyped",
-        "title": "Toggle highlighting untyped code",
+        "command": "sorbet.restart",
+        "title": "Restart",
         "category": "Sorbet"
       },
       {
@@ -79,13 +86,8 @@
         "category": "Sorbet"
       },
       {
-        "command": "sorbet.copySymbolToClipboard",
-        "title": "Copy Symbol to Clipboard",
-        "category": "Sorbet"
-      },
-      {
-        "command": "sorbet.rename",
-        "title": "Rename Symbol",
+        "command": "sorbet.toggleHighlightUntyped",
+        "title": "Toggle highlighting untyped code",
         "category": "Sorbet"
       }
     ],
@@ -269,12 +271,6 @@
       }
     },
     "menus": {
-      "commandPalette": [
-        {
-          "command": "sorbet.showOutput",
-          "when": "editorLangId == ruby"
-        }
-      ],
       "editor/context": [
         {
           "when": "resourceLangId == ruby",


### PR DESCRIPTION
Fix Command Enablement Rules:
- `sorbet.copySymbolToClipboard` and `sorbet.rename` require a Ruby file to be open in an editor to be executed.
   - If there is no editor, they do nothing so no point on them being enabled.
   - Today actually they fail if the extension has not been loaded because they are not part of the `activationEvents` list. Adding them to the list  is not the right fix (in fact, after VSCode 1.75, commands should not even be there):
        ```
        command 'sorbet.copySymbolToClipboard' not found
        ```
- `sorbet.showOutput` is disabled  in the Command Palette if current file is not Ruby but this is inconsistent with the behavior of other non-editor dependent commands, like `sorbet.configure`. It also breaks the scenario where current editor is a non-Ruby file (e.g. a README file) but the project does contain Ruby files so looking at Sorbet output is still needed.
- `sorbet.toggleHighlightUntyped` fails when no workspace is open (`_startSorbetProcess` in `LanguageClient`  assumes there is `activeLspConfig` all the time - this can be improved in a separate PR):
    ```
    Activating extension 'sorbet.sorbet-vscode-extension' failed: 
    Cannot read properties of null (reading 'command').
    ```

Misc:
- Sort command definitions alphabetically by commandId so it is easier to maintain the list.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Commands failing or missing in some scenarios.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
