### PR TITLE
ENFORCE that packages are sorted

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1453,8 +1453,10 @@ vector<ast::ParsedFile> rewriteFilesFast(core::GlobalState &gs, vector<ast::Pars
 }
 
 void Packager::findPackages(core::GlobalState &gs, absl::Span<ast::ParsedFile> files) {
-    // Ensure files are in canonical order.
-    fast_sort(files, [](const auto &a, const auto &b) -> bool { return a.file < b.file; });
+    // We want them sorted in a stable order so that "redefinition of package" errors always show up
+    // in the same file across runs.
+    ENFORCE(absl::c_is_sorted(files, [](const auto &a, const auto &b) -> bool { return a.file < b.file; }),
+            "pipeline::index should have sorted the files already");
 
     // Step 1: Find packages and determine their imports/exports.
     {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

From a scan of callers, the input should have already been sorted
because it would have been the result of calling `pipeline::index`. So I
think that we can save a little time and also avoid reordering things in
the borrowed `absl::Span` by simply not sorting.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests
