### PR TITLE
don't store type symbols in the v5+ depdb

### DIFF
--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -344,7 +344,10 @@ const map<int, int> MsgpackWriter::typeCount{
     {2, 4},
     {3, 5},
     {4, 5},
-    {5, 5},
+    // v5 requires clients to have their own representation for common
+    // definition types, rather than stuffing symbols into the symbol
+    // array.
+    {5, 0},
 };
 
 const map<int, vector<string>> MsgpackWriter::parsedFileAttrMap{


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Every parsed file contains an array of symbols (well, really strings, but hey) representing constant names that occur in the file.  For instance, `T::Array` would create two symbols, one each for `T` and `Array`.

In versions 4 and below of the depdb, this array of symbols always stored some small number of symbols for the types of definitions found in the file.  It turns out that while these preallocated symbols are not large in terms of their size in the db, they do drastically inflate the overall number of symbols stored in the depdb, since they're stored for each and every file.  Roughly ~15% of the symbols in the depdb in Stripe's codebase are these type definition symbols.

There's no particular reason that this should be necessary: clients can map the integer stored in the depdb to symbols themselves, they can leave the integer alone, they can turn it into a `T::Enum`, etc. etc.  Let's make things smaller and require less processing by not having these preallocated symbols.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
