### PR TITLE
Don't consider T.must(T.untyped) redundant

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1857,14 +1857,9 @@ public:
             return;
         }
         auto ret = Types::dropNil(gs, args.args[0]->type);
-        if (ret == args.args[0]->type) {
+        if (ret == args.args[0]->type && !args.args[0]->type.isUntyped()) {
             if (auto e = gs.beginError(args.argLoc(0), errors::Infer::InvalidCast)) {
-                if (args.args[0]->type.isUntyped()) {
-                    e.setHeader("`{}` called on `{}`, which is redundant", methodName, args.args[0]->type.show(gs));
-                } else {
-                    e.setHeader("`{}` called on `{}`, which is never `{}`", methodName, args.args[0]->type.show(gs),
-                                "nil");
-                }
+                e.setHeader("`{}` called on `{}`, which is never `{}`", methodName, args.args[0]->type.show(gs), "nil");
                 e.addErrorSection(args.args[0]->explainGot(gs, args.originForUninitialized));
                 auto replaceLoc = args.callLoc();
                 const auto locWithoutTMust = args.argLoc(0);

--- a/test/testdata/desugar/oror_ivar.rb
+++ b/test/testdata/desugar/oror_ivar.rb
@@ -54,7 +54,8 @@ module Config
   sig {returns(Integer)}
   def self.accidentally_untyped
     @accidentally_untyped ||= T.let(T.unsafe(nil), T.nilable(String))
-    T.must(@accidentally_untyped) # error: `T.must` called on `T.untyped`, which is redundant
+    # No errors are expected
+    T.must(@accidentally_untyped)
   end
 
   sig {void}

--- a/test/testdata/desugar/oror_ivar.rb.autocorrects.exp
+++ b/test/testdata/desugar/oror_ivar.rb.autocorrects.exp
@@ -55,7 +55,8 @@ module Config
   sig {returns(Integer)}
   def self.accidentally_untyped
     @accidentally_untyped ||= T.let(T.unsafe(nil), T.nilable(String))
-    @accidentally_untyped # error: `T.must` called on `T.untyped`, which is redundant
+    # No errors are expected
+    T.must(@accidentally_untyped)
   end
 
   sig {void}

--- a/test/testdata/infer/must_untyped.rb
+++ b/test/testdata/infer/must_untyped.rb
@@ -1,7 +1,7 @@
 # typed: strict
 
+# No errors are expected
 T.must(T.unsafe(nil))
-#      ^^^^^^^^^^^^^ error: `T.must` called on `T.untyped`, which is redundant
 
-T.must_because(T.unsafe(nil)) {'reason'}
-#              ^^^^^^^^^^^^^ error: `T.must_because` called on `T.untyped`, which is redundant
+# No errors are expected
+T.must_because(T.unsafe(nil)) { 'reason' }


### PR DESCRIPTION
### Motivation
In my opinion, calling `T.must` with an untyped object is not redundant, and the autofix for it changes the semantics of the code.

Consider the following:

```
sig {params(something: T.untyped).void}
def foo(something)
    T.must_because(something) { "Called foo with nil!" }.bar
end
```

The author was expecting to catch (through `T.must`) the exact place where `something` is `nil`, and have their custom message.

The autofix proposes changing this just to:

```
sig {params(something: T.untyped).void}
def foo(something)
    something.bar
end
```
And depend on Ruby's behavior for handling the `nil`, or for whatever `method_missing` handling might be going on.

`T.must` here is not redundant: it's a way to be explicit about what we want to happen when the object is `nil`.

This, tied with the fact that there is now an option to highlight untyped code makes me think that we need to remove this error.

### Test plan
Modified existing tests