### PR TITLE
Fix bug in subtyping with nested any+all types

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1458,6 +1458,10 @@ bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &cons
         } else if (a1 == nullptr) {
             // If neither t1 <: o2->left nor t1 <: o2->right, it might mean that we tried to split
             // up an OrType when we weren't meant to. It could be that t1 is an AndType of an OrType
+            //
+            // Note: This is deliberately a case where the code to handle an OrType is not
+            // symmetric (nor even anti-symmetric) with the code to handle an AndType. (There is no
+            // corresponding logic in the `a1 != nullptr` condition below.)
             return false;
         }
     }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1388,8 +1388,6 @@ bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &cons
     auto *a1 = cast_type<AndType>(t1);
     auto *o2 = cast_type<OrType>(t2);
 
-    // TODO(jez) With the fallthrough case below, do we still need this? Is it a "performance
-    // optimization" to keep?
     if (a1 != nullptr) {
         // If the left is an And of an Or, then we can reorder it to be an Or of
         // an And, which lets us recurse on smaller types

--- a/test/testdata/infer/nested_any_all.rb
+++ b/test/testdata/infer/nested_any_all.rb
@@ -1,0 +1,38 @@
+# typed: true
+
+module M1; end
+module M2; end
+
+module A; end
+module B; end
+
+module Main
+  extend T::Sig
+
+  sig {params(x: T.all(M1, T.any(A, B), M2)).returns(T.any(A, B))}
+  def self.test1(x)
+    T.reveal_type(x) # error: `T.all(M1, T.any(A, B), M2)`
+    x
+  end
+
+  # remove M2, shouldn't matter
+  sig {params(x: T.all(M1, T.any(A, B))).returns(T.any(A, B))}
+  def self.test2(x)
+    T.reveal_type(x) # error: `T.all(M1, T.any(A, B))`
+    x
+  end
+
+  # reorder T.any and M2, shouldn't matter
+  sig {params(x: T.all(M1, M2, T.any(A, B))).returns(T.any(A, B))}
+  def self.test3(x)
+    T.reveal_type(x) # error: `T.all(M1, M2, T.any(A, B))`
+    x
+  end
+
+  # associate the other way, shouldn't matter
+  sig {params(x: T.all(M1, T.all(M2, T.any(A, B)))).returns(T.any(A, B))}
+  def self.test4(x)
+    T.reveal_type(x) # error: `T.all(M2, T.any(A, B), M1)`
+    x
+  end
+end

--- a/test/testdata/infer/nested_any_all_crash1.rb
+++ b/test/testdata/infer/nested_any_all_crash1.rb
@@ -1,0 +1,46 @@
+# typed: true
+
+class A; end
+class B; end
+module M; end
+
+module Foo
+  extend T::Sig
+  extend T::Helpers
+
+  interface!
+
+  sig {abstract.void}
+  def foo; end
+end
+
+class X1
+  extend T::Sig
+  include Foo
+  sig {override.void}
+  def foo; end
+end
+
+class Y < B; end
+
+class Z
+  extend T::Sig
+
+  include M
+  include Foo
+
+  sig {override.void}
+  def foo; end
+end
+
+module Main
+  extend T::Sig
+
+  TypeArg = T.type_alias {T.all(T.any(A, B, M), Foo, T.any(X1, Y, Z))}
+
+  sig {params(x: TypeArg).void}
+  def self.test(x)
+    x.foo
+  end
+end
+

--- a/test/testdata/infer/nested_any_all_crash2.rb
+++ b/test/testdata/infer/nested_any_all_crash2.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+class A; end
+
+class Parent; end
+class Child < Parent; end
+
+module IFoo; end
+class Foo
+  include IFoo
+end
+
+module Main
+  extend T::Sig
+
+  sig {params(x: T.all(T.any(A, Parent), IFoo, T.any(Foo, Child))).void}
+  def self.test(x)
+    T.reveal_type(x) # error: `T.all(IFoo, T.any(A, Parent), T.any(Foo, Child))`
+  end
+end

--- a/test/testdata/infer/nested_any_all_crash3.rb
+++ b/test/testdata/infer/nested_any_all_crash3.rb
@@ -11,7 +11,7 @@ module Main
 
   sig {params(x: T.all(M1, T.any(M2, T.all(M1, T.any(A, B))))).void}
   def self.test(x)
-    T.reveal_type(x)
+    T.reveal_type(x) # error: `T.all(M1, T.any(M2, T.all(M1, T.any(A, B))))`
   end
 end
 

--- a/test/testdata/infer/nested_any_all_crash3.rb
+++ b/test/testdata/infer/nested_any_all_crash3.rb
@@ -1,0 +1,28 @@
+# typed: true
+
+module M1; end
+module M2; end
+
+class A; end
+class B; end
+
+module Main
+  extend T::Sig
+
+  sig {params(x: T.all(M1, T.any(M2, T.all(M1, T.any(A, B))))).void}
+  def self.test(x)
+    T.reveal_type(x)
+  end
+end
+
+# Once upon a time, this raised an exception like this:
+#
+# Exception::raise(): core/types/subtyping.cc:647 enforced condition Types::isSubType(gs, ret, t2) has failed:
+# M1 & (M2 | (M1 & (A | B)))
+#  is not a subtype of
+# M2 | (M1 & (A | B))
+# was glbbing with
+# M1
+#
+# Backtrace:
+#   #3 0x1b1c2a9 sorbet::core::Types::all()

--- a/test/testdata/infer/no_short_circuit_type_constraint_nested.rb
+++ b/test/testdata/infer/no_short_circuit_type_constraint_nested.rb
@@ -1,0 +1,82 @@
+# typed: true
+
+# The problem demonstrated in this test is very similar to the one in
+# no_short_circuit_type_constraint.rb. The core problem boils down to Sorbet's
+# type constraints accumulating greedily.
+#
+# There is more context in that test. For the time being, it's not _wrong_ for
+# Sorbet to infer this type, it's just not quite as narrow as you'd want it to
+# be.
+#
+# It's also worth noting that sometimes users don't have control over how their
+# nested types are created--the order may be determined by the order that
+# Sorbet lubs basic block branches and glbs type tests. So sometimes the bad
+# case below can happen because of no fault of the user.
+
+module M1; end
+module M2; end
+
+module A; end
+module B; end
+
+module Main
+  extend T::Sig
+
+  # Type signature indicates that we're trying to remove the `B` from the input.
+  sig do
+    type_parameters(:U)
+      .params(x: T.any(T.type_parameter(:U), B))
+      .returns(T.type_parameter(:U))
+  end
+  def self.remove_the_b(x)
+    case x
+    when B then raise
+    else x
+    end
+  end
+
+  sig do
+    type_parameters(:U)
+      .params(x: T.all(M1, T.any(A, B), M2))
+      .void
+  end
+  def self.test1(x)
+    # Sorbet gets this type because when faced with a type like
+    #
+    #   X & Y  <:  A | B
+    #
+    # It needs to decide which comparison to do first: split the AndType:
+    #   X & Y <: A   ||   X & Y <: B
+    # or split the OrType:
+    #   X <: A | B   ||   Y <: A | B
+    # Since Sorbet's inference algorithm is greedy, one of the two choices will
+    # always be wrong. In our case, `A` is actually `T.type_parameter(:U)`, and
+    # the `OrType` is split first, which leads to a comparison like
+    #
+    #      X & Y  <:  T.type_parameter(:U)
+    #   => T.all(T.all(M1, T.any(A, B)), M2)  <:  T.type_parameter(:U)
+    #
+    # which has the effect of recording the `B` in the type parameter, instead
+    # of dropping it.
+    inferred = remove_the_b(x)
+    T.reveal_type(inferred) # error: `T.all(M1, A, M2)`
+  end
+
+  sig do
+    type_parameters(:U)
+      .params(x: T.all(M1, M2, T.any(A, B)))
+      .void
+  end
+  def self.test2(x)
+    # Written this way, things work, because we have a special case which
+    # unwraps a specific case of an OrType nested inside an AndType:
+    #
+    #      X & (F | G)        <:  t2
+    #   => (X & F) | (X & G)  <:  t2
+    #
+    # That is, we distribute and continue, which splits the A | B.
+
+    inferred = remove_the_b(x)
+    T.reveal_type(inferred) # error: `T.all(A, M1, M2)`
+  end
+end

--- a/test/testdata/infer/no_short_circuit_type_constraint_nested.rb
+++ b/test/testdata/infer/no_short_circuit_type_constraint_nested.rb
@@ -58,8 +58,10 @@ module Main
     #
     # which has the effect of recording the `B` in the type parameter, instead
     # of dropping it.
+    #
+    # Ideally, this would reveal `T.all(M1, A, M2)` or something similar
     inferred = remove_the_b(x)
-    T.reveal_type(inferred) # error: `T.all(M1, A, M2)`
+    T.reveal_type(inferred) # error: `T.all(M1, T.any(A, B), M2)`
   end
 
   sig do

--- a/test/testdata/infer/no_short_circuit_type_constraint_nested.rb
+++ b/test/testdata/infer/no_short_circuit_type_constraint_nested.rb
@@ -45,9 +45,9 @@ module Main
     #
     #   X & Y  <:  A | B
     #
-    # It needs to decide which comparison to do first: split the AndType:
+    # It needs to decide which comparison to do first: split the OrType:
     #   X & Y <: A   ||   X & Y <: B
-    # or split the OrType:
+    # or split the AndType:
     #   X <: A | B   ||   Y <: A | B
     # Since Sorbet's inference algorithm is greedy, one of the two choices will
     # always be wrong. In our case, `A` is actually `T.type_parameter(:U)`, and


### PR DESCRIPTION
### Motivation

Fixes #4525

cc @areitz-stripe

There is a lot of subtlety in this change, and some parts of it are not great.
I have tried to leave behind comments where relevant.

Specifically: there are now some cases that will do two extra recursive calls to
`isSubTypeUnderConstraint`, where before Sorbet would have simply returned
`false`. In some of those cases, returning `false` _happens_ to be the correct
answer, but in some other cases, we have to do two more
`isSubTypeUnderConstraint` calls in order to figure out that in fact the answer
should be `true`.

As far as performance, as far as I can tell this doesn't cause a noticeable
change to performance on Stripe's codebase.

### Test plan

I've added a lot of tests, including all the test cases from the linked issue
but also some new ones.