### PR TITLE
lazily allocate structures in `Signature#initialize`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -39,8 +39,6 @@ class T::Private::Methods::Signature
   def initialize(method:, method_name:, raw_arg_types:, raw_return_type:, bind:, mode:, check_level:, on_failure:, parameters: method.parameters, override_allow_incompatible: false, defined_raw: false)
     @method = method
     @method_name = method_name
-    @arg_types = []
-    @kwarg_types = {}
     @block_type = nil
     @block_name = nil
     @rest_type = nil
@@ -51,14 +49,17 @@ class T::Private::Methods::Signature
     @bind = bind ? T::Utils.coerce(bind) : bind
     @mode = mode
     @check_level = check_level
-    @req_arg_count = 0
-    @req_kwarg_names = []
     @has_rest = false
     @has_keyrest = false
     @parameters = parameters
     @on_failure = on_failure
     @override_allow_incompatible = override_allow_incompatible
     @defined_raw = defined_raw
+
+    arg_types = nil
+    kwarg_types = nil
+    req_arg_count = 0
+    req_kwarg_names = nil
 
     # If sig params are declared but there is a single parameter with a missing name
     # **and** the method ends with a "=", assume it is a writer method generated
@@ -109,7 +110,7 @@ class T::Private::Methods::Signature
 
       case param_kind
       when :req
-        if @arg_types.length > @req_arg_count
+        if (arg_types ? arg_types.length : 0) > req_arg_count
           # Note that this is actually is supported by Ruby, but it would add complexity to
           # support it here, and I'm happy to discourage its use anyway.
           #
@@ -120,14 +121,14 @@ class T::Private::Methods::Signature
           # see this error. The simplest resolution is to rename your method.
           raise "Required params after optional params are not supported in method declarations. Method: #{method_desc}"
         end
-        @arg_types << [param_name, type]
-        @req_arg_count += 1
+        (arg_types ||= []) << [param_name, type]
+        req_arg_count += 1
       when :opt
-        @arg_types << [param_name, type]
+        (arg_types ||= []) << [param_name, type]
       when :key, :keyreq
-        @kwarg_types[param_name] = type
+        (kwarg_types ||= {})[param_name] = type
         if param_kind == :keyreq
-          @req_kwarg_names << param_name
+          (req_kwarg_names ||= []) << param_name
         end
       when :block
         @block_name = param_name
@@ -146,6 +147,11 @@ class T::Private::Methods::Signature
 
       i += 1
     end
+
+    @arg_types = arg_types || EMPTY_LIST
+    @kwarg_types = kwarg_types || EMPTY_HASH
+    @req_arg_count = req_arg_count
+    @req_kwarg_names = req_kwarg_names || EMPTY_LIST
   end
 
   attr_writer :method_name
@@ -238,5 +244,6 @@ class T::Private::Methods::Signature
     "#{@method} at #{loc}"
   end
 
+  EMPTY_LIST = [].freeze
   EMPTY_HASH = {}.freeze
 end

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -57,10 +57,10 @@ class T::Private::Methods::Signature
     @defined_raw = defined_raw
 
     # Use T.unsafe in lieu of T.let(..., T.nilable(...))
-    arg_types = T.unsafe(nil)
-    kwarg_types = T.unsafe(nil)
+    arg_types = T.let(nil, T.untyped)
+    kwarg_types = T.let(nil, T.untyped)
     req_arg_count = 0
-    req_kwarg_names = T.unsafe(nil)
+    req_kwarg_names = T.let(nil, T.untyped)
 
     # If sig params are declared but there is a single parameter with a missing name
     # **and** the method ends with a "=", assume it is a writer method generated
@@ -122,14 +122,14 @@ class T::Private::Methods::Signature
           # see this error. The simplest resolution is to rename your method.
           raise "Required params after optional params are not supported in method declarations. Method: #{method_desc}"
         end
-        (arg_types ||= T.unsafe([])) << [param_name, type]
+        (arg_types ||= []) << [param_name, type]
         req_arg_count += 1
       when :opt
-        (arg_types ||= T.unsafe([])) << [param_name, type]
+        (arg_types ||= []) << [param_name, type]
       when :key, :keyreq
-        (kwarg_types ||= T.unsafe({}))[param_name] = type
+        (kwarg_types ||= {})[param_name] = type
         if param_kind == :keyreq
-          (req_kwarg_names ||= T.unsafe([])) << param_name
+          (req_kwarg_names ||= []) << param_name
         end
       when :block
         @block_name = param_name

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -56,10 +56,11 @@ class T::Private::Methods::Signature
     @override_allow_incompatible = override_allow_incompatible
     @defined_raw = defined_raw
 
-    arg_types = nil
-    kwarg_types = nil
+    # Use T.unsafe in lieu of T.let(..., T.nilable(...))
+    arg_types = T.unsafe(nil)
+    kwarg_types = T.unsafe(nil)
     req_arg_count = 0
-    req_kwarg_names = nil
+    req_kwarg_names = T.unsafe(nil)
 
     # If sig params are declared but there is a single parameter with a missing name
     # **and** the method ends with a "=", assume it is a writer method generated

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -56,7 +56,7 @@ class T::Private::Methods::Signature
     @override_allow_incompatible = override_allow_incompatible
     @defined_raw = defined_raw
 
-    # Use T.unsafe in lieu of T.let(..., T.nilable(...))
+    # Use T.untyped in lieu of T.nilable to try to avoid unnecessary allocations.
     arg_types = T.let(nil, T.untyped)
     kwarg_types = T.let(nil, T.untyped)
     req_arg_count = 0

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -122,14 +122,14 @@ class T::Private::Methods::Signature
           # see this error. The simplest resolution is to rename your method.
           raise "Required params after optional params are not supported in method declarations. Method: #{method_desc}"
         end
-        (arg_types ||= []) << [param_name, type]
+        (arg_types ||= T.unsafe([])) << [param_name, type]
         req_arg_count += 1
       when :opt
-        (arg_types ||= []) << [param_name, type]
+        (arg_types ||= T.unsafe([])) << [param_name, type]
       when :key, :keyreq
-        (kwarg_types ||= {})[param_name] = type
+        (kwarg_types ||= T.unsafe({}))[param_name] = type
         if param_kind == :keyreq
-          (req_kwarg_names ||= []) << param_name
+          (req_kwarg_names ||= T.unsafe([])) << param_name
         end
       when :block
         @block_name = param_name


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We allocate lists and hashes for several things in our internal `Signature` object:

* argument types for positional arguments
* argument types for kwargs
* required kwarg names

We unconditionally allocate these, even though most functions tilt towards positional or kwargs, but not both.  e.g. Stripe's codebase is majority positional-argument only functions.

We can save some memory by lazily allocating these objects, and using frozen copies if it turned out that we never allocated them, so as to present the same interface to the outside world (e.g. Tapioca).

We sneak in a change to use local variables for the core loop, since those are epsilon faster to access than instance variables.

This change saves not quite 2% of the memory allocated by `sorbet-runtime` when preloading Stripe's main service.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
