### PR TITLE
serialize `LocOffsets` as `(start,len)` for better encoding

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1042,7 +1042,8 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
 
 void SerializerImpl::pickle(Pickler &p, LocOffsets loc) {
     p.putU4(loc.beginLoc);
-    p.putU4(loc.endLoc);
+    // The length of the loc likely encodes as a smaller varint.
+    p.putU4(loc.endLoc - loc.beginLoc);
 }
 
 void SerializerImpl::pickle(Pickler &p, Loc loc) {
@@ -1057,7 +1058,9 @@ Loc SerializerImpl::unpickleLoc(UnPickler &p) {
 }
 
 LocOffsets SerializerImpl::unpickleLocOffsets(UnPickler &p) {
-    return LocOffsets{p.getU4(), p.getU4()};
+    uint32_t start = p.getU4();
+    uint32_t length = p.getU4();
+    return LocOffsets{start, start + length};
 }
 
 vector<uint8_t> Serializer::store(const GlobalState &gs) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Encoding the length instead of the end means a smaller encoding for msgpack (see #7302); it should also mean a smaller encoding for the varint encoding used by Sorbet's serialization code.

And indeed, a freshly-written cache on Stripe's codebase is about 15% smaller with this change.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
