### PR TITLE
Add cases for T::Class in updateKnowledge for `===`/`is_a?`

### DIFF
--- a/test/testdata/infer/generics/validator.rb
+++ b/test/testdata/infer/generics/validator.rb
@@ -1,0 +1,138 @@
+# typed: strict
+class Module; include T::Sig; end
+
+sig { params(x: T.anything).void }
+def example(x)
+  int_validator = Validator::Cls.make(Integer)
+  res = int_validator.parse!(x)
+  T.reveal_type(res) # error: `Integer`
+
+  str_validator = Validator::Cls.make(String)
+  res = str_validator.parse!(x)
+  T.reveal_type(res) # error: `String`
+
+  res = Validator::Any.make(int_validator, str_validator).parse!(x)
+  T.reveal_type(res) # error: `T.any(Integer, String)`
+end
+
+
+module Validator
+  extend T::Generic
+  abstract!
+
+  Type = type_member
+
+  class ParseResult < StandardError
+    sig { params(msg: T.nilable(String)).void }
+    def initialize(msg = nil)
+      super
+    end
+  end
+
+  sig do
+    abstract
+      .params(x: T.anything)
+      .returns(T.any(Type, ParseResult))
+  end
+  def try_parse(x); end
+
+  sig(:final) {params(x: T.anything).returns(Type)}
+  def parse!(x)
+    case (res = self.try_parse(x))
+    when ParseResult then Kernel.raise(res)
+    else res
+    end
+  end
+
+  class Cls
+    extend T::Generic
+    include Validator
+
+    Type = type_member
+
+    # TODO(jez) T::Module?
+    sig { params(klass: T::Class[Type]).void }
+    def initialize(klass)
+      @klass = klass
+    end
+
+    private_class_method :new
+    sig do
+      type_parameters(:Type)
+        .params(klass: T::Class[T.type_parameter(:Type)])
+        .returns(T.all(T.attached_class, Cls[T.type_parameter(:Type)]))
+    end
+    def self.make(klass)
+      self.new(klass)
+    end
+
+    sig { override.params(x: T.anything).returns(T.any(Type, ParseResult)) }
+    def try_parse(x)
+      case x
+      when @klass
+        T.reveal_type(x) # error: `T.anything`
+        return x # error: Expected `T.any(Validator::ParseResult, Validator::Cls::Type)` but found `T.anything` for method result type
+      else
+        # In real code, might not want to print arbitrary value, might just
+        # want to print the class (PII, etc.).
+        return ParseResult.new("#{x} is not an instance of #{@klass}")
+      end
+    end
+  end
+
+  class Any
+    extend T::Generic
+    include Validator
+
+    # TODO(jez) Would like to be able to use fixed here
+    TypeReal = type_member { {fixed: T.any(Left, Right)} }
+    #                                      ^^^^ error: is not allowed in this context
+    #                                            ^^^^^ error: is not allowed in this context
+    Type = type_member
+    Left = type_member
+    Right = type_member
+
+    sig { params(left: Validator[Left], right: Validator[Right]).void }
+    def initialize(left, right)
+      @left = left
+      @right = right
+    end
+
+    private_class_method :new
+    sig do
+      type_parameters(:Left, :Right)
+        .params(
+          left: Validator[T.type_parameter(:Left)],
+          right: Validator[T.type_parameter(:Right)]
+        )
+        .returns(T.all(
+          T.attached_class,
+          Any[
+            T.any(T.type_parameter(:Left), T.type_parameter(:Right)),
+            T.type_parameter(:Left),
+            T.type_parameter(:Right)
+          ]
+        ))
+    end
+    def self.make(left, right)
+      self.new(left, right)
+    end
+
+    sig { override.params(x: T.anything).returns(T.any(Type, ParseResult)) }
+    def try_parse(x)
+      # TODO(jez) Would be able to avoid `T.cast` here if we could fix `Type`
+      # to `T.any(Left, Right)`
+      case (res = @left.try_parse(x))
+      when ParseResult
+        res = @right.try_parse(x)
+        T.reveal_type(res) # error: `T.any(Validator::ParseResult, Validator::Any::Right)`
+        return T.cast(res, T.any(Type, ParseResult))
+      else
+        T.reveal_type(res) # error: `Validator::Any::Left`
+        return T.cast(res, Type)
+      end
+    end
+  end
+end
+
+

--- a/test/testdata/infer/generics/validator.rb
+++ b/test/testdata/infer/generics/validator.rb
@@ -70,8 +70,8 @@ module Validator
     def try_parse(x)
       case x
       when @klass
-        T.reveal_type(x) # error: `T.anything`
-        return x # error: Expected `T.any(Validator::ParseResult, Validator::Cls::Type)` but found `T.anything` for method result type
+        T.reveal_type(x) # error: `Validator::Cls::Type`
+        return x
       else
         # In real code, might not want to print arbitrary value, might just
         # want to print the class (PII, etc.).

--- a/test/testdata/infer/t_class_triple_eq.rb
+++ b/test/testdata/infer/t_class_triple_eq.rb
@@ -1,0 +1,115 @@
+# typed: true
+extend T::Sig
+
+class Parent
+end
+
+class Child < Parent
+end
+
+sig do
+  params(
+    obj: Parent,
+    class_of: T.class_of(Parent),
+    t_class: T::Class[Parent]
+  )
+    .void
+end
+def example1(obj, class_of, t_class)
+  if obj.is_a?(class_of)
+    T.reveal_type(obj) # error: `Parent`
+  else
+    # Will be reached if `class_of` is `Child`
+    T.reveal_type(obj) # error: This code is unreachable
+  end
+
+  if obj.is_a?(t_class)
+    T.reveal_type(obj) # error: `Parent`
+  else
+    T.reveal_type(obj) # error: `Parent`
+  end
+
+  if class_of.===(obj)
+    T.reveal_type(obj) # error: `Parent`
+  else
+    # Will be reached if `class_of` is `Child`
+    T.reveal_type(obj) # error: This code is unreachable
+  end
+
+  if t_class.===(obj)
+    T.reveal_type(obj) # error: `Parent`
+  else
+    T.reveal_type(obj) # error: `Parent`
+  end
+end
+
+example1(Parent.new, Child, Child)
+
+
+sig do
+  params(
+    obj: T.any(Integer, String),
+    class_of: T.any(T.class_of(Integer), T.class_of(String)),
+    t_class: T::Class[T.any(Integer, String)]
+  )
+    .void
+end
+def example2(obj, class_of, t_class)
+  if obj.is_a?(class_of)
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  else
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  end
+
+  if obj.is_a?(t_class)
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  else
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  end
+
+  if class_of.===(obj)
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  else
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  end
+
+  if t_class.===(obj)
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  else
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  end
+end
+
+sig do
+  params(
+    obj: Object,
+    class_of: T.any(T.class_of(Integer), T.class_of(String)),
+    t_class: T::Class[T.any(Integer, String)]
+  )
+    .void
+end
+def example3(obj, class_of, t_class)
+  if obj.is_a?(class_of)
+    T.reveal_type(obj) # error: `Object`
+  else
+    T.reveal_type(obj) # error: `Object`
+  end
+
+  if obj.is_a?(t_class)
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  else
+    T.reveal_type(obj) # error: `Object`
+  end
+
+  if class_of.===(obj)
+    T.reveal_type(obj) # error: `Object`
+  else
+    T.reveal_type(obj) # error: `Object`
+  end
+
+  if t_class.===(obj)
+    T.reveal_type(obj) # error: `T.any(Integer, String)`
+  else
+    T.reveal_type(obj) # error: `Object`
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`T::Class` parity with `T.class_of`

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.