### PR TITLE
Show demangled package name in blame output

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1293,8 +1293,8 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
         writer.String("package");
         if (sym.exists() && sym.loc(gs).exists()) {
             const auto file = sym.loc(gs).file();
-            const auto pkg = gs.packageDB().getPackageNameForFile(file);
-            if (pkg == core::NameRef::noName()) {
+            const auto &pkg = gs.packageDB().getPackageForFile(gs, file);
+            if (pkg.exists()) {
                 writer.String("<none>");
             } else {
                 writer.String(pkg.show(gs));

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1294,7 +1294,7 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
         if (sym.exists() && sym.loc(gs).exists()) {
             const auto file = sym.loc(gs).file();
             const auto &pkg = gs.packageDB().getPackageForFile(gs, file);
-            if (pkg.exists()) {
+            if (!pkg.exists()) {
                 writer.String("<none>");
             } else {
                 writer.String(pkg.show(gs));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have other data sources within Stripe that use the demangled package
name. The mangled name is an artifact of Sorbet's internals, not a
public API.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We do not have tests for this. I am assuming that if it compiles it works.

I did trace the code to make sure that PackageInfo::show shows the demangled name.