### PR TITLE
fix finding usage of an enum from LSP

### DIFF
--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -131,20 +131,21 @@ vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *
         }
     }
 
+    auto statLocZero = stat.loc().copyWithZeroLength();
     auto name = ctx.state.enterNameConstant(ctx.state.freshNameUnique(core::UniqueNameKind::TEnum, lhs->cnst, 1));
-    auto classCnst = ast::MK::UnresolvedConstant(lhs->loc, ast::MK::EmptyTree(), name);
+    auto classCnst = ast::MK::UnresolvedConstant(statLocZero, ast::MK::EmptyTree(), name);
     ast::ClassDef::ANCESTORS_store parent;
     parent.emplace_back(klass->name.deepCopy());
     ast::ClassDef::RHS_store classRhs;
     auto classDef =
-        ast::MK::Class(stat.loc(), stat.loc(), classCnst.deepCopy(), std::move(parent), std::move(classRhs));
+        ast::MK::Class(statLocZero, statLocZero, classCnst.deepCopy(), std::move(parent), std::move(classRhs));
 
     ast::Send::Flags flags = {};
     flags.isPrivateOk = true;
     auto singletonAsgn = ast::MK::Assign(
-        stat.loc(), std::move(asgn->lhs),
-        ast::make_expression<ast::Cast>(stat.loc(), core::Types::todo(),
-                                        selfNew->withNewBody(stat.loc(), classCnst.deepCopy(), core::Names::new_()),
+        statLocZero, std::move(asgn->lhs),
+        ast::make_expression<ast::Cast>(statLocZero, core::Types::todo(),
+                                        selfNew->withNewBody(statLocZero, classCnst.deepCopy(), core::Names::new_()),
                                         core::Names::uncheckedLet(), std::move(classCnst)));
     vector<ast::ExpressionPtr> result;
     result.emplace_back(std::move(classDef));

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -145,7 +145,7 @@ vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *
     auto singletonAsgn = ast::MK::Assign(
         statLocZero, std::move(asgn->lhs),
         ast::make_expression<ast::Cast>(statLocZero, core::Types::todo(),
-                                        selfNew->withNewBody(statLocZero, classCnst.deepCopy(), core::Names::new_()),
+                                        selfNew->withNewBody(selfNew->loc, classCnst.deepCopy(), core::Names::new_()),
                                         core::Names::uncheckedLet(), std::move(classCnst)));
     vector<ast::ExpressionPtr> result;
     result.emplace_back(std::move(classDef));

--- a/test/testdata/lsp/find_refs_enum.rb
+++ b/test/testdata/lsp/find_refs_enum.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+  # ^ def: X
+  end
+end
+
+puts(MyEnum::X)
+#            ^ usage: X

--- a/test/testdata/rewriter/t_enum_kwargs.rb
+++ b/test/testdata/rewriter/t_enum_kwargs.rb
@@ -14,7 +14,7 @@ class Test < T::Enum
     D = new(10, "bar", c: 20, d: 30)
 
     E = new(10, "bar", c: 20, d: 30, f: "error")
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument
+    #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument
     F = new(1, "bar", 3, 4, c: 20)
     #                 ^^^^ error: Too many positional arguments
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #4711 .  We needed to make sure that some of the intermediate structure we created for enums can't be located by LSP.

Reviewing commit by commit makes it easier to see where the seemingly unrelated testcase change comes from, and I think the error location is more accurate now.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
