### PR TITLE
Error if using `===` on `T::Array` instead of `Array`

### DIFF
--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -322,38 +322,56 @@ end
 module T::Array
   # Type syntax to specify the element type of a standard library Array
   def self.[](type); end
+  # Don't use case/when on T::Array--just use `when Array` instead.
+  def self.===(arg0); end
 end
 module T::Hash
   # Type syntax to specify the key and value types of a standard library Hash
   def self.[](keys, values); end
+  # Don't use case/when on T::Hash--just use `when Hash` instead.
+  def self.===(arg0); end
 end
 module T::Set
   # Type syntax to specify the element type of a standard library Set
   def self.[](type); end
+  # Don't use case/when on T::Set--just use `when Set` instead.
+  def self.===(arg0); end
 end
 module T::Range
   # Type syntax to specify the element type of a standard library Range
   def self.[](type); end
+  # Don't use case/when on T::Range--just use `when Range` instead.
+  def self.===(arg0); end
 end
 module T::Class
   # Type syntax to specify the element type of a standard library Class
   def self.[](type); end
+  # Don't use case/when on T::Class--just use `when Class` instead.
+  def self.===(arg0); end
 end
 module T::Enumerable
   # Type syntax to specify the element type of a standard library Enumerable
   def self.[](type); end
+  # Don't use case/when on T::Enumerable--just use `when Enumerable` instead.
+  def self.===(arg0); end
 end
 module T::Enumerator
   # Type syntax to specify the element type of a standard library Enumerator
   def self.[](type); end
+  # Don't use case/when on T::Enumerator--just use `when Enumerator` instead.
+  def self.===(arg0); end
 end
 module T::Enumerator::Lazy
   # Type syntax to specify the element type of a standard library Enumerator::Lazy
   def self.[](type); end
+  # Don't use case/when on T::Enumerator::Lazy--just use `when Enumerator::Lazy` instead.
+  def self.===(arg0); end
 end
 module T::Enumerator::Chain
   # Type syntax to specify the element type of a standard library Enumerator::Chain
   def self.[](type); end
+  # Don't use case/when on T::Enumerator::Chain--just use `when Enumerator::Chain` instead.
+  def self.===(arg0); end
 end
 
 # Type syntax for either a `true` or `false` value.

--- a/test/testdata/infer/no_when_t_forwarder.rb
+++ b/test/testdata/infer/no_when_t_forwarder.rb
@@ -8,3 +8,6 @@ when T::Hash
 when T::Set
   #  ^^^^^^ error: Use `Set` without any `T::` prefix to match on a stdlib generic type
 end
+
+T::Array.===([])
+#        ^^^ error: Use `Array` without any `T::` prefix to match on a stdlib generic type

--- a/test/testdata/infer/no_when_t_forwarder.rb
+++ b/test/testdata/infer/no_when_t_forwarder.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+case T.unsafe(nil)
+when T::Array
+  #  ^^^^^^^^ error: Use `Array` without any `T::` prefix to match on a stdlib generic type
+when T::Hash
+  #  ^^^^^^^ error: Use `Hash` without any `T::` prefix to match on a stdlib generic type
+when T::Set
+  #  ^^^^^^ error: Use `Set` without any `T::` prefix to match on a stdlib generic type
+end

--- a/test/testdata/infer/no_when_t_forwarder.rb.autocorrects.exp
+++ b/test/testdata/infer/no_when_t_forwarder.rb.autocorrects.exp
@@ -9,4 +9,7 @@ when Hash
 when Set
   #  ^^^^^^ error: Use `Set` without any `T::` prefix to match on a stdlib generic type
 end
+
+Array.===([])
+#        ^^^ error: Use `Array` without any `T::` prefix to match on a stdlib generic type
 # ------------------------------

--- a/test/testdata/infer/no_when_t_forwarder.rb.autocorrects.exp
+++ b/test/testdata/infer/no_when_t_forwarder.rb.autocorrects.exp
@@ -1,0 +1,12 @@
+# -- test/testdata/infer/no_when_t_forwarder.rb --
+# typed: true
+
+case T.unsafe(nil)
+when T::Array
+  #  ^^^^^^^^ error: Use `Array` without any `T::` prefix to match on a stdlib generic type
+when T::Hash
+  #  ^^^^^^^ error: Use `Hash` without any `T::` prefix to match on a stdlib generic type
+when T::Set
+  #  ^^^^^^ error: Use `Set` without any `T::` prefix to match on a stdlib generic type
+end
+# ------------------------------

--- a/test/testdata/infer/no_when_t_forwarder.rb.autocorrects.exp
+++ b/test/testdata/infer/no_when_t_forwarder.rb.autocorrects.exp
@@ -2,11 +2,11 @@
 # typed: true
 
 case T.unsafe(nil)
-when T::Array
+when Array
   #  ^^^^^^^^ error: Use `Array` without any `T::` prefix to match on a stdlib generic type
-when T::Hash
+when Hash
   #  ^^^^^^^ error: Use `Hash` without any `T::` prefix to match on a stdlib generic type
-when T::Set
+when Set
   #  ^^^^^^ error: Use `Set` without any `T::` prefix to match on a stdlib generic type
 end
 # ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Requested by a user


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

<img width="974" alt="Screenshot 2023-08-10 at 4 59 54 PM" src="https://github.com/sorbet/sorbet/assets/5544532/f6fb8f2d-6a10-4e64-b069-73863a4b89c3">
