### PR TITLE
Add types for constructor of KeyError

### DIFF
--- a/rbi/core/errors.rbi
+++ b/rbi/core/errors.rbi
@@ -170,6 +170,10 @@ end
 # h.fetch("baz") #=> KeyError: key not found: "baz"
 # ```
 class KeyError < IndexError
+  # Construct a new KeyError exception with the given message, receiver and key.
+  sig { params(msg: T.untyped, receiver: T.untyped, key: T.untyped).void }
+  def initialize(msg = nil, receiver: nil, key: nil); end
+
   # Return the key caused this
   # [`KeyError`](https://docs.ruby-lang.org/en/2.7.0/KeyError.html) exception.
   def key; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

cc @neilparikh 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Breaking changes out of #7212

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

<https://ruby-doc.org/core-2.7.2/KeyError.html>

n/a