### PR TITLE
[EXPERIMENTAL] enable `USE_RVARGC` for sorbet_ruby 3.1 builds

### DIFF
--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -36,6 +36,7 @@ ruby(
     cppopts = [
         "-Wdate-time",
         "-D_FORTIFY_SOURCE=2",
+        "-DUSE_RVARGC",
         "-fPIC",
     ] + select({
         # Don't include JIT statistics unless we're building JIT support


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Enables variable-width allocation in Ruby 3.1, which is guarded behind this compile time flag

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
