### PR TITLE
Docs: fix link in error reference

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3965,7 +3965,7 @@ Or if it's imperative to continue using `is_a?`, change the type to
 ## 7039
 
 For more information, see how to place
-[bounds on type members](generics.md#bounds-on-type-member-s-and-type-template-s-fixed-upper-lower).
+[bounds on type members](generics.md#bounds-on-type_members-and-type_templates-fixed-upper-lower).
 
 Consider this example:
 


### PR DESCRIPTION
Link points to https://sorbet.org/docs/generics#bounds-on-type-member-s-and-type-template-s-fixed-upper-lower

It should point to https://sorbet.org/docs/generics#bounds-on-type_members-and-type_templates-fixed-upper-lower
