### PR TITLE
Add tests for `MetricsClient`.

### DIFF
--- a/vscode_extension/src/connections.ts
+++ b/vscode_extension/src/connections.ts
@@ -1,12 +1,12 @@
 import { ChildProcess } from "child_process";
-import { OutputChannelLog } from "./log";
+import { Log } from "./log";
 
 /**
  * Attempts to stop the given child process. Tries a SIGINT, then a SIGTERM, then a SIGKILL.
  */
 export async function stopProcess(
   p: ChildProcess | null,
-  log: OutputChannelLog,
+  log: Log,
 ): Promise<void> {
   if (!p || !p.pid) {
     // Process is already dead.

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -76,7 +76,7 @@ export function activate(context: ExtensionContext) {
       showSorbetConfigurationPicker(sorbetExtensionContext),
     ),
     commands.registerCommand(cmdIds.SHOW_OUTPUT_COMMAND_ID, () =>
-      sorbetExtensionContext.log.outputChannel.show(true),
+      sorbetExtensionContext.logOutputChannel.show(true),
     ),
     commands.registerCommand(cmdIds.SORBET_ENABLE_COMMAND_ID, () =>
       sorbetExtensionContext.configuration.setEnabled(true),

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -117,7 +117,7 @@ export class SorbetLanguageClient implements ErrorHandler {
           // Support queries on generated files with sorbet:// URIs that do not exist editor-side.
           { language: "ruby", scheme: "sorbet" },
         ],
-        outputChannel: this.context.log.outputChannel,
+        outputChannel: this.context.logOutputChannel,
         initializationOptions: {
           // Opt in to sorbet/showOperation notifications.
           supportsOperationNotifications: true,

--- a/vscode_extension/src/log.ts
+++ b/vscode_extension/src/log.ts
@@ -51,9 +51,56 @@ export function getLogLevelFromString(name: string): LogLevel | undefined {
 }
 
 /**
+ * Logger.
+ */
+export interface Log {
+  /**
+   * Appends a new debug message to the log.
+   * @param message Log message.
+   */
+  debug(message: string): void;
+
+  /**
+   * Appends a new error message to the log.
+   * @param message Log message.
+   * @param error Error.
+   */
+  error(message: string, error?: Error): void;
+
+  /**
+   * Appends a new error message to the log.
+   * @param errorOrMessage Error or log message.
+   */
+  error(errorOrMessage: string | Error): void;
+
+  /**
+   * Appends a new information message to the log.
+   * @param message Log message.
+   */
+  info(message: string): void;
+
+  /**
+   * Log level.
+   */
+  level: LogLevel;
+
+  /**
+   * Appends a new trace message to the log.
+   * @param message Log message.
+   */
+  trace(message: string): void;
+
+  /**
+   * Appends a new warning message to the log.
+   * @param message Log message.
+   */
+  warning(message: string): void;
+}
+
+/**
  * Output Channel-based implementation of logger.
  */
-export class OutputChannelLog implements Disposable {
+export class OutputChannelLog implements Log, Disposable {
   private wrappedLevel: LogLevel;
   public readonly outputChannel: OutputChannel;
 

--- a/vscode_extension/src/test/commands/showSorbetActions.test.ts
+++ b/vscode_extension/src/test/commands/showSorbetActions.test.ts
@@ -3,12 +3,12 @@ import * as assert from "assert";
 import * as path from "path";
 import * as sinon from "sinon";
 
+import { createLogStub } from "../testUtils";
 import {
   Action,
   getAvailableActions,
   showSorbetActions,
 } from "../../commands/showSorbetActions";
-import { LogLevel, OutputChannelLog } from "../../log";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
 import { SorbetStatusProvider } from "../../sorbetStatusProvider";
 import { ServerStatus } from "../../types";
@@ -65,7 +65,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       .resolves(undefined); // User canceled
     testRestorables.push(showQuickPickSingleStub);
 
-    const log = new OutputChannelLog("Test", LogLevel.Info);
+    const log = createLogStub();
     const statusProvider = <SorbetStatusProvider>{
       serverStatus: ServerStatus.RUNNING,
     };

--- a/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
+++ b/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
@@ -3,9 +3,9 @@ import * as assert from "assert";
 import * as path from "path";
 import * as sinon from "sinon";
 
+import { createLogStub } from "../testUtils";
 import { showSorbetConfigurationPicker } from "../../commands/showSorbetConfigurationPicker";
 import { SorbetExtensionConfig, SorbetLspConfig } from "../../config";
-import { LogLevel, OutputChannelLog } from "../../log";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
 
 suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
@@ -40,7 +40,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       .resolves(undefined); // User canceled
     testRestorables.push(showQuickPickSingleStub);
 
-    const log = new OutputChannelLog("Test", LogLevel.Info);
+    const log = createLogStub();
     const configuration = <SorbetExtensionConfig>(<unknown>{
       activeLspConfig,
       lspConfigs: [activeLspConfig, otherLspConfig],

--- a/vscode_extension/src/test/metricsClient.test.ts
+++ b/vscode_extension/src/test/metricsClient.test.ts
@@ -1,0 +1,87 @@
+import * as path from "path";
+import * as sinon from "sinon";
+
+import { createLogStub } from "./testUtils";
+import {
+  METRIC_PREFIX,
+  MetricClient,
+  NoOpApi,
+  NoOpMetricsEmitter,
+} from "../metricsClient";
+import { SorbetExtensionContext } from "../sorbetExtensionContext";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  let testRestorables: { restore: () => void }[];
+
+  setup(() => {
+    testRestorables = [];
+  });
+
+  teardown(() => {
+    testRestorables.forEach((r) => r.restore());
+  });
+
+  test("emitCountMetric calls MetricsEmitter.increment once with correct params ", async () => {
+    const expectedMetricName = "metricClient.test.emitCountMetric";
+    const expectedCount = 123;
+    const expectedTags = { foo: "bar" };
+
+    const incrementStub = sinon.stub(NoOpMetricsEmitter.prototype, "increment");
+    testRestorables.push(incrementStub);
+    const client = new MetricClient(
+      <SorbetExtensionContext>{
+        configuration: {
+          activeLspConfig: undefined,
+        },
+        log: createLogStub(),
+      },
+      new NoOpApi(),
+    );
+
+    await client.emitCountMetric(
+      expectedMetricName,
+      expectedCount,
+      expectedTags,
+    );
+
+    sinon.assert.calledOnce(incrementStub);
+    sinon.assert.calledWithMatch(
+      incrementStub,
+      `${METRIC_PREFIX}${expectedMetricName}`,
+      expectedCount,
+      expectedTags,
+    );
+  });
+
+  test("emitTimingMetric calls MetricsEmitter.timing once with correct params ", async () => {
+    const expectedMetricName = "metricClient.test.emitCountMetric";
+    const expectedCount = 123;
+    const expectedTags = { foo: "bar" };
+
+    const timingStub = sinon.stub(NoOpMetricsEmitter.prototype, "timing");
+    testRestorables.push(timingStub);
+    const client = new MetricClient(
+      <SorbetExtensionContext>{
+        configuration: {
+          activeLspConfig: undefined,
+        },
+        log: createLogStub(),
+      },
+      new NoOpApi(),
+    );
+
+    await client.emitTimingMetric(
+      expectedMetricName,
+      expectedCount,
+      expectedTags,
+    );
+
+    sinon.assert.calledOnce(timingStub);
+    sinon.assert.calledWithMatch(
+      timingStub,
+      `${METRIC_PREFIX}${expectedMetricName}`,
+      expectedCount,
+      expectedTags,
+    );
+  });
+});

--- a/vscode_extension/src/test/testUtils.ts
+++ b/vscode_extension/src/test/testUtils.ts
@@ -1,0 +1,16 @@
+import { Log, LogLevel } from "../log";
+
+/**
+ * Stub {@link Log} interface.
+ * @param level Default log-level.
+ */
+export function createLogStub(level = LogLevel.Critical): Log {
+  return {
+    debug: (_message: string) => {},
+    error: (_messageOrError: string | Error) => {},
+    info: (_message: string) => {},
+    trace: (_message: string) => {},
+    warning: (_message: string) => {},
+    level,
+  };
+}


### PR DESCRIPTION
Add tests for `MetricsClient`.
- To simplify mocking, a `Log` interface is introduced to reflect the log-only aspect of `OutputChannelLog` (i.e. exclude the `OutputChannel` UI-component).

Follow up to
- https://github.com/sorbet/sorbet/pull/7055

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
