### PR TITLE
write symbols in a more convenient place for depdb v6

### DIFF
--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -150,6 +150,17 @@ void MsgpackWriter::packReference(core::Context ctx, ParsedFile &pf, Reference &
 MsgpackWriter::MsgpackWriter(int version)
     : version(assertValidVersion(version)), refAttrs(refAttrMap.at(version)), defAttrs(defAttrMap.at(version)) {}
 
+void writeSymbols(core::Context ctx, mpack_writer_t *writer, const vector<core::NameRef> &symbols) {
+    int i = -1;
+    mpack_start_array(writer, symbols.size());
+    for (auto sym : symbols) {
+        ++i;
+        auto str = sym.shortName(ctx);
+        packString(writer, str);
+    }
+    mpack_finish_array(writer);
+}
+
 string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg) {
     char *body;
     size_t bodySize;
@@ -193,14 +204,7 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
 
     mpack_start_array(&writer, pfAttrs.size());
 
-    int i = -1;
-    mpack_start_array(&writer, symbols.size());
-    for (auto sym : symbols) {
-        ++i;
-        auto str = sym.shortName(ctx);
-        packString(&writer, str);
-    }
-    mpack_finish_array(&writer);
+    writeSymbols(ctx, &writer, symbols);
 
     if (version >= 6) {
         uint32_t value = 0;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In depdb v5, we write the symbols (`NameRef`, in Sorbet terms, and strings in the actual file) in the header for the parsed file, so that we can be sure they are available before the body of the file is parsed.

Oddly enough, we don't write the *filename* in the header, but I digress.

Some of the depdb-processing code that we have at Stripe features the ability to skip over depdb entries depending on the name of the file, which drastically speeds up certain kinds of applications.  Except that, given the above, for a file we are going to skip over, we are required to:

* read the entire symbols array;
* read the filename;
* only then decide whether we're going to skip things.

As the symbols array can be quite large, it would be much nicer if we could postpone its reading until *after* we've read the filename, so that dealing with even skipped files will deal with a smaller amount of data.

This PR, then, moves the symbols array into the "body" of the parsed file entry, and arranges for it to be able to be skipped over, just like we skip over defs and refs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
