### PR TITLE
Fix: Loaded Config ID might be invalid

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Version history
+## 0.3.22
+- Fix: 0.3.21 introduced an unintended behavior change: empty configurations Ids are treated the same as stale ones, causing Sorbet to stay in `Disabled` state until a new configuration is selected.
+
 ## 0.3.21
 - Provide UI hints on state of untyped code highlighting.
 - Internal code clean-up.

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -309,8 +309,8 @@ export class SorbetExtensionConfig implements Disposable {
     >("selectedLspConfigId", undefined);
 
     // Ensure `selectedLspConfigId` points to an existing configuration - loaded
-    // Id could be `undefined, empty or stale.
-    if (!this.selectedLspConfigId || !this.selectedLspConfig) {
+    // Id could be `undefined, empty.
+    if (!this.selectedLspConfigId) {
       this.selectedLspConfigId = this.lspConfigs[0]?.id;
     }
 

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -307,9 +307,10 @@ export class SorbetExtensionConfig implements Disposable {
     this.selectedLspConfigId = this.sorbetWorkspaceContext.get<
       string | undefined
     >("selectedLspConfigId", undefined);
-    if (this.selectedLspConfigId === undefined) {
-      // If no selectedLspConfigId has been explicitly set, but there
-      // are configurations, default to the first one.
+
+    // Ensure `selectedLspConfigId` points to an existing configuration - loaded
+    // Id could be `undefined, empty or stale.
+    if (!this.selectedLspConfigId || !this.selectedLspConfig) {
       this.selectedLspConfigId = this.lspConfigs[0]?.id;
     }
 

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -309,7 +309,7 @@ export class SorbetExtensionConfig implements Disposable {
     >("selectedLspConfigId", undefined);
 
     // Ensure `selectedLspConfigId` points to an existing configuration - loaded
-    // Id could be `undefined, empty.
+    // Id could be `undefined` or empty string.
     if (!this.selectedLspConfigId) {
       this.selectedLspConfigId = this.lspConfigs[0]?.id;
     }

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -308,8 +308,7 @@ export class SorbetExtensionConfig implements Disposable {
       string | undefined
     >("selectedLspConfigId", undefined);
 
-    // Ensure `selectedLspConfigId` points to an existing configuration - loaded
-    // Id could be `undefined` or empty string.
+    // Ensure `selectedLspConfigId` is a valid Id (not `undefined` or empty)
     if (!this.selectedLspConfigId) {
       this.selectedLspConfigId = this.lspConfigs[0]?.id;
     }

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -226,6 +226,12 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
     this.context.log.info("Running Sorbet LSP.");
     const [command, ...args] =
       this.context.configuration.activeLspConfig?.command ?? [];
+    if (!command) {
+      const msg = `Missing command-line data to start Sorbet. ConfigId:${this.context.configuration.activeLspConfig?.id}`;
+      this.context.log.error(msg);
+      return Promise.reject(new Error(msg));
+    }
+
     this.context.log.debug(` > ${command} ${args.join(" ")}`);
     this.sorbetProcess = spawn(command, args, {
       cwd: workspace.rootPath,

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -332,7 +332,7 @@ suite("SorbetExtensionConfig", async () => {
       });
 
       [undefined, ""].forEach((configId) => {
-        test(`when \`sorbet.selectedLspConfigId\` is ${configId}, picks first available`, async () => {
+        test(`when \`sorbet.selectedLspConfigId\` is '${configId}', picks first available configuration`, async () => {
           const workspaceConfig = new FakeWorkspaceConfiguration([
             ["enabled", true],
             ["lspConfigs", [fooLspConfig, barLspConfig]],

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -331,6 +331,28 @@ suite("SorbetExtensionConfig", async () => {
         );
       });
 
+      [undefined, ""].forEach((configId) => {
+        test(`when \`sorbet.selectedLspConfigId\` is ${configId}, picks first available`, async () => {
+          const workspaceConfig = new FakeWorkspaceConfiguration([
+            ["enabled", true],
+            ["lspConfigs", [fooLspConfig, barLspConfig]],
+            ["selectedLspConfigId", configId],
+          ]);
+          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
+          assert.strictEqual(sorbetConfig.enabled, true, "should be enabled");
+          assert.strictEqual(
+            sorbetConfig.selectedLspConfig,
+            sorbetConfig.lspConfigs[0],
+            "selectedLspConfig should be undefined",
+          );
+          assert.strictEqual(
+            sorbetConfig.activeLspConfig,
+            sorbetConfig.lspConfigs[0],
+            "activeLspConfig should be undefined",
+          );
+        });
+      });
+
       test("when `sorbet.selectedLspConfigId` matches none of the defined `sorbet.lspConfigs`", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration([
           ["enabled", true],


### PR DESCRIPTION
**Issue**
After releasing 0.3.21, there was at least one report of Sorbet remaining in `Disabled` state even when invoking `Sorbet Enabled`.  Logs point to `activeLspConfig?.command` returning `undefined`. Investigation points to this [line](https://github.com/sorbet/sorbet/pull/7123/files#diff-74b4789fcb47d46267de76e12453d322e7d44aa20837f54fda491077ad3ce8c1R307) being modified incorrectly by not accounting for empty string (this is a conjecture, however, as we have not debugged a repro scenario).

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

**Fix**
- Update `selectedLspConfigId` check to account for empty string. 
- Add tests to prevent regressions (or unintentional behavior changes).
- Add explicit error and better logging to diagnose the issue.
- There is the possibility of stale config IDs causing a similar issue (as Id is persisted as a `Memento`) but there is a test that actually ensures no config is selected in that case so not changing that behavior until it is better understood.
-
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Issue possibly introduced in https://github.com/sorbet/sorbet/pull/7123/

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
