### PR TITLE
Support "Find all implementations" on overridable

### DIFF
--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -47,7 +47,7 @@ const MethodImplementationResults findMethodImplementations(const core::GlobalSt
     return res;
 }
 
-core::MethodRef findOverridedMethod(const core::GlobalState &gs, const core::MethodRef method) {
+core::MethodRef findOverriddenMethod(const core::GlobalState &gs, const core::MethodRef method) {
     auto ownerClass = method.data(gs)->owner;
 
     for (auto mixin : ownerClass.data(gs)->mixins()) {
@@ -83,11 +83,11 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
     if (auto def = queryResponse->isMethodDef()) {
         // User called "Go to Implementation" from the abstract function definition
         auto method = def->symbol;
-        core::MethodRef overridedMethod = method;
+        core::MethodRef overriddenMethod = method;
         if (method.data(gs)->flags.isOverride) {
-            overridedMethod = findOverridedMethod(gs, method);
+            overriddenMethod = findOverriddenMethod(gs, method);
         }
-        auto locationsOrError = findMethodImplementations(gs, overridedMethod);
+        auto locationsOrError = findMethodImplementations(gs, overriddenMethod);
 
         if (locationsOrError.error != nullptr) {
             response->error = move(locationsOrError.error);
@@ -124,12 +124,12 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
         }
 
         auto calledMethod = mainResponse.method;
-        auto overridedMethod = calledMethod;
+        auto overriddenMethod = calledMethod;
         if (calledMethod.data(gs)->flags.isOverride) {
-            overridedMethod = findOverridedMethod(gs, overridedMethod);
+            overriddenMethod = findOverriddenMethod(gs, overriddenMethod);
         }
 
-        auto locationsOrError = findMethodImplementations(gs, overridedMethod);
+        auto locationsOrError = findMethodImplementations(gs, overriddenMethod);
 
         if (locationsOrError.error != nullptr) {
             response->error = move(locationsOrError.error);

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -27,7 +27,8 @@ unique_ptr<ResponseError> makeInvalidRequestError(core::SymbolRef symbol, const 
 
 const MethodImplementationResults findMethodImplementations(const core::GlobalState &gs, core::MethodRef method) {
     MethodImplementationResults res;
-    if (!method.data(gs)->flags.isAbstract) {
+    auto flags = method.data(gs)->flags;
+    if (!flags.isAbstract && !flags.isOverridable) {
         res.error = makeInvalidRequestError(method, gs);
         return res;
     }

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -82,13 +82,7 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
     auto queryResponse = move(queryResult.responses[0]);
     if (auto def = queryResponse->isMethodDef()) {
         // User called "Go to Implementation" from the abstract function definition
-        core::SymbolRef maybeMethod = def->symbol;
-        if (!maybeMethod.isMethod()) {
-            response->error = makeInvalidRequestError(maybeMethod, gs);
-            return response;
-        }
-
-        auto method = maybeMethod.asMethodRef();
+        auto method = def->symbol;
         core::MethodRef overridedMethod = method;
         if (method.data(gs)->flags.isOverride) {
             overridedMethod = findOverridedMethod(gs, method);

--- a/test/testdata/lsp/find_implementation_overridable.rb
+++ b/test/testdata/lsp/find_implementation_overridable.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class Parent
+  extend T::Sig
+
+  sig {overridable.void}
+  def foo; end
+  #   ^ find-implementation: foo
+end
+
+class Child < Parent
+  sig {override.void}
+  def foo; end
+  #   ^ implementation: fo
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

No real reason to reject this.

Honestly, we could simply allow you to find all "implementations" of any method,
there's nothing in the code that requires it. But for now let's just keep it at
`overridable` and `abstract` methods only.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.