### PR TITLE
Always bind `Copy Symbol`  and `Rename Symbol` command IDs.

### DIFF
--- a/vscode_extension/src/commandIds.ts
+++ b/vscode_extension/src/commandIds.ts
@@ -19,6 +19,11 @@ export const SHOW_CONFIG_PICKER_COMMAND_ID = "sorbet.configure";
 export const SHOW_OUTPUT_COMMAND_ID = "sorbet.showOutput";
 
 /**
+ * Copy Symbol to Clipboard.
+ */
+export const SORBET_COPY_SYMBOL_COMMAND_ID = "sorbet.copySymbolToClipboard";
+
+/**
  * Enable Sorbet.
  */
 export const SORBET_ENABLE_COMMAND_ID = "sorbet.enable";
@@ -27,6 +32,11 @@ export const SORBET_ENABLE_COMMAND_ID = "sorbet.enable";
  * Disable Sorbet.
  */
 export const SORBET_DISABLE_COMMAND_ID = "sorbet.disable";
+
+/**
+ * Rename Symbol at a given document position.
+ */
+export const SORBET_RENAME_SYMBOL_COMMAND_ID = "sorbet.rename";
 
 /**
  * Restart Sorbet.

--- a/vscode_extension/src/commands/copySymbolToClipboard.ts
+++ b/vscode_extension/src/commands/copySymbolToClipboard.ts
@@ -1,0 +1,63 @@
+import { env, window } from "vscode";
+import {
+  SymbolInformation,
+  TextDocumentPositionParams,
+} from "vscode-languageclient/node";
+import { SorbetExtensionContext } from "../sorbetExtensionContext";
+import { ServerStatus } from "../types";
+
+/**
+ * Copy symbol at current
+ * @param context Context
+ */
+export async function copySymbolToClipboard(
+  context: SorbetExtensionContext,
+): Promise<void> {
+  // eslint-disable-next-line no-debugger
+  debugger;
+  const { activeLanguageClient: client } = context.statusProvider;
+  if (client?.status !== ServerStatus.RUNNING) {
+    context.log.warning("Sorbet LSP client is not ready.");
+    return;
+  }
+
+  const capabilities = <any>(
+    client.languageClient.initializeResult?.capabilities
+  );
+  if (!capabilities?.sorbetShowSymbolProvider) {
+    context.log.warning(
+      'Sorbet LSP client does not support "show symbol" capability.',
+    );
+    return;
+  }
+
+  const editor = window.activeTextEditor;
+  if (!editor) {
+    context.log.debug("No active editor to copy symbol from.");
+    return;
+  }
+
+  if (!editor.selection.isEmpty) {
+    context.log.debug(
+      "Cannot determine target symbol from a non-empty selection.",
+    );
+    return; // something is selected, abort
+  }
+
+  const position = editor.selection.active;
+  const params: TextDocumentPositionParams = {
+    textDocument: {
+      uri: editor.document.uri.toString(),
+    },
+    position,
+  };
+  const response: SymbolInformation = await client.languageClient.sendRequest(
+    "sorbet/showSymbol",
+    params,
+  );
+
+  await env.clipboard.writeText(response.name);
+  context.log.debug(
+    `Copied symbol name to the clipboard. Name:${response.name}`,
+  );
+}

--- a/vscode_extension/src/commands/renameSymbol.ts
+++ b/vscode_extension/src/commands/renameSymbol.ts
@@ -1,0 +1,42 @@
+import { commands, Position, Uri } from "vscode";
+import { TextDocumentPositionParams } from "vscode-languageclient";
+import { SorbetExtensionContext } from "../sorbetExtensionContext";
+import { ServerStatus } from "../types";
+
+/**
+ * Rename symbol at {@link TextDocumentPositionParams position}.
+ *
+ * Unfortunately, we need this command as a wrapper around `editor.action.rename`,
+ * because VSCode doesn't allow calling it from the JSON RPC
+ * https://github.com/microsoft/vscode/issues/146767
+ *
+ * @param context Context.
+ * @param params Document position.
+ */
+export async function renameSymbol(
+  context: SorbetExtensionContext,
+  params: TextDocumentPositionParams,
+): Promise<void> {
+  const { activeLanguageClient: client } = context.statusProvider;
+  if (client?.status !== ServerStatus.RUNNING) {
+    context.log.warning("Sorbet LSP client is not ready.");
+    return;
+  }
+
+  const {
+    textDocument: { uri },
+    position: { line, character },
+  } = params;
+
+  try {
+    commands.executeCommand("editor.action.rename", [
+      Uri.parse(uri),
+      new Position(line, character),
+    ]);
+  } catch (error) {
+    context.log.error(
+      `Failed to rename symbol at ${uri}:${line}:${character}`,
+      error instanceof Error ? error : undefined,
+    );
+  }
+}

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -1,6 +1,10 @@
 import { commands, ExtensionContext, Uri, workspace } from "vscode";
-import { TextDocumentItem } from "vscode-languageclient";
+import {
+  TextDocumentItem,
+  TextDocumentPositionParams,
+} from "vscode-languageclient";
 import * as cmdIds from "./commandIds";
+import { copySymbolToClipboard } from "./commands/copySymbolToClipboard";
 import { setLogLevel } from "./commands/setLogLevel";
 import { showSorbetActions } from "./commands/showSorbetActions";
 import { showSorbetConfigurationPicker } from "./commands/showSorbetConfigurationPicker";
@@ -8,6 +12,7 @@ import { getLogLevelFromEnvironment, LogLevel } from "./log";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { SorbetStatusBarEntry } from "./sorbetStatusBarEntry";
 import { ServerStatus, RestartReason } from "./types";
+import { renameSymbol } from "./commands/renameSymbol";
 
 /**
  * Extension entrypoint.
@@ -78,11 +83,19 @@ export function activate(context: ExtensionContext) {
     commands.registerCommand(cmdIds.SHOW_OUTPUT_COMMAND_ID, () =>
       sorbetExtensionContext.logOutputChannel.show(true),
     ),
+    commands.registerCommand(cmdIds.SORBET_COPY_SYMBOL_COMMAND_ID, () =>
+      copySymbolToClipboard(sorbetExtensionContext),
+    ),
     commands.registerCommand(cmdIds.SORBET_ENABLE_COMMAND_ID, () =>
       sorbetExtensionContext.configuration.setEnabled(true),
     ),
     commands.registerCommand(cmdIds.SORBET_DISABLE_COMMAND_ID, () =>
       sorbetExtensionContext.configuration.setEnabled(false),
+    ),
+    commands.registerCommand(
+      cmdIds.SORBET_RENAME_SYMBOL_COMMAND_ID,
+      (params: TextDocumentPositionParams) =>
+        renameSymbol(sorbetExtensionContext, params),
     ),
     commands.registerCommand(
       cmdIds.SORBET_RESTART_COMMAND_ID,


### PR DESCRIPTION
`Copy Symbol`  and `Rename Symbol` commands are  bound to their command Ids only after `LanguageClient.onReady` happens. This is incorrect as before this happens VSCode would fail saying the IDs are unknown by the extension. It is better to bind the commands early and explicitly handle the scenarios when the client is not ready.

Refactoring the commands also starts the refactoring of the `LanguageClient` class (actually, initial refactoring is what showed this issue) and will allow to write tests for each one.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
