### PR TITLE
Add disable nudges option to vscode extension

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -30,6 +30,7 @@
     "onCommand:sorbet.setLogLevel",
     "onCommand:sorbet.showOutput",
     "onCommand:sorbet.toggleHighlightUntyped",
+    "onCommand:sorbet.toggleTypedFalseCompletionNudges",
     "onLanguage:ruby",
     "workspaceContains:sorbet/*"
   ],
@@ -94,6 +95,12 @@
       {
         "command": "sorbet.toggleHighlightUntyped",
         "title": "Toggle highlighting untyped code",
+        "category": "Sorbet",
+        "enablement": "workbenchState != empty"
+      },
+      {
+        "command": "sorbet.toggleTypedFalseCompletionNudges",
+        "title": "Toggle the auto-complete nudge in `typed: false` files",
         "category": "Sorbet",
         "enablement": "workbenchState != empty"
       }
@@ -257,6 +264,11 @@
           "type": "boolean",
           "description": "Shows warning for untyped values.",
           "default": false
+        },
+        "sorbet.typedFalseCompletionNudges": {
+          "type": "boolean",
+          "description": "Displays an auto-complete nudge in `typed: false` files.",
+          "default": true
         },
         "sorbet.configFilePatterns": {
           "type": "array",

--- a/vscode_extension/src/commandIds.ts
+++ b/vscode_extension/src/commandIds.ts
@@ -53,3 +53,9 @@ export const SORBET_SAVE_PACKAGE_FILES = "sorbet.savePackageFiles";
  */
 export const TOGGLE_HIGHLIGHT_UNTYPED_COMMAND_ID =
   "sorbet.toggleHighlightUntyped";
+
+/**
+ * Toggle the auto-complete nudge in `typed: false` files.
+ */
+export const TOGGLE_TYPED_FALSE_COMPLETION_NUDGES_COMMAND_ID =
+  "sorbet.toggleTypedFalseCompletionNudges";

--- a/vscode_extension/src/commands/toggleTypedFalseCompletionNudges.ts
+++ b/vscode_extension/src/commands/toggleTypedFalseCompletionNudges.ts
@@ -1,0 +1,20 @@
+import { SorbetExtensionContext } from "../sorbetExtensionContext";
+import { RestartReason } from "../types";
+
+/**
+ * Toggle the auto-complete nudge in `typed: false` files.
+ * @param context Sorbet extension context.
+ * @returns `true` if the nudge is enabled, `false` otherwise.
+ */
+export async function toggleTypedFalseCompletionNudges(
+  context: SorbetExtensionContext,
+): Promise<boolean> {
+  const targetState = !context.configuration.typedFalseCompletionNudges;
+  await context.configuration.setTypedFalseCompletionNudges(targetState);
+  context.log.info(
+    `Untyped file auto-complete nudge: ${targetState ? "enabled" : "disabled"}`,
+  );
+
+  await context.statusProvider.restartSorbet(RestartReason.CONFIG_CHANGE);
+  return context.configuration.typedFalseCompletionNudges;
+}

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -210,6 +210,7 @@ export class SorbetExtensionConfig implements Disposable {
   private userLspConfigs: ReadonlyArray<SorbetLspConfig>;
   private wrappedEnabled: boolean;
   private wrappedHighlightUntyped: boolean;
+  private wrappedTypedFalseCompletionNudges: boolean;
   private wrappedRevealOutputOnError: boolean;
 
   constructor(sorbetWorkspaceContext: ISorbetWorkspaceContext) {
@@ -222,6 +223,7 @@ export class SorbetExtensionConfig implements Disposable {
     this.standardLspConfigs = [];
     this.userLspConfigs = [];
     this.wrappedHighlightUntyped = false;
+    this.wrappedTypedFalseCompletionNudges = true;
     this.wrappedRevealOutputOnError = false;
 
     const workspaceFolders = this.sorbetWorkspaceContext.workspaceFolders();
@@ -273,6 +275,10 @@ export class SorbetExtensionConfig implements Disposable {
     this.wrappedHighlightUntyped = this.sorbetWorkspaceContext.get(
       "highlightUntyped",
       this.highlightUntyped,
+    );
+    this.wrappedTypedFalseCompletionNudges = this.sorbetWorkspaceContext.get(
+      "typedFalseCompletionNudges",
+      this.typedFalseCompletionNudges,
     );
 
     Disposable.from(...this.configFileWatchers).dispose();
@@ -395,6 +401,10 @@ export class SorbetExtensionConfig implements Disposable {
     return this.wrappedHighlightUntyped;
   }
 
+  public get typedFalseCompletionNudges(): boolean {
+    return this.wrappedTypedFalseCompletionNudges;
+  }
+
   public get enabled(): boolean {
     return this.wrappedEnabled;
   }
@@ -406,6 +416,11 @@ export class SorbetExtensionConfig implements Disposable {
 
   public async setHighlightUntyped(b: boolean): Promise<void> {
     await this.sorbetWorkspaceContext.update("highlightUntyped", b);
+    this.refresh();
+  }
+
+  public async setTypedFalseCompletionNudges(b: boolean): Promise<void> {
+    await this.sorbetWorkspaceContext.update("typedFalseCompletionNudges", b);
     this.refresh();
   }
 }

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -8,6 +8,7 @@ import { setLogLevel } from "./commands/setLogLevel";
 import { showSorbetActions } from "./commands/showSorbetActions";
 import { showSorbetConfigurationPicker } from "./commands/showSorbetConfigurationPicker";
 import { toggleUntypedCodeHighlighting } from "./commands/toggleUntypedCodeHighlighting";
+import { toggleTypedFalseCompletionNudges } from "./commands/toggleTypedFalseCompletionNudges";
 import { getLogLevelFromEnvironment, LogLevel } from "./log";
 import { SorbetContentProvider, SORBET_SCHEME } from "./sorbetContentProvider";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
@@ -88,6 +89,10 @@ export function activate(context: ExtensionContext) {
     ),
     commands.registerCommand(cmdIds.TOGGLE_HIGHLIGHT_UNTYPED_COMMAND_ID, () =>
       toggleUntypedCodeHighlighting(sorbetExtensionContext),
+    ),
+    commands.registerCommand(
+      cmdIds.TOGGLE_TYPED_FALSE_COMPLETION_NUDGES_COMMAND_ID,
+      () => toggleTypedFalseCompletionNudges(sorbetExtensionContext),
     ),
   );
 

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -59,6 +59,8 @@ function createClient(
       // Let Sorbet know that we can handle sorbet:// URIs for generated files.
       supportsSorbetURIs: true,
       highlightUntyped: context.configuration.highlightUntyped,
+      enableTypedFalseCompletionNudges:
+        context.configuration.typedFalseCompletionNudges,
     },
     errorHandler,
     revealOutputChannelOn: context.configuration.revealOutputOnError

--- a/vscode_extension/src/test/commands/toggleTypedFalseCompletionNudges.test.ts
+++ b/vscode_extension/src/test/commands/toggleTypedFalseCompletionNudges.test.ts
@@ -1,0 +1,67 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as sinon from "sinon";
+
+import { createLogStub } from "../testUtils";
+import { toggleTypedFalseCompletionNudges } from "../../commands/toggleTypedFalseCompletionNudges";
+import { SorbetExtensionConfig } from "../../config";
+import { SorbetExtensionContext } from "../../sorbetExtensionContext";
+import { SorbetStatusProvider } from "../../sorbetStatusProvider";
+import { RestartReason } from "../../types";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  let testRestorables: { restore: () => void }[];
+
+  setup(() => {
+    testRestorables = [];
+  });
+
+  teardown(() => {
+    testRestorables.forEach((r) => r.restore());
+  });
+
+  test("toggleTypedFalseCompletionNudges", async () => {
+    const initialState = true;
+    let currentState = initialState;
+
+    const log = createLogStub();
+
+    const setTypedFalseCompletionNudgesSpy = sinon.spy((value: boolean) => {
+      currentState = value;
+    });
+    const configuration = <SorbetExtensionConfig>(<unknown>{
+      get typedFalseCompletionNudges() {
+        return currentState;
+      },
+      setTypedFalseCompletionNudges: setTypedFalseCompletionNudgesSpy,
+    });
+
+    const restartSorbetSpy = sinon.spy((_reason: RestartReason) => {});
+    const statusProvider = <SorbetStatusProvider>(<unknown>{
+      restartSorbet: restartSorbetSpy,
+    });
+
+    const context = <SorbetExtensionContext>{
+      log,
+      configuration,
+      statusProvider,
+    };
+
+    assert.strictEqual(
+      await toggleTypedFalseCompletionNudges(context),
+      !initialState,
+    );
+
+    sinon.assert.calledOnce(setTypedFalseCompletionNudgesSpy);
+    sinon.assert.calledWithExactly(
+      setTypedFalseCompletionNudgesSpy,
+      !initialState,
+    );
+
+    sinon.assert.calledOnce(restartSorbetSpy);
+    sinon.assert.calledWithExactly(
+      restartSorbetSpy,
+      RestartReason.CONFIG_CHANGE,
+    );
+  });
+});


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Add the option added [here](https://github.com/sorbet/sorbet/pull/7206) to the vscode extension config.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Unsure if all the changes here require coverage, would appreciate a nudge (😉) in the right direction if there's coverage I should be updating.

See included automated tests.
