### PR TITLE
Allow potentially using THP (transparent huge pages) in sorbet_ruby

### DIFF
--- a/third_party/ruby/thp.patch
+++ b/third_party/ruby/thp.patch
@@ -1,18 +1,14 @@
 diff --git eval.c eval.c
-index 844c537cc4..f15ee3d2ea 100644
+index 844c537cc4..0fd751650a 100644
 --- eval.c
 +++ eval.c
-@@ -72,13 +72,6 @@ ruby_setup(void)
- 
-     ruby_init_stack((void *)&state);
- 
--    /*
--     * Disable THP early before mallocs happen because we want this to
--     * affect as many future pages as possible for CoW-friendliness
--     */
--#if defined(__linux__) && defined(PR_SET_THP_DISABLE)
--    prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
--#endif
+@@ -77,7 +77,9 @@ ruby_setup(void)
+      * affect as many future pages as possible for CoW-friendliness
+      */
+ #if defined(__linux__) && defined(PR_SET_THP_DISABLE)
++  if (strncmp(getenv("STRIPE_RUBY_ENABLE_THP"), "true", 4) != 0) {
+     prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
++  }
+ #endif
      Init_BareVM();
      Init_heap();
-     rb_vm_encoded_insn_data_table_init();

--- a/third_party/ruby/thp.patch
+++ b/third_party/ruby/thp.patch
@@ -1,14 +1,16 @@
 diff --git eval.c eval.c
-index 844c537cc4..0fd751650a 100644
+index 844c537cc4..9b460fb898 100644
 --- eval.c
 +++ eval.c
-@@ -77,7 +77,9 @@ ruby_setup(void)
+@@ -77,7 +77,10 @@ ruby_setup(void)
       * affect as many future pages as possible for CoW-friendliness
       */
  #if defined(__linux__) && defined(PR_SET_THP_DISABLE)
-+  if (strncmp(getenv("STRIPE_RUBY_ENABLE_THP"), "true", 4) != 0) {
-     prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
-+  }
+-    prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
++    char *enable_thp = getenv("STRIPE_RUBY_ENABLE_THP");
++    if (enable_thp != NULL && strncmp(enable_thp, "true", 4) != 0) {
++        prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
++    }
  #endif
      Init_BareVM();
      Init_heap();

--- a/third_party/ruby/thp.patch
+++ b/third_party/ruby/thp.patch
@@ -1,0 +1,18 @@
+diff --git eval.c eval.c
+index 844c537cc4..f15ee3d2ea 100644
+--- eval.c
++++ eval.c
+@@ -72,13 +72,6 @@ ruby_setup(void)
+ 
+     ruby_init_stack((void *)&state);
+ 
+-    /*
+-     * Disable THP early before mallocs happen because we want this to
+-     * affect as many future pages as possible for CoW-friendliness
+-     */
+-#if defined(__linux__) && defined(PR_SET_THP_DISABLE)
+-    prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
+-#endif
+     Init_BareVM();
+     Init_heap();
+     rb_vm_encoded_insn_data_table_init();

--- a/third_party/ruby/thp.patch
+++ b/third_party/ruby/thp.patch
@@ -1,5 +1,5 @@
 diff --git eval.c eval.c
-index 844c537cc4..9b460fb898 100644
+index 844c537cc4..62ce1e142d 100644
 --- eval.c
 +++ eval.c
 @@ -77,7 +77,10 @@ ruby_setup(void)
@@ -8,7 +8,7 @@ index 844c537cc4..9b460fb898 100644
  #if defined(__linux__) && defined(PR_SET_THP_DISABLE)
 -    prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
 +    char *enable_thp = getenv("STRIPE_RUBY_ENABLE_THP");
-+    if (enable_thp != NULL && strncmp(enable_thp, "true", 4) != 0) {
++    if (enable_thp == NULL || strncmp(enable_thp, "true", 4) != 0) {
 +        prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
 +    }
  #endif

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -59,12 +59,12 @@ def register_ruby_dependencies():
         strip_prefix = strip_prefix,
         build_file = ruby_build,
         patches = [
-            "@com_stripe_ruby_typer//third_party/ruby:thp.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-remove-write-barrier.patch",
             "@com_stripe_ruby_typer//third_party/ruby:dtoa.patch",
             "@com_stripe_ruby_typer//third_party/ruby:penelope_procc.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-fix-malloc-increase-calculation.patch",  # https://github.com/ruby/ruby/pull/4860
             "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by.patch",  # https://github.com/ruby/ruby/pull/6791
+            "@com_stripe_ruby_typer//third_party/ruby:thp.patch",
         ],
     )
 
@@ -89,8 +89,8 @@ def register_ruby_dependencies():
         strip_prefix = "ruby-3.1.4",
         build_file = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD",
         patches = [
-            "@com_stripe_ruby_typer//third_party/ruby:thp.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by-3_1.patch",  # https://github.com/ruby/ruby/pull/6791
+            "@com_stripe_ruby_typer//third_party/ruby:thp.patch",
         ],
     )
 

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -59,6 +59,7 @@ def register_ruby_dependencies():
         strip_prefix = strip_prefix,
         build_file = ruby_build,
         patches = [
+            "@com_stripe_ruby_typer//third_party/ruby:thp.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-remove-write-barrier.patch",
             "@com_stripe_ruby_typer//third_party/ruby:dtoa.patch",
             "@com_stripe_ruby_typer//third_party/ruby:penelope_procc.patch",

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -89,6 +89,7 @@ def register_ruby_dependencies():
         strip_prefix = "ruby-3.1.4",
         build_file = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD",
         patches = [
+            "@com_stripe_ruby_typer//third_party/ruby:thp.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by-3_1.patch",  # https://github.com/ruby/ruby/pull/6791
         ],
     )


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The Ruby interpreter outright disables THP since it might have bad interactions with dirty pages (i.e., if a single bit in a 2MB page is dirtied now the entire things needs to be invalidated/flushed instead of just 4K) w.r.t GC etc. However, we would like to experiment with enabling it for memory-intensive workloads 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
