### PR TITLE
Add `enableTypedFalseCompletionNudges` config to VS Code extension

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -258,6 +258,11 @@
           "description": "Shows warning for untyped values.",
           "default": false
         },
+        "sorbet.enableTypedFalseCompletionNudges": {
+          "type": "boolean",
+          "description": "Enable \"file is not `#typed: true` or higher\" completion nudges",
+          "default": true
+        },
         "sorbet.configFilePatterns": {
           "type": "array",
           "description": "List of workspace file patterns that contribute to Sorbet's configuration.  Changes to any of those files should trigger a restart of any actively running Sorbet language server.",

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -211,6 +211,7 @@ export class SorbetExtensionConfig implements Disposable {
   private wrappedEnabled: boolean;
   private wrappedHighlightUntyped: boolean;
   private wrappedRevealOutputOnError: boolean;
+  private wrappedEnableTypedFalseCompletionNudges: boolean;
 
   constructor(sorbetWorkspaceContext: ISorbetWorkspaceContext) {
     this.configFilePatterns = [];
@@ -223,6 +224,7 @@ export class SorbetExtensionConfig implements Disposable {
     this.userLspConfigs = [];
     this.wrappedHighlightUntyped = false;
     this.wrappedRevealOutputOnError = false;
+    this.wrappedEnableTypedFalseCompletionNudges = true;
 
     const workspaceFolders = this.sorbetWorkspaceContext.workspaceFolders();
     this.wrappedEnabled = workspaceFolders?.length
@@ -273,6 +275,10 @@ export class SorbetExtensionConfig implements Disposable {
     this.wrappedHighlightUntyped = this.sorbetWorkspaceContext.get(
       "highlightUntyped",
       this.highlightUntyped,
+    );
+    this.wrappedEnableTypedFalseCompletionNudges = this.sorbetWorkspaceContext.get(
+      "enableTypedFalseCompletionNudges",
+      this.enableTypedFalseCompletionNudges,
     );
 
     Disposable.from(...this.configFileWatchers).dispose();
@@ -399,6 +405,10 @@ export class SorbetExtensionConfig implements Disposable {
     return this.wrappedEnabled;
   }
 
+  public get enableTypedFalseCompletionNudges(): boolean {
+    return this.wrappedEnableTypedFalseCompletionNudges;
+  }
+
   public async setEnabled(b: boolean): Promise<void> {
     await this.sorbetWorkspaceContext.update("enabled", b);
     this.refresh();
@@ -406,6 +416,14 @@ export class SorbetExtensionConfig implements Disposable {
 
   public async setHighlightUntyped(b: boolean): Promise<void> {
     await this.sorbetWorkspaceContext.update("highlightUntyped", b);
+    this.refresh();
+  }
+
+  public async setEnableTypedFalseCompletionNudges(b: boolean): Promise<void> {
+    await this.sorbetWorkspaceContext.update(
+      "enableTypedFalseCompletionNudges",
+      b,
+    );
     this.refresh();
   }
 }

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -59,6 +59,8 @@ function createClient(
       // Let Sorbet know that we can handle sorbet:// URIs for generated files.
       supportsSorbetURIs: true,
       highlightUntyped: context.configuration.highlightUntyped,
+      enableTypedFalseCompletionNudges:
+        context.configuration.enableTypedFalseCompletionNudges,
     },
     errorHandler,
     revealOutputChannelOn: context.configuration.revealOutputOnError


### PR DESCRIPTION
This is a follow-up to my PR from last week which added the `enableTypedFalseCompletionNudges` config option to the LSP.

### Motivation
Let users of the VS Code extension configure this option.


### Test plan
Tested locally. I didn't see any relevant specs to update.
