### PR TITLE
Misuse of `static` no longer falsifies untyped blame

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -77,15 +77,27 @@ TypePtr Types::Float() {
 }
 
 TypePtr Types::arrayOfUntyped(sorbet::core::SymbolRef blame) {
-    static vector<TypePtr> targs{Types::untyped(blame)};
-    static auto res = make_type<AppliedType>(Symbols::Array(), move(targs));
-    return res;
+    if constexpr (!sorbet::track_untyped_blame_mode && !sorbet::debug_mode) {
+        static vector<TypePtr> targs{Types::untypedUntracked()};
+        static auto res = make_type<AppliedType>(Symbols::Array(), move(targs));
+        return res;
+    } else {
+        vector<TypePtr> targs{Types::untyped(blame)};
+        auto res = make_type<AppliedType>(Symbols::Array(), move(targs));
+        return res;
+    }
 }
 
 TypePtr Types::rangeOfUntyped(sorbet::core::SymbolRef blame) {
-    static vector<TypePtr> targs{Types::untyped(blame)};
-    static auto res = make_type<AppliedType>(Symbols::Range(), move(targs));
-    return res;
+    if constexpr (!sorbet::track_untyped_blame_mode && !sorbet::debug_mode) {
+        static vector<TypePtr> targs{Types::untypedUntracked()};
+        static auto res = make_type<AppliedType>(Symbols::Range(), move(targs));
+        return res;
+    } else {
+        vector<TypePtr> targs{Types::untyped(blame)};
+        auto res = make_type<AppliedType>(Symbols::Range(), move(targs));
+        return res;
+    }
 }
 
 TypePtr Types::hashOfUntyped() {
@@ -95,10 +107,14 @@ TypePtr Types::hashOfUntyped() {
 }
 
 TypePtr Types::hashOfUntyped(sorbet::core::SymbolRef blame) {
-    auto untypedWithBlame = Types::untyped(blame);
-    static vector<TypePtr> targs{untypedWithBlame, untypedWithBlame, untypedWithBlame};
-    static auto res = make_type<AppliedType>(Symbols::Hash(), move(targs));
-    return res;
+    if constexpr (!sorbet::track_untyped_blame_mode && !sorbet::debug_mode) {
+        return Types::hashOfUntyped();
+    } else {
+        auto untypedWithBlame = Types::untyped(blame);
+        vector<TypePtr> targs{untypedWithBlame, untypedWithBlame, untypedWithBlame};
+        auto res = make_type<AppliedType>(Symbols::Hash(), move(targs));
+        return res;
+    }
 }
 
 TypePtr Types::procClass() {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The first time these `arrayOfUntyped` / `rangeOfUntyped` /
`hashOfUntyped` methods were called, the blame was being cached in a
`static` variable and then reused throughout the lifetime of the
program.

In Stripe's codebase, we were seeing a lot of untyped blame to
`<build-hash>` and none to `<shapeUnderlying>`, which I thought was
strange because a program as simple as:

```ruby
res = {foo: 0}
foo = res[:foo].even?
```

should be enough to show an untyped blame to `<shapeUnderlying>`... and
on small examples it was!

I only realized that something was up because I tried adding some extra
error sections to the "usage of untyped" error, and I noticed that the
blame symbol was different in my editor vs at the command line on small
examples. This was enough to let me run the code under a debugger which
eventually led me to these lines.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is hard to write an automated test for, because we don't have many (any?)
tests of our untyped blame setup (it involves a custom build of Sorbet).

I verified manually that this fixes the problem I was seeing locally. I plan to
deploy this to Stripe's codebase and test in prod to see whether we start seeing
blames for `<shapeUnderlying>` in our nightly job.