### PR TITLE
Raise exception when `link` initialization fails during `statsd` init

### DIFF
--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -77,8 +77,7 @@ public:
     StatsdClientWrapper(string host, int port, string prefix)
         : link(statsd_init_with_namespace(host.c_str(), port, cleanMetricName(prefix).c_str())) {
         if (link == nullptr) {
-            Exception::raise("statsd initialization failed: link == nullptr. host: {} port: {} prefix: {}", host, port,
-                             prefix);
+            Exception::raise("statsd initialization failed: host: {} port: {} prefix: {}", host, port, prefix);
         }
     }
 

--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -77,7 +77,7 @@ public:
     StatsdClientWrapper(string host, int port, string prefix)
         : link(statsd_init_with_namespace(host.c_str(), port, cleanMetricName(prefix).c_str())) {
         if (link == nullptr) {
-            Exception::raise("statsd initialization failed: host: {} port: {} prefix: {}", host, port, prefix);
+            Exception::raise("statsd initialization failed: host={} port={} prefix={}", host, port, prefix);
         }
     }
 

--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -49,6 +49,8 @@ class StatsdClientWrapper {
     }
 
     void addMetric(string_view name, size_t value, string_view type, vector<pair<const char *, const char *>> tags) {
+        ENFORCE(link != nullptr);
+
         for (const auto &[key, value] : extraGlobalTags) {
             tags.emplace_back(key.c_str(), value.c_str());
         }
@@ -73,7 +75,12 @@ class StatsdClientWrapper {
 
 public:
     StatsdClientWrapper(string host, int port, string prefix)
-        : link(statsd_init_with_namespace(host.c_str(), port, cleanMetricName(prefix).c_str())) {}
+        : link(statsd_init_with_namespace(host.c_str(), port, cleanMetricName(prefix).c_str())) {
+        if (link == nullptr) {
+            Exception::raise("statsd initialization failed: link == nullptr. host: {} port: {} prefix: {}", host, port,
+                             prefix);
+        }
+    }
 
     ~StatsdClientWrapper() {
         if (!packet.empty()) {

--- a/test/cli/statsd-invalid-link/test.out
+++ b/test/cli/statsd-invalid-link/test.out
@@ -1,12 +1,2 @@
-No errors! Great job.
-Name or service not known
 Exception::raise(): statsd initialization failed: host: f4K#l1N&.com port: 8200 prefix: foo.bar.counters
-
-Backtrace:
-  #3 0xef93fc sorbet::StatsD::submitCounters()
-  #4 0xb8be92 sorbet::realmain::realmain()
-  #5 0xb85662 main
-  #6 0x7fa6cf576083 __libc_start_main
-  #7 0xb8556e _start
-
 caught N6sorbet15SorbetExceptionE: statsd initialization failed: host: f4K#l1N&.com port: 8200 prefix: foo.bar.counters

--- a/test/cli/statsd-invalid-link/test.out
+++ b/test/cli/statsd-invalid-link/test.out
@@ -1,0 +1,12 @@
+No errors! Great job.
+Name or service not known
+Exception::raise(): statsd initialization failed: host: f4K#l1N&.com port: 8200 prefix: foo.bar.counters
+
+Backtrace:
+  #3 0xef93fc sorbet::StatsD::submitCounters()
+  #4 0xb8be92 sorbet::realmain::realmain()
+  #5 0xb85662 main
+  #6 0x7fa6cf576083 __libc_start_main
+  #7 0xb8556e _start
+
+caught N6sorbet15SorbetExceptionE: statsd initialization failed: host: f4K#l1N&.com port: 8200 prefix: foo.bar.counters

--- a/test/cli/statsd-invalid-link/test.out
+++ b/test/cli/statsd-invalid-link/test.out
@@ -1,2 +1,2 @@
-Exception::raise(): statsd initialization failed: host: f4K#l1N&.com port: 8200 prefix: foo.bar.counters
-caught N6sorbet15SorbetExceptionE: statsd initialization failed: host: f4K#l1N&.com port: 8200 prefix: foo.bar.counters
+Exception::raise(): statsd initialization failed: host=f4K#l1N&.com port=8200 prefix=foo.bar.counters
+caught N6sorbet15SorbetExceptionE: statsd initialization failed: host=f4K#l1N&.com port=8200 prefix=foo.bar.counters

--- a/test/cli/statsd-invalid-link/test.sh
+++ b/test/cli/statsd-invalid-link/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# checking exception is raised when host is invlaid
+main/sorbet --silence-dev-message -e 'class Foo; end' --statsd-host="f4K#l1N&.com" --statsd-prefix=foo.bar

--- a/test/cli/statsd-invalid-link/test.sh
+++ b/test/cli/statsd-invalid-link/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # checking exception is raised when host is invlaid
-main/sorbet --silence-dev-message -e 'class Foo; end' --statsd-host="f4K#l1N&.com" --statsd-prefix=foo.bar
+main/sorbet --silence-dev-message -e 'class Foo; end' --statsd-host="f4K#l1N&.com" --statsd-prefix=foo.bar 2> >(grep --color=never "statsd initialization failed")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We should fail loudly and clearly when `statsd` initialization fails and `link` is `nullptr`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
