### PR TITLE
Move the `x[...]` error loc

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -1007,6 +1007,15 @@ struct DispatchArgs {
     }
     Loc blockLoc(const GlobalState &gs) const;
 
+    Loc errLoc() const {
+        auto funLoc = this->funLoc();
+        if (funLoc.exists() && !funLoc.empty()) {
+            return funLoc;
+        } else {
+            return this->callLoc();
+        }
+    }
+
     DispatchArgs withSelfAndThisRef(const TypePtr &newSelfRef) const;
     DispatchArgs withThisRef(const TypePtr &newThisRef) const;
     DispatchArgs withErrorsSuppressed() const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -1009,8 +1009,11 @@ struct DispatchArgs {
 
     Loc errLoc() const {
         auto funLoc = this->funLoc();
+        auto recvLoc = this->receiverLoc();
         if (funLoc.exists() && !funLoc.empty()) {
             return funLoc;
+        } else if (this->name == Names::squareBrackets() && recvLoc.exists() && !recvLoc.empty()) {
+            return core::Loc(this->locs.file, recvLoc.endPos(), this->callLoc().endPos());
         } else {
             return this->callLoc();
         }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -214,9 +214,7 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
             // Short circuit here to avoid constructing an expensive error message.
             return emptyResult;
         }
-        auto funLoc = args.funLoc();
-        auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
-        auto e = gs.beginError(errLoc, errors::Infer::CallOnTypeArgument);
+        auto e = gs.beginError(args.errLoc(), errors::Infer::CallOnTypeArgument);
         if (e) {
             auto thisStr = args.thisType.show(gs);
             if (args.fullType.type != args.thisType) {
@@ -241,9 +239,7 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
                 return emptyResult;
             }
 
-            auto funLoc = args.funLoc();
-            auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
-            auto e = gs.beginError(errLoc, errors::Infer::CallOnUnboundedTypeMember);
+            auto e = gs.beginError(args.errLoc(), errors::Infer::CallOnUnboundedTypeMember);
             if (e) {
                 auto member = typeMember.data(gs)->owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()
                                   ? "template"
@@ -559,8 +555,7 @@ const ShapeType *fromKwargsHash(const GlobalState &gs, const TypePtr &ty) {
 //    (with a subtype check on the key type, once we have generics)
 DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &args, core::ClassOrModuleRef symbol,
                                   const vector<TypePtr> &targs) {
-    auto funLoc = args.funLoc();
-    auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
+    auto errLoc = args.errLoc();
     if (symbol == core::Symbols::untyped()) {
         auto what = core::errors::Infer::errorClassForUntyped(gs, args.locs.file, args.thisType);
         if (auto e = gs.beginError(errLoc, what)) {
@@ -1565,8 +1560,7 @@ DispatchResult badMetaTypeCall(const GlobalState &gs, const DispatchArgs &args, 
 } // namespace
 
 DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
-    auto funLoc = args.funLoc();
-    auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
+    auto errLoc = args.errLoc();
     switch (args.name.rawId()) {
         case Names::new_().rawId(): {
             if (!canCallNew(gs, wrapped)) {
@@ -3929,9 +3923,7 @@ public:
         auto isOnlySymbol =
             Types::isSubType(gs, args.fullType.type, Types::any(gs, Types::nilClass(), Types::Symbol()));
         if (isOnlySymbol && Types::all(gs, args.fullType.type, args.args[0]->type).isBottom()) {
-            auto funLoc = args.funLoc();
-            auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
-            if (auto e = gs.beginError(errLoc, errors::Infer::NonOverlappingEqual)) {
+            if (auto e = gs.beginError(args.errLoc(), errors::Infer::NonOverlappingEqual)) {
                 e.setHeader("Comparison between `{}` and `{}` is always false", args.fullType.type.show(gs),
                             args.args[0]->type.show(gs));
                 e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
@@ -3965,9 +3957,7 @@ public:
             // to because it would likely be a cause for surprise).
             Types::isSubType(gs, args.args[0]->type, Types::any(gs, Types::nilClass(), Types::Symbol())) &&
             Types::all(gs, args.fullType.type, args.args[0]->type).isBottom()) {
-            auto funLoc = args.funLoc();
-            auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
-            if (auto e = gs.beginError(errLoc, errors::Infer::NonOverlappingEqual)) {
+            if (auto e = gs.beginError(args.errLoc(), errors::Infer::NonOverlappingEqual)) {
                 e.setHeader("Comparison between `{}` and `{}` is always false", args.fullType.type.show(gs),
                             args.args[0]->type.show(gs));
                 e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
@@ -4239,9 +4229,7 @@ public:
         }
         auto forwarderSym = forwarderSingleton.data(gs)->attachedClass(gs);
 
-        auto funLoc = args.funLoc();
-        auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
-        if (auto e = gs.beginError(errLoc, core::errors::Infer::MetaTypeDispatchCall)) {
+        if (auto e = gs.beginError(args.errLoc(), core::errors::Infer::MetaTypeDispatchCall)) {
             auto realSym = forwarderSym.maybeUnwrapBuiltinGenericForwarder();
             ENFORCE(realSym.exists());
             auto realStr = realSym.show(gs);

--- a/test/cli/autocorrect/test.out
+++ b/test/cli/autocorrect/test.out
@@ -24,7 +24,7 @@ autocorrect.rb:19: Method `params` does not exist on `T.class_of(<root>)` https:
 
 autocorrect.rb:4: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      4 |foo[0]
-        ^^^^^^
+           ^^^
   Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
@@ -240,7 +240,7 @@ autocorrect.rb:15: Method `bar=` does not exist on `NilClass` component of `T.ni
 
 autocorrect.rb:17: Method `[]` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     17 |[1].max_by {|l,r| 1}[2]
-        ^^^^^^^^^^^^^^^^^^^^^^^
+                            ^^^
   Got `T.nilable(Integer)` originating from:
     autocorrect.rb:17:
     17 |[1].max_by {|l,r| 1}[2]

--- a/test/cli/suggest_t_must/test.out
+++ b/test/cli/suggest_t_must/test.out
@@ -1,6 +1,6 @@
 suggest_t_must.rb:4: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      4 |foo[0]
-        ^^^^^^
+           ^^^
   Got `T.nilable(String)` originating from:
     suggest_t_must.rb:3:
      3 |foo = T.let(nil, T.nilable(String))

--- a/test/cli/suggest_t_unsafe/test.out
+++ b/test/cli/suggest_t_unsafe/test.out
@@ -16,7 +16,7 @@ suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argu
 
 suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      8 |foo[0]
-        ^^^^^^
+           ^^^
   Got `T.nilable(String)` originating from:
     suggest_t_unsafe.rb:7:
      7 |foo = T.let(nil, T.nilable(String))
@@ -132,7 +132,7 @@ suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argu
 
 suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      8 |foo[0]
-        ^^^^^^
+           ^^^
   Got `T.nilable(String)` originating from:
     suggest_t_unsafe.rb:7:
      7 |foo = T.let(nil, T.nilable(String))

--- a/test/testdata/infer/square_bracket_err_loc.rb
+++ b/test/testdata/infer/square_bracket_err_loc.rb
@@ -1,0 +1,18 @@
+# typed: strong
+extend T::Sig
+
+sig {params(x: T::Hash[T.untyped, T::Hash[T.untyped, T.untyped]]).void}
+def example1(x)
+  x["foo"]["bar"]
+  #       ^^^^^^^ error: Method `[]` does not exist on `NilClass` component
+end
+
+sig {params(x: T.nilable(T::Hash[T.untyped, T::Hash[T.untyped, T.untyped]])).void}
+def example2(x)
+  x["foo"]["bar"]
+  #^^^^^^^ error: Method `[]` does not exist on `NilClass` component
+  #       ^^^^^^^ error: Call to method `[]` on `T.untyped`
+
+end
+
+

--- a/test/testdata/resolver/generic_enum.rb
+++ b/test/testdata/resolver/generic_enum.rb
@@ -14,14 +14,14 @@ end
 extend T::Sig
 sig {params(xy: T.any(MyEnum::X[Integer], MyEnum::Y[Integer])).void}
 #                     ^^^^^^^^^^^^^^^^^^ error: Expected a class or module
-#                     ^^^^^^^^^^^^^^^^^^ error: Method `[]` does not exist
+#                              ^^^^^^^^^ error: Method `[]` does not exist
 #                                         ^^^^^^^^^^^^^^^^^^ error: Expected a class or module
-#                                         ^^^^^^^^^^^^^^^^^^ error: Method `[]` does not exist
+#                                                  ^^^^^^^^^ error: Method `[]` does not exist
 def foo(xy)
 end
 
 XY = T.type_alias {T.any(MyEnum::X[Integer], MyEnum::Y[Integer])}
 #                        ^^^^^^^^^^^^^^^^^^ error: Expected a class or module
-#                        ^^^^^^^^^^^^^^^^^^ error: Method `[]` does not exist
+#                                 ^^^^^^^^^ error: Method `[]` does not exist
 #                                            ^^^^^^^^^^^^^^^^^^ error: Expected a class or module
-#                                            ^^^^^^^^^^^^^^^^^^ error: Method `[]` does not exist
+#                                                     ^^^^^^^^^ error: Method `[]` does not exist


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In a big chain of methods like

```ruby
x['foo']['bar']['baz']
```

The error locations look like this on master currently:

```ruby
  x['foo']['bar']['baz']
# ^^^^^^^^
# ^^^^^^^^^^^^^^^
# ^^^^^^^^^^^^^^^^^^^^^^
```

After this change, they look like this:

```ruby
  x['foo']['bar']['baz']
#  ^^^^^^^
#         ^^^^^^^
#                ^^^^^^^
```

This matters for both "call to method on `NilClass` component" errors and also
for usage of untyped errors--Sorbet should not highlight the `x` if `x` has a
type!




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.