### PR TITLE
Update location of type member on a fast path

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1430,6 +1430,7 @@ private:
                         }) != members.end());
             }
             sym = existingTypeMember;
+            sym.data(ctx)->addLoc(ctx, ctx.locAt(typeMember.asgnLoc));
         } else {
             auto name = typeMember.name;
             auto oldSym = onSymbol.data(ctx)->findMemberNoDealias(ctx, name);

--- a/test/testdata/lsp/fast_path/type_args_loc.1.rbupdate
+++ b/test/testdata/lsp/fast_path/type_args_loc.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+
+class TypeMemberLoc
+  extend T::Generic
+  X = type_member
+  Y = type_template
+end
+
+T.reveal_type(TypeMemberLoc::X) # error: Revealed type: `Runtime object representing type: TypeMemberLoc::X`
+T.reveal_type(TypeMemberLoc::Y) # error: Revealed type: `Runtime object representing type: T.class_of(TypeMemberLoc)::Y`

--- a/test/testdata/lsp/fast_path/type_args_loc.rb
+++ b/test/testdata/lsp/fast_path/type_args_loc.rb
@@ -1,0 +1,30 @@
+# typed: true
+
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+
+class TypeMemberLoc
+  extend T::Generic
+  X = type_member
+  Y = type_template
+end
+
+T.reveal_type(TypeMemberLoc::X) # error: Revealed type: `Runtime object representing type: TypeMemberLoc::X`
+T.reveal_type(TypeMemberLoc::Y) # error: Revealed type: `Runtime object representing type: T.class_of(TypeMemberLoc)::Y`
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The PR is a continuation of an effort to eliminate all crashes caused by faulty locations (https://github.com/sorbet/sorbet/pull/7398, https://github.com/sorbet/sorbet/pull/7407, https://github.com/sorbet/sorbet/pull/7381, https://github.com/sorbet/sorbet/pull/7411)

This change updates the location of `type_member` and `type_argument` after the fast path update

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Less crashes

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
