### PR TITLE
Kernel#respond_to_missing? should return T::Boolean

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -635,7 +635,7 @@ module Kernel
   # When the method name parameter is given as a string, the string is converted to a symbol.
   #
   # See respond_to?, and the example of BasicObject.
-  sig {params(method_name: Symbol, include_private: T::Boolean).returns(T.anything)}
+  sig {params(method_name: Symbol, include_private: T::Boolean).returns(T::Boolean)}
   private def respond_to_missing?(method_name, include_private = false); end
 
   sig do


### PR DESCRIPTION
I think `Kernel#respond_to_missing?` should return Boolean based on https://github.com/ruby/ruby/blob/89802078f9f406be411032814e1960e62dbc7ce2/vm_method.c#L2869-L2888

### Motivation
My codebase stop working because of this change.

https://github.com/LTe/acts-as-messageable/blob/d3b8574e9ed21aba7d61ef6f2d24a0539dd3e9b7/lib/acts_as_messageable/rails6.rb#L58-L61

The problem is with `super` call.

### Test plan

This should work:

https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Asig%20%7B%20params%28method_name%3A%20Symbol%2C%20include_private%3A%20T%3A%3ABoolean%29.returns%28T%3A%3ABoolean%29%20%7D%0Adef%20respond_to_missing%3F%28method_name%2C%20include_private%20%3D%20false%29%0A%20%20%5B%3Amethod_name%5D.include%3F%28method_name%29%20%7C%7C%20super%0Aend
