### PR TITLE
Stress test resolver in the test runner

### DIFF
--- a/main/pipeline/BUILD
+++ b/main/pipeline/BUILD
@@ -37,6 +37,7 @@ cc_library(
         "//payload/text",
         "//resolver",
         "//rewriter",
+        "//main/pipeline/definition_checker",
     ],
 )
 
@@ -76,5 +77,6 @@ cc_library(
         "//payload/text",
         "//resolver",
         "//rewriter",
+        "//main/pipeline/definition_checker",
     ],
 )

--- a/main/pipeline/definition_checker/BUILD
+++ b/main/pipeline/definition_checker/BUILD
@@ -1,0 +1,12 @@
+cc_library(
+    name = "definition_checker",
+    srcs = [
+        "DefinitionLinesDenylistEnforcer.cc",
+    ],
+    hdrs = ["DefinitionLinesDenylistEnforcer.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//ast/treemap",
+        "//core",
+    ],
+)

--- a/main/pipeline/definition_checker/DefinitionLinesDenylistEnforcer.cc
+++ b/main/pipeline/definition_checker/DefinitionLinesDenylistEnforcer.cc
@@ -9,6 +9,7 @@ ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, a
     ast::TreeWalk::apply(core::Context(gs, core::Symbols::root(), what.file), enforcer, what.tree);
     return what;
 }
+
 bool DefinitionLinesDenylistEnforcer::isAllowListed(core::Context ctx, core::SymbolRef sym) {
     return sym.name(ctx) == core::Names::staticInit() || sym.name(ctx) == core::Names::Constants::Root() ||
            sym.name(ctx) == core::Names::unresolvedAncestors();

--- a/main/pipeline/definition_checker/DefinitionLinesDenylistEnforcer.cc
+++ b/main/pipeline/definition_checker/DefinitionLinesDenylistEnforcer.cc
@@ -1,0 +1,36 @@
+#include "main/pipeline/definition_checker/DefinitionLinesDenylistEnforcer.h"
+#include "ast/treemap/treemap.h"
+
+namespace sorbet::pipeline::definition_checker {
+
+ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, ast::ParsedFile what,
+                                                        int prohibitedLinesStart, int prohibitedLinesEnd) {
+    DefinitionLinesDenylistEnforcer enforcer(what.file, prohibitedLinesStart, prohibitedLinesEnd);
+    ast::TreeWalk::apply(core::Context(gs, core::Symbols::root(), what.file), enforcer, what.tree);
+    return what;
+}
+bool DefinitionLinesDenylistEnforcer::isAllowListed(core::Context ctx, core::SymbolRef sym) {
+    return sym.name(ctx) == core::Names::staticInit() || sym.name(ctx) == core::Names::Constants::Root() ||
+           sym.name(ctx) == core::Names::unresolvedAncestors();
+}
+
+void DefinitionLinesDenylistEnforcer::checkLoc(core::Context ctx, core::Loc loc) {
+    auto detailStart = core::Loc::offset2Pos(file.data(ctx), loc.beginPos());
+    auto detailEnd = core::Loc::offset2Pos(file.data(ctx), loc.endPos());
+    ENFORCE(!(detailStart.line >= prohibitedLinesStart && detailEnd.line <= prohibitedLinesEnd));
+}
+
+void DefinitionLinesDenylistEnforcer::checkSym(core::Context ctx, core::SymbolRef sym) {
+    if (isAllowListed(ctx, sym)) {
+        return;
+    }
+    checkLoc(ctx, sym.loc(ctx));
+}
+
+void DefinitionLinesDenylistEnforcer::preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
+    checkSym(ctx, ast::cast_tree_nonnull<ast::ClassDef>(tree).symbol);
+}
+void DefinitionLinesDenylistEnforcer::preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
+    checkSym(ctx, ast::cast_tree_nonnull<ast::MethodDef>(tree).symbol);
+}
+} // namespace sorbet::pipeline::definition_checker

--- a/main/pipeline/definition_checker/DefinitionLinesDenylistEnforcer.h
+++ b/main/pipeline/definition_checker/DefinitionLinesDenylistEnforcer.h
@@ -1,0 +1,36 @@
+#ifndef SORBET_PIPELINE_DEFINITION_CHECKER
+#define SORBET_PIPELINE_DEFINITION_CHECKER
+
+#include "ast/Trees.h"
+#include "core/Context.h"
+#include "core/FileRef.h"
+
+namespace sorbet::pipeline::definition_checker {
+class DefinitionLinesDenylistEnforcer {
+private:
+    const core::FileRef file;
+    const int prohibitedLinesStart;
+    const int prohibitedLinesEnd;
+
+    bool isAllowListed(core::Context ctx, core::SymbolRef sym);
+
+    void checkLoc(core::Context ctx, core::Loc loc);
+
+    void checkSym(core::Context ctx, core::SymbolRef sym);
+
+public:
+    DefinitionLinesDenylistEnforcer(core::FileRef file, int prohibitedLinesStart, int prohibitedLinesEnd)
+        : file(file), prohibitedLinesStart(prohibitedLinesStart), prohibitedLinesEnd(prohibitedLinesEnd) {
+        // Can be equal if file was empty.
+        ENFORCE(prohibitedLinesStart <= prohibitedLinesEnd);
+        ENFORCE(file.exists());
+    };
+
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree);
+    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree);
+};
+
+ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, ast::ParsedFile what,
+                                                        int prohibitedLinesStart, int prohibitedLinesEnd);
+} // namespace sorbet::pipeline::definition_checker
+#endif

--- a/test/BUILD
+++ b/test/BUILD
@@ -247,6 +247,21 @@ pipeline_tests(
 )
 
 pipeline_tests(
+    "stress_corpus",
+    glob(
+        [
+            "testdata/**/*.rb",
+            "testdata/**/*.exp",
+        ],
+        exclude = [
+            "testdata/compiler/**/*",
+            "testdata/ruby_benchmark/**/*",
+        ],
+    ),
+    "StressResolverTests",
+)
+
+pipeline_tests(
     "test_packager",
     glob(
         [

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -15,7 +15,7 @@ def dropExtension(p):
 _TEST_SCRIPT = """#!/usr/bin/env bash
 export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_12_0_0/bin/llvm-symbolizer
 set -x
-exec {runner} --single_test="{test}"
+exec {runner} --single_test="{test}" {extra_args}
 """
 
 def _exp_test_impl(ctx):
@@ -24,6 +24,7 @@ def _exp_test_impl(ctx):
         content = _TEST_SCRIPT.format(
             runner = ctx.executable.runner.short_path,
             test = ctx.file.test.path,
+            extra_args = ' '.join(ctx.attr.extra_args),
         ),
     )
 
@@ -50,6 +51,7 @@ exp_test = rule(
         "_llvm_symbolizer": attr.label(
             default = "//test:llvm-symbolizer",
         ),
+        "extra_args": attr.string_list()
     },
 )
 
@@ -110,6 +112,7 @@ _TEST_RUNNERS = {
     "LSPTests": ":lsp_test_runner",
     "WhitequarkParserTests": ":parser_test_runner",
     "PackagerTests": ":pipeline_test_runner",
+    "StressResolverTests": ":pipeline_test_runner",
 }
 
 def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], tags = []):
@@ -199,6 +202,7 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
             test = sentinel,
             size = "small",
             tags = tags + extra_tags,
+            extra_args = ["--stress_incremental_resolver"] if test_name_prefix == "StressResolverTests" else []
         )
 
     native.test_suite(

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -33,6 +33,7 @@
 #include "main/autogen/data/definitions.h"
 #include "main/autogen/data/version.h"
 #include "main/minimize/minimize.h"
+#include "main/pipeline/definition_checker/DefinitionLinesDenylistEnforcer.h"
 #include "main/pipeline/pipeline.h"
 #include "namer/namer.h"
 #include "packager/packager.h"
@@ -739,7 +740,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     // now we test the incremental resolver
 
     auto disableStressIncremental =
-        BooleanPropertyAssertion::getValue("disable-stress-incremental", assertions).value_or(false);
+        BooleanPropertyAssertion::getValue("disable-stress-incremental", assertions).value_or(false) ||
+        !shouldStressResolver;
     if (disableStressIncremental) {
         MESSAGE("errors OK");
         return;
@@ -749,6 +751,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     auto symbolsBefore = gs->symbolsUsedTotal();
 
     vector<ast::ParsedFile> newTrees;
+    UnorderedMap<core::FileRef, int> prohibitedLinesMap;
     for (auto &f : trees) {
         if (f.file.data(*gs).strictLevel == core::StrictLevel::Ignore) {
             newTrees.emplace_back(move(f));
@@ -757,6 +760,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
         const int prohibitedLines = f.file.data(*gs).source().size();
         auto newSource = absl::StrCat(string(prohibitedLines + 1, '\n'), f.file.data(*gs).source());
+        prohibitedLinesMap[f.file] = prohibitedLines;
         auto newFile =
             make_shared<core::File>(string(f.file.data(*gs).path()), move(newSource), f.file.data(*gs).sourceType);
         gs->replaceFile(f.file, move(newFile));
@@ -822,6 +826,13 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     // resolver
     trees = move(resolver::Resolver::runIncremental(*gs, move(trees), ranIncremantalNamer).result());
+
+    if (shouldStressResolver) {
+        for (auto &f : trees) {
+            f = sorbet::pipeline::definition_checker::checkNoDefinitionsInsideProhibitedLines(
+                *gs, move(f), 0, prohibitedLinesMap[f.file]);
+        }
+    }
 
     if (enablePackager) {
         trees = packager::VisibilityChecker::run(*gs, *workers, move(trees));

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -59,6 +59,7 @@ namespace sorbet::test {
 using namespace std;
 
 string singleTest;
+bool shouldStressResolver;
 
 constexpr string_view whitelistedTypedNoneTest = "missing_typed_sigil.rb"sv;
 constexpr string_view packageFileName = "__package.rb"sv;
@@ -847,7 +848,9 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 int main(int argc, char *argv[]) {
     cxxopts::Options options("test_corpus", "Test corpus for Sorbet typechecker");
     options.allow_unrecognised_options().add_options()("single_test", "run over single test.",
-                                                       cxxopts::value<std::string>()->default_value(""), "testpath");
+                                                       cxxopts::value<std::string>()->default_value(""), "testpath")(
+        "stress_incremental_resolver", "Force incremental updates to discover resolver & namer bugs",
+        cxxopts::value<bool>()->implicit_value("true"));
     auto res = options.parse(argc, argv);
 
     if (res.count("single_test") != 1) {
@@ -856,7 +859,7 @@ int main(int argc, char *argv[]) {
     }
 
     sorbet::test::singleTest = res["single_test"].as<std::string>();
-
+    sorbet::test::shouldStressResolver = res["stress_incremental_resolver"].as<bool>();
     doctest::Context context(argc, argv);
     return context.run();
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The change adds a flag `--stress_incremental_resolver` to the test executor. 

It works in the same fashion as in the Sorbet itself. After running a test the runner will double the size of the file, and move all of the code into the second half. After that the code will be re-typchecked. If any `Loc`s will point to the first half of file an `ENFORCE` will fire an error.

To launch a test with a new flag on, you should run
```bash
bazel test  //test:test_StressResolverTests/...
```
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Sorbet sometime crashes, because `Loc`s are not properly updated after user adds or removes a bulk of lines. The new mode for the test runner should help us to detect those cases.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
