### PR TITLE
backport ruby patch for bad loaded features behavior

### DIFF
--- a/third_party/ruby/rb-provide-feature.patch
+++ b/third_party/ruby/rb-provide-feature.patch
@@ -1,0 +1,15 @@
+diff --git load.c load.c
+index 812fe2fe93..bc0571124d 100644
+--- load.c
++++ load.c
+@@ -625,6 +625,10 @@ rb_provide_feature(rb_vm_t *vm, VALUE feature)
+     rb_str_freeze(feature);
+ 
+     get_loaded_features_index(vm);
++    // If loaded_features and loaded_features_snapshot share the same backing
++    // array, pushing into it would cause the whole array to be copied.
++    // To avoid this we first clear loaded_features_snapshot.
++    rb_ary_clear(vm->loaded_features_snapshot);
+     rb_ary_push(features, rb_fstring(feature));
+     features_index_add(vm, feature, INT2FIX(RARRAY_LEN(features)-1));
+     reset_loaded_features_snapshot(vm);

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -90,6 +90,7 @@ def register_ruby_dependencies():
         patches = [
             "@com_stripe_ruby_typer//third_party/ruby:penelope_procc-3_1.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by-3_1.patch",  # https://github.com/ruby/ruby/pull/6791
+            "@com_stripe_ruby_typer//third_party/ruby:rb-provide-feature.patch",  # https://github.com/ruby/ruby/pull/5593
         ],
     )
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Seems like this patch could plausibly fix some runaway allocations while preloading Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
