### PR TITLE
Hide untyped argument errors if method accepts T.anything

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -294,7 +294,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
             //     TypeErrorDiagnostics::explainUntyped(gs, e, what, expectedType, argSym.loc, originForUninitialized);
             //     return e.build();
             // }
-        } else if (argTpe.type.isUntyped()) {
+        } else if (argTpe.type.isUntyped() && expectedType != Types::top()) {
             auto what = core::errors::Infer::errorClassForUntyped(gs, argLoc.file(), argTpe.type);
             if (auto e = gs.beginError(argLoc, what)) {
                 e.setHeader("Argument passed to parameter `{}` is `{}`", argSym.argumentName(gs), "T.untyped");

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -164,9 +164,8 @@ class Module < Object
   # instance of one of *mod*'s descendants. Of limited use for modules, but can
   # be used in `case` statements to classify objects by class.
   sig do
-    type_parameters(:U)
-    .params(
-        other: T.type_parameter(:U),
+    params(
+        other: T.anything
     )
     .returns(T::Boolean)
   end

--- a/test/testdata/infer/strong_rescue.rb
+++ b/test/testdata/infer/strong_rescue.rb
@@ -11,7 +11,6 @@ def example1
   rescue TypeError => e
 # ^^^^^^ error: Conditional branch on `T.untyped`
 # ^^^^^^ error: Conditional branch on `T.untyped`
-    #    ^^^^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
     T.reveal_type(e) # error: `TypeError`
   else
   ensure
@@ -24,7 +23,6 @@ def example2
   rescue; puts("")
 # ^^^^^^ error: Conditional branch on `T.untyped`
 # ^^^^^^ error: Conditional branch on `T.untyped`
-# ^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
   ensure
   end
 end
@@ -35,7 +33,6 @@ def example3
   rescue => e; T.reveal_type(e)
 # ^^^^^^ error: Conditional branch on `T.untyped`
 # ^^^^^^ error: Conditional branch on `T.untyped`
-    #       ^ error: Argument passed to parameter `other` is `T.untyped`
     #          ^^^^^^^^^^^^^^^^ error: `StandardError`
   ensure
   end
@@ -48,7 +45,6 @@ def example4
   rescue; puts("")
 # ^^^^^^ error: Conditional branch on `T.untyped`
 # ^^^^^^ error: Conditional branch on `T.untyped`
-# ^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
   ensure
   end
 end
@@ -59,7 +55,6 @@ def example5
   rescue Exception => e
 # ^^^^^^ error: Conditional branch on `T.untyped`
 # ^^^^^^ error: Conditional branch on `T.untyped`
-    #    ^^^^^^^^^ error: Argument passed to parameter `other` is `T.untyped`
     T.reveal_type(e) # error: `Exception`
   else
   ensure

--- a/test/testdata/infer/strong_top.rb
+++ b/test/testdata/infer/strong_top.rb
@@ -1,0 +1,4 @@
+# typed: strong
+
+x = T.unsafe(nil)
+Integer.===(x)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's no use in reporting this as a usage of untyped that needs to be fixed,
because the method says that it's okay to be given anything.

This is most pressing for things like

```ruby
case x
when A
  # do something
end
```

A counterargument to this feature would be that the user actually would like to
see that, because if there were better types, the condition would be dead.

But this causes two problems:

- Sorbet uses `A.===(x)` to update its knowledge of the type of variables in
  `rescue` handling.
- We already allow doing `T.let(x, A)` as a way to hide the check. But that only
  works if you're sure of the type, because if you're wrong, it will raise. At
  least with the `case`, you'll still be forced to handle the `else` case
  (usually).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.