### PR TITLE
Magic symbols for tracking untyped 

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -80,7 +80,7 @@ struct MethodBuilder {
 
     MethodBuilder &untypedArg(NameRef name) {
         auto &arg = gs.enterMethodArgumentSymbol(Loc::none(), method, name);
-        arg.type = Types::untyped(gs, method);
+        arg.type = Types::untyped(method);
         return *this;
     }
 
@@ -100,7 +100,7 @@ struct MethodBuilder {
     MethodBuilder &repeatedUntypedArg(NameRef name) {
         auto &arg = gs.enterMethodArgumentSymbol(Loc::none(), method, name);
         arg.flags.isRepeated = true;
-        arg.type = Types::untyped(gs, method);
+        arg.type = Types::untyped(method);
         return *this;
     }
 
@@ -115,7 +115,7 @@ struct MethodBuilder {
         auto &arg = gs.enterMethodArgumentSymbol(Loc::none(), method, name);
         arg.flags.isKeyword = true;
         arg.flags.isRepeated = true;
-        arg.type = Types::untyped(gs, method);
+        arg.type = Types::untyped(method);
         return *this;
     }
 
@@ -131,7 +131,7 @@ struct MethodBuilder {
     }
 
     MethodRef buildWithResultUntyped() {
-        return buildWithResult(Types::untyped(gs, method));
+        return buildWithResult(Types::untyped(method));
     }
 };
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -856,6 +856,15 @@ void GlobalState::initEmpty() {
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Utils());
     klass.data(*this)->setIsModule(true);
 
+    klass = enterClassSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::UntypedSource());
+    ENFORCE(klass == Symbols::Magic_UntypedSource());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::super());
+    ENFORCE(field == Symbols::Magic_UntypedSource_super());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::proc());
+    ENFORCE(field == Symbols::Magic_UntypedSource_proc());
+
     int reservedCount = 0;
 
     // Set the correct resultTypes for all synthesized classes

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -901,7 +901,8 @@ void GlobalState::initEmpty() {
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::YieldLoadArg());
     ENFORCE(field == Symbols::Magic_UntypedSource_YieldLoadArg());
 
-    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::GetCurrentException());
+    field =
+        enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::GetCurrentException());
     ENFORCE(field == Symbols::Magic_UntypedSource_GetCurrentException());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::LoadYieldParams());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -865,6 +865,15 @@ void GlobalState::initEmpty() {
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::proc());
     ENFORCE(field == Symbols::Magic_UntypedSource_proc());
 
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::ArrayOfUntyped());
+    ENFORCE(field == Symbols::Magic_UntypedSource_ArrayOfUntyped());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::RangeOfUntyped());
+    ENFORCE(field == Symbols::Magic_UntypedSource_RangeOfUntyped());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::HashOfUntyped());
+    ENFORCE(field == Symbols::Magic_UntypedSource_HashOfUntyped());
+
     int reservedCount = 0;
 
     // Set the correct resultTypes for all synthesized classes

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -895,6 +895,21 @@ void GlobalState::initEmpty() {
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeLub());
     ENFORCE(field == Symbols::Magic_UntypedSource_shapeLub());
 
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::squareBracketsEq());
+    ENFORCE(field == Symbols::Magic_UntypedSource_squareBracketsEq());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::YieldLoadArg());
+    ENFORCE(field == Symbols::Magic_UntypedSource_YieldLoadArg());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::GetCurrentException());
+    ENFORCE(field == Symbols::Magic_UntypedSource_GetCurrentException());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::LoadYieldParams());
+    ENFORCE(field == Symbols::Magic_UntypedSource_LoadYieldParams());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::applyTypeArguments());
+    ENFORCE(field == Symbols::Magic_UntypedSource_applyTypeArguments());
+
     int reservedCount = 0;
 
     // Set the correct resultTypes for all synthesized classes

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -685,18 +685,18 @@ void GlobalState::initEmpty() {
     // Synthesize <Magic>.<build-hash>(*vs : T.untyped) => Hash
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::buildHash())
                  .repeatedUntypedArg(Names::arg0())
-                 .buildWithResult(Types::hashOfUntyped());
+                 .buildWithResult(Types::hashOfUntyped(Symbols::Magic_UntypedSource_buildHash()));
     // Synthesize <Magic>.<build-array>(*vs : T.untyped) => Array
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::buildArray())
                  .repeatedUntypedArg(Names::arg0())
-                 .buildWithResult(Types::arrayOfUntyped());
+                 .buildWithResult(Types::arrayOfUntyped(Symbols::Magic_UntypedSource_buildArray()));
 
     // Synthesize <Magic>.<build-range>(from: T.untyped, to: T.untyped) => Range
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::buildRange())
                  .untypedArg(Names::arg0())
                  .untypedArg(Names::arg1())
                  .untypedArg(Names::arg2())
-                 .buildWithResult(Types::rangeOfUntyped());
+                 .buildWithResult(Types::rangeOfUntyped(Symbols::Magic_UntypedSource_buildRange()));
 
     // Synthesize <Magic>.<regex-backref>(arg0: T.untyped) => T.nilable(String)
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::regexBackref())
@@ -865,14 +865,35 @@ void GlobalState::initEmpty() {
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::proc());
     ENFORCE(field == Symbols::Magic_UntypedSource_proc());
 
-    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::ArrayOfUntyped());
-    ENFORCE(field == Symbols::Magic_UntypedSource_ArrayOfUntyped());
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::buildArray());
+    ENFORCE(field == Symbols::Magic_UntypedSource_buildArray());
 
-    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::RangeOfUntyped());
-    ENFORCE(field == Symbols::Magic_UntypedSource_RangeOfUntyped());
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::buildRange());
+    ENFORCE(field == Symbols::Magic_UntypedSource_buildRange());
 
-    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::HashOfUntyped());
-    ENFORCE(field == Symbols::Magic_UntypedSource_HashOfUntyped());
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::buildHash());
+    ENFORCE(field == Symbols::Magic_UntypedSource_buildHash());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::mergeHashValues());
+    ENFORCE(field == Symbols::Magic_UntypedSource_mergeHashValues());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::expandSplat());
+    ENFORCE(field == Symbols::Magic_UntypedSource_expandSplat());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::splat());
+    ENFORCE(field == Symbols::Magic_UntypedSource_splat());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::tupleUnderlying());
+    ENFORCE(field == Symbols::Magic_UntypedSource_tupleUnderlying());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeUnderlying());
+    ENFORCE(field == Symbols::Magic_UntypedSource_shapeUnderlying());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::tupleLub());
+    ENFORCE(field == Symbols::Magic_UntypedSource_tupleLub());
+
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeLub());
+    ENFORCE(field == Symbols::Magic_UntypedSource_shapeLub());
 
     int reservedCount = 0;
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -895,7 +895,8 @@ void GlobalState::initEmpty() {
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeLub());
     ENFORCE(field == Symbols::Magic_UntypedSource_shapeLub());
 
-    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeSquareBracketsEq());
+    field =
+        enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeSquareBracketsEq());
     ENFORCE(field == Symbols::Magic_UntypedSource_shapeSquareBracketsEq());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::YieldLoadArg());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -895,8 +895,8 @@ void GlobalState::initEmpty() {
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeLub());
     ENFORCE(field == Symbols::Magic_UntypedSource_shapeLub());
 
-    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::squareBracketsEq());
-    ENFORCE(field == Symbols::Magic_UntypedSource_squareBracketsEq());
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeSquareBracketsEq());
+    ENFORCE(field == Symbols::Magic_UntypedSource_shapeSquareBracketsEq());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::YieldLoadArg());
     ENFORCE(field == Symbols::Magic_UntypedSource_YieldLoadArg());
@@ -907,9 +907,6 @@ void GlobalState::initEmpty() {
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::LoadYieldParams());
     ENFORCE(field == Symbols::Magic_UntypedSource_LoadYieldParams());
-
-    field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::applyTypeArguments());
-    ENFORCE(field == Symbols::Magic_UntypedSource_applyTypeArguments());
 
     int reservedCount = 0;
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1105,16 +1105,44 @@ public:
         return FieldRef::fromRaw(5);
     }
 
-    static FieldRef Magic_UntypedSource_ArrayOfUntyped() {
+    static FieldRef Magic_UntypedSource_buildArray() {
         return FieldRef::fromRaw(6);
     }
 
-    static FieldRef Magic_UntypedSource_RangeOfUntyped() {
+    static FieldRef Magic_UntypedSource_buildRange() {
         return FieldRef::fromRaw(7);
     }
 
-    static FieldRef Magic_UntypedSource_HashOfUntyped() {
+    static FieldRef Magic_UntypedSource_buildHash() {
         return FieldRef::fromRaw(8);
+    }
+
+    static FieldRef Magic_UntypedSource_mergeHashValues() {
+        return FieldRef::fromRaw(9);
+    }
+
+    static FieldRef Magic_UntypedSource_expandSplat() {
+        return FieldRef::fromRaw(10);
+    }
+
+    static FieldRef Magic_UntypedSource_splat() {
+        return FieldRef::fromRaw(11);
+    }
+
+    static FieldRef Magic_UntypedSource_tupleUnderlying() {
+        return FieldRef::fromRaw(12);
+    }
+
+    static FieldRef Magic_UntypedSource_shapeUnderlying() {
+        return FieldRef::fromRaw(13);
+    }
+
+    static FieldRef Magic_UntypedSource_tupleLub() {
+        return FieldRef::fromRaw(14);
+    }
+
+    static FieldRef Magic_UntypedSource_shapeLub() {
+        return FieldRef::fromRaw(15);
     }
 
     static constexpr int MAX_PROC_ARITY = 10;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1105,6 +1105,18 @@ public:
         return FieldRef::fromRaw(5);
     }
 
+    static FieldRef Magic_UntypedSource_ArrayOfUntyped() {
+        return FieldRef::fromRaw(6);
+    }
+
+    static FieldRef Magic_UntypedSource_RangeOfUntyped() {
+        return FieldRef::fromRaw(7);
+    }
+
+    static FieldRef Magic_UntypedSource_HashOfUntyped() {
+        return FieldRef::fromRaw(8);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static ClassOrModuleRef Proc0() {
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - MAX_PROC_ARITY * 2 - 2);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1145,6 +1145,26 @@ public:
         return FieldRef::fromRaw(15);
     }
 
+    static FieldRef Magic_UntypedSource_squareBracketsEq() {
+        return FieldRef::fromRaw(16);
+    }
+
+    static FieldRef Magic_UntypedSource_YieldLoadArg() {
+        return FieldRef::fromRaw(17);
+    }
+
+    static FieldRef Magic_UntypedSource_GetCurrentException() {
+        return FieldRef::fromRaw(18);
+    }
+
+    static FieldRef Magic_UntypedSource_LoadYieldParams() {
+        return FieldRef::fromRaw(19);
+    }
+
+    static FieldRef Magic_UntypedSource_applyTypeArguments() {
+        return FieldRef::fromRaw(20);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static ClassOrModuleRef Proc0() {
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - MAX_PROC_ARITY * 2 - 2);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1093,6 +1093,18 @@ public:
         return MethodRef::fromRaw(16);
     }
 
+    static ClassOrModuleRef Magic_UntypedSource() {
+        return ClassOrModuleRef::fromRaw(101);
+    }
+
+    static FieldRef Magic_UntypedSource_super() {
+        return FieldRef::fromRaw(4);
+    }
+
+    static FieldRef Magic_UntypedSource_proc() {
+        return FieldRef::fromRaw(5);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static ClassOrModuleRef Proc0() {
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - MAX_PROC_ARITY * 2 - 2);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1145,7 +1145,7 @@ public:
         return FieldRef::fromRaw(15);
     }
 
-    static FieldRef Magic_UntypedSource_squareBracketsEq() {
+    static FieldRef Magic_UntypedSource_shapeSquareBracketsEq() {
         return FieldRef::fromRaw(16);
     }
 
@@ -1159,10 +1159,6 @@ public:
 
     static FieldRef Magic_UntypedSource_LoadYieldParams() {
         return FieldRef::fromRaw(19);
-    }
-
-    static FieldRef Magic_UntypedSource_applyTypeArguments() {
-        return FieldRef::fromRaw(20);
     }
 
     static constexpr int MAX_PROC_ARITY = 10;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -24,7 +24,7 @@ using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
 const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 50;
-const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 16;
+const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 21;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 73;
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -146,14 +146,14 @@ TypePtr ClassOrModule::unsafeComputeExternalType(GlobalState &gs) {
 
             if (ref.isLegacyStdlibGeneric()) {
                 // Instantiate certain covariant stdlib generics with T.untyped, instead of <top>
-                targs.emplace_back(Types::untyped(gs, ref));
+                targs.emplace_back(Types::untyped(ref));
             } else if (tmData->flags.isFixed || tmData->flags.isCovariant) {
                 // Default fixed or covariant parameters to their upper bound.
                 targs.emplace_back(lambdaParam->upperBound);
             } else if (tmData->flags.isInvariant) {
                 // We instantiate Invariant type members as T.untyped as this will behave a bit like
                 // a unification variable with Types::glb.
-                targs.emplace_back(Types::untyped(gs, ref));
+                targs.emplace_back(Types::untyped(ref));
             } else {
                 // The remaining case is a contravariant parameter, which gets defaulted to its lower bound.
                 targs.emplace_back(lambdaParam->lowerBound);
@@ -457,7 +457,7 @@ TypePtr ArgInfo::argumentTypeAsSeenByImplementation(Context ctx, core::TypeConst
     auto klass = owner.enclosingClass(ctx);
     auto instantiated = Types::resultTypeAsSeenFrom(ctx, type, klass, klass, klass.data(ctx)->selfTypeArgs(ctx));
     if (instantiated == nullptr) {
-        instantiated = core::Types::untyped(ctx, owner);
+        instantiated = core::Types::untyped(owner);
     }
     if (owner.data(ctx)->flags.isGenericMethod) {
         instantiated = core::Types::instantiate(ctx, instantiated, constr);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -24,7 +24,7 @@ using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
 const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 50;
-const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 6;
+const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 9;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 73;
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -22,9 +22,9 @@ namespace sorbet::core {
 
 using namespace std;
 
-const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 213;
+const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
 const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 50;
-const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
+const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 6;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 73;
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -24,7 +24,7 @@ using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
 const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 50;
-const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 9;
+const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 16;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 73;
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -24,7 +24,7 @@ using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
 const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 50;
-const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 21;
+const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 73;
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -108,9 +108,10 @@ public:
     static TypePtr Float();
     static TypePtr Boolean();
     static TypePtr Object();
-    static TypePtr arrayOfUntyped();
-    static TypePtr rangeOfUntyped();
+    static TypePtr arrayOfUntyped(sorbet::core::SymbolRef blame);
+    static TypePtr rangeOfUntyped(sorbet::core::SymbolRef blame);
     static TypePtr hashOfUntyped();
+    static TypePtr hashOfUntyped(sorbet::core::SymbolRef blame);
     static TypePtr procClass();
     static TypePtr nilableProcClass();
     static TypePtr declBuilderForProcsSingletonClass();

--- a/core/Types.h
+++ b/core/Types.h
@@ -97,7 +97,7 @@ public:
     static TypePtr top();
     static TypePtr bottom();
     static TypePtr nilClass();
-    static TypePtr untyped(const core::GlobalState &gs, core::SymbolRef blame);
+    static TypePtr untyped(core::SymbolRef blame);
     static TypePtr untypedUntracked();
     static TypePtr void_();
     static TypePtr trueClass();

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -501,11 +501,16 @@ NameDef names[] = {
     {"Rational", "Rational", true},
     // A magic non user-creatable class with methods to keep state between passes
     {"Magic", "<Magic>", true},
+    // A magic non user-creatable class to attach symbols for blaming untyped to
     {"UntypedSource", "<UntypedSource>", true},
     {"tupleUnderlying", "<tupleUnderlying>", true},
     {"shapeUnderlying", "<shapeUnderlying>", true},
     {"tupleLub", "<tupleLub>", true},
     {"shapeLub", "<shapeLub>", true},
+    {"YieldLoadArg", "<YieldLoadArg>", true},
+    {"GetCurrentException", "<GetCurrentException>", true},
+    {"LoadYieldParams", "<LoadYieldParams>", true},
+    {"applyTypeArguments", "<applyTypeArguments>", true},
     // A magic non user-creatable class for binding procs to attached_class
     {"BindToAttachedClass", "<BindToAttachedClass>", true},
     // A magic non user-creatable class for binding procs to self_type

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -502,6 +502,9 @@ NameDef names[] = {
     // A magic non user-creatable class with methods to keep state between passes
     {"Magic", "<Magic>", true},
     {"UntypedSource", "<UntypedSource>", true},
+    {"ArrayOfUntyped", "<ArrayOfUntyped>", true},
+    {"RangeOfUntyped", "<RangeOfUntyped>", true},
+    {"HashOfUntyped", "<HashOfUntyped>", true},
     // A magic non user-creatable class for binding procs to attached_class
     {"BindToAttachedClass", "<BindToAttachedClass>", true},
     // A magic non user-creatable class for binding procs to self_type

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -501,6 +501,7 @@ NameDef names[] = {
     {"Rational", "Rational", true},
     // A magic non user-creatable class with methods to keep state between passes
     {"Magic", "<Magic>", true},
+    {"UntypedSource", "<UntypedSource>", true},
     // A magic non user-creatable class for binding procs to attached_class
     {"BindToAttachedClass", "<BindToAttachedClass>", true},
     // A magic non user-creatable class for binding procs to self_type

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -502,9 +502,10 @@ NameDef names[] = {
     // A magic non user-creatable class with methods to keep state between passes
     {"Magic", "<Magic>", true},
     {"UntypedSource", "<UntypedSource>", true},
-    {"ArrayOfUntyped", "<ArrayOfUntyped>", true},
-    {"RangeOfUntyped", "<RangeOfUntyped>", true},
-    {"HashOfUntyped", "<HashOfUntyped>", true},
+    {"tupleUnderlying", "<tupleUnderlying>", true},
+    {"shapeUnderlying", "<shapeUnderlying>", true},
+    {"tupleLub", "<tupleLub>", true},
+    {"shapeLub", "<shapeLub>", true},
     // A magic non user-creatable class for binding procs to attached_class
     {"BindToAttachedClass", "<BindToAttachedClass>", true},
     // A magic non user-creatable class for binding procs to self_type

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -510,7 +510,7 @@ NameDef names[] = {
     {"YieldLoadArg", "<YieldLoadArg>", true},
     {"GetCurrentException", "<GetCurrentException>", true},
     {"LoadYieldParams", "<LoadYieldParams>", true},
-    {"applyTypeArguments", "<applyTypeArguments>", true},
+    {"shapeSquareBracketsEq", "<shapeSquareBracketsEq>", true},
     // A magic non user-creatable class for binding procs to attached_class
     {"BindToAttachedClass", "<BindToAttachedClass>", true},
     // A magic non user-creatable class for binding procs to self_type

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3294,7 +3294,7 @@ public:
             // people's codebases to it.
             //
             // TODO(jez) This could be another "if you're in `typed: strict` you need typed shapes"
-            res.returnType = Types::untypedUntracked();
+            res.returnType = Types::untyped(Symbols::Magic_UntypedSource_squareBracketsEq());
         }
     }
 } Shape_squareBracketsEq;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -275,7 +275,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
                                Loc originForUninitialized, bool mayBeSetter = false) {
     TypePtr expectedType = Types::resultTypeAsSeenFrom(gs, argSym.type, method.data(gs)->owner, inClass, targs);
     if (!expectedType) {
-        expectedType = Types::untyped(gs, method);
+        expectedType = Types::untyped(method);
     }
 
     expectedType = Types::replaceSelfType(gs, expectedType, selfType);
@@ -333,7 +333,7 @@ unique_ptr<Error> missingArg(const GlobalState &gs, Loc argsLoc, Loc receiverLoc
         e.setHeader("Missing required keyword argument `{}` for method `{}`", argName, method.show(gs));
         auto expectedType = Types::resultTypeAsSeenFrom(gs, arg.type, method.data(gs)->owner, inClass, targs);
         if (expectedType == nullptr) {
-            expectedType = Types::untyped(gs, method);
+            expectedType = Types::untyped(method);
         }
         e.addErrorLine(arg.loc, "Keyword argument `{}` declared to expect type `{}` here:", argName,
                        expectedType.show(gs));
@@ -568,7 +568,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             TypeErrorDiagnostics::explainUntyped(gs, e, what, args.fullType, args.originForUninitialized);
         }
 
-        return DispatchResult(Types::untyped(gs, args.thisType.untypedBlame()), std::move(args.selfType),
+        return DispatchResult(Types::untyped(args.thisType.untypedBlame()), std::move(args.selfType),
                               Symbols::noMethod());
     } else if (symbol == Symbols::void_()) {
         if (!args.suppressErrors) {
@@ -1045,7 +1045,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         auto kwParamType =
                             Types::resultTypeAsSeenFrom(gs, kwParam->type, method.data(gs)->owner, symbol, targs);
                         if (kwParamType == nullptr) {
-                            kwParamType = Types::untyped(gs, method);
+                            kwParamType = Types::untyped(method);
                         }
                         // TODO(jez) Highlight untyped code for this error
                         if (Types::isSubTypeUnderConstraint(gs, *constr, kwSplatValueType, kwParamType,
@@ -1339,7 +1339,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
 
         TypePtr blockType = Types::resultTypeAsSeenFrom(gs, bspec.type, data->owner, symbol, targs);
         if (!blockType) {
-            blockType = Types::untyped(gs, method);
+            blockType = Types::untyped(method);
         }
 
         component.blockReturnType = Types::getProcReturnType(gs, Types::dropNil(gs, blockType));
@@ -1401,7 +1401,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     }
 
     if (!resultType) {
-        resultType = Types::untyped(gs, method);
+        resultType = Types::untyped(method);
     } else if (!constr->isEmpty() && constr->isSolved()) {
         resultType = Types::instantiate(gs, resultType, *constr);
     }
@@ -1434,7 +1434,7 @@ TypePtr getMethodArguments(const GlobalState &gs, ClassOrModuleRef klass, NameRe
             continue;
         }
         if (arg.type == nullptr) {
-            args.emplace_back(core::Types::untyped(gs, method));
+            args.emplace_back(core::Types::untyped(method));
             continue;
         }
         args.emplace_back(Types::resultTypeAsSeenFrom(gs, arg.type, data->owner, klass, targs));
@@ -1456,14 +1456,14 @@ DispatchResult AppliedType::dispatchCall(const GlobalState &gs, const DispatchAr
 
 TypePtr ClassType::getCallArguments(const GlobalState &gs, NameRef name) const {
     if (symbol == core::Symbols::untyped()) {
-        return Types::untyped(gs, Symbols::noSymbol());
+        return Types::untyped(Symbols::noSymbol());
     }
     return getMethodArguments(gs, symbol, name, vector<TypePtr>{});
 }
 
 TypePtr BlamedUntyped::getCallArguments(const GlobalState &gs, NameRef name) const {
     // BlamedUntyped are always untyped.
-    return Types::untyped(gs, blame);
+    return Types::untyped(blame);
 }
 
 TypePtr AppliedType::getCallArguments(const GlobalState &gs, NameRef name) const {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -625,7 +625,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             }
             return result;
         } else if (args.name == core::Names::super()) {
-            return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
+            return DispatchResult(Types::untyped(Symbols::Magic_UntypedSource_super()), std::move(args.selfType), Symbols::noMethod());
         }
         auto result = DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
         if (args.suppressErrors) {
@@ -3908,7 +3908,8 @@ public:
             res.returnType = core::Types::procClass();
             return;
         }
-        vector<core::TypePtr> targs(*numberOfPositionalBlockParams + 1, core::Types::untypedUntracked());
+        auto untypedWithBlame = core::Types::untyped(Symbols::Magic_UntypedSource_proc());
+        vector<core::TypePtr> targs(*numberOfPositionalBlockParams + 1, untypedWithBlame);
         auto procClass = core::Symbols::Proc(*numberOfPositionalBlockParams);
         res.returnType = make_type<core::AppliedType>(procClass, move(targs));
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -625,7 +625,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             }
             return result;
         } else if (args.name == core::Names::super()) {
-            return DispatchResult(Types::untyped(Symbols::Magic_UntypedSource_super()), std::move(args.selfType), Symbols::noMethod());
+            return DispatchResult(Types::untyped(Symbols::Magic_UntypedSource_super()), std::move(args.selfType),
+                                  Symbols::noMethod());
         }
         auto result = DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
         if (args.suppressErrors) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -415,7 +415,6 @@ MethodRef guessOverload(const GlobalState &gs, ClassOrModuleRef inClass, MethodR
 
         // If keyword args are present, interpret them as an untyped hash
         if (numPosArgs < args.size()) {
-            // TODO(neil): this should actually blame to an error recovery magic symbol
             checkArg(numPosArgs, Types::hashOfUntyped());
         }
     }
@@ -2145,7 +2144,7 @@ public:
         auto secondArgIsNil = other.isNilClass();
         if (firstArgIsNil) {
             if (secondArgIsNil) {
-                rangeElemType = Types::untyped(Symbols::Magic_UntypedSource_buildArray());
+                rangeElemType = Types::untyped(Symbols::Magic_UntypedSource_buildRange());
             } else {
                 rangeElemType = Types::dropNil(gs, other);
             }
@@ -2991,7 +2990,6 @@ public:
         if (!dispatched.main.errors.empty()) {
             // In case of an error, the splat is converted to an array with a single
             // element; be conservative in what we declare the element type to be.
-            // TODO(neil): this should actually blame to an error recovery magic symbol
             res.returnType = Types::arrayOfUntyped(Symbols::Magic_UntypedSource_splat());
         } else {
             res.returnType = dispatched.returnType;
@@ -3294,7 +3292,7 @@ public:
             // people's codebases to it.
             //
             // TODO(jez) This could be another "if you're in `typed: strict` you need typed shapes"
-            res.returnType = Types::untyped(Symbols::Magic_UntypedSource_squareBracketsEq());
+            res.returnType = Types::untyped(Symbols::Magic_UntypedSource_shapeSquareBracketsEq());
         }
     }
 } Shape_squareBracketsEq;

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -373,7 +373,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                                 result = make_type<TupleType>(move(elemLubs));
                             }
                         } else {
-                            result = Types::arrayOfUntyped();
+                            result = Types::arrayOfUntyped(Symbols::Magic_UntypedSource_tupleLub());
                         }
                     } else {
                         result = lub(gs, a1.underlying(gs), t2.underlying(gs));
@@ -392,7 +392,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                                 ++i;
                                 auto optind = h1.indexForKey(el2);
                                 if (!optind.has_value()) {
-                                    result = Types::hashOfUntyped();
+                                    result = Types::hashOfUntyped(Symbols::Magic_UntypedSource_shapeLub());
                                     return;
                                 }
                                 auto &inserted =
@@ -408,7 +408,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                                 result = make_type<ShapeType>(h2->keys, move(valueLubs));
                             }
                         } else {
-                            result = Types::hashOfUntyped();
+                            result = Types::hashOfUntyped(Symbols::Magic_UntypedSource_shapeLub());
                         }
                     } else {
                         bool allowProxyInLub = isa_type<TupleType>(t2);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1031,7 +1031,7 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
     }
 
     if (genericClass.data(gs)->typeMembers().empty()) {
-        return Types::untypedUntracked();
+        return Types::untyped(Symbols::Magic_UntypedSource_applyTypeArguments());
     }
 
     vector<TypePtr> targs;
@@ -1082,7 +1082,7 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
             if (validBounds) {
                 targs.emplace_back(argType);
             } else {
-                targs.emplace_back(Types::untypedUntracked());
+                targs.emplace_back(Types::untyped(Symbols::Magic_UntypedSource_applyTypeArguments()));
             }
 
             ++it;
@@ -1090,7 +1090,7 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
             auto tupleArgs = targs;
             targs.emplace_back(make_type<TupleType>(tupleArgs));
         } else {
-            targs.emplace_back(Types::untypedUntracked());
+            targs.emplace_back(Types::untyped(Symbols::Magic_UntypedSource_applyTypeArguments()));
         }
     }
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -76,21 +76,26 @@ TypePtr Types::Float() {
     return make_type<ClassType>(Symbols::Float());
 }
 
-TypePtr Types::arrayOfUntyped() {
-    static vector<TypePtr> targs{Types::untyped(Symbols::Magic_UntypedSource_ArrayOfUntyped())};
+TypePtr Types::arrayOfUntyped(sorbet::core::SymbolRef blame) {
+    static vector<TypePtr> targs{Types::untyped(blame)};
     static auto res = make_type<AppliedType>(Symbols::Array(), move(targs));
     return res;
 }
 
-TypePtr Types::rangeOfUntyped() {
-    static vector<TypePtr> targs{Types::untyped(Symbols::Magic_UntypedSource_RangeOfUntyped())};
+TypePtr Types::rangeOfUntyped(sorbet::core::SymbolRef blame) {
+    static vector<TypePtr> targs{Types::untyped(blame)};
     static auto res = make_type<AppliedType>(Symbols::Range(), move(targs));
     return res;
 }
 
 TypePtr Types::hashOfUntyped() {
-    // TODO: is it okay that we are sharing this untyped object?
-    auto untypedWithBlame = Types::untyped(Symbols::Magic_UntypedSource_HashOfUntyped());
+    static vector<TypePtr> targs{Types::untypedUntracked(), Types::untypedUntracked(), Types::untypedUntracked()};
+    static auto res = make_type<AppliedType>(Symbols::Hash(), move(targs));
+    return res;
+}
+
+TypePtr Types::hashOfUntyped(sorbet::core::SymbolRef blame) {
+    auto untypedWithBlame = Types::untyped(blame);
     static vector<TypePtr> targs{untypedWithBlame, untypedWithBlame, untypedWithBlame};
     static auto res = make_type<AppliedType>(Symbols::Hash(), move(targs));
     return res;
@@ -443,7 +448,7 @@ ShapeType::ShapeType(vector<TypePtr> keys, vector<TypePtr> values) : keys(move(k
 }
 
 TypePtr ShapeType::underlying(const GlobalState &gs) const {
-    return Types::hashOfUntyped();
+    return Types::hashOfUntyped(Symbols::Magic_UntypedSource_shapeUnderlying());
 }
 
 std::optional<size_t> ShapeType::indexForKey(const TypePtr &t) const {
@@ -506,7 +511,7 @@ std::optional<size_t> ShapeType::indexForKey(const FloatLiteralType &lit) const 
 
 TypePtr TupleType::underlying(const GlobalState &gs) const {
     if (this->elems.empty()) {
-        return Types::arrayOfUntyped();
+        return Types::arrayOfUntyped(Symbols::Magic_UntypedSource_tupleUnderlying());
     } else {
         return Types::arrayOf(gs, Types::dropLiteral(gs, Types::lubAll(gs, this->elems)));
     }

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -39,7 +39,7 @@ TypePtr Types::untypedUntracked() {
     return make_type<ClassType>(Symbols::untyped());
 }
 
-TypePtr Types::untyped(const sorbet::core::GlobalState &gs, sorbet::core::SymbolRef blame) {
+TypePtr Types::untyped(sorbet::core::SymbolRef blame) {
     if constexpr (!sorbet::track_untyped_blame_mode && !sorbet::debug_mode) {
         return untypedUntracked();
     }

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -77,19 +77,21 @@ TypePtr Types::Float() {
 }
 
 TypePtr Types::arrayOfUntyped() {
-    static vector<TypePtr> targs{Types::untypedUntracked()};
+    static vector<TypePtr> targs{Types::untyped(Symbols::Magic_UntypedSource_ArrayOfUntyped())};
     static auto res = make_type<AppliedType>(Symbols::Array(), move(targs));
     return res;
 }
 
 TypePtr Types::rangeOfUntyped() {
-    static vector<TypePtr> targs{Types::untypedUntracked()};
+    static vector<TypePtr> targs{Types::untyped(Symbols::Magic_UntypedSource_RangeOfUntyped())};
     static auto res = make_type<AppliedType>(Symbols::Range(), move(targs));
     return res;
 }
 
 TypePtr Types::hashOfUntyped() {
-    static vector<TypePtr> targs{Types::untypedUntracked(), Types::untypedUntracked(), Types::untypedUntracked()};
+    // TODO: is it okay that we are sharing this untyped object?
+    auto untypedWithBlame = Types::untyped(Symbols::Magic_UntypedSource_HashOfUntyped());
+    static vector<TypePtr> targs{untypedWithBlame, untypedWithBlame, untypedWithBlame};
     static auto res = make_type<AppliedType>(Symbols::Hash(), move(targs));
     return res;
 }

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1031,7 +1031,8 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
     }
 
     if (genericClass.data(gs)->typeMembers().empty()) {
-        return Types::untyped(Symbols::Magic_UntypedSource_applyTypeArguments());
+        // TODO(neil): this should actually blame to an error recovery magic symbol
+        return Types::untypedUntracked();
     }
 
     vector<TypePtr> targs;
@@ -1082,7 +1083,8 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
             if (validBounds) {
                 targs.emplace_back(argType);
             } else {
-                targs.emplace_back(Types::untyped(Symbols::Magic_UntypedSource_applyTypeArguments()));
+                // TODO(neil): this should actually blame to an error recovery magic symbol
+                targs.emplace_back(Types::untypedUntracked());
             }
 
             ++it;
@@ -1090,7 +1092,8 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
             auto tupleArgs = targs;
             targs.emplace_back(make_type<TupleType>(tupleArgs));
         } else {
-            targs.emplace_back(Types::untyped(Symbols::Magic_UntypedSource_applyTypeArguments()));
+            // TODO(neil): this should actually blame to an error recovery magic symbol
+            targs.emplace_back(Types::untypedUntracked());
         }
     }
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -916,18 +916,6 @@ void Environment::populateFrom(core::Context ctx, const Environment &other) {
     this->pinnedTypes = other.pinnedTypes;
 }
 
-core::TypePtr Environment::getReturnType(core::Context ctx, const core::TypePtr &procType) {
-    if (!procType.derivesFrom(ctx, core::Symbols::Proc())) {
-        return core::Types::untypedUntracked();
-    }
-    auto *applied = core::cast_type<core::AppliedType>(procType);
-    if (applied == nullptr || applied->targs.empty()) {
-        return core::Types::untypedUntracked();
-    }
-    // Proc types have their return type as the first targ
-    return applied->targs.front();
-}
-
 core::TypePtr flatmapHack(core::Context ctx, const core::TypePtr &receiver, const core::TypePtr &returnType,
                           core::NameRef fun, const core::Loc &loc) {
     if (fun != core::Names::flatMap()) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1104,10 +1104,10 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 if (send.link) {
                     // This should eventually become ENFORCEs but currently they are wrong
                     if (!retainedResult->main.blockReturnType) {
-                        retainedResult->main.blockReturnType = core::Types::untyped(ctx, retainedResult->main.method);
+                        retainedResult->main.blockReturnType = core::Types::untyped(retainedResult->main.method);
                     }
                     if (!retainedResult->main.blockPreType) {
-                        retainedResult->main.blockPreType = core::Types::untyped(ctx, retainedResult->main.method);
+                        retainedResult->main.blockPreType = core::Types::untyped(retainedResult->main.method);
                     }
                     ENFORCE(retainedResult->main.sendTp);
                 }
@@ -1198,7 +1198,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         tp.origins.emplace_back(symbol.loc(ctx));
                     } else {
                         tp.origins.emplace_back(core::Loc::none());
-                        tp.type = core::Types::untyped(ctx, symbol);
+                        tp.type = core::Types::untyped(symbol);
                     }
                 } else if (symbol.isTypeAlias(ctx)) {
                     ENFORCE(symbol.resultType(ctx) != nullptr);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1327,7 +1327,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     tuple->elems.front().derivesFrom(ctx, core::Symbols::Array())) {
                     tp.type = std::move(tuple->elems.front());
                 } else if (params == nullptr) {
-                    tp.type = core::Types::untypedUntracked();
+                    tp.type = core::Types::untyped(core::Symbols::Magic_UntypedSource_LoadYieldParams());
                 } else {
                     tp.type = params;
                 }
@@ -1348,7 +1348,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         const core::TypeAndOrigins &argsType = getAndFillTypeAndOrigin(ctx, i.yieldParam);
                         tp.type = argsType.type;
                     } else {
-                        tp.type = core::Types::untypedUntracked();
+                        tp.type = core::Types::untyped(core::Symbols::Magic_UntypedSource_YieldLoadArg());
                     }
                     tp.origins.emplace_back(ctx.locAt(bind.loc));
                     return;
@@ -1509,7 +1509,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::GetCurrentException &i) {
-                tp.type = core::Types::untypedUntracked();
+                tp.type = core::Types::untyped(core::Symbols::Magic_UntypedSource_GetCurrentException());
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::LoadSelf &l) {

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -186,10 +186,6 @@ class Environment {
     void assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef cond, core::Loc loc,
                          const UnorderedMap<cfg::LocalRef, VariableState> &filter);
 
-    // Extract the return value type from a proc. This should potentially be a
-    // method on `Type` or otherwise handled there.
-    core::TypePtr getReturnType(core::Context ctx, const core::TypePtr &procType);
-
     void cloneFrom(const Environment &rhs);
 
     core::TypeAndOrigins getTypeFromRebind(core::Context ctx, const core::DispatchComponent &main,

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -60,7 +60,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         } else if (cfg->symbol.data(ctx)->name.isAnyStaticInitName(ctx)) {
             methodReturnType = core::Types::top();
         } else {
-            methodReturnType = core::Types::untyped(ctx, cfg->symbol);
+            methodReturnType = core::Types::untyped(cfg->symbol);
         }
     } else {
         auto enclosingClass = cfg->symbol.enclosingClass(ctx);

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -31,7 +31,7 @@ void DefLocSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &
             if (localExp && lspQuery.matchesLoc(ctx.locAt(localExp->loc))) {
                 tp.type = argType.type;
                 if (tp.type == nullptr) {
-                    tp.type = core::Types::untyped(ctx, methodDef.symbol);
+                    tp.type = core::Types::untyped(methodDef.symbol);
                 }
                 tp.origins.emplace_back(ctx.locAt(localExp->loc));
                 core::lsp::QueryResponse::pushQueryResponse(
@@ -113,7 +113,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
                 tp.type = symbol.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx).data(ctx)->externalType();
             } else {
                 auto resultType = symbol.resultType(ctx);
-                tp.type = resultType == nullptr ? core::Types::untyped(ctx, symbol) : resultType;
+                tp.type = resultType == nullptr ? core::Types::untyped(symbol) : resultType;
             }
 
             core::lsp::ConstantResponse::Scopes scopes;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -226,7 +226,7 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
         result = targetClass.data(gs)->externalType();
     } else {
         auto resultType = constant.resultType(gs);
-        result = resultType == nullptr ? core::Types::untyped(gs, constant) : resultType;
+        result = resultType == nullptr ? core::Types::untyped(constant) : resultType;
     }
 
     if (constant.isTypeAlias(gs)) {

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -106,7 +106,7 @@ bool resolveTypeMember(core::GlobalState &gs, core::ClassOrModuleRef parent, cor
 
         auto typeMember = gs.enterTypeMember(sym.data(gs)->loc(), sym, name, core::Variance::Invariant);
         typeMember.data(gs)->flags.isFixed = true;
-        auto untyped = core::Types::untyped(gs, sym);
+        auto untyped = core::Types::untyped(sym);
         typeMember.data(gs)->resultType = core::make_type<core::LambdaParam>(typeMember, untyped, untyped);
         typeAliases[sym.id()].emplace_back(parentTypeMember, typeMember);
         return false;
@@ -132,7 +132,7 @@ bool resolveTypeMember(core::GlobalState &gs, core::ClassOrModuleRef parent, cor
         auto synthesizedName = gs.freshNameUnique(core::UniqueNameKind::TypeVarName, name, 1);
         auto typeMember = gs.enterTypeMember(sym.data(gs)->loc(), sym, synthesizedName, core::Variance::Invariant);
         typeMember.data(gs)->flags.isFixed = true;
-        auto untyped = core::Types::untyped(gs, sym);
+        auto untyped = core::Types::untyped(sym);
         typeMember.data(gs)->resultType = core::make_type<core::LambdaParam>(typeMember, untyped, untyped);
         typeAliases[sym.id()].emplace_back(parentTypeMember, typeMember);
         return false;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -700,7 +700,7 @@ private:
                         e.addErrorLine(ctx.locAt(job.out->original.loc()), "Type alias used here");
                     }
 
-                    resolvedField.data(gs)->resultType = core::Types::untyped(ctx, resolved);
+                    resolvedField.data(gs)->resultType = core::Types::untyped(resolved);
                 }
             }
             job.out->symbol = resolved;
@@ -931,7 +931,7 @@ private:
                 e.setHeader("Type aliases are not allowed in generic classes");
                 e.addErrorLine(enclosingTypeMember.data(ctx)->loc(), "Here is enclosing generic member");
             }
-            job.lhs.setResultType(ctx, core::Types::untyped(ctx, job.lhs));
+            job.lhs.setResultType(ctx, core::Types::untyped(job.lhs));
             return true;
         }
         if (isFullyResolved(ctx, rhs)) {
@@ -3691,7 +3691,7 @@ private:
                 }
 
                 if (arg.type == nullptr) {
-                    arg.type = core::Types::untyped(ctx, method);
+                    arg.type = core::Types::untyped(method);
                 }
 
                 // We silence the "type not specified" error when a sig does not mention the synthesized block arg.

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -880,8 +880,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
             }
         }
         case core::Names::untyped().rawId():
-            return TypeSyntax::ResultType{core::Types::untyped(ctx, args.untypedBlame),
-                                          core::Symbols::noClassOrModule()};
+            return TypeSyntax::ResultType{core::Types::untyped(args.untypedBlame), core::Symbols::noClassOrModule()};
         case core::Names::selfType().rawId():
             if (args.allowSelfType) {
                 return TypeSyntax::ResultType{core::make_type<core::SelfType>(), core::Symbols::noClassOrModule()};


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible 
changes. -->

Adds new magic symbols that denote sources of untyped, and updates a few places to use them along with `types::untyped` rather than `types::untypedUntracked`. If the untyped blames to `<root>#<none>` is still large after this, we can add symbols to more places where untyped is used.

Example with running sorbet with the `--track-untyped` flag on the following code:
```
# typed: true
class TestUntyped
  def test_shaped
    b = {
      1 => 2,
      2 => 3,
      foo: :bar
    }
    b[1].bar
  end

  def test_super
    a = super
    a.foo
  end
end
```

```
[{"path":"<none>","package":"<none>","owner":"<Magic>::<UntypedSource>","name":"<HashOfUntyped>","count":2},
{"path":"<none>","package":"<none>","owner":"<Magic>::<UntypedSource>","name":"<super>","count":2}
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Better tracking of untyped for cases that currently blame to `root#none`

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-pr-on-payserver and a few manual test cases.