### PR TITLE
Update IRB RBI to match the latest version

### DIFF
--- a/rbi/stdlib/irb.rbi
+++ b/rbi/stdlib/irb.rbi
@@ -1525,7 +1525,7 @@ class IRB::OutputMethod::NotImplementedError < ::StandardError; end
 
 class IRB::ReidlineInputMethod < ::IRB::RelineInputMethod; end
 
-class IRB::RelineInputMethod < ::IRB::InputMethod
+class IRB::RelineInputMethod < ::IRB::StdioInputMethod
   include(::Reline)
 
   # Creates a new input method object using
@@ -1561,7 +1561,7 @@ class IRB::RelineInputMethod < ::IRB::InputMethod
   def line(line_no); end
 end
 
-class IRB::ReadlineInputMethod < ::IRB::InputMethod
+class IRB::ReadlineInputMethod < ::IRB::StdioInputMethod
   include(::Readline)
 
   # Creates a new input method object using


### PR DESCRIPTION
Update the parent classes of `RelineInputMethod` and `ReadlineInputMethod` to match the latest version of IRB.

### Motivation

The parent classes changed on this PR https://github.com/ruby/irb/pull/671.

### Test plan

N/A