### PR TITLE
Add method_missing to basic_object

### DIFF
--- a/rbi/core/basic_object.rbi
+++ b/rbi/core/basic_object.rbi
@@ -297,4 +297,7 @@ class BasicObject
 
   sig {overridable.params(method: Symbol).returns(T.untyped)}
   private def singleton_method_added(method); end
+
+  sig {params(method: Symbol, args: T.untyped).returns(T.untyped)}
+  private def method_missing(method, *args); end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

<https://github.com/ruby/ruby/blob/v3_2_0/vm_eval.c#L2587>

The method is there at runtime. This is important for calls to `super`
from within overrides of `method_missing`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a - RBI changes