### PR TITLE
Delete an ENFORCE because it's not true

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2007,7 +2007,6 @@ public:
             // In that case, there's no attachedClass to look for an `initialize` method on.
             // We could _maybe_ imagine trying to dispatch to `initialize` on the `<AttachedClass>`
             // type argument? But I haven't thought about what the consequences of that would be.
-            ENFORCE(self == Symbols::Class());
             return;
         }
         auto instanceTy = attachedClass.data(gs)->externalType();

--- a/test/testdata/resolver/module_superclass.rb
+++ b/test/testdata/resolver/module_superclass.rb
@@ -11,7 +11,12 @@ class SubclassObject < Object; end
 class SubclassModule2 < Module; end
 
 # It's not okay to subclass Class
-class SubclassClass < Class; end # error: `SubclassClass` is a subclass of `Class` which is not allowed
+class SubclassClass < Class # error: `SubclassClass` is a subclass of `Class` which is not allowed
+  # ... but we can't ENFORCE that it _never_ happens
+  def example
+    new
+  end
+end
 
 module M; end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We could change the ENFORCE to something like `derivesFrom(self, Class)`
except:

- that would not hold if `requires_ancestor` was enabled beacuse of how
requires_ancestor is currently implemented (by hijacking method
dispatch, instead of using the equivalent of `T.bind` like how Scala
does it)

- Even if it were true, it wouldn't be useful--we'd just be saying
"method dispatch is still working"


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.