### PR TITLE
Naming Style: No-underscore, camel-case filenames

### DIFF
--- a/vscode_extension/.eslintrc.yaml
+++ b/vscode_extension/.eslintrc.yaml
@@ -99,8 +99,8 @@ rules:
   'newline-per-chained-call': [2, {ignoreChainWithDepth: 5}]
   # Disallow multiple empty lines
   'no-multiple-empty-lines': 2
-  # Allow dangling underscores in identifiers
-  'no-underscore-dangle': 0
+  # Disallow dangling underscores
+  'no-underscore-dangle': [2, {enforceInMethodNames: true}]
   # Allow useless computed keys.
   # We disable useless computed _string_ keys in a forked version of this
   # rule, no-useless-computed-string-key. We allow computed number keys

--- a/vscode_extension/src/commands/showSorbetActions.ts
+++ b/vscode_extension/src/commands/showSorbetActions.ts
@@ -22,10 +22,10 @@ export const enum Action {
  * Show available actions in a drop-down.
  */
 export class ShowSorbetActions {
-  private readonly _statusProvider: SorbetStatusProvider;
+  private readonly statusProvider: SorbetStatusProvider;
 
   constructor(context: SorbetExtensionContext) {
-    this._statusProvider = context.statusProvider;
+    this.statusProvider = context.statusProvider;
   }
 
   public async execute(): Promise<void> {
@@ -63,7 +63,7 @@ export class ShowSorbetActions {
    */
   public getAvailableActions(): Action[] {
     const actions = [Action.ViewOutput];
-    switch (this._statusProvider.serverStatus) {
+    switch (this.statusProvider.serverStatus) {
       case ServerStatus.ERROR:
         actions.push(Action.RestartSorbet);
         break;

--- a/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
+++ b/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
@@ -9,15 +9,15 @@ interface SorbetQuickPickItem extends QuickPickItem {
 /**
  * Show Sorbet Configuration picker.
  */
-export default class ShowSorbetConfigurationPicker {
-  private readonly _extensionConfig: SorbetExtensionConfig;
+export class ShowSorbetConfigurationPicker {
+  private readonly configuration: SorbetExtensionConfig;
 
   public constructor(context: SorbetExtensionContext) {
-    this._extensionConfig = context.config;
+    this.configuration = context.configuration;
   }
 
   public async execute(): Promise<void> {
-    const { activeLspConfig, lspConfigs } = this._extensionConfig;
+    const { activeLspConfig, lspConfigs } = this.configuration;
     const items: SorbetQuickPickItem[] = lspConfigs.map((config) => ({
       label: `${config.isEqualTo(activeLspConfig) ? "• " : ""}${config.name}`,
       description: config.description,
@@ -35,9 +35,9 @@ export default class ShowSorbetConfigurationPicker {
     if (selectedItem) {
       const { lspConfig } = selectedItem;
       if (lspConfig) {
-        this._extensionConfig.setActiveLspConfigId(lspConfig.id);
+        this.configuration.setActiveLspConfigId(lspConfig.id);
       } else {
-        this._extensionConfig.setEnabled(false);
+        this.configuration.setEnabled(false);
       }
     }
   }

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -15,7 +15,7 @@ import * as fs from "fs";
 /**
  * Compare two `string` arrays for deep, in-order equality.
  */
-export function deepEqual(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
+function deepEqual(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
   return a.length === b.length && a.every((itemA, index) => itemA === b[index]);
 }
 
@@ -128,47 +128,48 @@ export interface ISorbetWorkspaceContext {
 
 /** Default implementation accesses `workspace` directly. */
 export class DefaultSorbetWorkspaceContext implements ISorbetWorkspaceContext {
-  static _workspaceStateChangeEmitter = new EventEmitter<string>();
-  private _workspaceState: Memento;
-  private _cachedSorbetConfiguration = workspace.getConfiguration("sorbet");
-  private _emitter = new EventEmitter<ConfigurationChangeEvent>();
+  static workspaceStateChangeEmitter = new EventEmitter<string>();
+  private workspaceState: Memento;
+  private cachedSorbetConfiguration = workspace.getConfiguration("sorbet");
+  private onConfigurationChangeEmitter = new EventEmitter<
+    ConfigurationChangeEvent
+  >();
+
   constructor(extensionContext: ExtensionContext) {
-    this._workspaceState = extensionContext.workspaceState;
+    this.workspaceState = extensionContext.workspaceState;
     workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration("sorbet")) {
         // update the cached configuration before firing
-        this._cachedSorbetConfiguration = workspace.getConfiguration("sorbet");
-        this._emitter.fire(e);
+        this.cachedSorbetConfiguration = workspace.getConfiguration("sorbet");
+        this.onConfigurationChangeEmitter.fire(e);
       }
     });
-    DefaultSorbetWorkspaceContext._workspaceStateChangeEmitter.event((k) => {
-      this._emitter.fire({
+    DefaultSorbetWorkspaceContext.workspaceStateChangeEmitter.event((k) => {
+      this.onConfigurationChangeEmitter.fire({
         affectsConfiguration: () => k.startsWith("sorbet."),
       });
     });
   }
 
   public get<T>(section: string, defaultValue: T): T {
-    const workspaceStateValue = this._workspaceState.get<T>(
-      `sorbet.${section}`,
-    );
+    const workspaceStateValue = this.workspaceState.get<T>(`sorbet.${section}`);
     if (workspaceStateValue !== undefined) {
       return workspaceStateValue;
     }
-    return this._cachedSorbetConfiguration.get(section, defaultValue);
+    return this.cachedSorbetConfiguration.get(section, defaultValue);
   }
 
   public update(section: string, value: any): Thenable<void> {
     const key = `sorbet.${section}`;
-    return this._workspaceState
+    return this.workspaceState
       .update(key, value)
       .then(() =>
-        DefaultSorbetWorkspaceContext._workspaceStateChangeEmitter.fire(key),
+        DefaultSorbetWorkspaceContext.workspaceStateChangeEmitter.fire(key),
       );
   }
 
   public get onDidChangeConfiguration(): Event<ConfigurationChangeEvent> {
-    return this._emitter.event;
+    return this.onConfigurationChangeEmitter.event;
   }
 
   public workspaceFolders(): readonly WorkspaceFolder[] | undefined {
@@ -179,18 +180,18 @@ export class DefaultSorbetWorkspaceContext implements ISorbetWorkspaceContext {
    * This function is a workaround to make it possible to enable Sorbet on first launch.
    *
    * The `sorbet.enabled` setting always has its default value set to `false` from `package.json` and cannot be
-   * undefined. That means that invoking `workspaceContext.get("enabled", this._enabled)` will always return `false` on
-   * first launch regardless of the value of `this._enabled`.
+   * undefined. That means that invoking `workspaceContext.get("enabled", this.enabled)` will always return `false` on
+   * first launch regardless of the value of `this.enabled`.
    *
    * To workaround this, we check if `sorbet.enabled` is still undefined in the workspace state and in every type of
    * configuration other than the `defaultValue`. If that's the case, then we can update the workspace state and enable
    * Sorbet on first launch.
    */
   public initializeEnabled(enabled: boolean) {
-    const stateEnabled = this._workspaceState.get("sorbet.enabled");
+    const stateEnabled = this.workspaceState.get("sorbet.enabled");
 
     if (stateEnabled === undefined) {
-      const cachedConfig = this._cachedSorbetConfiguration.inspect("enabled");
+      const cachedConfig = this.cachedSorbetConfiguration.inspect("enabled");
 
       if (
         cachedConfig?.globalValue === undefined &&
@@ -207,83 +208,81 @@ export class DefaultSorbetWorkspaceContext implements ISorbetWorkspaceContext {
 }
 
 export class SorbetExtensionConfig implements Disposable {
-  private _sorbetWorkspaceContext: ISorbetWorkspaceContext;
-  private _onLspConfigChangeEmitter = new EventEmitter<
+  private sorbetWorkspaceContext: ISorbetWorkspaceContext;
+  private readonly onLspConfigChangeEmitter = new EventEmitter<
     SorbetLspConfigChangeEvent
   >();
 
   /** "Standard" LSP configs. */
-  private _lspConfigs: ReadonlyArray<SorbetLspConfig> = [];
+  private wrappedLspConfigs: ReadonlyArray<SorbetLspConfig> = [];
   /**
    * "Custom" LSP configs that override/supplement "standard" LSP configs.
    *
    * If there is a '_lspConfig' and a '_userLspConfigs'
    */
-  private _userLspConfigs: ReadonlyArray<SorbetLspConfig> = [];
-  private _selectedLspConfigId: string | undefined = undefined;
+  private userLspConfigs: ReadonlyArray<SorbetLspConfig> = [];
+  private selectedLspConfigId: string | undefined = undefined;
 
-  private _enabled: boolean;
-  private _revealOutputOnError: boolean = false;
-  private _highlightUntyped: boolean = false;
-  private _configFilePatterns: ReadonlyArray<string> = [];
-  private _configFileWatchers: ReadonlyArray<FileSystemWatcher> = [];
+  private wrappedEnabled: boolean;
+  private wrappedRevealOutputOnError: boolean = false;
+  private wrappedHighlightUntyped: boolean = false;
+  private configFilePatterns: ReadonlyArray<string> = [];
+  private configFileWatchers: ReadonlyArray<FileSystemWatcher> = [];
 
   constructor(sorbetWorkspaceContext: ISorbetWorkspaceContext) {
-    this._sorbetWorkspaceContext = sorbetWorkspaceContext;
-    this._sorbetWorkspaceContext.onDidChangeConfiguration((_) =>
-      this._refresh(),
-    );
+    this.sorbetWorkspaceContext = sorbetWorkspaceContext;
+    this.sorbetWorkspaceContext.onDidChangeConfiguration((_) => this.refresh());
 
     const workspaceFolders = sorbetWorkspaceContext.workspaceFolders();
-    this._enabled = workspaceFolders
+    this.wrappedEnabled = workspaceFolders
       ? fs.existsSync(`${workspaceFolders[0].uri.fsPath}/sorbet/config`)
       : false;
 
-    this._sorbetWorkspaceContext.initializeEnabled(this._enabled);
+    this.sorbetWorkspaceContext.initializeEnabled(this.wrappedEnabled);
 
-    this._refresh();
+    this.refresh();
   }
 
   /**
    * Refreshes the configuration from this._sorbetWorkspaceConfiguration,
    * emitting change events as necessary.
    */
-  private _refresh(): void {
+  private refresh(): void {
     const oldLspConfig = this.activeLspConfig;
-    const workspaceContext = this._sorbetWorkspaceContext;
-    this._enabled = workspaceContext.get("enabled", this._enabled);
-    this._revealOutputOnError = workspaceContext.get(
+    const workspaceContext = this.sorbetWorkspaceContext;
+    this.wrappedEnabled = workspaceContext.get("enabled", this.wrappedEnabled);
+    this.wrappedRevealOutputOnError = workspaceContext.get(
       "revealOutputOnError",
       this.revealOutputOnError,
     );
-    this._highlightUntyped = workspaceContext.get(
+    this.wrappedHighlightUntyped = workspaceContext.get(
       "highlightUntyped",
       this.highlightUntyped,
     );
 
-    const oldConfigFilePatterns = this._configFilePatterns;
-    this._configFilePatterns = [
-      ...workspaceContext.get("configFilePatterns", this._configFilePatterns),
+    const oldConfigFilePatterns = this.configFilePatterns;
+    this.configFilePatterns = [
+      ...workspaceContext.get("configFilePatterns", this.configFilePatterns),
     ];
-    Disposable.from(...this._configFileWatchers).dispose();
-    this._configFileWatchers = this._configFilePatterns.map((pattern) => {
+    Disposable.from(...this.configFileWatchers).dispose();
+    this.configFileWatchers = this.configFilePatterns.map((pattern) => {
       const watcher = workspace.createFileSystemWatcher(pattern);
-      const _onConfigChange = (_: Uri) => {
+      const onConfigChange = (_uri: Uri) => {
         const c = this.activeLspConfig;
-        this._onLspConfigChangeEmitter.fire({
+        this.onLspConfigChangeEmitter.fire({
           oldLspConfig: c,
           newLspConfig: c,
         });
       };
-      watcher.onDidChange(_onConfigChange);
-      watcher.onDidCreate(_onConfigChange);
-      watcher.onDidDelete(_onConfigChange);
+      watcher.onDidChange(onConfigChange);
+      watcher.onDidCreate(onConfigChange);
+      watcher.onDidDelete(onConfigChange);
       return watcher;
     });
     const iLspConfigs = workspaceContext.get("lspConfigs", []);
-    this._lspConfigs = iLspConfigs.map((c) => new SorbetLspConfig(c));
+    this.wrappedLspConfigs = iLspConfigs.map((c) => new SorbetLspConfig(c));
     const iUserLspConfigs = workspaceContext.get("userLspConfigs", []);
-    this._userLspConfigs = iUserLspConfigs.map((c) => new SorbetLspConfig(c));
+    this.userLspConfigs = iUserLspConfigs.map((c) => new SorbetLspConfig(c));
     let configId = workspaceContext.get<string | undefined>(
       "selectedLspConfigId",
       undefined,
@@ -296,13 +295,13 @@ export class SorbetExtensionConfig implements Disposable {
         configId = configs[0].id;
       }
     }
-    this._selectedLspConfigId = configId;
+    this.selectedLspConfigId = configId;
     const newLspConfig = this.activeLspConfig;
     if (
       !SorbetLspConfig.areEqual(oldLspConfig, newLspConfig) ||
-      !deepEqual(oldConfigFilePatterns, this._configFilePatterns)
+      !deepEqual(oldConfigFilePatterns, this.configFilePatterns)
     ) {
-      this._onLspConfigChangeEmitter.fire({
+      this.onLspConfigChangeEmitter.fire({
         oldLspConfig,
         newLspConfig,
       });
@@ -313,7 +312,7 @@ export class SorbetExtensionConfig implements Disposable {
    * An event that fires when the (effective) active configuration changes.
    */
   public get onLspConfigChange(): Event<SorbetLspConfigChangeEvent> {
-    return this._onLspConfigChangeEmitter.event;
+    return this.onLspConfigChangeEmitter.event;
   }
 
   /**
@@ -322,7 +321,7 @@ export class SorbetExtensionConfig implements Disposable {
   public get lspConfigs(): ReadonlyArray<SorbetLspConfig> {
     const results: Array<SorbetLspConfig> = [];
     const resultIds = new Set<String>();
-    [...this._userLspConfigs, ...this._lspConfigs].forEach((c) => {
+    [...this.userLspConfigs, ...this.wrappedLspConfigs].forEach((c) => {
       if (!resultIds.has(c.id)) {
         results.push(c);
         resultIds.add(c.id);
@@ -348,7 +347,7 @@ export class SorbetExtensionConfig implements Disposable {
    * the `id` refers to a `SorbetLspConfig` that does not exist, return `undefined`.
    */
   public get selectedLspConfig(): SorbetLspConfig | undefined {
-    return this.lspConfigs.find((c) => c.id === this._selectedLspConfigId);
+    return this.lspConfigs.find((c) => c.id === this.selectedLspConfigId);
   }
 
   /**
@@ -358,9 +357,9 @@ export class SorbetExtensionConfig implements Disposable {
    * configuration.)
    */
   public setSelectedLspConfigId(id: string): Thenable<void> {
-    return this._sorbetWorkspaceContext
+    return this.sorbetWorkspaceContext
       .update("selectedLspConfigId", id)
-      .then(this._refresh.bind(this));
+      .then(this.refresh.bind(this));
   }
 
   /**
@@ -371,36 +370,36 @@ export class SorbetExtensionConfig implements Disposable {
    */
   public setActiveLspConfigId(id: string): Thenable<void> {
     return Promise.all([
-      this._sorbetWorkspaceContext.update("selectedLspConfigId", id),
-      this._sorbetWorkspaceContext.update("enabled", true),
-    ]).then(this._refresh.bind(this));
+      this.sorbetWorkspaceContext.update("selectedLspConfigId", id),
+      this.sorbetWorkspaceContext.update("enabled", true),
+    ]).then(this.refresh.bind(this));
   }
 
   public get revealOutputOnError(): boolean {
-    return this._revealOutputOnError;
+    return this.wrappedRevealOutputOnError;
   }
 
   public get highlightUntyped(): boolean {
-    return this._highlightUntyped;
+    return this.wrappedHighlightUntyped;
   }
 
   public get enabled(): boolean {
-    return this._enabled;
+    return this.wrappedEnabled;
   }
 
   public setEnabled(b: boolean): Thenable<void> {
-    return this._sorbetWorkspaceContext
+    return this.sorbetWorkspaceContext
       .update("enabled", b)
-      .then(this._refresh.bind(this));
+      .then(this.refresh.bind(this));
   }
 
   public setHighlightUntyped(b: boolean): Thenable<void> {
-    return this._sorbetWorkspaceContext
+    return this.sorbetWorkspaceContext
       .update("highlightUntyped", b)
-      .then(this._refresh.bind(this));
+      .then(this.refresh.bind(this));
   }
 
   dispose() {
-    Disposable.from(...this._configFileWatchers).dispose();
+    Disposable.from(...this.configFileWatchers).dispose();
   }
 }

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -45,12 +45,10 @@ export function activate(context: ExtensionContext) {
       // URIs are of the form sorbet:[file_path]
       provideTextDocumentContent: async (uri: Uri): Promise<string> => {
         let content: string;
-        const {
-          activeLanguageClient: activeSorbetLanguageClient,
-        } = sorbetExtensionContext.statusProvider;
+        const { activeLanguageClient } = sorbetExtensionContext.statusProvider;
         console.log(`Opening sorbet: file. URI:${uri}`);
-        if (activeSorbetLanguageClient) {
-          const response: TextDocumentItem = await activeSorbetLanguageClient.languageClient.sendRequest(
+        if (activeLanguageClient) {
+          const response: TextDocumentItem = await activeLanguageClient.languageClient.sendRequest(
             "sorbet/readFile",
             {
               uri: uri.toString(),

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -9,7 +9,7 @@ import {
   SORBET_RESTART_COMMAND_ID,
 } from "./commandIds";
 import { ShowSorbetActions } from "./commands/showSorbetActions";
-import ShowSorbetConfigurationPicker from "./commands/showSorbetConfigurationPicker";
+import { ShowSorbetConfigurationPicker } from "./commands/showSorbetConfigurationPicker";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { SorbetStatusBarEntry } from "./sorbetStatusBarEntry";
 import { ServerStatus, RestartReason } from "./types";
@@ -21,7 +21,7 @@ export function activate(context: ExtensionContext) {
   const sorbetExtensionContext = new SorbetExtensionContext(context);
   context.subscriptions.push(
     sorbetExtensionContext,
-    sorbetExtensionContext.config.onLspConfigChange(
+    sorbetExtensionContext.configuration.onLspConfigChange(
       async ({ oldLspConfig, newLspConfig }) => {
         const { statusProvider } = sorbetExtensionContext;
         if (oldLspConfig && newLspConfig) {
@@ -46,7 +46,7 @@ export function activate(context: ExtensionContext) {
       provideTextDocumentContent: async (uri: Uri): Promise<string> => {
         let content: string;
         const {
-          activeSorbetLanguageClient,
+          activeLanguageClient: activeSorbetLanguageClient,
         } = sorbetExtensionContext.statusProvider;
         console.log(`Opening sorbet: file. URI:${uri}`);
         if (activeSorbetLanguageClient) {
@@ -78,10 +78,10 @@ export function activate(context: ExtensionContext) {
       sorbetExtensionContext.outputChannel.show(),
     ),
     commands.registerCommand(SORBET_ENABLE_COMMAND_ID, () =>
-      sorbetExtensionContext.config.setEnabled(true),
+      sorbetExtensionContext.configuration.setEnabled(true),
     ),
     commands.registerCommand(SORBET_DISABLE_COMMAND_ID, () =>
-      sorbetExtensionContext.config.setEnabled(false),
+      sorbetExtensionContext.configuration.setEnabled(false),
     ),
     commands.registerCommand(
       SORBET_RESTART_COMMAND_ID,
@@ -89,8 +89,10 @@ export function activate(context: ExtensionContext) {
         sorbetExtensionContext.statusProvider.restartSorbet(reason),
     ),
     commands.registerCommand("sorbet.toggleHighlightUntyped", () =>
-      sorbetExtensionContext.config
-        .setHighlightUntyped(!sorbetExtensionContext.config.highlightUntyped)
+      sorbetExtensionContext.configuration
+        .setHighlightUntyped(
+          !sorbetExtensionContext.configuration.highlightUntyped,
+        )
         .then(() =>
           sorbetExtensionContext.statusProvider.restartSorbet(
             RestartReason.CONFIG_CHANGE,

--- a/vscode_extension/src/metricsClient.ts
+++ b/vscode_extension/src/metricsClient.ts
@@ -76,7 +76,7 @@ export class MetricClient {
    */
   private buildTags(tags: Tags) {
     return {
-      config_id: this.context.config.activeLspConfig?.id ?? "disabled",
+      config_id: this.context.configuration.activeLspConfig?.id ?? "disabled",
       sorbet_extension_version: this.sorbetExtensionVersion,
       ...tags,
     };

--- a/vscode_extension/src/sorbetExtensionContext.ts
+++ b/vscode_extension/src/sorbetExtensionContext.ts
@@ -4,7 +4,7 @@ import { MetricClient } from "./metricsClient";
 import { SorbetStatusProvider } from "./sorbetStatusProvider";
 
 export class SorbetExtensionContext implements Disposable {
-  public readonly config: SorbetExtensionConfig;
+  public readonly configuration: SorbetExtensionConfig;
   private readonly disposable: Disposable;
   public readonly extensionContext: ExtensionContext;
   public readonly metrics: MetricClient;
@@ -12,7 +12,7 @@ export class SorbetExtensionContext implements Disposable {
   public readonly statusProvider: SorbetStatusProvider;
 
   constructor(context: ExtensionContext) {
-    this.config = new SorbetExtensionConfig(
+    this.configuration = new SorbetExtensionConfig(
       new DefaultSorbetWorkspaceContext(context),
     );
     this.extensionContext = context;
@@ -20,7 +20,7 @@ export class SorbetExtensionContext implements Disposable {
     this.outputChannel = window.createOutputChannel("Sorbet");
     this.statusProvider = new SorbetStatusProvider(this);
 
-    this.disposable = Disposable.from(this.config, this.outputChannel);
+    this.disposable = Disposable.from(this.configuration, this.outputChannel);
   }
 
   /**

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -1,5 +1,5 @@
 import { Disposable, Event, EventEmitter } from "vscode";
-import SorbetLanguageClient from "./LanguageClient";
+import { SorbetLanguageClient } from "./languageClient";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { RestartReason, ServerStatus, ShowOperationParams } from "./types";
 
@@ -12,25 +12,25 @@ export type StatusChangedEvent = {
 };
 
 export class SorbetStatusProvider implements Disposable {
-  private _activeSorbetLanguageClient?: SorbetLanguageClient;
-  private readonly _context: SorbetExtensionContext;
-  private readonly _disposables: Disposable[];
+  private wrappedActiveLanguageClient?: SorbetLanguageClient;
+  private readonly context: SorbetExtensionContext;
+  private readonly disposables: Disposable[];
   /** Mutex for startSorbet. Prevents us from starting multiple processes at once. */
-  private _isStarting: boolean;
-  private _lastSorbetRetryTime: number;
-  private readonly _onShowOperationEmitter: EventEmitter<ShowOperationParams>;
-  private readonly _onStatusChangedEmitter: EventEmitter<StatusChangedEvent>;
+  private isStarting: boolean;
+  private lastSorbetRetryTime: number;
+  private readonly onShowOperationEmitter: EventEmitter<ShowOperationParams>;
+  private readonly onStatusChangedEmitter: EventEmitter<StatusChangedEvent>;
 
   constructor(context: SorbetExtensionContext) {
-    this._context = context;
-    this._isStarting = false;
-    this._lastSorbetRetryTime = 0;
-    this._onShowOperationEmitter = new EventEmitter<ShowOperationParams>();
-    this._onStatusChangedEmitter = new EventEmitter<StatusChangedEvent>();
+    this.context = context;
+    this.isStarting = false;
+    this.lastSorbetRetryTime = 0;
+    this.onShowOperationEmitter = new EventEmitter<ShowOperationParams>();
+    this.onStatusChangedEmitter = new EventEmitter<StatusChangedEvent>();
 
-    this._disposables = [
-      this._onShowOperationEmitter,
-      this._onStatusChangedEmitter,
+    this.disposables = [
+      this.onShowOperationEmitter,
+      this.onStatusChangedEmitter,
     ];
   }
 
@@ -38,47 +38,45 @@ export class SorbetStatusProvider implements Disposable {
    * Dispose and free associated resources.
    */
   public dispose() {
-    Disposable.from(...this._disposables).dispose();
+    Disposable.from(...this.disposables).dispose();
   }
 
   /**
    * Current Sorbet client, if any.
    */
-  public get activeSorbetLanguageClient(): SorbetLanguageClient | undefined {
-    return this._activeSorbetLanguageClient;
+  public get activeLanguageClient(): SorbetLanguageClient | undefined {
+    return this.wrappedActiveLanguageClient;
   }
 
-  private set activeSorbetLanguageClient(
-    value: SorbetLanguageClient | undefined,
-  ) {
-    if (this._activeSorbetLanguageClient === value) {
+  private set activeLanguageClient(value: SorbetLanguageClient | undefined) {
+    if (this.wrappedActiveLanguageClient === value) {
       return;
     }
 
     // Clean-up existing client, if any.
-    if (this._activeSorbetLanguageClient) {
-      this._activeSorbetLanguageClient.dispose();
-      const i = this._disposables.indexOf(this._activeSorbetLanguageClient);
+    if (this.wrappedActiveLanguageClient) {
+      this.wrappedActiveLanguageClient.dispose();
+      const i = this.disposables.indexOf(this.wrappedActiveLanguageClient);
       if (i !== -1) {
-        this._disposables.splice(i, 1);
+        this.disposables.splice(i, 1);
       }
     }
 
     // Hook-up new client for clean-up, if any.
     if (value) {
-      const i = this._disposables.indexOf(value);
+      const i = this.disposables.indexOf(value);
       if (i === -1) {
-        this._disposables.push(value);
+        this.disposables.push(value);
       }
     }
 
-    this._activeSorbetLanguageClient = value;
+    this.wrappedActiveLanguageClient = value;
 
     // State might have changed based on new client.
-    if (this._activeSorbetLanguageClient) {
-      this._onStatusChangedEmitter.fire({
-        status: this._activeSorbetLanguageClient.status,
-        error: this._activeSorbetLanguageClient.lastError,
+    if (this.wrappedActiveLanguageClient) {
+      this.onStatusChangedEmitter.fire({
+        status: this.wrappedActiveLanguageClient.status,
+        error: this.wrappedActiveLanguageClient.lastError,
       });
     }
   }
@@ -87,14 +85,14 @@ export class SorbetStatusProvider implements Disposable {
    * Event raised on a {@link ShowOperationParams show-operation} event.
    */
   public get onShowOperation(): Event<ShowOperationParams> {
-    return this._onShowOperationEmitter.event;
+    return this.onShowOperationEmitter.event;
   }
 
   /**
    * Event raised on {@link ServerStatus status} changes.
    */
   public get onStatusChanged(): Event<StatusChangedEvent> {
-    return this._onStatusChangedEmitter.event;
+    return this.onStatusChangedEmitter.event;
   }
 
   /**
@@ -104,7 +102,7 @@ export class SorbetStatusProvider implements Disposable {
   public async restartSorbet(reason: RestartReason): Promise<void> {
     await this.stopSorbet(ServerStatus.RESTARTING);
     // `reason` is an enum type with a small and finite number of values.
-    this._context.metrics.emitCountMetric(`restart.${reason}`, 1);
+    this.context.metrics.emitCountMetric(`restart.${reason}`, 1);
     await this.startSorbet();
   }
 
@@ -112,48 +110,48 @@ export class SorbetStatusProvider implements Disposable {
    * Error information, if {@link serverStatus} is {@link ServerStatus.ERROR}
    */
   public get serverError(): string | undefined {
-    return this.activeSorbetLanguageClient?.lastError;
+    return this.activeLanguageClient?.lastError;
   }
 
   /**
    * Return current {@link ServerStatus server status}.
    */
   public get serverStatus(): ServerStatus {
-    return this.activeSorbetLanguageClient?.status || ServerStatus.DISABLED;
+    return this.activeLanguageClient?.status || ServerStatus.DISABLED;
   }
 
   /**
    * Start Sorbet.
    */
   public async startSorbet(): Promise<void> {
-    if (this._isStarting) {
+    if (this.isStarting) {
       return;
     }
 
     // Debounce by MIN_TIME_BETWEEN_RETRIES_MS. Returns 0 if the calculated time to sleep is negative.
     const sleepMS =
-      MIN_TIME_BETWEEN_RETRIES_MS - (Date.now() - this._lastSorbetRetryTime);
+      MIN_TIME_BETWEEN_RETRIES_MS - (Date.now() - this.lastSorbetRetryTime);
     if (sleepMS > 0) {
       // Wait timeToSleep ms. Use mutex, as this yields the event loop for future events.
       console.log(`Waiting ${sleepMS.toFixed(0)}ms before restarting Sorbet…`);
-      this._isStarting = true;
+      this.isStarting = true;
       await new Promise((res) => setTimeout(res, sleepMS));
-      this._isStarting = false;
+      this.isStarting = false;
     }
-    this._lastSorbetRetryTime = Date.now();
+    this.lastSorbetRetryTime = Date.now();
 
     // Create client
     const newClient = new SorbetLanguageClient(
-      this._context,
+      this.context,
       (reason: RestartReason) => this.restartSorbet(reason),
     );
     // Use property-setter to ensure proper setup.
-    this.activeSorbetLanguageClient = newClient;
+    this.activeLanguageClient = newClient;
 
     newClient.onStatusChange = (status: ServerStatus) => {
       // Ignore event if this is not the current client (e.g. old client being shut down).
-      if (this.activeSorbetLanguageClient === newClient) {
-        this._onStatusChangedEmitter.fire({
+      if (this.activeLanguageClient === newClient) {
+        this.onStatusChangedEmitter.fire({
           status,
           error: newClient.lastError,
         });
@@ -166,8 +164,8 @@ export class SorbetStatusProvider implements Disposable {
       "sorbet/showOperation",
       (params: ShowOperationParams) => {
         // Ignore event if this is not the current client (e.g. old client being shut down).
-        if (this.activeSorbetLanguageClient === newClient) {
-          this._onShowOperationEmitter.fire(params);
+        if (this.activeLanguageClient === newClient) {
+          this.onShowOperationEmitter.fire(params);
         }
       },
     );
@@ -179,7 +177,7 @@ export class SorbetStatusProvider implements Disposable {
    */
   public async stopSorbet(newStatus: ServerStatus): Promise<void> {
     // Use property-setter to ensure proper clean-up.
-    this.activeSorbetLanguageClient = undefined;
-    this._onStatusChangedEmitter.fire({ status: newStatus, stopped: true });
+    this.activeLanguageClient = undefined;
+    this.onStatusChangedEmitter.fire({ status: newStatus, stopped: true });
   }
 }

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -20,12 +20,17 @@ import {
 
 /** Imitate the WorkspaceConfiguration. */
 class FakeWorkspaceConfiguration implements ISorbetWorkspaceContext {
-  public _emitter = new EventEmitter<ConfigurationChangeEvent>();
-  public backingStore: Map<String, any>;
-  public defaults: Map<String, any>;
-  constructor(public properties: Iterable<[String, any]> = []) {
-    this.backingStore = new Map<String, any>(properties);
+  public readonly backingStore: Map<String, any>;
+  public readonly defaults: Map<String, any>;
+  private readonly configurationChangeEmitter: EventEmitter<
+    ConfigurationChangeEvent
+  >;
 
+  constructor(properties: Iterable<[String, any]> = []) {
+    this.backingStore = new Map<String, any>(properties);
+    this.configurationChangeEmitter = new EventEmitter<
+      ConfigurationChangeEvent
+    >();
     const defaultProperties = extensions.getExtension(
       "sorbet.sorbet-vscode-extension",
     )!.packageJSON.contributes.configuration.properties;
@@ -68,7 +73,7 @@ class FakeWorkspaceConfiguration implements ISorbetWorkspaceContext {
     }
     this.backingStore.set(section, value);
     return Promise.resolve(
-      this._emitter.fire({
+      this.configurationChangeEmitter.fire({
         affectsConfiguration: (s: string, _?: Uri) => {
           return section.startsWith(`${s}.`);
         },
@@ -77,7 +82,7 @@ class FakeWorkspaceConfiguration implements ISorbetWorkspaceContext {
   }
 
   get onDidChangeConfiguration() {
-    return this._emitter.event;
+    return this.configurationChangeEmitter.event;
   }
 
   workspaceFolders() {

--- a/vscode_extension/src/test/languageClient.test.ts
+++ b/vscode_extension/src/test/languageClient.test.ts
@@ -6,8 +6,8 @@ import {
 } from "vscode-languageclient/node";
 import { RequestType } from "vscode-languageserver-protocol";
 import * as assert from "assert";
-import { shimLanguageClient } from "../LanguageClient";
-import TestLanguageServerSpecialURIs from "./TestLanguageServerSpecialURIs";
+import { shimLanguageClient } from "../languageClient";
+import { TestLanguageServerSpecialURIs } from "./testLanguageServerSpecialURIs";
 import { MetricsEmitter, Tags } from "../metricsClient";
 
 const enum MetricType {
@@ -58,7 +58,7 @@ class RecordingMetricsEmitter implements MetricsEmitter {
 
 function createLanguageClient(): LanguageClient {
   // The server is implemented in node
-  const serverModule = require.resolve("./TestLanguageServer");
+  const serverModule = require.resolve("./testLanguageServer");
   // The debug options for the server
   const debugOptions = { execArgv: [] };
 

--- a/vscode_extension/src/test/testLanguageServer.ts
+++ b/vscode_extension/src/test/testLanguageServer.ts
@@ -4,7 +4,7 @@ import {
   InitializeParams,
   TextDocumentSyncKind,
 } from "vscode-languageserver/node";
-import TestLanguageServerSpecialURIs from "./TestLanguageServerSpecialURIs";
+import { TestLanguageServerSpecialURIs } from "./testLanguageServerSpecialURIs";
 
 // Create a connection for the server. The connection uses Node's IPC as a transport.
 // Also include all preview / proposed LSP features.

--- a/vscode_extension/src/test/testLanguageServerSpecialURIs.ts
+++ b/vscode_extension/src/test/testLanguageServerSpecialURIs.ts
@@ -1,7 +1,5 @@
-enum TestLanguageServerSpecialURIs {
+export enum TestLanguageServerSpecialURIs {
   SUCCESS = "file:///success",
   FAILURE = "file:///failure",
   EXIT = "file:///exit",
 }
-
-export default TestLanguageServerSpecialURIs;


### PR DESCRIPTION
Extension code uses a `_` prefix to denote private fields and methods but Typescript naming guidelines discourage that, e.g.  [Google](https://google.github.io/styleguide/tsguide.html#identifiers-underscore-prefix-suffix ), [TypeScript internal](https://github.com/microsoft/TypeScript/wiki/Coding-guidelines).

  - This can be revisited but this change defines a common baseline and standardizes the codebase.
  - Getters/setters are usually the one case where `_` helps with naming conflicts but for now adopting [Google](https://google.github.io/styleguide/tsguide.html#properties-used-outside-of-class-lexical-scope)'s recommendation of using a full word prefix like `wrapped` instead (it seems that prefix might be useful during code reviews more than `internal`). This is open to discussion, however, as [Typescript's own handbook](https://www.typescriptlang.org/docs/handbook/2/classes.html#getters--setters) uses an underscore in this case.
   - Enable `no-underscore-dangle` eslint rule.

Misc:
 - Stopped exporting  `deepEqual` from config.ts (feedback from previous PR so fixing as the file is being modified on this PR).
 - Removed the last two cases of default exports. See https://google.github.io/styleguide/tsguide.html#exports
 - Updated last cases of files not using camelCase names.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
