### PR TITLE
Update a location for the `<AttachedClass>` in the namer

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1215,6 +1215,11 @@ private:
 
                 auto singletonClass = symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
                 singletonClass.data(ctx)->addLoc(ctx, ctx.locAt(klass.declLoc));
+                for (const auto &typeMember : singletonClass.data(ctx)->typeMembers()) {
+                    if (typeMember.data(ctx)->name == core::Names::Constants::AttachedClass()) {
+                        typeMember.data(ctx)->addLoc(ctx, ctx.locAt(klass.declLoc));
+                    }
+                }
 
                 // This willDeleteOldDefs condition is a hack to improve performance when editing within a method body.
                 // Ideally, we would be able to make finalizeSymbols fast/incremental enough to run on all edits.

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1215,10 +1215,10 @@ private:
 
                 auto singletonClass = symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
                 singletonClass.data(ctx)->addLoc(ctx, ctx.locAt(klass.declLoc));
-                for (const auto &typeMember : singletonClass.data(ctx)->typeMembers()) {
-                    if (typeMember.data(ctx)->name == core::Names::Constants::AttachedClass()) {
-                        typeMember.data(ctx)->addLoc(ctx, ctx.locAt(klass.declLoc));
-                    }
+                auto attachedClassTM =
+                    singletonClass.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass());
+                if (attachedClassTM.exists() && attachedClassTM.isTypeMember()) {
+                    attachedClassTM.asTypeMemberRef().data(ctx)->addLoc(ctx, ctx.locAt(klass.declLoc));
                 }
 
                 // This willDeleteOldDefs condition is a hack to improve performance when editing within a method body.

--- a/test/testdata/deviations/superclass_implicit.rb.symbol-table-raw.exp
+++ b/test/testdata/deviations/superclass_implicit.rb.symbol-table-raw.exp
@@ -4,7 +4,7 @@ class <C <U <root>>> < <C <U Object>> ()
       argument <blk><block> @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=??? end=???}
   class <C <U A>> < <C <U B>> () @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=14:1 end=14:12}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U B>> $1> () @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=14:1 end=14:12}
-    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=11:1 end=11:8}
+    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=14:1 end=14:12}
     method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=14:1 end=15:4}
       argument <blk><block> @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=??? end=???}
   class <C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/deviations/superclass_implicit.rb start=8:1 end=8:8}

--- a/test/testdata/namer/superclass_redefinition.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/superclass_redefinition.rb.symbol-table-raw.exp
@@ -4,7 +4,7 @@ class <C <U <root>>> < <C <U Object>> ()
       argument <blk><block> @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=7:1 end=7:12}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=7:1 end=7:12}
-    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=2:1 end=2:17}
+    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=7:1 end=7:12}
     method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=7:1 end=8:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=??? end=???}
   class <C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/namer/superclass_redefinition.rb start=4:1 end=4:8}

--- a/test/testdata/resolver/simple.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/simple.rb.symbol-table-raw.exp
@@ -21,7 +21,7 @@ class <C <U <root>>> < <C <U Object>> ()
           argument <blk><block> @ Loc {file=test/testdata/resolver/simple.rb start=??? end=???}
       class <C <U Outer2>>::<C <U Inner1>>::<C <U Inner2>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/simple.rb start=21:3 end=21:23}
       class <C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/simple.rb start=21:3 end=21:23}
-        type-member(+) <C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Outer2::Inner1::Inner2) @ Loc {file=test/testdata/resolver/simple.rb start=13:5 end=13:17}
+        type-member(+) <C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Outer2::Inner1::Inner2) @ Loc {file=test/testdata/resolver/simple.rb start=21:3 end=21:23}
         method <C <U Outer2>>::<C <U Inner1>>::<S <C <U Inner2>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/simple.rb start=21:3 end=24:6}
           argument <blk><block> @ Loc {file=test/testdata/resolver/simple.rb start=??? end=???}
     class <C <U Outer2>>::<S <C <U Inner1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/simple.rb start=9:3 end=9:15}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Similar to https://github.com/sorbet/sorbet/pull/7398

In the fast path edit Sorbet doesn't update a location for the type argument `<AttachedClass>`. As a result after a large fast path edit (like deleting a long comment) the `<AttachedClass>`'s location may point to the wrong part of file
The change fixes it.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less crashes

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
