### PR TITLE
Another Ruby 3.2 parser update

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1119,8 +1119,8 @@ public:
                                      std::move(value));
     }
 
-    unique_ptr<Node> kwnilarg(const token *dstar, const token *nil) {
-        return make_unique<Kwnilarg>(tokLoc(dstar).join(tokLoc(nil)));
+    unique_ptr<Node> kwnilarg(unique_ptr<Node> node) {
+        return make_unique<Kwnilarg>(node->loc);
     }
 
     unique_ptr<Node> kwrestarg(const token *dstar, const token *name) {
@@ -2332,9 +2332,9 @@ ForeignPtr kwoptarg(SelfPtr builder, const token *name, ForeignPtr value) {
     return build->toForeign(build->kwoptarg(name, build->cast_node(value)));
 }
 
-ForeignPtr kwnilarg(SelfPtr builder, const token *dstar, const token *nil) {
+ForeignPtr kwnilarg(SelfPtr builder, ForeignPtr node) {
     auto build = cast_builder(builder);
-    return build->toForeign(build->kwnilarg(dstar, nil));
+    return build->toForeign(build->kwnilarg(build->cast_node(node)));
 }
 
 ForeignPtr kwrestarg(SelfPtr builder, const token *dstar, const token *name) {

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -4166,9 +4166,9 @@ f_opt_paren_args: f_paren_args
 
      kwrest_mark: tPOW | tDSTAR
 
-      f_no_kwarg: kwrest_mark kNIL
+      f_no_kwarg: p_kwnorest
                     {
-                      $$ = driver.alloc.node_list(driver.build.kwnilarg(self, $1, $2));
+                      $$ = driver.alloc.node_list(driver.build.kwnilarg(self, $1->at(0)));
                     }
 
         f_kwrest: kwrest_mark tIDENTIFIER

--- a/parser/parser/include/ruby_parser/builder.hh
+++ b/parser/parser/include/ruby_parser/builder.hh
@@ -116,7 +116,7 @@ struct builder {
     ForeignPtr (*keywordZsuper)(SelfPtr builder, const token *keyword);
     ForeignPtr (*kwarg)(SelfPtr builder, const token *name);
     ForeignPtr (*kwoptarg)(SelfPtr builder, const token *name, ForeignPtr value);
-    ForeignPtr (*kwnilarg)(SelfPtr builder, const token *dstar, const token *nil);
+    ForeignPtr (*kwnilarg)(SelfPtr builder, ForeignPtr node);
     ForeignPtr (*kwrestarg)(SelfPtr builder, const token *dstar, const token *name);
     ForeignPtr (*kwsplat)(SelfPtr builder, const token *dstar, ForeignPtr arg);
     ForeignPtr (*line_literal)(SelfPtr builder, const token *tok);


### PR DESCRIPTION
Follow up to #6877

### Motivation
This PR attempts to bring the Sorbet parser grammar closer to whitequarks by making changes inspired by the following whitequark commits:
- https://github.com/whitequark/parser/commit/820cc04
- https://github.com/whitequark/parser/commit/1d275fc

These two changes replace instances of the `kwrest_mark` and `kNIL` tokens with the `p_kwnorest` rule. Afaik, it is a refactor and should not change the behavior of the parser, but should make it easier to implement other parser changes in the future.

### Implementation

The changes in this PR don't mirror the whitequark changes 1-to-1 because they expose a difference in the underlying implementation between the two parsers:

The whitequark parser has the `p_kwnorest` rule return a list of tokens, and then other rules pull the tokens from that list and consume them.

The Sorbet parser doesn't have a concept of a "list of tokens," if I understand it correctly. I tried implementing this change where the `p_kwnorest` rule returns a node list, but then the tokens are converted to nodes and hard to access. I also tried to create a new data structure in the parser called a token list (#7138) but Alex pointed out that initializing those data structures would consume more memory, which didn't seem worth it.

In the end, what we did was change the builder to build `Kwnilarg` nodes from one node rather than two tokens. It uses the location of the first token as the location of the node.

### Test plan

No change in functionality, existing tests should continue to pass.