### PR TITLE
prototype: linked generic type pairs

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -298,12 +298,25 @@ public:
         bool isContravariant : 1;
         bool isFixed : 1;
 
-        constexpr static uint8_t NUMBER_OF_FLAGS = 6;
+        // Type-member-specific flags
+        bool isLinkedGenericPair_ : 1;
+
+        constexpr static uint8_t NUMBER_OF_FLAGS = 7;
         constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         Flags() noexcept
             : isTypeArgument(false), isTypeMember(false), isCovariant(false), isInvariant(false),
-              isContravariant(false), isFixed(false) {}
+              isContravariant(false), isFixed(false), isLinkedGenericPair_(false) {}
+
+        bool isLinkedGenericPair() {
+            ENFORCE(isTypeMember);
+            return isLinkedGenericPair_;
+        }
+
+        void setIsLinkedGenericPair(bool isLinkedGenericPair) {
+            ENFORCE(isTypeMember);
+            this->isLinkedGenericPair_ = isLinkedGenericPair;
+        }
 
         uint8_t serialize() const {
             // Can replace this with std::bit_cast in C++20

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -192,12 +192,16 @@ NameDef names[] = {
     {"typeAlias", "type_alias"},
     {"typeMember", "type_member"},
     {"typeTemplate", "type_template"},
+    // TODO(jez) Pick a better name
+    {"linkedGenericTypePair", "linked_generic_type_pair"},
     {"covariant", "out"},
     {"contravariant", "in"},
     {"fixed"},
     {"lower"},
     {"upper"},
     {"declareHasAttachedClass", "has_attached_class!"},
+    // TODO(jez) Delete this; temporary for prototyping
+    {"LinkedGenericTypePair", "LinkedGenericTypePair", true},
 
     {"prop"},
     {"tokenProp", "token_prop"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1955,6 +1955,39 @@ public:
             return;
         }
 
+        auto singletonExternalType = singleton.data(gs)->externalType();
+        if (const auto *thisApplied = cast_type<AppliedType>(args.thisType)) {
+            const auto *singletonAppliedType = cast_type<AppliedType>(singletonExternalType);
+            ENFORCE(singletonAppliedType != nullptr, "should be true as long as !self.data(gs)->isModule()");
+
+            vector<TypePtr> targs;
+            int ttIdx = -1;
+            for (auto tt : singleton.data(gs)->typeMembers()) {
+                ttIdx++;
+
+                // TODO(jez) Eventually, check some flag on the symbol for this information
+                if (tt.data(gs)->name != core::Names::Constants::LinkedGenericTypePair()) {
+                    targs.emplace_back(singletonAppliedType->targs[ttIdx]);
+                    continue;
+                }
+
+                size_t tmIdx = 0;
+                for (auto tm : thisApplied->klass.data(gs)->typeMembers()) {
+                    if (tm.data(gs)->name == tt.data(gs)->name) {
+                        targs.emplace_back(thisApplied->targs[tmIdx]);
+                        break;
+                    }
+                    tmIdx++;
+                }
+                ENFORCE(tmIdx != thisApplied->klass.data(gs)->typeMembers().size(),
+                        "Did not find linked type member corresponding to type template!");
+            }
+
+            // TODO(jez) Validate that the type we just made is a valid type
+            // Fully defined, does not reference another type's type members, valid bounds, etc.
+            singletonExternalType = make_type<AppliedType>(singleton, move(targs));
+        }
+
         // `singleton` might have more type members than just the `<AttachedClass>` one.
         // Calling `externalType` is the easiest way to get proper defaults for all of those.
         // For the `<AttachedClass>` type member, we'll default it to its upper bound, like
@@ -1965,7 +1998,7 @@ public:
         // like normal, and ends up something like
         //     T.class_of(MyClass)[T.all(TypeOfReceiver, MyClass)]
         // (This matters, btw, in case the receiver is something like a generic.)
-        res.returnType = Types::all(gs, tClassSelfType, singleton.data(gs)->externalType());
+        res.returnType = Types::all(gs, tClassSelfType, singletonExternalType);
     }
 } Object_class;
 
@@ -1992,6 +2025,38 @@ public:
             return;
         }
         auto instanceTy = attachedClass.data(gs)->externalType();
+
+        const auto *thisApplied = cast_type<AppliedType>(args.thisType);
+        const auto *instanceTyApplied = cast_type<AppliedType>(instanceTy);
+        if (thisApplied != nullptr && instanceTyApplied != nullptr) {
+            vector<TypePtr> targs;
+            int tmIdx = -1;
+            for (auto tm : attachedClass.data(gs)->typeMembers()) {
+                tmIdx++;
+
+                // TODO(jez) Eventually, check some flag on the symbol for this information
+                if (tm.data(gs)->name != core::Names::Constants::LinkedGenericTypePair()) {
+                    targs.emplace_back(instanceTyApplied->targs[tmIdx]);
+                    continue;
+                }
+
+                size_t ttIdx = 0;
+                for (auto tt : thisApplied->klass.data(gs)->typeMembers()) {
+                    if (tt.data(gs)->name == tm.data(gs)->name) {
+                        targs.emplace_back(thisApplied->targs[ttIdx]);
+                        break;
+                    }
+                    ttIdx++;
+                }
+                ENFORCE(ttIdx != thisApplied->klass.data(gs)->typeMembers().size(),
+                        "Did not find linked type template corresponding to type member!");
+            }
+
+            // TODO(jez) Validate that the type we just made is a valid type
+            // Fully defined, does not reference another type's type members, valid bounds, etc.
+            instanceTy = make_type<AppliedType>(attachedClass, move(targs));
+        }
+
         // The Ruby VM treats `initialize` as private by default, but allows calling it directly within `new`.
         DispatchArgs innerArgs{Names::initialize(),
                                args.locs,

--- a/rewriter/TypeMembers.cc
+++ b/rewriter/TypeMembers.cc
@@ -30,6 +30,7 @@ void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
             continue;
         }
 
+        // TODO(jez) Update this to check for duplicate linkedGenericTypePair
         auto it = typeMembers.find(lhs->cnst);
         if (it != typeMembers.end()) {
             if (auto e = ctx.beginError(lhs->loc, core::errors::Namer::InvalidTypeDefinition)) {

--- a/test/testdata/infer/generics/data_view.rb
+++ b/test/testdata/infer/generics/data_view.rb
@@ -1,0 +1,66 @@
+# typed: strict
+# TODO(jez) minimize these tests a bit more
+
+class Module; include T::Sig; end
+
+
+class Model
+  include T::Props
+
+  sig {returns(T.self_type)}
+  def reload
+    self
+  end
+end
+
+class View
+  extend T::Generic
+  abstract!
+
+  LinkedGenericTypePair = type_member { {upper: Model} }
+
+  sig {params(instance: LinkedGenericTypePair).void}
+  def initialize(instance)
+    @instance = instance
+  end
+
+  sig {returns(LinkedGenericTypePair)}
+  def instance
+    @instance
+  end
+
+  sig {returns(T.self_type).checked(:tests)}
+  def reload
+    reloaded = T.reveal_type(instance.reload)
+    klass = self.class
+    T.reveal_type(klass)
+    klass.from_instance('')
+    result = klass.from_instance(reloaded)
+    T.reveal_type(result)
+    result
+  end
+
+  class << self
+    extend T::Generic
+    LinkedGenericTypePair = type_member { {upper: Model} }
+
+    sig { params(instance: LinkedGenericTypePair).returns(T.attached_class) }
+    def from_instance(instance)
+      instance.class.prop
+
+      # Not pictured: could use props to forward values to `new`
+      props = instance.class.props
+      T.reveal_type(props)
+
+      T.reveal_type(self)
+      new('')
+
+      result = new(instance)
+      T.reveal_type(result)
+
+      result2 = self[LinkedGenericTypePair].new(instance)
+      self[LinkedGenericTypePair].new('')
+      result2
+    end
+  end
+end

--- a/test/testdata/infer/generics/my_t_enum.rb
+++ b/test/testdata/infer/generics/my_t_enum.rb
@@ -1,0 +1,73 @@
+# typed: true
+
+class Module; include T::Sig; end
+
+class MyTEnum
+  extend T::Generic
+  abstract!
+
+  LinkedGenericTypePair = type_member
+
+  sig {params(serialized_val: LinkedGenericTypePair).void}
+  def initialize(serialized_val)
+    @serialized_val = serialized_val
+  end
+
+  sig {returns(LinkedGenericTypePair)}
+  def serialize; @serialized_val; end
+
+  class << self
+    extend T::Generic
+    LinkedGenericTypePair = type_member
+
+    sig {params(serialized_val: LinkedGenericTypePair).returns(T.nilable(T.attached_class))}
+    def try_deserialize(serialized_val)
+      raise "Not initialized" if @mapping.nil?
+      deserialized = @mapping[serialized_val]
+      T.reveal_type(deserialized)
+      deserialized
+    end
+
+    sig {params(blk: T.proc.void).void}
+    def enums(&blk)
+      @values = T.let(nil, T.nilable(T::Array[T.attached_class]))
+      yield
+      @mapping = T.let(nil, T.nilable(T::Hash[LinkedGenericTypePair, T.attached_class]))
+      @mapping = {}
+
+      # ... populate mapping ...
+    end
+  end
+end
+
+sig do
+  params(
+    klass: T.class_of(MyTEnum)[MyTEnum[String], String],
+    serialized_val: String,
+  )
+    .returns(MyTEnum[String])
+end
+def example1(klass, serialized_val)
+  instance = klass.try_deserialize(serialized_val)
+  T.reveal_type(instance)
+  result = T.must(instance)
+  result
+end
+
+sig do
+  params(
+    obj: MyTEnum[String],
+    serialized_val: String,
+  )
+    .returns(T.class_of(MyTEnum)[MyTEnum[String], String])
+end
+def example2(obj, serialized_val)
+  klass = obj.class
+  T.reveal_type(klass)
+  instance = klass.try_deserialize(serialized_val)
+  T.reveal_type(instance)
+  result = T.must(instance)
+  T.reveal_type(result.class)
+  result.class
+end
+


### PR DESCRIPTION
**Not meant to be committed, just wanted to save my work**

I do not know if/when I will have time to return to this.

- - - - -

Hacky, because it hard-codes the `LinkedGenericTypePair` name, and uses
`class << self` tricks to get the constants to resolve correctly

Any final solution here is likely going to have to come up with a clever
trick for how to get

```ruby
sig {returns(X)}
```

to resolve as either the `type_member` or the `type_template` depending
on whether the sig is on top of an instance or singleton class method.

(In my examples, I was abusing `class << self` to get this to resolve,
just to test that the calls.cc intrinsics work as expected.)

Some strategies for getting the syntax to parse, none of which I'm
attached to:

- desugar to `class << self`, and require people to use `class << self`
  to use that type in a sig (confusing)
- hijack constant resolution somehow?
- at the point where we would have reported a "you're using a
  type_member / type_template from the wrong scope" error, simply change
  it to the linked symbol if necessary
- find a clever way to use UniqueName's, so that you can rewrite without
  having to use `class << self`
- attempt to build some first-party support for these linked pairs,
  which would involve changing FoundDefinitions and namer and resolver.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.