### PR TITLE
Release a single macOS gem

### DIFF
--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -37,13 +37,9 @@ git_commit_count=$(git rev-list --count HEAD)
 release_version="0.5.${git_commit_count}"
 sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-static.gemspec
 if [[ "darwin" == "$kernel_name" ]]; then
-    # Our binary should work on almost all OSes. The oldest v8 publishes is -14
-    # so I'm going with that for now.
-    for i in {14..23}; do
-        sed -i.bak "s/Gem::Platform::CURRENT/'universal-darwin-$i'/" sorbet-static.gemspec
-        gem build sorbet-static.gemspec
-        mv sorbet-static.gemspec.bak sorbet-static.gemspec
-    done
+    sed -i.bak "s/Gem::Platform::CURRENT/'universal-darwin'/" sorbet-static.gemspec
+    gem build sorbet-static.gemspec
+    mv sorbet-static.gemspec.bak sorbet-static.gemspec
 else
     gem build sorbet-static.gemspec
 fi


### PR DESCRIPTION
### Motivation
No longer need PRs like: https://github.com/sorbet/sorbet/pull/7267

> the person who originally set up our macOS gem publishing pipeline was not aware of the latter
> one day we will get around to changing that

https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1688133457614739

### Test plan

I will try releasing a version of sorbet-static to my local repo and see if it works