### PR TITLE
Remove a disable-fast-path annotation

### DIFF
--- a/test/testdata/resolver/bad_alias.rb
+++ b/test/testdata/resolver/bad_alias.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 class A
   extend T::Generic
   B = type_member


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This test already passes on the fast path. Let's not regress that.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.