### PR TITLE
Fix three bugs in sync-rdoc.rb

### DIFF
--- a/rbi/tools/sync-rdoc.rb
+++ b/rbi/tools/sync-rdoc.rb
@@ -480,6 +480,14 @@ class SyncRDoc
       opts = RDoc::Options.new
       opts.parse(['--all'])
       opts.setup_generator("darkfish")
+
+      $LOAD_PATH.each do |path|
+        darkfish_dir = File.join(path, 'rdoc/generator/template/darkfish/')
+        next unless File.directory?(darkfish_dir)
+        opts.template_dir = darkfish_dir
+        break
+      end
+
       opts
     end
   end
@@ -531,10 +539,10 @@ class SyncRDoc
 
   def process_file!(file)
     to_replace = []
-    puts file.path
     DocParser.new(file).each_doc do |path, def_node, doc_range, indentation|
       next if SKIP.any? {|s| s.is_a?(String) ? path == s : path =~ s}
-      next unless ONLY_IN_FILE[path] == file.path
+      only_in_file = ONLY_IN_FILE[path]
+      next if only_in_file && only_in_file != file.path
       namespace, separator, name = path.rpartition(/::|\.|\#/)
       code_obj = case separator
       when ""


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- The template_dir thing becomes required on more recent versions of
  rdoc. In my testing, it was required to get it to work on Ruby 3.2

- The `puts` was a debug print, never should have been committed.

- The `ONLY_IN_FILE` had the unfortunate side effect of only allowing
  kernel.rbi to be updated.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested locally