### PR TITLE
fix writing symbols for depdb v6

### DIFF
--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -13,7 +13,6 @@ private:
     int version;
     const std::vector<std::string> &refAttrs;
     const std::vector<std::string> &defAttrs;
-    mpack_writer_t writer;
 
     std::vector<core::NameRef> symbols;
     UnorderedMap<core::NameRef, uint32_t> symbolIds;
@@ -23,14 +22,14 @@ private:
     static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
 
     // a bunch of helpers
-    void packName(core::NameRef nm);
-    void packNames(std::vector<core::NameRef> &names);
-    void packBool(bool b);
-    void packReferenceRef(ReferenceRef ref);
-    void packDefinitionRef(DefinitionRef ref);
-    void packRange(uint32_t begin, uint32_t end);
-    void packDefinition(core::Context ctx, ParsedFile &pf, Definition &def, const AutogenConfig &autogenCfg);
-    void packReference(core::Context ctx, ParsedFile &pf, Reference &ref);
+    void packName(mpack_writer_t *writer, core::NameRef nm);
+    void packNames(mpack_writer_t *writer, std::vector<core::NameRef> &names);
+    void packBool(mpack_writer_t *writer, bool b);
+    void packReferenceRef(mpack_writer_t *writer, ReferenceRef ref);
+    void packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref);
+    void packRange(mpack_writer_t *writer, uint32_t begin, uint32_t end);
+    void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def, const AutogenConfig &autogenCfg);
+    void packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref);
     static int assertValidVersion(int version) {
         if (version < AutogenVersion::MIN_VERSION || version > AutogenVersion::MAX_VERSION) {
             Exception::raise("msgpack version {} not in available range [{}, {}]", version, AutogenVersion::MIN_VERSION,

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -28,7 +28,8 @@ private:
     void packReferenceRef(mpack_writer_t *writer, ReferenceRef ref);
     void packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref);
     void packRange(mpack_writer_t *writer, uint32_t begin, uint32_t end);
-    void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def, const AutogenConfig &autogenCfg);
+    void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
+                        const AutogenConfig &autogenCfg);
     void packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref);
     static int assertValidVersion(int version) {
         if (version < AutogenVersion::MIN_VERSION || version > AutogenVersion::MAX_VERSION) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I moved symbol writing for depdb v6 in #7447 , but failed to notice that the symbols would only be populated by writing definitions and references...which now happened after we wrote the symbols to the file.  So we wound up writing no symbols whatsoever.

This PR puts everything back in its proper place.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I tested depdb generation performance on Stripe's codebase and did not observe much of a difference; parallelism covers a multitude of performance sins.
