### PR TITLE
Add support for Ruby 3.3dev for sorbet_ruby

### DIFF
--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -114,7 +114,7 @@ run_cmd ./configure \
         --with-rubyhdrdir='${{includedir}}' \
         --with-rubyarchhdrdir='${{includedir}}/ruby-arch' \
         --disable-install-doc \
-        --prefix=/ 
+        --prefix=/
 
 run_cmd make V=1 -j8
 run_cmd make V=1 install

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -114,8 +114,7 @@ run_cmd ./configure \
         --with-rubyhdrdir='${{includedir}}' \
         --with-rubyarchhdrdir='${{includedir}}/ruby-arch' \
         --disable-install-doc \
-        --prefix=/ \
-        --without-git
+        --prefix=/ 
 
 run_cmd make V=1 -j8
 run_cmd make V=1 install

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -114,7 +114,8 @@ run_cmd ./configure \
         --with-rubyhdrdir='${{includedir}}' \
         --with-rubyarchhdrdir='${{includedir}}/ruby-arch' \
         --disable-install-doc \
-        --prefix=/
+        --prefix=/ \
+        --without-git
 
 run_cmd make V=1 -j8
 run_cmd make V=1 install

--- a/third_party/ruby/ruby-versions.txt
+++ b/third_party/ruby/ruby-versions.txt
@@ -1,3 +1,4 @@
 sorbet_ruby_2_7
 sorbet_ruby_3_1
 sorbet_ruby_3_2
+sorbet_ruby_3_3_preview

--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -19,7 +19,7 @@ ruby(
         "//conditions:default": [],
     }) + select({
         # Do not enable the JIT unless opted in.
-        "@com_stripe_ruby_typer//tools/config:jit_enabled": [],
+        "@com_stripe_ruby_typer//tools/config:jit_enabled": ["--enable-yjit=stats"],
         "//conditions:default": ["--disable-jit-support"],
     }),
     copts = [

--- a/third_party/ruby/ruby_3_3.BUILD
+++ b/third_party/ruby/ruby_3_3.BUILD
@@ -20,7 +20,7 @@ ruby(
         "//conditions:default": [],
     }) + select({
         # Do not enable the JIT unless opted in.
-        "@com_stripe_ruby_typer//tools/config:jit_enabled": ["--enable-yjit=stats"],
+        "@com_stripe_ruby_typer//tools/config:jit_enabled": ["--enable-yjit"],
         "//conditions:default": ["--disable-jit-support"],
     }),
     copts = [
@@ -38,11 +38,7 @@ ruby(
         "-Wdate-time",
         "-D_FORTIFY_SOURCE=2",
         "-fPIC",
-    ] + select({
-        # Don't include JIT statistics unless we're building JIT support
-        "@com_stripe_ruby_typer//tools/config:jit_enabled": ["-DYJIT_STATS=1"],
-        "//conditions:default": [],
-    }),
+    ] ,
     extra_srcs = [],
     gems = [
         "@bundler_stripe//file",

--- a/third_party/ruby/ruby_3_3.BUILD
+++ b/third_party/ruby/ruby_3_3.BUILD
@@ -38,7 +38,7 @@ ruby(
         "-Wdate-time",
         "-D_FORTIFY_SOURCE=2",
         "-fPIC",
-    ] ,
+    ],
     extra_srcs = [],
     gems = [
         "@bundler_stripe//file",

--- a/third_party/ruby/ruby_3_3.BUILD
+++ b/third_party/ruby/ruby_3_3.BUILD
@@ -1,0 +1,72 @@
+# vim: ft=bzl sw=4 ts=4 et
+
+load("@com_stripe_ruby_typer//third_party/ruby:build-ruby.bzl", "ruby")
+
+ruby(
+    append_srcs = [],
+    configure_flags = [
+        "--enable-shared",
+        "--sysconfdir=/etc",
+        "--localstatedir=/var",
+        "--disable-maintainer-mode",
+        "--disable-dependency-tracking",
+        "--disable-install-doc",
+        "--without-git",
+    ] + select({
+        # Enforce that we don't need Ruby to build in release builds.
+        # (In non-release builds, we allow for an available system Ruby to
+        # speed up the build.)
+        "@com_stripe_ruby_typer//tools/config:release": ["--with-baseruby=no"],
+        "//conditions:default": [],
+    }) + select({
+        # Do not enable the JIT unless opted in.
+        "@com_stripe_ruby_typer//tools/config:jit_enabled": ["--enable-yjit=stats"],
+        "//conditions:default": ["--disable-jit-support"],
+    }),
+    copts = [
+        "-g",
+        "-fstack-protector-strong",
+        "-Wformat",
+        "-Werror=format-security",
+        # The Ruby build is very noisy without this flag.
+        "-Wno-compound-token-split-by-macro",
+    ] + select({
+        "@com_stripe_ruby_typer//tools/config:dbg": [],
+        "//conditions:default": ["-O2"],
+    }),
+    cppopts = [
+        "-Wdate-time",
+        "-D_FORTIFY_SOURCE=2",
+        "-fPIC",
+    ] + select({
+        # Don't include JIT statistics unless we're building JIT support
+        "@com_stripe_ruby_typer//tools/config:jit_enabled": ["-DYJIT_STATS=1"],
+        "//conditions:default": [],
+    }),
+    extra_srcs = [],
+    gems = [
+        "@bundler_stripe//file",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": [
+            "-Wl,-Bsymbolic-functions",
+            "-Wl,-z,relro",
+            "-Wl,-z,noexecstack",
+        ],
+        "@platforms//os:osx": [
+            "-mlinker-version=400",
+        ],
+        "//conditions:default": [],
+    }),
+    rubygems = "@rubygems_update_stripe//file",
+    deps = select({
+        "@platforms//os:osx": [
+            "@system_ssl_darwin//:ssl",
+            "@system_ssl_darwin//:crypto",
+        ],
+        "@platforms//os:linux": [
+            "@system_ssl_linux//:ssl",
+            "@system_ssl_linux//:crypto",
+        ],
+    }),
+)

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -9,8 +9,7 @@ def register_ruby_dependencies():
         sha256 = "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4",
         strip_prefix = "yaml-{}".format(libyaml_version),
         build_file = "@com_stripe_ruby_typer//third_party/ruby:libyaml.BUILD",
-    ) 
-
+    )
 
     http_archive(
         name = "rules_rust",
@@ -103,7 +102,7 @@ def register_ruby_dependencies():
         strip_prefix = "ruby-3.2.2",
         build_file = ruby_build,
     )
-    
+
     http_archive(
         name = "sorbet_ruby_3_3_preview",
         urls = _ruby_urls("3.3/ruby-3.3.0-preview1.tar.gz"),

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -31,6 +31,7 @@ def register_ruby_dependencies():
     )
 
     ruby_build = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD"
+    ruby_3_3_build = "@com_stripe_ruby_typer//third_party/ruby:ruby_3_3.BUILD"
     ruby_for_compiler_build = "@com_stripe_ruby_typer//third_party/ruby:ruby_for_compiler.BUILD"
 
     http_archive(
@@ -108,7 +109,7 @@ def register_ruby_dependencies():
         urls = _ruby_urls("3.3/ruby-3.3.0-preview1.tar.gz"),
         sha256 = "c3454a911779b8d747ab0ea87041030d002d533edacb2485fe558b7084da25ed",
         strip_prefix = "ruby-3.3.0-preview1",
-        build_file = ruby_build,
+        build_file = ruby_3_3_build,
     )
 
 def _rubygems_urls(gem):

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -9,7 +9,8 @@ def register_ruby_dependencies():
         sha256 = "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4",
         strip_prefix = "yaml-{}".format(libyaml_version),
         build_file = "@com_stripe_ruby_typer//third_party/ruby:libyaml.BUILD",
-    )
+    ) 
+
 
     http_archive(
         name = "rules_rust",
@@ -99,6 +100,14 @@ def register_ruby_dependencies():
         urls = _ruby_urls("3.2/ruby-3.2.2.tar.gz"),
         sha256 = "96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc",
         strip_prefix = "ruby-3.2.2",
+        build_file = ruby_build,
+    )
+    
+    http_archive(
+        name = "sorbet_ruby_3_3_preview",
+        urls = _ruby_urls("3.3/ruby-3.3.0-preview1.tar.gz"),
+        sha256 = "c3454a911779b8d747ab0ea87041030d002d533edacb2485fe558b7084da25ed",
+        strip_prefix = "ruby-3.3.0-preview1",
         build_file = ruby_build,
     )
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Trying to test out Ruby 3.3.0 on pay-server to take YJIT for a spin. Couple of things to note here:

1. This passes in `--without-git` : this is because otherwise the Ruby build always tries to clone bundled gems from GitHub
2. Under `lib/rubygems` lies a new YAML parser with limited functionality. `gemrc` files must now only use YAML syntax supported bby this parser.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
