### PR TITLE
remove `sorbet_ruby_3_0` from the build

### DIFF
--- a/third_party/ruby/ruby-versions.txt
+++ b/third_party/ruby/ruby-versions.txt
@@ -1,3 +1,2 @@
 sorbet_ruby_2_7
-sorbet_ruby_3_0
 sorbet_ruby_3_1

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -67,14 +67,6 @@ def register_ruby_dependencies():
     )
 
     http_archive(
-        name = "sorbet_ruby_3_0",
-        urls = _ruby_urls("3.0/ruby-3.0.4.tar.gz"),
-        sha256 = "70b47c207af04bce9acea262308fb42893d3e244f39a4abc586920a1c723722b",
-        strip_prefix = "ruby-3.0.4",
-        build_file = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD",
-    )
-
-    http_archive(
         name = "sorbet_ruby_3_1",
         urls = _ruby_urls("3.1/ruby-3.1.2.tar.gz"),
         sha256 = "61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We are planning on skipping 3.0 and moving to 3.1 directly, so we don't need to keep this extra build around.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
