### PR TITLE
Enable `quotes` eslint rule

### DIFF
--- a/vscode_extension/.eslintrc.yaml
+++ b/vscode_extension/.eslintrc.yaml
@@ -23,6 +23,10 @@ rules:
   no-plusplus: 0
   # This rule generates false positives with typescript enums
   no-shadow: "off"
+  quotes:
+    - error
+    - double
+    - avoidEscape: true
   # This requires way too much space otherwise between fields.
   lines-between-class-members:
     - 2

--- a/vscode_extension/src/commands/copySymbolToClipboard.ts
+++ b/vscode_extension/src/commands/copySymbolToClipboard.ts
@@ -61,7 +61,7 @@ export async function copySymbolToClipboard(
         location: ProgressLocation.Notification,
       },
       async (progress, token) => {
-        progress.report({ message: `Querying Sorbet …` });
+        progress.report({ message: "Querying Sorbet …" });
         const r = await client.sendRequest<SymbolInformation>(
           "sorbet/showSymbol",
           params,

--- a/vscode_extension/src/test/languageClient.test.ts
+++ b/vscode_extension/src/test/languageClient.test.ts
@@ -120,7 +120,7 @@ suite("LanguageClient", () => {
         assert.equal(metrics.length, 1);
         const m = metrics[0];
         assert.equal(m[0], MetricType.Timing);
-        assert.equal(m[1], `latency.textDocument_hover_ms`);
+        assert.equal(m[1], "latency.textDocument_hover_ms");
         assert.equal(m[3].success, "true");
       }
 
@@ -142,7 +142,7 @@ suite("LanguageClient", () => {
         assert.equal(metrics.length, 1);
         const m = metrics[0];
         assert.equal(m[0], MetricType.Timing);
-        assert.equal(m[1], `latency.textDocument_hover_ms`);
+        assert.equal(m[1], "latency.textDocument_hover_ms");
         assert.equal(m[3].success, "true");
       }
 
@@ -164,7 +164,7 @@ suite("LanguageClient", () => {
         assert.equal(metrics.length, 1);
         const m = metrics[0];
         assert.equal(m[0], MetricType.Timing);
-        assert.equal(m[1], `latency.textDocument_hover_ms`);
+        assert.equal(m[1], "latency.textDocument_hover_ms");
         assert.equal(m[3].success, "false");
       }
 
@@ -181,7 +181,7 @@ suite("LanguageClient", () => {
         assert.equal(metrics.length, 1);
         const m = metrics[0];
         assert.equal(m[0], MetricType.Timing);
-        assert.equal(m[1], `latency.textDocument_hover_ms`);
+        assert.equal(m[1], "latency.textDocument_hover_ms");
         assert.equal(m[3].success, "false");
       }
     });


### PR DESCRIPTION
Enable `quotes` _eslint_ rule to prevent/clean-up unnecessary use of backticks on non-template strings.
- Used `double` (as in double-quotes) as default for non-template strings since that is seems to be the standard in use already.
- Autofixed existing violations.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Standardized codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
