### PR TITLE
Clean up `config.ts`.

### DIFF
--- a/vscode_extension/src/sorbetExtensionContext.ts
+++ b/vscode_extension/src/sorbetExtensionContext.ts
@@ -13,15 +13,15 @@ export class SorbetExtensionContext implements Disposable {
   private readonly wrappedLog: OutputChannelLog;
 
   constructor(context: ExtensionContext) {
-    this.configuration = new SorbetExtensionConfig(
-      new DefaultSorbetWorkspaceContext(context),
-    );
+    const sorbetWorkspaceContext = new DefaultSorbetWorkspaceContext(context);
+    this.configuration = new SorbetExtensionConfig(sorbetWorkspaceContext);
     this.extensionContext = context;
     this.wrappedLog = new OutputChannelLog("Sorbet");
     this.metrics = new MetricClient(this);
     this.statusProvider = new SorbetStatusProvider(this);
 
     this.disposable = Disposable.from(
+      sorbetWorkspaceContext,
       this.configuration,
       this.statusProvider,
       this.wrappedLog,

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -51,6 +51,8 @@ class FakeWorkspaceConfiguration implements ISorbetWorkspaceContext {
     this.defaults = new Map<String, any>(defaultValues);
   }
 
+  dispose() {}
+
   get<T>(section: string, defaultValue: T): T {
     if (this.backingStore.has(section)) {
       return this.backingStore.get(section);
@@ -129,60 +131,31 @@ suite("SorbetLspConfig", () => {
     ctorArg.description = "modified";
     ctorArg.cwd = "modified";
     ctorArg.command.push("modified");
-    assert.equal(
+    assert.strictEqual(
       lspConfig.id,
       "one",
       "Modifying ctor id should not affect object",
     );
-    assert.equal(
+    assert.strictEqual(
       lspConfig.name,
       "two",
       "Modifying ctor name should not affect object",
     );
-    assert.equal(
+    assert.strictEqual(
       lspConfig.description,
       "three",
       "Modifying ctor description should not affect object",
     );
-    assert.equal(
+    assert.strictEqual(
       lspConfig.cwd,
       "four",
       "Modifying ctor cwd should not affect object",
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       lspConfig.command,
       ["five", "six"],
       "Modifying ctor command should not affect object",
     );
-  });
-
-  test("toJSON() result should be deeply equal to ctor json", () => {
-    const json = {
-      id: "one",
-      name: "two",
-      description: "three",
-      cwd: "four",
-      command: ["five", "six"],
-    };
-    const lspConfig = new SorbetLspConfig(json);
-    const toJson = lspConfig.toJSON();
-    assert.notEqual(json, toJson, "Should not be identical");
-    assert.deepEqual(json, toJson, "Should be deeply equal");
-  });
-
-  test("toJSON() results should be deeply equal", () => {
-    const json = {
-      id: "one",
-      name: "two",
-      description: "three",
-      cwd: "four",
-      command: ["five", "six"],
-    };
-    const lspConfig = new SorbetLspConfig(json);
-    const toJson = lspConfig.toJSON();
-    const toJson2 = lspConfig.toJSON();
-    assert.notEqual(toJson, toJson2, "Should not be identical object");
-    assert.deepEqual(toJson, toJson2, "Should be deeply equal");
   });
 
   suite("equality", () => {
@@ -241,13 +214,17 @@ suite("SorbetExtensionConfig", async () => {
       test("sorbet is disabled", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration();
         const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
-        assert.equal(sorbetConfig.enabled, false, "should not be enabled");
+        assert.strictEqual(
+          sorbetConfig.enabled,
+          false,
+          "should not be enabled",
+        );
         assert.deepStrictEqual(
           sorbetConfig.selectedLspConfig,
           new SorbetLspConfig(workspaceConfig.defaults.get("lspConfigs")[0]),
           "LSP configs should have been set to first default",
         );
-        assert.equal(
+        assert.strictEqual(
           sorbetConfig.activeLspConfig,
           null,
           "should not have an active LSP config",
@@ -274,23 +251,27 @@ suite("SorbetExtensionConfig", async () => {
       test("populates SorbetExtensionConfig", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration([
           ["enabled", true],
-          ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+          ["lspConfigs", [fooLspConfig, barLspConfig]],
           ["selectedLspConfigId", "bar"],
         ]);
         const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
-        assert.equal(sorbetConfig.enabled, true, "extension should be enabled");
+        assert.strictEqual(
+          sorbetConfig.enabled,
+          true,
+          "extension should be enabled",
+        );
         const { lspConfigs, selectedLspConfig, activeLspConfig } = sorbetConfig;
-        assert.equal(
+        assert.strictEqual(
           lspConfigs.length,
           2,
           "Should have two configs (foo and bar)",
         );
-        assert.equal(
+        assert.strictEqual(
           selectedLspConfig && selectedLspConfig.id,
           barLspConfig.id,
           "selected config should be bar",
         );
-        assert.equal(
+        assert.strictEqual(
           activeLspConfig,
           selectedLspConfig,
           "Active config should be same as selected",
@@ -306,18 +287,22 @@ suite("SorbetExtensionConfig", async () => {
           .returns(false);
 
         const workspaceConfig = new FakeWorkspaceConfiguration([
-          ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+          ["lspConfigs", [fooLspConfig, barLspConfig]],
           ["selectedLspConfigId", barLspConfig.id],
         ]);
         const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
-        assert.equal(sorbetConfig.enabled, false, "should not be enabled");
+        assert.strictEqual(
+          sorbetConfig.enabled,
+          false,
+          "should not be enabled",
+        );
         const { selectedLspConfig } = sorbetConfig;
-        assert.equal(
+        assert.strictEqual(
           selectedLspConfig && selectedLspConfig.id,
           barLspConfig.id,
           "should have a selected LSP config",
         );
-        assert.equal(
+        assert.strictEqual(
           sorbetConfig.activeLspConfig,
           null,
           "but should not have an active LSP config",
@@ -329,17 +314,17 @@ suite("SorbetExtensionConfig", async () => {
       test("when `sorbet.selectedLspConfigId` is missing", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration([
           ["enabled", true],
-          ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+          ["lspConfigs", [fooLspConfig, barLspConfig]],
         ]);
         const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
-        assert.equal(sorbetConfig.enabled, true, "should be enabled");
+        assert.strictEqual(sorbetConfig.enabled, true, "should be enabled");
         const { selectedLspConfig } = sorbetConfig;
-        assert.equal(
+        assert.strictEqual(
           selectedLspConfig && selectedLspConfig.id,
           fooLspConfig.id,
           "selectedLspConfig should default to first config",
         );
-        assert.equal(
+        assert.strictEqual(
           sorbetConfig.activeLspConfig,
           selectedLspConfig,
           "activeLspConfig should also default to first config",
@@ -349,17 +334,17 @@ suite("SorbetExtensionConfig", async () => {
       test("when `sorbet.selectedLspConfigId` matches none of the defined `sorbet.lspConfigs`", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration([
           ["enabled", true],
-          ["lspConfigs", [fooLspConfig.toJSON()]],
+          ["lspConfigs", [fooLspConfig]],
           ["selectedLspConfigId", barLspConfig.id],
         ]);
         const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
-        assert.equal(sorbetConfig.enabled, true, "should be enabled");
-        assert.equal(
+        assert.strictEqual(sorbetConfig.enabled, true, "should be enabled");
+        assert.strictEqual(
           sorbetConfig.selectedLspConfig,
           undefined,
           "selectedLspConfig should be undefined",
         );
-        assert.equal(
+        assert.strictEqual(
           sorbetConfig.activeLspConfig,
           undefined,
           "activeLspConfig should be undefined",
@@ -369,7 +354,7 @@ suite("SorbetExtensionConfig", async () => {
       test("multiple instances of SorbetExtensionConfig stay in sync with each other", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration([
           ["enabled", true],
-          ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+          ["lspConfigs", [fooLspConfig, barLspConfig]],
           ["selectedLspConfigId", fooLspConfig.id],
         ]);
         const sorbetConfig1 = new SorbetExtensionConfig(workspaceConfig);
@@ -393,17 +378,17 @@ suite("SorbetExtensionConfig", async () => {
     suite("when `sorbet.userLspConfigs` is specified", async () => {
       test("when values are distinct from `lspConfigs`", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration([
-          ["lspConfigs", [fooLspConfig.toJSON()]],
-          ["userLspConfigs", [barLspConfig.toJSON()]],
+          ["lspConfigs", [fooLspConfig]],
+          ["userLspConfigs", [barLspConfig]],
         ]);
         const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
         const { selectedLspConfig, lspConfigs } = sorbetConfig;
-        assert.deepEqual(
+        assert.deepStrictEqual(
           lspConfigs,
           [barLspConfig, fooLspConfig],
           "items from userLspConfigs should precede items from lspConfigs",
         );
-        assert.deepEqual(
+        assert.deepStrictEqual(
           selectedLspConfig,
           barLspConfig,
           "First element of userLspConfigs should be the selected/default config",
@@ -419,23 +404,23 @@ suite("SorbetExtensionConfig", async () => {
           fooLspConfig,
           "Precondition: userFoo and foo should be different configs",
         );
-        assert.equal(
+        assert.strictEqual(
           userConfig.id,
           fooLspConfig.id,
           "Precondition: userFoo and foo should have the same id",
         );
         const workspaceConfig = new FakeWorkspaceConfiguration([
-          ["lspConfigs", [fooLspConfig.toJSON()]],
-          ["userLspConfigs", [userConfig.toJSON()]],
+          ["lspConfigs", [fooLspConfig]],
+          ["userLspConfigs", [userConfig]],
         ]);
         const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
         const { selectedLspConfig, lspConfigs } = sorbetConfig;
-        assert.deepEqual(
+        assert.deepStrictEqual(
           lspConfigs,
           [userConfig],
           "Item from userLspConfigs should override same id from lspConfigs",
         );
-        assert.deepEqual(
+        assert.deepStrictEqual(
           selectedLspConfig,
           userConfig,
           "Selected config should be first of userLspConfigs",
@@ -448,19 +433,19 @@ suite("SorbetExtensionConfig", async () => {
     test("fires onLspConfigChange event when enabling the extension", async () => {
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", false],
-        ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig, barLspConfig]],
         ["selectedLspConfigId", barLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
       sorbetConfig.setEnabled(true).then(() => {
-        assert.equal(
+        assert.strictEqual(
           listener.called,
           true,
           "should have called listener onLspConfigChange",
         );
-        assert.deepEqual(
+        assert.deepStrictEqual(
           listener.getCall(0).args[0],
           {
             oldLspConfig: null,
@@ -474,19 +459,19 @@ suite("SorbetExtensionConfig", async () => {
     test("fires onLspConfigChange event when disabling the extension", async () => {
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", true],
-        ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig, barLspConfig]],
         ["selectedLspConfigId", barLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
       sorbetConfig.setEnabled(false).then(() => {
-        assert.equal(
+        assert.strictEqual(
           listener.called,
           true,
           "should have called listener onLspConfigChange",
         );
-        assert.deepEqual(
+        assert.deepStrictEqual(
           listener.getCall(0).args[0],
           {
             oldLspConfig: barLspConfig,
@@ -498,19 +483,19 @@ suite("SorbetExtensionConfig", async () => {
     });
   });
 
-  suite(".selectedLspConfigId", async () => {
+  suite(".setSelectedLspConfigId", async () => {
     test("fires onLspConfigChange event when changing LSPConfig", async () => {
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", true],
-        ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig, barLspConfig]],
         ["selectedLspConfigId", barLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
       sorbetConfig.setSelectedLspConfigId(fooLspConfig.id).then(() => {
-        assert.equal(listener.called, true, "should be notified");
-        assert.deepEqual(
+        assert.strictEqual(listener.called, true, "should be notified");
+        assert.deepStrictEqual(
           listener.getCall(0).args[0],
           {
             oldLspConfig: barLspConfig,
@@ -524,29 +509,29 @@ suite("SorbetExtensionConfig", async () => {
     test("does not fire onLspConfigChange event when unchanged", async () => {
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", true],
-        ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig, barLspConfig]],
         ["selectedLspConfigId", barLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
-      assert.equal(sorbetConfig.selectedLspConfig!.id, barLspConfig.id);
+      assert.strictEqual(sorbetConfig.selectedLspConfig!.id, barLspConfig.id);
       sorbetConfig.setSelectedLspConfigId(barLspConfig!.id).then(() => {
-        assert.equal(listener.called, false, "should not be notified");
+        assert.strictEqual(listener.called, false, "should not be notified");
       });
     });
 
     test("does not fire onLspConfigChange event when extension disabled", async () => {
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", false],
-        ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig, barLspConfig]],
         ["selectedLspConfigId", barLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
       sorbetConfig.setSelectedLspConfigId(fooLspConfig.id).then(() => {
-        assert.equal(listener.called, false, "should not be notified");
+        assert.strictEqual(listener.called, false, "should not be notified");
       });
     });
   });
@@ -555,36 +540,36 @@ suite("SorbetExtensionConfig", async () => {
     test("does not fire when extension is disabled", async () => {
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", false],
-        ["lspConfigs", [fooLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig]],
         ["selectedLspConfigId", fooLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
-      workspaceConfig.update("lspConfigs", [barLspConfig.toJSON()]);
+      workspaceConfig.update("lspConfigs", [barLspConfig]);
       workspaceConfig.update("selectedLspConfigId", barLspConfig.id);
-      assert.equal(listener.called, false, "should not be notified");
+      assert.strictEqual(listener.called, false, "should not be notified");
     });
 
     test("fires when active LSP config is modified", async () => {
       const modifiedBarLspConfig = new SorbetLspConfig({
-        ...barLspConfig.toJSON(),
+        ...barLspConfig,
         command: ["different", "command", "here"],
       });
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", true],
-        ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig, barLspConfig]],
         ["selectedLspConfigId", barLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
       workspaceConfig.update("lspConfigs", [
-        fooLspConfig.toJSON(),
-        modifiedBarLspConfig.toJSON(),
+        fooLspConfig,
+        modifiedBarLspConfig,
       ]);
-      assert.equal(listener.called, true, "should be notified");
-      assert.deepEqual(
+      assert.strictEqual(listener.called, true, "should be notified");
+      assert.deepStrictEqual(
         listener.getCall(0).args[0],
         {
           oldLspConfig: barLspConfig,
@@ -596,51 +581,48 @@ suite("SorbetExtensionConfig", async () => {
 
     test("does not fire when non-active LSP config is modified", async () => {
       const modifiedFooLspConfig = new SorbetLspConfig({
-        ...fooLspConfig.toJSON(),
+        ...fooLspConfig,
         command: ["different", "command", "here"],
       });
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", true],
-        ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig, barLspConfig]],
         ["selectedLspConfigId", barLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
       workspaceConfig.update("lspConfigs", [
-        modifiedFooLspConfig.toJSON(),
-        barLspConfig.toJSON(),
+        modifiedFooLspConfig,
+        barLspConfig,
       ]);
-      assert.equal(listener.called, false, "should not be notified");
+      assert.strictEqual(listener.called, false, "should not be notified");
     });
 
     test("does not fire when a new (non-active) LSP config is added", async () => {
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", true],
-        ["lspConfigs", [barLspConfig.toJSON()]],
+        ["lspConfigs", [barLspConfig]],
         ["selectedLspConfigId", barLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
-      workspaceConfig.update("lspConfigs", [
-        fooLspConfig.toJSON(),
-        barLspConfig.toJSON(),
-      ]);
-      assert.equal(listener.called, false, "should not be notified");
+      workspaceConfig.update("lspConfigs", [fooLspConfig, barLspConfig]);
+      assert.strictEqual(listener.called, false, "should not be notified");
     });
 
     test("does not fire when a non-active LSP config is removed", async () => {
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", true],
-        ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig, barLspConfig]],
         ["selectedLspConfigId", barLspConfig.id],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
-      workspaceConfig.update("lspConfigs", [barLspConfig.toJSON()]);
-      assert.equal(
+      workspaceConfig.update("lspConfigs", [barLspConfig]);
+      assert.strictEqual(
         listener.called,
         false,
         "should not have called listener onLspConfigChange",
@@ -650,21 +632,18 @@ suite("SorbetExtensionConfig", async () => {
     test("fires when the active LSP changes by nature of being the first lspConfig", async () => {
       const workspaceConfig = new FakeWorkspaceConfiguration([
         ["enabled", true],
-        ["lspConfigs", [fooLspConfig.toJSON(), barLspConfig.toJSON()]],
+        ["lspConfigs", [fooLspConfig, barLspConfig]],
       ]);
       const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
       const listener = sinon.spy();
       sorbetConfig.onLspConfigChange(listener);
-      workspaceConfig.update("lspConfigs", [
-        barLspConfig.toJSON(),
-        fooLspConfig.toJSON(),
-      ]);
-      assert.equal(
+      workspaceConfig.update("lspConfigs", [barLspConfig, fooLspConfig]);
+      assert.strictEqual(
         listener.called,
         true,
         "should have called listener onLspConfigChange",
       );
-      assert.deepEqual(
+      assert.deepStrictEqual(
         listener.getCall(0).args[0],
         {
           oldLspConfig: fooLspConfig,


### PR DESCRIPTION
Cleanup `config.ts` to match code style added on previous refactoring PRs, e.g. initialize fields in constructor, user `readonly` when appropriate, etc.
- Updates `config.test.ts` to use `assert.strictEqual` and `assert.deepStrictEqual` as the non-`strict` versions show deprecation warnings.
- Removes `SorbetLspConfig.toJSON` method since it is unnecessary for all scenarios (and class only exposed readonly props now, so the implicit cloning does not seem to be a requirement either).
- Async  calls now use `await`, and `Disposable` types are disposed when appropriate.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Continue effort to std'ize extension code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
