### PR TITLE
Fix Psych.load_stream sig

### DIFF
--- a/rbi/stdlib/psych.rbi
+++ b/rbi/stdlib/psych.rbi
@@ -613,10 +613,11 @@ module Psych
       filename: T.nilable(String),
       fallback: T.untyped,
       kwargs: T.untyped,
+      block: T.nilable(T.proc.params(node: T.untyped).void),
     )
     .returns(T::Array[T.untyped])
   end
-  def self.load_stream(yaml, filename: nil, fallback: [], **kwargs); end
+  def self.load_stream(yaml, filename: nil, fallback: [], **kwargs, &block); end
 
   ###
   # Load the document contained in `filename`. Returns the yaml contained in


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This commit adds an optional block to the `Psych.load_stream` sig to better match the [current implementation](https://github.com/ruby/psych/blob/51cc86ff3f7cf98bc48d7eb1adf1e3c34b4ac475/lib/psych.rb#L627-L631).


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This became a type error in our codebase recently when we updated sorbet.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A.
