### PR TITLE
Update CSV RBIs to accept Tempfile input

### DIFF
--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -407,6 +407,7 @@ end
 ::Sorbet::Private::Static::IOLike = T.type_alias do
   T.any(
     IO,
-    StringIO
+    StringIO,
+    Tempfile
   )
 end

--- a/test/testdata/rbi/ruby_typer.rb
+++ b/test/testdata/rbi/ruby_typer.rb
@@ -7,5 +7,5 @@ extend T::Sig
 
 sig {params(x: Sorbet::Private::Static::IOLike).void}
 def foo(x)
-  T.reveal_type(x) # error: Revealed type: `T.any(IO, StringIO)`
+  T.reveal_type(x) # error: Revealed type: `T.any(IO, StringIO, Tempfile)`
 end


### PR DESCRIPTION
### Motivation
I have to use `T.unsafe` to work with Tempfile inputs right now. CSV operates on anything that responds to `gets`: https://github.com/ruby/ruby/blob/1f4d4558484b370999954f3ede7e3aa3a3a01ef3/lib/csv/parser.rb#L235

Tempfile [delegates to File](https://github.com/ruby/ruby/blob/e51014f9c05aa65cbf203442d37fef7c12390015/lib/tempfile.rb#L89), File [subclasses IO](https://ruby-doc.org/core-2.7.0/File.html) so adding it to IOLike seems appropriate.

### Test plan
See included automated tests.
