### PR TITLE
Write the blame symbol when pickling BlamedUntyped

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -418,7 +418,10 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
     switch (what.tag()) {
         case TypePtr::Tag::UnresolvedAppliedType:
         case TypePtr::Tag::UnresolvedClassType:
-        case TypePtr::Tag::BlamedUntyped:
+        case TypePtr::Tag::BlamedUntyped: {
+            p.putU4(what.untypedBlame().rawId());
+            break;
+        }
         case TypePtr::Tag::ClassType: {
             auto c = cast_type_nonnull<ClassType>(what);
             p.putU4(c.symbol.id());
@@ -521,7 +524,10 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
     }
 
     switch (static_cast<TypePtr::Tag>(tag)) {
-        case TypePtr::Tag::BlamedUntyped:
+        case TypePtr::Tag::BlamedUntyped: {
+            SymbolRef blame = SymbolRef::fromRaw(p.getU4());
+            return make_type<BlamedUntyped>(blame);
+        }
         case TypePtr::Tag::UnresolvedClassType:
         case TypePtr::Tag::UnresolvedAppliedType:
         case TypePtr::Tag::ClassType:

--- a/test/cli/untyped-blames/a.rb
+++ b/test/cli/untyped-blames/a.rb
@@ -3,12 +3,12 @@ class TestUntyped
   extend T::Sig
   
   sig { returns(T.untyped) }
-  def test
+  def test2
     2
   end
 
   def local_call
-    a = test
+    a = test2
   end
 
   def unsafe

--- a/test/cli/untyped-blames/a.rb
+++ b/test/cli/untyped-blames/a.rb
@@ -1,0 +1,21 @@
+# typed: true
+class TestUntyped
+  extend T::Sig
+  
+  sig { returns(T.untyped) }
+  def test
+    2
+  end
+
+  def local_call
+    a = test
+  end
+
+  def unsafe
+    T.unsafe(1)
+  end
+
+  def method_call
+    Method.new.call
+  end
+end

--- a/test/cli/untyped-blames/a.rb
+++ b/test/cli/untyped-blames/a.rb
@@ -3,12 +3,12 @@ class TestUntyped
   extend T::Sig
   
   sig { returns(T.untyped) }
-  def test2
+  def test
     2
   end
 
   def local_call
-    a = test2
+    a = test
   end
 
   def unsafe

--- a/test/cli/untyped-blames/test.out
+++ b/test/cli/untyped-blames/test.out
@@ -1,0 +1,24 @@
+No errors! Great job.
+[
+  {
+    "path": "https://github.com/sorbet/sorbet/tree/master/rbi/core/method.rbi",
+    "package": "<none>",
+    "owner": "Method",
+    "name": "call",
+    "count": 1
+  },
+  {
+    "path": "test/cli/untyped-blames/a.rb",
+    "package": "<none>",
+    "owner": "TestUntyped",
+    "name": "test",
+    "count": 1
+  },
+  {
+    "path": "https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi",
+    "package": "<none>",
+    "owner": "T.class_of(T)",
+    "name": "unsafe",
+    "count": 1
+  }
+]

--- a/test/cli/untyped-blames/test.sh
+++ b/test/cli/untyped-blames/test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main/sorbet --silence-dev-message --track-untyped --print=untyped-blame:untyped-blames.json --max-threads=0 test/cli/untyped-blames 2>&1
+cat untyped-blames.json | jq 'sort_by(.name)'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`T.untyped`s coming from methods defined in payload RBIs had no untyped blame symbol, because it wasn't serialized after we computed the initial global state.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Better tracking of `T.untyped`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

`test-pr-on-pay-server` + manual test:
```ruby
# typed: true
class TestUntyped
  extend T::Sig
  
  sig { returns(T.untyped) }
  def test
    2
  end

  def local_call
    a = test
  end

  def unsafe
    T.unsafe(1)
  end

  def method_call
    Method.new.call
  end
end
```
```
[{"path":"https://github.com/sorbet/sorbet/tree/master/rbi/core/method.rbi","package":"<none>","owner":"Method","name":"call","count":1},
{"path":"untyped_track.rb","package":"<none>","owner":"TestUntyped","name":"test","count":1},
{"path":"https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi","package":"<none>","owner":"T.class_of(T)","name":"unsafe","count":1}]
```