### PR TITLE
Fix Loc-related crash in definition_validator

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -740,8 +740,7 @@ void validateSuperClass(core::Context ctx, const core::ClassOrModuleRef sym, con
         return;
     }
 
-    if (auto e = ctx.state.beginError(core::Loc(sym.data(ctx)->loc().file(), classDef.declLoc),
-                                      core::errors::Resolver::NonClassSuperclass)) {
+    if (auto e = ctx.state.beginError(ctx.locAt(classDef.declLoc), core::errors::Resolver::NonClassSuperclass)) {
         auto superClassFqn = superClass.show(ctx);
         e.setHeader("The super class `{}` of `{}` does not derive from `{}`", superClassFqn, sym.show(ctx),
                     core::Symbols::Class().show(ctx));

--- a/test/testdata/definition_validator/superclass_class_loc__1.rb
+++ b/test/testdata/definition_validator/superclass_class_loc__1.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Parent
+end
+
+class Child < Parent
+end

--- a/test/testdata/definition_validator/superclass_class_loc__1.rb
+++ b/test/testdata/definition_validator/superclass_class_loc__1.rb
@@ -3,5 +3,5 @@
 module Parent
 end
 
-class Child < Parent
+class Child < Parent # error: does not derive from `Class`
 end

--- a/test/testdata/definition_validator/superclass_class_loc__2.rbi
+++ b/test/testdata/definition_validator/superclass_class_loc__2.rbi
@@ -13,6 +13,6 @@
 # the other file. With a sufficiently long comment, that causes an array access
 # out of bounds.
 
-class Child < Parent
+class Child < Parent # error: does not derive from `Class`
   def example; end
 end

--- a/test/testdata/definition_validator/superclass_class_loc__2.rbi
+++ b/test/testdata/definition_validator/superclass_class_loc__2.rbi
@@ -1,0 +1,18 @@
+# typed: true
+
+# This is a rather large comment at the start of the file which exposes a bug
+# where we were accidentally turning a LocOffset from this file into a Loc for
+# the other file. With a sufficiently long comment, that causes an array access
+# out of bounds.
+# This is a rather large comment at the start of the file which exposes a bug
+# where we were accidentally turning a LocOffset from this file into a Loc for
+# the other file. With a sufficiently long comment, that causes an array access
+# out of bounds.
+# This is a rather large comment at the start of the file which exposes a bug
+# where we were accidentally turning a LocOffset from this file into a Loc for
+# the other file. With a sufficiently long comment, that causes an array access
+# out of bounds.
+
+class Child < Parent
+  def example; end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This crash did not actually manifest as a problem with updating locs on the fast
path. Instead, it was a simple logic bug where we were assuming that the current
`ClassDef` AST node would also necessarily be the same as the canonical
definition of the class's symbol.

In general that's a bad assumption. Specifically, this usually manifests for
classes which have definitions split between a source and RBI file.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.