### PR TITLE
Revert "Update IRB RBI to match the latest version (#7289)"

### DIFF
--- a/rbi/stdlib/irb.rbi
+++ b/rbi/stdlib/irb.rbi
@@ -1525,7 +1525,7 @@ class IRB::OutputMethod::NotImplementedError < ::StandardError; end
 
 class IRB::ReidlineInputMethod < ::IRB::RelineInputMethod; end
 
-class IRB::RelineInputMethod < ::IRB::StdioInputMethod
+class IRB::RelineInputMethod < ::IRB::InputMethod
   include(::Reline)
 
   # Creates a new input method object using
@@ -1561,7 +1561,7 @@ class IRB::RelineInputMethod < ::IRB::StdioInputMethod
   def line(line_no); end
 end
 
-class IRB::ReadlineInputMethod < ::IRB::StdioInputMethod
+class IRB::ReadlineInputMethod < ::IRB::InputMethod
   include(::Readline)
 
   # Creates a new input method object using


### PR DESCRIPTION
This reverts commit 7d3ddd6e4bccd439a289cf011a052c0b8b3b9be0.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This breaks anybody on older versions of `irb` with autogenerated RBIs.  My mistake for merging this.

I'm not sure what the right fix here is; it's possible that we should just not have `irb` RBIs in the stdlib, since it has been decoupled from Ruby releases for a while?

cc @vinistock 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
