### PR TITLE
Fix two problems in duplicate type member reporting

### DIFF
--- a/rewriter/TypeMembers.cc
+++ b/rewriter/TypeMembers.cc
@@ -11,7 +11,7 @@ using namespace std;
 namespace sorbet::rewriter {
 
 void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
-    UnorderedSet<core::NameRef> typeMembers;
+    UnorderedMap<core::NameRef, core::LocOffsets> typeMembers;
 
     for (auto &expr : cdef->rhs) {
         auto assn = ast::cast_tree<ast::Assign>(expr);
@@ -20,7 +20,8 @@ void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
         }
 
         auto rhs = ast::cast_tree<ast::Send>(assn->rhs);
-        if (!rhs || !rhs->recv.isSelfReference() || rhs->fun != core::Names::typeMember()) {
+        if (!rhs || !rhs->recv.isSelfReference() ||
+            (rhs->fun != core::Names::typeMember() && rhs->fun != core::Names::typeTemplate())) {
             continue;
         }
 
@@ -29,15 +30,19 @@ void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
             continue;
         }
 
-        if (typeMembers.contains(lhs->cnst)) {
+        auto it = typeMembers.find(lhs->cnst);
+        if (it != typeMembers.end()) {
             if (auto e = ctx.beginError(lhs->loc, core::errors::Namer::InvalidTypeDefinition)) {
-                e.setHeader("Duplicate type member `{}`", lhs->cnst.show(ctx));
+                auto memTem = rhs->fun == core::Names::typeMember() ? "member" : "template";
+                e.setHeader("Duplicate type {} `{}`", memTem, lhs->cnst.show(ctx));
+                e.addErrorLine(ctx.locAt(it->second), "Previous definition");
+                e.replaceWith(fmt::format("Delete duplicate type {}", memTem), ctx.locAt(expr.loc()), "");
             }
             expr = ast::MK::EmptyTree();
-            return;
+            continue;
         }
 
-        typeMembers.insert(lhs->cnst);
+        typeMembers[lhs->cnst] = expr.loc();
     }
 }
 

--- a/test/testdata/rewriter/duplicate_type_member.rb
+++ b/test/testdata/rewriter/duplicate_type_member.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+class A
+  extend T::Generic
+
+  X = type_member
+  X = type_member
+# ^ error: Duplciate type member `X`
+  X = type_member
+end
+
+class B
+  extend T::Generic
+
+  Y = type_template
+  Y = type_template
+  Y = type_template
+end

--- a/test/testdata/rewriter/duplicate_type_member.rb
+++ b/test/testdata/rewriter/duplicate_type_member.rb
@@ -5,9 +5,9 @@ class A
 
   X = type_member
   X = type_member
-# ^ error: Duplciate type member `X`
+# ^ error: Duplicate type member `X`
   X = type_member
-# ^ error: Duplciate type member `X`
+# ^ error: Duplicate type member `X`
 end
 
 class B
@@ -15,7 +15,7 @@ class B
 
   Y = type_template
   Y = type_template
-# ^ error: Duplciate type member `Y`
+# ^ error: Duplicate type member `Y`
   Y = type_template
-# ^ error: Duplciate type member `Y`
+# ^ error: Duplicate type member `Y`
 end

--- a/test/testdata/rewriter/duplicate_type_member.rb
+++ b/test/testdata/rewriter/duplicate_type_member.rb
@@ -15,7 +15,7 @@ class B
 
   Y = type_template
   Y = type_template
-# ^ error: Duplicate type member `Y`
+# ^ error: Duplicate type template `Y`
   Y = type_template
-# ^ error: Duplicate type member `Y`
+# ^ error: Duplicate type template `Y`
 end

--- a/test/testdata/rewriter/duplicate_type_member.rb
+++ b/test/testdata/rewriter/duplicate_type_member.rb
@@ -7,6 +7,7 @@ class A
   X = type_member
 # ^ error: Duplciate type member `X`
   X = type_member
+# ^ error: Duplciate type member `X`
 end
 
 class B
@@ -14,5 +15,7 @@ class B
 
   Y = type_template
   Y = type_template
+# ^ error: Duplciate type member `Y`
   Y = type_template
+# ^ error: Duplciate type member `Y`
 end

--- a/test/testdata/rewriter/duplicate_type_member.rb.autocorrects.exp
+++ b/test/testdata/rewriter/duplicate_type_member.rb.autocorrects.exp
@@ -1,0 +1,23 @@
+# -- test/testdata/rewriter/duplicate_type_member.rb --
+# typed: true
+
+class A
+  extend T::Generic
+
+  X = type_member
+  
+# ^ error: Duplciate type member `X`
+  
+# ^ error: Duplciate type member `X`
+end
+
+class B
+  extend T::Generic
+
+  Y = type_template
+  
+# ^ error: Duplciate type member `Y`
+  
+# ^ error: Duplciate type member `Y`
+end
+# ------------------------------

--- a/test/testdata/rewriter/duplicate_type_member.rb.autocorrects.exp
+++ b/test/testdata/rewriter/duplicate_type_member.rb.autocorrects.exp
@@ -6,9 +6,9 @@ class A
 
   X = type_member
   
-# ^ error: Duplciate type member `X`
+# ^ error: Duplicate type member `X`
   
-# ^ error: Duplciate type member `X`
+# ^ error: Duplicate type member `X`
 end
 
 class B
@@ -16,8 +16,8 @@ class B
 
   Y = type_template
   
-# ^ error: Duplciate type member `Y`
+# ^ error: Duplicate type template `Y`
   
-# ^ error: Duplciate type member `Y`
+# ^ error: Duplicate type template `Y`
 end
 # ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes #7100 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

1.  Sorbet was completely ignoring duplicate `type_template`'s
2.  Sorbet was only reporting a duplicate `type_member` warning for the first
    duplicate. The second or later duplicate was not flagged.
3.  There is now an autocorrect to delete the line with the duplicate.
4.  The error message now links to the definition of the first type
    member/template.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.