### PR TITLE
Add `--suggest-unsafe` autocorrect to suggest `T::InexactStruct`

### DIFF
--- a/test/testdata/definition_validator/subclass_t_struct_multi_file.autocorrects.exp
+++ b/test/testdata/definition_validator/subclass_t_struct_multi_file.autocorrects.exp
@@ -2,7 +2,7 @@
 # typed: true
 # enable-suggest-unsafe: true
 
-class Parent < T::Struct
+class Parent < T::InexactStruct
 end
 # ------------------------------
 # -- test/testdata/definition_validator/subclass_t_struct_multi_file__2.rb --

--- a/test/testdata/definition_validator/subclass_t_struct_multi_file.autocorrects.exp
+++ b/test/testdata/definition_validator/subclass_t_struct_multi_file.autocorrects.exp
@@ -1,0 +1,21 @@
+# -- test/testdata/definition_validator/subclass_t_struct_multi_file__1.rb --
+# typed: true
+# enable-suggest-unsafe: true
+
+class Parent < T::Struct
+end
+# ------------------------------
+# -- test/testdata/definition_validator/subclass_t_struct_multi_file__2.rb --
+# typed: true
+
+class Child2 < Parent # error: Subclassing `Parent` is not allowed
+end
+
+# ------------------------------
+# -- test/testdata/definition_validator/subclass_t_struct_multi_file__3.rb --
+# typed: true
+
+class Child3 < Parent # error: Subclassing `Parent` is not allowed
+end
+
+# ------------------------------

--- a/test/testdata/definition_validator/subclass_t_struct_multi_file__1.rb
+++ b/test/testdata/definition_validator/subclass_t_struct_multi_file__1.rb
@@ -1,0 +1,5 @@
+# typed: true
+# enable-suggest-unsafe: true
+
+class Parent < T::Struct
+end

--- a/test/testdata/definition_validator/subclass_t_struct_multi_file__2.rb
+++ b/test/testdata/definition_validator/subclass_t_struct_multi_file__2.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+class Child2 < Parent # error: Subclassing `Parent` is not allowed
+end
+

--- a/test/testdata/definition_validator/subclass_t_struct_multi_file__3.rb
+++ b/test/testdata/definition_validator/subclass_t_struct_multi_file__3.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+class Child3 < Parent # error: Subclassing `Parent` is not allowed
+end
+

--- a/test/testdata/definition_validator/subclass_t_struct_simple.rb
+++ b/test/testdata/definition_validator/subclass_t_struct_simple.rb
@@ -1,0 +1,9 @@
+# typed: true
+# enable-suggest-unsafe: true
+
+class Parent < T::Struct
+end
+
+class Child < Parent # error: Subclassing `Parent` is not allowed
+end
+

--- a/test/testdata/definition_validator/subclass_t_struct_simple.rb
+++ b/test/testdata/definition_validator/subclass_t_struct_simple.rb
@@ -7,3 +7,6 @@ end
 class Child < Parent # error: Subclassing `Parent` is not allowed
 end
 
+# autocorrect not implemented
+Child2 = Class.new(Parent) do # error: Subclassing `Parent` is not allowed
+end

--- a/test/testdata/definition_validator/subclass_t_struct_simple.rb.autocorrects.exp
+++ b/test/testdata/definition_validator/subclass_t_struct_simple.rb.autocorrects.exp
@@ -2,7 +2,7 @@
 # typed: true
 # enable-suggest-unsafe: true
 
-class Parent < T::Struct
+class Parent < T::InexactStruct
 end
 
 class Child < Parent # error: Subclassing `Parent` is not allowed

--- a/test/testdata/definition_validator/subclass_t_struct_simple.rb.autocorrects.exp
+++ b/test/testdata/definition_validator/subclass_t_struct_simple.rb.autocorrects.exp
@@ -1,0 +1,11 @@
+# -- test/testdata/definition_validator/subclass_t_struct_simple.rb --
+# typed: true
+# enable-suggest-unsafe: true
+
+class Parent < T::Struct
+end
+
+class Child < Parent # error: Subclassing `Parent` is not allowed
+end
+
+# ------------------------------

--- a/test/testdata/definition_validator/subclass_t_struct_simple.rb.autocorrects.exp
+++ b/test/testdata/definition_validator/subclass_t_struct_simple.rb.autocorrects.exp
@@ -8,4 +8,7 @@ end
 class Child < Parent # error: Subclassing `Parent` is not allowed
 end
 
+# autocorrect not implemented
+Child2 = Class.new(Parent) do # error: Subclassing `Parent` is not allowed
+end
 # ------------------------------

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -115,11 +115,19 @@ for this_src in "${rb_src[@]}" DUMMY; do
     if grep -q '^# enable-experimental-requires-ancestor: true' "${srcs[@]}"; then
       needs_requires_ancestor=true
     fi
+
     if grep -q '^# typed-super: false' "${srcs[@]}"; then
       needs_typed_super_false=true
     else
       needs_typed_super_false=false
     fi
+
+    if grep -q '^# enable-suggest-unsafe: true' "${srcs[@]}"; then
+      needs_suggest_unsafe=true
+    else
+      needs_suggest_unsafe=false
+    fi
+
     for pass in "${passes[@]}"; do
       candidate="$basename.$pass.exp"
       # Document symbols is weird, because it's (currently) the only exp-style
@@ -171,6 +179,11 @@ for this_src in "${rb_src[@]}" DUMMY; do
       fi
       if $needs_typed_super_false; then
         args+=("--typed-super=false")
+      else
+        args+=()
+      fi
+      if $needs_suggest_unsafe; then
+        args+=("--suggest-unsafe")
       else
         args+=()
       fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sometimes people make struct-like things that they later wish were `T::Struct`s.
The codemod generally looks like:

Given `Args` is a struct-like superclass,

- Factor the special sauce of the struct to a module/interface like `IArgs` /
  `IArgs::ClassMethods`.
- Replace things like `class Example < Args` with
  `class Example < T::Struct; include IArgs`
- Fix the errors

Most of those errors are simply type errors that come from the fact that the
constructor is typed now.

But sometimes, people have set up complex inheritance hierarchies. The easiest
fix during the codemod is to simply opt those classes out of the newfound type
safety by marking them `T::InexactStruct` instead of `T::Struct`, and circle
back to fixing each one with more targeted fixes.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Note that the autocorrect does not necessarily fire in the same file that the
error is reported, and that we correctly de-dup the autocorrect.