### PR TITLE
Update a location for alias method on a fast path

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2597,7 +2597,9 @@ class ResolveTypeMembersAndFieldsWalk {
             return;
         }
 
-        auto alias = ctx.state.enterMethodSymbol(ctx.locAt(job.fromNameLoc), job.owner, job.fromName);
+        auto loc = ctx.locAt(job.fromNameLoc);
+        auto alias = ctx.state.enterMethodSymbol(loc, job.owner, job.fromName);
+        alias.data(ctx)->addLoc(ctx, loc);
         alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(toMethod));
 
         // Add a fake keyword argument to remember the toName (for fast path hashing).

--- a/test/testdata/lsp/fast_path/alias_method_loc.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method_loc.1.rbupdate
@@ -7,3 +7,4 @@ class Alias
 end
 
 Alias.new.method_with_specific_nam
+#         ^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `method_with_specific_nam` does not exist on `Alias`

--- a/test/testdata/lsp/fast_path/alias_method_loc.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method_loc.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+
+class Alias
+  def foo; end
+
+  alias_method :method_with_specific_name, :foo
+end
+
+Alias.new.method_with_specific_nam

--- a/test/testdata/lsp/fast_path/alias_method_loc.rb
+++ b/test/testdata/lsp/fast_path/alias_method_loc.rb
@@ -17,3 +17,4 @@ class Alias
 end
 
 Alias.new.method_with_specific_nam
+#         ^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `method_with_specific_nam` does not exist on `Alias`

--- a/test/testdata/lsp/fast_path/alias_method_loc.rb
+++ b/test/testdata/lsp/fast_path/alias_method_loc.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+
+class Alias
+  def foo; end
+
+  alias_method :method_with_specific_name, :foo
+end
+
+Alias.new.method_with_specific_nam

--- a/test/testdata/resolver/multi_alias_method.rb.symbol-table.exp
+++ b/test/testdata/resolver/multi_alias_method.rb.symbol-table.exp
@@ -13,7 +13,7 @@ class ::<root> < ::Object ()
     method ::<Class:A>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:3
       argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
   class ::B < ::Object () @ test/testdata/resolver/multi_alias_method.rb:12
-    method ::B#from (does_not_exist1, does_not_exist2) -> <Alias: ::Sorbet::Private::Static#<bad-method-alias-stub> > @ test/testdata/resolver/multi_alias_method.rb:13
+    method ::B#from (does_not_exist1, does_not_exist2) -> <Alias: ::Sorbet::Private::Static#<bad-method-alias-stub> > @ test/testdata/resolver/multi_alias_method.rb:14
       argument does_not_exist1<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=13:23 end=13:39}
       argument does_not_exist2<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=14:23 end=14:39}
   class ::<Class:B>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/multi_alias_method.rb:12


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The PR is a continuation of an effort to eliminate all crashes caused by faulty locations (https://github.com/sorbet/sorbet/pull/7398, https://github.com/sorbet/sorbet/pull/7407, https://github.com/sorbet/sorbet/pull/7381, https://github.com/sorbet/sorbet/pull/7411, https://github.com/sorbet/sorbet/pull/7414, https://github.com/sorbet/sorbet/pull/7418, https://github.com/sorbet/sorbet/pull/7419, https://github.com/sorbet/sorbet/pull/7424)

The locations for alias methods are set in the resolver, but never updated on a fast path. I've added a fix for that.

I'm currently having a hard time testing this change. I found it because [a test](https://github.com/sorbet/sorbet/blob/iz/alias-method-loc/test/testdata/namer/alias_method.rb) failed on [the DefinitionLinesDenylistEnforcer branch](https://github.com/sorbet/sorbet/pull/7381/).

I tried to turn the same test into an LSP fast path test by adding a large comment in the top of the file, and deleting it in the `.1.rbupdate`. It passes without any issues even without a fix. However, If I set up a sandbox directory with Sorbet and one file with the alias_method test, and actually add and delete the comment, Sorbet crashes.

Probably there is a gap between actual LSP behaviour and our test harness.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Less crashes

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
