### PR TITLE
Change `Class.new`'s return type to `T::Class[T.untyped]`

### DIFF
--- a/rbi/core/class.rbi
+++ b/rbi/core/class.rbi
@@ -128,7 +128,7 @@ class Class < Module
   #
   # If a block is given, it is passed the class object, and the block is
   # evaluated in the context of this class like class_eval.
-  sig { params(blk: T.untyped).returns(T::Class[Object]) }
+  sig { params(blk: T.untyped).returns(T::Class[T.untyped]) }
   sig do
     type_parameters(:Parent)
       .params(

--- a/test/testdata/infer/class_new_block.rb
+++ b/test/testdata/infer/class_new_block.rb
@@ -4,20 +4,20 @@ class A
   extend T::Sig
 
   klass = Class.new do
-    sig { params(blk: T.proc.void) .void }
-    def initialize(&blk)
+    sig { params(n: Integer, blk: T.proc.void).void }
+    def initialize(n, &blk)
     end
   end
-  T.reveal_type(klass) # error: `T::Class[Object]`
+  T.reveal_type(klass) # error: `T::Class[T.untyped]`
 
   blk = ->(){}
 
   inst = klass.new
-  T.reveal_type(inst) # error: `Object`
+  T.reveal_type(inst) # error: `T.untyped`
 
-  inst = klass.new(0) # error: Wrong number of arguments for constructor. Expected: `0`, got: `1`
-  T.reveal_type(inst) # error: `Object`
+  inst = klass.new(0)
+  T.reveal_type(inst) # error: `T.untyped`
 
-  inst = klass.new(&blk) # error: `BasicObject#initialize` does not take a block
-  T.reveal_type(inst) # error: `Object`
+  inst = klass.new(0, &blk)
+  T.reveal_type(inst) # error: `T.untyped`
 end

--- a/test/testdata/rbi/class.rb
+++ b/test/testdata/rbi/class.rb
@@ -9,16 +9,16 @@ Parent.attached_object
 Parent.new.singleton_class.attached_object
 
 c1 = Class.new
-T.reveal_type(c1) # error: Revealed type: `T::Class[Object]`
-T.reveal_type(c1.new) # error: Revealed type: `Object`
+T.reveal_type(c1) # error: Revealed type: `T::Class[T.untyped]`
+T.reveal_type(c1.new) # error: Revealed type: `T.untyped`
 
 c2 = Class.new(Parent)
 T.reveal_type(c2) # error: Revealed type: `T.class_of(Parent)`
 T.reveal_type(c2.new) # error: Revealed type: `Parent`
 
 c3 = Class.new { |cls| cls.superclass }
-T.reveal_type(c3) # error: Revealed type: `T::Class[Object]`
-T.reveal_type(c3.new) # error: Revealed type: `Object`
+T.reveal_type(c3) # error: Revealed type: `T::Class[T.untyped]`
+T.reveal_type(c3.new) # error: Revealed type: `T.untyped`
 
 c4 = Class.new(Parent) { |cls| cls.superclass }
 T.reveal_type(c4) # error: Revealed type: `T.class_of(Parent)`

--- a/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
@@ -39,7 +39,7 @@ bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$6
 # backedges
 # - bb2(rubyRegionId=1)
 bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
-    _cls: T::Class[Object] = Solve<<block-pre-call-temp>$6, new>
+    _cls: T::Class[T.untyped] = Solve<<block-pre-call-temp>$6, new>
     <self>: T.class_of(A) = <selfRestore>$7
     <cfgAlias>$18: T.class_of(Class)[T::Class[T.anything]] = alias <C Class>
     <cfgAlias>$20: T.class_of(A) = alias <C A>


### PR DESCRIPTION
### Motivation

The current `T::Class[Object]` means in some cases incorrect typing error would be raised when using `Class.new` to create a class with a custom constructor, like:

```rb
class A
  r = Class.new do
    def initialize(a)
    end
  end

  r.new(123) # => reporting wrong number of arguments
end
```

This PR fixes the issue by changing the return type to `T::Class[T.untyped]`.
