### PR TITLE
Structure extension logging

### DIFF
--- a/vscode_extension/.vscode/launch.json
+++ b/vscode_extension/.vscode/launch.json
@@ -6,6 +6,9 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
+            "env": {
+                "VSCODE_SORBETEXT_LOG_LEVEL": "trace"
+              },
             "args": [
                 "--extensionDevelopmentPath=${workspaceRoot}"
             ],

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -27,8 +27,9 @@
     "onCommand:sorbet.disable",
     "onCommand:sorbet.enable",
     "onCommand:sorbet.restart",
-    "onCommand:sorbet.toggleHighlightUntyped",
+    "onCommand:sorbet.setLogLevel",
     "onCommand:sorbet.showOutput",
+    "onCommand:sorbet.toggleHighlightUntyped",
     "onLanguage:ruby",
     "workspaceContains:sorbet/*"
   ],
@@ -78,6 +79,11 @@
       {
         "command": "sorbet.restart",
         "title": "Restart",
+        "category": "Sorbet"
+      },
+      {
+        "command": "sorbet.setLogLevel",
+        "title": "Set Log Level…",
         "category": "Sorbet"
       },
       {

--- a/vscode_extension/src/commandIds.ts
+++ b/vscode_extension/src/commandIds.ts
@@ -1,15 +1,20 @@
 /**
- * Show available actions. See {@link ShowSorbetActions}.
+ * Set log level available actions.
+ */
+export const SET_LOGLEVEL_COMMAND_ID = "sorbet.setLogLevel";
+
+/**
+ * Show available actions.
  */
 export const SHOW_ACTIONS_COMMAND_ID = "sorbet.showAvailableActions";
 
 /**
- * Show Configuration picker. See {@link ShowSorbetConfigurationPicker}.
+ * Show Configuration picker.
  */
 export const SHOW_CONFIG_PICKER_COMMAND_ID = "sorbet.configure";
 
 /**
- * Show Sorbet Output panel. See {@link ShowSorbetOutput}.
+ * Show Sorbet Output panel.
  */
 export const SHOW_OUTPUT_COMMAND_ID = "sorbet.showOutput";
 

--- a/vscode_extension/src/commands/setLogLevel.ts
+++ b/vscode_extension/src/commands/setLogLevel.ts
@@ -1,0 +1,55 @@
+import { QuickPickItem, window } from "vscode";
+import { LogLevel } from "../log";
+import { SorbetExtensionContext } from "../sorbetExtensionContext";
+
+/**
+ * Set logging level on associated 'Log' instance.
+ */
+export class SetLogLevel {
+  private readonly context: SorbetExtensionContext;
+
+  constructor(context: SorbetExtensionContext) {
+    this.context = context;
+  }
+
+  /**
+   * Execute command.
+   * @param level Log level. If not provided, user will be prompted for it.
+   */
+  public async execute(level?: LogLevel): Promise<void> {
+    const newLevel = level ?? (await this.getLogLevel());
+    if (newLevel === undefined) {
+      return; // Canceled
+    }
+    this.context.log.level = newLevel;
+  }
+
+  private async getLogLevel(): Promise<LogLevel | undefined> {
+    const items = [
+      LogLevel.Trace,
+      LogLevel.Debug,
+      LogLevel.Info,
+      LogLevel.Warning,
+      LogLevel.Error,
+      LogLevel.Critical,
+      LogLevel.Off,
+    ].map((logLevel) => {
+      const item = <
+        QuickPickItem & {
+          level: LogLevel;
+        }
+      >{
+        label: `${this.context.log.level === logLevel ? "• " : ""}${
+          LogLevel[logLevel]
+        }`,
+        level: logLevel,
+      };
+      return item;
+    });
+
+    const selectedLevel = await window.showQuickPick(items, {
+      placeHolder: "Select log level",
+    });
+    return selectedLevel?.level;
+  }
+}

--- a/vscode_extension/src/connections.ts
+++ b/vscode_extension/src/connections.ts
@@ -1,16 +1,20 @@
 import { ChildProcess } from "child_process";
+import { OutputChannelLog } from "./log";
 
 /**
  * Attempts to stop the given child process. Tries a SIGINT, then a SIGTERM, then a SIGKILL.
  */
-export async function stopProcess(p: ChildProcess | null): Promise<void> {
+export async function stopProcess(
+  p: ChildProcess | null,
+  log: OutputChannelLog,
+): Promise<void> {
   if (!p || !p.pid) {
     // Process is already dead.
     return;
   }
   return new Promise<void>((res) => {
     let hasExited = false;
-    console.log(`Stopping process ${p.pid}`);
+    log.debug(`Stopping process ${p.pid}`);
     function onExit() {
       if (!hasExited) {
         hasExited = true;
@@ -22,12 +26,12 @@ export async function stopProcess(p: ChildProcess | null): Promise<void> {
     p.kill("SIGINT");
     setTimeout(() => {
       if (!hasExited) {
-        console.log("Process did not respond to SIGINT. Sending a SIGTERM.");
+        log.debug("Process did not respond to SIGINT. Sending a SIGTERM.");
       }
       p.kill("SIGTERM");
       setTimeout(() => {
         if (!hasExited) {
-          console.log("Process did not respond to SIGTERM. Sending a SIGKILL.");
+          log.debug("Process did not respond to SIGTERM. Sending a SIGKILL.");
           p.kill("SIGKILL");
           setTimeout(res, 100);
         }

--- a/vscode_extension/src/log.ts
+++ b/vscode_extension/src/log.ts
@@ -1,0 +1,157 @@
+import { Disposable, OutputChannel, window } from "vscode";
+
+/**
+ * The severity level of a log message.
+ * Based on $/src/vs/vscode.proposed.d.ts
+ */
+export enum LogLevel {
+  Trace = 1,
+  Debug = 2,
+  Info = 3,
+  Warning = 4,
+  Error = 5,
+  Critical = 6,
+  Off = 7,
+}
+/**
+ * Environment variable defining log level.
+ */
+export const VSCODE_SORBETEXT_LOG_LEVEL = "VSCODE_SORBETEXT_LOG_LEVEL";
+
+/**
+ * Get log-level as defined in env, otherwise returns `defaultLevel`.
+ * @param name Environment variable name.
+ * @param defaultLevel Default value if environment does not define a valid one.
+ */
+export function getLogLevelFromEnvironment(
+  name: string = VSCODE_SORBETEXT_LOG_LEVEL,
+  defaultLevel: LogLevel = LogLevel.Info,
+): LogLevel {
+  let logLevel = defaultLevel;
+  const envLogLevel = process.env[name]?.trim();
+  if (envLogLevel) {
+    const parsedLogLevel = getLogLevelFromString(envLogLevel);
+    if (parsedLogLevel !== undefined) {
+      logLevel = parsedLogLevel;
+    }
+  }
+  return logLevel;
+}
+
+/**
+ * Get `LogLevel` from name, case-insensitively.
+ * @param name Log level name.
+ */
+export function getLogLevelFromString(name: string): LogLevel | undefined {
+  const upcaseLevel = name.toUpperCase();
+  const entry = Object.entries(LogLevel).find(
+    (e) => e[0].toUpperCase() === upcaseLevel,
+  );
+  return entry && <LogLevel>entry[1];
+}
+
+/**
+ * Output Channel-based implementation of logger.
+ */
+export class OutputChannelLog implements Disposable {
+  private wrappedLevel: LogLevel;
+  public readonly outputChannel: OutputChannel;
+
+  constructor(name: string, level: LogLevel = LogLevel.Info) {
+    this.wrappedLevel = level;
+    // Future:
+    // - VSCode 1.66 allows to pass-in a `language` to support syntax coloring.
+    // - VSCode 1.75 allows to create a `LogOutputChannel`.
+    this.outputChannel = window.createOutputChannel(name);
+  }
+
+  private appendLine(level: string, message: string): void {
+    const formattedMessage = `${new Date().toISOString()} [${level.toLowerCase()}] ${message}`.trim();
+    this.outputChannel.appendLine(formattedMessage);
+  }
+
+  /**
+   * Appends a new debug message to the log.
+   * @param message Log message.
+   */
+  public debug(message: string): void {
+    if (this.level <= LogLevel.Debug) {
+      this.appendLine("Debug", message);
+    }
+  }
+
+  /**
+   * Dispose and free associated resources.
+   */
+  public dispose() {
+    this.outputChannel.dispose();
+  }
+
+  /**
+   * Appends a new error message to the log.
+   * @param errorOrMessage Error or log message.
+   * @param error Error (only used when `errorOrMessage` is not a `string`).
+   */
+  public error(errorOrMessage: string | Error, error?: Error): void {
+    if (this.level <= LogLevel.Error) {
+      let message: string;
+      if (typeof errorOrMessage === "string") {
+        message = errorOrMessage;
+        if (error) {
+          message += ` Error: ${err2Str(error)}`;
+        }
+      } else {
+        message = err2Str(errorOrMessage);
+      }
+      this.appendLine("Error", message);
+    }
+
+    function err2Str(err: Error) {
+      return err.message || err.name || `\n${err.stack || ""}`;
+    }
+  }
+
+  /**
+   * Appends a new information message to the log.
+   * @param message Log message.
+   */
+  public info(message: string): void {
+    if (this.level <= LogLevel.Info) {
+      this.appendLine("Info", message);
+    }
+  }
+
+  /**
+   * Log level.
+   */
+  public get level(): LogLevel {
+    return this.wrappedLevel;
+  }
+
+  public set level(level: LogLevel) {
+    if (this.wrappedLevel !== level) {
+      this.wrappedLevel = level;
+      this.outputChannel.appendLine(`Log level changed to: ${LogLevel[level]}`);
+    }
+  }
+
+  /**
+   * Appends a new trace message to the log.
+   * @param message Log message.
+   */
+  public trace(message: string): void {
+    if (this.level <= LogLevel.Trace) {
+      this.appendLine("Trace", message);
+    }
+  }
+
+  /**
+   * Appends a new warning message to the log.
+   * @param message Log message.
+   */
+  public warning(message: string): void {
+    if (this.level <= LogLevel.Warning) {
+      this.appendLine("Warning", message);
+    }
+  }
+}

--- a/vscode_extension/src/metricsClient.ts
+++ b/vscode_extension/src/metricsClient.ts
@@ -89,17 +89,13 @@ export class MetricClient {
         "sorbet.metrics.getExportedApi",
       );
       if (api) {
-        this.context.outputChannel.appendLine("Metrics-gathering initialized.");
+        this.context.log.info("Metrics-gathering initialized.");
         sorbetMetricsApi = api as Api;
         if (!sorbetMetricsApi.metricsEmitter.timing) {
-          this.context.outputChannel.appendLine(
-            "  Timer metrics disabled (unsupported API).",
-          );
+          this.context.log.info("Timer metrics disabled (unsupported API).");
         }
       } else {
-        this.context.outputChannel.appendLine(
-          "Metrics-gathering disabled (no API)",
-        );
+        this.context.log.info("Metrics-gathering disabled (no API)");
         sorbetMetricsApi = NoOpApi.INSTANCE;
       }
     } catch (reason) {
@@ -110,7 +106,7 @@ export class MetricClient {
           ? "Define the 'sorbet.metrics.getExportedApi' command to enable metrics gathering"
           : (<any>reason).message;
 
-      this.context.outputChannel.appendLine(
+      this.context.log.error(
         `Metrics-gathering disabled (error): ${adjustedReason}`,
       );
     }

--- a/vscode_extension/src/sorbetExtensionContext.ts
+++ b/vscode_extension/src/sorbetExtensionContext.ts
@@ -1,5 +1,6 @@
-import { Disposable, ExtensionContext, OutputChannel, window } from "vscode";
+import { Disposable, ExtensionContext } from "vscode";
 import { DefaultSorbetWorkspaceContext, SorbetExtensionConfig } from "./config";
+import { OutputChannelLog } from "./log";
 import { MetricClient } from "./metricsClient";
 import { SorbetStatusProvider } from "./sorbetStatusProvider";
 
@@ -7,8 +8,8 @@ export class SorbetExtensionContext implements Disposable {
   public readonly configuration: SorbetExtensionConfig;
   private readonly disposable: Disposable;
   public readonly extensionContext: ExtensionContext;
+  public readonly log: OutputChannelLog;
   public readonly metrics: MetricClient;
-  public readonly outputChannel: OutputChannel;
   public readonly statusProvider: SorbetStatusProvider;
 
   constructor(context: ExtensionContext) {
@@ -16,11 +17,15 @@ export class SorbetExtensionContext implements Disposable {
       new DefaultSorbetWorkspaceContext(context),
     );
     this.extensionContext = context;
+    this.log = new OutputChannelLog("Sorbet");
     this.metrics = new MetricClient(this);
-    this.outputChannel = window.createOutputChannel("Sorbet");
     this.statusProvider = new SorbetStatusProvider(this);
 
-    this.disposable = Disposable.from(this.configuration, this.outputChannel);
+    this.disposable = Disposable.from(
+      this.configuration,
+      this.log,
+      this.statusProvider,
+    );
   }
 
   /**

--- a/vscode_extension/src/sorbetStatusBarEntry.ts
+++ b/vscode_extension/src/sorbetStatusBarEntry.ts
@@ -126,9 +126,7 @@ export class SorbetStatusBarEntry implements Disposable {
           tooltip = "The Sorbet server is currently running.";
           break;
         default:
-          this.context.outputChannel.appendLine(
-            `Invalid ServerStatus: ${this.serverStatus}`,
-          );
+          this.context.log.error(`Invalid ServerStatus: ${this.serverStatus}`);
           text = "";
           tooltip = "";
           break;

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -133,7 +133,9 @@ export class SorbetStatusProvider implements Disposable {
       MIN_TIME_BETWEEN_RETRIES_MS - (Date.now() - this.lastSorbetRetryTime);
     if (sleepMS > 0) {
       // Wait timeToSleep ms. Use mutex, as this yields the event loop for future events.
-      console.log(`Waiting ${sleepMS.toFixed(0)}ms before restarting Sorbet…`);
+      this.context.log.debug(
+        `Waiting ${sleepMS.toFixed(0)}ms before restarting Sorbet…`,
+      );
       this.isStarting = true;
       await new Promise((res) => setTimeout(res, sleepMS));
       this.isStarting = false;


### PR DESCRIPTION
Structure extension logging based on implementation used by Stripe's internal extensions:
- instead of using `OutputChannel.appendLine`,  logging methods with different levels (trace, debug, info, warning, error) are used.
- log entries now follow the format `«UTC Date Time» [«level»] «message»` (equivalent to one used by VSCode as well as Github and other extensions).
  - VSCode 1.65 does not provide support to specify a language that would colorize this format automatically
  - Some internal components request the `OutputChannel` reference to write their own logs, so the format is broken by them (but now difference is evident).
  - Existing code calling `console.log` was converted into what seemed to be the approrpiate level for each call (i.e. find-and-replaced  was NOT used to convert existign calls).
- Log levels allow to show/hide information as needed.  Extension defaults to write out `info` or higher level messages meaning that now, by default, `Sorbet` output have fewer messages.  This can be controlled via
  -  `Sorbet: Set Log Level…` command (similar to VSCode's) . Setting a value this way DOES NOT persist across sessions.
- `VSCODE_SORBETEXT_LOG_LEVEL` environment variable . The value is the name of the level, e.g. "debug" and it is case-insensitive.
  -  This feature is used to automtaically enable `trace` level when debugging the extension itself.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Improve log format

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
