### PR TITLE
Update location for type member's static field on fast path

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1399,6 +1399,8 @@ private:
 
         core::TypeMemberRef sym;
         auto existingTypeMember = ctx.state.lookupTypeMemberSymbol(onSymbol, typeMember.name);
+        auto typeMemberName = typeMember.name;
+
         if (existingTypeMember.exists()) {
             // if we already have a type member but it was constructed in a different file from the one we're
             // looking at, then we need to raise an error
@@ -1432,27 +1434,28 @@ private:
             sym = existingTypeMember;
             sym.data(ctx)->addLoc(ctx, ctx.locAt(typeMember.asgnLoc));
         } else {
-            auto name = typeMember.name;
-            auto oldSym = onSymbol.data(ctx)->findMemberNoDealias(ctx, name);
+            auto oldSym = onSymbol.data(ctx)->findMemberNoDealias(ctx, typeMemberName);
             if (oldSym.exists()) {
                 emitRedefinedConstantError(ctx, typeMember.nameLoc, oldSym.name(ctx), core::SymbolRef::Kind::TypeMember,
                                            oldSym);
-                name = ctx.state.nextMangledName(onSymbol, name);
+                typeMemberName = ctx.state.nextMangledName(onSymbol, typeMemberName);
             }
-            sym = ctx.state.enterTypeMember(ctx.locAt(typeMember.asgnLoc), onSymbol, name, variance);
+            sym = ctx.state.enterTypeMember(ctx.locAt(typeMember.asgnLoc), onSymbol, typeMemberName, variance);
 
             // The todo bounds will be fixed by the resolver in ResolveTypeParamsWalk.
             auto todo = core::make_type<core::ClassType>(core::Symbols::todo());
             sym.data(ctx)->resultType = core::make_type<core::LambdaParam>(sym, todo, todo);
+        }
 
-            if (isTypeTemplate) {
-                auto typeTemplateAliasName = typeMember.name;
-                auto context = ctx.owner.enclosingClass(ctx);
+        if (isTypeTemplate) {
+            auto typeTemplateAliasName = typeMember.name;
+            auto context = ctx.owner.enclosingClass(ctx);
+            if (!existingTypeMember.exists()) {
                 auto oldSym = context.data(ctx)->findMemberNoDealias(ctx, typeTemplateAliasName);
                 if (oldSym.exists() &&
                     !(oldSym.loc(ctx) == ctx.locAt(typeMember.asgnLoc) || oldSym.loc(ctx).isTombStoned(ctx))) {
-                    emitRedefinedConstantError(ctx, typeMember.nameLoc, name, core::SymbolRef::Kind::TypeMember,
-                                               oldSym);
+                    emitRedefinedConstantError(ctx, typeMember.nameLoc, typeMemberName,
+                                               core::SymbolRef::Kind::TypeMember, oldSym);
                     typeTemplateAliasName = ctx.state.nextMangledName(context, typeTemplateAliasName);
                 }
                 // This static field with an AliasType is how we get `MyTypeTemplate` to resolve,

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1450,7 +1450,10 @@ private:
         if (isTypeTemplate) {
             auto typeTemplateAliasName = typeMember.name;
             auto context = ctx.owner.enclosingClass(ctx);
-            if (!existingTypeMember.exists()) {
+            if (existingTypeMember.exists()) {
+                auto alias = ctx.state.lookupStaticFieldSymbol(context, typeTemplateAliasName);
+                alias.data(ctx)->addLoc(ctx, ctx.locAt(typeMember.asgnLoc));
+            } else {
                 auto oldSym = context.data(ctx)->findMemberNoDealias(ctx, typeTemplateAliasName);
                 if (oldSym.exists() &&
                     !(oldSym.loc(ctx) == ctx.locAt(typeMember.asgnLoc) || oldSym.loc(ctx).isTombStoned(ctx))) {
@@ -1464,9 +1467,6 @@ private:
                 auto alias =
                     ctx.state.enterStaticFieldSymbol(ctx.locAt(typeMember.asgnLoc), context, typeTemplateAliasName);
                 alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
-            } else {
-                auto alias = ctx.state.lookupStaticFieldSymbol(context, typeTemplateAliasName);
-                alias.data(ctx)->addLoc(ctx, ctx.locAt(typeMember.asgnLoc));
             }
         }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1464,6 +1464,9 @@ private:
                 auto alias =
                     ctx.state.enterStaticFieldSymbol(ctx.locAt(typeMember.asgnLoc), context, typeTemplateAliasName);
                 alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
+            } else {
+                auto alias = ctx.state.lookupStaticFieldSymbol(context, typeTemplateAliasName);
+                alias.data(ctx)->addLoc(ctx, ctx.locAt(typeMember.asgnLoc));
             }
         }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The PR is a continuation of an effort to eliminate all crashes caused by faulty locations (https://github.com/sorbet/sorbet/pull/7398, https://github.com/sorbet/sorbet/pull/7407, https://github.com/sorbet/sorbet/pull/7381, https://github.com/sorbet/sorbet/pull/7411, https://github.com/sorbet/sorbet/pull/7414, https://github.com/sorbet/sorbet/pull/7418, https://github.com/sorbet/sorbet/pull/7419)

During namer run Sorbet creates symbols for type members. If the type member is a type template, then namer will also create a static field with the same name: https://github.com/sorbet/sorbet/blob/d7257093237535e120787dc4a23de1f9699b77ea/namer/namer.cc#L1448-L1464

There is a comment explaining why is it needed for resolver, but I don't fully understand it.

During the fast path if the location of the type template change (and the location of the static field change respectively), Sorbet will not update it. The PR introduces a fix to that bug.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
On a branch with [DefinitionLinesDenylistEnforcer](https://github.com/sorbet/sorbet/pull/7381/) the [generic_class_overrides.rb test](https://github.com/sorbet/sorbet/blob/master/test/testdata/infer/generic_class_overrides.rb) has been failing, because the location for [the Arg static field](https://github.com/sorbet/sorbet/blob/master/test/testdata/infer/generic_class_overrides.rb#L128) was not updated prorely

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
