### PR TITLE
withSelfRef -> withSelfAndThisRef

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -1006,7 +1006,7 @@ struct DispatchArgs {
     }
     Loc blockLoc(const GlobalState &gs) const;
 
-    DispatchArgs withSelfRef(const TypePtr &newSelfRef) const;
+    DispatchArgs withSelfAndThisRef(const TypePtr &newSelfRef) const;
     DispatchArgs withThisRef(const TypePtr &newThisRef) const;
     DispatchArgs withErrorsSuppressed() const;
 };

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -74,8 +74,8 @@ DispatchResult FloatLiteralType::dispatchCall(const GlobalState &gs, const Dispa
 
 DispatchResult OrType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
     categoryCounterInc("dispatch_call", "ortype");
-    auto leftRet = left.dispatchCall(gs, args.withSelfRef(left));
-    auto rightRet = right.dispatchCall(gs, args.withSelfRef(right));
+    auto leftRet = left.dispatchCall(gs, args.withSelfAndThisRef(left));
+    auto rightRet = right.dispatchCall(gs, args.withSelfAndThisRef(right));
     return DispatchResult::merge(gs, DispatchResult::Combinator::OR, std::move(leftRet), std::move(rightRet));
 }
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1115,7 +1115,7 @@ Loc DispatchArgs::blockLoc(const GlobalState &gs) const {
     return blockLoc;
 }
 
-DispatchArgs DispatchArgs::withSelfRef(const TypePtr &newSelfRef) const {
+DispatchArgs DispatchArgs::withSelfAndThisRef(const TypePtr &newSelfRef) const {
     return DispatchArgs{
         name,        locs,          numPosArgs, args, newSelfRef, fullType, newSelfRef, block, originForUninitialized,
         isPrivateOk, suppressErrors};


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The implementation of this method actually updated both `thisType` and
`selfType`, not just self type. Which is actually what I hoped it did,
and I was about to make another method that did that. So let's just
rename it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests