### PR TITLE
Adds support for darwin-23 kernel

### DIFF
--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -39,7 +39,7 @@ sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-static.gemspec
 if [[ "darwin" == "$kernel_name" ]]; then
     # Our binary should work on almost all OSes. The oldest v8 publishes is -14
     # so I'm going with that for now.
-    for i in {14..22}; do
+    for i in {14..23}; do
         sed -i.bak "s/Gem::Platform::CURRENT/'universal-darwin-$i'/" sorbet-static.gemspec
         gem build sorbet-static.gemspec
         mv sorbet-static.gemspec.bak sorbet-static.gemspec


### PR DESCRIPTION
Adds support for macOS 14 Sonora and the darwin-23 kernel
I'm not really familiar with this project, but PR is based on https://github.com/sorbet/sorbet/pull/6061 - and it seems fairly simple.

### Motivation
Installing `sorbet-static` fails on macOS 14 / Sonora as there is no gem compiled for the darwin-23 kernel.

```
Could not find gem 'sorbet-static (= 0.5.10983)' with platforms [...], 'arm64-darwin-23' in rubygems repository
https://rubygems.org/ or installed locally or in gems cached in vendor/cache.

The source contains the following gems matching 'sorbet-static (= 0.5.10983)':
  * sorbet-static-0.5.10983-java
  * sorbet-static-0.5.10983-universal-darwin-14
  * sorbet-static-0.5.10983-universal-darwin-15
  * sorbet-static-0.5.10983-universal-darwin-16
  * sorbet-static-0.5.10983-universal-darwin-17
  * sorbet-static-0.5.10983-universal-darwin-18
  * sorbet-static-0.5.10983-universal-darwin-19
  * sorbet-static-0.5.10983-universal-darwin-20
  * sorbet-static-0.5.10983-universal-darwin-21
  * sorbet-static-0.5.10983-universal-darwin-22
  * sorbet-static-0.5.10983-x86_64-linux
```

### Test plan
As I'm unfamiliar with the project, please let me know if you need further testing beyond the automated testing for this change.
See included automated tests.
