### PR TITLE
Fix RBI definition for `Thread#backtrace`

### DIFF
--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -370,7 +370,7 @@ class Thread < Object
   def add_trace_func(proc); end
 
   # Returns the current backtrace of the target thread.
-  sig {params(args: T.untyped).returns(T::Array[T.untyped])}
+  sig {params(args: T.untyped).returns(T.nilable(T::Array[T.untyped]))}
   def backtrace(*args); end
 
   # Returns the execution stack for the target thread---an array containing


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Fix sig for for `Thread#backtrace`. It used to define `T::Array[T.untyped]` type for return value, while `nil` can be return there too.

The documentation, e.g https://docs.ruby-lang.org/en/2.7.0/Thread.html#method-i-backtrace, does state
> backtrace → array

but it seems incorrect.

The method can return `nil`, e.g. for a terminated thread:
```
[19] pry(main)> RUBY_VERSION
=> "2.7.8"
[20] pry(main)> t = Thread.new { puts "done" }; nil
=> done
nil
[21] pry(main)> t.status
=> false
[22] pry(main)> t.backtrace
=> nil
```

From the source code https://github.com/ruby/ruby/blob/v2_7_8/vm_backtrace.c#L953-L954:
```ruby
static VALUE
thread_backtrace_to_ary(int argc, const VALUE *argv, VALUE thval, int to_str)
{
    rb_thread_t *target_th = rb_thread_ptr(thval);

    if (target_th->to_kill || target_th->status == THREAD_KILLED)
      return Qnil;

    return ec_backtrace_to_ary(target_th->ec, argc, argv, 0, 0, to_str);
}
```

In https://docs.ruby-lang.org/en/3.0/Thread.html#method-i-backtrace (Ruby 3.0), the documentation was fixed:
> backtrace → array or nil

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fix an incorrect RBI-definition for `Thread#backtrace` from Ruby core lib.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
