### PR TITLE
Add benchmark for `T.unsafe` and `T.must`

### DIFF
--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -57,6 +57,32 @@ module SorbetBenchmarks
         false.is_a?(Integer)
       end
 
+      time_block("T.unsafe", iterations_in_block: 10) do
+        T.unsafe(0)
+        T.unsafe(1)
+        T.unsafe(2)
+        T.unsafe(3)
+        T.unsafe(nil)
+        T.unsafe(0)
+        T.unsafe(1)
+        T.unsafe(2)
+        T.unsafe(3)
+        T.unsafe(nil)
+      end
+
+      time_block("T.must on non-nil", iterations_in_block: 10) do
+        T.must(0)
+        T.must(1)
+        T.must(2)
+        T.must(3)
+        T.must(false)
+        T.must(0)
+        T.must(1)
+        T.must(2)
+        T.must(3)
+        T.must(false)
+      end
+
       type = T::Utils.coerce(Integer)
       time_block("T::Types::Simple#valid?", iterations_in_block: 10) do
         type.valid?(0)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

```
❯ bex rake bench:typecheck
Vanilla Ruby method call: 20.054 ns
Vanilla Ruby is_a?: 27.801 ns
T.unsafe: 20.787 ns
T.must on non-nil: 21.413 ns
```

Just to have these, for people to see.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

manually tested