### PR TITLE
Update the location for `sealed_subclasses` after fast path edit

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1327,6 +1327,11 @@ MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRe
     if (store.exists()) {
         ENFORCE(store.isMethod(), "existing symbol is not a method");
         counterInc("symbols.hit");
+        if (!store.locs(*this).empty() && absl::c_count(store.locs(*this), loc) == 0) {
+            ENFORCE(!symbolTableFrozen);
+            store.asMethodRef().data(*this)->addLoc(*this, loc);
+            wasModified_ = true;
+        }
         return store.asMethodRef();
     }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1327,11 +1327,6 @@ MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRe
     if (store.exists()) {
         ENFORCE(store.isMethod(), "existing symbol is not a method");
         counterInc("symbols.hit");
-        if (!store.locs(*this).empty() && absl::c_count(store.locs(*this), loc) == 0) {
-            ENFORCE(!symbolTableFrozen);
-            store.asMethodRef().data(*this)->addLoc(*this, loc);
-            wasModified_ = true;
-        }
         return store.asMethodRef();
     }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1261,8 +1261,11 @@ private:
             symbolData->flags.isSealed = true;
 
             auto classOfKlass = symbolData->singletonClass(ctx);
-            auto sealedSubclasses =
-                ctx.state.enterMethodSymbol(ctx.locAt(mod.loc), classOfKlass, core::Names::sealedSubclasses());
+            auto loc = ctx.locAt(mod.loc);
+            auto sealedSubclasses = ctx.state.enterMethodSymbol(loc, classOfKlass, core::Names::sealedSubclasses());
+            if (absl::c_count(sealedSubclasses.data(ctx)->locs(), loc) == 0) {
+                sealedSubclasses.data(ctx)->addLoc(ctx, loc);
+            }
             auto &blkArg =
                 ctx.state.enterMethodArgumentSymbol(core::Loc::none(), sealedSubclasses, core::Names::blkArg());
             blkArg.flags.isBlock = true;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1263,9 +1263,7 @@ private:
             auto classOfKlass = symbolData->singletonClass(ctx);
             auto loc = ctx.locAt(mod.loc);
             auto sealedSubclasses = ctx.state.enterMethodSymbol(loc, classOfKlass, core::Names::sealedSubclasses());
-            if (absl::c_count(sealedSubclasses.data(ctx)->locs(), loc) == 0) {
-                sealedSubclasses.data(ctx)->addLoc(ctx, loc);
-            }
+            sealedSubclasses.data(ctx)->addLoc(ctx, loc);
             auto &blkArg =
                 ctx.state.enterMethodArgumentSymbol(core::Loc::none(), sealedSubclasses, core::Names::blkArg());
             blkArg.flags.isBlock = true;

--- a/test/testdata/lsp/fast_path/sealed_subclasses.1.rbupdate
+++ b/test/testdata/lsp/fast_path/sealed_subclasses.1.rbupdate
@@ -1,0 +1,16 @@
+# typed: true
+
+class Parent
+  extend T::Helpers
+  sealed!
+end
+
+class Child < Parent
+  extend T::Sig
+
+  sig { override.returns(Integer) }
+  def self.sealed_subclasses
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Return type `Integer` does not match return type of overridden method `Parent.sealed_subclasses`
+    0
+  end
+end

--- a/test/testdata/lsp/fast_path/sealed_subclasses.rb
+++ b/test/testdata/lsp/fast_path/sealed_subclasses.rb
@@ -1,0 +1,32 @@
+# typed: true
+
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+
+class Parent
+  extend T::Helpers
+  sealed!
+end
+
+class Child < Parent
+  extend T::Sig
+
+  sig { override.returns(Integer) }
+  def self.sealed_subclasses
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Return type `Integer` does not match return type of overridden method `Parent.sealed_subclasses`
+    0
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

After the fast path edit the location for the `sealed_subclasses` method was not properly updated, and caused crashes. The change adds a logic the namer to fix that. 

There is a method `enterMethodSymbol`, which is called inside of a namer. It has a shortcut if a symbol for a method is already defined, it wouldn't do anything. There is a corner case of deleting or adding a bunch of lines in a file (see the test) which will not define any new symbols, but should update the locations. The shortcut wasn't checking if the location have been updated. Because of that the symbol for a method might point to a part of a file which doesn't exist anymore, and Sorbet will crash. The change fixes that bug.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Less crashes!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
