### PR TITLE
Add `Psych.safe_load_file` definition

### DIFF
--- a/rbi/stdlib/psych.rbi
+++ b/rbi/stdlib/psych.rbi
@@ -630,6 +630,14 @@ module Psych
   # specified `fallback` return value, which defaults to `false`.
   sig { params(filename: T.any(String, Pathname), kwargs: T.untyped).returns(T.untyped) }
   def self.load_file(filename, **kwargs); end
+
+  ###
+  # Safely loads the document contained in +filename+.  Returns the yaml contained in
+  # +filename+ as a Ruby object, or if the file is empty, it returns
+  # the specified +fallback+ return value, which defaults to +false+.
+  # See safe_load for options.
+  sig { params(filename: T.any(String, Pathname), kwargs: T.untyped).returns(T.untyped) }
+  def self.safe_load_file(filename, **kwargs); end
 end
 
 class Psych::Exception < RuntimeError


### PR DESCRIPTION
Adding `Psych.safe_load_file` ([source](https://github.com/ruby/psych/blob/da3b799544a04e620ab042311a8c3ea61af69108/lib/psych.rb#L653-L662)).

Note that `safe_load_file` is only available in Ruby 3+.  If I should be adding a guard to this, I'd appreciate someone pointing me at an example elsewhere in the codebase 🙏 

### Motivation
[Rubocop's new `Style/YAMLFileRead` rule](https://github.com/rubocop/rubocop/pull/11745) recommends `YAML.safe_load_file(path)` over `YAML.safe_load(File.read(path))`.

### Test plan
I don't see tests for `safe_load`, so I think I don't have to test this.  Please let me know if I'm incorrect.