### PR TITLE
Add missing RBI definitions for `Ripper` class

### DIFF
--- a/rbi/stdlib/ripper.rbi
+++ b/rbi/stdlib/ripper.rbi
@@ -188,6 +188,21 @@ class Ripper
   # ```
   sig {params(src: String, filename: String, lineno: Integer).returns(T::Array[String])}
   def self.tokenize(src, filename = "-", lineno = 1); end
+
+  # Create a new
+  # [`Ripper`](https://docs.ruby-lang.org/en/2.7.0/Ripper.html) object. `src` must be a
+  # [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html), an
+  # [`IO`](https://docs.ruby-lang.org/en/2.7.0/IO.html), or an
+  # [`Object`](https://docs.ruby-lang.org/en/2.7.0/Object.html) which has
+  # [`gets`](https://docs.ruby-lang.org/en/2.7.0/Kernel.html#method-i-gets) method.
+  #
+  # This method does not starts parsing. See also
+  # [`Ripper#parse`](https://docs.ruby-lang.org/en/2.7.0/Ripper.html#method-i-parse) and
+  # [`Ripper.parse`](https://docs.ruby-lang.org/en/2.7.0/Ripper.html#method-c-parse).
+  def initialize(src, filename="(ripper)", lineno=1); end
+
+  # Start parsing and returns the value of the root action.
+  def parse; end
 end
 
 # This class handles only scanner events, which are dispatched in the 'right'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The change adds RBI definitions for [`Ripper#initialize`](https://docs.ruby-lang.org/en/2.7.0/Ripper.html#method-c-new) and [`Ripper#parse`](https://docs.ruby-lang.org/en/2.7.0/Ripper.html#method-i-parse) methods.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The change adds missing RBI definitions for [`Ripper`](https://docs.ruby-lang.org/en/2.7.0/Ripper.html) class from Ruby stdlib.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
