### PR TITLE
Fix debugging of TypeScript code

### DIFF
--- a/vscode_extension/.vscode/launch.json
+++ b/vscode_extension/.vscode/launch.json
@@ -15,7 +15,10 @@
             "outFiles": [
                 "${workspaceRoot}/out/**/*.js"
             ],
-            "preLaunchTask": "watch"
+            "preLaunchTask": "watch",
+            "resolveSourceMapLocations": [
+                "${workspaceFolder}/out/**"
+            ],
         },
         {
             "name": "Run Extension Tests",
@@ -29,7 +32,10 @@
             "outFiles": [
                 "${workspaceFolder}/out/src/test/**/*.js"
             ],
-            "preLaunchTask": "watch"
+            "preLaunchTask": "watch",
+            "resolveSourceMapLocations": [
+                "${workspaceFolder}/out/**"
+            ],
         }
     ]
 }


### PR DESCRIPTION
Fix debugging of TypeScript code. In particular, it has not been possible to step into, or set breakpoints, in TypeScript code referenced by tests.
- Broken debugging experience is what led to the leftover `debugger` statement fixed on https://github.com/sorbet/sorbet/pull/7094.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
