### PR TITLE
Revert "🔊 Make combinedLogger use the same time format as debug loggers (#7301)"

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -409,7 +409,6 @@ int realmain(int argc, char *argv[]) {
             vector<spdlog::sink_ptr> sinks{stderrColorSink, fileSink};
             auto combinedLogger = make_shared<spdlog::logger>("consoleAndFile", begin(sinks), end(sinks));
             combinedLogger->flush_on(spdlog::level::err);
-            combinedLogger->set_pattern("[%Y-%m-%dT%T.%f] [%n] [%l] %v");
             combinedLogger->set_level(spdlog::level::trace); // pass through everything, let the sinks decide
 
             spdlog::register_logger(combinedLogger);

--- a/test/cli/logging/test.sh
+++ b/test/cli/logging/test.sh
@@ -2,7 +2,7 @@ LOG_FILE=$(mktemp)
 main/sorbet --silence-dev-message -e '1' -q --debug-log-file="$LOG_FILE"
 echo LOG BEGINS
 # only keep message parts, drop timings and the entire counter section
-sed -E "s/\\[[0-9]+\\-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+.[0-9]+\\]/TIMESTAMP/"< "$LOG_FILE" |  # replace timestamps
+sed -E "s/\\[[0-9]+\\-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+.[0-9]+\\]/TIMESTAMP/"< "$LOG_FILE" |  # replace timestamps
   grep 'TIMESTAMP'                                                                       |  # Only give first lines
   grep -Eve ': [0-9]+\.?[0-9]*(e(-|\+))?[0-9]*ms$'                                                       |  # remove timings
   grep -v debug-log-file                                                                     # remove header line that contains generated log name


### PR DESCRIPTION
This reverts commit fb4754a802629845674e429ea5859636e4655608.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This caused a change to how error messages are printed even when printing for
CI, causing more log chunder.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is not tested, as otherwise we wouldn't have had to revert.