### PR TITLE
Disable "Copy Symbol to Clipboard" when there is a selection.

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Version history
+## 0.3.24
+- Disable the `Copy Symbol to Clipboard` command when there is a text selection.
+
 ## 0.3.23
 - Fix: Sorbet extension fails when opening a project containing Ruby code but no active configuration.
 

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -58,7 +58,7 @@
         "command": "sorbet.copySymbolToClipboard",
         "title": "Copy Symbol to Clipboard",
         "category": "Sorbet",
-        "enablement": "editorLangId == ruby"
+        "enablement": "editorLangId == ruby && !editorHasSelection"
       },
       {
         "command": "sorbet.disable",


### PR DESCRIPTION
Disable the `Copy Symbol to Clipboard` command when there is a text selection in the currently active editor. 
1. [Command implementation](https://github.com/sorbet/sorbet/blob/65631d703baa2df596d83d7ba50c961629d05574/vscode_extension/src/commands/copySymbolToClipboard.ts#L35) silently does nothing today.
2. We already disable the command when current active editor is not a Ruby file, so this change really is aligning both behaviors.
3. It is not great to disable UI without providing some feedback to the user on why it is disabled, but it is worse to silently do nothing (as contents of the clipboard remain untouched they lead to other issues).

See [Enablement of Commands](https://code.visualstudio.com/api/extension-guides/command#enablement-of-commands) for a description of behavior.

<p align=center>
<img width="320" alt="image" src="https://github.com/sorbet/sorbet/assets/46902661/d79614c5-a2ea-49a0-ba51-41fa06fd895f">
</p>

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
 The issue here is one of expectations: 
- A selection might cover multiple symbols or lines of code, so it cannot be used as-is.
- A selection includes a start and an end locations, as well as a cursor location.  None of these matches the location of the mouse cursor when using the context menu, and there is no information on whether the command is being run via mouse to support "some scenarios" so using the current editor cursor location might give unexpected results when using the mouse.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
