### PR TITLE
Refactor `sorbet` content provider

### DIFF
--- a/vscode_extension/src/sorbetContentProvider.ts
+++ b/vscode_extension/src/sorbetContentProvider.ts
@@ -1,0 +1,49 @@
+import { TextDocumentContentProvider, Uri } from "vscode";
+import { CancellationToken, TextDocumentItem } from "vscode-languageclient";
+import { SorbetExtensionContext } from "./sorbetExtensionContext";
+
+/**
+ * URI scheme supported by {@link SorbetContentProvider}.
+ */
+export const SORBET_SCHEME = "sorbet";
+
+/**
+ * Content provider for URIs with `sorbet` scheme.
+ */
+export class SorbetContentProvider implements TextDocumentContentProvider {
+  private readonly context: SorbetExtensionContext;
+
+  constructor(context: SorbetExtensionContext) {
+    this.context = context;
+  }
+
+  /**
+   * Provide textual content for a given uri.
+   */
+  public async provideTextDocumentContent(
+    uri: Uri,
+    token?: CancellationToken,
+  ): Promise<string> {
+    let content: string;
+    const { activeLanguageClient } = this.context.statusProvider;
+    if (activeLanguageClient) {
+      this.context.log.info(`Retrieving file contents. URI:${uri}`);
+      const response = await activeLanguageClient.languageClient.sendRequest<
+        TextDocumentItem
+      >(
+        "sorbet/readFile",
+        {
+          uri: uri.toString(),
+        },
+        token,
+      );
+      content = response.text;
+    } else {
+      this.context.log.info(
+        `Cannot retrieve file contents, no active Sorbet client. URI:${uri}`,
+      );
+      content = "";
+    }
+    return content;
+  }
+}

--- a/vscode_extension/src/test/sorbetContentProvider.test.ts
+++ b/vscode_extension/src/test/sorbetContentProvider.test.ts
@@ -1,0 +1,67 @@
+import * as vscode from "vscode";
+import * as assert from "assert";
+import * as path from "path";
+import * as sinon from "sinon";
+
+import { LanguageClient } from "vscode-languageclient/node";
+import { createLogStub } from "./testUtils";
+import { SorbetLanguageClient } from "../languageClient";
+import { LogLevel } from "../log";
+import { SorbetExtensionContext } from "../sorbetExtensionContext";
+import { SorbetContentProvider } from "../sorbetContentProvider";
+import { SorbetStatusProvider } from "../sorbetStatusProvider";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  let testRestorables: { restore: () => void }[];
+
+  setup(() => {
+    testRestorables = [];
+  });
+
+  teardown(() => {
+    testRestorables.forEach((r) => r.restore());
+  });
+
+  test("provideTextDocumentContent succeeds", async () => {
+    const fileUri = vscode.Uri.parse("sorbet:/test/file", true);
+    const expectedContents = "";
+
+    const sendRequestSpy = sinon.spy(async (_method, _params) => ({
+      text: expectedContents,
+    }));
+    const statusProvider = <SorbetStatusProvider>{
+      activeLanguageClient: <SorbetLanguageClient>{
+        languageClient: <LanguageClient>(<unknown>{
+          sendRequest: sendRequestSpy,
+        }),
+      },
+    };
+    const context = <SorbetExtensionContext>{
+      log: createLogStub(LogLevel.Info),
+      statusProvider,
+    };
+
+    const provider = new SorbetContentProvider(context);
+    assert.strictEqual(
+      await provider.provideTextDocumentContent(fileUri),
+      expectedContents,
+    );
+
+    sinon.assert.calledOnce(sendRequestSpy);
+    sinon.assert.calledWith(sendRequestSpy, "sorbet/readFile", {
+      uri: fileUri.toString(),
+    });
+  });
+
+  test("provideTextDocumentContent handles no activeLanguageClient", async () => {
+    const fileUri = vscode.Uri.parse("sorbet:/test/file", true);
+    const statusProvider = <SorbetStatusProvider>{};
+    const context = <SorbetExtensionContext>{
+      log: createLogStub(LogLevel.Info),
+      statusProvider,
+    };
+
+    const provider = new SorbetContentProvider(context);
+    assert.strictEqual(await provider.provideTextDocumentContent(fileUri), "");
+  });
+});


### PR DESCRIPTION
Refactor `sorbet` text document content provider into its own file so it is easy to test.
- Add tests.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
