### PR TITLE
Enable sorbet-ruby to build 3.2 including rust-based YJIT

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,6 +76,17 @@ load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 
 node_repositories()
 
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
+
+rules_rust_dependencies()
+
+rust_register_toolchains(
+    edition = "2021",
+    versions = [
+        "1.58.1",
+    ],
+)
+
 BAZEL_VERSION = "5.2.0"
 
 BAZEL_INSTALLER_VERSION_LINUX_X86_64_SHA = "7d9ef51beab5726c55725fb36675c6fed0518576d3ba51fb4067580ddf7627c4"

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -62,6 +62,11 @@ export PATH="$(dirname "{cc}"):$(dirname $(realpath {rustc})):$PATH"
 # tool/rbinstall.rb will explicitly ignore symlinks when installing files,
 # and this feels more maintainable than patching it.
 cp -aL "{src_dir}"/* "$build_dir"
+# Manually copy over .bundle as bundled gems are no longer installed
+# https://github.com/ruby/ruby/pull/6234
+if [[ -d "{src_dir}/.bundle" ]]; then
+  cp -raL "{src_dir}/.bundle" "$build_dir"
+fi
 
 {install_extra_srcs}
 {install_append_srcs}
@@ -237,7 +242,7 @@ def _build_ruby_impl(ctx):
     # Outputs
     binaries = [
         ctx.actions.declare_file("toolchain/bin/{}".format(binary))
-        for binary in ["ruby", "erb", "gem", "irb", "rdoc", "ri", "bundle", "bundler"]
+        for binary in ["ruby", "erb", "gem", "irb", "rdoc", "ri", "bundle", "bundler", "rake"]
     ]
 
     libdir = ctx.actions.declare_directory("toolchain/lib")

--- a/third_party/ruby/libyaml.BUILD
+++ b/third_party/ruby/libyaml.BUILD
@@ -1,0 +1,7 @@
+exports_files(glob(["**/*"]))
+
+filegroup(
+    name = "libyaml",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/ruby/ruby-versions.txt
+++ b/third_party/ruby/ruby-versions.txt
@@ -1,2 +1,3 @@
 sorbet_ruby_2_7
 sorbet_ruby_3_1
+sorbet_ruby_3_2

--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -10,7 +10,6 @@ ruby(
         "--localstatedir=/var",
         "--disable-maintainer-mode",
         "--disable-dependency-tracking",
-        "--disable-jit-support",
         "--disable-install-doc",
     ] + select({
         # Enforce that we don't need Ruby to build in release builds.

--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -17,6 +17,10 @@ ruby(
         # speed up the build.)
         "@com_stripe_ruby_typer//tools/config:release": ["--with-baseruby=no"],
         "//conditions:default": [],
+    }) + select({
+        # Do not enable the JIT unless opted in.
+        "@com_stripe_ruby_typer//tools/config:jit_enabled": [],
+        "//conditions:default": ["--disable-jit-support"],
     }),
     copts = [
         "-g",
@@ -32,7 +36,11 @@ ruby(
     cppopts = [
         "-Wdate-time",
         "-D_FORTIFY_SOURCE=2",
-    ],
+    ] + select({
+        # Don't include JIT statistics unless we're building JIT support
+        "@com_stripe_ruby_typer//tools/config:jit_enabled": ["-DYJIT_STATS=1"],
+        "//conditions:default": [],
+    }),
     extra_srcs = [],
     gems = [
         "@bundler_stripe//file",

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -2,6 +2,21 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 # We define our externals here instead of directly in WORKSPACE
 def register_ruby_dependencies():
+    libyaml_version = "0.2.5"
+    http_archive(
+        name = "libyaml",
+        urls = _github_public_urls("yaml/libyaml/releases/download/{}/yaml-{}.tar.gz".format(libyaml_version, libyaml_version)),
+        sha256 = "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4",
+        strip_prefix = "yaml-{}".format(libyaml_version),
+        build_file = "@com_stripe_ruby_typer//third_party/ruby:libyaml.BUILD",
+    )
+
+    http_archive(
+        name = "rules_rust",
+        sha256 = "25209daff2ba21e818801c7b2dab0274c43808982d6aea9f796d899db6319146",
+        urls = _github_public_urls("bazelbuild/rules_rust/releases/download/0.21.1/rules_rust-v0.21.1.tar.gz"),
+    )
+
     http_file(
         name = "bundler_stripe",
         urls = _rubygems_urls("bundler-1.17.3.gem"),
@@ -78,6 +93,14 @@ def register_ruby_dependencies():
         ],
     )
 
+    http_archive(
+        name = "sorbet_ruby_3_2",
+        urls = _ruby_urls("3.2/ruby-3.2.2.tar.gz"),
+        sha256 = "96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc",
+        strip_prefix = "ruby-3.2.2",
+        build_file = ruby_build,
+    )
+
 def _rubygems_urls(gem):
     """
     Produce a url list that works both with rubygems, and stripe's internal gem cache.
@@ -94,4 +117,13 @@ def _ruby_urls(path):
     return [
         "https://cache.ruby-lang.org/pub/ruby/{}".format(path),
         "https://artifactory-content.stripe.build/artifactory/ruby-lang-cache/pub/ruby/{}".format(path),
+    ]
+
+def _github_public_urls(path):
+    """
+    Produce a url list that works both with github, and stripe's internal artifact cache.
+    """
+    return [
+        "https://github.com/{}".format(path),
+        "https://artifactory-content.stripe.build/artifactory/github-archives/{}".format(path),
     ]

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -84,3 +84,10 @@ config_setting(
         "define": "release=true",
     },
 )
+
+config_setting(
+    name = "jit_enabled",
+    values = {
+        "define": "jit_enabled=true",
+    },
+)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
I haven't written a ton of bazel, very keen on getting more feedback on the approach. I've left inline comments calling out things I want more eyes on.

There are two main changes here (I tried to break apart by commit but the first includes a few rust references)
1. Include libyaml source so that the Psych gem bundled with 3.2 can be built, [see this ruby issue for more details](https://bugs.ruby-lang.org/issues/18571). The ruby 3.2 release notes mention that libffi source is not included either, the build passes without any changes required though which surprised me. I tried to build ruby 3.3.0-preview1 and that failed because of the missing libffi source. I'm going to work on that in parallel to getting a first round of reviews, flagging it for now.
2. Bring in the rust toolchain so that `rustc` can be added to `$PATH` before `./configure` is run. I've opted for rust 1.58.1 as the YJIT release notes [mention it requires rust 1.58 or higher](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/#:~:text=Building%20YJIT%20now%20requires%20Rust%201.58.0%2B). We could try a new version as rust has good backwards compatibility, we can benchmark internally to see if there's any performance improvement with newer versions. 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We'd like to roll out 3.2 and try out the new YJIT implementation internally for its potential savings, need to build it first!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
