### PR TITLE
Fix crash in 'Missing abstract method'

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -946,8 +946,7 @@ private:
             return;
         }
 
-        auto classOrModuleDeclaredAt = sym.data(ctx)->loc();
-        if (classOrModuleDeclaredAt.exists() && classOrModuleDeclaredAt.file().data(ctx).isRBI()) {
+        if (ctx.file.data(ctx).isRBI()) {
             return;
         }
 
@@ -956,8 +955,7 @@ private:
             return;
         }
 
-        auto errorBuilder =
-            ctx.beginError(classOrModuleDeclaredAt.offsets(), core::errors::Resolver::BadAbstractMethod);
+        auto errorBuilder = ctx.beginError(classDef.declLoc, core::errors::Resolver::BadAbstractMethod);
         if (!errorBuilder) {
             return;
         }
@@ -967,6 +965,7 @@ private:
             (missingAbstractMethods.size() > 1 ? "" : fmt::format(" `{}`", missingAbstractMethods.front().show(ctx)));
         errorBuilder.setHeader("Missing definition{} for abstract method{}{}", pluralization, pluralization, suffix);
 
+        auto classOrModuleDeclaredAt = ctx.locAt(classDef.declLoc);
         auto classOrModuleEndsAt = ctx.locAt(classDef.loc.copyEndWithZeroLength());
         auto hasSingleLineDefinition =
             classOrModuleDeclaredAt.position(ctx).first.line == classOrModuleEndsAt.position(ctx).second.line;

--- a/test/testdata/definition_validator/abstract_loc_crash__1.rb
+++ b/test/testdata/definition_validator/abstract_loc_crash__1.rb
@@ -1,0 +1,27 @@
+# typed: strict
+
+# This is a rather large comment at the start of the file which exposes a bug
+# where we were accidentally turning a LocOffset from this file into a Loc for
+# the other file. With a sufficiently long comment, that causes an array access
+# out of bounds.
+# This is a rather large comment at the start of the file which exposes a bug
+# where we were accidentally turning a LocOffset from this file into a Loc for
+# the other file. With a sufficiently long comment, that causes an array access
+# out of bounds.
+# This is a rather large comment at the start of the file which exposes a bug
+# where we were accidentally turning a LocOffset from this file into a Loc for
+# the other file. With a sufficiently long comment, that causes an array access
+# out of bounds.
+
+class Parent
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig { abstract.void }
+  def example; end
+end
+
+# The canonical `loc()` of Child is here
+class Child < Parent # error: Missing definition for abstract method
+end

--- a/test/testdata/definition_validator/abstract_loc_crash__2.rb
+++ b/test/testdata/definition_validator/abstract_loc_crash__2.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+# This being typed: true means that this is not the canonical loc of `Child`
+
+class Child < Parent # error: Missing definition for abstract method
+end

--- a/test/testdata/resolver/duplicate_abstract_errors.rb
+++ b/test/testdata/resolver/duplicate_abstract_errors.rb
@@ -8,8 +8,8 @@ class Parent
   def self.foo; end
 end
 
-class Child < Parent
-  class << self # error: Missing definition for abstract method `Parent.foo`
+class Child < Parent # error: Missing definition for abstract method `Parent.foo`
+  class << self
     extend T::Sig
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were using the symbol's `LocOffset` combined with the current file, but
there was no guarantee that the symbol's canonical loc corresponds to the
current file.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.