### PR TITLE
wip: Experiment with alternative syntax for generics

### DIFF
--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -173,6 +173,7 @@ public:
     NameRef addQuestion(GlobalState &gs) const;
 
     NameRef addAt(GlobalState &gs) const;
+    NameRef removeAt(const GlobalState &gs) const;
     NameRef lookupWithAt(const GlobalState &gs) const;
 
     NameRef prepend(GlobalState &gs, std::string_view s) const;

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -421,6 +421,17 @@ NameRef NameRef::addAt(GlobalState &gs) const {
     return gs.enterNameUTF8(nameEq);
 }
 
+NameRef NameRef::removeAt(const GlobalState &gs) const {
+    auto name = this->dataUtf8(gs);
+    if (!absl::StartsWith(name->utf8, "@")) {
+        return noName();
+    }
+
+    auto utf8 = name->utf8;
+    utf8.remove_prefix(1);
+    return gs.lookupNameUTF8(utf8);
+}
+
 NameRef NameRef::prepend(GlobalState &gs, string_view s) const {
     auto name = this->dataUtf8(gs);
     string nameEq = absl::StrCat(s, name->utf8);

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -357,7 +357,7 @@ module T::Private::Methods
     builder
       .instance_exec(&declaration_block.blk)
       .finalize!
-      .decl
+      .__decl__
   end
 
   def self.build_sig(hook_mod, method_name, original_method, current_declaration)

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -207,6 +207,10 @@ module T::Private::Methods
 
       __decl__.type_parameters = names
 
+      names.each do |name|
+        instance_variable_set("@#{name}", T::Types::TypeParameter.make(name))
+      end
+
       self
     end
 

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -21,7 +21,7 @@ module T::Utils
       elsif val.is_a?(::Hash)
         T::Types::FixedHash.new(val)
       elsif val.is_a?(T::Private::Methods::DeclBuilder)
-        T::Private::Methods.finalize_proc(val.decl)
+        T::Private::Methods.finalize_proc(val.__decl__)
       elsif val.is_a?(::T::Enum)
         T::Types::TEnum.new(val)
       elsif val.is_a?(::String)

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -23,12 +23,12 @@ module Opus::Types::Test
       mod.fn(1) # executes the sig block
 
       assert(builder)
-      assert_equal(mod, builder.decl.mod)
-      assert_equal({x: Integer}, builder.decl.params)
-      assert_equal(String, builder.decl.returns)
-      assert_equal(:always, builder.decl.checked)
-      assert_equal('standard', builder.decl.mode)
-      assert_equal(true, builder.decl.finalized)
+      assert_equal(mod, builder.__decl__.mod)
+      assert_equal({x: Integer}, builder.__decl__.params)
+      assert_equal(String, builder.__decl__.returns)
+      assert_equal(:always, builder.__decl__.checked)
+      assert_equal('standard', builder.__decl__.mode)
+      assert_equal(true, builder.__decl__.finalized)
     end
 
     it 'requires params not have any positional args' do
@@ -127,17 +127,17 @@ module Opus::Types::Test
         end
 
         Child1.new.implement_me
-        assert_equal('abstract', builders[:abstract].decl.mode)
+        assert_equal('abstract', builders[:abstract].__decl__.mode)
 
         Child1.new.override_me
-        assert_equal('overridable', builders[:overridable].decl.mode)
-        assert_equal('override', builders[:override].decl.mode)
+        assert_equal('overridable', builders[:overridable].__decl__.mode)
+        assert_equal('override', builders[:override].__decl__.mode)
 
         Child2.new.implement_me
-        assert_equal('overridable_override', builders[:override_overridable].decl.mode)
+        assert_equal('overridable_override', builders[:override_overridable].__decl__.mode)
 
         Child3.new.implement_me
-        assert_equal('overridable_override', builders[:overridable_override].decl.mode)
+        assert_equal('overridable_override', builders[:overridable_override].__decl__.mode)
       end
 
       INVALID_MODE_TESTS = [
@@ -213,7 +213,7 @@ module Opus::Types::Test
             def self.test_method; end
           end
           mod.test_method
-          assert_equal(:always, builder.decl.checked)
+          assert_equal(:always, builder.__decl__.checked)
         end
 
         describe 'runtime levels' do

--- a/test/testdata/resolver/type_parameter_at.rb
+++ b/test/testdata/resolver/type_parameter_at.rb
@@ -1,0 +1,14 @@
+# typed: true
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(x: @U)
+    .returns(@U)
+end
+def foo(x)
+  T.reveal_type(x)
+  ''
+end
+
+p T::Utils.signature_for_method(method(:foo))


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Just a fun experiment for a Friday afternoon.

Not saying we should necessarily flesh this out. But it wasn't that hard to
build either.

Right now, the biggest downside here is that you wouldn't be able to use this syntax inside a method body, e.g. `T.let(nil, T.nilable(@U))` wouldn't work.

If we do decide that the verbosity of type_parameter's is worth solving, we could either abandon this approach and choose something else that works everywhere, or we could build better error messages statically.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

<img width="760" alt="image" src="https://github.com/sorbet/sorbet/assets/5544532/48565149-2f51-4207-a611-c9a061408c37">


- [ ] @jez write tests