### PR TITLE
Add `--did-you-mean=false` option

### DIFF
--- a/core/Error.cc
+++ b/core/Error.cc
@@ -196,6 +196,13 @@ void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {
     this->autocorrects.emplace_back(move(autocorrect));
 }
 
+void ErrorBuilder::didYouMean(const std::string &replacement, Loc loc) {
+    std::string formatted = fmt::format("Replace with `{}`", replacement);
+    auto isDidYouMean = true;
+    addAutocorrect(
+        AutocorrectSuggestion{move(formatted), {AutocorrectSuggestion::Edit{loc, replacement}}, isDidYouMean});
+}
+
 // This will sometimes be bypassed in lieu of just calling build() so put your
 // logic in build() instead.
 ErrorBuilder::~ErrorBuilder() {

--- a/core/Error.cc
+++ b/core/Error.cc
@@ -197,6 +197,10 @@ void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {
 }
 
 void ErrorBuilder::didYouMean(const std::string &replacement, Loc loc) {
+    if (!gs.didYouMean) {
+        return;
+    }
+
     std::string formatted = fmt::format("Replace with `{}`", replacement);
     auto isDidYouMean = true;
     addAutocorrect(

--- a/core/Error.h
+++ b/core/Error.h
@@ -167,12 +167,7 @@ public:
         std::string formatted = fmt::format(replacement, std::forward<Args>(args)...);
         addAutocorrect(AutocorrectSuggestion{title, {AutocorrectSuggestion::Edit{loc, move(formatted)}}});
     }
-    void didYouMean(const std::string &replacement, Loc loc) {
-        std::string formatted = fmt::format("Replace with `{}`", replacement);
-        auto isDidYouMean = true;
-        addAutocorrect(
-            AutocorrectSuggestion{move(formatted), {AutocorrectSuggestion::Edit{loc, replacement}}, isDidYouMean});
-    }
+    void didYouMean(const std::string &replacement, Loc loc);
 
     // build() builds and returns the reported Error. Only valid if state ==
     // WillBuild. This passes ownership of the error to the caller; ErrorBuilder

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2036,6 +2036,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
 
     result->silenceErrors = this->silenceErrors;
     result->autocorrect = this->autocorrect;
+    result->didYouMean = this->didYouMean;
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
@@ -2133,6 +2134,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->fileRefByPath = this->fileRefByPath;
     result->silenceErrors = this->silenceErrors;
     result->autocorrect = this->autocorrect;
+    result->didYouMean = this->didYouMean;
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
     result->censorForSnapshotTests = this->censorForSnapshotTests;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -231,6 +231,7 @@ public:
     int globalStateId;
     bool silenceErrors = false;
     bool autocorrect = false;
+    bool didYouMean = true;
     bool trackUntyped = false;
     bool printingFileTable = false;
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -319,6 +319,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "directory passed to Sorbet, if any.",
                                     cxxopts::value<string>()->default_value(empty.pathPrefix), "prefix");
     options.add_options("advanced")("a,autocorrect", "Auto-correct source files with suggested fixes");
+    options.add_options("advanced")("did-you-mean", "Whether to include 'Did you mean' suggestions in autocorrects",
+                                    cxxopts::value<bool>()->default_value("true"));
     options.add_options("advanced")("P,progress", "Draw progressbar");
     options.add_options("advanced")("license", "Show license");
     options.add_options("advanced")("color", "Use color output", cxxopts::value<string>()->default_value("auto"),
@@ -757,6 +759,7 @@ void readOptions(Options &opts,
 
         opts.silenceErrors = raw["quiet"].as<bool>();
         opts.autocorrect = raw["autocorrect"].as<bool>();
+        opts.didYouMean = raw["did-you-mean"].as<bool>();
         opts.inlineInput = raw["e"].as<string>();
         if (opts.autocorrect && opts.silenceErrors) {
             logger->error("You may not use autocorrect when silencing errors.");

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -152,6 +152,7 @@ struct Options {
     bool traceParser = false;
     bool noErrorCount = false;
     bool autocorrect = false;
+    bool didYouMean = true;
     bool waitForDebugger = false;
     bool censorForSnapshotTests = false;
     bool forceHashing = false;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -468,9 +468,8 @@ int realmain(int argc, char *argv[]) {
     if (opts.silenceErrors) {
         gs->silenceErrors = true;
     }
-    if (opts.autocorrect) {
-        gs->autocorrect = true;
-    }
+    gs->autocorrect = opts.autocorrect;
+    gs->didYouMean = opts.didYouMean;
     if (opts.print.isAutogen()) {
         gs->runningUnderAutogen = true;
     }

--- a/test/cli/did-you-mean-false/test.out
+++ b/test/cli/did-you-mean-false/test.out
@@ -1,0 +1,52 @@
+test.rb:17: Expected `Integer` but found `T.nilable(Integer)` for argument `x` https://srb.help/7002
+    17 |  takes_integer(x)
+                        ^
+  Expected `Integer` for argument `x` of method `Object#takes_integer`:
+    test.rb:11:
+    11 |sig {params(x: Integer).void}
+                    ^
+  Got `T.nilable(Integer)` originating from:
+    test.rb:16:
+    16 |def takes_nilable_integer(x)
+                                  ^
+  Autocorrect: Done
+    test.rb:17: Replaced with `T.must(x)`
+    17 |  takes_integer(x)
+                        ^
+
+test.rb:9: Method `my_metho` does not exist on `A` https://srb.help/7003
+     9 |A.new.my_metho
+              ^^^^^^^^
+  Got `A` originating from:
+    test.rb:9:
+     9 |A.new.my_metho
+        ^^^^^
+  Autocorrect: Done
+    test.rb:9: Replaced with `my_method`
+     9 |A.new.my_metho
+              ^^^^^^^^
+    test.rb:5: Defined here
+     5 |  def my_method
+          ^^^^^^^^^^^^^
+Errors: 2
+
+--------------------------------------------------------------------------
+
+# typed: true
+extend T::Sig
+
+class A
+  def my_method
+  end
+end
+
+A.new.my_method
+
+sig {params(x: Integer).void}
+def takes_integer(x)
+end
+
+sig {params(x: T.nilable(Integer)).void}
+def takes_nilable_integer(x)
+  takes_integer(T.must(x))
+end

--- a/test/cli/did-you-mean-false/test.out
+++ b/test/cli/did-you-mean-false/test.out
@@ -21,10 +21,6 @@ test.rb:9: Method `my_metho` does not exist on `A` https://srb.help/7003
     test.rb:9:
      9 |A.new.my_metho
         ^^^^^
-  Autocorrect: Done
-    test.rb:9: Replaced with `my_method`
-     9 |A.new.my_metho
-              ^^^^^^^^
     test.rb:5: Defined here
      5 |  def my_method
           ^^^^^^^^^^^^^
@@ -40,7 +36,7 @@ class A
   end
 end
 
-A.new.my_method
+A.new.my_metho
 
 sig {params(x: Integer).void}
 def takes_integer(x)

--- a/test/cli/did-you-mean-false/test.rb
+++ b/test/cli/did-you-mean-false/test.rb
@@ -1,0 +1,18 @@
+# typed: true
+extend T::Sig
+
+class A
+  def my_method
+  end
+end
+
+A.new.my_metho
+
+sig {params(x: Integer).void}
+def takes_integer(x)
+end
+
+sig {params(x: T.nilable(Integer)).void}
+def takes_nilable_integer(x)
+  takes_integer(x)
+end

--- a/test/cli/did-you-mean-false/test.sh
+++ b/test/cli/did-you-mean-false/test.sh
@@ -8,7 +8,7 @@ tmp="$(mktemp -d)"
 cp "$infile" "$tmp"
 
 cd "$tmp" || exit 1
-if "$cwd/main/sorbet" --silence-dev-message -a test.rb 2>&1; then
+if "$cwd/main/sorbet" --silence-dev-message -a --did-you-mean=false test.rb 2>&1; then
   echo "Expected to fail!"
   exit 1
 fi

--- a/test/cli/did-you-mean-false/test.sh
+++ b/test/cli/did-you-mean-false/test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+cwd="$(pwd)"
+infile="$cwd/test/cli/did-you-mean-false/test.rb"
+
+tmp="$(mktemp -d)"
+
+cp "$infile" "$tmp"
+
+cd "$tmp" || exit 1
+if "$cwd/main/sorbet" --silence-dev-message -a test.rb 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+cat test.rb
+rm test.rb

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -161,6 +161,15 @@ There is no way to have Sorbet **only** apply autocorrect suggestions in a given
 file. Instead, use a version control system to undo autocorrect changes Sorbet
 makes in files that should not be changed.
 
+Sometimes, Sorbet autocorrects include suggestions to rename a method, for
+example to fix a supposed typo. Sometimes these "did you mean" suggestions can
+accidentally change the meaning of a program. To disable these did you mean
+suggestions, use `--did-you-mean=false`:
+
+```
+❯ srb tc --autocorrect --did-you-mean=false
+```
+
 ### Silencing errors in bulk
 
 Sometimes, Sorbet doesn't know how to **fix** an error, it only knows how to


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sometimes a change to make something go from untyped -> typed introduces new
errors. Many of these errors show up as "Method does not exist" errors. But then
a case like this can happen:

- The new type is actually too broad. The type went from `T.untyped` to
  `Parent`. Sorbet reports an error like "No method `foo` on `Parent`"

- But in this particular case, the method `foo` does actually exist at runtime,
  because at runtime the type is always `Child`.

- There is a similar method on the parent, called `foot`, and Sorbet thinks that
  the call to `foo` is a typo for `foot`, so it inserts a "did you mean"
  autocorrect.

These situations are problematic for large codemods. In those cases, it's
preferred to simply ignore the did you mean suggestions.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.