### PR TITLE
Don't mutate isPackage bit after file creation

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -346,11 +346,9 @@ bool File::permitOverloadDefinitions() const {
 }
 
 bool File::isPackage() const {
-    return flags.isPackage;
-}
-
-void File::setIsPackage(bool isPackage) {
-    this->flags.isPackage = isPackage;
+    // If the `__package.rb` file is at `typed: ignore`, then we haven't even parsed it.
+    // Any loop over "all package files" is really only wants "all non-ignored package files."
+    return flags.isPackage && this->strictLevel != StrictLevel::Ignore;
 }
 
 bool File::isOpenInClient() const {

--- a/core/Files.h
+++ b/core/Files.h
@@ -55,7 +55,6 @@ public:
     static bool isPackagePath(std::string_view path);
 
     bool isPackage() const;
-    void setIsPackage(bool isPackage);
 
     // Whether the file is open in the LSP client. (Always false if not running under LSP.)
     bool isOpenInClient() const;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1469,21 +1469,6 @@ void Packager::findPackages(core::GlobalState &gs, absl::Span<ast::ParsedFile> f
                 continue;
             }
 
-            if (file.file.data(gs).strictLevel == core::StrictLevel::Ignore) {
-                // if the `__package.rb` file is at `typed:
-                // ignore`, then we haven't even parsed it, which
-                // means none of the other stuff here is going to
-                // actually work (since it all assumes we've got a
-                // file to actually analyze.) If we've got a
-                // `typed: ignore` package, then skip it.
-
-                // `File::isPackage` is determined by the filename, so we need to clear it explicitly at this point
-                // to ensure that the file is no longer treated as a package.
-                file.file.data(gs).setIsPackage(false);
-
-                continue;
-            }
-
             core::MutableContext ctx(gs, core::Symbols::root(), file.file);
             auto pkg = runPackageInfoFinder(ctx, file, gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes(),
                                             gs.packageDB().extraPackageFilesDirectorySlashPrefixes());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We had a special case for ignored package files in packager. It's
cleaner to handle this without mutation.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a