### PR TITLE
Simplify `client` check in `toggleUntypedCodeHighlighting`

### DIFF
--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -10,22 +10,22 @@ export async function toggleUntypedCodeHighlighting(
 ): Promise<boolean> {
   const targetState = !context.configuration.highlightUntyped;
   await context.configuration.setHighlightUntyped(targetState);
-  const { activeLanguageClient: client } = context.statusProvider;
-  if (!client || client === undefined) {
-    context.log.debug("ToggleUntyped: No active Sorbet LSP.");
-  }
-
   context.log.info(
     `ToggleUntyped: Untyped code highlighting: ${
       targetState ? "enabled" : "disabled"
     }`,
   );
 
-  client?.sendNotification("workspace/didChangeConfiguration", {
-    settings: {
-      highlightUntyped: targetState,
-    },
-  });
+  const { activeLanguageClient: client } = context.statusProvider;
+  if (client) {
+    client.sendNotification("workspace/didChangeConfiguration", {
+      settings: {
+        highlightUntyped: targetState,
+      },
+    });
+  } else {
+    context.log.debug("ToggleUntyped: No active Sorbet LSP to notify.");
+  }
 
-  return context.configuration.highlightUntyped;
+  return targetState;
 }


### PR DESCRIPTION
Simplify `client` check in `toggleUntypedCodeHighlighting` by removing a couple of redundant falsy checks.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
