### PR TITLE
Add new `"...": T.untyped` syntax for argument forwarding

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -419,6 +419,7 @@ NameDef names[] = {
     {"fwdArgs", "<fwd-args>"},
     {"fwdKwargs", "<fwd-kwargs>"},
     {"fwdBlock", "<fwd-block>"},
+    {"fwdDots", "..."},
 
     // Enumerable#flat_map has special-case logic in Infer
     {"flatMap", "flat_map"},

--- a/test/testdata/resolver/fwd_args.rb
+++ b/test/testdata/resolver/fwd_args.rb
@@ -1,0 +1,96 @@
+# typed: true
+class Module; include T::Sig; end
+
+# Basically the only thing you can do with argument forwarding is to make
+# everything untyped.
+#
+# What you might want Sorbet to do is to infer the signature of the thing
+# you're trying to forward arguments to, but sorbet doesn't let the types of
+# one method depend on the types of another method, for performance.
+
+class OnlyFwdArgs
+  sig {params("...": T.untyped).void}
+  def self.example1(...)
+    p(...)
+  # ^^^^^^ error: Splats are only supported where the size of the array is known statically
+
+    T.unsafe(self).p(...)
+  end
+
+  sig do
+    type_parameters(:U)
+      .params("...": T.type_parameter(:U))
+    #         ^^^^^^ error: Block argument type must be either `Proc` or a `T.proc` type
+      .void
+  end
+  def self.example2(...)
+  end
+
+  sig do
+    params("...": T.proc.void).void
+  end
+  def self.example3(...)
+  end
+
+  example3(0)
+  #        ^ error: Expected `T.proc.void` but found `Integer(0)` for argument `"...":`
+  #          ^ error: requires a block parameter, but no block was passed
+
+  sig do
+    params("...": T.nilable(T.proc.void)).void
+  end
+  def self.example4(...)
+  end
+
+  example4(0)
+  #        ^ error: Expected `T.nilable(T.proc.void)` but found `Integer(0)` for argument `"...":`
+end
+
+
+class WithLeadingArgs
+  sig {params(x: Integer, "...": T.untyped).void}
+  def self.example1(x, ...)
+    T.reveal_type(x) # error: `Integer`
+
+    p(...)
+  # ^^^^^^ error: Splats are only supported where the size of the array is known statically
+
+    T.unsafe(self).p(...)
+  end
+
+  example1('')
+  #        ^^ error: Expected `Integer` but found `String("")` for argument `x`
+  example1('', 0, 'anything else', foo: :bar)
+  #        ^^ error: Expected `Integer` but found `String("")` for argument `x`
+
+  sig do
+    type_parameters(:U)
+      .params(
+        x: Integer,
+        "...": T.type_parameter(:U)
+      # ^^^^^^ error: Block argument type must be either `Proc` or a `T.proc` type
+      )
+      .void
+  end
+  def self.example2(x, ...)
+    T.reveal_type(x) # error: `Integer`
+  end
+
+  sig do
+    params(x: Integer, "...": T.proc.void).void
+  end
+  def self.example3(x, ...)
+  end
+
+  example3(0)
+  #          ^ error: requires a block parameter, but no block was passed
+
+  sig do
+    params(x: Integer, "...": T.nilable(T.proc.void)).void
+  end
+  def self.example4(x, ...)
+  end
+
+  example4(0)
+end
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Requested by a user.

Previously, Sorbet would force you to write out the args individually if you
wanted to give them a certain type.

Some people expressed annoyance at that, as it conflicts with certain style
guides. If you're content to have all the arguments have the same type (usually:
`T.untyped`), there's no reason why Sorbet needs to reject using `...`.

However, style guides that mandate using `...` always instead of `*args,
**kwargs, &blk` will not work with Sorbet if users want to provide types for
those things independently. For example, if you want your method defined using
`...` to take only `Integer` positional params but only `String` keyword
arguments, you'll still need to split the `...` into `*args, **kwargs, &blk` to
have a name you can use to provide those types independently.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.