### PR TITLE
Make the types for `T::Enum.inherited` more narrow

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -357,7 +357,7 @@ class T::Enum
     @fully_initialized = true
   end
 
-  sig {params(child_class: Module).void}
+  sig {params(child_class: T::Class[T.anything]).void}
   def self.inherited(child_class)
     super
 


### PR DESCRIPTION
cc @neilparikh

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Pulling out changes from #7212


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a