### PR TITLE
Update location for the singleton class even if it's unknown 

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1206,19 +1206,28 @@ private:
                 symbol.data(ctx)->addLoc(ctx, ctx.locAt(klass.declLoc));
             }
 
-            if (!isUnknown) {
-                if (klass.definesBehavior) {
-                    auto &behaviorLocs = classBehaviorLocs[symbol];
-                    behaviorLocs.emplace_back(ctx.locAt(klass.declLoc));
-                    symbol.data(ctx)->flags.isBehaviorDefining = true;
-                }
+            // we want to force create singleton class only if it's a known definition
+            core::ClassOrModuleRef singletonClass;
+            if (isUnknown) {
+                singletonClass = symbol.data(ctx)->lookupSingletonClass(ctx);
+            } else {
+                singletonClass = symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
+            }
 
-                auto singletonClass = symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
+            if (singletonClass.exists()) {
                 singletonClass.data(ctx)->addLoc(ctx, ctx.locAt(klass.declLoc));
                 auto attachedClassTM =
                     singletonClass.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass());
                 if (attachedClassTM.exists() && attachedClassTM.isTypeMember()) {
                     attachedClassTM.asTypeMemberRef().data(ctx)->addLoc(ctx, ctx.locAt(klass.declLoc));
+                }
+            }
+
+            if (!isUnknown) {
+                if (klass.definesBehavior) {
+                    auto &behaviorLocs = classBehaviorLocs[symbol];
+                    behaviorLocs.emplace_back(ctx.locAt(klass.declLoc));
+                    symbol.data(ctx)->flags.isBehaviorDefining = true;
                 }
 
                 // This willDeleteOldDefs condition is a hack to improve performance when editing within a method body.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The PR is a continuation of an effort to eliminate all crashes caused by faulty locations (https://github.com/sorbet/sorbet/pull/7398, https://github.com/sorbet/sorbet/pull/7407, https://github.com/sorbet/sorbet/pull/7381, https://github.com/sorbet/sorbet/pull/7411, https://github.com/sorbet/sorbet/pull/7414, https://github.com/sorbet/sorbet/pull/7418)

On a branch with the `DefinitionLinesDenylistEnforcer` https://github.com/sorbet/sorbet/pull/7381 I was looking into a failing test called [test/testdata/desugar/accidentally_quadratic.rb](https://github.com/sorbet/sorbet/blob/master/test/testdata/desugar/accidentally_quadratic.rb).

It was failing, because we didn't update the location for a symbol with name `<Class:FakeData>`, which is `FakeData`'s singleton class.

This symbol is created in a call to `finalizeAncestors` during full resolver run https://github.com/sorbet/sorbet/blob/35f9c563b8b69bbb695b50c4a5e93c44ae1fe27c/resolver/GlobalPass.cc#L267-L274

In the fast path namer run, we skip updating the location for the unknown singleton classes: https://github.com/sorbet/sorbet/blob/35f9c563b8b69bbb695b50c4a5e93c44ae1fe27c/namer/namer.cc#L1209-L1222

The PR fixes that, and updates the location for even unknown singleton classes. I tried to be careful and added extra checks to not create a singleton class by mistake.

I wasn't able to come up with a good test for that, because we probably don't error on unknown singletons?

I've tried following tests, but unfortunately all of them work as expected and do not crash on a location of a singleton class symbol
```ruby
# typed: true
# large comment, which will be deleted in the .1.rbupdate to trigger fast path

extend T::Sig

module FakeData::X
  Z = "test"
end

xyz = FakeData
T.reveal_type(xyz.class)

```

```ruby
# typed: true
# large comment, which will be deleted in the .1.rbupdate to trigger fast path

extend T::Sig

module FakeData::X
      # ^ def: fake
  Z = "test"
end

FakeData
# ^ usage: fake

```

```ruby
# typed: true
# large comment, which will be deleted in the .1.rbupdate to trigger fast path

extend T::Sig

module Foo::Bar
  X = 7

  class Foo::Qux
  end
end
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Less crashes

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
