### PR TITLE
Update type-annotations.md

### DIFF
--- a/website/docs/type-annotations.md
+++ b/website/docs/type-annotations.md
@@ -132,8 +132,10 @@ smart enough to understand that either:
 
 A current shortcoming of Sorbet is that in many cases it cannot reuse static
 type knowledge in order to automatically determine the type of an instance or
-class variable. In the following example it can, Sorbet will naturally understand that
-`@x` is of type `Integer`, and that `@y` is also of the same type.
+class variable. In the following example, Sorbet will naturally understand that
+`@x` is of type `Integer`, but it cannot determine the static type of `@y`
+without a `T.let` and therefore treats it as `T.untyped` when used in other
+methods:
 
 ```ruby
 class Foo
@@ -141,9 +143,12 @@ class Foo
   def initialize(x, y)
     @x = x
     @y = y + 0
+  end
 
+  sig {void}
+  def example
     T.reveal_type(@x)  # Integer
-    T.reveal_type(@y)  # Integer
+    T.reveal_type(@y)  # T.untyped
   end
 end
 ```

--- a/website/docs/type-annotations.md
+++ b/website/docs/type-annotations.md
@@ -132,9 +132,8 @@ smart enough to understand that either:
 
 A current shortcoming of Sorbet is that in many cases it cannot reuse static
 type knowledge in order to automatically determine the type of an instance or
-class variable. In the following example, Sorbet will naturally understand that
-`@x` is of type `Integer`, but it cannot determine the static type of `@y`
-without a `T.let` and therefore treats it as `T.untyped`:
+class variable. In the following example it can, Sorbet will naturally understand that
+`@x` is of type `Integer`, and that `@y` is also of the same type.
 
 ```ruby
 class Foo
@@ -144,7 +143,7 @@ class Foo
     @y = y + 0
 
     T.reveal_type(@x)  # Integer
-    T.reveal_type(@y)  # T.untyped
+    T.reveal_type(@y)  # Integer
   end
 end
 ```


### PR DESCRIPTION
I don't think my phrasing is correct, but running this in Sorbet.run produces the correct types for both `@x` and`@y`. Maybe we remove this section ?

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Running this in Sorbet.run produces the correct types but the docs say otherwise.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This example is currently incorrect.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
