### PR TITLE
Show untyped blame in the editor if available

### DIFF
--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -119,44 +119,25 @@ void TypeErrorDiagnostics::insertTypeArguments(const GlobalState &gs, ErrorBuild
     }
 }
 
-namespace {
-
-void showBlame(const GlobalState &gs, ErrorBuilder &e, const TypePtr &untyped) {
-    if constexpr (sorbet::track_untyped_blame_mode || sorbet::debug_mode) {
-        auto blameSymbol = untyped.untypedBlame();
-        if (blameSymbol.exists()) {
-            auto loc = blameSymbol.loc(gs);
-            if (loc.exists()) {
-                e.addErrorLine(loc, "Blames to `{}`, defined here", blameSymbol.show(gs));
-            } else {
-                e.addErrorNote("Blames to `{}`", blameSymbol.show(gs));
-            }
-        } else {
-            e.addErrorNote("Blames to `{}`", "<none>");
-        }
-    }
-}
-
-} // namespace
-
 void TypeErrorDiagnostics::explainUntyped(const GlobalState &gs, ErrorBuilder &e, ErrorClass what,
                                           const TypeAndOrigins &untyped, Loc originForUninitialized) {
     e.addErrorSection(untyped.explainGot(gs, originForUninitialized));
     if (what == core::errors::Infer::UntypedValue) {
         e.addErrorNote("Support for `{}` is minimal. Consider using `{}` instead.", "typed: strong", "typed: strict");
     } else {
-        showBlame(gs, e, untyped.type);
-    }
-}
-
-void TypeErrorDiagnostics::explainUntyped(const GlobalState &gs, ErrorBuilder &e, ErrorClass what, TypePtr untyped,
-                                          Loc origin, Loc originForUninitialized) {
-    auto untypedTpo = TypeAndOrigins{untyped, origin};
-    e.addErrorSection(untypedTpo.explainGot(gs, originForUninitialized));
-    if (what == core::errors::Infer::UntypedValue) {
-        e.addErrorNote("Support for `{}` is minimal. Consider using `{}` instead.", "typed: strong", "typed: strict");
-    } else {
-        showBlame(gs, e, untyped);
+        if constexpr (sorbet::track_untyped_blame_mode || sorbet::debug_mode) {
+            auto blameSymbol = untyped.type.untypedBlame();
+            if (blameSymbol.exists()) {
+                auto loc = blameSymbol.loc(gs);
+                if (loc.exists()) {
+                    e.addErrorLine(loc, "Blames to `{}`, defined here", blameSymbol.show(gs));
+                } else {
+                    e.addErrorNote("Blames to `{}`", blameSymbol.show(gs));
+                }
+            } else {
+                e.addErrorNote("Blames to `{}`", "<none>");
+            }
+        }
     }
 }
 

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -133,6 +133,20 @@ void TypeErrorDiagnostics::explainUntyped(const GlobalState &gs, ErrorBuilder &e
     e.addErrorSection(untypedTpo.explainGot(gs, originForUninitialized));
     if (what == core::errors::Infer::UntypedValue) {
         e.addErrorNote("Support for `{}` is minimal. Consider using `{}` instead.", "typed: strong", "typed: strict");
+    } else {
+        if constexpr (sorbet::track_untyped_blame_mode || sorbet::debug_mode) {
+            auto blameSymbol = untyped.type.untypedBlame();
+            if (blameSymbol.exists()) {
+                auto loc = blameSymbol.loc(gs);
+                if (loc.exists()) {
+                    e.addErrorLine(loc, "Blames to `{}`, defined here", blameSymbol.show(gs));
+                } else {
+                    e.addErrorNote("Blames to `{}`", blameSymbol.show(gs));
+                }
+            } else {
+                e.addErrorNote("Blames to `{}`", "<none>");
+            }
+        }
     }
 }
 

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -122,22 +122,23 @@ void TypeErrorDiagnostics::insertTypeArguments(const GlobalState &gs, ErrorBuild
 void TypeErrorDiagnostics::explainUntyped(const GlobalState &gs, ErrorBuilder &e, ErrorClass what,
                                           const TypeAndOrigins &untyped, Loc originForUninitialized) {
     e.addErrorSection(untyped.explainGot(gs, originForUninitialized));
+
+    if constexpr (sorbet::track_untyped_blame_mode || sorbet::debug_mode) {
+        auto blameSymbol = untyped.type.untypedBlame();
+        if (blameSymbol.exists()) {
+            auto loc = blameSymbol.loc(gs);
+            if (loc.exists()) {
+                e.addErrorLine(loc, "Blames to `{}`, defined here", blameSymbol.show(gs));
+            } else {
+                e.addErrorNote("Blames to `{}`", blameSymbol.show(gs));
+            }
+        } else {
+            e.addErrorNote("Blames to `{}`", "<none>");
+        }
+    }
+
     if (what == core::errors::Infer::UntypedValue) {
         e.addErrorNote("Support for `{}` is minimal. Consider using `{}` instead.", "typed: strong", "typed: strict");
-    } else {
-        if constexpr (sorbet::track_untyped_blame_mode || sorbet::debug_mode) {
-            auto blameSymbol = untyped.type.untypedBlame();
-            if (blameSymbol.exists()) {
-                auto loc = blameSymbol.loc(gs);
-                if (loc.exists()) {
-                    e.addErrorLine(loc, "Blames to `{}`, defined here", blameSymbol.show(gs));
-                } else {
-                    e.addErrorNote("Blames to `{}`", blameSymbol.show(gs));
-                }
-            } else {
-                e.addErrorNote("Blames to `{}`", "<none>");
-            }
-        }
     }
 }
 

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -135,7 +135,7 @@ void TypeErrorDiagnostics::explainUntyped(const GlobalState &gs, ErrorBuilder &e
         e.addErrorNote("Support for `{}` is minimal. Consider using `{}` instead.", "typed: strong", "typed: strict");
     } else {
         if constexpr (sorbet::track_untyped_blame_mode || sorbet::debug_mode) {
-            auto blameSymbol = untyped.type.untypedBlame();
+            auto blameSymbol = untyped.untypedBlame();
             if (blameSymbol.exists()) {
                 auto loc = blameSymbol.loc(gs);
                 if (loc.exists()) {

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -29,9 +29,6 @@ public:
     static void explainUntyped(const GlobalState &gs, ErrorBuilder &e, ErrorClass what, const TypeAndOrigins &untyped,
                                Loc originForUninitialized);
 
-    static void explainUntyped(const GlobalState &gs, ErrorBuilder &e, ErrorClass what, TypePtr untyped, Loc origin,
-                               Loc originForUninitialized);
-
     static std::optional<core::AutocorrectSuggestion::Edit>
     editForDSLMethod(const GlobalState &gs, FileRef fileToEdit, Loc defaultInsertLoc, ClassOrModuleRef inWhat,
                      ClassOrModuleRef dslOwner, std::string_view dsl);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2572,7 +2572,7 @@ public:
             auto what = core::errors::Infer::errorClassForUntyped(gs, args.locs.file, receiver->type);
             if (auto e = gs.beginError(args.argLoc(0), what)) {
                 e.setHeader("Call to method `{}` on `{}`", fn.show(gs), "T.untyped");
-                TypeErrorDiagnostics::explainUntyped(gs, e, what, args.fullType, args.originForUninitialized);
+                TypeErrorDiagnostics::explainUntyped(gs, e, what, *receiver, args.originForUninitialized);
             }
 
             res.returnType = receiver->type;

--- a/test/cli/track-untyped/test.out
+++ b/test/cli/track-untyped/test.out
@@ -5,6 +5,9 @@ a.rb:6: Call to method `foo` on `T.untyped` https://srb.help/7018
     a.rb:5:
      5 |def example_untyped(arg0)
                             ^^^^
+    a.rb:5: Blames to `Object#example_untyped`, defined here
+     5 |def example_untyped(arg0)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Support for `typed: strong` is minimal. Consider using `typed: strict` instead.
 
@@ -15,6 +18,9 @@ a.rb:8: Conditional branch on `T.untyped` https://srb.help/7018
     a.rb:6:
      6 |  result = arg0.foo
                    ^^^^^^^^
+    a.rb:5: Blames to `Object#example_untyped`, defined here
+     5 |def example_untyped(arg0)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Support for `typed: strong` is minimal. Consider using `typed: strict` instead.
 
@@ -32,6 +38,9 @@ a.rb:9: Argument passed to parameter `arg0` is `T.untyped` https://srb.help/7018
     a.rb:8:
      8 |  if result
              ^^^^^^
+    a.rb:5: Blames to `Object#example_untyped`, defined here
+     5 |def example_untyped(arg0)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Support for `typed: strong` is minimal. Consider using `typed: strict` instead.
 
@@ -45,6 +54,9 @@ a.rb:12: Value returned from method is `T.untyped` https://srb.help/7018
     a.rb:8:
      8 |  if result
              ^^^^^^
+    a.rb:5: Blames to `Object#example_untyped`, defined here
+     5 |def example_untyped(arg0)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Support for `typed: strong` is minimal. Consider using `typed: strict` instead.
 
@@ -55,6 +67,9 @@ b.rb:4: Call to method `foo` on `T.untyped` https://srb.help/7018
     b.rb:4:
      4 |T.unsafe(nil).foo
         ^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#LCENSORED: Blames to `T.unsafe`, defined here
+    NN |  def self.unsafe(value); end
+          ^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Support for `typed: strong` is minimal. Consider using `typed: strict` instead.
 Errors: 5


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This helps a little bit for tracking down the untyped blames if you happen to
have a build which tracks this information.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not easy to test automatically, because testing it would depend on the build
configuration.

<img width="544" alt="image" src="https://github.com/sorbet/sorbet/assets/5544532/fc546dcd-afb8-48a3-b5f5-886257d88664">

