### PR TITLE
no-op: Move pipeline::packager out of pipeline::resolve

### DIFF
--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -76,6 +76,8 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
     vector<ast::ParsedFile> single;
     single.emplace_back(move(file));
 
+    // We run computeFileHashForAST with the empty set of options which means we can skip calling pipeline::package()
+
     auto workers = WorkerPool::create(0, lgs->tracer());
     core::FoundDefHashes foundHashes; // out parameter
     realmain::pipeline::resolve(lgs, move(single), opts(), *workers, &foundHashes);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -460,6 +460,9 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
                 }
             }
         }
+
+        pipeline::package(*gs, absl::Span<ast::ParsedFile>(indexedCopies), config->opts, workers);
+
         // Only need to compute FoundDefHashes when running to compute a FileHash
         auto foundHashes = nullptr;
         auto maybeResolved = pipeline::resolve(gs, move(indexedCopies), config->opts, workers, foundHashes);

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -418,6 +418,8 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }
 
+    pipeline::package(*rbiGS, absl::Span<ast::ParsedFile>(rbiIndexed), opts, workers);
+
     // Only need to compute FoundDefHashes when running to compute a FileHash
     auto foundHashes = nullptr;
     rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers, foundHashes).result());

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -763,6 +763,9 @@ int realmain(int argc, char *argv[]) {
             runAutogen(*gs, opts, autogenCfg, *workers, indexed, opts.autogenConstantCacheConfig.changedFiles);
 #endif
         } else {
+            // packager intentionally runs outside of rewriter so that its output does not get cached.
+            pipeline::package(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers);
+
             // Only need to compute hashes when running to compute a FileHash
             auto foundHashes = nullptr;
             indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers, foundHashes).result());

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -695,7 +695,7 @@ public:
         ENFORCE(pkg.exists());
     }
 
-    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
+    void preTransformClassDef(core::Context ctx, const ast::ExpressionPtr &tree) {
         auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         if (classDef.symbol == core::Symbols::root()) {
             // Ignore top-level <root>
@@ -706,7 +706,7 @@ public:
             return;
         }
 
-        ast::UnresolvedConstantLit *constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
+        auto *constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
         if (constantLit == nullptr) {
             return;
         }
@@ -728,7 +728,7 @@ public:
         }
     }
 
-    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
+    void postTransformClassDef(core::Context ctx, const ast::ExpressionPtr &tree) {
         auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         if (classDef.symbol == core::Symbols::root()) {
             // Sanity check bookkeeping
@@ -745,7 +745,7 @@ public:
             }
         }
 
-        ast::UnresolvedConstantLit *constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
+        auto *constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
         if (constantLit == nullptr) {
             return;
         }
@@ -753,7 +753,7 @@ public:
         popConstantLit(constantLit);
     }
 
-    void preTransformAssign(core::Context ctx, ast::ExpressionPtr &original) {
+    void preTransformAssign(core::Context ctx, const ast::ExpressionPtr &original) {
         if (errorDepth > 0) {
             errorDepth++;
             return;
@@ -776,13 +776,13 @@ public:
         }
     }
 
-    void postTransformAssign(core::Context ctx, ast::ExpressionPtr &original) {
+    void postTransformAssign(core::Context ctx, const ast::ExpressionPtr &original) {
         if (errorDepth > 0) {
             errorDepth--;
         }
     }
 
-    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &original) {
+    void preTransformMethodDef(core::Context ctx, const ast::ExpressionPtr &original) {
         if (errorDepth > 0) {
             errorDepth++;
             return;
@@ -791,13 +791,13 @@ public:
         checkBehaviorLoc(ctx, def.declLoc);
     }
 
-    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &original) {
+    void postTransformMethodDef(core::Context ctx, const ast::ExpressionPtr &original) {
         if (errorDepth > 0) {
             errorDepth--;
         }
     }
 
-    void preTransformSend(core::Context ctx, ast::ExpressionPtr &original) {
+    void preTransformSend(core::Context ctx, const ast::ExpressionPtr &original) {
         if (errorDepth > 0) {
             errorDepth++;
             return;
@@ -805,7 +805,7 @@ public:
         checkBehaviorLoc(ctx, original.loc());
     }
 
-    void postTransformSend(core::Context ctx, ast::ExpressionPtr &original) {
+    void postTransformSend(core::Context ctx, const ast::ExpressionPtr &original) {
         if (errorDepth > 0) {
             errorDepth--;
         }
@@ -839,7 +839,7 @@ public:
     }
 
 private:
-    void pushConstantLit(core::Context ctx, ast::UnresolvedConstantLit *lit) {
+    void pushConstantLit(core::Context ctx, const ast::UnresolvedConstantLit *lit) {
         ENFORCE(tmpNameParts.empty());
         auto prevDepth = namespaces.depth();
         while (lit != nullptr) {
@@ -866,7 +866,7 @@ private:
         tmpNameParts.clear();
     }
 
-    void popConstantLit(ast::UnresolvedConstantLit *lit) {
+    void popConstantLit(const ast::UnresolvedConstantLit *lit) {
         while (lit != nullptr) {
             if (rootConsts == 0) {
                 namespaces.popName();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1610,8 +1610,6 @@ vector<ast::ParsedFile> Packager::runIncremental(core::GlobalState &gs, vector<a
     files = rewriteFilesFast(gs, move(files));
     ENFORCE(gs.namesUsedTotal() == namesUsed);
     return files;
-    Packager::setPackageNameOnFiles(gs, files);
-    return files;
 }
 
 namespace {

--- a/payload/text/populate.cc
+++ b/payload/text/populate.cc
@@ -24,6 +24,9 @@ void populateRBIsInto(unique_ptr<core::GlobalState> &gs) {
     auto workers = WorkerPool::create(emptyOpts.threads, gs->tracer());
     auto indexed =
         realmain::pipeline::index(*gs, absl::Span<core::FileRef>(payloadFiles), emptyOpts, *workers, kvstore);
+
+    // We don't run the payload with any packager options, so we can skip pipeline::package()
+
     // While we want the FoundMethodHashes to end up in the payload, these hashes (including
     // LocalGlobalStateHashes and UsageHash) are not computed until `computeFileHashes` is called in
     // realmain when the `storeState` flag is passed. This means that e.g. sorbet-orig -e

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -69,7 +69,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         file.data(*gs).strictLevel = core::StrictLevel::True;
     }
 
-    indexed = realmain::pipeline::index(*gs, inputFiles, *opts, *workers, kvstore);
+    indexed = realmain::pipeline::index(*gs, absl::Span<core::FileRef>(inputFiles), *opts, *workers, kvstore);
     auto foundHashes = nullptr;
     indexed = move(realmain::pipeline::resolve(gs, move(indexed), *opts, *workers, foundHashes).result());
     realmain::pipeline::typecheck(*gs, move(indexed), *opts, *workers);

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -70,6 +70,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     }
 
     indexed = realmain::pipeline::index(*gs, absl::Span<core::FileRef>(inputFiles), *opts, *workers, kvstore);
+    // We don't run this fuzzer with any packager options, so we can skip pipeline::package()
     auto foundHashes = nullptr;
     indexed = move(realmain::pipeline::resolve(gs, move(indexed), *opts, *workers, foundHashes).result());
     realmain::pipeline::typecheck(*gs, move(indexed), *opts, *workers);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These are some further no-op changes, following up on #7199 and prepping for a
future change to only index a subset of the codebase using the package graph.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.