### PR TITLE
Bump from 3.1.2 to 3.1.4

### DIFF
--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -36,6 +36,7 @@ ruby(
     cppopts = [
         "-Wdate-time",
         "-D_FORTIFY_SOURCE=2",
+        "-fPIC",
     ] + select({
         # Don't include JIT statistics unless we're building JIT support
         "@com_stripe_ruby_typer//tools/config:jit_enabled": ["-DYJIT_STATS=1"],

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -83,14 +83,12 @@ def register_ruby_dependencies():
 
     http_archive(
         name = "sorbet_ruby_3_1",
-        urls = _ruby_urls("3.1/ruby-3.1.2.tar.gz"),
-        sha256 = "61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e",
-        strip_prefix = "ruby-3.1.2",
+        urls = _ruby_urls("3.1/ruby-3.1.4.tar.gz"),
+        sha256 = "a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6",
+        strip_prefix = "ruby-3.1.4",
         build_file = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD",
         patches = [
-            "@com_stripe_ruby_typer//third_party/ruby:penelope_procc-3_1.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by-3_1.patch",  # https://github.com/ruby/ruby/pull/6791
-            "@com_stripe_ruby_typer//third_party/ruby:rb-provide-feature.patch",  # https://github.com/ruby/ruby/pull/5593
         ],
     )
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This switches to 3.1.4 as the chosen 3.1 version instead of 3.1.2.

This also had to add `-fPIC` to `cppopts` in order to fix a linker failure around linking the ffi library, and also removed two patches that are already present upstream in 3.1.4.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
