### PR TITLE
write a global header for v5 autogen depdb

### DIFF
--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -174,4 +174,8 @@ string ParsedFile::toMsgpack(core::Context ctx, int version, const AutogenConfig
     return write.pack(ctx, *this, autogenCfg);
 }
 
+string ParsedFile::msgpackGlobalHeader(int version) {
+    return MsgpackWriter::msgpackGlobalHeader(version);
+}
+
 } // namespace sorbet::autogen

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -175,6 +175,8 @@ struct ParsedFile {
 
     std::string toString(const core::GlobalState &gs, int version) const;
     std::string toMsgpack(core::Context ctx, int version, const AutogenConfig &autogenCfg);
+    static std::string msgpackGlobalHeader(int version);
+
     std::vector<core::NameRef> showFullName(const core::GlobalState &gs, DefinitionRef id) const;
     QualifiedName showQualifiedName(const core::GlobalState &gs, DefinitionRef id) const;
     std::vector<std::string> listAllClasses(core::Context ctx);

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -31,8 +31,8 @@ void MsgpackWriter::packNames(vector<core::NameRef> &names) {
     mpack_finish_array(&writer);
 }
 
-void MsgpackWriter::packString(string_view str) {
-    mpack_write_str(&writer, str.data(), str.size());
+void packString(mpack_writer_t *writer, string_view str) {
+    mpack_write_str(writer, str.data(), str.size());
 }
 
 void MsgpackWriter::packBool(bool b) {
@@ -162,13 +162,13 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
     mpack_start_array(&writer, 6);
 
     mpack_write_true(&writer); // did_resolution
-    packString(ctx.state.getPrintablePath(pf.path));
+    packString(&writer, ctx.state.getPrintablePath(pf.path));
     mpack_write_u32(&writer, pf.cksum);
 
     // requires
     mpack_start_array(&writer, pf.requireStatements.size());
     for (auto nm : pf.requireStatements) {
-        packString(nm.show(ctx));
+        packString(&writer, nm.show(ctx));
     }
     mpack_finish_array(&writer);
 
@@ -194,7 +194,7 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
 
     mpack_start_map(&writer, 5);
 
-    packString("symbols");
+    packString(&writer, "symbols");
     int i = -1;
     int numTypes = typeCount.at(version);
     mpack_start_array(&writer, symbols.size());
@@ -232,26 +232,26 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
             str = v;
         }
 
-        packString(str);
+        packString(&writer, str);
     }
     mpack_finish_array(&writer);
 
-    packString("ref_count");
+    packString(&writer, "ref_count");
     mpack_write_u32(&writer, pf.refs.size());
-    packString("def_count");
+    packString(&writer, "def_count");
     mpack_write_u32(&writer, pf.defs.size());
 
-    packString("ref_attrs");
+    packString(&writer, "ref_attrs");
     mpack_start_array(&writer, refAttrs.size());
     for (auto attr : refAttrs) {
-        packString(attr);
+        packString(&writer, attr);
     }
     mpack_finish_array(&writer);
 
-    packString("def_attrs");
+    packString(&writer, "def_attrs");
     mpack_start_array(&writer, defAttrs.size());
     for (auto attr : defAttrs) {
-        packString(attr);
+        packString(&writer, attr);
     }
     mpack_finish_array(&writer);
 

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -192,9 +192,18 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
     size_t headerSize;
     mpack_writer_init_growable(&writer, &header, &headerSize);
 
-    mpack_start_map(&writer, 5);
+    const vector<string> &pfAttrs = parsedFileAttrMap.at(version);
+    const bool writesAttributeStrings = version <= 4;
 
-    packString(&writer, "symbols");
+    if (writesAttributeStrings) {
+        mpack_start_map(&writer, pfAttrs.size());
+    } else {
+        mpack_start_array(&writer, pfAttrs.size());
+    }
+
+    if (writesAttributeStrings) {
+        packString(&writer, "symbols");
+    }
     int i = -1;
     int numTypes = typeCount.at(version);
     mpack_start_array(&writer, symbols.size());
@@ -236,24 +245,31 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
     }
     mpack_finish_array(&writer);
 
-    packString(&writer, "ref_count");
+    if (writesAttributeStrings) {
+        packString(&writer, "ref_count");
+    }
     mpack_write_u32(&writer, pf.refs.size());
-    packString(&writer, "def_count");
+    if (writesAttributeStrings) {
+        packString(&writer, "def_count");
+    }
     mpack_write_u32(&writer, pf.defs.size());
 
-    packString(&writer, "ref_attrs");
-    mpack_start_array(&writer, refAttrs.size());
-    for (auto attr : refAttrs) {
-        packString(&writer, attr);
-    }
-    mpack_finish_array(&writer);
+    if (version <= 4) {
+        ENFORCE(writesAttributeStrings);
+        packString(&writer, "ref_attrs");
+        mpack_start_array(&writer, refAttrs.size());
+        for (auto attr : refAttrs) {
+            packString(&writer, attr);
+        }
+        mpack_finish_array(&writer);
 
-    packString(&writer, "def_attrs");
-    mpack_start_array(&writer, defAttrs.size());
-    for (auto attr : defAttrs) {
-        packString(&writer, attr);
+        packString(&writer, "def_attrs");
+        mpack_start_array(&writer, defAttrs.size());
+        for (auto attr : defAttrs) {
+            packString(&writer, attr);
+        }
+        mpack_finish_array(&writer);
     }
-    mpack_finish_array(&writer);
 
     mpack_write_object_bytes(&writer, body, bodySize);
     MPACK_FREE(body);
@@ -266,6 +282,47 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
     return ret;
 }
 
+string MsgpackWriter::msgpackGlobalHeader(int version) {
+    string header;
+
+    if (version <= 4) {
+        return header;
+    }
+
+    const vector<string> &pfAttrs = parsedFileAttrMap.at(version);
+    const vector<string> &refAttrs = refAttrMap.at(version);
+    const vector<string> &defAttrs = defAttrMap.at(version);
+
+    mpack_writer_t writer;
+    char *body;
+    size_t bodySize;
+    mpack_writer_init_growable(&writer, &body, &bodySize);
+
+    mpack_start_array(&writer, pfAttrs.size());
+    for (const auto &attr : pfAttrs) {
+        packString(&writer, attr);
+    }
+
+    mpack_start_array(&writer, refAttrs.size());
+    for (const auto &attr : refAttrs) {
+        packString(&writer, attr);
+    }
+    mpack_finish_array(&writer);
+
+    mpack_start_array(&writer, defAttrs.size());
+    for (const auto &attr : defAttrs) {
+        packString(&writer, attr);
+    }
+    mpack_finish_array(&writer);
+
+    mpack_writer_destroy(&writer);
+
+    header = string(body, bodySize);
+    MPACK_FREE(body);
+
+    return header;
+}
+
 // Support back-compat down to V2. V3 includes an additional
 // symbol for definition Type, namely TypeAlias.
 const map<int, int> MsgpackWriter::typeCount{
@@ -273,6 +330,27 @@ const map<int, int> MsgpackWriter::typeCount{
     {3, 5},
     {4, 5},
     {5, 5},
+};
+
+const map<int, vector<string>> MsgpackWriter::parsedFileAttrMap{
+    {
+        4,
+        {
+            "symbols",
+            "ref_count",
+            "def_count",
+            "ref_attrs",
+            "def_attrs",
+        },
+    },
+    {
+        5,
+        {
+            "symbols",
+            "ref_count",
+            "def_count",
+        },
+    },
 };
 
 const map<int, vector<string>> MsgpackWriter::refAttrMap{

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -334,6 +334,26 @@ const map<int, int> MsgpackWriter::typeCount{
 
 const map<int, vector<string>> MsgpackWriter::parsedFileAttrMap{
     {
+        2,
+        {
+            "symbols",
+            "ref_count",
+            "def_count",
+            "ref_attrs",
+            "def_attrs",
+        },
+    },
+    {
+        3,
+        {
+            "symbols",
+            "ref_count",
+            "def_count",
+            "ref_attrs",
+            "def_attrs",
+        },
+    },
+    {
         4,
         {
             "symbols",

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -20,6 +20,7 @@ private:
 
     static const std::map<int, std::vector<std::string>> refAttrMap;
     static const std::map<int, std::vector<std::string>> defAttrMap;
+    static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
     static const std::map<int, int> typeCount;
 
     // a bunch of helpers
@@ -42,6 +43,7 @@ private:
 public:
     MsgpackWriter(int version);
 
+    static std::string msgpackGlobalHeader(int version);
     std::string pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg);
 };
 

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -25,7 +25,6 @@ private:
     // a bunch of helpers
     void packName(core::NameRef nm);
     void packNames(std::vector<core::NameRef> &names);
-    void packString(std::string_view str);
     void packBool(bool b);
     void packReferenceRef(ReferenceRef ref);
     void packDefinitionRef(DefinitionRef ref);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -211,11 +211,11 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
         fileq->push(i, 1);
     }
     auto crcBuilder = autogen::CRCBuilder::create();
+    int autogenVersion = opts.autogenVersion == 0 ? autogen::AutogenVersion::MAX_VERSION : opts.autogenVersion;
 
-    workers.multiplexJob("runAutogen", [&gs, &opts, &indexed, &autogenCfg, crcBuilder, fileq, resultq]() {
+    workers.multiplexJob("runAutogen", [&gs, &autogenVersion, &opts, &indexed, &autogenCfg, crcBuilder, fileq, resultq]() {
         AutogenResult out;
         int n = 0;
-        int autogenVersion = opts.autogenVersion == 0 ? autogen::AutogenVersion::MAX_VERSION : opts.autogenVersion;
         {
             Timer timeit(logger, "autogenWorker");
             int idx = 0;
@@ -279,6 +279,9 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
     if (opts.print.Autogen.enabled || opts.print.AutogenMsgPack.enabled) {
         {
             Timer timeit(logger, "autogenDependencyDBPrint");
+            if (opts.print.AutogenMsgPack.enabled) {
+                opts.print.AutogenMsgPack.print(autogen::ParsedFile::msgpackGlobalHeader(autogenVersion));
+            }
             for (auto &elem : merged) {
                 if (opts.print.Autogen.enabled) {
                     opts.print.Autogen.print(elem.strval);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -213,56 +213,57 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
     auto crcBuilder = autogen::CRCBuilder::create();
     int autogenVersion = opts.autogenVersion == 0 ? autogen::AutogenVersion::MAX_VERSION : opts.autogenVersion;
 
-    workers.multiplexJob("runAutogen", [&gs, &autogenVersion, &opts, &indexed, &autogenCfg, crcBuilder, fileq, resultq]() {
-        AutogenResult out;
-        int n = 0;
-        {
-            Timer timeit(logger, "autogenWorker");
-            int idx = 0;
+    workers.multiplexJob(
+        "runAutogen", [&gs, &autogenVersion, &opts, &indexed, &autogenCfg, crcBuilder, fileq, resultq]() {
+            AutogenResult out;
+            int n = 0;
+            {
+                Timer timeit(logger, "autogenWorker");
+                int idx = 0;
 
-            for (auto result = fileq->try_pop(idx); !result.done(); result = fileq->try_pop(idx)) {
-                ++n;
-                auto &tree = indexed[idx];
-                if (tree.file.data(gs).isPackage()) {
-                    continue;
-                }
-                if (autogenVersion < autogen::AutogenVersion::VERSION_INCLUDE_RBI && tree.file.data(gs).isRBI()) {
-                    continue;
-                }
-
-                core::Context ctx(gs, core::Symbols::root(), tree.file);
-                auto pf = autogen::Autogen::generate(ctx, move(tree), autogenCfg, *crcBuilder);
-                tree = move(pf.tree);
-
-                AutogenResult::Serialized serialized;
-
-                if (opts.print.Autogen.enabled) {
-                    Timer timeit(logger, "autogenToString");
-                    serialized.strval = pf.toString(ctx, autogenVersion);
-                }
-                if (opts.print.AutogenMsgPack.enabled) {
-                    Timer timeit(logger, "autogenToMsgpack");
-                    serialized.msgpack = pf.toMsgpack(ctx, autogenVersion, autogenCfg);
-                }
-
-                if (!tree.file.data(gs).isRBI()) {
-                    // Exclude RBI files because they are not loadable and should not appear in
-                    // auto-loader related output.
-                    if (opts.print.AutogenSubclasses.enabled) {
-                        Timer timeit(logger, "autogenSubclasses");
-                        serialized.subclasses = autogen::Subclasses::listAllSubclasses(
-                            ctx, pf, opts.autogenSubclassesAbsoluteIgnorePatterns,
-                            opts.autogenSubclassesRelativeIgnorePatterns);
+                for (auto result = fileq->try_pop(idx); !result.done(); result = fileq->try_pop(idx)) {
+                    ++n;
+                    auto &tree = indexed[idx];
+                    if (tree.file.data(gs).isPackage()) {
+                        continue;
                     }
+                    if (autogenVersion < autogen::AutogenVersion::VERSION_INCLUDE_RBI && tree.file.data(gs).isRBI()) {
+                        continue;
+                    }
+
+                    core::Context ctx(gs, core::Symbols::root(), tree.file);
+                    auto pf = autogen::Autogen::generate(ctx, move(tree), autogenCfg, *crcBuilder);
+                    tree = move(pf.tree);
+
+                    AutogenResult::Serialized serialized;
+
+                    if (opts.print.Autogen.enabled) {
+                        Timer timeit(logger, "autogenToString");
+                        serialized.strval = pf.toString(ctx, autogenVersion);
+                    }
+                    if (opts.print.AutogenMsgPack.enabled) {
+                        Timer timeit(logger, "autogenToMsgpack");
+                        serialized.msgpack = pf.toMsgpack(ctx, autogenVersion, autogenCfg);
+                    }
+
+                    if (!tree.file.data(gs).isRBI()) {
+                        // Exclude RBI files because they are not loadable and should not appear in
+                        // auto-loader related output.
+                        if (opts.print.AutogenSubclasses.enabled) {
+                            Timer timeit(logger, "autogenSubclasses");
+                            serialized.subclasses = autogen::Subclasses::listAllSubclasses(
+                                ctx, pf, opts.autogenSubclassesAbsoluteIgnorePatterns,
+                                opts.autogenSubclassesRelativeIgnorePatterns);
+                        }
+                    }
+
+                    out.prints.emplace_back(idx, move(serialized));
                 }
-
-                out.prints.emplace_back(idx, move(serialized));
             }
-        }
 
-        out.counters = getAndClearThreadCounters();
-        resultq->push(move(out), n);
-    });
+            out.counters = getAndClearThreadCounters();
+            resultq->push(move(out), n);
+        });
 
     AutogenResult out;
     for (auto res = resultq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), *logger); !res.done();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The current autogen depdb format for a file that Sorbet knows about looks like this; each line of the table represents one msgpack object of the appropriate kind:

```
|----------------|
| "symbols"      |
| string array   |
| "ref_count"    |
| int            |
| "def_count"    |
| int            |
| "ref_attrs"    |
| string array   |
| "def_attrs"    |
| string array   |
|----------------|
| ...actual data |
|----------------|
```

The DB is then generated by writing out the above format for each file Sorbet knows about and concatenating them together.

This format has the virtue of being fairly self-describing (the header is stored as a msgpack map, so reading it is a single line of Ruby), but it also has the downside of being somewhat verbose: we're writing the strings in the above header for every file, and the string arrays for `ref_attrs` and `def_attrs` are duplicated for every file.

This PR changes things so we write a single, global header at the start of the file describing the fields in the header for each individual file, as well as the `ref_attrs` and `def_attrs` used throughout the file.  This does make processing the files slightly more complicated, as there's more state to pass around, but we now have to parse less per-file and we do less I/O for the entire DB, so I think the tradeoff is worth it.

This change cuts a little over 10% off the size of depdb for Stripe's codebase.

I meant to add a version number at the very start of the header; I will do that in a followup PR.

I don't love the conditionals in `msgpack.cc`; I think that once v5 stabilizes and is supported in Stripe's codebase, we could simply remove support for previous versions.  Then we would only really support three states:

1. A single, current version
2. The current version and the next version
3. (After some time) Make the next version the current and drop the support for the previous, bringing us back to state 1

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
