### PR TITLE
Don't duplicate vector when calling pipeline::index

### DIFF
--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -164,10 +164,10 @@ void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spd
 
 vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::GlobalState> &gs,
                                                            const realmain::options::Options &opts,
-                                                           spdlog::logger &logger, vector<core::FileRef> &files,
+                                                           spdlog::logger &logger, vector<core::FileRef> &&files,
                                                            WorkerPool &workers,
                                                            const unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    auto asts = realmain::pipeline::index(*gs, files, opts, workers, kvstore);
+    auto asts = realmain::pipeline::index(*gs, move(files), opts, workers, kvstore);
     ENFORCE_NO_TIMER(asts.size() == files.size());
 
     // Below, we rewrite ASTs to an empty GlobalState and use them for hashing.

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -50,7 +50,7 @@ public:
      */
     static std::vector<ast::ParsedFile>
     indexAndComputeFileHashes(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
-                              spdlog::logger &logger, std::vector<core::FileRef> &files, WorkerPool &workers,
+                              spdlog::logger &logger, std::vector<core::FileRef> &&files, WorkerPool &workers,
                               const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 };
 } // namespace sorbet::hashing

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -304,7 +304,7 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPoo
         // which one it will be.
         initialGS->errorQueue = make_shared<core::ErrorQueue>(
             initialGS->errorQueue->logger, initialGS->errorQueue->tracer, make_shared<core::NullFlusher>());
-        auto trees = hashing::Hashing::indexAndComputeFileHashes(initialGS, config->opts, *config->logger, frefs,
+        auto trees = hashing::Hashing::indexAndComputeFileHashes(initialGS, config->opts, *config->logger, move(frefs),
                                                                  workers, kvstore);
         update.updatedFileIndexes.resize(trees.size());
         for (auto &ast : trees) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -91,7 +91,7 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
             indexed.resize(initialGS->filesUsed());
 
             auto asts = hashing::Hashing::indexAndComputeFileHashes(initialGS, config->opts, *config->logger,
-                                                                    inputFiles, workers, ownedKvstore);
+                                                                    move(inputFiles), workers, ownedKvstore);
             // asts are in fref order, but we (currently) don't index and compute file hashes for payload files, so
             // vector index != FileRef ID. Fix that by slotting them into `indexed`.
             for (auto &ast : asts) {

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -413,7 +413,7 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
     // I'm ignoring everything relating to caching here, because missing methods is likely
     // to run on a new _unknown.rbi file every time and I didn't want to think about it.
     // If this phase gets slow, we can consider whether caching would speed things up.
-    auto rbiIndexed = pipeline::index(*rbiGS, rbiInputFiles, opts, workers, nullptr);
+    auto rbiIndexed = pipeline::index(*rbiGS, move(rbiInputFiles), opts, workers, nullptr);
     if (rbiGS->hadCriticalError()) {
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -529,7 +529,7 @@ vector<ast::ParsedFile> mergeIndexResults(core::GlobalState &cgs, const options:
     return ret;
 }
 
-vector<ast::ParsedFile> indexSuppliedFiles(core::GlobalState &baseGs, vector<core::FileRef> &files,
+vector<ast::ParsedFile> indexSuppliedFiles(core::GlobalState &baseGs, vector<core::FileRef> &&files,
                                            const options::Options &opts, WorkerPool &workers,
                                            const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     auto resultq = make_shared<BlockingBoundedQueue<IndexThreadResultPack>>(files.size());
@@ -572,7 +572,7 @@ vector<ast::ParsedFile> indexSuppliedFiles(core::GlobalState &baseGs, vector<cor
     return mergeIndexResults(baseGs, opts, resultq, workers, kvstore);
 }
 
-vector<ast::ParsedFile> index(core::GlobalState &gs, vector<core::FileRef> files, const options::Options &opts,
+vector<ast::ParsedFile> index(core::GlobalState &gs, vector<core::FileRef> &&files, const options::Options &opts,
                               WorkerPool &workers, const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     Timer timeit(gs.tracer(), "index");
     vector<ast::ParsedFile> ret;
@@ -593,7 +593,7 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, vector<core::FileRef> files
         }
         ENFORCE(files.size() == ret.size());
     } else {
-        ret = indexSuppliedFiles(gs, files, opts, workers, kvstore);
+        ret = indexSuppliedFiles(gs, move(files), opts, workers, kvstore);
     }
 
     fast_sort(ret, [](ast::ParsedFile const &a, ast::ParsedFile const &b) { return a.file < b.file; });

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -18,7 +18,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 
-std::vector<ast::ParsedFile> index(core::GlobalState &gs, std::vector<core::FileRef> files,
+std::vector<ast::ParsedFile> index(core::GlobalState &gs, std::vector<core::FileRef> &&files,
                                    const options::Options &opts, WorkerPool &workers,
                                    const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -641,7 +641,7 @@ int realmain(int argc, char *argv[]) {
             // only the package files that we know we need to load, it would cut down command-line rbi generation by
             // seconds.
             auto packageFileRefs = pipeline::reserveFiles(gs, packageFiles);
-            auto packages = pipeline::index(*gs, packageFileRefs, opts, *workers, nullptr);
+            auto packages = pipeline::index(*gs, move(packageFileRefs), opts, *workers, nullptr);
             {
                 core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
                 core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
@@ -700,9 +700,10 @@ int realmain(int argc, char *argv[]) {
         {
             if (!opts.storeState.empty() || opts.forceHashing) {
                 // Calculate file hashes alongside indexing when --store-state is specified for LSP mode
-                indexed = hashing::Hashing::indexAndComputeFileHashes(gs, opts, *logger, inputFiles, *workers, kvstore);
+                indexed =
+                    hashing::Hashing::indexAndComputeFileHashes(gs, opts, *logger, move(inputFiles), *workers, kvstore);
             } else {
-                indexed = pipeline::index(*gs, inputFiles, opts, *workers, kvstore);
+                indexed = pipeline::index(*gs, move(inputFiles), opts, *workers, kvstore);
             }
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);

--- a/payload/text/populate.cc
+++ b/payload/text/populate.cc
@@ -22,7 +22,7 @@ void populateRBIsInto(unique_ptr<core::GlobalState> &gs) {
     realmain::options::Options emptyOpts;
     unique_ptr<const OwnedKeyValueStore> kvstore;
     auto workers = WorkerPool::create(emptyOpts.threads, gs->tracer());
-    auto indexed = realmain::pipeline::index(*gs, payloadFiles, emptyOpts, *workers, kvstore);
+    auto indexed = realmain::pipeline::index(*gs, move(payloadFiles), emptyOpts, *workers, kvstore);
     // While we want the FoundMethodHashes to end up in the payload, these hashes (including
     // LocalGlobalStateHashes and UsageHash) are not computed until `computeFileHashes` is called in
     // realmain when the `storeState` flag is passed. This means that e.g. sorbet-orig -e

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -69,7 +69,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         file.data(*gs).strictLevel = core::StrictLevel::True;
     }
 
-    indexed = realmain::pipeline::index(*gs, inputFiles, *opts, *workers, kvstore);
+    indexed = realmain::pipeline::index(*gs, move(inputFiles), *opts, *workers, kvstore);
     auto foundHashes = nullptr;
     indexed = move(realmain::pipeline::resolve(gs, move(indexed), *opts, *workers, foundHashes).result());
     realmain::pipeline::typecheck(*gs, move(indexed), *opts, *workers);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Slight memory and performance optimization. In a codebase with 250,000 files,
this will save about 1 MB, because a FileRef is 4 bytes. So in all likelihood,
this won't translate to a noticeable performance improvement. But it's still
nice to have.

This change is safe because `indexSuppliedFiles` in `pipeline.cc` is already
`move`'ing each FileRef out of the vector to enqueue it, which ensures that no
one after a call to `pipeline::index` happens could be relying on the elements
still being there.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests