### PR TITLE
Add tests for `Copy Symbol` and `Rename Symbol` commands

### DIFF
--- a/vscode_extension/src/commands/copySymbolToClipboard.ts
+++ b/vscode_extension/src/commands/copySymbolToClipboard.ts
@@ -13,8 +13,6 @@ import { ServerStatus } from "../types";
 export async function copySymbolToClipboard(
   context: SorbetExtensionContext,
 ): Promise<void> {
-  // eslint-disable-next-line no-debugger
-  debugger;
   const { activeLanguageClient: client } = context.statusProvider;
   if (client?.status !== ServerStatus.RUNNING) {
     context.log.warning("Sorbet LSP client is not ready.");

--- a/vscode_extension/src/commands/renameSymbol.ts
+++ b/vscode_extension/src/commands/renameSymbol.ts
@@ -17,8 +17,7 @@ export async function renameSymbol(
   context: SorbetExtensionContext,
   params: TextDocumentPositionParams,
 ): Promise<void> {
-  const { activeLanguageClient: client } = context.statusProvider;
-  if (client?.status !== ServerStatus.RUNNING) {
+  if (context.statusProvider.serverStatus !== ServerStatus.RUNNING) {
     context.log.warning("Sorbet LSP client is not ready.");
     return;
   }

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -5,6 +5,7 @@ import {
 } from "vscode-languageclient";
 import * as cmdIds from "./commandIds";
 import { copySymbolToClipboard } from "./commands/copySymbolToClipboard";
+import { renameSymbol } from "./commands/renameSymbol";
 import { setLogLevel } from "./commands/setLogLevel";
 import { showSorbetActions } from "./commands/showSorbetActions";
 import { showSorbetConfigurationPicker } from "./commands/showSorbetConfigurationPicker";
@@ -12,7 +13,6 @@ import { getLogLevelFromEnvironment, LogLevel } from "./log";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { SorbetStatusBarEntry } from "./sorbetStatusBarEntry";
 import { ServerStatus, RestartReason } from "./types";
-import { renameSymbol } from "./commands/renameSymbol";
 
 /**
  * Extension entrypoint.

--- a/vscode_extension/src/test/commands/copySymbolToClipboard.test.ts
+++ b/vscode_extension/src/test/commands/copySymbolToClipboard.test.ts
@@ -1,0 +1,155 @@
+import * as vscode from "vscode";
+import * as vsclc from "vscode-languageclient/node";
+import * as assert from "assert";
+import * as path from "path";
+import * as sinon from "sinon";
+
+import { createLogStub } from "../testUtils";
+import { copySymbolToClipboard } from "../../commands/copySymbolToClipboard";
+import { SorbetLanguageClient } from "../../languageClient";
+import { LogLevel } from "../../log";
+import { SorbetExtensionContext } from "../../sorbetExtensionContext";
+import { SorbetStatusProvider } from "../../sorbetStatusProvider";
+import { ServerStatus } from "../../types";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  let testRestorables: { restore: () => void }[];
+
+  setup(() => {
+    testRestorables = [];
+  });
+
+  teardown(() => {
+    testRestorables.forEach((r) => r.restore());
+  });
+
+  test("copySymbolToClipboard: does nothing if client is not present", async () => {
+    const writeTextSpy = sinon.spy(() => assert.fail());
+    const envClipboardStub = sinon.stub(vscode, "env").value(<any>{
+      clipboard: <any>{
+        writeText: writeTextSpy,
+      },
+    });
+    testRestorables.push(envClipboardStub);
+
+    const statusProvider = <SorbetStatusProvider>{
+      activeLanguageClient: undefined,
+    };
+    const context = <SorbetExtensionContext>{
+      log: createLogStub(LogLevel.Info),
+      statusProvider,
+    };
+    await copySymbolToClipboard(context);
+
+    sinon.assert.notCalled(writeTextSpy);
+  });
+
+  test("copySymbolToClipboard: does nothing if client is not ready", async () => {
+    const writeTextSpy = sinon.spy(() => assert.fail());
+    const envClipboardStub = sinon.stub(vscode, "env").value(<any>{
+      clipboard: <any>{
+        writeText: writeTextSpy,
+      },
+    });
+    testRestorables.push(envClipboardStub);
+
+    const statusProvider = <SorbetStatusProvider>{
+      activeLanguageClient: <SorbetLanguageClient>{
+        status: ServerStatus.DISABLED,
+      },
+    };
+    const context = <SorbetExtensionContext>{
+      log: createLogStub(LogLevel.Info),
+      statusProvider,
+    };
+    await copySymbolToClipboard(context);
+
+    sinon.assert.notCalled(writeTextSpy);
+  });
+
+  test("copySymbolToClipboard: does nothing if client does not support `sorbetShowSymbolProvider`", async () => {
+    const writeTextSpy = sinon.spy(() => assert.fail());
+    const envClipboardStub = sinon.stub(vscode, "env").value(<any>{
+      clipboard: <any>{
+        writeText: writeTextSpy,
+      },
+    });
+    testRestorables.push(envClipboardStub);
+
+    const statusProvider = <SorbetStatusProvider>{
+      activeLanguageClient: <SorbetLanguageClient>{
+        status: ServerStatus.RUNNING,
+        languageClient: <vsclc.LanguageClient>{
+          initializeResult: <any>{
+            capabilities: {
+              sorbetShowSymbolProvider: false,
+            },
+          },
+        },
+      },
+    };
+
+    const context = <SorbetExtensionContext>{
+      log: createLogStub(LogLevel.Info),
+      statusProvider,
+    };
+    await copySymbolToClipboard(context);
+
+    sinon.assert.notCalled(writeTextSpy);
+  });
+
+  test("copySymbolToClipboard: copies symbol to clipbaord whne there is a valid selection", async () => {
+    const expectedUri = vscode.Uri.parse("file://workspace/test.rb");
+    const expectedSymbolName = "test_symbol_name";
+
+    const writeTextSpy = sinon.spy((value: String) =>
+      assert.strictEqual(value, expectedSymbolName),
+    );
+    const envClipboardStub = sinon.stub(vscode, "env").value(<any>{
+      clipboard: <any>{
+        writeText: writeTextSpy,
+      },
+    });
+    testRestorables.push(envClipboardStub);
+
+    const activeTextEditorStub = sinon
+      .stub(vscode.window, "activeTextEditor")
+      .get(
+        () =>
+          <vscode.TextEditor>{
+            document: { uri: expectedUri },
+            selection: new vscode.Selection(1, 1, 1, 1),
+          },
+      );
+    testRestorables.push(activeTextEditorStub);
+    testRestorables.push(activeTextEditorStub);
+    const sendRequestSpy = sinon.spy(
+      (_method: string, _param: vsclc.TextDocumentPositionParams) =>
+        <vsclc.SymbolInformation>{
+          name: expectedSymbolName,
+        },
+    );
+
+    const statusProvider = <SorbetStatusProvider>{
+      activeLanguageClient: <SorbetLanguageClient>{
+        status: ServerStatus.RUNNING,
+        languageClient: <vsclc.LanguageClient>{
+          initializeResult: <any>{
+            capabilities: {
+              sorbetShowSymbolProvider: true,
+            },
+          },
+          sendRequest: <any>sendRequestSpy,
+        },
+      },
+    };
+    const context = <SorbetExtensionContext>{
+      log: createLogStub(LogLevel.Info),
+      statusProvider,
+    };
+    await copySymbolToClipboard(context);
+
+    sinon.assert.calledOnce(writeTextSpy);
+    sinon.assert.calledWith(writeTextSpy, expectedSymbolName);
+  });
+});

--- a/vscode_extension/src/test/commands/renameSymbol.test.ts
+++ b/vscode_extension/src/test/commands/renameSymbol.test.ts
@@ -1,0 +1,70 @@
+import * as vscode from "vscode";
+import * as vsclc from "vscode-languageclient";
+import * as assert from "assert";
+import * as path from "path";
+import * as sinon from "sinon";
+
+import { createLogStub } from "../testUtils";
+import { renameSymbol } from "../../commands/renameSymbol";
+import { LogLevel } from "../../log";
+import { SorbetExtensionContext } from "../../sorbetExtensionContext";
+import { SorbetStatusProvider } from "../../sorbetStatusProvider";
+import { ServerStatus } from "../../types";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  let testRestorables: { restore: () => void }[];
+
+  setup(() => {
+    testRestorables = [];
+  });
+
+  teardown(() => {
+    testRestorables.forEach((r) => r.restore());
+  });
+
+  test("renameSymbol: does nothing if client is not ready", async () => {
+    const executeStub = sinon.stub(vscode.commands, "executeCommand");
+    testRestorables.push(executeStub);
+
+    const statusProvider = <SorbetStatusProvider>{
+      serverStatus: ServerStatus.ERROR,
+    };
+    const context = <SorbetExtensionContext>{
+      log: createLogStub(LogLevel.Info),
+      statusProvider,
+    };
+    await renameSymbol(context, <vsclc.TextDocumentPositionParams>{});
+
+    sinon.assert.notCalled(executeStub);
+  });
+
+  test("renameSymbol: invokes `editor.action.rename`", async () => {
+    const expectedLine = 77;
+    const expectedCharacter = 99;
+    const expectedUri = vscode.Uri.parse("file://workspace/test.rb");
+
+    const executeStub = sinon
+      .stub(vscode.commands, "executeCommand")
+      .resolves();
+    testRestorables.push(executeStub);
+
+    const statusProvider = <SorbetStatusProvider>{
+      serverStatus: ServerStatus.RUNNING,
+    };
+    const context = <SorbetExtensionContext>{
+      log: createLogStub(LogLevel.Info),
+      statusProvider,
+    };
+    await renameSymbol(context, <vsclc.TextDocumentPositionParams>{
+      textDocument: { uri: expectedUri.toString() },
+      position: { line: expectedLine, character: expectedCharacter },
+    });
+
+    sinon.assert.calledOnce(executeStub);
+    const [commandName, [uri, position]] = executeStub.firstCall.args;
+    assert.strictEqual(commandName, "editor.action.rename");
+    assert.strictEqual(uri.toString(), expectedUri.toString());
+    assert.strictEqual(position.line, expectedLine);
+    assert.strictEqual(position.character, expectedCharacter);
+  });
+});


### PR DESCRIPTION
Add tests for `Copy Symbol` and `Rename Symbol` commands
- **Fix**: Remove leftover `debugger` call in https://github.com/sorbet/sorbet/pull/7093.  This issue will be ultimately prevented in the future via https://github.com/sorbet/sorbet/pull/7095

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
