### PR TITLE
Default to test_import if referenced from test

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -401,6 +401,7 @@ public:
                 e.setHeader("`{}` is defined in a test namespace and cannot be referenced in a non-test file",
                             lit.symbol.show(ctx));
             }
+            return;
         }
 
         auto &db = ctx.state.packageDB();

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -456,7 +456,7 @@ public:
             if (auto e = ctx.beginError(lit.loc, core::errors::Packager::MissingImport)) {
                 auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
                 e.setHeader("`{}` resolves but its package is not imported", lit.symbol.show(ctx));
-                bool isTestImport = otherFile.data(ctx).isPackagedTest();
+                bool isTestImport = otherFile.data(ctx).isPackagedTest() || ctx.file.data(ctx).isPackagedTest();
                 e.addErrorLine(pkg.declLoc(), "Exported from package here");
                 if (auto exp = this->package.addImport(ctx, pkg, isTestImport)) {
                     e.addAutocorrect(std::move(exp.value()));

--- a/test/cli/package-autocorrect-missing-import/foo.test.rb
+++ b/test/cli/package-autocorrect-missing-import/foo.test.rb
@@ -2,4 +2,6 @@
 
 module Test::Foo::MyPackage
   Test::Foo::Bar::OtherPackage::TestUtil
+
+  Foo::Bar::OtherPackage::ImportMeTestOnly
 end

--- a/test/cli/package-autocorrect-missing-import/foo_class.rb
+++ b/test/cli/package-autocorrect-missing-import/foo_class.rb
@@ -13,4 +13,6 @@ end
 module Foo::MyPackage
   Foo::Bar::OtherPackage::OtherClass # resolves via root
   Foo::Bar::MyClass::SUBCLASSES # resolves via root
+
+  Test::Foo::Bar::OtherPackage::TestUtil
 end

--- a/test/cli/package-autocorrect-missing-import/other/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/other/__package.rb
@@ -2,5 +2,6 @@
 
 class Foo::Bar::OtherPackage < PackageSpec
   export Foo::Bar::OtherPackage::OtherClass
+  export Foo::Bar::OtherPackage::ImportMeTestOnly
   export Test::Foo::Bar::OtherPackage::TestUtil
 end

--- a/test/cli/package-autocorrect-missing-import/other/import_me_test_only.rb
+++ b/test/cli/package-autocorrect-missing-import/other/import_me_test_only.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::OtherPackage::ImportMeTestOnly
+end

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -60,17 +60,6 @@ foo_class.rb:17: `Test::Foo::Bar::OtherPackage::TestUtil` is defined in a test n
     17 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-foo_class.rb:17: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
-    17 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    __package.rb:6: Inserted `test_import Foo::Bar::OtherPackage`
-     6 |  # import Foo::Bar::OtherPackage ## MISSING!
-                                                     ^
-
 foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +81,7 @@ foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its packa
     __package.rb:6: Inserted `test_import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
-Errors: 8
+Errors: 7
 
 --------------------------------------------------------------------------
 

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -74,7 +74,7 @@ foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its packa
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
+    __package.rb:6: Inserted `test_import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
 Errors: 6

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -66,7 +66,18 @@ foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package
     __package.rb:6: Inserted `test_import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
-Errors: 5
+
+foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
+     6 |  Foo::Bar::OtherPackage::ImportMeTestOnly
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Exported from package here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
+Errors: 6
 
 --------------------------------------------------------------------------
 

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -56,6 +56,21 @@ foo_class.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package i
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
 
+foo_class.rb:17: `Test::Foo::Bar::OtherPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    17 |  Test::Foo::Bar::OtherPackage::TestUtil
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+foo_class.rb:17: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+    17 |  Test::Foo::Bar::OtherPackage::TestUtil
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Exported from package here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    __package.rb:6: Inserted `test_import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
+
 foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +92,7 @@ foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its packa
     __package.rb:6: Inserted `test_import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
-Errors: 6
+Errors: 8
 
 --------------------------------------------------------------------------
 

--- a/test/testdata/packager/export_for_test/foo/foo.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.rb
@@ -36,7 +36,6 @@ module Opus::Foo
   Opus::TestImported::TIClass
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Opus::TestImported::TIClass` in non-test file
   Test::Opus::TestImported::TITestClass
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Test::Opus::TestImported::TITestClass` in non-test file
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::TestImported::TITestClass` is defined in a test namespace
 
 

--- a/test/testdata/packager/lsp_features/family.rb
+++ b/test/testdata/packager/lsp_features/family.rb
@@ -41,7 +41,6 @@ module Simpsons
   end
 
   Test::Krabappel::Popquiz
-# ^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Test::Krabappel::Popquiz` in non-test file
 # ^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Krabappel::Popquiz` is defined in a test namespace
   #                ^^^^^^^ usage: popquiz
 # ^^^^^^^^^^^^^^^ importusage: krabappel-pkg

--- a/test/testdata/packager/simple_test_import/main_lib/lib.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.rb
@@ -12,6 +12,5 @@ class Project::MainLib::Lib
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::UtilHelper` is defined in a test namespace
 
   Test::Project::Util::Unexported
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` resolves but is not exported from `Project::Util`
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` is defined in a test namespace
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already have the ability to convert a `test_import` to an `import` the first
time that would become necessary. So if we're about to add an import to a
package, and that package takes a dependency on another package only because of
an edge in test code, we should have the autocorrect suggest `test_import`.

Note that this is separate from the existing `test_import` autocorrect behavior,
which says that if the import is a test-only definition that it should of course
only be imported with `test_import` (because the definition should never be
referenced from non-test code).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.