### PR TITLE
Use the "Property" kind for attr things

### DIFF
--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -155,13 +155,17 @@ struct FoundMethod final {
     struct Flags {
         bool isSelfMethod : 1;
         bool isRewriterSynthesized : 1;
+        // Controls whether this gets compiled as a VM_METHOD_TYPE_IVAR method, for performance
         bool isAttrReader : 1;
+        // Controls whether to display this as an attr_*/prop-defined method in the LSP client
+        // This is best effort and thus UI-only! Should not be used for the sake of type checking.
+        bool isAttr : 1;
         bool discardDef : 1;
         bool genericPropGetter : 1;
 
         // In C++20 we can replace this with bit field initialzers
         Flags()
-            : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false),
+            : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), isAttr(false), discardDef(false),
               genericPropGetter(false) {}
     };
     Flags flags;

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -159,14 +159,14 @@ struct FoundMethod final {
         bool isAttrReader : 1;
         // Controls whether to display this as an attr_*/prop-defined method in the LSP client
         // This is best effort and thus UI-only! Should not be used for the sake of type checking.
-        bool isAttr : 1;
+        bool isAttrBestEffortUIOnly : 1;
         bool discardDef : 1;
         bool genericPropGetter : 1;
 
         // In C++20 we can replace this with bit field initialzers
         Flags()
-            : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), isAttr(false), discardDef(false),
-              genericPropGetter(false) {}
+            : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), isAttrBestEffortUIOnly(false),
+              discardDef(false), genericPropGetter(false) {}
     };
     Flags flags;
     CheckSize(Flags, 1, 1);

--- a/main/lsp/LSPLoop.h
+++ b/main/lsp/LSPLoop.h
@@ -99,7 +99,7 @@ std::string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef met
 std::string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant);
 core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr);
-SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym, bool isAttr);
+SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym, bool isAttrBestEffortUIOnly);
 
 // Returns all subclasses of ClassOrModuleRef (including itself)
 //

--- a/main/lsp/LSPLoop.h
+++ b/main/lsp/LSPLoop.h
@@ -99,7 +99,7 @@ std::string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef met
 std::string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant);
 core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &type, core::SymbolRef inWhat,
                             core::TypePtr receiver, const core::TypeConstraint *constr);
-SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym);
+SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym, bool isAttr);
 
 // Returns all subclasses of ClassOrModuleRef (including itself)
 //

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -259,7 +259,7 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
     return resultType;
 }
 
-SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef symbol) {
+SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef symbol, bool isAttr) {
     if (symbol.isClassOrModule()) {
         auto klass = symbol.asClassOrModuleRef();
         if (klass.data(gs)->isModule()) {
@@ -272,6 +272,8 @@ SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym
         auto method = symbol.asMethodRef();
         if (method.data(gs)->name == core::Names::initialize()) {
             return SymbolKind::Constructor;
+        } else if (isAttr) {
+            return SymbolKind::Property;
         } else {
             return SymbolKind::Method;
         }

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -259,7 +259,7 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
     return resultType;
 }
 
-SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef symbol, bool isAttr) {
+SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef symbol, bool isAttrBestEffortUIOnly) {
     if (symbol.isClassOrModule()) {
         auto klass = symbol.asClassOrModuleRef();
         if (klass.data(gs)->isModule()) {
@@ -272,7 +272,7 @@ SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym
         auto method = symbol.asMethodRef();
         if (method.data(gs)->name == core::Names::initialize()) {
             return SymbolKind::Constructor;
-        } else if (isAttr) {
+        } else if (isAttrBestEffortUIOnly) {
             return SymbolKind::Property;
         } else {
             return SymbolKind::Method;

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -23,17 +23,18 @@ namespace {
 // ensure that both of the locs we're looking at are referencing the same file.
 // (We could do this with the locs from the symbol table, but it seems simpler
 // to do things this way.)
-struct SymbolFileLocs {
+struct ASTSymbolInfo {
     core::Loc loc;
     core::Loc declLoc;
+    bool isAttr;
 };
 
 class SymbolFileLocSaver {
 public:
     core::FileRef fref;
-    UnorderedMap<core::SymbolRef, SymbolFileLocs> &mapping;
+    UnorderedMap<core::SymbolRef, ASTSymbolInfo> &mapping;
 
-    SymbolFileLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, SymbolFileLocs> &mapping)
+    SymbolFileLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, ASTSymbolInfo> &mapping)
         : fref(fref), mapping(mapping) {}
 
     void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &expr) {
@@ -42,7 +43,8 @@ public:
             return;
         }
 
-        mapping[klass.symbol] = SymbolFileLocs{core::Loc{fref, klass.loc}, core::Loc{fref, klass.declLoc}};
+        auto isAttr = false;
+        mapping[klass.symbol] = ASTSymbolInfo{core::Loc{fref, klass.loc}, core::Loc{fref, klass.declLoc}, isAttr};
     }
 
     void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &expr) {
@@ -51,17 +53,18 @@ public:
             return;
         }
 
-        mapping[method.symbol] = SymbolFileLocs{core::Loc{fref, method.loc}, core::Loc{fref, method.declLoc}};
+        auto isAttr = method.flags.isAttr;
+        mapping[method.symbol] = ASTSymbolInfo{core::Loc{fref, method.loc}, core::Loc{fref, method.declLoc}, isAttr};
     }
 };
 
-std::unique_ptr<DocumentSymbol>
-symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef, core::FileRef filter,
-                         const UnorderedMap<core::SymbolRef, SymbolFileLocs> &defMapping,
-                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced);
+std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef,
+                                                         core::FileRef filter,
+                                                         const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping,
+                                                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced);
 
 void symbolRef2DocumentSymbolWalkMembers(const core::GlobalState &gs, core::SymbolRef sym, core::FileRef filter,
-                                         const UnorderedMap<core::SymbolRef, SymbolFileLocs> &defMapping,
+                                         const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping,
                                          const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced,
                                          vector<unique_ptr<DocumentSymbol>> &out) {
     if (!sym.isClassOrModule()) {
@@ -90,7 +93,7 @@ struct RangeInfo {
 };
 
 std::optional<RangeInfo> rangesForSymbol(const core::GlobalState &gs, core::SymbolRef symRef,
-                                         const UnorderedMap<core::SymbolRef, SymbolFileLocs> &defMapping,
+                                         const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping,
                                          const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced) {
     RangeInfo info;
     auto it = defMapping.find(symRef);
@@ -119,10 +122,15 @@ std::optional<RangeInfo> rangesForSymbol(const core::GlobalState &gs, core::Symb
     return info;
 }
 
-std::unique_ptr<DocumentSymbol>
-symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef, core::FileRef filter,
-                         const UnorderedMap<core::SymbolRef, SymbolFileLocs> &defMapping,
-                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced) {
+bool symbolIsAttr(core::SymbolRef symRef, const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping) {
+    auto it = defMapping.find(symRef);
+    return it != defMapping.end() && it->second.isAttr;
+}
+
+std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef,
+                                                         core::FileRef filter,
+                                                         const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping,
+                                                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced) {
     if (!symRef.exists()) {
         return nullptr;
     }
@@ -133,7 +141,7 @@ symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef, co
     if (!info.has_value()) {
         return nullptr;
     }
-    auto kind = symbolRef2SymbolKind(gs, symRef);
+    auto kind = symbolRef2SymbolKind(gs, symRef, symbolIsAttr(symRef, defMapping));
 
     string name;
     auto owner = symRef.owner(gs);
@@ -310,7 +318,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
                        [&deduplicatedCandidates](const auto ref) { return !deduplicatedCandidates.contains(ref); }),
         candidates.end());
 
-    UnorderedMap<core::SymbolRef, SymbolFileLocs> defMapping;
+    UnorderedMap<core::SymbolRef, ASTSymbolInfo> defMapping;
     SymbolFileLocSaver saver{fref, defMapping};
     core::Context ctx{gs, core::Symbols::root(), fref};
     auto resolved = typechecker.getResolved({fref});

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -26,7 +26,7 @@ namespace {
 struct ASTSymbolInfo {
     core::Loc loc;
     core::Loc declLoc;
-    bool isAttr;
+    bool isAttrBestEffortUIOnly;
 };
 
 class SymbolFileLocSaver {
@@ -43,8 +43,9 @@ public:
             return;
         }
 
-        auto isAttr = false;
-        mapping[klass.symbol] = ASTSymbolInfo{core::Loc{fref, klass.loc}, core::Loc{fref, klass.declLoc}, isAttr};
+        auto isAttrBestEffortUIOnly = false;
+        mapping[klass.symbol] =
+            ASTSymbolInfo{core::Loc{fref, klass.loc}, core::Loc{fref, klass.declLoc}, isAttrBestEffortUIOnly};
     }
 
     void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &expr) {
@@ -53,8 +54,9 @@ public:
             return;
         }
 
-        auto isAttr = method.flags.isAttr;
-        mapping[method.symbol] = ASTSymbolInfo{core::Loc{fref, method.loc}, core::Loc{fref, method.declLoc}, isAttr};
+        auto isAttrBestEffortUIOnly = method.flags.isAttrBestEffortUIOnly;
+        mapping[method.symbol] =
+            ASTSymbolInfo{core::Loc{fref, method.loc}, core::Loc{fref, method.declLoc}, isAttrBestEffortUIOnly};
     }
 };
 
@@ -124,7 +126,7 @@ std::optional<RangeInfo> rangesForSymbol(const core::GlobalState &gs, core::Symb
 
 bool symbolIsAttr(core::SymbolRef symRef, const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping) {
     auto it = defMapping.find(symRef);
-    return it != defMapping.end() && it->second.isAttr;
+    return it != defMapping.end() && it->second.isAttrBestEffortUIOnly;
 }
 
 std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef,

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -59,7 +59,11 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
         return response;
     }
 
-    auto symInfo = make_unique<SymbolInformation>(sym.show(gs), symbolRef2SymbolKind(gs, sym),
+    // To be able to get this information, we'd have to walk the tree. It's not that important for
+    // this method, so let's just fall back to treating attributes as methods.
+    auto isAttr = false;
+
+    auto symInfo = make_unique<SymbolInformation>(sym.show(gs), symbolRef2SymbolKind(gs, sym, isAttr),
                                                   config.loc2Location(gs, sym.loc(gs)));
 
     auto container = sym.owner(gs);

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -61,9 +61,9 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
 
     // To be able to get this information, we'd have to walk the tree. It's not that important for
     // this method, so let's just fall back to treating attributes as methods.
-    auto isAttr = false;
+    auto isAttrBestEffortUIOnly = false;
 
-    auto symInfo = make_unique<SymbolInformation>(sym.show(gs), symbolRef2SymbolKind(gs, sym, isAttr),
+    auto symInfo = make_unique<SymbolInformation>(sym.show(gs), symbolRef2SymbolKind(gs, sym, isAttrBestEffortUIOnly),
                                                   config.loc2Location(gs, sym.loc(gs)));
 
     auto container = sym.owner(gs);

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -91,10 +91,14 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::symbolRef2SymbolInformation
         if (location == nullptr) {
             continue;
         }
+        // To be able to get this information, we'd have to walk the tree. It's not that important for
+        // this method, so let's just fall back to treating attributes as methods.
+        auto isAttr = false;
+
         // VSCode does its own internal ranking based on comparing the query string against the result name.
         // Therefore have the name be the fully qualified name if it makes sense (e.g. Foo::Bar instead of Bar)
-        auto result =
-            make_unique<SymbolInformation>(symRef.show(gs), symbolRef2SymbolKind(gs, symRef), std::move(location));
+        auto result = make_unique<SymbolInformation>(symRef.show(gs), symbolRef2SymbolKind(gs, symRef, isAttr),
+                                                     std::move(location));
         auto container = symRef.owner(gs);
         if (container != core::Symbols::root()) {
             result->containerName = container.show(gs);

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -298,6 +298,7 @@ vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *
             }
 
             ast::MethodDef::Flags flags;
+            flags.isAttr = true;
             if (sigIsUnchecked(ctx, sig)) {
                 flags.isAttrReader = true;
             }
@@ -337,7 +338,10 @@ vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *
             } else {
                 body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName), ast::MK::Local(loc, name));
             }
-            stats.emplace_back(ast::MK::SyntheticMethod1(loc, loc, setName, ast::MK::Local(argLoc, name), move(body)));
+            ast::MethodDef::Flags flags;
+            flags.isAttr = true;
+            stats.emplace_back(
+                ast::MK::SyntheticMethod1(loc, loc, setName, ast::MK::Local(argLoc, name), move(body), flags));
         }
     }
 

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -298,7 +298,7 @@ vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *
             }
 
             ast::MethodDef::Flags flags;
-            flags.isAttr = true;
+            flags.isAttrBestEffortUIOnly = true;
             if (sigIsUnchecked(ctx, sig)) {
                 flags.isAttrReader = true;
             }
@@ -339,7 +339,7 @@ vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *
                 body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName), ast::MK::Local(loc, name));
             }
             ast::MethodDef::Flags flags;
-            flags.isAttr = true;
+            flags.isAttrBestEffortUIOnly = true;
             stats.emplace_back(
                 ast::MK::SyntheticMethod1(loc, loc, setName, ast::MK::Local(argLoc, name), move(body), flags));
         }

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -251,12 +251,14 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
 
 ast::ExpressionPtr ASTUtil::mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
                                   ast::MethodDef::Flags flags) {
+    flags.isAttr = true;
     auto ret = ast::MK::SyntheticMethod0(loc, loc, name, move(rhs), flags);
     return ret;
 }
 
 ast::ExpressionPtr ASTUtil::mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
                                   ast::ExpressionPtr rhs, ast::MethodDef::Flags flags) {
+    flags.isAttr = true;
     return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs), flags);
 }
 

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -251,14 +251,14 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
 
 ast::ExpressionPtr ASTUtil::mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
                                   ast::MethodDef::Flags flags) {
-    flags.isAttr = true;
+    flags.isAttrBestEffortUIOnly = true;
     auto ret = ast::MK::SyntheticMethod0(loc, loc, name, move(rhs), flags);
     return ret;
 }
 
 ast::ExpressionPtr ASTUtil::mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
                                   ast::ExpressionPtr rhs, ast::MethodDef::Flags flags) {
-    flags.isAttr = true;
+    flags.isAttrBestEffortUIOnly = true;
     return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs), flags);
 }
 

--- a/test/testdata/lsp/document_symbols_attr.rb
+++ b/test/testdata/lsp/document_symbols_attr.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+class A < T::Struct
+  extend T::Sig
+
+  const :foo, Integer
+  prop :bar, String
+
+  attr_reader :qux
+  attr_accessor :zap
+
+  sig {returns(Integer)}
+  attr_reader :checked_qux
+
+  sig {returns(String)}
+  attr_reader :checked_zap
+end

--- a/test/testdata/lsp/document_symbols_attr.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_attr.rb.document-symbols.exp
@@ -83,7 +83,7 @@
                 {
                     "name": "bar",
                     "detail": "",
-                    "kind": 6,
+                    "kind": 7,
                     "range": {
                         "start": {
                             "line": 6,
@@ -109,7 +109,7 @@
                 {
                     "name": "bar=",
                     "detail": "",
-                    "kind": 6,
+                    "kind": 7,
                     "range": {
                         "start": {
                             "line": 6,
@@ -135,7 +135,7 @@
                 {
                     "name": "checked_qux",
                     "detail": "",
-                    "kind": 6,
+                    "kind": 7,
                     "range": {
                         "start": {
                             "line": 12,
@@ -161,7 +161,7 @@
                 {
                     "name": "checked_zap",
                     "detail": "",
-                    "kind": 6,
+                    "kind": 7,
                     "range": {
                         "start": {
                             "line": 15,
@@ -187,7 +187,7 @@
                 {
                     "name": "foo",
                     "detail": "",
-                    "kind": 6,
+                    "kind": 7,
                     "range": {
                         "start": {
                             "line": 5,
@@ -239,7 +239,7 @@
                 {
                     "name": "qux",
                     "detail": "",
-                    "kind": 6,
+                    "kind": 7,
                     "range": {
                         "start": {
                             "line": 8,
@@ -265,7 +265,7 @@
                 {
                     "name": "zap",
                     "detail": "",
-                    "kind": 6,
+                    "kind": 7,
                     "range": {
                         "start": {
                             "line": 9,
@@ -291,7 +291,7 @@
                 {
                     "name": "zap=",
                     "detail": "",
-                    "kind": 6,
+                    "kind": 7,
                     "range": {
                         "start": {
                             "line": 9,

--- a/test/testdata/lsp/document_symbols_attr.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_attr.rb.document-symbols.exp
@@ -1,0 +1,320 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "A",
+            "detail": "",
+            "kind": 5,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 16,
+                    "character": 3
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 19
+                }
+            },
+            "children": [
+                {
+                    "name": "@bar",
+                    "detail": "",
+                    "kind": 8,
+                    "range": {
+                        "start": {
+                            "line": 6,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 11
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 6,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 11
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "@foo",
+                    "detail": "",
+                    "kind": 8,
+                    "range": {
+                        "start": {
+                            "line": 5,
+                            "character": 9
+                        },
+                        "end": {
+                            "line": 5,
+                            "character": 12
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 5,
+                            "character": 9
+                        },
+                        "end": {
+                            "line": 5,
+                            "character": 12
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "bar",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 6,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 19
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 6,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 19
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "bar=",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 6,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 19
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 6,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 19
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "checked_qux",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 12,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 12,
+                            "character": 26
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 12,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 12,
+                            "character": 26
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "checked_zap",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 15,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 15,
+                            "character": 26
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 15,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 15,
+                            "character": 26
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "foo",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 5,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 5,
+                            "character": 21
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 5,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 5,
+                            "character": 21
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "initialize",
+                    "detail": "",
+                    "kind": 9,
+                    "range": {
+                        "start": {
+                            "line": 2,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 16,
+                            "character": 3
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 2,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 19
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "qux",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 8,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 8,
+                            "character": 18
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 8,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 8,
+                            "character": 18
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "zap",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 9,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 9,
+                            "character": 20
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 9,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 9,
+                            "character": 20
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "zap=",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 9,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 9,
+                            "character": 20
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 9,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 9,
+                            "character": 20
+                        }
+                    },
+                    "children": []
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When using the document outline, it's useful to tell which methods are
props and which are actual methods. There's actually support in the LSP
spec for that, so I'd like to implement it.

It's a little hacky, because Sorbet doesn't really track this in its core
structures. Props are just methods to Sorbet. We do have some flags on the
method def for this, but those flags are currently

- only used for attr_reader-alike things, not setters
- very much tied to the runtime/compiler side of things. For example,
  adding a runtime-checked sig to an `attr_reader` will not mark the
  symbol as `isAttrReader`

So I've added a new flag to MethodDef. I've opted not to store this on the
Symbol, because I want it to be harder to accidentally use this flag for
the purpose of type checking (there is more written about my reasoning
here: <https://blog.jez.io/syntactic-control-flow/>). We also have a couple
spare bits there, so it should be fine.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

<img width="385" alt="Screenshot 2023-06-12 at 4 29 10 PM" src="https://github.com/sorbet/sorbet/assets/5544532/f5672c4c-c9e0-4037-b3a8-9719af148c32">
