### PR TITLE
Add Regexp::TimeoutError type

### DIFF
--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -1363,4 +1363,12 @@ class Regexp < Object
     params(pats: T.untyped).returns(Regexp)
   end
   def self.union(*pats); end
+
+
+  # [TimeoutError](https://docs.ruby-lang.org/en/3.2/Regexp/TimeoutError.html) 
+  # is raised when the timeout set by calling
+  # [::timeout=][https://docs.ruby-lang.org/en/3.2/Regexp.html#method-c-timeout-3D]
+  # is reached during matching.
+  class Regexp::TimeoutError < RegexpError
+  end
 end

--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -1369,6 +1369,6 @@ class Regexp < Object
   # is raised when the timeout set by calling
   # [::timeout=][https://docs.ruby-lang.org/en/3.2/Regexp.html#method-c-timeout-3D]
   # is reached during matching.
-  class Regexp::TimeoutError < RegexpError
+  class TimeoutError < RegexpError
   end
 end

--- a/test/testdata/rbi/regexp.rb
+++ b/test/testdata/rbi/regexp.rb
@@ -37,3 +37,5 @@ T.reveal_type(Regexp.timeout) # error: type: `T.nilable(Float)`
 T.reveal_type(Regexp.timeout = 3.0) # error: type: `Float(3.000000)`
 T.reveal_type(Regexp.timeout) # error: type: `T.nilable(Float)`
 T.reveal_type(Regexp.timeout = nil) # error: type: `NilClass`
+
+Regexp::TimeoutError.new


### PR DESCRIPTION
Support for setting the global timeout on `Regexp` was added in https://github.com/sorbet/sorbet/pull/6773, but the class for the error raised when the timeout is reached wasn't.


### Test plan
See included automated tests - I'm not sure if new error classes need any tests beyond being referenced in a `typed: true` test file.
