### PR TITLE
Add missing EXCEPTION_NaN constant to bigdecimal

### DIFF
--- a/rbi/stdlib/bigdecimal.rbi
+++ b/rbi/stdlib/bigdecimal.rbi
@@ -171,7 +171,7 @@ class BigDecimal < Numeric
 
   # Determines what happens when the result of a computation is not a number (NaN). See
   # [`BigDecimal.mode`](https://docs.ruby-lang.org/en/2.7.0/BigDecimal.html#method-c-mode).
-  EXCEPTION_NaN = T.let(T.unsafe(nil, Integer)
+  EXCEPTION_NaN = T.let(T.unsafe(nil), Integer)
 
   # Determines what happens when the result of a computation is an overflow (a
   # result too large to be represented). See

--- a/rbi/stdlib/bigdecimal.rbi
+++ b/rbi/stdlib/bigdecimal.rbi
@@ -168,6 +168,11 @@ class BigDecimal < Numeric
   # Determines what happens when the result of a computation is infinity. See
   # [`BigDecimal.mode`](https://docs.ruby-lang.org/en/2.7.0/BigDecimal.html#method-c-mode).
   EXCEPTION_INFINITY = T.let(T.unsafe(nil), Integer)
+
+  # Determines what happens when the result of a computation is not a number (NaN). See
+  # [`BigDecimal.mode`](https://docs.ruby-lang.org/en/2.7.0/BigDecimal.html#method-c-mode).
+  EXCEPTION_NaN = T.let(T.unsafe(nil, Integer)
+
   # Determines what happens when the result of a computation is an overflow (a
   # result too large to be represented). See
   # [`BigDecimal.mode`](https://docs.ruby-lang.org/en/2.7.0/BigDecimal.html#method-c-mode).


### PR DESCRIPTION
This adds a missing mode for BigDecimial as documented on in the stdlib -
https://docs.ruby-lang.org/en/2.7.0/BigDecimal.html


### Motivation
This is currently a missing class Constant for BigDecimal

### Test plan
This only changes signatures so no new test cases are added.
