### PR TITLE
Index all `__package.rb` files before everything else

### DIFF
--- a/core/FileRef.h
+++ b/core/FileRef.h
@@ -47,6 +47,11 @@ public:
     const File &dataAllowingUnsafe(const GlobalState &gs) const;
     File &dataAllowingUnsafe(GlobalState &gs) const;
 
+    // Normally, using .data requires that the file have been read.
+    // But File::Flag data is populated when the File is created, before needing to read the
+    // file. This helper exposes that without tripping an ENFORCE.
+    bool isPackage(const GlobalState &gs) const;
+
 private:
     uint32_t _id;
 };

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -302,6 +302,12 @@ File &FileRef::dataAllowingUnsafe(GlobalState &gs) const {
     return *(gs.files[_id]);
 }
 
+bool FileRef::isPackage(const GlobalState &gs) const {
+    ENFORCE(gs.files[_id]);
+    ENFORCE(gs.files[_id]->sourceType != File::Type::TombStone);
+    return dataAllowingUnsafe(gs).isPackage();
+}
+
 string_view File::path() const {
     return this->path_;
 }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -708,7 +708,7 @@ int realmain(int argc, char *argv[]) {
                 // index doesn't depend on this order, because it is already indexes files in
                 // parallel and sorts the resulting parsed files at the end. For that reason, I've
                 // chosen not to use stable_partition here.
-                auto packageFilesEnd = absl::c_partition(inputFiles, [&](auto f) { return f.data(*gs).isPackage(); });
+                auto packageFilesEnd = absl::c_partition(inputFiles, [&](auto f) { return f.isPackage(*gs); });
                 auto numPackageFiles = distance(inputFiles.begin(), packageFilesEnd);
                 auto inputPackageFiles = inputFilesSpan.first(numPackageFiles);
                 inputFilesSpan = inputFilesSpan.subspan(numPackageFiles);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We want to start using the package graph for the sake of skipping some
work, which means we have to make sure that package files are indexed
before we do anything else. Eventually a second step will be to both
index **and** parse the package DB before we do anything else, and I
will do that in a follow up change.

But for the time being, I want to start slowly and make sure nothing is
breaking.

This _should_ be a no-op change, though it will involve one more fork +
join step, which might make Sorbet slower on pay-server because of this.
While that's not great, we should recover that time and more when we
start using this to type check a subset of the codebase.

It's also worth noting that we will need to make corresponding changes
to LSP eventually. Those will definitely come, but for now I plan to
experiment mostly with the command line mode of Sorbet.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I think this should be covered by existing tests.
There should not be any new behavior in this test.

I also plan for Stripe's codebase to be the main arbiter of this change.