### PR TITLE
typedSuper option defaults to true

### DIFF
--- a/main/options/options.h
+++ b/main/options/options.h
@@ -176,7 +176,7 @@ struct Options {
     bool enableCounters = false;
     std::string errorUrlBase = "https://srb.help/";
     bool ruby3KeywordArgs = false;
-    bool typedSuper = false;
+    bool typedSuper = true;
     std::set<int> isolateErrorCode;
     std::set<int> suppressErrorCode;
     bool noErrorSections = false;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Not all option defaults come via CLI option parsing. Sometimes we create
an `Options` struct directly. For example, in sorbet.run when we create
an LSP wrapper.

`true` is already the default specified in the `cxxopts` declaration of this
option.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a