### PR TITLE
Fix crash with locs and staticInit methods

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2514,6 +2514,9 @@ MethodRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {
         auto blkLoc = core::Loc::none(loc.file());
         auto &blkSym = enterMethodArgumentSymbol(blkLoc, sym, core::Names::blkArg());
         blkSym.flags.isBlock = true;
+    } else {
+        // Ensures that locs get properly updated on the fast path
+        sym.data(*this)->addLoc(*this, loc);
     }
     return sym;
 }
@@ -2533,6 +2536,9 @@ MethodRef GlobalState::staticInitForFile(Loc loc) {
         auto blkLoc = core::Loc::none(loc.file());
         auto &blkSym = this->enterMethodArgumentSymbol(blkLoc, sym, core::Names::blkArg());
         blkSym.flags.isBlock = true;
+    } else {
+        // Ensures that locs get properly updated on the fast path
+        sym.data(*this)->addLoc(*this, loc);
     }
     return sym;
 }

--- a/test/testdata/deviations/superclass_implicit.rb.symbol-table-raw.exp
+++ b/test/testdata/deviations/superclass_implicit.rb.symbol-table-raw.exp
@@ -5,7 +5,7 @@ class <C <U <root>>> < <C <U Object>> ()
   class <C <U A>> < <C <U B>> () @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=14:1 end=14:12}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U B>> $1> () @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=14:1 end=14:12}
     type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=11:1 end=11:8}
-    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=11:1 end=12:4}
+    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=14:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=??? end=???}
   class <C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=8:1 end=8:8}
   class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=8:1 end=8:8}

--- a/test/testdata/lsp/fast_path/static_init_file_locs.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_init_file_locs.1.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+
+if T.unsafe(nil)
+  x = 1
+end
+T.reveal_type(x)

--- a/test/testdata/lsp/fast_path/static_init_file_locs.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_init_file_locs.1.rbupdate
@@ -3,4 +3,4 @@
 if T.unsafe(nil)
   x = 1
 end
-T.reveal_type(x)
+T.reveal_type(x) # error: `T.nilable(Integer)`

--- a/test/testdata/lsp/fast_path/static_init_file_locs.rb
+++ b/test/testdata/lsp/fast_path/static_init_file_locs.rb
@@ -19,4 +19,4 @@
 if T.unsafe(nil)
   x = 1
 end
-T.reveal_type(x)
+T.reveal_type(x) # error: `T.nilable(Integer)`

--- a/test/testdata/lsp/fast_path/static_init_file_locs.rb
+++ b/test/testdata/lsp/fast_path/static_init_file_locs.rb
@@ -1,0 +1,22 @@
+# typed: true
+
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+
+if T.unsafe(nil)
+  x = 1
+end
+T.reveal_type(x)

--- a/test/testdata/lsp/fast_path/static_init_method_locs.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_init_method_locs.1.rbupdate
@@ -4,5 +4,5 @@ class A
   if T.unsafe(nil)
     x = 1
   end
-  T.reveal_type(x)
+  T.reveal_type(x) # error: `T.nilable(Integer)`
 end

--- a/test/testdata/lsp/fast_path/static_init_method_locs.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_init_method_locs.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  if T.unsafe(nil)
+    x = 1
+  end
+  T.reveal_type(x)
+end

--- a/test/testdata/lsp/fast_path/static_init_method_locs.rb
+++ b/test/testdata/lsp/fast_path/static_init_method_locs.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+
+class A
+  if T.unsafe(nil)
+    x = 1
+  end
+  T.reveal_type(x)
+end

--- a/test/testdata/lsp/fast_path/static_init_method_locs.rb
+++ b/test/testdata/lsp/fast_path/static_init_method_locs.rb
@@ -14,5 +14,5 @@ class A
   if T.unsafe(nil)
     x = 1
   end
-  T.reveal_type(x)
+  T.reveal_type(x) # error: `T.nilable(Integer)`
 end

--- a/test/testdata/namer/circular_mixin.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/circular_mixin.rb.symbol-table-raw.exp
@@ -4,10 +4,10 @@ class <C <U <root>>> < <C <U Object>> ()
       argument <blk><block> @ Loc {file=test/testdata/namer/circular_mixin.rb start=??? end=???}
   module <C <U A>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> (<C <U B>>, <C <U StubMixin>>) @ Loc {file=test/testdata/namer/circular_mixin.rb start=11:1 end=11:9}
   class <S <C <U A>> $1> < <C <U Module>> () @ Loc {file=test/testdata/namer/circular_mixin.rb start=11:1 end=11:9}
-    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/circular_mixin.rb start=2:1 end=2:14}
+    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/circular_mixin.rb start=11:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/circular_mixin.rb start=??? end=???}
   module <C <U B>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> (<C <U StubMixin>>) @ Loc {file=test/testdata/namer/circular_mixin.rb start=7:1 end=7:9}
   class <S <C <U B>> $1> < <C <U Module>> () @ Loc {file=test/testdata/namer/circular_mixin.rb start=7:1 end=7:9}
-    method <S <C <U B>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/circular_mixin.rb start=3:1 end=3:14}
+    method <S <C <U B>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/circular_mixin.rb start=7:1 end=9:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/circular_mixin.rb start=??? end=???}
 

--- a/test/testdata/namer/superclass_redefinition.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/superclass_redefinition.rb.symbol-table-raw.exp
@@ -5,7 +5,7 @@ class <C <U <root>>> < <C <U Object>> ()
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=7:1 end=7:12}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=7:1 end=7:12}
     type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=2:1 end=2:17}
-    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=2:1 end=3:4}
+    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=7:1 end=8:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=??? end=???}
   class <C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=4:1 end=4:8}
   class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=4:1 end=4:8}

--- a/test/testdata/resolver/simple.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/simple.rb.symbol-table-raw.exp
@@ -22,7 +22,7 @@ class <C <U <root>>> < <C <U Object>> ()
       class <C <U Outer2>>::<C <U Inner1>>::<C <U Inner2>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/simple.rb start=21:3 end=21:23}
       class <C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/simple.rb start=21:3 end=21:23}
         type-member(+) <C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Outer2::Inner1::Inner2) @ Loc {file=test/testdata/resolver/simple.rb start=13:5 end=13:17}
-        method <C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/simple.rb start=13:5 end=18:8}
+        method <C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/simple.rb start=21:3 end=24:6}
           argument <blk><block> @ Loc {file=test/testdata/resolver/simple.rb start=??? end=???}
     class <C <U Outer2>>::<S <C <U Inner1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/simple.rb start=9:3 end=9:15}
       type-member(+) <C <U Outer2>>::<S <C <U Inner1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U Outer2>>::<S <C <U Inner1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Outer2::Inner1) @ Loc {file=test/testdata/resolver/simple.rb start=9:3 end=9:15}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fix a bad loc crash.

This suggests that we likely want addLoc to happen in enterMethodSymbol, but I'm
not really looking forward to making that change at the moment because I suspect
it will be a little more complicated in the presence of method redefinitions.
It might be fine, but that'll have to be a problem for another day.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

The included test doesn't actually manage to repro the crash for some reason.
It's super weird, because I the edits described in the test reproduce the crash
100% of the time for me when I apply them myself in the editor.

Anyways, this is what the crash looks like in the debug-log-file:

```
[2023-08-15 10:29:24.264] [consoleAndFile] [error] msg="Bad offset2Pos off" path="/home/jez/.dotfiles/vim/bundle/vim-sorbet/.empty/test/testdata/lsp/bar.rb" off="108""
[2023-08-15 10:29:24.264] [consoleAndFile] [error] source="# typed: strict\nbegin\n  x =\n  while true\n    raise\n  end\nrescue\n  T.reveal_type(x) # error: `NilClass`\nend\n"
[2023-08-15 10:29:24.264] [consoleAndFile] [error] Exception::raise(): core/Loc.cc:43 enforced condition false has failed: (no message provided)

[2023-08-15 10:29:24.382] [consoleAndFile] [error] Backtrace:
  #3 0xbbde42 
  #4 0x1a54540 sorbet::core::Loc::offset2Pos()
  #5 0x1a548e4 sorbet::core::Loc::position()
  #6 0x1a566e7 sorbet::core::Loc::filePosToString()
  #7 0x19d82f0 sorbet::core::ErrorLine::toString()
  #8 0x19d8d82 sorbet::core::ErrorSection::toString()
  #9 0x19d96e2 sorbet::core::Error::toString()
  #10 0x19ec39e sorbet::core::ErrorQueue::pushError()
  #11 0x1a37592 sorbet::core::GlobalState::_error()
  #12 0x19daa20 sorbet::core::ErrorBuilder::~ErrorBuilder()
  #13 0x1af4b06 sorbet::core::(anonymous namespace)::T_revealType::apply()
  #14 0x1ae8662 sorbet::core::(anonymous namespace)::dispatchCallSymbol()
  #15 0x1add3e6 sorbet::core::ClassType::dispatchCall()
  #16 0x1abf655 sorbet::core::(anonymous namespace)::CALL_MEMBER_impl_dispatchCall<>::call<>()
  #17 0x1abf337 sorbet::core::TypePtr::dispatchCall()
  #18 0x12d9567 sorbet::infer::Environment::processBinding()::$_0::operator()()
  #19 0x12d8b93 sorbet::typecaseHelper<>()
  #20 0x12d452d sorbet::typecase<>()
  #21 0x12d2390 sorbet::infer::Environment::processBinding()
  #22 0x12be2b5 sorbet::infer::Inference::run()
  #23 0xfa22a4 sorbet::realmain::pipeline::CFGCollectorAndTyper::preTransformMethodDef()
  #24 0xfa204a sorbet::ast::MapFunctions<>::CALL_MEMBER_impl_preTransformMethodDef<>::call<>()
  #25 0xfa133f sorbet::ast::TreeMapper<>::mapMethodDef()
  #26 0xfa0489 sorbet::ast::TreeMapper<>::mapIt()
  #27 0xfa12e4 sorbet::ast::TreeMapper<>::mapClassDef()
  #28 0xfa043b sorbet::ast::TreeMapper<>::mapIt()
  #29 0xfa1f98 sorbet::ast::TreeMapper<>::mapInsSeq()
  #30 0xfa0d2d sorbet::ast::TreeMapper<>::mapIt()
  #31 0xfa00ba sorbet::ast::ShallowWalk::apply<>()
  #32 0xf6c9fc sorbet::realmain::pipeline::(anonymous namespace)::typecheckOne()
  #33 0xf6bc7d sorbet::realmain::pipeline::typecheck()::$_5::operator()()
  #34 0xf6b90d std::__1::__invoke<>()
  #35 0xf6b8bd std::__1::__invoke_void_return_wrapper<>::__call<>()
  #36 0xf6b88d std::__1::__function::__alloc_func<>::operator()()
  #37 0xf6aa59 std::__1::__function::__func<>::operator()()
  #38 0x174f832 std::__1::__function::__value_func<>::operator()()
  #39 0x17460d5 std::__1::function<>::operator()()
  #40 0x1be96ca sorbet::WorkerPoolImpl::multiplexJob()::$_2::operator()()
  #41 0x1be966d std::__1::__invoke<>()
  #42 0x1be961d std::__1::__invoke_void_return_wrapper<>::__call<>()
  #43 0x1be95ed std::__1::__function::__alloc_func<>::operator()()
  #44 0x1be87f9 std::__1::__function::__func<>::operator()()
  #45 0x1bedf02 std::__1::__function::__value_func<>::operator()()
  #46 0x1becb25 std::__1::function<>::operator()()
  #47 0x1be6a8d sorbet::WorkerPoolImpl::WorkerPoolImpl()::$_0::operator()()
  #48 0x1be69cd std::__1::__invoke<>()
  #49 0x1be697d std::__1::__invoke_void_return_wrapper<>::__call<>()
  #50 0x1be694d std::__1::__function::__alloc_func<>::operator()()
  #51 0x1be5b69 std::__1::__function::__func<>::operator()()
  #52 0x174f832 std::__1::__function::__value_func<>::operator()()
  #53 0x17460d5 std::__1::function<>::operator()()
  #54 0x1bf16a3 Joinable::trampoline()
  #55 0x7f80d8aa7609 start_thread
  #56 0x7f80d89c6133 __clone

[2023-08-15 10:29:24.389] [consoleAndFile] [error] Backtrace:
  #3 0x1d0f258 std::terminate()
  #4 0xbadb7b 
  #5 0x19daab8 
  #6 0x1af4b06 sorbet::core::(anonymous namespace)::T_revealType::apply()
  #7 0x1ae8662 sorbet::core::(anonymous namespace)::dispatchCallSymbol()
  #8 0x1add3e6 sorbet::core::ClassType::dispatchCall()
  #9 0x1abf655 sorbet::core::(anonymous namespace)::CALL_MEMBER_impl_dispatchCall<>::call<>()
  #10 0x1abf337 sorbet::core::TypePtr::dispatchCall()
  #11 0x12d9567 sorbet::infer::Environment::processBinding()::$_0::operator()()
  #12 0x12d8b93 sorbet::typecaseHelper<>()
  #13 0x12d452d sorbet::typecase<>()
  #14 0x12d2390 sorbet::infer::Environment::processBinding()
  #15 0x12be2b5 sorbet::infer::Inference::run()
  #16 0xfa22a4 sorbet::realmain::pipeline::CFGCollectorAndTyper::preTransformMethodDef()
  #17 0xfa204a sorbet::ast::MapFunctions<>::CALL_MEMBER_impl_preTransformMethodDef<>::call<>()
  #18 0xfa133f sorbet::ast::TreeMapper<>::mapMethodDef()
  #19 0xfa0489 sorbet::ast::TreeMapper<>::mapIt()
  #20 0xfa12e4 sorbet::ast::TreeMapper<>::mapClassDef()
  #21 0xfa043b sorbet::ast::TreeMapper<>::mapIt()
  #22 0xfa1f98 sorbet::ast::TreeMapper<>::mapInsSeq()
  #23 0xfa0d2d sorbet::ast::TreeMapper<>::mapIt()
  #24 0xfa00ba sorbet::ast::ShallowWalk::apply<>()
  #25 0xf6c9fc sorbet::realmain::pipeline::(anonymous namespace)::typecheckOne()
  #26 0xf6bc7d sorbet::realmain::pipeline::typecheck()::$_5::operator()()
  #27 0xf6b90d std::__1::__invoke<>()
  #28 0xf6b8bd std::__1::__invoke_void_return_wrapper<>::__call<>()
  #29 0xf6b88d std::__1::__function::__alloc_func<>::operator()()
  #30 0xf6aa59 std::__1::__function::__func<>::operator()()
  #31 0x174f832 std::__1::__function::__value_func<>::operator()()
  #32 0x17460d5 std::__1::function<>::operator()()
  #33 0x1be96ca sorbet::WorkerPoolImpl::multiplexJob()::$_2::operator()()
  #34 0x1be966d std::__1::__invoke<>()
  #35 0x1be961d std::__1::__invoke_void_return_wrapper<>::__call<>()
  #36 0x1be95ed std::__1::__function::__alloc_func<>::operator()()
  #37 0x1be87f9 std::__1::__function::__func<>::operator()()
  #38 0x1bedf02 std::__1::__function::__value_func<>::operator()()
  #39 0x1becb25 std::__1::function<>::operator()()
  #40 0x1be6a8d sorbet::WorkerPoolImpl::WorkerPoolImpl()::$_0::operator()()
  #41 0x1be69cd std::__1::__invoke<>()
  #42 0x1be697d std::__1::__invoke_void_return_wrapper<>::__call<>()
  #43 0x1be694d std::__1::__function::__alloc_func<>::operator()()
  #44 0x1be5b69 std::__1::__function::__func<>::operator()()
  #45 0x174f832 std::__1::__function::__value_func<>::operator()()
  #46 0x17460d5 std::__1::function<>::operator()()
  #47 0x1bf16a3 Joinable::trampoline()
  #48 0x7f80d8aa7609 start_thread
  #49 0x7f80d89c6133 __clone
```


And it goes away 100% of the time after the changes in this PR. So I'm not
really dwelling on the test case too much.