### PR TITLE
Widen type on Benchmark::Job#report method

### DIFF
--- a/rbi/stdlib/benchmark.rbi
+++ b/rbi/stdlib/benchmark.rbi
@@ -327,7 +327,7 @@ class Benchmark::Job
   # Registers the given label and block pair in the job list.
   sig do
     params(
-        label: String,
+        label: Object,
         blk: T.proc.void
     )
     .returns(T.self_type)
@@ -341,7 +341,7 @@ class Benchmark::Job
   # Registers the given label and block pair in the job list.
   sig do
     params(
-        label: String,
+        label: Object,
         blk: T.proc.void
     )
     .returns(T.self_type)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The Ruby VM calls `.to_s` on this. Usually benchmark code is very
informal, where it doesn't really matter that you're adhering to super
strict types.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a