### PR TITLE
Take an absl::Span in pipeline::index instead of a vector

### DIFF
--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -164,7 +164,7 @@ void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spd
 
 vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::GlobalState> &gs,
                                                            const realmain::options::Options &opts,
-                                                           spdlog::logger &logger, vector<core::FileRef> &files,
+                                                           spdlog::logger &logger, absl::Span<core::FileRef> files,
                                                            WorkerPool &workers,
                                                            const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     auto asts = realmain::pipeline::index(*gs, files, opts, workers, kvstore);

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -50,7 +50,7 @@ public:
      */
     static std::vector<ast::ParsedFile>
     indexAndComputeFileHashes(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
-                              spdlog::logger &logger, std::vector<core::FileRef> &files, WorkerPool &workers,
+                              spdlog::logger &logger, absl::Span<core::FileRef> files, WorkerPool &workers,
                               const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 };
 } // namespace sorbet::hashing

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -304,8 +304,8 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPoo
         // which one it will be.
         initialGS->errorQueue = make_shared<core::ErrorQueue>(
             initialGS->errorQueue->logger, initialGS->errorQueue->tracer, make_shared<core::NullFlusher>());
-        auto trees = hashing::Hashing::indexAndComputeFileHashes(initialGS, config->opts, *config->logger, frefs,
-                                                                 workers, kvstore);
+        auto trees = hashing::Hashing::indexAndComputeFileHashes(initialGS, config->opts, *config->logger,
+                                                                 absl::Span<core::FileRef>(frefs), workers, kvstore);
         update.updatedFileIndexes.resize(trees.size());
         for (auto &ast : trees) {
             const int i = fileToPos[ast.file];

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -90,8 +90,8 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
             inputFiles = pipeline::reserveFiles(initialGS, config->opts.inputFileNames);
             indexed.resize(initialGS->filesUsed());
 
-            auto asts = hashing::Hashing::indexAndComputeFileHashes(initialGS, config->opts, *config->logger,
-                                                                    inputFiles, workers, ownedKvstore);
+            auto asts = hashing::Hashing::indexAndComputeFileHashes(
+                initialGS, config->opts, *config->logger, absl::Span<core::FileRef>(inputFiles), workers, ownedKvstore);
             // asts are in fref order, but we (currently) don't index and compute file hashes for payload files, so
             // vector index != FileRef ID. Fix that by slotting them into `indexed`.
             for (auto &ast : asts) {

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -413,7 +413,7 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
     // I'm ignoring everything relating to caching here, because missing methods is likely
     // to run on a new _unknown.rbi file every time and I didn't want to think about it.
     // If this phase gets slow, we can consider whether caching would speed things up.
-    auto rbiIndexed = pipeline::index(*rbiGS, rbiInputFiles, opts, workers, nullptr);
+    auto rbiIndexed = pipeline::index(*rbiGS, absl::Span<core::FileRef>(rbiInputFiles), opts, workers, nullptr);
     if (rbiGS->hadCriticalError()) {
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -529,7 +529,7 @@ vector<ast::ParsedFile> mergeIndexResults(core::GlobalState &cgs, const options:
     return ret;
 }
 
-vector<ast::ParsedFile> indexSuppliedFiles(core::GlobalState &baseGs, vector<core::FileRef> &files,
+vector<ast::ParsedFile> indexSuppliedFiles(core::GlobalState &baseGs, absl::Span<core::FileRef> files,
                                            const options::Options &opts, WorkerPool &workers,
                                            const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     auto resultq = make_shared<BlockingBoundedQueue<IndexThreadResultPack>>(files.size());
@@ -572,7 +572,7 @@ vector<ast::ParsedFile> indexSuppliedFiles(core::GlobalState &baseGs, vector<cor
     return mergeIndexResults(baseGs, opts, resultq, workers, kvstore);
 }
 
-vector<ast::ParsedFile> index(core::GlobalState &gs, vector<core::FileRef> files, const options::Options &opts,
+vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> files, const options::Options &opts,
                               WorkerPool &workers, const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     Timer timeit(gs.tracer(), "index");
     vector<ast::ParsedFile> ret;

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -18,9 +18,8 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 
-std::vector<ast::ParsedFile> index(core::GlobalState &gs, std::vector<core::FileRef> files,
-                                   const options::Options &opts, WorkerPool &workers,
-                                   const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
+std::vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> files, const options::Options &opts,
+                                   WorkerPool &workers, const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 
 std::vector<ast::ParsedFile> package(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                      const options::Options &opts, WorkerPool &workers);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -641,7 +641,7 @@ int realmain(int argc, char *argv[]) {
             // only the package files that we know we need to load, it would cut down command-line rbi generation by
             // seconds.
             auto packageFileRefs = pipeline::reserveFiles(gs, packageFiles);
-            auto packages = pipeline::index(*gs, packageFileRefs, opts, *workers, nullptr);
+            auto packages = pipeline::index(*gs, absl::Span<core::FileRef>(packageFileRefs), opts, *workers, nullptr);
             {
                 core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
                 core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
@@ -700,9 +700,10 @@ int realmain(int argc, char *argv[]) {
         {
             if (!opts.storeState.empty() || opts.forceHashing) {
                 // Calculate file hashes alongside indexing when --store-state is specified for LSP mode
-                indexed = hashing::Hashing::indexAndComputeFileHashes(gs, opts, *logger, inputFiles, *workers, kvstore);
+                indexed = hashing::Hashing::indexAndComputeFileHashes(
+                    gs, opts, *logger, absl::Span<core::FileRef>(inputFiles), *workers, kvstore);
             } else {
-                indexed = pipeline::index(*gs, inputFiles, opts, *workers, kvstore);
+                indexed = pipeline::index(*gs, absl::Span<core::FileRef>(inputFiles), opts, *workers, kvstore);
             }
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);

--- a/payload/text/populate.cc
+++ b/payload/text/populate.cc
@@ -22,7 +22,8 @@ void populateRBIsInto(unique_ptr<core::GlobalState> &gs) {
     realmain::options::Options emptyOpts;
     unique_ptr<const OwnedKeyValueStore> kvstore;
     auto workers = WorkerPool::create(emptyOpts.threads, gs->tracer());
-    auto indexed = realmain::pipeline::index(*gs, payloadFiles, emptyOpts, *workers, kvstore);
+    auto indexed =
+        realmain::pipeline::index(*gs, absl::Span<core::FileRef>(payloadFiles), emptyOpts, *workers, kvstore);
     // While we want the FoundMethodHashes to end up in the payload, these hashes (including
     // LocalGlobalStateHashes and UsageHash) are not computed until `computeFileHashes` is called in
     // realmain when the `storeState` flag is passed. This means that e.g. sorbet-orig -e


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

1.  Previously, we were taking the vector by value in `pipeline::index`,
    which was wasteful, because no one ever used the vector after that.
    Taking it by span avoids a copy.

2.  In the future, I want to be able to ask Sorbet to operate on a
    subset of the input (e.g., only the first N, where there are N
    `__package.rb` files at the start of the vector). Using `absl::Span`
    everywhere will make this easier.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.