### PR TITLE
Drop nonexistent 'to_utc_time' Date method

### DIFF
--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -444,9 +444,6 @@ class Date
   sig {returns(T.self_type)}
   def succ(); end
 
-  sig {returns(T.untyped)}
-  def to_utc_time(); end
-
   # Returns the Julian day number. This is a whole number, which is adjusted by
   # the offset as the local time.
   #

--- a/rbi/stdlib/date_time.rbi
+++ b/rbi/stdlib/date_time.rbi
@@ -523,9 +523,6 @@ class DateTime < Date
   sig {returns(T.untyped)}
   def blank?(); end
 
-  sig {returns(T.untyped)}
-  def to_utc_time(); end
-
   sig do
     params(
       locale: T.untyped,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Non-existent stdlib Date/DateTime method

https://ruby-doc.org/3.2.2/exts/date/Date.html
https://ruby-doc.org/3.2.2/exts/date/DateTime.html

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
