### PR TITLE
Stop exposing `LanguageClient` instance from `SorbetLanguageClient`

### DIFF
--- a/vscode_extension/src/commands/copySymbolToClipboard.ts
+++ b/vscode_extension/src/commands/copySymbolToClipboard.ts
@@ -19,10 +19,7 @@ export async function copySymbolToClipboard(
     return;
   }
 
-  const capabilities = <any>(
-    client.languageClient.initializeResult?.capabilities
-  );
-  if (!capabilities?.sorbetShowSymbolProvider) {
+  if (!client.capabilities?.sorbetShowSymbolProvider) {
     context.log.warning(
       'Sorbet LSP client does not support "show symbol" capability.',
     );
@@ -49,7 +46,7 @@ export async function copySymbolToClipboard(
     },
     position,
   };
-  const response: SymbolInformation = await client.languageClient.sendRequest(
+  const response = await client.sendRequest<SymbolInformation>(
     "sorbet/showSymbol",
     params,
   );

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -210,8 +210,7 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
   }
 
   /**
-   *
-   * @returns
+   * Resolves when client is ready to serve requests.
    */
   public onReady(): Promise<void> {
     return this.languageClient.onReady();
@@ -239,10 +238,14 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
    */
   public sendRequest<TResponse>(
     method: string,
-    params: any,
+    param: any,
     token?: CancellationToken,
   ): Promise<TResponse> {
-    return this.languageClient.sendRequest<TResponse>(method, params, token);
+    // Do not pass `token` if undefined, otherwise `param` ends up being passed
+    // as `[...param, undefined]` instead of `param`.
+    return token
+      ? this.languageClient.sendRequest<TResponse>(method, param, token)
+      : this.languageClient.sendRequest<TResponse>(method, param);
   }
 
   /**

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -1,11 +1,19 @@
 import { ChildProcess, spawn } from "child_process";
-import { Disposable, Event, EventEmitter, workspace } from "vscode";
+import {
+  CancellationToken,
+  Disposable,
+  Event,
+  EventEmitter,
+  workspace,
+} from "vscode";
 import {
   CloseAction,
   ErrorAction,
   ErrorHandler,
+  GenericNotificationHandler,
   LanguageClient,
   RevealOutputChannelOn,
+  ServerCapabilities,
   ServerOptions,
 } from "vscode-languageclient/node";
 
@@ -35,6 +43,37 @@ const VALID_STATE_TRANSITIONS: ReadonlyMap<
   // Error is a terminal state for this class.
   [ServerStatus.ERROR, new Set()],
 ]);
+
+/**
+ * Create Sorbet Language Client.
+ */
+function createClient(
+  context: SorbetExtensionContext,
+  serverOptions: ServerOptions,
+  errorHandler: ErrorHandler,
+) {
+  const client = new LanguageClient("ruby", "Sorbet", serverOptions, {
+    documentSelector: [
+      { language: "ruby", scheme: "file" },
+      // Support queries on generated files with sorbet:// URIs that do not exist editor-side.
+      { language: "ruby", scheme: "sorbet" },
+    ],
+    outputChannel: context.logOutputChannel,
+    initializationOptions: {
+      // Opt in to sorbet/showOperation notifications.
+      supportsOperationNotifications: true,
+      // Let Sorbet know that we can handle sorbet:// URIs for generated files.
+      supportsSorbetURIs: true,
+      highlightUntyped: context.configuration.highlightUntyped,
+    },
+    errorHandler,
+    revealOutputChannelOn: context.configuration.revealOutputOnError
+      ? RevealOutputChannelOn.Error
+      : RevealOutputChannelOn.Never,
+  });
+
+  return client;
+}
 
 /**
  * Shims the language client object so that all requests sent get timed. Exported for tests.
@@ -70,10 +109,14 @@ export function shimLanguageClient(
   return client;
 }
 
+export type SorbetServerCapabilities = ServerCapabilities & {
+  sorbetShowSymbolProvider: boolean;
+};
+
 export class SorbetLanguageClient implements Disposable, ErrorHandler {
   private readonly context: SorbetExtensionContext;
   private readonly disposables: Disposable[];
-  public readonly languageClient: LanguageClient;
+  private readonly languageClient: LanguageClient;
   private readonly onStatusChangeEmitter: EventEmitter<ServerStatus>;
   private readonly restart: (reason: RestartReason) => void;
   private sorbetProcess?: ChildProcess;
@@ -93,11 +136,7 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
     this.wrappedStatus = ServerStatus.INITIALIZING;
 
     this.languageClient = shimLanguageClient(
-      SorbetLanguageClient.createClient(
-        context,
-        () => this.startSorbetProcess(),
-        this,
-      ),
+      createClient(context, () => this.startSorbetProcess(), this),
       (metric, value, tags) =>
         this.context.metrics.emitTimingMetric(metric, value, tags),
     );
@@ -153,39 +192,39 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
     });
   }
 
-  private static createClient(
-    context: SorbetExtensionContext,
-    serverOptions: ServerOptions,
-    errorHandler: ErrorHandler,
-  ) {
-    const client = new LanguageClient("ruby", "Sorbet", serverOptions, {
-      documentSelector: [
-        { language: "ruby", scheme: "file" },
-        // Support queries on generated files with sorbet:// URIs that do not exist editor-side.
-        { language: "ruby", scheme: "sorbet" },
-      ],
-      outputChannel: context.logOutputChannel,
-      initializationOptions: {
-        // Opt in to sorbet/showOperation notifications.
-        supportsOperationNotifications: true,
-        // Let Sorbet know that we can handle sorbet:// URIs for generated files.
-        supportsSorbetURIs: true,
-        highlightUntyped: context.configuration.highlightUntyped,
-      },
-      errorHandler,
-      revealOutputChannelOn: context.configuration.revealOutputOnError
-        ? RevealOutputChannelOn.Error
-        : RevealOutputChannelOn.Never,
-    });
-
-    return client;
+  /**
+   * Sorbet language server {@link SorbetServerCapabilities capabilities}. Only
+   * available if the server has been initialized.
+   */
+  public get capabilities(): SorbetServerCapabilities | undefined {
+    return <SorbetServerCapabilities | undefined>(
+      this.languageClient.initializeResult?.capabilities
+    );
   }
 
   /**
    * Contains error message when {@link status} is {@link ServerStatus.ERROR}.
    */
-  public get lastError(): string {
-    return this.wrappedLastError ?? "";
+  public get lastError(): string | undefined {
+    return this.wrappedLastError;
+  }
+
+  /**
+   *
+   * @returns
+   */
+  public onReady(): Promise<void> {
+    return this.languageClient.onReady();
+  }
+
+  /**
+   * Register a handler for a language server notification. See {@link LanguageClient.onNotification}.
+   */
+  public onNotification(
+    method: string,
+    handler: GenericNotificationHandler,
+  ): Disposable {
+    return this.languageClient.onNotification(method, handler);
   }
 
   /**
@@ -193,6 +232,17 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
    */
   public get onStatusChange(): Event<ServerStatus> {
     return this.onStatusChangeEmitter.event;
+  }
+
+  /**
+   * Send a request to language server. See {@link LanguageClient.sendRequest}.
+   */
+  public sendRequest<TResponse>(
+    method: string,
+    params: any,
+    token?: CancellationToken,
+  ): Promise<TResponse> {
+    return this.languageClient.sendRequest<TResponse>(method, params, token);
   }
 
   /**

--- a/vscode_extension/src/sorbetContentProvider.ts
+++ b/vscode_extension/src/sorbetContentProvider.ts
@@ -25,12 +25,10 @@ export class SorbetContentProvider implements TextDocumentContentProvider {
     token?: CancellationToken,
   ): Promise<string> {
     let content: string;
-    const { activeLanguageClient } = this.context.statusProvider;
-    if (activeLanguageClient) {
+    const { activeLanguageClient: client } = this.context.statusProvider;
+    if (client) {
       this.context.log.info(`Retrieving file contents. URI:${uri}`);
-      const response = await activeLanguageClient.languageClient.sendRequest<
-        TextDocumentItem
-      >(
+      const response = await client.sendRequest<TextDocumentItem>(
         "sorbet/readFile",
         {
           uri: uri.toString(),

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -163,9 +163,9 @@ export class SorbetStatusProvider implements Disposable {
     );
 
     // Wait for `ready` before accessing `languageClient`.
-    await newClient.languageClient.onReady();
+    await newClient.onReady();
     this.disposables.push(
-      newClient.languageClient.onNotification(
+      newClient.onNotification(
         "sorbet/showOperation",
         (params: ShowOperationParams) => {
           // Ignore event if this is not the current client (e.g. old client being shut down).

--- a/vscode_extension/src/test/commands/copySymbolToClipboard.test.ts
+++ b/vscode_extension/src/test/commands/copySymbolToClipboard.test.ts
@@ -78,14 +78,10 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
 
     const statusProvider = <SorbetStatusProvider>{
       activeLanguageClient: <SorbetLanguageClient>{
-        status: ServerStatus.RUNNING,
-        languageClient: <vsclc.LanguageClient>{
-          initializeResult: <any>{
-            capabilities: {
-              sorbetShowSymbolProvider: false,
-            },
-          },
+        capabilities: {
+          sorbetShowSymbolProvider: false,
         },
+        status: ServerStatus.RUNNING,
       },
     };
 
@@ -98,7 +94,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     sinon.assert.notCalled(writeTextSpy);
   });
 
-  test("copySymbolToClipboard: copies symbol to clipbaord whne there is a valid selection", async () => {
+  test("copySymbolToClipboard: copies symbol to clipboard whne there is a valid selection", async () => {
     const expectedUri = vscode.Uri.parse("file://workspace/test.rb");
     const expectedSymbolName = "test_symbol_name";
 
@@ -132,15 +128,11 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
 
     const statusProvider = <SorbetStatusProvider>{
       activeLanguageClient: <SorbetLanguageClient>{
-        status: ServerStatus.RUNNING,
-        languageClient: <vsclc.LanguageClient>{
-          initializeResult: <any>{
-            capabilities: {
-              sorbetShowSymbolProvider: true,
-            },
-          },
-          sendRequest: <any>sendRequestSpy,
+        capabilities: {
+          sorbetShowSymbolProvider: true,
         },
+        sendRequest: <any>sendRequestSpy,
+        status: ServerStatus.RUNNING,
       },
     };
     const context = <SorbetExtensionContext>{

--- a/vscode_extension/src/test/sorbetContentProvider.test.ts
+++ b/vscode_extension/src/test/sorbetContentProvider.test.ts
@@ -3,7 +3,6 @@ import * as assert from "assert";
 import * as path from "path";
 import * as sinon from "sinon";
 
-import { LanguageClient } from "vscode-languageclient/node";
 import { createLogStub } from "./testUtils";
 import { SorbetLanguageClient } from "../languageClient";
 import { LogLevel } from "../log";
@@ -30,11 +29,9 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       text: expectedContents,
     }));
     const statusProvider = <SorbetStatusProvider>{
-      activeLanguageClient: <SorbetLanguageClient>{
-        languageClient: <LanguageClient>(<unknown>{
-          sendRequest: sendRequestSpy,
-        }),
-      },
+      activeLanguageClient: <SorbetLanguageClient>(<unknown>{
+        sendRequest: sendRequestSpy,
+      }),
     };
     const context = <SorbetExtensionContext>{
       log: createLogStub(LogLevel.Info),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Stop exposing the inner `LanguageClient` instance from `SorbetLanguageClient` as it leads to confusion (e.g. what client to use for given scenario)

This PR only encapsulates `LanguageClient`  as a private field and exposes required methods. This will allow in the future to expose better purpose specific methods - e.g. instead of exposing the generic `sendRequest`, we could have better purpose-specific methods like `readFile` and `getSymbolInformation` (as used today).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
