### PR TITLE
Update T::Enum#serialize defintion to be public

### DIFF
--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -245,6 +245,10 @@ void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
         auto sig = ast::MK::Sig0(klass->declLoc, std::move(return_type_ast));
         auto method = ast::MK::SyntheticMethod0(klass->loc, klass->declLoc, core::Names::serialize(),
                                                 ast::MK::RaiseTypedUnimplemented(klass->declLoc));
+        auto visibility =
+            ast::MK::Send0(klass->declLoc, ast::MK::Self(klass->declLoc), core::Names::public_(), klass->declLoc);
+
+        klass->rhs.emplace_back(std::move(visibility));
         klass->rhs.emplace_back(std::move(sig));
         klass->rhs.emplace_back(std::move(method));
     }

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -245,8 +245,11 @@ void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
         auto sig = ast::MK::Sig0(klass->declLoc, std::move(return_type_ast));
         auto method = ast::MK::SyntheticMethod0(klass->loc, klass->declLoc, core::Names::serialize(),
                                                 ast::MK::RaiseTypedUnimplemented(klass->declLoc));
-        auto visibility =
-            ast::MK::Send0(klass->declLoc, ast::MK::Self(klass->declLoc), core::Names::public_(), klass->declLoc);
+        ast::Send::ARGS_store nargs;
+        ast::Send::Flags flags;
+        flags.isPrivateOk = true;
+        auto visibility = ast::MK::Send(klass->declLoc, ast::MK::Self(klass->declLoc), core::Names::public_(),
+                                        klass->declLoc, 0, std::move(nargs), flags);
 
         klass->rhs.emplace_back(std::move(visibility));
         klass->rhs.emplace_back(std::move(sig));

--- a/test/testdata/rewriter/t_enum.rb
+++ b/test/testdata/rewriter/t_enum.rb
@@ -70,3 +70,19 @@ class EnumWithNil < T::Enum
 end
 
 T.reveal_type(EnumWithNil::X.serialize) # error: Revealed type: `NilClass`
+
+
+class EnumWithPrivate < T::Enum
+  extend T::Sig
+
+  enums do
+    X = new(nil)
+  end
+
+  private
+
+  sig { void }
+  def unrelated_method; end
+end
+
+EnumWithPrivate::X.serialize

--- a/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
@@ -110,8 +110,10 @@ bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-te
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(MyEnum)):
+bb7[rubyRegionId=0, firstDead=4](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(MyEnum)):
     <statTemp>$23: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$25, enums>
+    <self>: T.class_of(MyEnum) = <selfRestore>$26
+    <statTemp>$87: T.class_of(MyEnum) = <self>: T.class_of(MyEnum).public()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -340,8 +342,10 @@ bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-ca
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(EnumsDoEnum)):
+bb7[rubyRegionId=0, firstDead=4](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(EnumsDoEnum)):
     <statTemp>$23: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$25, enums>
+    <self>: T.class_of(EnumsDoEnum) = <selfRestore>$26
+    <statTemp>$88: T.class_of(EnumsDoEnum) = <self>: T.class_of(EnumsDoEnum).public()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -526,8 +530,9 @@ bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(BadConsts), <block-pre-call
 
 # backedges
 # - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=20](<block-pre-call-temp>$46: Sorbet::Private::Static::Void, <selfRestore>$47: T.class_of(BadConsts), <C After>$84: BadConsts::After, <C StaticField3>$91: Integer, <C StaticField4>$93: Integer):
+bb7[rubyRegionId=0, firstDead=22](<block-pre-call-temp>$46: Sorbet::Private::Static::Void, <selfRestore>$47: T.class_of(BadConsts), <C After>$84: BadConsts::After, <C StaticField3>$91: Integer, <C StaticField4>$93: Integer):
     <statTemp>$44: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$46, enums>
+    <self>: T.class_of(BadConsts) = <selfRestore>$47
     <cfgAlias>$75: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$77: T.class_of(BadConsts::After) = alias <C After$1>
     <statTemp>$73: Sorbet::Private::Static::Void = <cfgAlias>$75: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$77: T.class_of(BadConsts::After))
@@ -546,6 +551,7 @@ bb7[rubyRegionId=0, firstDead=20](<block-pre-call-temp>$46: Sorbet::Private::Sta
     keep_for_ide$94: T.untyped = <keep-alive> keep_for_ide$94
     <castTemp>$96: Integer(1) = 1
     <C StaticField4>$93: Integer = cast(<castTemp>$96: Integer(1), Integer);
+    <statTemp>$97: T.class_of(BadConsts) = <self>: T.class_of(BadConsts).public()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 

--- a/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.rewrite-tree.exp
@@ -29,6 +29,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
+    <self>.public()
+
     <runtime method definition of serialize>
   end
 
@@ -77,6 +79,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of something_outside>
 
+    <self>.public()
+
     <runtime method definition of serialize>
   end
 
@@ -120,6 +124,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C StaticField3> = 3
 
     <emptyTree>::<C StaticField4> = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
+
+    <self>.public()
 
     <runtime method definition of serialize>
   end


### PR DESCRIPTION
Ensure that `T::Enum#serialize` is defined as public

### Motivation
The recent `T::Enum#serialize` change adds the definition for serialize to the end of the enum, so if the class use te `private` keyword, the serialize method will also be private.

```ruby
class MyEnum < T::Enum
  extend(T::Sig)

  enums do
    MyValue = new('MV')
  end

  private

  sig { void }
  def something_private
  end
end

MyEnum::MyValue.serialize
```
[sorbet.run](https://sorbet.run/#%23%20typed%3A%20strict%0A%0Aclass%20MyEnum%20%3C%20T%3A%3AEnum%0A%20%20extend%28T%3A%3ASig%29%0A%0A%20%20enums%20do%0A%20%20%20%20MyValue%20%3D%20new%28'MV'%29%0A%20%20end%0A%0A%20%20private%0A%0A%20%20sig%20%7B%20void%20%7D%0A%20%20def%20something_private%0A%20%20end%0Aend%0A%0AMyEnum%3A%3AMyValue.serialize)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
