### PR TITLE
Mark `BasicObject#==` overridable

### DIFF
--- a/rbi/core/basic_object.rbi
+++ b/rbi/core/basic_object.rbi
@@ -117,10 +117,11 @@ class BasicObject
   # 1.eql? 1.0   #=> false
   # ```
   sig do
-    params(
-        other: BasicObject,
-    )
-    .returns(T::Boolean)
+    overridable
+      .params(
+        other: T.anything,
+      )
+      .returns(T::Boolean)
   end
   def ==(other); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This obviates the need for the FAQ entry explaining people what
signature to use when overriding `BasicObject#==`.

Users can always use `override(allow_incompatible: true)` to opt out of
these checks in existing signatures.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

wip