### PR TITLE
Allow simple type aliases in generic classes

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -27,7 +27,7 @@ constexpr ErrorClass AbstractMethodOutsideAbstract{5021, StrictLevel::False};
 constexpr ErrorClass ConcreteMethodInInterface{5022, StrictLevel::False};
 constexpr ErrorClass BadAbstractMethod{5023, StrictLevel::False};
 constexpr ErrorClass RecursiveTypeAlias{5024, StrictLevel::False};
-constexpr ErrorClass TypeAliasInGenericClass{5025, StrictLevel::False};
+// constexpr ErrorClass TypeAliasInGenericClass{5025, StrictLevel::False};
 constexpr ErrorClass BadStdlibGeneric{5026, StrictLevel::False};
 constexpr ErrorClass OutOfOrderConstantAccess{5027, StrictLevel::False};
 
@@ -80,6 +80,7 @@ constexpr ErrorClass BindNonBlockParameter{5071, StrictLevel::False};
 constexpr ErrorClass TypeMemberScopeMismatch{5072, StrictLevel::False};
 constexpr ErrorClass AbstractClassInstantiated{5073, StrictLevel::True};
 constexpr ErrorClass HasAttachedClassIncluded{5074, StrictLevel::False};
+constexpr ErrorClass TypeAliasToTypeMember{5075, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2165,11 +2165,11 @@ class ResolveTypeMembersAndFieldsWalk {
         }
         auto allowSelfType = true;
         auto allowRebind = false;
-        auto allowTypeMember = true;
+        auto typeMember = TypeSyntaxArgs::TypeMember::Allowed;
         auto allowUnspecifiedTypeParameter = !lastTry;
         auto ctx = core::Context(gs, job.owner.enclosingClass(gs), job.file);
         auto type = TypeSyntax::getResultType(ctx, job.cast->typeExpr, emptySig,
-                                              TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember,
+                                              TypeSyntaxArgs{allowSelfType, allowRebind, typeMember,
                                                              allowUnspecifiedTypeParameter, core::Symbols::noSymbol()});
         if (type == core::Types::todo()) {
             return false;
@@ -2397,12 +2397,11 @@ class ResolveTypeMembersAndFieldsWalk {
                     ParsedSig emptySig;
                     auto allowSelfType = true;
                     auto allowRebind = false;
-                    auto allowTypeMember = false;
+                    auto typeMember = TypeSyntaxArgs::TypeMember::BannedInTypeMember;
                     auto allowUnspecifiedTypeParameter = false;
-                    core::TypePtr resTy =
-                        TypeSyntax::getResultType(ctx, value, emptySig,
-                                                  TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember,
-                                                                 allowUnspecifiedTypeParameter, lhs});
+                    core::TypePtr resTy = TypeSyntax::getResultType(
+                        ctx, value, emptySig,
+                        TypeSyntaxArgs{allowSelfType, allowRebind, typeMember, allowUnspecifiedTypeParameter, lhs});
 
                     switch (key->asSymbol().rawId()) {
                         case core::Names::fixed().rawId():
@@ -2536,10 +2535,10 @@ class ResolveTypeMembersAndFieldsWalk {
 
         auto allowSelfType = true;
         auto allowRebind = false;
-        auto allowTypeMember = true;
+        auto typeMember = TypeSyntaxArgs::TypeMember::Allowed;
         auto allowUnspecifiedTypeParameter = false;
         lhs.setResultType(ctx, TypeSyntax::getResultType(ctx, block->body, ParsedSig{},
-                                                         TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember,
+                                                         TypeSyntaxArgs{allowSelfType, allowRebind, typeMember,
                                                                         allowUnspecifiedTypeParameter, lhs}));
     }
 

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -31,7 +31,7 @@ ParsedSig TypeSyntax::parseSigTop(core::Context ctx, const ast::Send &sigSend, c
     auto args = TypeSyntaxArgs{
         /* allowSelfType */ true,
         /* allowRebind */ false,
-        /* allowTypeMember */ true,
+        TypeSyntaxArgs::TypeMember::Allowed,
         /* allowUnspecifiedTypeParameter */ false,
         blameSymbol,
     };
@@ -1124,7 +1124,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
 
             bool isTypeTemplate = symOwner->isSingletonClass(ctx);
 
-            if (args.allowTypeMember) {
+            if (args.typeMember == TypeSyntaxArgs::TypeMember::Allowed) {
                 bool ctxIsSingleton = ctxOwnerData->isSingletonClass(ctx);
 
                 // Check if we're processing a type within the class that

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -64,25 +64,29 @@ struct ParsedSig {
 struct TypeSyntaxArgs {
     const bool allowSelfType;
     const bool allowRebind;
-    const bool allowTypeMember;
+    enum class TypeMember {
+        Allowed,
+        BannedInTypeMember,
+    };
+    const TypeMember typeMember;
     const bool allowUnspecifiedTypeParameter;
     const core::SymbolRef untypedBlame;
 
-    TypeSyntaxArgs(bool allowSelfType, bool allowRebind, bool allowTypeMember, bool allowUnspecifiedTypeParameter,
+    TypeSyntaxArgs(bool allowSelfType, bool allowRebind, TypeMember typeMember, bool allowUnspecifiedTypeParameter,
                    core::SymbolRef untypedBlame)
-        : allowSelfType(allowSelfType), allowRebind(allowRebind), allowTypeMember(allowTypeMember),
+        : allowSelfType(allowSelfType), allowRebind(allowRebind), typeMember(typeMember),
           allowUnspecifiedTypeParameter(allowUnspecifiedTypeParameter), untypedBlame(untypedBlame) {}
 
     TypeSyntaxArgs withoutRebind() const {
-        return TypeSyntaxArgs{allowSelfType, false, allowTypeMember, allowUnspecifiedTypeParameter, untypedBlame};
+        return TypeSyntaxArgs{allowSelfType, false, typeMember, allowUnspecifiedTypeParameter, untypedBlame};
     }
 
     TypeSyntaxArgs withRebind() const {
-        return TypeSyntaxArgs{allowSelfType, true, allowTypeMember, allowUnspecifiedTypeParameter, untypedBlame};
+        return TypeSyntaxArgs{allowSelfType, true, typeMember, allowUnspecifiedTypeParameter, untypedBlame};
     }
 
     TypeSyntaxArgs withoutSelfType() const {
-        return TypeSyntaxArgs{false, allowRebind, allowTypeMember, allowUnspecifiedTypeParameter, untypedBlame};
+        return TypeSyntaxArgs{false, allowRebind, typeMember, allowUnspecifiedTypeParameter, untypedBlame};
     }
 };
 

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -67,6 +67,7 @@ struct TypeSyntaxArgs {
     enum class TypeMember {
         Allowed,
         BannedInTypeMember,
+        BannedInTypeAlias,
     };
     const TypeMember typeMember;
     const bool allowUnspecifiedTypeParameter;

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -62,11 +62,16 @@ struct ParsedSig {
 };
 
 struct TypeSyntaxArgs {
-    const bool allowSelfType = false;
-    const bool allowRebind = false;
-    const bool allowTypeMember = false;
-    const bool allowUnspecifiedTypeParameter = false;
+    const bool allowSelfType;
+    const bool allowRebind;
+    const bool allowTypeMember;
+    const bool allowUnspecifiedTypeParameter;
     const core::SymbolRef untypedBlame;
+
+    TypeSyntaxArgs(bool allowSelfType, bool allowRebind, bool allowTypeMember, bool allowUnspecifiedTypeParameter,
+                   core::SymbolRef untypedBlame)
+        : allowSelfType(allowSelfType), allowRebind(allowRebind), allowTypeMember(allowTypeMember),
+          allowUnspecifiedTypeParameter(allowUnspecifiedTypeParameter), untypedBlame(untypedBlame) {}
 
     TypeSyntaxArgs withoutRebind() const {
         return TypeSyntaxArgs{allowSelfType, false, allowTypeMember, allowUnspecifiedTypeParameter, untypedBlame};
@@ -78,10 +83,6 @@ struct TypeSyntaxArgs {
 
     TypeSyntaxArgs withoutSelfType() const {
         return TypeSyntaxArgs{false, allowRebind, allowTypeMember, allowUnspecifiedTypeParameter, untypedBlame};
-    }
-
-    TypeSyntaxArgs withoutTypeMember() const {
-        return TypeSyntaxArgs{allowSelfType, allowRebind, false, allowUnspecifiedTypeParameter, untypedBlame};
     }
 };
 

--- a/test/testdata/lsp/fast_path/type_alias_in_generic_class__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/type_alias_in_generic_class__1.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
 
 class Box
-  MyInteger = T.type_alias {String} # error: Type aliases are not allowed in generic classes
+  MyInteger = T.type_alias {String}
 end

--- a/test/testdata/lsp/fast_path/type_alias_in_generic_class__1.rb
+++ b/test/testdata/lsp/fast_path/type_alias_in_generic_class__1.rb
@@ -1,5 +1,5 @@
 # typed: true
 
 class Box
-  MyInteger = T.type_alias {Integer} # error: Type aliases are not allowed in generic classes
+  MyInteger = T.type_alias {Integer}
 end

--- a/test/testdata/lsp/fast_path/type_alias_in_generic_class__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/type_alias_in_generic_class__2.1.rbupdate
@@ -2,6 +2,12 @@
 # exclude-from-file-update: true
 
 class Box
+  extend T::Sig
   extend T::Generic
   Elem = type_member
+
+  sig { params(x: MyInteger).void }
+  def example(x)
+    T.reveal_type(x) # error: `String`
+  end
 end

--- a/test/testdata/lsp/fast_path/type_alias_in_generic_class__2.rb
+++ b/test/testdata/lsp/fast_path/type_alias_in_generic_class__2.rb
@@ -2,6 +2,12 @@
 # spacer for exclude-from-file-update
 
 class Box
+  extend T::Sig
   extend T::Generic
   Elem = type_member
+
+  sig { params(x: MyInteger).void }
+  def example(x)
+    T.reveal_type(x) # error: `Integer`
+  end
 end

--- a/test/testdata/resolver/bad_alias.rb
+++ b/test/testdata/resolver/bad_alias.rb
@@ -3,7 +3,7 @@ class A
   extend T::Generic
   B = type_member
 
-  S = T.type_alias {Integer} # error: Type aliases are not allowed in generic classes
+  S = T.type_alias {Integer}
 end
 
 

--- a/test/testdata/resolver/generic_type_alias.rb
+++ b/test/testdata/resolver/generic_type_alias.rb
@@ -1,0 +1,67 @@
+# typed: true
+class Module; include T::Sig; end
+
+class Box
+  extend T::Generic
+  Elem = type_member
+
+  sig { params(val: Elem).void }
+  def initialize(val); @val = val; end
+
+  sig { returns(Elem) }
+  def val; @val; end
+end
+
+class ComplicatedBox < Box
+  ReturnType = T.type_alias do
+    T.any(Integer, String, Float, Symbol) # error: Type aliases are not allowed in generic classes
+  end
+  Elem = type_member { {fixed: ReturnType} }
+end
+
+sig { params(box: ComplicatedBox).returns(ComplicatedBox::ReturnType) }
+def example_good3(box)
+  T.reveal_type(box.val) # error: `T.untyped`
+  nil
+end
+
+class BoxBad
+  extend T::Generic
+  abstract!
+
+  Elem = type_member
+  MyElem = T.type_alias { Elem } # error: Type aliases are not allowed in generic classes
+  MyElem2 = T.type_alias { T.nilable(Elem) } # error: Type aliases are not allowed in generic classes
+
+  sig { abstract.returns(Elem) }
+  def returns_elem; end
+
+  sig { returns(MyElem) }
+  def returns_my_elem
+    T.let(returns_my_elem, Elem)
+    T.let(returns_my_elem, MyElem)
+    my_elem = returns_my_elem
+    T.reveal_type(my_elem) # error: `T.untyped`
+    nil
+  end
+end
+
+sig do
+  params(
+    x: BoxBad::Elem,
+    #  ^^^^^^^^^^^^ error: `type_member` type `BoxBad::Elem` used outside of the class definition
+    y: BoxBad::MyElem,
+    z: BoxBad::MyElem2
+  )
+    .void
+end
+def bad_box_example(
+  x,
+  y,
+  z
+)
+  T.reveal_type(x) # error: `T.untyped`
+  T.reveal_type(y) # error: `T.untyped`
+  T.reveal_type(z) # error: `T.untyped`
+end
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In the last week or two I've had multiple people ask me whether they could just
write something like `IntBox::Elem` in a signature outside of `IntBox` if `Elem`
is `fixed` in `IntBox`. The conversation usually goes like

- me: "just mention the fixed type in the sig--it's constant"
- them: "it's a huge type and I don't want to copy it all over the place"
- me: "define a type alias, put that in the `fixed` bound, and use the type
  alias everywhere. oh btw you have to define the type alias outside of your
  class"

We _definitely_ don't need to reject simple type aliases in generic classes. The
notes in the linked 5025 error docs don't apply to Sorbet's type aliases.

Asking "could we allow type members in type aliases" is an interesting question,
and I am not fully convinced yet that we can't, but we don't need to fully solve
that yet (can solve in the future), is not a solution to the immediate
motivation, and honestly I have a feeling that the real solution there will be
linked generic type pairs and/or type members bounded by type members.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.