### PR TITLE
Allow T.bind(self, T.untyped) followup

### DIFF
--- a/test/testdata/infer/bound_proc_strict.rb
+++ b/test/testdata/infer/bound_proc_strict.rb
@@ -1,0 +1,14 @@
+# typed: strict
+
+class UntypedBind
+  extend T::Sig
+
+  sig { void }
+  def foo
+    T.reveal_type(self) # error: type: `UntypedBind`
+    T.bind(self, T.untyped)
+    T.reveal_type(self) # error: type: `T.untyped`
+    T.bind(self, UntypedBind)
+    T.reveal_type(self) # error: type: `UntypedBind`
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

#7219 didn't actually silence the error, because of the `else if` case after, and it wasn't caught by the test because it's a `typed: strict` error (the test file I added a test case to was `typed: true`).

It will be easier to review this PR with `?w=1`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
