### PR TITLE
Allow `Gem::Version.initialize` to accept `Gem::Version`

### DIFF
--- a/rbi/stdlib/rubygems.rbi
+++ b/rbi/stdlib/rubygems.rbi
@@ -2634,7 +2634,7 @@ class Gem::Version < Object
 
   sig do
     params(
-      version: String,
+      version: T.any(String, Gem::Version),
     )
     .void
   end


### PR DESCRIPTION
`Gem::Version.initialize` checks if `version.to_s` matches a regex pattern:

https://github.com/rubygems/rubygems/blob/c2c0966858be58d47fc5d423dcf761926ba0bceb/lib/rubygems/version.rb#L221-L224

https://github.com/rubygems/rubygems/blob/c2c0966858be58d47fc5d423dcf761926ba0bceb/lib/rubygems/version.rb#L173-L177

https://github.com/rubygems/rubygems/blob/c2c0966858be58d47fc5d423dcf761926ba0bceb/lib/rubygems/version.rb#L158-L159

Tautologically, this must be true. 


### Motivation
It's not currently possible to create sub-classes of `Gem::Version` that accept a wider range of inputs, and narrow the type.

### Test plan
