### PR TITLE
[WIP] Use the entire loc when querying in code_actions.cc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.rbi linguist-language=Ruby
+*.rbedited linguist-language=Ruby
 *.rb diff=ruby
 *.rbi diff=ruby
 *.md diff=markdown

--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -52,7 +52,7 @@ LSPQuery::filterAndDedup(const core::GlobalState &gs,
     return responses;
 }
 
-LSPQueryResult LSPQuery::byLoc(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker, string_view uri,
+LSPQueryResult LSPQuery::byPosition(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker, string_view uri,
                                const Position &pos, LSPMethod forMethod, bool errorIfFileIsUntyped) {
     Timer timeit(config.logger, "setupLSPQueryByLoc");
     const core::GlobalState &gs = typechecker.state();

--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -52,8 +52,9 @@ LSPQuery::filterAndDedup(const core::GlobalState &gs,
     return responses;
 }
 
-LSPQueryResult LSPQuery::byPosition(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker, string_view uri,
-                               const Position &pos, LSPMethod forMethod, bool errorIfFileIsUntyped) {
+LSPQueryResult LSPQuery::byPosition(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
+                                    string_view uri, const Position &pos, LSPMethod forMethod,
+                                    bool errorIfFileIsUntyped) {
     Timer timeit(config.logger, "setupLSPQuery::byPosition");
     const core::GlobalState &gs = typechecker.state();
     auto fref = config.uri2FileRef(gs, uri);

--- a/main/lsp/LSPQuery.h
+++ b/main/lsp/LSPQuery.h
@@ -12,8 +12,8 @@ public:
                    const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses);
 
     static LSPQueryResult byPosition(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
-                                std::string_view uri, const Position &pos, LSPMethod forMethod,
-                                bool errorIfFileIsUntyped = true);
+                                     std::string_view uri, const Position &pos, LSPMethod forMethod,
+                                     bool errorIfFileIsUntyped = true);
     static LSPQueryResult byLoc(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
                                 std::string_view uri, const core::Loc &loc, LSPMethod forMethod,
                                 bool errorIfFileIsUntyped = true);

--- a/main/lsp/LSPQuery.h
+++ b/main/lsp/LSPQuery.h
@@ -11,7 +11,7 @@ public:
     filterAndDedup(const core::GlobalState &gs,
                    const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses);
 
-    static LSPQueryResult byLoc(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
+    static LSPQueryResult byPosition(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
                                 std::string_view uri, const Position &pos, LSPMethod forMethod,
                                 bool errorIfFileIsUntyped = true);
     static LSPQueryResult bySymbolInFiles(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,

--- a/main/lsp/LSPQuery.h
+++ b/main/lsp/LSPQuery.h
@@ -14,6 +14,9 @@ public:
     static LSPQueryResult byPosition(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
                                 std::string_view uri, const Position &pos, LSPMethod forMethod,
                                 bool errorIfFileIsUntyped = true);
+    static LSPQueryResult byLoc(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
+                                std::string_view uri, const core::Loc &loc, LSPMethod forMethod,
+                                bool errorIfFileIsUntyped = true);
     static LSPQueryResult bySymbolInFiles(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
                                           core::SymbolRef symbol, std::vector<core::FileRef> frefs);
     static LSPQueryResult bySymbol(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -190,7 +190,7 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
         }
     }
 
-    auto queryResult = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->range->start,
+    auto queryResult = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, loc,
                                        LSPMethod::TextDocumentCodeAction, false);
 
     // Generate "Move method" code actions only for class method definitions

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -190,7 +190,7 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
         }
     }
 
-    auto queryResult = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->range->start,
+    auto queryResult = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->range->start,
                                        LSPMethod::TextDocumentCodeAction, false);
 
     // Generate "Move method" code actions only for class method definitions

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -190,8 +190,8 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
         }
     }
 
-    auto queryResult = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, loc,
-                                       LSPMethod::TextDocumentCodeAction, false);
+    auto queryResult =
+        LSPQuery::byLoc(config, typechecker, params->textDocument->uri, loc, LSPMethod::TextDocumentCodeAction, false);
 
     // Generate "Move method" code actions only for class method definitions
     if (queryResult.error == nullptr) {

--- a/main/lsp/requests/code_action_resolve.cc
+++ b/main/lsp/requests/code_action_resolve.cc
@@ -38,7 +38,7 @@ unique_ptr<ResponseMessage> CodeActionResolveTask::runRequest(LSPTypecheckerDele
     }
     const auto &actualParams = *params->data;
 
-    const auto queryResult = LSPQuery::byLoc(config, typechecker, actualParams->textDocument->uri,
+    const auto queryResult = LSPQuery::byPosition(config, typechecker, actualParams->textDocument->uri,
                                              *actualParams->range->start, LSPMethod::CodeActionResolve, false);
 
     if (queryResult.error != nullptr) {

--- a/main/lsp/requests/code_action_resolve.cc
+++ b/main/lsp/requests/code_action_resolve.cc
@@ -39,7 +39,7 @@ unique_ptr<ResponseMessage> CodeActionResolveTask::runRequest(LSPTypecheckerDele
     const auto &actualParams = *params->data;
 
     const auto queryResult = LSPQuery::byPosition(config, typechecker, actualParams->textDocument->uri,
-                                             *actualParams->range->start, LSPMethod::CodeActionResolve, false);
+                                                  *actualParams->range->start, LSPMethod::CodeActionResolve, false);
 
     if (queryResult.error != nullptr) {
         response->error =

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1239,7 +1239,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
     }
     auto queryLoc = maybeQueryLoc.value();
 
-    auto result = LSPQuery::byLoc(config, typechecker, uri, pos, LSPMethod::TextDocumentCompletion);
+    auto result = LSPQuery::byPosition(config, typechecker, uri, pos, LSPMethod::TextDocumentCompletion);
 
     if (result.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -53,7 +53,7 @@ DefinitionTask::DefinitionTask(const LSPConfiguration &config, MessageId id,
 unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDefinition);
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::TextDocumentDefinition, false);
     if (result.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -54,7 +54,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDefinition);
     const core::GlobalState &gs = typechecker.state();
     auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::TextDocumentDefinition, false);
+                                       LSPMethod::TextDocumentDefinition, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -38,7 +38,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
     const core::GlobalState &gs = typechecker.state();
     auto uri = params->textDocument->uri;
     auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::TextDocumentDocumentHighlight, false);
+                                       LSPMethod::TextDocumentDocumentHighlight, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -37,7 +37,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
 
     const core::GlobalState &gs = typechecker.state();
     auto uri = params->textDocument->uri;
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::TextDocumentDocumentHighlight, false);
     if (result.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -42,7 +42,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
 
     const core::GlobalState &gs = typechecker.state();
     auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::TextDocumentHover);
+                                       LSPMethod::TextDocumentHover);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -41,7 +41,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentHover);
 
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::TextDocumentHover);
     if (result.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -67,7 +67,7 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
 
     const core::GlobalState &gs = typechecker.state();
     auto queryResult = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                       LSPMethod::TextDocumentImplementation);
+                                            LSPMethod::TextDocumentImplementation);
 
     if (queryResult.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -66,7 +66,7 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentImplementation);
 
     const core::GlobalState &gs = typechecker.state();
-    auto queryResult = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto queryResult = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                        LSPMethod::TextDocumentImplementation);
 
     if (queryResult.error) {

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -102,7 +102,7 @@ unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerDelegate
 
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.prepareRename");
     auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::TextDocumentPrepareRename, false);
+                                       LSPMethod::TextDocumentPrepareRename, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -101,7 +101,7 @@ unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerDelegate
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentPrepareRename);
 
     prodCategoryCounterInc("lsp.messages.processed", "textDocument.prepareRename");
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::TextDocumentPrepareRename, false);
     if (result.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -67,7 +67,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
     ShowOperation op(config, ShowOperation::Kind::References);
 
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::TextDocumentReferences, false);
     if (result.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -68,7 +68,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
 
     const core::GlobalState &gs = typechecker.state();
     auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::TextDocumentReferences, false);
+                                       LSPMethod::TextDocumentReferences, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -297,7 +297,7 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
     ShowOperation op(config, ShowOperation::Kind::Rename);
 
     auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::TextDocumentRename);
+                                       LSPMethod::TextDocumentRename);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -296,7 +296,7 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
 
     ShowOperation op(config, ShowOperation::Kind::Rename);
 
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::TextDocumentRename);
     if (result.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -67,7 +67,7 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
     }
 
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::TextDocumentSignatureHelp);
     if (result.error) {
         // An error happened while setting up the query.
@@ -92,7 +92,7 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
             }
             auto src = fref.data(gs).source();
             auto loc = params->position->toLoc(gs, fref);
-            ENFORCE(loc.has_value(), "LSPQuery::byLoc should have reported an error earlier if nullopt");
+            ENFORCE(loc.has_value(), "LSPQuery::byPosition should have reported an error earlier if nullopt");
             string_view call_str = src.substr(sendLocIndex, loc.value().endPos() - sendLocIndex);
             int numberCommas = absl::c_count(call_str, ',');
             // Active parameter depends on number of ,'s in the current string being typed. (0 , = first arg, 1 , =

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -68,7 +68,7 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
 
     const core::GlobalState &gs = typechecker.state();
     auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::TextDocumentSignatureHelp);
+                                       LSPMethod::TextDocumentSignatureHelp);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -18,7 +18,7 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
     // To match the behavior of Go To Definition, we don't error in an untyped file, but instead
     // be okay with returning an empty result for certain queries.
     auto errorIfFileIsUntyped = false;
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::SorbetShowSymbol, errorIfFileIsUntyped);
     if (result.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -19,7 +19,7 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
     // be okay with returning an empty result for certain queries.
     auto errorIfFileIsUntyped = false;
     auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::SorbetShowSymbol, errorIfFileIsUntyped);
+                                       LSPMethod::SorbetShowSymbol, errorIfFileIsUntyped);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -91,7 +91,7 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentTypeDefinition);
     const core::GlobalState &gs = typechecker.state();
     auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::TextDocumentTypeDefinition, false);
+                                       LSPMethod::TextDocumentTypeDefinition, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -90,7 +90,7 @@ TypeDefinitionTask::TypeDefinitionTask(const LSPConfiguration &config, MessageId
 unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentTypeDefinition);
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byPosition(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::TextDocumentTypeDefinition, false);
     if (result.error) {
         // An error happened while setting up the query.

--- a/test/testdata/lsp/code_actions/delete_must.B.rbedited
+++ b/test/testdata/lsp/code_actions/delete_must.B.rbedited
@@ -2,9 +2,9 @@
 # selective-apply-code-action: refactor.rewrite
 
 xs = T::Array[Integer].new.first
-xs.even?
+T.must(xs).even?
 # ^ apply-code-action: [A] Delete T.must
 
   xs = T::Array[Integer].new.first
-  T.must(xs).even?
+  xs.even?
 # ^^^^^^ apply-code-action: [B] Delete T.must

--- a/test/testdata/lsp/code_actions/delete_must.rb
+++ b/test/testdata/lsp/code_actions/delete_must.rb
@@ -4,3 +4,7 @@
 xs = T::Array[Integer].new.first
 T.must(xs).even?
 # ^ apply-code-action: [A] Delete T.must
+
+  xs = T::Array[Integer].new.first
+  T.must(xs).even?
+# ^^^^^^ apply-code-action: [B] Delete T.must


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

In `code_actions.cc`, we would receive a range from the LSP client, and then use that to construct a `Loc`. However, we ignore that `Loc` and then queried by just the start of the range (and then create a new `Loc` with from the start in the query). This meant that if the user had selected `T.must`, the query would return just `T`.

This PR renames `byLoc` to `byPosition`, and then creates a new `byLoc` method that takes in the `loc`, and passes that the full loc we constructed.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, if you selected `T.must` and then try to apply a code action, the Delete T.must code action would not be offered.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
