### PR TITLE
Change loc for `&&` and `||` condition

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1167,9 +1167,12 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         thenp = std::move(rhs);
                     }
                     auto lhsLoc = lhs.loc();
+                    auto condLoc = lhsLoc.exists() && thenp.loc().exists()
+                                       ? core::LocOffsets{lhsLoc.endPos(), thenp.loc().beginPos()}
+                                       : lhsLoc;
                     auto temp = MK::Assign(loc, andAndTemp, std::move(lhs));
                     auto iff =
-                        MK::If(loc, MK::Local(lhsLoc, andAndTemp), std::move(thenp), MK::Local(lhsLoc, andAndTemp));
+                        MK::If(loc, MK::Local(condLoc, andAndTemp), std::move(thenp), MK::Local(lhsLoc, andAndTemp));
                     auto wrapped = MK::InsSeq1(loc, std::move(temp), std::move(iff));
                     result = std::move(wrapped);
                 }
@@ -1184,8 +1187,11 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 } else {
                     core::NameRef tempName = dctx.freshNameUnique(core::Names::orOr());
                     auto lhsLoc = lhs.loc();
+                    auto condLoc = lhsLoc.exists() && rhs.loc().exists()
+                                       ? core::LocOffsets{lhsLoc.endPos(), rhs.loc().beginPos()}
+                                       : lhsLoc;
                     auto temp = MK::Assign(loc, tempName, std::move(lhs));
-                    auto iff = MK::If(loc, MK::Local(lhsLoc, tempName), MK::Local(lhsLoc, tempName), std::move(rhs));
+                    auto iff = MK::If(loc, MK::Local(condLoc, tempName), MK::Local(lhsLoc, tempName), std::move(rhs));
                     auto wrapped = MK::InsSeq1(loc, std::move(temp), std::move(iff));
                     result = std::move(wrapped);
                 }

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -190,6 +190,8 @@ public:
     // (file-level static init).
     bool isAnyStaticInitName(const GlobalState &gs) const;
 
+    bool isUniqueNameOf(const GlobalState &gs, NameRef name) const;
+
     // All the names that Environment::updateKnowledge treats as special for the purposes of
     // updating control flow-sensitive type knowledge.
     //

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -249,6 +249,10 @@ bool NameRef::isAnyStaticInitName(const GlobalState &gs) const {
     }
 }
 
+bool NameRef::isUniqueNameOf(const GlobalState &gs, NameRef name) const {
+    return this->kind() == NameKind::UNIQUE && this->dataUnique(gs)->original == name;
+}
+
 bool NameRef::isUpdateKnowledgeName() const {
     switch (this->rawId()) {
         case Names::bang().rawId():

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -230,12 +230,10 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                         bool andAndOrOr = false;
                         if (ident != nullptr) {
                             auto name = ident->what.data(*cfg)._name;
-                            if (name.kind() == core::NameKind::UNIQUE &&
-                                name.dataUnique(ctx)->original == core::Names::andAnd()) {
+                            if (name.isUniqueNameOf(ctx, core::Names::andAnd())) {
                                 e.setHeader("Left side of `{}` condition was always `{}`", "&&", "truthy");
                                 andAndOrOr = true;
-                            } else if (name.kind() == core::NameKind::UNIQUE &&
-                                       name.dataUnique(ctx)->original == core::Names::orOr()) {
+                            } else if (name.isUniqueNameOf(ctx, core::Names::orOr())) {
                                 e.setHeader("Left side of `{}` condition was always `{}`", "||", "falsy");
                                 andAndOrOr = true;
                             }
@@ -264,6 +262,23 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
 
                             auto alwaysWhat = prevBasicBlock->bexit.thenb->id == bb->id ? "falsy" : "truthy";
                             auto bexitLoc = ctx.locAt(prevBasicBlock->bexit.loc);
+
+                            auto bexitVar = cond.variable.data(*cfg)._name;
+                            if ((bexitVar.isUniqueNameOf(ctx, core::Names::andAnd()) ||
+                                 bexitVar.isUniqueNameOf(ctx, core::Names::orOr())) &&
+                                !prevBasicBlock->exprs.empty() &&
+                                prevBasicBlock->exprs.back().bind.variable == cond.variable) {
+                                // ^ This condition is a hack that hardcodes the most common structure of the CFG
+                                // we'd need to handle. If we had SSA form in Sorbet's CFG, we wouldn't have to pray
+                                // that the bexit var's initializer is the .back() of the expression in the block
+                                // (despite how rare it is for that to _not_ be the case).
+
+                                // We want to show one location for the "Conditional branch on untyped" warning/error,
+                                // but setting that location clobbers the location we need for this autocorrect to work.
+                                // So we have to claw back what the LHS of the || or && would have been.
+                                bexitLoc = ctx.locAt(prevBasicBlock->exprs.back().loc);
+                            }
+
                             e.addErrorLine(bexitLoc, "This condition was always `{}` (`{}`)", alwaysWhat,
                                            cond.type.show(ctx));
 

--- a/test/cli/autocorrect_and_and/test.out
+++ b/test/cli/autocorrect_and_and/test.out
@@ -9,6 +9,9 @@ autocorrect_and_and.rb:12: Call to method `even?` after `&&` assumes result type
     autocorrect_and_and.rb:12:
     12 |    if a.foo && a.foo.even?
                ^^^^^
+    autocorrect_and_and.rb:12:
+    12 |    if a.foo && a.foo.even?
+                    ^^^^
   Note:
     Sorbet never assumes that a method called twice returns the same result both times.
     Either factor out a variable or use `&.`
@@ -31,6 +34,9 @@ autocorrect_and_and.rb:17: Call to method `even?` after `&&` assumes result type
     autocorrect_and_and.rb:16:
     16 |    if a.foo &&
                ^^^^^
+    autocorrect_and_and.rb:16:
+    16 |    if a.foo &&
+    17 |        a.foo.even?
   Note:
     Sorbet never assumes that a method called twice returns the same result both times.
     Either factor out a variable or use `&.`
@@ -53,6 +59,9 @@ autocorrect_and_and.rb:22: Call to method `even?` after `&&` assumes result type
     autocorrect_and_and.rb:21:
     21 |    if foo &&
                ^^^
+    autocorrect_and_and.rb:21:
+    21 |    if foo &&
+    22 |        foo.even?
   Note:
     Sorbet never assumes that a method called twice returns the same result both times.
     Either factor out a variable or use `&.`
@@ -87,6 +96,9 @@ autocorrect_and_and.rb:36: Call to method `even?` after `&&` assumes result type
     autocorrect_and_and.rb:35:
     35 |    if a.foo && a.foo.
                ^^^^^
+    autocorrect_and_and.rb:35:
+    35 |    if a.foo && a.foo.
+                    ^^^^
   Note:
     Sorbet never assumes that a method called twice returns the same result both times.
     Either factor out a variable or use `&.`

--- a/test/cli/suggest-sig/test.out
+++ b/test/cli/suggest-sig/test.out
@@ -177,11 +177,14 @@ suggest-sig.rb:85: This code is unreachable https://srb.help/7006
                             ^^^^
     suggest-sig.rb:85: This condition was always `truthy` (`TrueClass`)
     85 |  if true || qux || blah
-             ^^^^^^^^^^^
+             ^^^^
   Got `TrueClass` originating from:
     suggest-sig.rb:85:
     85 |  if true || qux || blah
              ^^^^
+    suggest-sig.rb:85:
+    85 |  if true || qux || blah
+                 ^^^^
 
 suggest-sig.rb:88: This code is unreachable https://srb.help/7006
     88 |    takesString(x)
@@ -195,7 +198,10 @@ suggest-sig.rb:88: This code is unreachable https://srb.help/7006
              ^^^^
     suggest-sig.rb:85:
     85 |  if true || qux || blah
-             ^^^^^^^^^^^
+                 ^^^^
+    suggest-sig.rb:85:
+    85 |  if true || qux || blah
+                        ^^^^
 
 suggest-sig.rb:84: The method `dead` does not have a `sig` https://srb.help/7017
     84 |def dead(x)

--- a/test/testdata/infer/or_and_conditional_branch.rb
+++ b/test/testdata/infer/or_and_conditional_branch.rb
@@ -1,0 +1,45 @@
+# typed: strong
+extend T::Sig
+
+sig {params(lines: T::Array[String]).void}
+def foo1(lines)
+  min_space = lines
+    .map do |line|
+      if line.strip.empty?
+        nil
+      else
+        T.unsafe(line)
+      end
+    end
+  # ^^^ error: Value returned from block is `T.untyped`
+    .compact
+    .min || 0
+    #   ^^^^ error: Conditional branch on `T.untyped`
+end
+
+sig {params(lines: T::Array[String]).void}
+def foo2(lines)
+  min_space = lines
+    .map do |line|
+      if line.strip.empty?
+        nil
+      else
+        T.unsafe(line)
+      end
+    end
+  # ^^^ error: Value returned from block is `T.untyped`
+    .compact
+    .min && 0
+    #   ^^^^ error: Conditional branch on `T.untyped`
+end
+
+def dont_crash # error: does not have a `sig`
+  x = begin; end || begin; end
+  #   ^^^^^^^^^^ error: Left side of `||` condition was always `falsy`
+  x = begin; end && begin; end
+  #                 ^^^^^^^^^^ error: This code is unreachable
+  x = () || ()
+  #   ^^ error: Left side of `||` condition was always `falsy`
+  x = () && ()
+  #         ^^ error: This code is unreachable
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The loc for the local variable we used in the `cond` of the `If` that
`&&` and `||` desugar into was previously the whole LHS. In the case of
a long expression on the LHS, that meant that Sorbet would highlight
multiple lines of (irrelevant) code when showing a "This code is
untyped" error.

To my knowledge, the only place in Sorbet where the loc of a local
variable used in an `If` condition would matter is for the error message
about untyped code usages. That is: this loc is not important for any
other autocorrects like adding `T.must` or `T.unsafe`, where the
location of the error is going to get wrapped with a method call.

That means we're free to change this however we like. With that in mind,
I'd like to point to the `... || ...` instead, which makes it a little
more obvious where the "conditional branch on untyped" is coming from.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
