### PR TITLE
Split freshBlock into itself and freshBlockWithRegion

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -31,7 +31,11 @@ int CFG::numLocalVariables() const {
     return this->localVariables.size();
 }
 
-BasicBlock *CFG::freshBlock(int outerLoops, int rubyRegionId) {
+BasicBlock *CFG::freshBlock(int outerLoops, BasicBlock *current) {
+    return this->freshBlockWithRegion(outerLoops, current->rubyRegionId);
+}
+
+BasicBlock *CFG::freshBlockWithRegion(int outerLoops, int rubyRegionId) {
     int id = this->maxBasicBlockId++;
     auto &r = this->basicBlocks.emplace_back(make_unique<BasicBlock>());
     r->id = id;

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -32,6 +32,7 @@ int CFG::numLocalVariables() const {
 }
 
 BasicBlock *CFG::freshBlock(int outerLoops, BasicBlock *current) {
+    ENFORCE(current != nullptr);
     return this->freshBlockWithRegion(outerLoops, current->rubyRegionId);
 }
 
@@ -68,8 +69,8 @@ LocalRef CFG::enterLocal(core::LocalVariable variable) {
 }
 
 CFG::CFG() {
-    freshBlock(0, 0); // entry;
-    freshBlock(0, 0); // dead code;
+    freshBlockWithRegion(0, 0); // entry;
+    freshBlockWithRegion(0, 0); // dead code;
     deadBlock()->bexit.elseb = deadBlock();
     deadBlock()->bexit.thenb = deadBlock();
     deadBlock()->bexit.cond.variable = LocalRef::unconditional();

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -192,7 +192,8 @@ public:
 
 private:
     CFG();
-    BasicBlock *freshBlock(int outerLoops, int rubyBlockid);
+    BasicBlock *freshBlock(int outerLoops, BasicBlock *current);
+    BasicBlock *freshBlockWithRegion(int outerLoops, int rubyRegionId);
     void enterLocalInternal(core::LocalVariable variable, LocalRef &ref);
     std::vector<int> minLoops;
     std::vector<int> maxLoopWrite;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In a future change I'm going to introduce a boolean that will need to be set
explicitly in all of the places where people call `freshBlock` with a
`rubyRegionId` that isn't `current->rubyRegionId`.

To push people towards doing the right thing with this new boolean in future
changes, I've decided it makes sense to take the entire `current` basic block as
an argument, because if you're okay with using `current->rubyRegionId`, then
you'll also be okay with inheriting `current`'s flag for the fresh basic block.

This way, the short API is the API that people are more likely to use correctly
without having to think hard.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No-op change.