### PR TITLE
✨ Emit status/operation changes through VSCode extension's MetricsEmitter

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Version history
+
+## 0.3.26 (next)
+- Emit status/operation changes through `MetricsEmitter`
+
 ## 0.3.25
 - Toggling highlighting of untyped code does not require a restart now
   - Sends workspace/didChangeConfiguration notification to LSP server instead

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -13,6 +13,7 @@ import { getLogLevelFromEnvironment, LogLevel } from "./log";
 import { SorbetContentProvider, SORBET_SCHEME } from "./sorbetContentProvider";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { SorbetStatusBarEntry } from "./sorbetStatusBarEntry";
+import { SorbetStatusMetricsTracker } from "./sorbetStatusMetricsTracker";
 import { ServerStatus, RestartReason } from "./types";
 
 /**
@@ -41,6 +42,11 @@ export function activate(context: ExtensionContext) {
 
   const statusBarEntry = new SorbetStatusBarEntry(sorbetExtensionContext);
   context.subscriptions.push(statusBarEntry);
+
+  const statusMetricsTracker = new SorbetStatusMetricsTracker(
+    sorbetExtensionContext,
+  );
+  context.subscriptions.push(statusMetricsTracker);
 
   // Register providers
   context.subscriptions.push(

--- a/vscode_extension/src/sorbetStatusMetricsTracker.ts
+++ b/vscode_extension/src/sorbetStatusMetricsTracker.ts
@@ -1,0 +1,45 @@
+import { Disposable } from "vscode";
+
+import { SorbetExtensionContext } from "./sorbetExtensionContext";
+import { ServerStatus } from "./types";
+
+/**
+ * A Disposable that listens to status changes through the SorbetStatusProvider,
+ * and emit metrics about them through the configured MetricsEmitter
+ */
+export class SorbetStatusMetricsTracker implements Disposable {
+  private readonly context: SorbetExtensionContext;
+  private readonly disposable: Disposable;
+
+  constructor(context: SorbetExtensionContext) {
+    this.context = context;
+
+    this.disposable = Disposable.from(
+      this.context.statusProvider.onStatusChanged((e) => {
+        console.log(
+          `status changed: ${ServerStatus[e.status]} (error: '${e.error}')`,
+        );
+        this.context.metrics.emitTimingMetric("status.changed", new Date(), {
+          status: ServerStatus[e.status],
+          error: e.error || "",
+        });
+      }),
+      this.context.statusProvider.onShowOperation((_params) => {
+        console.log(
+          `operation changed: ${_params.operationName} went to ${_params.status}`,
+        );
+        this.context.metrics.emitTimingMetric("status.operation", new Date(), {
+          operationName: _params.operationName,
+          status: _params.status,
+        });
+      }),
+    );
+  }
+
+  /**
+   * Dispose and free associated resources.
+   */
+  public dispose() {
+    this.disposable.dispose();
+  }
+}

--- a/vscode_extension/src/sorbetStatusMetricsTracker.ts
+++ b/vscode_extension/src/sorbetStatusMetricsTracker.ts
@@ -16,18 +16,12 @@ export class SorbetStatusMetricsTracker implements Disposable {
 
     this.disposable = Disposable.from(
       this.context.statusProvider.onStatusChanged((e) => {
-        console.log(
-          `status changed: ${ServerStatus[e.status]} (error: '${e.error}')`,
-        );
         this.context.metrics.emitTimingMetric("status.changed", new Date(), {
           status: ServerStatus[e.status],
           error: e.error || "",
         });
       }),
       this.context.statusProvider.onShowOperation((_params) => {
-        console.log(
-          `operation changed: ${_params.operationName} went to ${_params.status}`,
-        );
         this.context.metrics.emitTimingMetric("status.operation", new Date(), {
           operationName: _params.operationName,
           status: _params.status,

--- a/vscode_extension/src/sorbetStatusMetricsTracker.ts
+++ b/vscode_extension/src/sorbetStatusMetricsTracker.ts
@@ -21,10 +21,10 @@ export class SorbetStatusMetricsTracker implements Disposable {
           error: e.error || "",
         });
       }),
-      this.context.statusProvider.onShowOperation((_params) => {
+      this.context.statusProvider.onShowOperation((params) => {
         this.context.metrics.emitTimingMetric("status.operation", new Date(), {
-          operationName: _params.operationName,
-          status: _params.status,
+          operationName: params.operationName,
+          status: params.status,
         });
       }),
     );

--- a/vscode_extension/src/types.ts
+++ b/vscode_extension/src/types.ts
@@ -29,7 +29,7 @@ export enum RestartReason {
 }
 
 // Note: Sorbet is either running/in the process or running, or in an error state. There's no benign idle/not running state.
-export const enum ServerStatus {
+export enum ServerStatus {
   // The language client is disabled.
   DISABLED,
   // The language client is restarting.


### PR DESCRIPTION
### Motivation
This extends the range of metrics the extension currently emit, so consumers that register `sorbet.metrics.getExportedApi` can get notified when a status/operation change happens.

Among other things, this would allow to know when Sorbet is available/done, and how long it took to get into that state.

### Test plan
Manually tested the extension, and saw the metrics being emitted.