### PR TITLE
Customize `T.must` error in Ruby 3.1+

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -16,6 +16,7 @@ module T::Private::Types; end
 # an ordering between groups.
 
 # These are pre-reqs for almost everything in here.
+require_relative 'types/errors/t_must_type_error'
 require_relative 'types/configuration'
 require_relative 'types/_types'
 require_relative 'types/private/decl_state'

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -219,8 +219,8 @@ module T
     return arg if arg == false
 
     begin
-      raise TypeError.new("Passed `nil` into T.must")
-    rescue TypeError => e # raise into rescue to ensure e.backtrace is populated
+      raise T::MustTypeError.new("Passed `nil` into T.must")
+    rescue T::MustTypeError => e # raise into rescue to ensure e.backtrace is populated
       T::Configuration.inline_type_error_handler(e, {kind: 'T.must', value: arg, type: nil})
     end
   end

--- a/gems/sorbet-runtime/lib/types/errors/t_must_type_error.rb
+++ b/gems/sorbet-runtime/lib/types/errors/t_must_type_error.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+# typed: true
+
+class T::MustTypeError < TypeError
+  # This approximates what the error_highlight gem does
+  if RubyVM::AbstractSyntaxTree.method(:of).parameters.include?([:key, :keep_script_lines])
+    def generate_snippet
+      # The line at index 1 in the backtrace is the call to T.must
+      backtrace_location = self.backtrace_locations&.[](1)
+      return "" unless backtrace_location
+
+      # Newer versions of error_highlight allow passing a backtrace_location
+      # directly to ErrorHighlight.spot doign it ourself is not much work at the
+      # benefit of working no matter what error_highlight version a project uses.
+      node = RubyVM::AbstractSyntaxTree.of(backtrace_location, keep_script_lines: true)
+      return "" unless node
+
+      spot = ErrorHighlight.spot(node, point_type: :args)
+      return "" unless spot
+
+      return ErrorHighlight.formatter.message_for(spot)
+    end
+  else
+    # ErrorHighlight requires `keep_script_lines: true` to get the text source of the node
+    def generate_snippet
+      ""
+    end
+  end
+
+  private :generate_snippet
+
+  if Exception.method_defined?(:detailed_message)
+    # New in Ruby 3.2
+    def detailed_message(highlight: false, error_highlight: true, **)
+      return super unless error_highlight
+      snippet = generate_snippet
+      if highlight && !snippet.empty?
+        snippet = "\e[1m" + snippet + "\e[m"
+      end
+      super + snippet
+    end
+  else
+    # For Ruby 3.1
+
+    # This is a marker to let `DidYouMean::Correctable#original_message` skip
+    # the following method definition of `to_s`.
+    # See https://github.com/ruby/did_you_mean/pull/152
+    SKIP_TO_S_FOR_SUPER_LOOKUP = true
+    private_constant :SKIP_TO_S_FOR_SUPER_LOOKUP
+
+    def to_s
+      msg = super
+      snippet = generate_snippet
+      if snippet != "" && !msg.include?(snippet)
+        msg + snippet
+      else
+        msg
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/test/types/must.rb
+++ b/gems/sorbet-runtime/test/types/must.rb
@@ -14,7 +14,7 @@ module Opus::Types::Test
       e = assert_raises(TypeError) do
         T.must(nil)
       end
-      assert_equal('Passed `nil` into T.must', e.message)
+      assert_equal('Passed `nil` into T.must', e.message.split("\n")[0])
     end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.