### PR TITLE
Allow code that uses `new` as a type factory to be marked abstract

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
@@ -35,10 +35,11 @@ module T::Private::Abstract::Declare
       # define_method because of the guard above
 
       mod.send(:define_singleton_method, :new) do |*args, &blk|
-        if T.unsafe(self) == mod
-          raise "#{mod} is declared as abstract; it cannot be instantiated"
+        super(*args, &blk).tap do |result|
+          if result.instance_of?(mod)
+            raise "#{mod} is declared as abstract; it cannot be instantiated"
+          end
         end
-        super(*args, &blk)
       end
 
       # Ruby doesn not emit "method redefined" warnings for aliased methods

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -604,6 +604,39 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     T::Private::Abstract::Validate.validate_abstract_module(klass)
   end
 
+  it 'allows abstract classes to return instances of other types' do
+    mod = Module.new do
+      def new(type: self)
+        if type == self
+          super()
+        else
+          type.new
+        end
+      end
+    end
+
+    superclass = Class.new do
+      extend mod
+    end
+
+    klass = Class.new(superclass) do
+      extend T::Sig
+      extend T::Helpers
+      abstract!
+    end
+
+    err = assert_raises(RuntimeError) do
+      klass.new
+    end
+
+    assert_includes(
+      err.message,
+      "is declared as abstract; it cannot be instantiated",
+    )
+
+    assert_instance_of(String, klass.new(type: String))
+  end
+
   it 'handles class scope change when already hooked' do
     klass = Class.new do
       extend T::Sig


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This PR changes the mechanics of the `new` method installed by `abstract!` to check the return type of `super` call instead of checking the type of the receiver to detect if an abstract instance is being created.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Some Ruby code uses the `new` method as a type factory to instantiate a type that is related to but not the same as the type of the receiver. That means, those classes cannot be marked as `abstract!`, since doing that would prevent the use of `new` on the class immediately.

This is specifically how Active Record handles STI, which is now broken. Consider the following example:

```ruby
  class Market < ActiveRecord::Base
    has_many :regions
  end

  class Region < ActiveRecord::Base
    abstract!
  end

  class Country < Region
  end

  class Province < Region
  end
```

Before Sorbet started patching `new` (pre #6888):
```ruby
[1] pry(main)> market.regions.build
RuntimeError: Region is declared as abstract; it cannot be instantiated
[2] pry(main)> market.regions.build(type: Country)
=> #<Country:0x00007f97c3b1a3c0 ... >
```

After Sorbet started patching `new` (post #6888):
```ruby
[1] pry(main)> market.regions.build
RuntimeError: Region is declared as abstract; it cannot be instantiated
[2] pry(main)> market.regions.build(type: Country)
RuntimeError: Region is declared as abstract; it cannot be instantiated
```

The difference is due to how [Active Record redefines `new`](https://github.com/rails/rails/blob/ef04fbb3b256beececfa44c47c4ec93ac6945e59/activerecord/lib/active_record/inheritance.rb#L56-L78) to return an instance of a subtype of the receiver as specified by the `type` argument. Sorbet's patching of `new` prevents that from happening, so the `type` argument is ignored and an exception is raised instead.

However, what we really want to prevent is for `new` to return an instance of the abstract type, not prevent it from returning a non-abstract type since the receiver was abstract. So this commit changes the behaviour of the `new` method `abstract!` installs to call `super` first, and then check if the returned instance is an instance of the abstract type. If it is, it raises an exception, otherwise it returns the instance.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
