### PR TITLE
Remove uninstantiated template from header

### DIFF
--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -95,9 +95,6 @@ protected:
 
     std::unique_ptr<LSPMessage> readAsync();
 
-    template <typename T>
-    void assertDiagnostics(std::vector<std::unique_ptr<LSPMessage>> messages, std::vector<ExpectedDiagnostic> expected);
-
     void assertErrorDiagnostics(std::vector<std::unique_ptr<LSPMessage>> messages,
                                 std::vector<ExpectedDiagnostic> expected);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When using templates, you have to either

- implement the template function in the header, so that it can be instantiated
  at any type that might be required in the future
- pray that code using your header only uses the instantiations that you use in
  your cc file

The way this could have failed before this PR is that someone could call

```cpp
assertDiagnostic<HoverAssertion>(...)
```

or something like that, and this would simply be a linker failure, because the
instantiation of `assertDiagnostic` at `<HoverAssertion>` can't be deduced from
the header file, and none of the libraries that get linked in will have already
defined that symbol.

At least this is my interpretation. Maybe @froydnj has a better way of
explaining it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a