### PR TITLE
remove no-longer needed `typeCount` map

### DIFF
--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -21,7 +21,6 @@ private:
     static const std::map<int, std::vector<std::string>> refAttrMap;
     static const std::map<int, std::vector<std::string>> defAttrMap;
     static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
-    static const std::map<int, int> typeCount;
 
     // a bunch of helpers
     void packName(core::NameRef nm);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This code is dead now that we eliminated support for depdb versions < 5 in #7421 .

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
