### PR TITLE
Copy failing compiler exp files to Artifacts

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -42,7 +42,9 @@ steps:
 
   - label: ":linux: test-compiler.sh"
     command: .buildkite/test-compiler.sh
-    artifact_paths: _out_/profile.json
+    artifact_paths:
+      - _out_/profile.json
+      - _out_/**/*.ll
     <<: *elastic
 
   - label: ":linux: test-vscode-extension.sh"

--- a/.buildkite/test-compiler.sh
+++ b/.buildkite/test-compiler.sh
@@ -76,6 +76,15 @@ if [ "$err" -ne 0 ]; then
   echo '  -c opt --config=forcedebug' >> "$failing_tests"
   echo '```' >> "$failing_tests"
 
+  # Lines look like "[ .. ] Actual LLVM output: test/testdata/compiler/intrinsics/t_must.sorbet.build/test/testdata/compiler/intrinsics/t_must.rb.opt.ll"
+  { ./bazel test --test_summary=terse --test_output=errors "${test_args[@]}" || true ; } | \
+    grep --only-matching 'Actual LLVM output: .*\.ll' | \
+    sed -e 's@.*Actual LLVM output: @bazel-out/k8-opt/bin/@' | \
+    xargs cp --target-directory=_out_
+
+  echo >> "$failing_tests"
+  echo 'If there are expectation file changes, you can find them in the Artifacts tab of the build' >> "$failing_tests"
+
   buildkite-agent annotate --context "test-static-sanitized.sh" --style error --append < "$failing_tests"
 
   exit "$err"

--- a/test/validate_exp.sh
+++ b/test/validate_exp.sh
@@ -102,6 +102,8 @@ for ext in "${exts[@]}"; do
         if grep "exists only in" "$diff_out" > /dev/null ; then
           cat "$diff_out"
           info "If this was an expected difference, you need to run tools/scripts/update_compiler_exp.sh"
+          info "(or in CI: you can find the new LLVM IR in the Artifacts tab)"
+          info "Actual LLVM output: $build_dir/$actual"
           something_failed "$(basename "$exp")"
         else
           if [ -n "${expected_failure}" ]; then
@@ -118,6 +120,8 @@ for ext in "${exts[@]}"; do
       else
         cat "$diff_out"
         info "If this was an expected difference, you need to run tools/scripts/update_compiler_exp.sh"
+        info "(or in CI: you can find the new LLVM IR in the Artifacts tab)"
+        info "Actual LLVM output: $build_dir/$actual"
         something_failed "$(basename "$exp")"
       fi
     fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes it easier to deal with Sorbet Compiler failure without having
to build the compiler locally.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Based on top of another change, where I had a failing compiler exp test:

<https://buildkite.com/sorbet/sorbet/builds/28922#018ad8fa-5132-4a70-bb49-75585645a129>