### PR TITLE
Update location of the static field on fast path

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1426,7 +1426,11 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
     if (store.exists()) {
         ENFORCE(store.isStaticField(*this), "existing symbol is not a static field");
         counterInc("symbols.hit");
-        return store.asFieldRef();
+
+        // Ensures that locs get properly updated on the fast path
+        auto fieldRef = store.asFieldRef();
+        fieldRef.data(*this)->addLoc(*this, loc);
+        return fieldRef;
     }
 
     ENFORCE(!symbolTableFrozen);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1353,7 +1353,6 @@ private:
             }
         }
         sym = ctx.state.enterStaticFieldSymbol(ctx.locAt(staticField.lhsLoc), scope, name);
-        sym.data(ctx)->addLoc(ctx, ctx.locAt(staticField.lhsLoc));
         // Reset resultType to nullptr for idempotency on the fast path--it will always be
         // re-entered in resolver.
         sym.data(ctx)->resultType = nullptr;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1353,6 +1353,7 @@ private:
             }
         }
         sym = ctx.state.enterStaticFieldSymbol(ctx.locAt(staticField.lhsLoc), scope, name);
+        sym.data(ctx)->addLoc(ctx, ctx.locAt(staticField.lhsLoc));
         // Reset resultType to nullptr for idempotency on the fast path--it will always be
         // re-entered in resolver.
         sym.data(ctx)->resultType = nullptr;

--- a/test/testdata/lsp/fast_path/static_field_loc.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_loc.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+#
+class B
+  extend T::Generic
+  R = 1
+  R = type_member
+# ^ error: Redefining constant `R` as a type member or type template
+end

--- a/test/testdata/lsp/fast_path/static_field_loc.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_loc.1.rbupdate
@@ -1,8 +1,7 @@
 # typed: true
 #
 class B
-  extend T::Generic
   R = 1
-  R = type_member
-# ^ error: Redefining constant `R` as a type member or type template
 end
+
+T.reveal_type(B::R) # error: Revealed type: `Integer`

--- a/test/testdata/lsp/fast_path/static_field_loc.rb
+++ b/test/testdata/lsp/fast_path/static_field_loc.rb
@@ -1,0 +1,27 @@
+# typed: true
+
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+#
+class B
+  extend T::Generic
+  R = 1
+  R = type_member
+# ^ error: Redefining constant `R` as a type member or type template
+end

--- a/test/testdata/lsp/fast_path/static_field_loc.rb
+++ b/test/testdata/lsp/fast_path/static_field_loc.rb
@@ -20,8 +20,7 @@
 # access that's out of bounds when reporting errors.
 #
 class B
-  extend T::Generic
   R = 1
-  R = type_member
-# ^ error: Redefining constant `R` as a type member or type template
 end
+
+T.reveal_type(B::R) # error: Revealed type: `Integer`

--- a/test/testdata/lsp/fast_path/type_alias_loc.1.rbupdate
+++ b/test/testdata/lsp/fast_path/type_alias_loc.1.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+
+X = T.type_alias {String}
+
+T.reveal_type(X) # error: Revealed type: `Runtime object representing type: String`
+

--- a/test/testdata/lsp/fast_path/type_alias_loc.rb
+++ b/test/testdata/lsp/fast_path/type_alias_loc.rb
@@ -1,0 +1,24 @@
+# typed: true
+
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+
+X = T.type_alias {String}
+
+T.reveal_type(X) # error: Revealed type: `Runtime object representing type: String`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The PR is a continuation of an effort to eliminate all crashes caused by faulty locations (https://github.com/sorbet/sorbet/pull/7398, https://github.com/sorbet/sorbet/pull/7407, https://github.com/sorbet/sorbet/pull/7381)

This change updates the location of the static field after the fast path update

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Less crashes

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
