### PR TITLE
Only use `initialize` DispatchResult if we found something

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -371,6 +371,8 @@ void GlobalState::initEmpty() {
     ENFORCE(klass == Symbols::Class());
     klass = synthesizeClass(core::Names::Constants::BasicObject(), 0);
     ENFORCE(klass == Symbols::BasicObject());
+    method = enterMethod(*this, Symbols::BasicObject(), Names::initialize()).build();
+    ENFORCE(method == Symbols::BasicObject_initialize());
     klass = synthesizeClass(core::Names::Constants::Kernel(), 0, true);
     ENFORCE(klass == Symbols::Kernel());
     klass = synthesizeClass(core::Names::Constants::Range());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -590,6 +590,10 @@ public:
         return ClassOrModuleRef();
     }
 
+    static MethodRef noMethod() {
+        return MethodRef();
+    }
+
     static ClassOrModuleRef top() {
         return ClassOrModuleRef::fromRaw(1);
     }
@@ -668,6 +672,10 @@ public:
 
     static ClassOrModuleRef BasicObject() {
         return ClassOrModuleRef::fromRaw(20);
+    }
+
+    static MethodRef BasicObject_initialize() {
+        return MethodRef::fromRaw(1);
     }
 
     static ClassOrModuleRef Kernel() {
@@ -831,10 +839,6 @@ public:
         return ClassOrModuleRef::fromRaw(58);
     }
 
-    static MethodRef noMethod() {
-        return MethodRef();
-    }
-
     static FieldRef noField() {
         return FieldRef::fromRaw(0);
     }
@@ -848,7 +852,7 @@ public:
     }
 
     static MethodRef Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder() {
-        return MethodRef::fromRaw(1);
+        return MethodRef::fromRaw(2);
     }
 
     static TypeArgumentRef
@@ -874,7 +878,7 @@ public:
     }
 
     static MethodRef Sorbet_Private_Static_badAliasMethodStub() {
-        return MethodRef::fromRaw(2);
+        return MethodRef::fromRaw(3);
     }
 
     static ClassOrModuleRef T_Helpers() {
@@ -934,7 +938,7 @@ public:
     }
 
     static MethodRef sig() {
-        return MethodRef::fromRaw(3);
+        return MethodRef::fromRaw(4);
     }
 
     static ClassOrModuleRef Enumerator_Lazy() {
@@ -974,15 +978,15 @@ public:
     }
 
     static MethodRef T_Private_Methods_DeclBuilder_abstract() {
-        return MethodRef::fromRaw(4);
-    }
-
-    static MethodRef T_Private_Methods_DeclBuilder_overridable() {
         return MethodRef::fromRaw(5);
     }
 
-    static MethodRef T_Private_Methods_DeclBuilder_override() {
+    static MethodRef T_Private_Methods_DeclBuilder_overridable() {
         return MethodRef::fromRaw(6);
+    }
+
+    static MethodRef T_Private_Methods_DeclBuilder_override() {
+        return MethodRef::fromRaw(7);
     }
 
     static ClassOrModuleRef T_Sig_WithoutRuntimeSingleton() {
@@ -990,7 +994,7 @@ public:
     }
 
     static MethodRef sigWithoutRuntime() {
-        return MethodRef::fromRaw(7);
+        return MethodRef::fromRaw(8);
     }
 
     static ClassOrModuleRef T_NonForcingConstants() {
@@ -998,7 +1002,7 @@ public:
     }
 
     static MethodRef SorbetPrivateStaticSingleton_sig() {
-        return MethodRef::fromRaw(8);
+        return MethodRef::fromRaw(9);
     }
 
     static ClassOrModuleRef PackageSpecRegistry() {
@@ -1014,19 +1018,19 @@ public:
     }
 
     static MethodRef PackageSpec_import() {
-        return MethodRef::fromRaw(9);
-    }
-
-    static MethodRef PackageSpec_test_import() {
         return MethodRef::fromRaw(10);
     }
 
-    static MethodRef PackageSpec_export() {
+    static MethodRef PackageSpec_test_import() {
         return MethodRef::fromRaw(11);
     }
 
-    static MethodRef PackageSpec_restrict_to_service() {
+    static MethodRef PackageSpec_export() {
         return MethodRef::fromRaw(12);
+    }
+
+    static MethodRef PackageSpec_restrict_to_service() {
+        return MethodRef::fromRaw(13);
     }
 
     static ClassOrModuleRef Encoding() {
@@ -1038,27 +1042,27 @@ public:
     }
 
     static MethodRef Class_new() {
-        return MethodRef::fromRaw(13);
-    }
-
-    static MethodRef todoMethod() {
         return MethodRef::fromRaw(14);
     }
 
-    static MethodRef rootStaticInit() {
+    static MethodRef todoMethod() {
         return MethodRef::fromRaw(15);
     }
 
-    static MethodRef PackageSpec_autoloader_compatibility() {
+    static MethodRef rootStaticInit() {
         return MethodRef::fromRaw(16);
     }
 
-    static MethodRef PackageSpec_visible_to() {
+    static MethodRef PackageSpec_autoloader_compatibility() {
         return MethodRef::fromRaw(17);
     }
 
-    static MethodRef PackageSpec_export_all() {
+    static MethodRef PackageSpec_visible_to() {
         return MethodRef::fromRaw(18);
+    }
+
+    static MethodRef PackageSpec_export_all() {
+        return MethodRef::fromRaw(19);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
@@ -1102,7 +1106,7 @@ public:
     }
 
     static MethodRef T_Generic_squareBrackets() {
-        return MethodRef::fromRaw(19);
+        return MethodRef::fromRaw(20);
     }
 
     static ClassOrModuleRef Magic_UntypedSource() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,7 +23,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 53;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 54;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 73;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1259,7 +1259,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 deleteLoc = extraArgsLoc.adjust(gs, -1, 0);
             }
 
-            if (args.name == Names::initialize()) {
+            if (args.name == Names::initialize() && data->owner == core::Symbols::BasicObject()) {
                 e.setHeader("Wrong number of arguments for constructor. Expected: `{}`, got: `{}`", 0, numArgsGiven);
                 e.addErrorLine(method.data(gs)->loc(), "`{}` defined here", args.name.show(gs));
                 e.replaceWith("Delete extra args", deleteLoc, "");

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1259,7 +1259,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 deleteLoc = extraArgsLoc.adjust(gs, -1, 0);
             }
 
-            if (args.name == Names::initialize() && data->owner == core::Symbols::BasicObject()) {
+            if (method == Symbols::BasicObject_initialize()) {
                 e.setHeader("Wrong number of arguments for constructor. Expected: `{}`, got: `{}`", 0, numArgsGiven);
                 e.addErrorLine(method.data(gs)->loc(), "`{}` defined here", args.name.show(gs));
                 e.replaceWith("Delete extra args", deleteLoc, "");

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2007,21 +2007,20 @@ public:
                                /* isPrivateOk */ true,
                                args.suppressErrors};
         auto dispatched = instanceTy.dispatchCall(gs, innerArgs);
-
-        for (auto &err : res.main.errors) {
-            dispatched.main.errors.emplace_back(std::move(err));
-        }
-        res.main.errors.clear();
-        res.main = move(dispatched.main);
-        if (!res.main.method.exists()) {
+        if (dispatched.main.method.exists()) {
             // If we actually dispatched to some `initialize` method, use that method as the result,
             // because it will be more interesting to people downstream who want to look at the
             // result.
             //
             // But if this class hasn't defined a custom `initialize` method, still record that we
             // dispatched to *something*, namely `Class#new`.
-            res.main.method = core::Symbols::Class_new();
+
+            for (auto &err : res.main.errors) {
+                dispatched.main.errors.emplace_back(std::move(err));
+            }
+            res.main = move(dispatched.main);
         }
+
         res.main.sendTp = instanceTy;
     }
 } Class_new;

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -506,7 +506,12 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
         if ((overridenMethod.data(ctx)->flags.isAbstract || overridenMethod.data(ctx)->flags.isOverridable ||
              (overridenMethod.data(ctx)->hasSig() && method.data(ctx)->flags.isOverride)) &&
             !method.data(ctx)->flags.isIncompatibleOverride && !isRBI &&
-            !method.data(ctx)->flags.isRewriterSynthesized) {
+            !method.data(ctx)->flags.isRewriterSynthesized &&
+            overridenMethod != core::Symbols::BasicObject_initialize()) {
+            // We only ignore BasicObject#initialize for backwards compatibility.
+            // One day, we may want to build something like overridable(allow_incompatible: true)
+            // and mark certain methods in the standard library as possible to be overridden incompatibly,
+            // without needing to write `override(allow_incompatible: true)`.
             validateCompatibleOverride(ctx, overridenMethod, method);
         }
     }

--- a/rbi/core/basic_object.rbi
+++ b/rbi/core/basic_object.rbi
@@ -223,6 +223,10 @@ class BasicObject
   end
   def equal?(other); end
 
+  # Default constructor. Does not do anything interesting.
+  sig {void}
+  def initialize(); end
+
   # Evaluates a string containing Ruby source code, or the given block, within
   # the context of the receiver (*obj*). In order to set the context, the
   # variable `self` is set to *obj* while the code is executing, giving the code

--- a/test/testdata/infer/block_arg.rb
+++ b/test/testdata/infer/block_arg.rb
@@ -57,7 +57,7 @@ class A
   # Constructors are dispatched via a different code path; ensure that
   # it knows how to enter blocks.
   def test_constructors
-    NoConstructor.new do |x|
+    NoConstructor.new do |x| # error: `BasicObject#initialize` does not take a block
       x + 1
     end
 

--- a/test/testdata/infer/constructors.rb
+++ b/test/testdata/infer/constructors.rb
@@ -22,8 +22,10 @@ class Bar
 
     Foo1.new(1) {}
     #        ^ error: Wrong number of arguments for constructor
+    #          ^^^ error: Method `BasicObject#initialize` does not take a block
     Foo1.new 1 do end
     #        ^ error: Wrong number of arguments for constructor
+    #         ^^^^^^^ error: Method `BasicObject#initialize` does not take a block
   end
 end
 

--- a/test/testdata/infer/constructors.rb.autocorrects.exp
+++ b/test/testdata/infer/constructors.rb.autocorrects.exp
@@ -21,10 +21,12 @@ class Bar
     Foo2.new(1)
     Foo3.new(1, 2)
 
-    Foo1.new() {}
+    Foo1.new()
     #        ^ error: Wrong number of arguments for constructor
-    Foo1.new  do end
+    #          ^^^ error: Method `BasicObject#initialize` does not take a block
+    Foo1.new
     #        ^ error: Wrong number of arguments for constructor
+    #         ^^^^^^^ error: Method `BasicObject#initialize` does not take a block
   end
 end
 

--- a/test/testdata/infer/private_initialize.rb
+++ b/test/testdata/infer/private_initialize.rb
@@ -26,7 +26,7 @@ class C
 end
 
 c = C.new
-c.initialize
+c.initialize # error: Non-private call to private method `initialize` on `C`
 
 class D
   def self.initialize
@@ -42,3 +42,10 @@ sig {params(xs: T::Array[T.class_of(E)]).void}
 def example(xs)
   xs.map(&:new)
 end
+
+class F
+  public def initialize
+  end
+end
+f = F.new
+f.initialize

--- a/test/testdata/infer/self_new_with_splat.rb
+++ b/test/testdata/infer/self_new_with_splat.rb
@@ -14,7 +14,7 @@ class Foo
 
   sig {returns(T.attached_class)}
   def self.also_works_with_block
-    new(*[]) do
+    new(*[]) do # error: `BasicObject#initialize` does not take a block
       1
     end
   end

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -146,8 +146,8 @@ def main
       # ^^^^^^ hover: The docs for BigFoo
 
   foo = BigFoo.new
-  #            ^^^ hover: sig { params(args: T.untyped, blk: T.untyped).returns(BigFoo) }
-  #            ^^^ hover: def new(*args, &blk); end
+  #            ^^^ hover: sig { returns(BigFoo) }
+  #            ^^^ hover: private def initialize; end
   hoo = BigFoo::LittleFoo1.new
                          # ^^^ hover: sig { returns(BigFoo::LittleFoo1) }
   raise "error message"

--- a/test/testdata/resolver/override_initialize.rb
+++ b/test/testdata/resolver/override_initialize.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig { override.params(x: Integer).void }
+  def initialize(x)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's a lot less error prone to take the whole dispatch component, rather
than pluck individual pieces off of it. But we should only do that if we
actually _want_ it. If the dispatch to `initialize` from `Class#new` fails,
we would overwrite the original dispatch to `Class#new`, and then claw back
some of the things we overwrote. While working on typing super, I realized
that we weren't copying the `constr` back if
`initialize` didn't exist, so it could end up that you'd dispatch to a
method that `.exists()` but you'd have `constr == nullptr` which is bad.

We had a test for this on the WIP changes to super. I wanted to do this
refactor as pre-work to prove that it's a no-op normally. This will end up
getting tested indirectly by way of the tests that will come in service of
`super`.

<br>

The first commit makes it so that if we didn't successfully dispatch to
an `initialize` method, we don't report any errors.

But we actually do want some errors: if you dispatch to `initialize` and it
"didn't exist" that used to mean that it dispatched to
`BasicObject#initialize`. There was some comment about why that was
undesirable to model in RBIs, but I think that doesn't apply anymore. We
can simply let the dispatch to `BasicObject#initialize` happen, and then
Sorbet will report errors like normal because `BasicObject#initialize` does
not take any arguments.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.