### PR TITLE
Reject all calls to abstract singleton class methods

### DIFF
--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -119,9 +119,9 @@ string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) 
 }
 
 Send::Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-           const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk,
+           const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, Flags flags,
            const shared_ptr<core::SendAndBlockLink> &link)
-    : flags(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
+    : flags(flags), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
       argLocs(std::move(argLocs)), link(move(link)) {
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
             args.size());

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -121,7 +121,7 @@ string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) 
 Send::Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
            const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk,
            const shared_ptr<core::SendAndBlockLink> &link)
-    : isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
+    : flags(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
       argLocs(std::move(argLocs)), link(move(link)) {
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
             args.size());

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -126,7 +126,7 @@ public:
     std::shared_ptr<core::SendAndBlockLink> link;
 
     Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-         const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk = false,
+         const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, Flags flags = Flags(),
          const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
 
     core::LocOffsets locWithoutBlock(core::LocOffsets bindLoc);

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -109,9 +109,11 @@ INSN(Send) : public Instruction {
 public:
     struct Flags {
         bool isPrivateOk : 1;
+        bool rejectAbstractMethodCall : 1;
         // In C++20 we can replace this with bit field initialzers
-        Flags() : isPrivateOk(false) {}
-        Flags(bool isPrivateOk) : isPrivateOk(isPrivateOk) {}
+        Flags() : isPrivateOk(false), rejectAbstractMethodCall(false) {}
+        Flags(bool isPrivateOk, bool rejectAbstractMethodCall)
+            : isPrivateOk(isPrivateOk), rejectAbstractMethodCall(rejectAbstractMethodCall) {}
     };
     CheckSize(Flags, 1, 1);
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -107,7 +107,15 @@ CheckSize(SolveConstraint, 24, 8);
 
 INSN(Send) : public Instruction {
 public:
-    bool isPrivateOk;
+    struct Flags {
+        bool isPrivateOk : 1;
+        // In C++20 we can replace this with bit field initialzers
+        Flags() : isPrivateOk(false) {}
+        Flags(bool isPrivateOk) : isPrivateOk(isPrivateOk) {}
+    };
+    CheckSize(Flags, 1, 1);
+
+    Flags flags;
     uint16_t numPosArgs;
     core::NameRef fun;
     VariableUseSite recv;

--- a/core/Types.h
+++ b/core/Types.h
@@ -970,6 +970,7 @@ struct DispatchArgs {
     // are cases where we call dispatchCall with no intention of showing the errors to the user. Producing those
     // unreported errors is expensive!
     bool suppressErrors;
+    bool rejectAbstractMethodCall;
     NameRef enclosingMethodForSuper;
 
     DispatchArgs(const DispatchArgs &) = delete;

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -52,6 +52,7 @@ constexpr ErrorClass IncorrectlyAssumedType{7045, StrictLevel::True};
 constexpr ErrorClass NonOverlappingEqual{7046, StrictLevel::True};
 constexpr ErrorClass UntypedValueInformation{7047, StrictLevel::True};
 constexpr ErrorClass UnknownSuperMethod{7048, StrictLevel::True};
+constexpr ErrorClass AbstractSingletonClassMethod{7049, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 
 ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file, const TypePtr &ptr);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1116,24 +1116,57 @@ Loc DispatchArgs::blockLoc(const GlobalState &gs) const {
 }
 
 DispatchArgs DispatchArgs::withSelfAndThisRef(const TypePtr &newSelfRef) const {
-    return DispatchArgs{name,        locs,           numPosArgs,
-                        args,        newSelfRef,     fullType,
-                        newSelfRef,  block,          originForUninitialized,
-                        isPrivateOk, suppressErrors, enclosingMethodForSuper};
+    return DispatchArgs{
+        name,
+        locs,
+        numPosArgs,
+        args,
+        newSelfRef,
+        fullType,
+        newSelfRef,
+        block,
+        originForUninitialized,
+        isPrivateOk,
+        suppressErrors,
+        rejectAbstractMethodCall,
+        enclosingMethodForSuper,
+    };
 }
 
 DispatchArgs DispatchArgs::withThisRef(const TypePtr &newThisRef) const {
-    return DispatchArgs{name,        locs,           numPosArgs,
-                        args,        selfType,       fullType,
-                        newThisRef,  block,          originForUninitialized,
-                        isPrivateOk, suppressErrors, enclosingMethodForSuper};
+    return DispatchArgs{
+        name,
+        locs,
+        numPosArgs,
+        args,
+        selfType,
+        fullType,
+        newThisRef,
+        block,
+        originForUninitialized,
+        isPrivateOk,
+        suppressErrors,
+        rejectAbstractMethodCall,
+        enclosingMethodForSuper,
+    };
 }
 
 DispatchArgs DispatchArgs::withErrorsSuppressed() const {
-    return DispatchArgs{name,        locs,     numPosArgs,
-                        args,        selfType, fullType,
-                        thisType,    block,    originForUninitialized,
-                        isPrivateOk, true,     enclosingMethodForSuper};
+    return DispatchArgs{
+        name,
+        locs,
+        numPosArgs,
+        args,
+        selfType,
+        fullType,
+        thisType,
+        block,
+        originForUninitialized,
+        isPrivateOk,
+        true,
+        rejectAbstractMethodCall,
+        enclosingMethodForSuper,
+    };
 }
 
 DispatchResult DispatchResult::merge(const GlobalState &gs, DispatchResult::Combinator kind, DispatchResult &&left,

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -1104,39 +1104,6 @@ public:
 
         validateOverriding(ctx, methodDef.symbol);
     }
-
-    void postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
-        auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
-        if (send.fun != core::Names::new_()) {
-            return;
-        }
-
-        auto *id = ast::cast_tree<ast::ConstantLit>(send.recv);
-        if (id == nullptr || !id->symbol.exists() || !id->symbol.isClassOrModule()) {
-            return;
-        }
-
-        auto symbol = id->symbol.asClassOrModuleRef().data(ctx);
-        if (!symbol->flags.isAbstract) {
-            return;
-        }
-
-        auto singletonClass = symbol->lookupSingletonClass(ctx.state);
-        if (!singletonClass.exists()) {
-            return;
-        }
-
-        auto method_new = singletonClass.data(ctx)->findMethodTransitive(ctx.state, core::Names::new_());
-        // If the .new method we find is owned by Class, that means
-        // there was no user defined .new method, which warrants an error.
-        if (method_new.data(ctx)->owner == core::Symbols::Class()) {
-            if (auto e = ctx.beginError(send.loc, core::errors::Resolver::AbstractClassInstantiated)) {
-                auto symbolName = id->symbol.show(ctx);
-                e.setHeader("Attempt to instantiate abstract class `{}`", symbolName);
-                e.addErrorLine(id->symbol.loc(ctx), "`{}` defined here", symbolName);
-            }
-        }
-    }
 };
 } // namespace
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -87,7 +87,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
                                     snd->recv.type,
                                     snd->link,
                                     originForUninitialized,
-                                    snd->isPrivateOk,
+                                    snd->flags.isPrivateOk,
                                     suppressErrors,
                                     currentMethodName};
     auto dispatchInfo = snd->recv.type.dispatchCall(ctx, dispatchArgs);

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -89,6 +89,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
                                     originForUninitialized,
                                     snd->flags.isPrivateOk,
                                     suppressErrors,
+                                    snd->flags.rejectAbstractMethodCall,
                                     currentMethodName};
     auto dispatchInfo = snd->recv.type.dispatchCall(ctx, dispatchArgs);
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1002,7 +1002,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                                 send.numPosArgs, args,
                                                 recvType.type,   recvType,
                                                 recvType.type,   send.link,
-                                                ownerLoc,        send.isPrivateOk,
+                                                ownerLoc,        send.flags.isPrivateOk,
                                                 suppressErrors,  inWhat.symbol.data(ctx)->name};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
 
@@ -1138,9 +1138,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         }
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx,
-                        core::lsp::SendResponse(retainedResult, send.argLocs, fun, ctx.owner.asMethodRef(),
-                                                send.isPrivateOk, ctx.file, bind.loc, send.receiverLoc, send.funLoc));
+                        ctx, core::lsp::SendResponse(retainedResult, send.argLocs, fun, ctx.owner.asMethodRef(),
+                                                     send.flags.isPrivateOk, ctx.file, bind.loc, send.receiverLoc,
+                                                     send.funLoc));
                 }
                 if (send.link) {
                     send.link->result = move(retainedResult);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -945,7 +945,8 @@ core::TypePtr flatmapHack(core::Context ctx, const core::TypePtr &receiver, cons
     };
 
     core::DispatchArgs dispatchArgs{core::Names::flatten(), locs,    1,   args, recvType.type, recvType,
-                                    recvType.type,          nullptr, loc, true, false,         currentMethodName};
+                                    recvType.type,          nullptr, loc, true, false,         false,
+                                    currentMethodName};
 
     auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
     if (dispatched.main.errors.empty()) {
@@ -998,12 +999,19 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 // This is the main place where we type check a method, so we default by assuming
                 // that we want to report all errors (supressing nothing).
                 auto suppressErrors = false;
-                core::DispatchArgs dispatchArgs{send.fun,        locs,
-                                                send.numPosArgs, args,
-                                                recvType.type,   recvType,
-                                                recvType.type,   send.link,
-                                                ownerLoc,        send.flags.isPrivateOk,
-                                                suppressErrors,  inWhat.symbol.data(ctx)->name};
+                core::DispatchArgs dispatchArgs{send.fun,
+                                                locs,
+                                                send.numPosArgs,
+                                                args,
+                                                recvType.type,
+                                                recvType,
+                                                recvType.type,
+                                                send.link,
+                                                ownerLoc,
+                                                send.flags.isPrivateOk,
+                                                suppressErrors,
+                                                send.flags.rejectAbstractMethodCall,
+                                                inWhat.symbol.data(ctx)->name};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
 
                 auto it = &dispatched;
@@ -1384,6 +1392,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     const auto numPosArgs = 1;
                     const auto suppressErrors = true;
                     const auto isPrivateOk = true;
+                    const auto rejectAbstractMethodCall = false;
                     const std::shared_ptr<const core::SendAndBlockLink> block = nullptr;
                     core::DispatchArgs dispatchArgs{core::Names::squareBrackets(),
                                                     locs,
@@ -1396,6 +1405,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                                     ctx.locAt(bind.loc),
                                                     isPrivateOk,
                                                     suppressErrors,
+                                                    rejectAbstractMethodCall,
                                                     inWhat.symbol.data(ctx)->name};
                     auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
                     tp.type = dispatched.returnType;

--- a/test/testdata/resolver/abstract_initialization.rb
+++ b/test/testdata/resolver/abstract_initialization.rb
@@ -69,3 +69,22 @@ class CommonRubyPattern
     a.new
   end
 end
+
+class AbstractSingletonClassMethod
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig { abstract.void }
+  def self.example
+  end
+
+  sig { void }
+  def self.main
+    self.example
+  end
+end
+
+AbstractSingletonClassMethod.example
+#                            ^^^^^^^ error: Call to abstract method `example` on singleton class `T.class_of(AbstractSingletonClassMethod)`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Before, we only had an error for something like `ConstantLit.new` if
`ConstantLit` were an abstract class.

It turns out, we can expand this to all methods, not just `new`.

I've also taken the opportunity to move this logic into `dispatchCallSymbol`, so
that we don't need to partially reimplement method dispatch in validator.cc by
way of `findMethodTransitive`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.