### PR TITLE
Correct `Pathname#write`'s signature

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -1383,13 +1383,20 @@ class Pathname < Object
   # [`File.write`](https://docs.ruby-lang.org/en/2.7.0/IO.html#method-c-write).
   sig do
     params(
-        arg0: String,
+        arg0: Object,
         offset: Integer,
-        open_args: Integer,
+        external_encoding: T.any(String, Encoding),
+        internal_encoding: T.any(String, Encoding),
+        encoding: T.any(String, Encoding),
+        textmode: BasicObject,
+        binmode: BasicObject,
+        autoclose: BasicObject,
+        mode: String,
+        perm: Integer
     )
     .returns(Integer)
   end
-  def write(arg0, offset=T.unsafe(nil), open_args=T.unsafe(nil)); end
+  def write(arg0, offset=T.unsafe(nil), external_encoding: T.unsafe(nil), internal_encoding: T.unsafe(nil), encoding: T.unsafe(nil), textmode: T.unsafe(nil), binmode: T.unsafe(nil), autoclose: T.unsafe(nil), mode: T.unsafe(nil), perm: T.unsafe(nil)); end
 
   # See
   # [`FileTest.zero?`](https://docs.ruby-lang.org/en/2.7.0/FileTest.html#method-i-zero-3F).


### PR DESCRIPTION
### Motivation

Since `Pathname#write` basically just forwards all the arguments to `IO.write`, its signature should match [`IO.write`'s](https://github.com/sorbet/sorbet/blob/ccb729be10307a29523505bc802da8ce96177b35/rbi/core/io.rbi#L3396-L3412) too.

This is pretty similar to what https://github.com/sorbet/sorbet/pull/3466 does for `Pathname#binwrite`
