### PR TITLE
add a few more features to the v5 depdb format

### DIFF
--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -174,8 +174,8 @@ string ParsedFile::toMsgpack(core::Context ctx, int version, const AutogenConfig
     return write.pack(ctx, *this, autogenCfg);
 }
 
-string ParsedFile::msgpackGlobalHeader(int version) {
-    return MsgpackWriter::msgpackGlobalHeader(version);
+string ParsedFile::msgpackGlobalHeader(int version, size_t numFiles) {
+    return MsgpackWriter::msgpackGlobalHeader(version, numFiles);
 }
 
 } // namespace sorbet::autogen

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -175,7 +175,7 @@ struct ParsedFile {
 
     std::string toString(const core::GlobalState &gs, int version) const;
     std::string toMsgpack(core::Context ctx, int version, const AutogenConfig &autogenCfg);
-    static std::string msgpackGlobalHeader(int version);
+    static std::string msgpackGlobalHeader(int version, size_t numFiles);
 
     std::vector<core::NameRef> showFullName(const core::GlobalState &gs, DefinitionRef id) const;
     QualifiedName showQualifiedName(const core::GlobalState &gs, DefinitionRef id) const;

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -298,6 +298,8 @@ string MsgpackWriter::msgpackGlobalHeader(int version) {
     size_t bodySize;
     mpack_writer_init_growable(&writer, &body, &bodySize);
 
+    mpack_write_u32(&writer, version);
+
     mpack_start_array(&writer, pfAttrs.size());
     for (const auto &attr : pfAttrs) {
         packString(&writer, attr);

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -293,7 +293,7 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
     return ret;
 }
 
-string MsgpackWriter::msgpackGlobalHeader(int version) {
+string MsgpackWriter::msgpackGlobalHeader(int version, size_t numFiles) {
     string header;
 
     if (version <= 4) {
@@ -327,6 +327,8 @@ string MsgpackWriter::msgpackGlobalHeader(int version) {
         packString(&writer, attr);
     }
     mpack_finish_array(&writer);
+
+    mpack_write_u64(&writer, numFiles);
 
     mpack_writer_destroy(&writer);
 

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -43,7 +43,7 @@ private:
 public:
     MsgpackWriter(int version);
 
-    static std::string msgpackGlobalHeader(int version);
+    static std::string msgpackGlobalHeader(int version, size_t numFiles);
     std::string pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg);
 };
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -281,7 +281,8 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
         {
             Timer timeit(logger, "autogenDependencyDBPrint");
             if (opts.print.AutogenMsgPack.enabled) {
-                opts.print.AutogenMsgPack.print(autogen::ParsedFile::msgpackGlobalHeader(autogenVersion));
+                opts.print.AutogenMsgPack.print(
+                    autogen::ParsedFile::msgpackGlobalHeader(autogenVersion, merged.size()));
             }
             for (auto &elem : merged) {
                 if (opts.print.Autogen.enabled) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

* A version number seems like a nice thing to have and doesn't cost us very much.
* Same with the number of files, which enables tools to preallocate space
* The size of written defs and refs is kind of an experiment for being able to skip reading defs and refs.  Right now we do it with code like:

```ruby
        num_def_attrs = def_attrs.size
        unpacker.read_array_header.times do
          unpacker.read_array_header
          num_def_attrs.times do
            unpacker.skip
          end
        end
```

and I'm betting we can do it faster simply by manipulating the underlying stream.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
