### PR TITLE
"Copy Symbol to Clipboard" shows a progress dialog when needed

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Version history
 ## 0.3.24
-- Disable the `Copy Symbol to Clipboard` command when there is a text selection.
+- `Copy Symbol to Clipboard`
+  - Disable command when there is a text selection.
+  - Show a progress dialog when Sorbet is not ready to process commands.
 
 ## 0.3.23
 - Fix: Sorbet extension fails when opening a project containing Ruby code but no active configuration.

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -1,11 +1,5 @@
 import { ChildProcess, spawn } from "child_process";
-import {
-  CancellationToken,
-  Disposable,
-  Event,
-  EventEmitter,
-  workspace,
-} from "vscode";
+import { Disposable, Event, EventEmitter, workspace } from "vscode";
 import {
   CloseAction,
   ErrorAction,
@@ -239,13 +233,8 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
   public sendRequest<TResponse>(
     method: string,
     param: any,
-    token?: CancellationToken,
   ): Promise<TResponse> {
-    // Do not pass `token` if undefined, otherwise `param` ends up being passed
-    // as `[...param, undefined]` instead of `param`.
-    return token
-      ? this.languageClient.sendRequest<TResponse>(method, param, token)
-      : this.languageClient.sendRequest<TResponse>(method, param);
+    return this.languageClient.sendRequest<TResponse>(method, param);
   }
 
   /**

--- a/vscode_extension/src/sorbetContentProvider.ts
+++ b/vscode_extension/src/sorbetContentProvider.ts
@@ -22,7 +22,7 @@ export class SorbetContentProvider implements TextDocumentContentProvider {
    */
   public async provideTextDocumentContent(
     uri: Uri,
-    token?: CancellationToken,
+    _token?: CancellationToken,
   ): Promise<string> {
     let content: string;
     const { activeLanguageClient: client } = this.context.statusProvider;
@@ -33,7 +33,6 @@ export class SorbetContentProvider implements TextDocumentContentProvider {
         {
           uri: uri.toString(),
         },
-        token,
       );
       content = response.text;
     } else {


### PR DESCRIPTION
**Issue**
The `sorbet/showSymbol`  [request](https://github.com/sorbet/sorbet/blob/166024b5c9688ea0053ded271485ad123c8aa337/vscode_extension/src/commands/copySymbolToClipboard.ts#L49) does not resolve until Sorbet can actually process the request. This can take more than a few seconds causing unexpected results as user tries the command, "nothing happens" and so they try again (or try a bit later at a different place). The requests eventually resolve, overriding the clipboard contents in whatever order they come back.  

**Fix**
Update "Copy Symbol to Clipboard" command so it shows a progress dialog when Sorbet's status is not `Idle` (otherwise it won't). Without UI, there is no way to know that there are pending requests, so this change introduces a progress dialog whenever Sorbet is not ready. 
- Whenever Sorbet is ready to process a request,  no notification is presented at all .
- Adding UI should help users understand an operation is pending. This notification is cancelable, so operations can be safely discarded (see not below about `LanguageClient.sendRequest`). 
- Ideally, the command would only allow one pending operation but that introduced more complexity on the PR (and need to figure out quirks about UX), so decided to do that as follow-up work (note that today, you can queue up multiple requests unknowingly, so this is just making those requests visible).

<p align=center>
<img width="400" alt="image" src="https://github.com/sorbet/sorbet/assets/46902661/5235c705-1704-47ab-8e04-3f95bc03590f">
</p>

**Misc**
- Found out that even though [LanguageClient.request](https://github.com/sorbet/sorbet/blob/166024b5c9688ea0053ded271485ad123c8aa337/vscode_extension/src/languageClient.ts#L247) takes in `CancellationToken`, it actually does not process any cancellation request.   This meant that after clicking on `Cancel`, the notification would go away but the request would keep going and at some point, the result would come back and override the clipboard.  This case is handled correctly on this PR, but to prevent mistakes, this PR removes the ability to pass a `CancellationToken` to the `sendRequest` method.
  - We need to verify if cancellation requests to the LSP are supported.

- Some logging entries in the command implementation were not ideal (e.g. they would report that the "current" Sorbet LSP client did not support the "showSymbol" capability when in reality there was not client to talk to), so they are updated.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
