### PR TITLE
Add sig for Rbconfig.ruby to RBIs

### DIFF
--- a/rbi/core/rb_config.rbi
+++ b/rbi/core/rb_config.rbi
@@ -48,4 +48,7 @@ module RbConfig
   MAKEFILE_CONFIG = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
   # Ruby installed directory.
   TOPDIR = T.let(T.unsafe(nil), String)
+
+  sig {returns(String)}
+  def self.ruby; end
 end


### PR DESCRIPTION
Definition:
https://github.com/ruby/ruby/blob/499eb3990faeaac2603787f2a41b2d9625e180dc/tool/mkconfig.rb#L386-L396
