### PR TITLE
Update location for type arguments on a fast path

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1299,6 +1299,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
         if (typeArg.dataAllowingNone(*this)->name == name) {
             ENFORCE(typeArg.dataAllowingNone(*this)->flags.hasFlags(flags), "existing symbol has wrong flags");
             counterInc("symbols.hit");
+            typeArg.data(*this)->addLoc(*this, loc);
             return typeArg;
         }
     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3560,6 +3560,7 @@ private:
                 if (typeSpec.type) {
                     auto name = ctx.state.freshNameUnique(core::UniqueNameKind::TypeVarName, typeSpec.name, 1);
                     auto sym = ctx.state.enterTypeArgument(typeSpec.loc, method, name, core::Variance::CoVariant);
+                    sym.data(ctx)->addLoc(ctx, typeSpec.loc);
                     auto asTypeVar = core::cast_type<core::TypeVar>(typeSpec.type);
                     ENFORCE(asTypeVar != nullptr);
                     asTypeVar->sym = sym;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3560,7 +3560,6 @@ private:
                 if (typeSpec.type) {
                     auto name = ctx.state.freshNameUnique(core::UniqueNameKind::TypeVarName, typeSpec.name, 1);
                     auto sym = ctx.state.enterTypeArgument(typeSpec.loc, method, name, core::Variance::CoVariant);
-                    sym.data(ctx)->addLoc(ctx, typeSpec.loc);
                     auto asTypeVar = core::cast_type<core::TypeVar>(typeSpec.type);
                     ENFORCE(asTypeVar != nullptr);
                     asTypeVar->sym = sym;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The PR is a continuation of an effort to eliminate all crashes caused by faulty locations (https://github.com/sorbet/sorbet/pull/7398, https://github.com/sorbet/sorbet/pull/7407, https://github.com/sorbet/sorbet/pull/7381, https://github.com/sorbet/sorbet/pull/7411, https://github.com/sorbet/sorbet/pull/7414)

The change in this pull request updates the location for the type_arguments. 

I have a hard time writing a test for this change. Firstly I've worked on this change on a branch with a addition to our test harness, which stress tests location correctness https://github.com/sorbet/sorbet/pull/7381. On that branch [all_bug.rb test](https://github.com/sorbet/sorbet/blob/master/test/testdata/infer/all_bug.rb) fails without the change from this PR.

I've tried localizing the error with following tests:

```ruby
# typed: true

# Here goes a large comment, which will be deleted on a fast path

extend T::Sig
extend T::Generic

sig do
  type_parameters(:U)
  .params(
    x: T.type_parameter(:U),
  )
  .returns(T.type_parameter(:U))
end
def foo(x)
  42
end
```

```ruby
# typed: true

# Here goes a large comment, which will be deleted on a fast path

extend T::Sig
extend T::Generic

sig do
  type_parameters(:U)
  .params(
    x: T.type_parameter(:U),
  )
  .void
end
def foo(x)
  T.reveal_type(x)
end
```

```ruby
# typed: true

# Here goes a large comment, which will be deleted on a fast path

extend T::Sig
extend T::Generic

sig do
  type_parameters(:U)
  .params(
    x: T.type_parameter(:U),
  )
  .void
end
def foo(x)
  x
# ^ hover: ...
end
```
```ruby
# typed: true

# Here goes a large comment, which will be deleted on a fast path

extend T::Sig
extend T::Generic

sig do
  type_parameters(:U)
  # ^ hover: ...
  .params(
    x: T.type_parameter(:U),
  )
  .void
end
def foo(x)
  x

end
```

None of those tests crash on master unfortunately. I'd appreciate any ideas about how I could test this change

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Less crashes

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
