### PR TITLE
Translate `before do` to `def <before>`

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -260,6 +260,7 @@ NameDef names[] = {
     {"describe"},
     {"it"},
     {"before"},
+    {"beforeAngles", "<before>"},
     {"after"},
     {"afterAngles", "<after>"},
     {"testEach", "test_each"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2747,7 +2747,8 @@ public:
             auto fieldName = fieldNameTy.asName().show(gs);
 
             auto suggestType = res.returnType;
-            if (definingMethodName != core::Names::initialize() && definingMethodName != core::Names::staticInit()) {
+            if (definingMethodName != core::Names::initialize() && definingMethodName != core::Names::staticInit() &&
+                definingMethodName != core::Names::beforeAngles()) {
                 suggestType = core::Types::any(gs, Types::nilClass(), suggestType);
             }
             e.setHeader("The {} variable `{}` must be declared using `{}` when specifying `{}`", fieldKind, fieldName,

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -31,6 +31,11 @@ bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym) {
         name == core::Names::unresolvedAncestors() || name == core::Names::Constants::AttachedClass()) {
         return true;
     }
+    // TODO(jez) We probably want to get rid of anything with angle brackets (like what
+    // completion.cc does) but that can be in another change.
+    if (name == core::Names::beforeAngles()) {
+        return true;
+    }
     // static-init for a file
     if (name.kind() == core::NameKind::UNIQUE && name.dataUnique(gs)->original == core::Names::staticInit()) {
         return true;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2215,8 +2215,9 @@ class ResolveTypeMembersAndFieldsWalk {
             // class or body, rather then nested in some block
             if (job.atTopLevel && ctx.owner.isClassOrModule()) {
                 // Declaring a class instance variable
-            } else if (job.atTopLevel && ctx.owner.name(ctx) == core::Names::initialize()) {
-                // Declaring a instance variable
+            } else if (job.atTopLevel && (ctx.owner.name(ctx) == core::Names::initialize() ||
+                                          ctx.owner.name(ctx) == core::Names::beforeAngles())) {
+                // Declaring a instance variable in either `initialize` or a `before do` block.
             } else if (ctx.owner.isMethod() &&
                        ctx.owner.asMethodRef().data(ctx)->owner.data(ctx)->isSingletonClass(ctx) &&
                        !core::Types::isSubType(ctx, core::Types::nilClass(), castType)) {

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -353,7 +353,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
     }
 
     if (send->numPosArgs() == 0 && (send->fun == core::Names::before() || send->fun == core::Names::after())) {
-        auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
+        auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::beforeAngles();
         ConstantMover constantMover;
         ast::TreeWalk::apply(ctx, constantMover, block->body);
         auto method = addSigVoid(

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -53,7 +53,8 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
             auto *send = ast::cast_tree<ast::Send>(stat);
             auto loc = send->loc;
             auto block = send->block();
-            auto method_name = send->fun == core::Names::setup() ? core::Names::initialize() : core::Names::teardown();
+            auto method_name =
+                send->fun == core::Names::setup() ? core::Names::beforeAngles() : core::Names::teardown();
 
             auto method = ast::MK::SyntheticMethod0(loc, loc, method_name, std::move(block->body));
             auto method_with_sig =

--- a/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
@@ -29,32 +29,6 @@
             },
             "children": [
                 {
-                    "name": "<before>",
-                    "detail": "",
-                    "kind": 6,
-                    "range": {
-                        "start": {
-                            "line": 4,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 6,
-                            "character": 5
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 4,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 6,
-                            "character": 5
-                        }
-                    },
-                    "children": []
-                },
-                {
                     "name": "describe 'with this block'",
                     "detail": "",
                     "kind": 5,
@@ -79,32 +53,6 @@
                         }
                     },
                     "children": [
-                        {
-                            "name": "<before>",
-                            "detail": "",
-                            "kind": 6,
-                            "range": {
-                                "start": {
-                                    "line": 9,
-                                    "character": 4
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "character": 7
-                                }
-                            },
-                            "selectionRange": {
-                                "start": {
-                                    "line": 9,
-                                    "character": 4
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "character": 7
-                                }
-                            },
-                            "children": []
-                        },
                         {
                             "name": "it 'runs another test'",
                             "detail": "",

--- a/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
@@ -29,6 +29,32 @@
             },
             "children": [
                 {
+                    "name": "<before>",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 4,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 4,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 5
+                        }
+                    },
+                    "children": []
+                },
+                {
                     "name": "describe 'with this block'",
                     "detail": "",
                     "kind": 5,
@@ -53,6 +79,32 @@
                         }
                     },
                     "children": [
+                        {
+                            "name": "<before>",
+                            "detail": "",
+                            "kind": 6,
+                            "range": {
+                                "start": {
+                                    "line": 9,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "character": 7
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 9,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "character": 7
+                                }
+                            },
+                            "children": []
+                        },
                         {
                             "name": "it 'runs another test'",
                             "detail": "",
@@ -104,60 +156,8 @@
                                 }
                             },
                             "children": []
-                        },
-                        {
-                            "name": "initialize",
-                            "detail": "",
-                            "kind": 9,
-                            "range": {
-                                "start": {
-                                    "line": 9,
-                                    "character": 4
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "character": 7
-                                }
-                            },
-                            "selectionRange": {
-                                "start": {
-                                    "line": 9,
-                                    "character": 4
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "character": 7
-                                }
-                            },
-                            "children": []
                         }
                     ]
-                },
-                {
-                    "name": "initialize",
-                    "detail": "",
-                    "kind": 9,
-                    "range": {
-                        "start": {
-                            "line": 4,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 6,
-                            "character": 5
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 4,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 6,
-                            "character": 5
-                        }
-                    },
-                    "children": []
                 }
             ]
         }

--- a/test/testdata/rewriter/before_do.rb
+++ b/test/testdata/rewriter/before_do.rb
@@ -1,0 +1,27 @@
+# typed: strict
+class Module; include T::Sig; end
+
+class MyTestGrandParent
+  sig {params(name: String).void}
+  def initialize(name)
+  end
+end
+
+class MyTestParent < MyTestGrandParent
+  before do
+    @x = T.let(1, Integer)
+  end
+end
+
+class MyTestChild < MyTestParent
+  sig {params(name: String).void}
+  def initialize(name)
+    super
+  end
+
+  describe 'example' do
+    it 'does thing' do
+      T.reveal_type(@x) # error: `Integer`
+    end
+  end
+end

--- a/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
@@ -1,0 +1,56 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Module><<C <todo sym>>> < (::<todo sym>)
+    <self>.include(<emptyTree>::<C T>::<C Sig>)
+  end
+
+  class <emptyTree>::<C MyTestGrandParent><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:name, <emptyTree>::<C String>).void()
+    end
+
+    def initialize<<todo method>>(name, &<blk>)
+      <emptyTree>
+    end
+
+    <runtime method definition of initialize>
+  end
+
+  class <emptyTree>::<C MyTestParent><<C <todo sym>>> < (<emptyTree>::<C MyTestGrandParent>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def initialize<<todo method>>(&<blk>)
+      @x = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
+    end
+
+    <runtime method definition of initialize>
+  end
+
+  class <emptyTree>::<C MyTestChild><<C <todo sym>>> < (<emptyTree>::<C MyTestParent>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:name, <emptyTree>::<C String>).void()
+    end
+
+    def initialize<<todo method>>(name, &<blk>)
+      <self>.<super>(ZSuperArgs)
+    end
+
+    <runtime method definition of initialize>
+
+    class <emptyTree>::<C <describe 'example'>><<C <todo sym>>> < (<self>)
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.void()
+      end
+
+      def <it 'does thing'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(@x)
+      end
+
+      begin
+        "does thing"
+        <runtime method definition of <it 'does thing'>>
+      end
+    end
+  end
+end

--- a/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
@@ -20,11 +20,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def initialize<<todo method>>(&<blk>)
+    def <before><<todo method>>(&<blk>)
       @x = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
     end
 
-    <runtime method definition of initialize>
+    <runtime method definition of <before>>
   end
 
   class <emptyTree>::<C MyTestChild><<C <todo sym>>> < (<emptyTree>::<C MyTestParent>)

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -56,7 +56,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def initialize<<todo method>>(&<blk>)
+    def <before><<todo method>>(&<blk>)
       begin
         @foo = <cast:let>(3, <todo sym>, <emptyTree>::<C Integer>)
         <self>.instance_helper()
@@ -156,7 +156,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of instance_helper>
 
-    <runtime method definition of initialize>
+    <runtime method definition of <before>>
 
     <runtime method definition of <after>>
 

--- a/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def initialize<<todo method>>(&<blk>)
+    def <before><<todo method>>(&<blk>)
       begin
         @a = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
         <self>.foo()
@@ -54,7 +54,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def initialize<<todo method>>(&<blk>)
+    def <before><<todo method>>(&<blk>)
       <self>.bar()
     end
 
@@ -102,9 +102,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of test_block_is_evaluated_in_the_context_of_an_instance>
 
-    <runtime method definition of initialize>
+    <runtime method definition of <before>>
 
-    <runtime method definition of initialize>
+    <runtime method definition of <before>>
 
     <runtime method definition of teardown>
 
@@ -180,7 +180,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def initialize<<todo method>>(&<blk>)
+    def <before><<todo method>>(&<blk>)
       @a = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
     end
 
@@ -202,7 +202,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of test_it_works>
 
-    <runtime method definition of initialize>
+    <runtime method definition of <before>>
 
     <runtime method definition of teardown>
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This prevents Sorbet's rewriter pass from defining an `initialize` method,
which might then further interfere with `super` dispatch.

Unblocks #7212 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.