### PR TITLE
Better loc for error message when `when` body is empty for `case` block

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2199,8 +2199,13 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                             cond = MK::If(loc, std::move(test), std::move(true_), std::move(cond));
                         }
                     }
-                    res =
-                        MK::If(when->loc, std::move(cond), node2TreeImpl(dctx, std::move(when->body)), std::move(res));
+
+                    auto whenBody = MK::Nil(when->loc);
+                    if (when->body != nullptr) {
+                        whenBody = node2TreeImpl(dctx, std::move(when->body));
+                    }
+
+                    res = MK::If(when->loc, std::move(cond), std::move(whenBody), std::move(res));
                 }
                 if (assign != nullptr) {
                     res = MK::InsSeq1(loc, std::move(assign), std::move(res));

--- a/test/cli/case-blank-when-body/blank.rb
+++ b/test/cli/case-blank-when-body/blank.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+extend T::Sig
+
+sig { params(x: Integer).returns(String) }
+def foo(x)
+  case x
+  when 1
+  when 2
+    "a"
+  else
+    "b"
+  end
+end

--- a/test/cli/case-blank-when-body/test.out
+++ b/test/cli/case-blank-when-body/test.out
@@ -1,0 +1,18 @@
+test/cli/case-blank-when-body/blank.rb:14: Expected `String` but found `T.nilable(String)` for method result type https://srb.help/7005
+    14 |end
+        ^^^
+  Expected `String` for result type of method `foo`:
+    test/cli/case-blank-when-body/blank.rb:6:
+     6 |def foo(x)
+        ^^^^^^^^^^
+  Got `T.nilable(String)` originating from:
+    test/cli/case-blank-when-body/blank.rb:8:
+     8 |  when 1
+     9 |  when 2
+    test/cli/case-blank-when-body/blank.rb:10:
+    10 |    "a"
+            ^^^
+    test/cli/case-blank-when-body/blank.rb:12:
+    12 |    "b"
+            ^^^
+Errors: 1

--- a/test/cli/case-blank-when-body/test.sh
+++ b/test/cli/case-blank-when-body/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+main/sorbet --silence-dev-message test/cli/case-blank-when-body/blank.rb 2>&1
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://github.com/sorbet/sorbet/issues/7417

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
