### PR TITLE
Fix Command Enablement Rules (2)

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -88,7 +88,8 @@
       {
         "command": "sorbet.toggleHighlightUntyped",
         "title": "Toggle highlighting untyped code",
-        "category": "Sorbet"
+        "category": "Sorbet",
+        "enablement": "workbenchState != empty"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Fix Command Enablement Rules:
- `sorbet.toggleHighlightUntyped` fails when no workspace is open (`_startSorbetProcess` in `LanguageClient`  assumes there is `activeLspConfig` all the time):
    ```
    Activating extension 'sorbet.sorbet-vscode-extension' failed: 
    Cannot read properties of null (reading 'command').
    ```

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Commands failing or missing in some scenarios. This was meant to be part of 
- https://github.com/sorbet/sorbet/pull/7061

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
