### PR TITLE
Update T::Types::Simple#name to fix equality issue

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -4,6 +4,8 @@
 module T::Types
   # Validates that an object belongs to the specified class.
   class Simple < Base
+    NAME_METHOD = Module.instance_method(:name)
+
     attr_reader :raw_type
 
     def initialize(raw_type)
@@ -16,7 +18,7 @@ module T::Types
       #
       # `name` isn't normally a hot path for types, but it is used in initializing a T::Types::Union,
       # and so in `T.nilable`, and so in runtime constructions like `x = T.let(nil, T.nilable(Integer))`.
-      @name ||= @raw_type.name.freeze
+      @name ||= NAME_METHOD.bind_call(@raw_type).freeze
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -5,6 +5,7 @@ module T::Types
   # Validates that an object belongs to the specified class.
   class Simple < Base
     NAME_METHOD = Module.instance_method(:name)
+    private_constant(:NAME_METHOD)
 
     attr_reader :raw_type
 
@@ -18,7 +19,7 @@ module T::Types
       #
       # `name` isn't normally a hot path for types, but it is used in initializing a T::Types::Union,
       # and so in `T.nilable`, and so in runtime constructions like `x = T.let(nil, T.nilable(Integer))`.
-      @name ||= NAME_METHOD.bind_call(@raw_type).freeze
+      @name ||= NAME_METHOD.bind(@raw_type).call.freeze
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -19,7 +19,7 @@ module T::Types
       #
       # `name` isn't normally a hot path for types, but it is used in initializing a T::Types::Union,
       # and so in `T.nilable`, and so in runtime constructions like `x = T.let(nil, T.nilable(Integer))`.
-      @name ||= NAME_METHOD.bind(@raw_type).call.freeze
+      @name ||= (NAME_METHOD.bind(@raw_type).call || @raw_type.name).freeze
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -131,7 +131,7 @@ module Opus::Types::Test
         MSG
       end
 
-      it "correctly handles a class that has overriden it's #name method" do
+      it "correctly handles a class that has overridden its #name method" do
         klass = Class.new do
           def name
             "String"

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -130,6 +130,19 @@ module Opus::Types::Test
           There might be a constant reloading problem in your application.
         MSG
       end
+
+      it "correctly handles a class that has overriden it's #name method" do
+        klass = Class.new do
+          def name
+            "String"
+          end
+        end
+
+        x = T::Types::Simple.new(String)
+        y = T::Types::Simple.new(klass)
+
+        refute_equal(x, y)
+      end
     end
 
     describe "Union" do

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -131,17 +131,47 @@ module Opus::Types::Test
         MSG
       end
 
-      it "correctly handles a class that has overridden its #name method" do
-        klass = Class.new do
-          def name
+      it "uses constant name for class with #name defined" do
+        NamedClass = Class.new do
+          def self.name
             "String"
           end
         end
 
-        x = T::Types::Simple.new(String)
-        y = T::Types::Simple.new(klass)
+        x = T::Types::Simple.new(NamedClass)
 
-        refute_equal(x, y)
+        assert_equal("#{TypesTest.name}::NamedClass", x.name)
+      ensure
+        TypesTest.send(:remove_const, :NamedClass)
+      end
+
+      it "uses #name for anonymous classes" do
+        klass = Class.new do
+          def self.name
+            "String"
+          end
+        end
+
+        x = T::Types::Simple.new(klass)
+
+        assert_equal("String", x.name)
+      end
+
+      it "handles equality with a class that has overridden its #name method" do
+        NamedClass = Class.new
+
+        klass = Class.new do
+          def self.name
+            "NamedClass"
+          end
+        end
+
+        x = T::Types::Simple.new(klass)
+        y = T::Types::Simple.new(NamedClass)
+
+        refute_equal(x.name, y.name)
+      ensure
+        TypesTest.send(:remove_const, :NamedClass)
       end
     end
 


### PR DESCRIPTION
Updated `T::Types::Simple#name` to fully qualify the name of a class rather than calling it's `#name` method so that equality checks better handle constant and `#name` redefinition.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

```ruby
class SomeAbstractClass
  sig { abstract.returns(T.any(Time, ActiveSupport::TimeWithZone, Date)) }
  def foo; end
end

class SomeClass < SomeAbstractClass
  sig { override.returns(ActiveSupport::TimeWithZone) }
  def foo; end 
end
```

Results in the following error:

> Incompatible return type in signature for implementation of method `foo`:
> * Base: `T.nilable(T.any(Date, Time))`
> * Implementation: `T.nilable(Time)`
> (The types must be covariant.)

Digging into why this occurs, it was discovered that `ActiveSupport::TimeWithZone#name` has been overridden to return `Time` ([source](https://github.com/rails/rails/blob/e88857bbb9d4e1dd64555c34541301870de4a45b/activesupport/lib/active_support/time_with_zone.rb#L44-L53)). 

This raises the point that checking equality for `#name` directly might cause some unexpected behaviour for anyone that adopts this approach.

The fix proposed in this PR addresses this by comparing the raw names using the `Module#name` method. This means that situations like this will also work correctly:
```ruby
Foo = Class.new
foo = Foo
Object.send(:remove_const, :Foo)
Foo = Class.new
foo == Foo # => false
foo.name == Foo.name # => true
```

### Test plan

See included automated tests.
