### PR TITLE
don't re-write `resolved` for refs in depdb v6

### DIFF
--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -140,6 +140,8 @@ void MsgpackWriter::packReference(core::Context ctx, ParsedFile &pf, Reference &
     // resolved
     if (ref.resolved.empty()) {
         mpack_write_nil(&writer);
+    } else if (version >= 6 && absl::c_equal(ref.name.nameParts, ref.resolved.nameParts)) {
+        mpack_write_true(&writer);
     } else {
         packNames(ref.resolved.nameParts);
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For ~85% of refs in Stripe's codebase, the resolved name is identical to the textual name.  For such resolved names, we can just write a special marker to indicate that the textual name should be re-used.

This change decreases the depdb size by ~10%, but it has a lot of positive knock-on effects for readers: enabling the vector for the symbols of textual names to be re-used, not re-hashing the symbols for resolved names, etc.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
