### PR TITLE
✨ Introduce MustOnUntyped error, and separate it from InvalidCast

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -53,6 +53,7 @@ constexpr ErrorClass NonOverlappingEqual{7046, StrictLevel::True};
 constexpr ErrorClass UntypedValueInformation{7047, StrictLevel::True};
 constexpr ErrorClass UnknownSuperMethod{7048, StrictLevel::True};
 constexpr ErrorClass TypecheckOverloadBody{7049, StrictLevel::True};
+constexpr ErrorClass MustOnUntyped{7050, StrictLevel::Strict};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 
 ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file, const TypePtr &ptr);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1858,8 +1858,9 @@ public:
         }
         auto ret = Types::dropNil(gs, args.args[0]->type);
         if (ret == args.args[0]->type) {
-            if (auto e = gs.beginError(args.argLoc(0), errors::Infer::InvalidCast)) {
-                if (args.args[0]->type.isUntyped()) {
+            auto code = args.args[0]->type.isUntyped() ? errors::Infer::MustOnUntyped : errors::Infer::InvalidCast;
+            if (auto e = gs.beginError(args.argLoc(0), code)) {
+                if (code == errors::Infer::MustOnUntyped) {
                     e.setHeader("`{}` called on `{}`, which is redundant", methodName, args.args[0]->type.show(gs));
                 } else {
                     e.setHeader("`{}` called on `{}`, which is never `{}`", methodName, args.args[0]->type.show(gs),

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -4348,6 +4348,16 @@ See also:
 
 See [Methods with Overloaded Signatures](overloads.md) for complete docs on.
 
+## 7050
+
+Calling `T.must` with an untyped object is an indication that code that was
+considered typed (and `T.must` was ensuring that the value was not `nil`) is not
+typed anymore.
+
+This was separated from [7015](#7015) to maintain this error in
+`# typed: strict` and above, but allow for [7015](#7015) to be enforced at lower
+strictness levels.
+
 <!-- -->
 
 [report an issue]: https://github.com/sorbet/sorbet/issues


### PR DESCRIPTION
### Motivation
This is an alternative to [[sorbet/pr/7460] Don't consider T.must(T.untyped) redundant](https://github.com/sorbet/sorbet/pull/7460)

### Motivation
In my opinion, calling `T.must` with an untyped object is not necessarily redundant, and the autofix for it changes the semantics of the code.

Consider the following:

```
sig {params(something: T.untyped).void}
def foo(something)
    T.must_because(something) { "Called foo with nil!" }.bar
end
```

The author was expecting to catch (through `T.must`) the exact place where `something` is `nil`, and have their custom message.

The autofix proposes changing this just to:

```
sig {params(something: T.untyped).void}
def foo(something)
    something.bar
end
```
And depend on Ruby's behavior for handling the `nil`, or for whatever `method_missing` handling might be going on.

`T.must` here is not redundant: it's a way to be explicit about what we want to happen when the object is `nil`.

Separating this error from [Sorbet Error Reference #7015](https://sorbet.org/docs/error-reference#7015) allows users to distinguish between them, and accept autofixes for one and not the other through `--isolate-error-code`

### Test plan
See included automated tests.