### PR TITLE
Improve `Toggle Untyped Highlight` command

### DIFF
--- a/vscode_extension/src/commandIds.ts
+++ b/vscode_extension/src/commandIds.ts
@@ -1,4 +1,14 @@
 /**
+ * Copy Symbol to Clipboard.
+ */
+export const COPY_SYMBOL_COMMAND_ID = "sorbet.copySymbolToClipboard";
+
+/**
+ * Rename Symbol at a given document position.
+ */
+export const RENAME_SYMBOL_COMMAND_ID = "sorbet.rename";
+
+/**
  * Set log level available actions.
  */
 export const SET_LOGLEVEL_COMMAND_ID = "sorbet.setLogLevel";
@@ -19,9 +29,9 @@ export const SHOW_CONFIG_PICKER_COMMAND_ID = "sorbet.configure";
 export const SHOW_OUTPUT_COMMAND_ID = "sorbet.showOutput";
 
 /**
- * Copy Symbol to Clipboard.
+ * Disable Sorbet.
  */
-export const SORBET_COPY_SYMBOL_COMMAND_ID = "sorbet.copySymbolToClipboard";
+export const SORBET_DISABLE_COMMAND_ID = "sorbet.disable";
 
 /**
  * Enable Sorbet.
@@ -29,16 +39,12 @@ export const SORBET_COPY_SYMBOL_COMMAND_ID = "sorbet.copySymbolToClipboard";
 export const SORBET_ENABLE_COMMAND_ID = "sorbet.enable";
 
 /**
- * Disable Sorbet.
- */
-export const SORBET_DISABLE_COMMAND_ID = "sorbet.disable";
-
-/**
- * Rename Symbol at a given document position.
- */
-export const SORBET_RENAME_SYMBOL_COMMAND_ID = "sorbet.rename";
-
-/**
  * Restart Sorbet.
  */
 export const SORBET_RESTART_COMMAND_ID = "sorbet.restart";
+
+/**
+ * Toggle highlighting of untyped code.
+ */
+export const TOGGLE_HIGHLIGHT_UNTYPED_COMMAND_ID =
+  "sorbet.toggleHighlightUntyped";

--- a/vscode_extension/src/commands/copySymbolToClipboard.ts
+++ b/vscode_extension/src/commands/copySymbolToClipboard.ts
@@ -7,8 +7,8 @@ import { SorbetExtensionContext } from "../sorbetExtensionContext";
 import { ServerStatus } from "../types";
 
 /**
- * Copy symbol at current
- * @param context Context
+ * Copy symbol at current.
+ * @param context Sorbet extension context.
  */
 export async function copySymbolToClipboard(
   context: SorbetExtensionContext,

--- a/vscode_extension/src/commands/renameSymbol.ts
+++ b/vscode_extension/src/commands/renameSymbol.ts
@@ -10,7 +10,7 @@ import { ServerStatus } from "../types";
  * because VSCode doesn't allow calling it from the JSON RPC
  * https://github.com/microsoft/vscode/issues/146767
  *
- * @param context Context.
+ * @param context Sorbet extension context.
  * @param params Document position.
  */
 export async function renameSymbol(

--- a/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
+++ b/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
@@ -8,6 +8,7 @@ export interface LspConfigQuickPickItem extends QuickPickItem {
 
 /**
  * Show Sorbet Configuration picker.
+ * @param context Sorbet extension context.
  */
 export async function showSorbetConfigurationPicker(
   context: SorbetExtensionContext,

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -1,0 +1,20 @@
+import { SorbetExtensionContext } from "../sorbetExtensionContext";
+import { RestartReason } from "../types";
+
+/**
+ * Toggle highlighting of untyped code.
+ * @param context Sorbet extension context.
+ * @returns `true` if highlighting is now enabled, `false` otherwise.
+ */
+export async function toggleUntypedCodeHighlighting(
+  context: SorbetExtensionContext,
+): Promise<boolean> {
+  const targetState = !context.configuration.highlightUntyped;
+  await context.configuration.setHighlightUntyped(targetState);
+  context.log.info(
+    `Untyped code highlighting: ${targetState ? "enabled" : "disabled"}`,
+  );
+
+  await context.statusProvider.restartSorbet(RestartReason.CONFIG_CHANGE);
+  return context.configuration.highlightUntyped;
+}

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -6,6 +6,7 @@ import { renameSymbol } from "./commands/renameSymbol";
 import { setLogLevel } from "./commands/setLogLevel";
 import { showSorbetActions } from "./commands/showSorbetActions";
 import { showSorbetConfigurationPicker } from "./commands/showSorbetConfigurationPicker";
+import { toggleUntypedCodeHighlighting } from "./commands/toggleUntypedCodeHighlighting";
 import { getLogLevelFromEnvironment, LogLevel } from "./log";
 import { SorbetContentProvider, SORBET_SCHEME } from "./sorbetContentProvider";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
@@ -49,6 +50,14 @@ export function activate(context: ExtensionContext) {
 
   // Register commands
   context.subscriptions.push(
+    commands.registerCommand(cmdIds.COPY_SYMBOL_COMMAND_ID, () =>
+      copySymbolToClipboard(sorbetExtensionContext),
+    ),
+    commands.registerCommand(
+      cmdIds.RENAME_SYMBOL_COMMAND_ID,
+      (params: TextDocumentPositionParams) =>
+        renameSymbol(sorbetExtensionContext, params),
+    ),
     commands.registerCommand(
       cmdIds.SET_LOGLEVEL_COMMAND_ID,
       (level?: LogLevel) => setLogLevel(sorbetExtensionContext, level),
@@ -62,9 +71,6 @@ export function activate(context: ExtensionContext) {
     commands.registerCommand(cmdIds.SHOW_OUTPUT_COMMAND_ID, () =>
       sorbetExtensionContext.logOutputChannel.show(true),
     ),
-    commands.registerCommand(cmdIds.SORBET_COPY_SYMBOL_COMMAND_ID, () =>
-      copySymbolToClipboard(sorbetExtensionContext),
-    ),
     commands.registerCommand(cmdIds.SORBET_ENABLE_COMMAND_ID, () =>
       sorbetExtensionContext.configuration.setEnabled(true),
     ),
@@ -72,25 +78,12 @@ export function activate(context: ExtensionContext) {
       sorbetExtensionContext.configuration.setEnabled(false),
     ),
     commands.registerCommand(
-      cmdIds.SORBET_RENAME_SYMBOL_COMMAND_ID,
-      (params: TextDocumentPositionParams) =>
-        renameSymbol(sorbetExtensionContext, params),
-    ),
-    commands.registerCommand(
       cmdIds.SORBET_RESTART_COMMAND_ID,
       (reason: RestartReason = RestartReason.COMMAND) =>
         sorbetExtensionContext.statusProvider.restartSorbet(reason),
     ),
-    commands.registerCommand("sorbet.toggleHighlightUntyped", () =>
-      sorbetExtensionContext.configuration
-        .setHighlightUntyped(
-          !sorbetExtensionContext.configuration.highlightUntyped,
-        )
-        .then(() =>
-          sorbetExtensionContext.statusProvider.restartSorbet(
-            RestartReason.CONFIG_CHANGE,
-          ),
-        ),
+    commands.registerCommand(cmdIds.TOGGLE_HIGHLIGHT_UNTYPED_COMMAND_ID, () =>
+      toggleUntypedCodeHighlighting(sorbetExtensionContext),
     ),
   );
 

--- a/vscode_extension/src/sorbetStatusBarEntry.ts
+++ b/vscode_extension/src/sorbetStatusBarEntry.ts
@@ -139,7 +139,7 @@ export class SorbetStatusBarEntry implements Disposable {
     function getRunningTooltip() {
       let txt = "The Sorbet server is currently running.";
       if (highlightUntyped) {
-        txt += "\n  Highlight untyped code";
+        txt += "\n  - Highlight untyped code";
       }
       return txt;
     }

--- a/vscode_extension/src/sorbetStatusBarEntry.ts
+++ b/vscode_extension/src/sorbetStatusBarEntry.ts
@@ -85,7 +85,7 @@ export class SorbetStatusBarEntry implements Disposable {
 
   private render() {
     const numOperations = this.operationStack.length;
-    const { activeLspConfig } = this.context.configuration;
+    const { activeLspConfig, highlightUntyped } = this.context.configuration;
     const sorbetName = activeLspConfig?.name ?? "Sorbet";
 
     let text: string;
@@ -98,7 +98,7 @@ export class SorbetStatusBarEntry implements Disposable {
     ) {
       const latestOp = this.operationStack[numOperations - 1];
       text = `${sorbetName}: ${latestOp.description} ${this.getSpinner()}`;
-      tooltip = latestOp.description;
+      tooltip = getRunningTooltip();
     } else {
       switch (this.serverStatus) {
         case ServerStatus.DISABLED:
@@ -123,7 +123,7 @@ export class SorbetStatusBarEntry implements Disposable {
           break;
         case ServerStatus.RUNNING:
           text = `${sorbetName}: Idle`;
-          tooltip = "The Sorbet server is currently running.";
+          tooltip = getRunningTooltip();
           break;
         default:
           this.context.log.error(`Invalid ServerStatus: ${this.serverStatus}`);
@@ -135,5 +135,13 @@ export class SorbetStatusBarEntry implements Disposable {
 
     this.statusBarItem.text = text;
     this.statusBarItem.tooltip = tooltip;
+
+    function getRunningTooltip() {
+      let txt = "The Sorbet server is currently running.";
+      if (highlightUntyped) {
+        txt += "\n  Highlight untyped code";
+      }
+      return txt;
+    }
   }
 }

--- a/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
+++ b/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
@@ -1,0 +1,64 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as sinon from "sinon";
+
+import { createLogStub } from "../testUtils";
+import { toggleUntypedCodeHighlighting } from "../../commands/toggleUntypedCodeHighlighting";
+import { SorbetExtensionConfig } from "../../config";
+import { SorbetExtensionContext } from "../../sorbetExtensionContext";
+import { SorbetStatusProvider } from "../../sorbetStatusProvider";
+import { RestartReason } from "../../types";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  let testRestorables: { restore: () => void }[];
+
+  setup(() => {
+    testRestorables = [];
+  });
+
+  teardown(() => {
+    testRestorables.forEach((r) => r.restore());
+  });
+
+  test("toggleUntypedCodeHighlighting", async () => {
+    const initialState = true;
+    let currentState = initialState;
+
+    const log = createLogStub();
+
+    const setHighlightUntypedSpy = sinon.spy((value: boolean) => {
+      currentState = value;
+    });
+    const configuration = <SorbetExtensionConfig>(<unknown>{
+      get highlightUntyped() {
+        return currentState;
+      },
+      setHighlightUntyped: setHighlightUntypedSpy,
+    });
+
+    const restartSorbetSpy = sinon.spy((_reason: RestartReason) => {});
+    const statusProvider = <SorbetStatusProvider>(<unknown>{
+      restartSorbet: restartSorbetSpy,
+    });
+
+    const context = <SorbetExtensionContext>{
+      log,
+      configuration,
+      statusProvider,
+    };
+
+    assert.strictEqual(
+      await toggleUntypedCodeHighlighting(context),
+      !initialState,
+    );
+
+    sinon.assert.calledOnce(setHighlightUntypedSpy);
+    sinon.assert.calledWithExactly(setHighlightUntypedSpy, !initialState);
+
+    sinon.assert.calledOnce(restartSorbetSpy);
+    sinon.assert.calledWithExactly(
+      restartSorbetSpy,
+      RestartReason.CONFIG_CHANGE,
+    );
+  });
+});


### PR DESCRIPTION
Improve `Toggle Untyped Highlight` command
- Provide UI cues about the current state of untyped code highlighting, in particular, now an info log entry is written and Sorbet's status bar tooltip shows the state. 
  - This was a usability issue raised by a user as there was not any hint of what new state the command toggled into (and it could take some time for decorators to show up, if they do for current editors).
- Refactor and add unit test.

Misc:
- The change to the status bar item's tooltip no longer unnecessarily duplicates the current operation name and instead just declares Sorbet is running.
- Rename some command IDs constants whose name was not logical.
- Update JSDocs for some functions.

**Status bar info**

<p align=center>
<img width="327" alt="image" src="https://github.com/sorbet/sorbet/assets/46902661/e4fe66c1-bfa8-4307-a2f1-29cb381a0746">
</p>

**Log entry**
<p align=center>
<img width="593" alt="image" src="https://github.com/sorbet/sorbet/assets/46902661/1a8372a3-ef77-4814-8ffe-12ebdbfbd8bd">
</p>

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
