### PR TITLE
Update location for the `mixes_in_class_methods` on a fast path

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1151,16 +1151,19 @@ private:
 
             // Get the fake property holding the mixes
             auto mixMethod = ownerKlass.data(gs)->findMethod(gs, core::Names::mixedInClassMethods());
+            auto loc = core::Loc{todo.file, send->loc};
             if (!mixMethod.exists()) {
                 // We never stored a mixin in this symbol
                 // Create a the fake property that will hold the mixed in modules
-                mixMethod = gs.enterMethodSymbol(core::Loc{todo.file, send->loc}, ownerKlass,
-                                                 core::Names::mixedInClassMethods());
+                mixMethod = gs.enterMethodSymbol(loc, ownerKlass, core::Names::mixedInClassMethods());
+
                 mixMethod.data(gs)->resultType = core::make_type<core::TupleType>(vector<core::TypePtr>{});
 
                 // Create a dummy block argument to satisfy sanitycheck during GlobalState::expandNames
                 auto &arg = gs.enterMethodArgumentSymbol(core::Loc::none(), mixMethod, core::Names::blkArg());
                 arg.flags.isBlock = true;
+            } else {
+                mixMethod.data(gs)->addLoc(gs, loc);
             }
 
             auto type = core::make_type<core::ClassType>(idSymbol);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The PR is a continuation of an effort to eliminate all crashes caused by faulty locations (https://github.com/sorbet/sorbet/pull/7398, https://github.com/sorbet/sorbet/pull/7407, https://github.com/sorbet/sorbet/pull/7381, https://github.com/sorbet/sorbet/pull/7411, https://github.com/sorbet/sorbet/pull/7414, https://github.com/sorbet/sorbet/pull/7418, https://github.com/sorbet/sorbet/pull/7419, https://github.com/sorbet/sorbet/pull/7424, https://github.com/sorbet/sorbet/pull/7434)

The change updates the location on the fast path for the `mixes_in_class_methods` symbol. I found this bug on [the DefinitionLinesDenylistEnforcer branch](https://github.com/sorbet/sorbet/pull/7381/).

However, I didn't manage to find the appropriate test for this change. I've tried turning [this test](https://github.com/sorbet/sorbet/blob/iz/mixes-class-methods-loc/test/testdata/resolver/mixes_in_class_methods.rb) into the fast path test, but it passes on master

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Less LSP crashes

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
