### PR TITLE
Fix `strptime` sig

### DIFF
--- a/rbi/stdlib/date_time.rbi
+++ b/rbi/stdlib/date_time.rbi
@@ -653,7 +653,7 @@ class DateTime < Date
   #
   # See also strptime(3) and
   # [`strftime`](https://docs.ruby-lang.org/en/2.7.0/DateTime.html#method-i-strftime).
-  sig {params(str: String, fmt: String, sg: Integer).returns(DateTime)}
+  sig {params(str: String, fmt: String, sg: Integer).returns(T.attached_class)}
   def self.strptime(str="-4712-01-01T00:00:00+00:00", fmt="%FT%T%z", sg=Date::ITALY); end
 
   # Creates a new


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

```ruby
irb(main):009:0> class MyDateTime < DateTime; end
=> nil
irb(main):010:0> MyDateTime.strptime("2023-07-19T12:12Z", "%Y-%m-%dT%H:%M%:z")
=> #<MyDateTime: 2023-07-19T12:12:00+00:00 ((2460145j,43920s,0n),+0s,2299161j)>
irb(main):011:0> _.class
=> MyDateTime
```
this would suggest we want to type it as `returns(T.attached_class)`.

h/t @jez 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
