### PR TITLE
If there's only a section header, still include in LSP

### DIFF
--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -169,6 +169,15 @@ void ErrorReporter::pushDiagnostics(uint32_t epoch, core::FileRef file, const ve
         for (auto &section : error->sections) {
             string sectionHeader = section.header;
 
+            if (section.messages.empty()) {
+                // Sometimes we just use section headers to report extra information, not connected
+                // to a specific line. The LSP spec needs a location, so let's just re-use the error->loc.
+                auto location = config->loc2Location(gs, error->loc);
+                relatedInformation.push_back(
+                    make_unique<DiagnosticRelatedInformation>(move(location), move(sectionHeader)));
+                continue;
+            }
+
             for (auto &errorLine : section.messages) {
                 string message = errorLine.formattedMessage.length() > 0 ? errorLine.formattedMessage : sectionHeader;
                 auto location = config->loc2Location(gs, errorLine.loc);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet reported more information in the command line error messages than was
possible to see in LSP.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

It's hard to write an automated test for this, because the `^^^ error` snapshots
only do the header messages. Normally for testing other error messages we use a
CLI test, but this is an LSP-specific problem so that wouldn't work.

We could use an LSP protocol test, but that seems annoying.

Our existing test suite will at least catch if this code causes a crash, and in
the mean time here are some screenshots showing that the feature works:

Command line:

<img width="765" alt="Screenshot 2023-09-15 at 1 19 25 PM" src="https://github.com/sorbet/sorbet/assets/5544532/9fec43b1-d914-4323-83a9-8e8dd0291b3a">

Before:
<img width="658" alt="Screenshot 2023-09-15 at 1 23 05 PM" src="https://github.com/sorbet/sorbet/assets/5544532/21901a44-0b9d-4932-9eea-e3c6e70aacc7">

After:

<img width="660" alt="Screenshot 2023-09-15 at 1 23 44 PM" src="https://github.com/sorbet/sorbet/assets/5544532/67808f1d-f61b-46ab-af5f-904a9802a995">

