### PR TITLE
Format one-line sig blocks in an autocorrect suggestion with spaces inside the curly braces.

### DIFF
--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -84,7 +84,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
         paramsString = fmt::format("params({}).", fmt::join(typeAndArgNames, ", "));
     }
 
-    auto oneline = fmt::format("{} {{{}{}{}}}", sigCall, flagString, paramsString, methodReturnType);
+    auto oneline = fmt::format("{} {{ {}{}{} }}", sigCall, flagString, paramsString, methodReturnType);
     if (oneline.size() <= MAX_PRETTY_WIDTH && typeAndArgNames.size() <= MAX_PRETTY_SIG_ARGS) {
         return oneline;
     }

--- a/test/testdata/definition_validator/missing_abstract_method_empty_body.rb.autocorrects.exp
+++ b/test/testdata/definition_validator/missing_abstract_method_empty_body.rb.autocorrects.exp
@@ -11,7 +11,7 @@ class Parent
 end
 
   class Child < Parent
-    sig {override.void}
+    sig { override.void }
     def foo; end
   end
 # ^^^^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method

--- a/test/testdata/definition_validator/missing_abstract_method_existing_class_body.rb.autocorrects.exp
+++ b/test/testdata/definition_validator/missing_abstract_method_existing_class_body.rb.autocorrects.exp
@@ -23,7 +23,7 @@ end
 
     sig {override.void}
     def baz; end
-    sig {override.void}
+    sig { override.void }
     def bar; end
   end
 # ------------------------------

--- a/test/testdata/definition_validator/missing_abstract_method_nested.rb.autocorrects.exp
+++ b/test/testdata/definition_validator/missing_abstract_method_nested.rb.autocorrects.exp
@@ -22,7 +22,7 @@ end
 
   class Child < Parent
 # ^^^^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method
-    sig {override.void}
+    sig { override.void }
     def bar; end
   end
 # ------------------------------

--- a/test/testdata/definition_validator/missing_abstract_method_short_sig.rb.autocorrects.exp
+++ b/test/testdata/definition_validator/missing_abstract_method_short_sig.rb.autocorrects.exp
@@ -12,7 +12,7 @@ end
 
   class Child < Parent
 # ^^^^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method
-    sig {override.params(bar: Integer).returns(String)}
+    sig { override.params(bar: Integer).returns(String) }
     def foo(bar); end
   end
 # ------------------------------

--- a/test/testdata/lsp/document_symbols.rb
+++ b/test/testdata/lsp/document_symbols.rb
@@ -36,7 +36,7 @@ module M
 
   sig(:final) {params(x: String).returns(String)}
   def bye(x)
-    # ^^^ hover: sig(:final) {params(x: String).returns(String)}
+    # ^^^ hover: sig(:final) { params(x: String).returns(String) }
     "goodbye, #{x}"
   end
 end

--- a/test/testdata/lsp/fast_path/method_signature_update_generics__usage.rb
+++ b/test/testdata/lsp/fast_path/method_signature_update_generics__usage.rb
@@ -4,6 +4,6 @@ module Bat extend T::Sig
   sig {returns(String)}
   def foo
     Foobar.bar(["hello"]) # error: Expected `T::Array[Integer]`
-    #      ^ hover: sig {params(s: T::Array[Integer]).returns(String)}
+    #      ^ hover: sig { params(s: T::Array[Integer]).returns(String) }
   end
 end

--- a/test/testdata/lsp/fast_path/method_signature_update_static__usage.rb
+++ b/test/testdata/lsp/fast_path/method_signature_update_static__usage.rb
@@ -4,6 +4,6 @@ module Bat extend T::Sig
   sig {returns(String)}
   def foo
     Foobar.bar("hello") # error: Expected `Integer`
-    #      ^ hover: sig {params(s: Integer).returns(String)}
+    #      ^ hover: sig { params(s: Integer).returns(String) }
   end
 end

--- a/test/testdata/lsp/fast_path/more_arguments.1.rbupdate
+++ b/test/testdata/lsp/fast_path/more_arguments.1.rbupdate
@@ -7,7 +7,7 @@ class Foo
   sig {params(x: Integer).returns(Integer)}
   def foo(x)
     # ^ hover: ```ruby
-    # ^ hover: sig {params(x: Integer).returns(Integer)}
+    # ^ hover: sig { params(x: Integer).returns(Integer) }
     # ^ hover: def foo(x); end
     42 + x
   end

--- a/test/testdata/lsp/fast_path/more_arguments.rb
+++ b/test/testdata/lsp/fast_path/more_arguments.rb
@@ -5,7 +5,7 @@ class Foo
 
   sig {returns(Integer)}
   def foo
-    # ^ hover: sig {returns(Integer)}
+    # ^ hover: sig { returns(Integer) }
     # ^ hover: def foo; end
     42
   end

--- a/test/testdata/lsp/fast_path/simple_hover.1.rbupdate
+++ b/test/testdata/lsp/fast_path/simple_hover.1.rbupdate
@@ -7,7 +7,7 @@ class Foo
   sig {returns(Integer)}
   def bar
     # ^ hover: ```ruby
-    # ^ hover: sig {returns(Integer)}
+    # ^ hover: sig { returns(Integer) }
     # ^ hover: def bar; end
     42
   end

--- a/test/testdata/lsp/fast_path/simple_hover.rb
+++ b/test/testdata/lsp/fast_path/simple_hover.rb
@@ -5,7 +5,7 @@ class Foo
 
   sig {returns(Integer)}
   def foo
-    # ^ hover: sig {returns(Integer)}
+    # ^ hover: sig { returns(Integer) }
     # ^ hover: def foo; end
     42
   end

--- a/test/testdata/lsp/fast_path/static_field_name.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_name.1.rbupdate
@@ -6,7 +6,7 @@ class X
   extend T::Sig
   sig {params(x: Integer).void}
   def foo(
-    # ^ hover: sig {params(x: Integer).void}
+    # ^ hover: sig { params(x: Integer).void }
     # ^ hover: def foo(x); end
     x
   # ^ hover: Integer

--- a/test/testdata/lsp/fast_path/static_field_name.rb
+++ b/test/testdata/lsp/fast_path/static_field_name.rb
@@ -5,7 +5,7 @@ class X
   extend T::Sig
   sig {params(x: Integer).void}
   def foo(
-    # ^ hover: sig {params(x: Integer).void}
+    # ^ hover: sig { params(x: Integer).void }
     # ^ hover: def foo(x); end
     x
   # ^ hover: Integer

--- a/test/testdata/lsp/genericMethods.rb
+++ b/test/testdata/lsp/genericMethods.rb
@@ -21,18 +21,18 @@ def main
   foo = Foo.new
   v1 = foo.id(1)
 # ^ hover: Integer
-         # ^ hover: sig {params(a: Integer).returns(Integer)}
+         # ^ hover: sig { params(a: Integer).returns(Integer) }
          # ^ usage: id
   v2 = foo.id("1")
 # ^ hover: String
-         # ^ hover: sig {params(a: String).returns(String)}
+         # ^ hover: sig { params(a: String).returns(String) }
          # ^ usage: id
   v3 = Foo.id(1)
 # ^ hover: Integer
-         # ^ hover: sig {params(a: Integer).returns(Integer)}
+         # ^ hover: sig { params(a: Integer).returns(Integer) }
          # ^ usage: staticid
   v4 = Foo.id("1")
 # ^ hover: String
-         # ^ hover: sig {params(a: String).returns(String)}
+         # ^ hover: sig { params(a: String).returns(String) }
          # ^ usage: staticid
 end

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -33,7 +33,7 @@ class BigFoo; extend T::Sig
       a.bar(1)
    # ^ hover: null
     # ^ hover: BigFoo::LittleFoo1
-      # ^ hover: sig {params(num: Integer).returns(Integer)}
+      # ^ hover: sig { params(num: Integer).returns(Integer) }
     end
   end
 
@@ -42,7 +42,7 @@ class BigFoo; extend T::Sig
               # ^ hover: Integer
                    # ^ hover: String
     4 + num1 + num2.to_i + @@static_variable.length
-           # ^ hover: sig {params(arg0: Integer).returns(Integer)}
+           # ^ hover: sig { params(arg0: Integer).returns(Integer) }
                            # ^^^^^^^^^^^^^^^ hover: Docs for Bar#static_variable
                            # ^^^^^^^^^^^^^^^ hover: String
   end
@@ -58,7 +58,7 @@ class BigFoo; extend T::Sig
 
   sig {params(num: Integer).returns(String)}
   private def quux(num)
-    #         ^ hover: sig {params(num: Integer).returns(String)}
+    #         ^ hover: sig { params(num: Integer).returns(String) }
     #         ^ hover: private def quux(num); end
     if num < 10
       s = 1
@@ -70,7 +70,7 @@ class BigFoo; extend T::Sig
 
   sig {void}
   protected def protected_fun; end;
-  #             ^ hover: sig {void}
+  #             ^ hover: sig { void }
   #             ^ hover: protected def protected_fun; end
 
   sig { returns([Integer, String]) }
@@ -82,7 +82,7 @@ class BigFoo; extend T::Sig
   sig {void}
   def tests_return_markdown
     # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 1 ```ruby
-    # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 2 sig {void}
+    # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 2 sig { void }
     # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 4 ```
     # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 6 ---
     # ^^^^^^^^^^^^^^^^^^^^^ hover-line: 8 Tests return markdown output
@@ -90,7 +90,7 @@ class BigFoo; extend T::Sig
 
   sig {returns(T.attached_class)}
   def self.factory
-    #      ^ hover: sig {returns(T.attached_class (of BigFoo))}
+    #      ^ hover: sig { returns(T.attached_class (of BigFoo)) }
     #      ^ hover: def self.factory; end
     new
   end
@@ -101,11 +101,11 @@ end
 
 def main
   BigFoo.bar(10, "hello")
-        # ^ hover: sig {params(num1: Integer, num2: String).returns(Integer)}
+        # ^ hover: sig { params(num1: Integer, num2: String).returns(Integer) }
         # ^ hover: ```ruby
         # Checks that we're sending Markdown.
   BigFoo.baz
-        # ^ hover: sig {void}
+        # ^ hover: sig { void }
   l = BigFoo.anotherFunc
 # ^ hover: [Integer, String] (2-tuple)
 
@@ -146,10 +146,10 @@ def main
       # ^^^^^^ hover: The docs for BigFoo
 
   foo = BigFoo.new
-  #            ^^^ hover: sig {params(args: T.untyped, blk: T.untyped).returns(BigFoo)}
+  #            ^^^ hover: sig { params(args: T.untyped, blk: T.untyped).returns(BigFoo) }
   #            ^^^ hover: def new(*args, &blk); end
   hoo = BigFoo::LittleFoo1.new
-                         # ^^^ hover: sig {returns(BigFoo::LittleFoo1)}
+                         # ^^^ hover: sig { returns(BigFoo::LittleFoo1) }
   raise "error message"
   # ^ hover-line: 4     arg0: T.any(T::Class[T.anything], Exception, String)
 end

--- a/test/testdata/lsp/hover_abstract.rb
+++ b/test/testdata/lsp/hover_abstract.rb
@@ -6,7 +6,7 @@ class AbstractItem
 
   sig {abstract.returns(String)}
   def self.name; end
-    # ^ hover: sig {abstract.returns(String)}
+    # ^ hover: sig { abstract.returns(String) }
 end
 
 class Dog < AbstractItem
@@ -14,7 +14,7 @@ class Dog < AbstractItem
 
   sig {override.returns(String)}
   def self.name
-    # ^ hover: sig {override.returns(String)}
+    # ^ hover: sig { override.returns(String) }
     'Dog'
   end
 end

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -14,8 +14,8 @@ def main
   breeds = dogs.map(&:breed)
 # ^ hover: T::Array[String]
               # ^ hover:     blk: T.proc.params(arg0: Dog).returns(String)
-                   # ^ hover: sig {returns(String)}
-                    # ^ hover: sig {returns(String)}
+                   # ^ hover: sig { returns(String) }
+                    # ^ hover: sig { returns(String) }
 
   # Safenav
   dog = Dog.new
@@ -24,23 +24,23 @@ def main
 # ^ hover: String
   #       ^ hover: Dog
   #          ^ hover: Dog
-  #           ^ hover: sig {returns(String)}
-  #            ^ hover: sig {returns(String)}
-  #             ^ hover: sig {returns(String)}
+  #           ^ hover: sig { returns(String) }
+  #            ^ hover: sig { returns(String) }
+  #             ^ hover: sig { returns(String) }
 
   maybeDog = T.let(nil, T.nilable(Dog))
   maybeBreed = maybeDog&.breed
 # ^ hover: T.nilable(String)
   #            ^ hover: T.nilable(Dog)
   #                     ^ hover: NilClass
-  #                      ^ hover: sig {returns(String)}
+  #                      ^ hover: sig { returns(String) }
   breed2 = T.let(nil, T.nilable(String))
   breed2 ||= maybeDog&.breed
 # ^ hover: T.nilable(String)
   #                   ^ hover: NilClass
-  #                    ^ hover: sig {returns(String)}
+  #                    ^ hover: sig { returns(String) }
   breed2 &&= maybeDog&.breed
   # ^ hover: T.nilable(String)
   #                   ^ hover: NilClass
-  #                    ^ hover: sig {returns(String)}
+  #                    ^ hover: sig { returns(String) }
 end

--- a/test/testdata/lsp/hover_call_block_splat.rb
+++ b/test/testdata/lsp/hover_call_block_splat.rb
@@ -9,9 +9,9 @@ module Foo
   sig {params(blk: T.proc.void).void}
   def baz(&blk)
     foo(&blk)
-  # ^ hover: sig {params(blk: T.proc.void).void}
+  # ^ hover: sig { params(blk: T.proc.void).void }
     foo {}
-  # ^ hover: sig {params(blk: T.proc.void).void}
+  # ^ hover: sig { params(blk: T.proc.void).void }
   end
 
   sig {params(args: Integer).void}
@@ -20,7 +20,7 @@ module Foo
   sig {params(x: Integer).void}
   def call_splat_fun(x)
     splat_fun(*[x, x])
-  # ^ hover: sig {params(args: Integer).void}
+  # ^ hover: sig { params(args: Integer).void }
   # ^ hover: def splat_fun(*args); end
   end
 end

--- a/test/testdata/lsp/hover_generics.rb
+++ b/test/testdata/lsp/hover_generics.rb
@@ -11,5 +11,5 @@ extend T::Generic, T::Sig
 end
 
 Box[Integer].new.read
-               # ^ hover: sig {returns(Integer)}
+               # ^ hover: sig { returns(Integer) }
 [1].map{|x| x + 1}

--- a/test/testdata/lsp/hover_method.rb
+++ b/test/testdata/lsp/hover_method.rb
@@ -4,26 +4,26 @@ class Foo
 
   sig {returns(Integer)}
   def bar
-    # ^ hover: sig {returns(Integer)}
+    # ^ hover: sig { returns(Integer) }
     # N.B. Checking two positions on below function call as they used to return different strings.
     baz("1")
-  # ^ hover: sig {params(arg0: String).returns(Integer)}
-   # ^ hover: sig {params(arg0: String).returns(Integer)}
+  # ^ hover: sig { params(arg0: String).returns(Integer) }
+   # ^ hover: sig { params(arg0: String).returns(Integer) }
   end
 
   # Docs for static bar
   sig {params(a: String).void}
   def self.bar(a)
-         # ^ hover: sig {params(a: String).void}
+         # ^ hover: sig { params(a: String).void }
   end
 
   sig {params(arg0: String).returns(Integer)}
   def baz(arg0)
     no_args_and_void
-  # ^ hover: sig {void}
+  # ^ hover: sig { void }
     Foo::bat(1)
   # ^ hover: T.class_of(Foo)
-       # ^ hover: sig {params(i: Integer).returns(Integer)}
+       # ^ hover: sig { params(i: Integer).returns(Integer) }
            # ^ hover: Integer(1)
     arg0.to_i
   end
@@ -37,17 +37,17 @@ class Foo
   sig {params(arg0: Integer).void}
   def typed_with_docs(arg0)
     # ^ hover: Docs above single-line sig
-    # ^ hover: sig {params(arg0: Integer).void}
+    # ^ hover: sig { params(arg0: Integer).void }
   end
 
   # Some docs for qux
   sig {void}
   def qux
     # ^^^ hover: Some docs for qux
-    # ^^^ hover: sig {void}
+    # ^^^ hover: sig { void }
     typed_with_docs(1)
   # ^ hover: Docs above single-line sig
-  # ^ hover: sig {params(arg0: Integer).void}
+  # ^ hover: sig { params(arg0: Integer).void }
   end
 
   sig {void}
@@ -64,7 +64,7 @@ class Foo
   sig {params(blk: T.proc.params(arg0: Integer, arg1: String).returns(String)).returns(String)}
   def self.blk_arg(&blk)
     yield(1, "hello")
-  # ^ hover: sig {params(arg0: Integer, arg1: String).returns(String)}
+  # ^ hover: sig { params(arg0: Integer, arg1: String).returns(String) }
   end
 
   sig {params(a: String, x: String).returns(T::Array[String])}
@@ -79,7 +79,7 @@ class Foo
   # Docs are below the sig
   def docs_below_sig
     # ^^^^^^^^^^^^^^ hover: Docs are below the sig
-    # ^^^^^^^^^^^^^^ hover: sig {void}
+    # ^^^^^^^^^^^^^^ hover: sig { void }
   end
 end
 
@@ -91,17 +91,17 @@ def main
                         # ^ hover: String
   rv2 = Foo.splat_arg("a", "b", "c")
 # ^ hover: T::Array[String]
-          # ^ hover: sig {params(a: String, x: String).returns(T::Array[String])}
+          # ^ hover: sig { params(a: String, x: String).returns(T::Array[String]) }
 
   Foo.bar('')
 # ^^^ hover: T.class_of(Foo)
     # ^^^ hover: Docs for static bar
-    # ^^^ hover: sig {params(a: String).void}
+    # ^^^ hover: sig { params(a: String).void }
 
   f = Foo.new
 # ^ hover: Foo
      # ^ hover: T.class_of(Foo)
   f.qux
   # ^^^ hover: Some docs for qux
-  # ^^^ hover: sig {void}
+  # ^^^ hover: sig { void }
 end

--- a/test/testdata/lsp/hover_operator_overload.rb
+++ b/test/testdata/lsp/hover_operator_overload.rb
@@ -5,7 +5,7 @@ class Dog
 
   sig {returns(String)}
   attr_reader :name
-# ^ hover: sig {returns(String)}
+# ^ hover: sig { returns(String) }
 
   sig {params(name: String).void}
   def initialize(name)
@@ -32,12 +32,12 @@ end
 def main
   fred = Dog.new('fred')
   di = Dog.new('di')
-  freddi = fred + di 
+  freddi = fred + di
               # ^ sig {params(plusDog: Dog).returns(Dog)}
-  
-  fred < di 
+
+  fred < di
      # ^ sig {params(ltDog: Dog).returns(Boolean)}
 
-  fred == di 
+  fred == di
      # ^ sig {params(eqDog: Dog).returns(Boolean)}
 end

--- a/test/testdata/lsp/hover_override.rb
+++ b/test/testdata/lsp/hover_override.rb
@@ -4,7 +4,7 @@ class Animal
 
   sig {overridable.returns(String)}
   def self.name; "Animal"; end
-    # ^ hover: sig {overridable.returns(String)}
+    # ^ hover: sig { overridable.returns(String) }
 end
 
 class Dog < Animal
@@ -12,7 +12,7 @@ class Dog < Animal
 
   sig {override.returns(String)}
   def self.name
-    # ^ hover: sig {override.returns(String)}
+    # ^ hover: sig { override.returns(String) }
     'Dog'
   end
 end

--- a/test/testdata/lsp/hover_proc_void.rb
+++ b/test/testdata/lsp/hover_proc_void.rb
@@ -4,6 +4,6 @@ extend T::Sig
 
 sig {params(blk: T.proc.void).void}
 def proc_void(&blk)
-  # ^ hover: sig {params(blk: T.proc.void).void}
+  # ^ hover: sig { params(blk: T.proc.void).void }
   # ^ hover: private def proc_void(&blk); end
 end

--- a/test/testdata/lsp/prop_factory_jump_to_def.rb
+++ b/test/testdata/lsp/prop_factory_jump_to_def.rb
@@ -10,6 +10,6 @@ class A < T::Struct
 
   prop :foo, String, factory: -> {A.bar}
   #                                 ^ usage: self_bar
-  #                                 ^ hover: sig {void}
+  #                                 ^ hover: sig { void }
   #                                 ^ hover: def self.bar; end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Closes #7258.

This changes the formatting of sig blocks in an autocorrect suggestion from e.g. `sig {override.void}` to `sig { override.void }`. This conforms with the style most commonly adopted in the Ruby community.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
