### PR TITLE
Print associativity for AndType and OrType

### DIFF
--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -221,8 +221,8 @@ string AliasType::show(const GlobalState &gs, ShowOptions options) const {
 }
 
 string AndType::toStringWithTabs(const GlobalState &gs, int tabs) const {
-    bool leftBrace = isa_type<OrType>(this->left);
-    bool rightBrace = isa_type<OrType>(this->right);
+    bool leftBrace = isa_type<OrType>(this->left) || isa_type<AndType>(this->left);
+    bool rightBrace = isa_type<OrType>(this->right) || isa_type<AndType>(this->right);
 
     return fmt::format("{}{}{} & {}{}{}", leftBrace ? "(" : "", this->left.toStringWithTabs(gs, tabs + 2),
                        leftBrace ? ")" : "", rightBrace ? "(" : "", this->right.toStringWithTabs(gs, tabs + 2),
@@ -250,8 +250,8 @@ string AndType::show(const GlobalState &gs, ShowOptions options) const {
 }
 
 string OrType::toStringWithTabs(const GlobalState &gs, int tabs) const {
-    bool leftBrace = isa_type<AndType>(this->left);
-    bool rightBrace = isa_type<AndType>(this->right);
+    bool leftBrace = isa_type<OrType>(this->left) || isa_type<AndType>(this->left);
+    bool rightBrace = isa_type<OrType>(this->right) || isa_type<AndType>(this->right);
 
     return fmt::format("{}{}{} | {}{}{}", leftBrace ? "(" : "", this->left.toStringWithTabs(gs, tabs + 2),
                        leftBrace ? ")" : "", rightBrace ? "(" : "", this->right.toStringWithTabs(gs, tabs + 2),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When using `TypePtr::toString` to debug problems with union/intersection
types, sometimes the problem comes because two types that look the same
have actually associated differently.

We had some code to print `(...)` when the order of operations mattered,
but we did not have the same code to disambiguate associativity given
the same kind of operation.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I have been using this locally. It's either untested, or maybe shows up in some
exp files.