### PR TITLE
Factor some common code

### DIFF
--- a/test/testdata/desugar/assign_empty_stmts.rb
+++ b/test/testdata/desugar/assign_empty_stmts.rb
@@ -1,3 +1,3 @@
 # typed: strict
-U = begin # error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+U = begin
 end

--- a/test/testdata/infer/suggest_field.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_field.rb.autocorrects.exp
@@ -11,7 +11,7 @@ class A
   def initialize
     @x = T.let(0, Integer)
   # ^^ error: The instance variable `@x` must be declared using `T.let` when specifying `# typed: strict`
-    @y = begin; end
+    @y = T.let(begin; end, NilClass)
   # ^^ error: The instance variable `@y` must be declared using `T.let` when specifying `# typed: strict`
     @z = T.let(returns_integer, Integer)
   # ^^ error: The instance variable `@z` must be declared using `T.let` when specifying `# typed: strict`

--- a/test/testdata/lsp/completion/missing_const_name.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_const_name.rb.desugar-tree.exp
@@ -22,7 +22,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   def test_constant_completion_before_keyword<<todo method>>(&<blk>)
     begin
       <emptyTree>::<C Outer>::<C <ConstantNameMissing>>
-      <emptyTree>
+      nil
     end
   end
 

--- a/test/testdata/lsp/completion/missing_fun.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_fun.rb.desugar-tree.exp
@@ -38,9 +38,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   def test_completion_between_keywords<<todo method>>(x, &<blk>)
     begin
-      <emptyTree>
+      nil
       x.<method-name-missing>()
-      <emptyTree>
+      nil
     end
   end
 

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -25,7 +25,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   xaaaaz = [<self>.yayayaya(), <self>.tutututu()]
 
-  <emptyTree>
+  nil
 
   nil
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was seeing some crashes that arise because we were desugaring `begin;
end` to `EmptyTree`.

That's super annoying when it happens, because EmptyTree is the only
node in Sorbet's AST that doesn't have a loc (it doesn't have a loc so
that we can manage to allocate only one of them and share it across all
trees).

Which honestly, is kind of dumb these days anyways? Because the
EmptyTree will get inlined into the pointer, so it's not like we're
actually allocating memory for the EmptyTree. We're just clinging to our
old habits.

Anyways, `Kwbegin` is `begin; end` while `Begin` is `( )` (because of
course `x = ()` is valid Ruby). Their implementations in desugar were
identical, except that `()` desugared to `Nil` instead of `EmptyTree`,
and thus got a loc. That's the behavior I want, so I factored out a
helper and used it in both places.

(Maybe in a future change change I'll make it so that EmptyTree is no
longer shared globally, but that's a problem for some other day.)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests