### PR TITLE
Consider generic methods in guessOverload

### DIFF
--- a/test/testdata/infer/generics/overloads_test.rb
+++ b/test/testdata/infer/generics/overloads_test.rb
@@ -19,5 +19,4 @@ res = example(xs)
 T.reveal_type(res) # error: `T.nilable(Integer)`
 
 res = example('')
-#             ^^ error: Expected `T::Array[T.type_parameter(:U)]` but found `String("")`
-T.reveal_type(res) # error: `NilClass`
+T.reveal_type(res) # error: `T.nilable(String)`

--- a/test/testdata/infer/generics/overloads_test.rb
+++ b/test/testdata/infer/generics/overloads_test.rb
@@ -1,0 +1,23 @@
+# typed: strict
+class Module; include T::Sig; end
+
+sig do
+  type_parameters(:U)
+    .params(x: T::Array[T.type_parameter(:U)])
+    .returns(T.nilable(T.type_parameter(:U)))
+end
+sig do
+  params(x: String)
+    .returns(T.nilable(String))
+end
+def example(x)
+end
+
+xs = T::Array[Integer].new
+
+res = example(xs)
+T.reveal_type(res) # error: `T.nilable(Integer)`
+
+res = example('')
+#             ^^ error: Expected `T::Array[T.type_parameter(:U)]` but found `String("")`
+T.reveal_type(res) # error: `NilClass`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, we would skip any argument that was not fully defined, and only
allow the fully defined arguments in an overload to disambiguate between
one alternative or another.

Fixes #7361


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.