### PR TITLE
be more parsimonious when replacing methods

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -94,7 +94,7 @@ module T::Private::ClassUtils
   # overriding it (if it is defined by one of mod's ancestors). Returns a ReplacedMethod instance
   # on which you can call `bind(...).call(...)` to call the original method, or `restore` to
   # restore the original method (by overwriting or removing the override).
-  def self.replace_method(mod, name, &blk)
+  def self.replace_method(mod, name, original_only=false, &blk)
     original_method = mod.instance_method(name)
     original_visibility = visibility_method_name(mod, name)
     original_owner = original_method.owner
@@ -120,8 +120,12 @@ module T::Private::ClassUtils
         def_with_visibility(mod, name, original_visibility, &blk)
       end
     end
-    new_method = mod.instance_method(name)
 
-    ReplacedMethod.new(mod, original_method, new_method, overwritten, original_visibility)
+    if original_only
+      original_method
+    else
+      new_method = mod.instance_method(name)
+      ReplacedMethod.new(mod, original_method, new_method, overwritten, original_visibility)
+    end
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -91,9 +91,12 @@ module T::Private::ClassUtils
   end
 
   # Replaces a method, either by overwriting it (if it is defined directly on `mod`) or by
-  # overriding it (if it is defined by one of mod's ancestors). Returns a ReplacedMethod instance
-  # on which you can call `bind(...).call(...)` to call the original method, or `restore` to
-  # restore the original method (by overwriting or removing the override).
+  # overriding it (if it is defined by one of mod's ancestors).  If `original_only` is
+  # false, returns a ReplacedMethod instance on which you can call `bind(...).call(...)`
+  # to call the original method, or `restore` to restore the original method (by
+  # overwriting or removing the override).
+  #
+  # If `original_only` is true, return the `UnboundMethod` representing the original method.
   def self.replace_method(mod, name, original_only=false, &blk)
     original_method = mod.instance_method(name)
     original_visibility = visibility_method_name(mod, name)

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -14,7 +14,7 @@ module T::Private::Methods::CallValidation
   def self.wrap_method_if_needed(mod, method_sig, original_method)
     original_visibility = visibility_method_name(mod, method_sig.method_name)
     if method_sig.mode == T::Private::Methods::Modes.abstract
-      T::Private::ClassUtils.replace_method(mod, method_sig.method_name) do |*args, &blk|
+      T::Private::ClassUtils.replace_method(mod, method_sig.method_name, true) do |*args, &blk|
         # TODO: write a cop to ensure that abstract methods have an empty body
         #
         # We allow abstract methods to be implemented by things further down the ancestor chain.

--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -10,7 +10,7 @@ end
 class T::Struct < T::InexactStruct
   def self.inherited(subclass)
     super(subclass)
-    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited) do |s|
+    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited, true) do |s|
       super(s)
       raise "#{self.name} is a subclass of T::Struct and cannot be subclassed"
     end
@@ -23,7 +23,7 @@ class T::ImmutableStruct < T::InexactStruct
   def self.inherited(subclass)
     super(subclass)
 
-    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited) do |s|
+    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited, true) do |s|
       super(s)
       raise "#{self.name} is a subclass of T::ImmutableStruct and cannot be subclassed"
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

In most of the places inside `sorbet-runtime` where we call `replace_method`, we mostly care about the side effect of replacing the method in question, and not about the return value.  In most places where we poke at the return value, we only care about calling `bind()` on it, with a subsequent `call()` at some point.

Ergo, allocating a `ReplacedMethod` object is really the uncommon case, and we should avoid allocating a `ReplacedMethod` if we don't need to.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These objects and the callsites for `bind`/`call` were showing up on some allocation profiles for preloading Stripe services..

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
