### PR TITLE
Update respond_to_missing signature to allow strings, in addition to symbols

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -635,7 +635,7 @@ module Kernel
   # When the method name parameter is given as a string, the string is converted to a symbol.
   #
   # See respond_to?, and the example of BasicObject.
-  sig {params(method_name: Symbol, include_private: T::Boolean).returns(T::Boolean)}
+  sig {params(method_name: T.any(Symbol, String), include_private: T::Boolean).returns(T::Boolean)}
   private def respond_to_missing?(method_name, include_private = false); end
 
   sig do


### PR DESCRIPTION
…

Source: vm_method.c in ruby https://github.com/ruby/ruby/blob/8f33d801c21c01fb15abed6cabd4d4b289554de3/vm_method.c#L2855C40-L2855C40

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
I am in the process of upgrading our sorbet, and got an error like:

```
components/pl/app/public/pl/domain_specific_language/runtime.rb:159: Expected `Symbol` but found `T.any(Symbol, String)` for argument `method_name` https://srb.help/7002
     159 |        super || begin self.class.const_defined?(m); rescue NameError; false end || @context.key?(m.to_sym)
                       ^
  Expected `Symbol` for argument `method_name` of method `Kernel#respond_to_missing?`:
    https://github.com/sorbet/sorbet/tree/4ef2b632ae1433ed1a544fd568f3481a4fc8f2df/rbi/core/kernel.rbi#L638:
     638 |  sig {params(method_name: Symbol, include_private: T::Boolean).returns(T::Boolean)}
```



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
