### PR TITLE
Better colors in missing abstract methods error

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -1016,8 +1016,8 @@ private:
             return;
         }
 
-        errorBuilder.addAutocorrect(
-            core::AutocorrectSuggestion{fmt::format("Define inherited abstract method{}", pluralization), edits});
+        errorBuilder.addAutocorrect(core::AutocorrectSuggestion{
+            fmt::format("Define inherited abstract method{}", missingAbstractMethods.size() > 1 ? "s" : ""), edits});
     }
 
     vector<core::MethodRef> findMissingAbstractMethods(const core::Context ctx, core::ClassOrModuleRef sym) {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -1017,7 +1017,9 @@ private:
         }
 
         errorBuilder.addAutocorrect(core::AutocorrectSuggestion{
-            fmt::format("Define inherited abstract method{}", missingAbstractMethods.size() > 1 ? "s" : ""), edits});
+            fmt::format("Define inherited abstract method{}", missingAbstractMethods.size() > 1 ? "s" : ""),
+            edits,
+        });
     }
 
     vector<core::MethodRef> findMissingAbstractMethods(const core::Context ctx, core::ClassOrModuleRef sym) {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -963,10 +963,12 @@ private:
             return;
         }
 
-        auto pluralization = (missingAbstractMethods.size() > 1 ? "s" : "");
-        auto suffix =
-            (missingAbstractMethods.size() > 1 ? "" : fmt::format(" `{}`", missingAbstractMethods.front().show(ctx)));
-        errorBuilder.setHeader("Missing definition{} for abstract method{}{}", pluralization, pluralization, suffix);
+        if (missingAbstractMethods.size() > 1) {
+            errorBuilder.setHeader("Missing definitions for abstract methods");
+        } else {
+            errorBuilder.setHeader("Missing definition for abstract method `{}`",
+                                   missingAbstractMethods.front().show(ctx));
+        }
 
         auto classOrModuleEndsAt = ctx.locAt(classDef.loc.copyEndWithZeroLength());
         auto hasSingleLineDefinition =


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This does two things:

- It makes it easier to search for this error message if you don't know
  what you're looking for.

- It uses the `{}` directly in the `setHeader` error message, which
  allows the error reporting framework to highlight the `{}` portion if
  it goes to a terminal.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested locally--this should not be visible in essentially any of our test
harnesses.

<img width="596" alt="image" src="https://github.com/sorbet/sorbet/assets/5544532/b439c63b-d188-4ce6-8ace-4ef028fda713">
