### PR TITLE
Add `--suggest-unsafe` autocorrect for alias_method

### DIFF
--- a/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
@@ -5,13 +5,13 @@ class <C <U <root>>> < <C <U Object>> ()
   module <C <U Alias>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=2:13}
     method <C <U Alias>>#<U alias_user> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=16:3 end=16:17}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
-    method <C <U Alias>>#<U bad_alias> (nonexistant_method) -> AliasType { symbol = <C <U Sorbet>>::<C <U Private>>::<C <U Static>>#<U <bad-method-alias-stub>> } @ Loc {file=test/testdata/namer/alias_method.rb start=13:3 end=13:47}
+    method <C <U Alias>>#<U bad_alias> (nonexistant_method) -> AliasType { symbol = <C <U Sorbet>>::<C <U Private>>::<C <U Static>>#<U <bad-method-alias-stub>> } @ Loc {file=test/testdata/namer/alias_method.rb start=13:16 end=13:26}
       argument nonexistant_method<keyword> @ Loc {file=test/testdata/namer/alias_method.rb start=13:28 end=13:47}
     method <C <U Alias>>#<U f> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=3:3 end=3:8}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
-    method <C <U Alias>>#<U f_alias> (f) -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=6:3 end=6:18}
+    method <C <U Alias>>#<U f_alias> (f) -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=6:9 end=6:16}
       argument f<keyword> @ Loc {file=test/testdata/namer/alias_method.rb start=6:17 end=6:18}
-    method <C <U Alias>>#<U f_alias_1> (f) -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=7:3 end=7:30}
+    method <C <U Alias>>#<U f_alias_1> (f) -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=7:16 end=7:26}
       argument f<keyword> @ Loc {file=test/testdata/namer/alias_method.rb start=7:28 end=7:30}
   class <S <C <U Alias>> $1> < <C <U Module>> () @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=2:13}
     method <S <C <U Alias>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=21:4}

--- a/test/testdata/resolver/alias_suggest_unsafe.rb
+++ b/test/testdata/resolver/alias_suggest_unsafe.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+class Child
+  alias_method :bar, :foo
+  #                  ^^^^ error: Can't make method alias from `bar` to non existing method `foo`
+end

--- a/test/testdata/resolver/alias_suggest_unsafe.rb
+++ b/test/testdata/resolver/alias_suggest_unsafe.rb
@@ -1,4 +1,5 @@
 # typed: true
+# enable-suggest-unsafe: true
 
 class Child
   alias_method :bar, :foo

--- a/test/testdata/resolver/alias_suggest_unsafe.rb.autocorrects.exp
+++ b/test/testdata/resolver/alias_suggest_unsafe.rb.autocorrects.exp
@@ -1,0 +1,8 @@
+# -- test/testdata/resolver/alias_suggest_unsafe.rb --
+# typed: true
+
+class Child
+  alias_method :bar, :foo
+  #                  ^^^^ error: Can't make method alias from `bar` to non existing method `foo`
+end
+# ------------------------------

--- a/test/testdata/resolver/alias_suggest_unsafe.rb.autocorrects.exp
+++ b/test/testdata/resolver/alias_suggest_unsafe.rb.autocorrects.exp
@@ -1,8 +1,9 @@
 # -- test/testdata/resolver/alias_suggest_unsafe.rb --
 # typed: true
+# enable-suggest-unsafe: true
 
 class Child
-  alias_method :bar, :foo
+  T.unsafe(self).alias_method :bar, :foo
   #                  ^^^^ error: Can't make method alias from `bar` to non existing method `foo`
 end
 # ------------------------------

--- a/test/testdata/resolver/multi_alias_method.rb
+++ b/test/testdata/resolver/multi_alias_method.rb
@@ -6,7 +6,7 @@ class A
   alias_method :from, :to
   alias_method :from, :to_bad
   #                   ^^^^^^^ error: Can't make method alias from `from` to non existing method `to_bad`
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Redefining method alias `A#from` from `A#to` to `Sorbet::Private::Static#<bad-method-alias-stub>`
+  #            ^^^^^ error: Redefining method alias `A#from` from `A#to` to `Sorbet::Private::Static#<bad-method-alias-stub>`
 end
 
 class B


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When doing codemods to upgrade files from `# typed: false` to `# typed: true`,
frequently you don't care about whether these methods exist, you just need to
silence them so that you can get the rest of the file out of `# typed: false`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.