### PR TITLE
Use T::Class in an overload for optparse

### DIFF
--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -803,13 +803,6 @@ class OptionParser
       )
       .returns(T.untyped)
   end
-  sig do
-    params(
-      opts: String,
-      block: T.nilable(T.proc.params(arg0: String).void)
-    )
-      .returns(T.untyped)
-  end
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
   def on(type=T.unsafe(nil), *opts, &block); end
 

--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -794,8 +794,24 @@ class OptionParser
   # Add option switch and handler. See
   # [`make_switch`](https://docs.ruby-lang.org/en/2.7.0/OptionParser.html#method-i-make_switch)
   # for an explanation of parameters.
+  sig do
+    type_parameters(:Type)
+      .params(
+        type: T::Class[T.type_parameter(:Type)],
+        opts: T.untyped,
+        block: T.nilable(T.proc.params(arg0: T.type_parameter(:Type)).void)
+      )
+      .returns(T.untyped)
+  end
+  sig do
+    params(
+      opts: String,
+      block: T.nilable(T.proc.params(arg0: String).void)
+    )
+      .returns(T.untyped)
+  end
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
-  def on(*opts, &block); end
+  def on(type=T.unsafe(nil), *opts, &block); end
 
   # Also aliased as:
   # [`def_head_option`](https://docs.ruby-lang.org/en/2.7.0/OptionParser.html#method-i-def_head_option)

--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -795,6 +795,14 @@ class OptionParser
   # [`make_switch`](https://docs.ruby-lang.org/en/2.7.0/OptionParser.html#method-i-make_switch)
   # for an explanation of parameters.
   sig do
+    params(
+      type: T.any(T.class_of(TrueClass), T.class_of(FalseClass)),
+      opts: T.untyped,
+      block: T.nilable(T.proc.params(arg0: T::Boolean).void)
+    )
+      .returns(T.untyped)
+  end
+  sig do
     type_parameters(:Type)
       .params(
         type: T::Class[T.type_parameter(:Type)],

--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -803,6 +803,14 @@ class OptionParser
       .returns(T.untyped)
   end
   sig do
+    params(
+      type: T.any(T.class_of(Shellwords), T.class_of(Array)),
+      opts: T.untyped,
+      block: T.nilable(T.proc.params(arg0: T::Array[String]).void)
+    )
+      .returns(T.untyped)
+  end
+  sig do
     type_parameters(:Type)
       .params(
         type: T::Class[T.type_parameter(:Type)],


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This adds an overload to allow users to opt into better typing for Ruby's default option parser gem.

See [Argument converters](https://github.com/ruby/optparse/blob/master/doc/optparse/argument_converters.rdoc) for more information.

It's not perfect, but for the cases where it attempts to do something, it's better than nothing, because the argument converter must be the first argument to `.on`. This is a limitation of Sorbet's support for overloads--we can't pluck out an argument from the middle or the end of the list. On the other hand, it makes for an easy escape hatch if for some reason this signature is wrong: just put the argument converter at the end of the list.

```ruby
# typed: true
require 'optparse'
parser = OptionParser.new
parser.on(Integer, '--n=N') do |value|
  T.reveal_type(value) # => `Integer`
end
parser.parse!
```






### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.