### PR TITLE
Add a rest arg to rewrite generated initialize method of before do end

### DIFF
--- a/test/testdata/infer/suggest_field.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_field.rb.autocorrects.exp
@@ -9,11 +9,11 @@ class A
 
   sig {void}
   def initialize
-    @x = T.let(0, Integer)
+    @x = T.let(0, T.nilable(Integer))
   # ^^ error: The instance variable `@x` must be declared using `T.let` when specifying `# typed: strict`
     @y = T.let(begin; end, NilClass)
   # ^^ error: The instance variable `@y` must be declared using `T.let` when specifying `# typed: strict`
-    @z = T.let(returns_integer, Integer)
+    @z = T.let(returns_integer, T.nilable(Integer))
   # ^^ error: The instance variable `@z` must be declared using `T.let` when specifying `# typed: strict`
   end
 

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -53,10 +53,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
+      <self>.params(:arg0, ::T.untyped()).void()
     end
 
-    def initialize<<todo method>>(&<blk>)
+    def initialize<<todo method>>(*arg0, &<blk>)
       begin
         @foo = <cast:let>(3, <todo sym>, <emptyTree>::<C Integer>)
         <self>.instance_helper()


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We currently rewrite `before do ... end` to:
```
sig { void }
def initialize
  ...
end
```
Once `super` is typechecked, this causes problems for the following:
```
class A
  def initialize(a)
  end
end
class B < A
  before do
  end
end
class C < B
  def initialize(a)
    super
  end
end
```

The super call will be typechecked against the rewriter generated `initialize`, and the arity will not match, even though it'll actually be calling `A#initialize`. Adding an `T.untyped` rest arg silences this error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
