### PR TITLE
Remove unused autoloader_compatibility annotation

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -634,11 +634,6 @@ void GlobalState::initEmpty() {
     method = this->staticInitForClass(core::Symbols::root(), Loc::none());
     ENFORCE(method == Symbols::rootStaticInit());
 
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::autoloaderCompatibility())
-                 .arg(Names::arg0())
-                 .build();
-    ENFORCE(method == Symbols::PackageSpec_autoloader_compatibility());
-
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::visibleTo()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_visible_to());
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1053,16 +1053,12 @@ public:
         return MethodRef::fromRaw(16);
     }
 
-    static MethodRef PackageSpec_autoloader_compatibility() {
+    static MethodRef PackageSpec_visible_to() {
         return MethodRef::fromRaw(17);
     }
 
-    static MethodRef PackageSpec_visible_to() {
-        return MethodRef::fromRaw(18);
-    }
-
     static MethodRef PackageSpec_export_all() {
-        return MethodRef::fromRaw(19);
+        return MethodRef::fromRaw(18);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
@@ -1106,7 +1102,7 @@ public:
     }
 
     static MethodRef T_Generic_squareBrackets() {
-        return MethodRef::fromRaw(20);
+        return MethodRef::fromRaw(19);
     }
 
     static ClassOrModuleRef Magic_UntypedSource() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,7 +23,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 54;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 53;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 73;

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -58,11 +58,6 @@ public:
         return false;
     }
 
-    bool legacyAutoloaderCompatibility() const {
-        notImplemented();
-        return true;
-    }
-
     bool exportAll() const {
         notImplemented();
         return false;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -64,7 +64,6 @@ public:
     };
 
     virtual bool ownsSymbol(const core::GlobalState &gs, core::SymbolRef symbol) const = 0;
-    virtual bool legacyAutoloaderCompatibility() const = 0;
     virtual bool exportAll() const = 0;
     virtual bool visibleToTests() const = 0;
 

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -452,7 +452,6 @@ NameDef names[] = {
     {"testImport", "test_import"},
     {"export_", "export"},
     {"restrictToService", "restrict_to_service"},
-    {"autoloaderCompatibility", "autoloader_compatibility"},
     {"legacy"},
     {"strict"},
     {"visibleTo", "visible_to"},

--- a/main/autogen/constant_hash.cc
+++ b/main/autogen/constant_hash.cc
@@ -74,16 +74,6 @@ struct ConstantHashWalk {
                 hashConstant(ctx, arg);
             }
             hashSoFar = core::mix(hashSoFar, core::_hash(")"));
-        } else if (send.fun == core::Names::autoloaderCompatibility()) {
-            hashSoFar = core::mix(hashSoFar, core::_hash("(a"));
-            if (send.hasPosArgs()) {
-                if (auto str = ast::cast_tree<ast::Literal>(send.posArgs().front())) {
-                    if (str->isString()) {
-                        hashSoFar = core::mix(hashSoFar, core::_hash(str->asString().shortName(ctx)));
-                    }
-                }
-            }
-            hashSoFar = core::mix(hashSoFar, core::_hash(")"));
         }
     }
 

--- a/main/autogen/test/constant_hash_test.cc
+++ b/main/autogen/test/constant_hash_test.cc
@@ -186,18 +186,6 @@ TEST_CASE("Require") { // NOLINT
                                      "do_the_thing!"));
 }
 
-TEST_CASE("Package Autoloader Compatibility") { // NOLINT
-    Helper helper;
-
-    auto req = helper.hashExample("autoloader_compatibility 'legacy'\n");
-
-    // removing the annotation should affect the hash
-    CHECK_NE(req, helper.hashExample("\n"));
-
-    // changing the annotation should affect the hash
-    CHECK_NE(req, helper.hashExample("autoloader_compatibility 'strict'\n"));
-}
-
 TEST_CASE("Extend/Include") {
     Helper helper;
 

--- a/test/cli/package-special-allowed-dsls/test.out
+++ b/test/cli/package-special-allowed-dsls/test.out
@@ -1,22 +1,20 @@
-baz/__package.rb:4: Argument to `autoloader_compatibility` must be a string literal https://srb.help/3706
+baz/__package.rb:4: Method `autoloader_compatibility` does not exist on `T.class_of(Project::Baz)` https://srb.help/7003
      4 |  autoloader_compatibility :invalid
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-baz/__package.rb:5: Argument to `autoloader_compatibility` can only be 'legacy' https://srb.help/3706
+baz/__package.rb:5: Method `autoloader_compatibility` does not exist on `T.class_of(Project::Baz)` https://srb.help/7003
      5 |  autoloader_compatibility 'something'
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-baz/__package.rb:6: Argument to `autoloader_compatibility` must be a string literal https://srb.help/3706
+baz/__package.rb:6: Method `autoloader_compatibility` does not exist on `T.class_of(Project::Baz)` https://srb.help/7003
      6 |  autoloader_compatibility :legacy
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    baz/__package.rb:6: Replace with `"legacy"`
-     6 |  autoloader_compatibility :legacy
-                                   ^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-foo/__package.rb:7: The 'strict' argument has been deprecated as an argument to `autoloader_compatibility` https://srb.help/3706
+foo/__package.rb:7: Method `autoloader_compatibility` does not exist on `T.class_of(Project::Foo)` https://srb.help/7003
      7 |  autoloader_compatibility 'strict'
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    If you wish to mark your package as strictly path-based-autoloading compatible, do not provide an autoloader_compatibility annotation
-Errors: 4
+          ^^^^^^^^^^^^^^^^^^^^^^^^
+
+bar/__package.rb:4: Method `autoloader_compatibility` does not exist on `T.class_of(Project::Bar)` https://srb.help/7003
+     4 |  autoloader_compatibility 'legacy'
+          ^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 5

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -587,23 +587,12 @@ not exist.
 > This error is specific to Stripe's custom `--stripe-packages` mode. If you are
 > at Stripe, please see [go/modularity](http://go/modularity) for more.
 
-### Import/export statements
-
 All `import` and `export` lines in a `__package.rb` file must have constant
 literals as their argument. Doing arbitrary computation of imports and exports
 is not allowed in `__package.rb` files.
 
 Also note that all `import` declarations must be unique, with no duplicated
 imports.
-
-### autoloader_compatibility declarations
-
-> See [go/pbal](http://go/pbal) for more details.
-
-`autoloader_compatibility` declarations must take a single String argument. The
-only allowed value is `legacy`, otherwise the declaration cannot be present.
-These declarations annotate a package as incompatible for path-based autoloading
-and are used by our Ruby code loading pipeline.
 
 ## 3707
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was a Stripe-internal annotation that is no longer used and no longer
serves a purpose. We can delete it now.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Updated existing tests.