### PR TITLE
fix: use cwd from config and expand workspaceFolder

### DIFF
--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -284,8 +284,15 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
     }
 
     this.context.log.debug(` > ${command} ${args.join(" ")}`);
+    const cwdTemplate = this.context.configuration.activeLspConfig!.cwd;
+    const cwd = cwdTemplate
+      ? cwdTemplate.replace(
+          "${workspaceFolder}", // eslint-disable-line no-template-curly-in-string
+          workspace.rootPath || "",
+        )
+      : workspace.rootPath || "";
     this.sorbetProcess = spawn(command, args, {
-      cwd: workspace.rootPath,
+      cwd,
     });
     // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
     // So, we need to handle both events. ¯\_(ツ)_/¯


### PR DESCRIPTION
This PR contains the same changeset as https://github.com/sorbet/sorbet/pull/6702 from @paddyobrien and thus fixes #6701 

The credit for the actual changes goes to @paddyobrien, I just rebased them on master

### Motivation

The [original PR](https://github.com/sorbet/sorbet/pull/6702) didn't get merged and conflicts, and I needed a patched version of the extension to use on my project.

### Test plan

It works on our project, where the ruby project is in a subfolder of the workspace, by setting the `cwd` option correctly. The version published on the Microsoft Marketplace doesn't work
