### PR TITLE
Add tests for `ShowSorbetActions` and `ShowSorbetConfigurationPicker`

### DIFF
--- a/vscode_extension/src/commands/showSorbetActions.ts
+++ b/vscode_extension/src/commands/showSorbetActions.ts
@@ -7,7 +7,6 @@ import {
   SORBET_RESTART_COMMAND_ID,
 } from "../commandIds";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
-import { SorbetStatusProvider } from "../sorbetStatusProvider";
 import { RestartReason, ServerStatus } from "../types";
 
 export const enum Action {
@@ -20,61 +19,56 @@ export const enum Action {
 
 /**
  * Show available actions in a drop-down.
+ * @param context Sorbet extension context.
  */
-export class ShowSorbetActions {
-  private readonly statusProvider: SorbetStatusProvider;
+export async function showSorbetActions(
+  context: SorbetExtensionContext,
+): Promise<void> {
+  const actions = getAvailableActions(context.statusProvider.serverStatus);
+  const selectedAction = await window.showQuickPick(actions, {
+    placeHolder: "Select an action",
+  });
 
-  constructor(context: SorbetExtensionContext) {
-    this.statusProvider = context.statusProvider;
+  switch (selectedAction) {
+    case Action.ConfigureSorbet:
+      await commands.executeCommand(SHOW_CONFIG_PICKER_COMMAND_ID);
+      break;
+    case Action.DisableSorbet:
+      await commands.executeCommand(SORBET_DISABLE_COMMAND_ID);
+      break;
+    case Action.EnableSorbet:
+      await commands.executeCommand(SORBET_ENABLE_COMMAND_ID);
+      break;
+    case Action.RestartSorbet:
+      await commands.executeCommand(
+        SORBET_RESTART_COMMAND_ID,
+        RestartReason.STATUS_BAR_BUTTON,
+      );
+      break;
+    case Action.ViewOutput:
+      await commands.executeCommand(SHOW_OUTPUT_COMMAND_ID);
+      break;
+    default:
+      break; // User canceled
   }
+}
 
-  public async execute(): Promise<void> {
-    const actions = this.getAvailableActions();
-    const selectedAction = await window.showQuickPick(actions, {
-      placeHolder: "Sorbet: Select action...",
-    });
-
-    switch (selectedAction) {
-      case Action.ConfigureSorbet:
-        await commands.executeCommand(SHOW_CONFIG_PICKER_COMMAND_ID);
-        break;
-      case Action.DisableSorbet:
-        await commands.executeCommand(SORBET_DISABLE_COMMAND_ID);
-        break;
-      case Action.EnableSorbet:
-        await commands.executeCommand(SORBET_ENABLE_COMMAND_ID);
-        break;
-      case Action.RestartSorbet:
-        await commands.executeCommand(
-          SORBET_RESTART_COMMAND_ID,
-          RestartReason.STATUS_BAR_BUTTON,
-        );
-        break;
-      case Action.ViewOutput:
-        await commands.executeCommand(SHOW_OUTPUT_COMMAND_ID);
-        break;
-      default:
-        break; // User canceled
-    }
+/**
+ * Get available {@link Action actions} based on Sorbet' status.
+ */
+export function getAvailableActions(serverStatus: ServerStatus): Action[] {
+  const actions = [Action.ViewOutput];
+  switch (serverStatus) {
+    case ServerStatus.ERROR:
+      actions.push(Action.RestartSorbet);
+      break;
+    case ServerStatus.DISABLED:
+      actions.push(Action.EnableSorbet);
+      break;
+    default:
+      actions.push(Action.RestartSorbet, Action.DisableSorbet);
+      break;
   }
-
-  /**
-   * Get available {@link Action actions} based on Sorbet' status.
-   */
-  public getAvailableActions(): Action[] {
-    const actions = [Action.ViewOutput];
-    switch (this.statusProvider.serverStatus) {
-      case ServerStatus.ERROR:
-        actions.push(Action.RestartSorbet);
-        break;
-      case ServerStatus.DISABLED:
-        actions.push(Action.EnableSorbet);
-        break;
-      default:
-        actions.push(Action.RestartSorbet, Action.DisableSorbet);
-        break;
-    }
-    actions.push(Action.ConfigureSorbet);
-    return actions;
-  }
+  actions.push(Action.ConfigureSorbet);
+  return actions;
 }

--- a/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
+++ b/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
@@ -1,44 +1,43 @@
 import { QuickPickItem, window } from "vscode";
-import { SorbetExtensionConfig, SorbetLspConfig } from "../config";
+import { SorbetLspConfig } from "../config";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
 
-interface SorbetQuickPickItem extends QuickPickItem {
+export interface LspConfigQuickPickItem extends QuickPickItem {
   lspConfig?: SorbetLspConfig;
 }
 
 /**
  * Show Sorbet Configuration picker.
  */
-export class ShowSorbetConfigurationPicker {
-  private readonly configuration: SorbetExtensionConfig;
+export async function showSorbetConfigurationPicker(
+  context: SorbetExtensionContext,
+): Promise<void> {
+  const {
+    configuration: { activeLspConfig, lspConfigs },
+  } = context;
 
-  public constructor(context: SorbetExtensionContext) {
-    this.configuration = context.configuration;
-  }
+  const items: LspConfigQuickPickItem[] = lspConfigs.map((lspConfig) => ({
+    label: `${lspConfig.isEqualTo(activeLspConfig) ? "• " : ""}${
+      lspConfig.name
+    }`,
+    description: lspConfig.description,
+    detail: lspConfig.command.join(" "),
+    lspConfig,
+  }));
+  items.push({
+    label: `${activeLspConfig ? "" : "• "}Disable Sorbet`,
+    description: "Disable the Sorbet extension",
+  });
 
-  public async execute(): Promise<void> {
-    const { activeLspConfig, lspConfigs } = this.configuration;
-    const items: SorbetQuickPickItem[] = lspConfigs.map((config) => ({
-      label: `${config.isEqualTo(activeLspConfig) ? "• " : ""}${config.name}`,
-      description: config.description,
-      detail: config.command.join(" "),
-      lspConfig: config,
-    }));
-    items.push({
-      label: `${activeLspConfig ? "" : "• "}Disable Sorbet`,
-      description: "Disable the Sorbet extension",
-    });
-
-    const selectedItem = await window.showQuickPick(items, {
-      placeHolder: "Select a Sorbet configuration",
-    });
-    if (selectedItem) {
-      const { lspConfig } = selectedItem;
-      if (lspConfig) {
-        this.configuration.setActiveLspConfigId(lspConfig.id);
-      } else {
-        this.configuration.setEnabled(false);
-      }
+  const selectedItem = await window.showQuickPick(items, {
+    placeHolder: "Select a Sorbet configuration",
+  });
+  if (selectedItem) {
+    const { lspConfig } = selectedItem;
+    if (lspConfig) {
+      context.configuration.setActiveLspConfigId(lspConfig.id);
+    } else {
+      context.configuration.setEnabled(false);
     }
   }
 }

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -1,10 +1,10 @@
 import { commands, ExtensionContext, Uri, workspace } from "vscode";
 import { TextDocumentItem } from "vscode-languageclient";
 import * as cmdIds from "./commandIds";
-import { SetLogLevel } from "./commands/setLogLevel";
-import { ShowSorbetActions } from "./commands/showSorbetActions";
-import { ShowSorbetConfigurationPicker } from "./commands/showSorbetConfigurationPicker";
-import { getLogLevelFromEnvironment } from "./log";
+import { setLogLevel } from "./commands/setLogLevel";
+import { showSorbetActions } from "./commands/showSorbetActions";
+import { showSorbetConfigurationPicker } from "./commands/showSorbetConfigurationPicker";
+import { getLogLevelFromEnvironment, LogLevel } from "./log";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { SorbetStatusBarEntry } from "./sorbetStatusBarEntry";
 import { ServerStatus, RestartReason } from "./types";
@@ -65,14 +65,15 @@ export function activate(context: ExtensionContext) {
 
   // Register commands
   context.subscriptions.push(
-    commands.registerCommand(cmdIds.SET_LOGLEVEL_COMMAND_ID, () =>
-      new SetLogLevel(sorbetExtensionContext).execute(),
+    commands.registerCommand(
+      cmdIds.SET_LOGLEVEL_COMMAND_ID,
+      (level?: LogLevel) => setLogLevel(sorbetExtensionContext, level),
     ),
     commands.registerCommand(cmdIds.SHOW_ACTIONS_COMMAND_ID, () =>
-      new ShowSorbetActions(sorbetExtensionContext).execute(),
+      showSorbetActions(sorbetExtensionContext),
     ),
     commands.registerCommand(cmdIds.SHOW_CONFIG_PICKER_COMMAND_ID, () =>
-      new ShowSorbetConfigurationPicker(sorbetExtensionContext).execute(),
+      showSorbetConfigurationPicker(sorbetExtensionContext),
     ),
     commands.registerCommand(cmdIds.SHOW_OUTPUT_COMMAND_ID, () =>
       sorbetExtensionContext.log.outputChannel.show(true),

--- a/vscode_extension/src/test/commands/setLogLevel.test.ts
+++ b/vscode_extension/src/test/commands/setLogLevel.test.ts
@@ -3,7 +3,7 @@ import * as assert from "assert";
 import * as path from "path";
 import * as sinon from "sinon";
 
-import { LogLevelQuickPickItem, SetLogLevel } from "../../commands/setLogLevel";
+import { LogLevelQuickPickItem, setLogLevel } from "../../commands/setLogLevel";
 import { LogLevel, OutputChannelLog } from "../../log";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
 
@@ -18,7 +18,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     testRestorables.forEach((r) => r.restore());
   });
 
-  test("Shows dropdown when target-level argument is NOT provided", async () => {
+  test("setLogLevel: Shows dropdown when target-level argument is NOT provided", async () => {
     const expectedLogLevel = LogLevel.Warning;
     const createOutputChannelStub = sinon
       .stub(vscode.window, "createOutputChannel")
@@ -38,8 +38,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     const log = new OutputChannelLog("Test", LogLevel.Info);
     const context = <SorbetExtensionContext>{ log };
 
-    const command = new SetLogLevel(context);
-    await assert.doesNotReject(command.execute());
+    await assert.doesNotReject(setLogLevel(context));
     assert.strictEqual(log.level, expectedLogLevel);
 
     sinon.assert.calledWithExactly(
@@ -81,7 +80,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     sinon.assert.calledOnce(createOutputChannelStub);
   });
 
-  test("Shows no-dropdown when target-level argument is provided ", async () => {
+  test("setLogLevel: Shows no-dropdown when target-level argument is provided ", async () => {
     const expectedLogLevel = LogLevel.Warning;
     const createOutputChannelStub = sinon
       .stub(vscode.window, "createOutputChannel")
@@ -96,8 +95,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     const log = new OutputChannelLog("Test", LogLevel.Info);
     const context = <SorbetExtensionContext>{ log };
 
-    const command = new SetLogLevel(context);
-    await assert.doesNotReject(command.execute(expectedLogLevel));
+    await assert.doesNotReject(setLogLevel(context, expectedLogLevel));
     assert.strictEqual(log.level, expectedLogLevel);
 
     sinon.assert.notCalled(showQuickPickSingleStub);

--- a/vscode_extension/src/test/commands/showSorbetActions.test.ts
+++ b/vscode_extension/src/test/commands/showSorbetActions.test.ts
@@ -10,8 +10,8 @@ import {
 } from "../../commands/showSorbetActions";
 import { LogLevel, OutputChannelLog } from "../../log";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
-import { ServerStatus } from "../../types";
 import { SorbetStatusProvider } from "../../sorbetStatusProvider";
+import { ServerStatus } from "../../types";
 
 suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
   let testRestorables: { restore: () => void }[];

--- a/vscode_extension/src/test/commands/showSorbetActions.test.ts
+++ b/vscode_extension/src/test/commands/showSorbetActions.test.ts
@@ -1,0 +1,87 @@
+import * as vscode from "vscode";
+import * as assert from "assert";
+import * as path from "path";
+import * as sinon from "sinon";
+
+import {
+  Action,
+  getAvailableActions,
+  showSorbetActions,
+} from "../../commands/showSorbetActions";
+import { LogLevel, OutputChannelLog } from "../../log";
+import { SorbetExtensionContext } from "../../sorbetExtensionContext";
+import { ServerStatus } from "../../types";
+import { SorbetStatusProvider } from "../../sorbetStatusProvider";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  let testRestorables: { restore: () => void }[];
+
+  setup(() => {
+    testRestorables = [];
+  });
+
+  teardown(() => {
+    testRestorables.forEach((r) => r.restore());
+  });
+
+  test("getAvailableActions", () => {
+    assert.deepStrictEqual(getAvailableActions(ServerStatus.DISABLED), [
+      Action.ViewOutput,
+      Action.EnableSorbet,
+      Action.ConfigureSorbet,
+    ]);
+
+    assert.deepStrictEqual(getAvailableActions(ServerStatus.ERROR), [
+      Action.ViewOutput,
+      Action.RestartSorbet,
+      Action.ConfigureSorbet,
+    ]);
+
+    assert.deepStrictEqual(getAvailableActions(ServerStatus.INITIALIZING), [
+      Action.ViewOutput,
+      Action.RestartSorbet,
+      Action.DisableSorbet,
+      Action.ConfigureSorbet,
+    ]);
+
+    assert.deepStrictEqual(getAvailableActions(ServerStatus.RESTARTING), [
+      Action.ViewOutput,
+      Action.RestartSorbet,
+      Action.DisableSorbet,
+      Action.ConfigureSorbet,
+    ]);
+
+    assert.deepStrictEqual(getAvailableActions(ServerStatus.RUNNING), [
+      Action.ViewOutput,
+      Action.RestartSorbet,
+      Action.DisableSorbet,
+      Action.ConfigureSorbet,
+    ]);
+  });
+
+  test("showSorbetActions: Shows dropdown (no-selection)", async () => {
+    const showQuickPickSingleStub = sinon
+      .stub(vscode.window, "showQuickPick")
+      .resolves(undefined); // User canceled
+    testRestorables.push(showQuickPickSingleStub);
+
+    const log = new OutputChannelLog("Test", LogLevel.Info);
+    const statusProvider = <SorbetStatusProvider>{
+      serverStatus: ServerStatus.RUNNING,
+    };
+    const context = <SorbetExtensionContext>{ log, statusProvider };
+
+    await assert.doesNotReject(showSorbetActions(context));
+
+    sinon.assert.calledOnce(showQuickPickSingleStub);
+    assert.deepStrictEqual(await showQuickPickSingleStub.firstCall.args[0], [
+      Action.ViewOutput,
+      Action.RestartSorbet,
+      Action.DisableSorbet,
+      Action.ConfigureSorbet,
+    ]);
+    assert.deepStrictEqual(await showQuickPickSingleStub.firstCall.args[1], {
+      placeHolder: "Select an action",
+    });
+  });
+});

--- a/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
+++ b/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
@@ -1,0 +1,78 @@
+import * as vscode from "vscode";
+import * as assert from "assert";
+import * as path from "path";
+import * as sinon from "sinon";
+
+import {
+  LspConfigQuickPickItem,
+  showSorbetConfigurationPicker,
+} from "../../commands/showSorbetConfigurationPicker";
+import { LogLevel, OutputChannelLog } from "../../log";
+import { SorbetExtensionContext } from "../../sorbetExtensionContext";
+import { SorbetExtensionConfig, SorbetLspConfig } from "../../config";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  let testRestorables: { restore: () => void }[];
+
+  setup(() => {
+    testRestorables = [];
+  });
+
+  teardown(() => {
+    testRestorables.forEach((r) => r.restore());
+  });
+
+  test("showSorbetConfigurationPicker: Shows dropdown (no-selection)", async () => {
+    const activeLspConfig = new SorbetLspConfig({
+      id: "test-config-id-active",
+      name: "test-config-id-active",
+      description: "",
+      cwd: "",
+      command: [],
+    });
+    const otherLspConfig = new SorbetLspConfig({
+      id: "test-config-id",
+      name: "test-config-id",
+      description: "",
+      cwd: "",
+      command: [],
+    });
+
+    const showQuickPickSingleStub = sinon
+      .stub(vscode.window, "showQuickPick")
+      .resolves(undefined); // User canceled
+    testRestorables.push(showQuickPickSingleStub);
+
+    const log = new OutputChannelLog("Test", LogLevel.Info);
+    const configuration = <SorbetExtensionConfig>(<unknown>{
+      activeLspConfig,
+      lspConfigs: [activeLspConfig, otherLspConfig],
+    });
+    const context = <SorbetExtensionContext>{ log, configuration };
+
+    await assert.doesNotReject(showSorbetConfigurationPicker(context));
+
+    sinon.assert.calledOnce(showQuickPickSingleStub);
+    assert.deepStrictEqual(await showQuickPickSingleStub.firstCall.args[0], [
+      {
+        label: `• ${activeLspConfig.name}`,
+        description: activeLspConfig.description,
+        detail: activeLspConfig.command.join(" "),
+        lspConfig: activeLspConfig,
+      },
+      {
+        label: otherLspConfig.name,
+        description: otherLspConfig.description,
+        detail: otherLspConfig.command.join(" "),
+        lspConfig: otherLspConfig,
+      },
+      {
+        label: "Disable Sorbet",
+        description: "Disable the Sorbet extension",
+      },
+    ]);
+    assert.deepStrictEqual(await showQuickPickSingleStub.firstCall.args[1], {
+      placeHolder: "Select a Sorbet configuration",
+    });
+  });
+});

--- a/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
+++ b/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
@@ -3,13 +3,10 @@ import * as assert from "assert";
 import * as path from "path";
 import * as sinon from "sinon";
 
-import {
-  LspConfigQuickPickItem,
-  showSorbetConfigurationPicker,
-} from "../../commands/showSorbetConfigurationPicker";
+import { showSorbetConfigurationPicker } from "../../commands/showSorbetConfigurationPicker";
+import { SorbetExtensionConfig, SorbetLspConfig } from "../../config";
 import { LogLevel, OutputChannelLog } from "../../log";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
-import { SorbetExtensionConfig, SorbetLspConfig } from "../../config";
 
 suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
   let testRestorables: { restore: () => void }[];


### PR DESCRIPTION
Add tests for `ShowSorbetActions` and `ShowSorbetConfigurationPicker` commands.
- Remove use of classes to model commands and use functions instead.  Classes only make sense when preserving state and so far no command has used this (And doesn't look like it will be a common feature).
- Looking at all commands at once, allowed to standardize some string values (arg names, comments, etc).

Follow up to
- https://github.com/sorbet/sorbet/pull/7069
- https://github.com/sorbet/sorbet/pull/7042/

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
