### PR TITLE
Factor out enrichMissingMethodError

### DIFF
--- a/core/Error.h
+++ b/core/Error.h
@@ -174,6 +174,10 @@ public:
     // will no longer report the error, and is the caller's responsibility to
     // pass it to GlobalState::_error if the error should actually be recorded.
     std::unique_ptr<Error> build();
+
+    Loc getLoc() const {
+        return this->loc;
+    };
 };
 
 template <typename H> H AbslHashValue(H h, const ErrorClass &m) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -579,7 +579,8 @@ void enrichMissingMethodError(const GlobalState &gs, const DispatchArgs &args, c
                                   " {{ |x| {}(x).{} }}", wrapInFn, shortName);
                 }
             }
-        } else if (errLoc == args.funLoc() && args.funLoc().source(gs) == absl::StrCat(args.name.shortName(gs), "=")) {
+        } else if (e.getLoc() == args.funLoc() &&
+                   args.funLoc().source(gs) == absl::StrCat(args.name.shortName(gs), "=")) {
             e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.funLoc(), "= {}({}) {}", wrapInFn,
                           args.receiverLoc().source(gs).value(), args.name.shortName(gs));
         } else {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Preparation for #7212, which will add types for certain `super` calls.

This code will all look a bit different when it's changed to support `super`,
because almost none of these autocorrects / suggestions apply to `super`.

With that in mind, it looks better if we can early exit from this method after
seeing that the error was caused by a call to `super`. I'd like to get this
refactor in now, so that the eventual diff is smaller.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.