### PR TITLE
Add option to disable nudges

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -104,6 +104,7 @@ LSPClientConfiguration::LSPClientConfiguration(const InitializeParams &params) {
         enableTypecheckInfo = initOptions->enableTypecheckInfo.value_or(false);
         enableSorbetURIs = initOptions->supportsSorbetURIs.value_or(false);
         enableHighlightUntyped = initOptions->highlightUntyped.value_or(false);
+        enableNudges = initOptions->enableNudges.value_or(true);
     }
 }
 

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -104,7 +104,7 @@ LSPClientConfiguration::LSPClientConfiguration(const InitializeParams &params) {
         enableTypecheckInfo = initOptions->enableTypecheckInfo.value_or(false);
         enableSorbetURIs = initOptions->supportsSorbetURIs.value_or(false);
         enableHighlightUntyped = initOptions->highlightUntyped.value_or(false);
-        enableNudges = initOptions->enableNudges.value_or(true);
+        enableTypedFalseCompletionNudges = initOptions->enableTypedFalseCompletionNudges.value_or(true);
     }
 }
 

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -37,6 +37,9 @@ public:
     /** If true, then LSP outputs a warning for untyped values */
     bool enableHighlightUntyped = false;
 
+    /** If false, nudges in `typed: false` files are disabled */
+    bool enableNudges = true;
+
     /**
      * Whether or not the active client has support for snippets in CompletionItems.
      * Note: There is a generated ClientCapabilities class, but it is cumbersome to work with as most fields are

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -38,7 +38,7 @@ public:
     bool enableHighlightUntyped = false;
 
     /** If false, nudges in `typed: false` files are disabled */
-    bool enableNudges = true;
+    bool enableTypedFalseCompletionNudges = true;
 
     /**
      * Whether or not the active client has support for snippets in CompletionItems.

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1256,8 +1256,8 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
             }
         }
 
-        auto enableNudges = config.getClientConfig().enableNudges;
-        if (enableNudges) {
+        auto enableTypedFalseCompletionNudges = config.getClientConfig().enableTypedFalseCompletionNudges;
+        if (enableTypedFalseCompletionNudges) {
             ENFORCE(fref.exists());
             auto level = fref.data(gs).strictLevel;
             if (!fref.data(gs).hasParseErrors() && level < core::StrictLevel::True) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1256,12 +1256,15 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
             }
         }
 
-        ENFORCE(fref.exists());
-        auto level = fref.data(gs).strictLevel;
-        if (!fref.data(gs).hasParseErrors() && level < core::StrictLevel::True) {
-            items.emplace_back(getCompletionItemForUntyped(gs, queryLoc, 0, "(file is not `# typed: true` or higher)"));
-            response->result = make_unique<CompletionList>(false, move(items));
-            return response;
+        auto enableNudges = config.getClientConfig().enableNudges;
+        if (enableNudges) {
+            ENFORCE(fref.exists());
+            auto level = fref.data(gs).strictLevel;
+            if (!fref.data(gs).hasParseErrors() && level < core::StrictLevel::True) {
+                items.emplace_back(getCompletionItemForUntyped(gs, queryLoc, 0, "(file is not `# typed: true` or higher)"));
+                response->result = make_unique<CompletionList>(false, move(items));
+                return response;
+            }
         }
 
         response->result = std::move(emptyResult);

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1261,7 +1261,8 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
             ENFORCE(fref.exists());
             auto level = fref.data(gs).strictLevel;
             if (!fref.data(gs).hasParseErrors() && level < core::StrictLevel::True) {
-                items.emplace_back(getCompletionItemForUntyped(gs, queryLoc, 0, "(file is not `# typed: true` or higher)"));
+                items.emplace_back(
+                    getCompletionItemForUntyped(gs, queryLoc, 0, "(file is not `# typed: true` or higher)"));
                 response->result = make_unique<CompletionList>(false, move(items));
                 return response;
             }

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1265,7 +1265,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        makeField("supportsSorbetURIs", makeOptional(JSONBool)),
                        makeField("enableTypecheckInfo", makeOptional(JSONBool)),
                        makeField("highlightUntyped", makeOptional(JSONBool)),
-                       makeField("enableNudges", makeOptional(JSONBool)),
+                       makeField("enableTypedFalseCompletionNudges", makeOptional(JSONBool)),
                    },
                    classTypes);
     auto InitializeParams =

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1265,6 +1265,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        makeField("supportsSorbetURIs", makeOptional(JSONBool)),
                        makeField("enableTypecheckInfo", makeOptional(JSONBool)),
                        makeField("highlightUntyped", makeOptional(JSONBool)),
+                       makeField("enableNudges", makeOptional(JSONBool)),
                    },
                    classTypes);
     auto InitializeParams =

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -276,7 +276,7 @@ const UnorderedMap<
         {"implementation", ImplementationAssertion::make},
         {"find-implementation", FindImplementationAssertion::make},
         {"show-symbol", ShowSymbolAssertion::make},
-        {"enable-nudges", BooleanPropertyAssertion::make},
+        {"enable-typed-false-completion-nudges", BooleanPropertyAssertion::make},
 };
 
 // Ignore any comments that have these labels (e.g. `# typed: true`).

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -276,6 +276,7 @@ const UnorderedMap<
         {"implementation", ImplementationAssertion::make},
         {"find-implementation", FindImplementationAssertion::make},
         {"show-symbol", ShowSymbolAssertion::make},
+        {"enable-nudges", BooleanPropertyAssertion::make},
 };
 
 // Ignore any comments that have these labels (e.g. `# typed: true`).

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -607,8 +607,8 @@ TEST_CASE("LSPTest") {
         sorbetInitOptions->enableTypecheckInfo = true;
         sorbetInitOptions->highlightUntyped =
             BooleanPropertyAssertion::getValue("highlight-untyped-values", assertions).value_or(false);
-        sorbetInitOptions->enableNudges =
-            BooleanPropertyAssertion::getValue("enable-nudges", assertions).value_or(true);
+        sorbetInitOptions->enableTypedFalseCompletionNudges =
+            BooleanPropertyAssertion::getValue("enable-typed-false-completion-nudges", assertions).value_or(true);
         auto initializedResponses = initializeLSP(rootPath, rootUri, *lspWrapper, nextId, true,
                                                   shouldUseCodeActionResolve, move(sorbetInitOptions));
         INFO("Should not receive any response to 'initialized' message.");

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -607,6 +607,8 @@ TEST_CASE("LSPTest") {
         sorbetInitOptions->enableTypecheckInfo = true;
         sorbetInitOptions->highlightUntyped =
             BooleanPropertyAssertion::getValue("highlight-untyped-values", assertions).value_or(false);
+        sorbetInitOptions->enableNudges =
+            BooleanPropertyAssertion::getValue("enable-nudges", assertions).value_or(true);
         auto initializedResponses = initializeLSP(rootPath, rootUri, *lspWrapper, nextId, true,
                                                   shouldUseCodeActionResolve, move(sorbetInitOptions));
         INFO("Should not receive any response to 'initialized' message.");

--- a/test/testdata/lsp/completion/nudges_disabled.rb
+++ b/test/testdata/lsp/completion/nudges_disabled.rb
@@ -1,0 +1,17 @@
+# typed: false
+
+# enable-nudges: false
+
+class AnImportantClass
+  def important_method(important_parameter)
+    important
+           # ^ completion: (nothing)
+  end
+end
+
+An # error: Unable to resolve constant
+# ^ completion: (nothing)
+
+AnImportantClass.n
+#                 ^ completion: (nothing)
+

--- a/test/testdata/lsp/completion/typed_false_completion_nudges_disabled.rb
+++ b/test/testdata/lsp/completion/typed_false_completion_nudges_disabled.rb
@@ -1,6 +1,6 @@
 # typed: false
 
-# enable-nudges: false
+# enable-typed-false-completion-nudges: false
 
 class AnImportantClass
   def important_method(important_parameter)


### PR DESCRIPTION
This PR adds a simple configuration option to turn off nudges in `#typed: false` files.

I wasn't sure if I should name the option `enableNudges` with a default true value or `disableNudges` with a default false value. Let me know if you want me to rename it to something else.

### Motivation
The `file is not # typed: true or higher` nudges conflict with GitHub Copilot and other autocomplete extensions.

@jez said "Go for it"

https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1691086045697219?thread_ts=1691085509.929519&cid=CHN2L03NH

### Test plan

See included automated tests.
