### PR TITLE
Add signatures for GC.[measure_]total_time (Ruby 3.1+)

### DIFF
--- a/rbi/core/gc.rbi
+++ b/rbi/core/gc.rbi
@@ -215,26 +215,17 @@ module GC
   # consistency if RGenGC is supported.
   def self.verify_internal_consistency; end
 
-  # call-seq:
-  #    GC.measure_total_time = true/false
-  #
   # Enable to measure GC time.
-  # You can get the result with <tt>GC.stat(:time)</tt>.
+  # You can get the result with `GC.stat(:time)`.
   # Note that GC time measurement can cause some performance overhead.
   sig {params(flag: T::Boolean).void}
   def self.measure_total_time=(flag); end
 
-  # call-seq:
-  #    GC.measure_total_time -> true/false
-  #
-  # Return measure_total_time flag (default: +true+).
+  # Return measure_total_time flag (default: `true`).
   # Note that measurement can affect the application performance.
   sig {returns(T::Boolean)}
   def self.measure_total_time; end
 
-  # call-seq:
-  #    GC.total_time -> int
-  #
   # Return measured GC total time in nano seconds.
   sig {returns(Integer)}
   def self.total_time; end

--- a/rbi/core/gc.rbi
+++ b/rbi/core/gc.rbi
@@ -214,6 +214,30 @@ module GC
   # This method is implementation specific. Now this method checks generational
   # consistency if RGenGC is supported.
   def self.verify_internal_consistency; end
+
+  # call-seq:
+  #    GC.measure_total_time = true/false
+  #
+  # Enable to measure GC time.
+  # You can get the result with <tt>GC.stat(:time)</tt>.
+  # Note that GC time measurement can cause some performance overhead.
+  sig {params(flag: T::Boolean).void}
+  def self.measure_total_time=(flag); end
+
+  # call-seq:
+  #    GC.measure_total_time -> true/false
+  #
+  # Return measure_total_time flag (default: +true+).
+  # Note that measurement can affect the application performance.
+  sig {returns(T::Boolean)}
+  def self.measure_total_time; end
+
+  # call-seq:
+  #    GC.total_time -> int
+  #
+  # Return measured GC total time in nano seconds.
+  sig {returns(Integer)}
+  def self.total_time; end
 end
 
 # The [`GC`](https://docs.ruby-lang.org/en/2.7.0/GC.html) profiler provides


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
These methods were added in Ruby 3.1.

### Motivation
Match https://github.com/ruby/ruby/blob/957bb7cb81995f26c671afce0ee50a5c660e540e/gc.rb#L270-L302
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
