### PR TITLE
Add additional sig for caller_locations

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -163,7 +163,7 @@ module T::Private::Methods
 
         definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
         is_redefined = target == ancestor
-        caller_loc = caller_locations&.find {|l| !l.to_s.start_with?(SORBET_RUNTIME_LIB_PATH)}
+        caller_loc = caller_locations.find {|l| !l.to_s.start_with?(SORBET_RUNTIME_LIB_PATH)}
         extra_info = "\n"
         if caller_loc
           extra_info = (is_redefined ? "Redefined" : "Overridden") + " here: #{caller_loc.path}:#{caller_loc.lineno}\n"

--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -176,7 +176,7 @@ module T::Props
         base_message = "Can't set #{klass.name}.#{prop} to #{val.inspect} (instance of #{val.class}) - need a #{type}"
 
         pretty_message = "Parameter '#{prop}': #{base_message}\n"
-        caller_loc = caller_locations&.find {|l| !l.to_s.include?('sorbet-runtime/lib/types/props')}
+        caller_loc = caller_locations.find {|l| !l.to_s.include?('sorbet-runtime/lib/types/props')}
         if caller_loc
           pretty_message += "Caller: #{caller_loc.path}:#{caller_loc.lineno}\n"
         end

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -168,6 +168,9 @@ module Kernel
     )
     .returns(T.nilable(T::Array[Thread::Backtrace::Location]))
   end
+  sig do
+    returns(T::Array[Thread::Backtrace::Location])
+  end
   def caller_locations(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
 
   # `catch` executes its block. If `throw` is not called, the block executes

--- a/test/cli/track-untyped/test.out
+++ b/test/cli/track-untyped/test.out
@@ -22,8 +22,8 @@ a.rb:9: Argument passed to parameter `arg0` is `T.untyped` https://srb.help/7018
      9 |    puts(result)
                  ^^^^^^
   Expected `BasicObject` for argument `arg0` of method `Kernel#puts`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1903:
-    1903 |        arg0: BasicObject,
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1906:
+    1906 |        arg0: BasicObject,
                   ^^^^
   Got `T.untyped` originating from:
     a.rb:6:

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -5,6 +5,10 @@ extend T::Sig
 T.assert_type!(caller, T::Array[String])
 T.assert_type!(caller(10), T.nilable(T::Array[String]))
 
+T.assert_type!(caller_locations, T::Array[Thread::Backtrace::Location])
+T.assert_type!(caller_locations(2, 10), T.nilable(T::Array[Thread::Backtrace::Location]))
+T.assert_type!(caller_locations(1..10), T.nilable(T::Array[Thread::Backtrace::Location]))
+
 T.assert_type!(BigDecimal('123', 1, exception: true), BigDecimal)
 T.assert_type!(Complex('123', exception: false), Complex)
 T.assert_type!(Float('123.0'), Float)


### PR DESCRIPTION
### Motivation

Similar to the `caller` method, `caller_locations` should only be nilable if a parameter is passed. I added an additional `sig` to indicate this so we don't need to use safe navigation unless a paramater is passed through. 


### Test plan

I removed the instances I found of using safe navigation on `caller_locations` when no parameters are passed, and added tests to `test/testdata/rbi/kernel.rb` per the comment below! 🙏 