### PR TITLE
Fix: Workspace with no active Sorbet configuration shows an initialization error.

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Version history
+## 0.3.23
+- Fix: Sorbet extension fails when opening a project containing Ruby code but no active configuration.
+
 ## 0.3.22
 - Fix: 0.3.21 introduced an unintended behavior change: empty configurations Ids are treated the same as stale ones, causing Sorbet to stay in `Disabled` state until a new configuration is selected.
 

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -125,6 +125,12 @@ export class SorbetStatusProvider implements Disposable {
    */
   public async startSorbet(): Promise<void> {
     if (this.isStarting) {
+      this.context.log.trace("Ignoring start request, already starting.");
+      return;
+    }
+
+    if (!this.context.configuration.activeLspConfig) {
+      this.context.log.info("Ignoring start request, no active configuration.");
       return;
     }
 


### PR DESCRIPTION
*Issue*: Opening a workspace that contains Ruby files but no active Sorbet configuration, shows an extension initialization error.

 *Fix*: Do not try to run Sorbet when there is no active configuratio (i.e. remain `Disabled`).

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://github.com/sorbet/sorbet/issues/7148

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
