### PR TITLE
Fix Ruby 3.3 build to use preview2 and YJIT in release mode

### DIFF
--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -105,9 +105,9 @@ def register_ruby_dependencies():
 
     http_archive(
         name = "sorbet_ruby_3_3_preview",
-        urls = _ruby_urls("3.3/ruby-3.3.0-preview1.tar.gz"),
-        sha256 = "c3454a911779b8d747ab0ea87041030d002d533edacb2485fe558b7084da25ed",
-        strip_prefix = "ruby-3.3.0-preview1",
+        urls = _ruby_urls("3.3/ruby-3.3.0-preview2.tar.gz"),
+        sha256 = "30ce8b0fe11b37b5ac088f5a5765744b935eac45bb89a9e381731533144f5991",
+        strip_prefix = "ruby-3.3.0-preview2",
         build_file = ruby_3_3_build,
     )
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
My mistake on the previous PR. This puts us on the latest tag'd ruby master, and builds YJIT in release mode.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
