### PR TITLE
Add a test for type_alias + self_type

### DIFF
--- a/test/testdata/resolver/type_alias_self_type.rb
+++ b/test/testdata/resolver/type_alias_self_type.rb
@@ -1,0 +1,27 @@
+# typed: strict
+
+class Example
+  extend T::Sig
+
+  # This magically becomes "the selftype of wherever this type alias is used"
+  # instead of "the self type of `self` right here" (i.e., the singleton class)
+  # I'm not sure if this behavior is intentional or accidental, but it is what
+  # it is so now we have a test for it. At least we don't crash.
+  X = T.type_alias { T.self_type }
+
+  sig { returns(X) }
+  def example
+    self
+  end
+
+  sig { returns(X) }
+  def self.example_singleton
+    self
+  end
+end
+
+x = Example.new.example
+T.reveal_type(x) # error: `Example`
+
+y = Example.example_singleton
+T.reveal_type(y) # error: `T.class_of(Example)`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I checked for a test with

    comm -1 -2 <(rg -l 'type_alias' test | sort) <(rg -l 'self_type' test | sort)

There were two files that matched this regex, and neither of them were
using both `type_alias` and `self_type` at the same time.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.