### PR TITLE
Add support for inference-based LSPQuery in RBI files

### DIFF
--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -318,7 +318,13 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     }
 
     core::TypePtr guessedReturnType;
-    if (!constr.isEmpty()) {
+    if (ctx.file.data(ctx).isRBI()) {
+        // We will always infer a return type of `NilClass` in an RBI file, because all RBI files
+        // have empty bodies. That's not useful--we'd rather infer `T.untyped` so that LSP
+        // replaces it with a tabstop the user can cycle through.
+        guessedReturnType = core::Types::untypedUntracked();
+
+    } else if (!constr.isEmpty()) {
         if (!constr.solve(ctx)) {
             return nullopt;
         }

--- a/test/testdata/lsp/queries_in_rbi.A.rbedited
+++ b/test/testdata/lsp/queries_in_rbi.A.rbedited
@@ -1,0 +1,35 @@
+# typed: true
+
+class A
+  # There's no `T::Sig` in scope here, because the user forgot or didn't want
+  # to put `extend T::Sig` (not required in RBI files), which means we can't
+  # give autocompletion results.
+  #
+  # NOTE that codebases which have `class Module; include T::Sig; end`, are able
+  # to get sig completion here
+
+  sig
+  #  ^ completion: (nothing)
+  def foo; end
+end
+
+class B
+  extend T::Sig
+
+  sig { params(x: ${1:T.untyped}).returns(${2:T.untyped}) }${0}
+  #  ^ completion: sig
+  #  ^ apply-completion: [A] item: 0
+  def foo(x); end
+end
+
+class C
+  sig {returns(T.noreturn)}
+  #               ^ hover: For more information, see https://sorbet.org/docs/noreturn
+  def always_raise; end
+end
+
+class D
+  sig {returns(T.noret)} # error: Unsupported method `T.noret`
+  #                   ^ completion: noreturn
+  def foo; end
+end

--- a/test/testdata/lsp/queries_in_rbi.rbi
+++ b/test/testdata/lsp/queries_in_rbi.rbi
@@ -1,0 +1,35 @@
+# typed: true
+
+class A
+  # There's no `T::Sig` in scope here, because the user forgot or didn't want
+  # to put `extend T::Sig` (not required in RBI files), which means we can't
+  # give autocompletion results.
+  #
+  # NOTE that codebases which have `class Module; include T::Sig; end`, are able
+  # to get sig completion here
+
+  sig
+  #  ^ completion: (nothing)
+  def foo; end
+end
+
+class B
+  extend T::Sig
+
+  sig
+  #  ^ completion: sig
+  #  ^ apply-completion: [A] item: 0
+  def foo(x); end
+end
+
+class C
+  sig {returns(T.noreturn)}
+  #               ^ hover: For more information, see https://sorbet.org/docs/noreturn
+  def always_raise; end
+end
+
+class D
+  sig {returns(T.noret)} # error: Unsupported method `T.noret`
+  #                   ^ completion: noreturn
+  def foo; end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This gives users access to hover, go-to-def, and completion in RBI
files.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.