### PR TITLE
Use const GlobalState in PackageInfoFinder

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -963,16 +963,14 @@ struct PackageInfoFinder {
 
         if ((send.fun == core::Names::import() || send.fun == core::Names::testImport()) && send.numPosArgs() == 1) {
             // null indicates an invalid import.
-            if (auto target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
-                auto name = getPackageName(ctx, target);
-
+            if (auto *target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
                 // Transform: `import Foo` -> `import <PackageSpecRegistry>::Foo`
                 auto importArg = move(send.getPosArg(0));
                 send.removePosArg(0);
                 ENFORCE(send.numPosArgs() == 0);
                 send.addPosArg(prependName(move(importArg), core::Names::Constants::PackageSpecRegistry()));
 
-                info->importedPackageNames.emplace_back(move(name), method2ImportType(send));
+                info->importedPackageNames.emplace_back(getPackageName(ctx, target), method2ImportType(send));
             }
         }
 
@@ -999,15 +997,13 @@ struct PackageInfoFinder {
                     return;
                 }
                 info->visibleToTests_ = true;
-            } else if (auto target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
-                auto name = getPackageName(ctx, target);
-
+            } else if (auto *target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
                 auto importArg = move(send.getPosArg(0));
                 send.removePosArg(0);
                 ENFORCE(send.numPosArgs() == 0);
                 send.addPosArg(prependName(move(importArg), core::Names::Constants::PackageSpecRegistry()));
 
-                info->visibleTo_.emplace_back(move(name));
+                info->visibleTo_.emplace_back(getPackageName(ctx, target));
             }
         }
     }
@@ -1028,9 +1024,8 @@ struct PackageInfoFinder {
             auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
             info = make_unique<PackageInfoImpl>();
             checkPackageName(ctx, nameTree);
-            auto packageName = getPackageName(ctx, nameTree);
 
-            info->name = move(packageName);
+            info->name = getPackageName(ctx, nameTree);
             info->loc = ctx.locAt(classDef.loc);
             info->declLoc_ = ctx.locAt(classDef.declLoc);
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -88,7 +88,7 @@ struct PackageName {
     }
 };
 
-enum class ImportType {
+enum class ImportType : uint8_t {
     Normal,
     Test, // test_import
 };

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -418,10 +418,14 @@ PackageName getPackageName(core::MutableContext ctx, const ast::UnresolvedConsta
     pName.fullName = getFullyQualifiedName(ctx, constantLit);
     pName.fullTestPkgName = pName.fullName.withPrefix(TEST_NAME);
 
-    // Foo::Bar => Foo_Bar_Package
-    pName.mangledName = core::packages::MangledName::mangledNameFromParts(ctx.state, pName.fullName.parts);
+    populateMangledName(ctx, pName);
 
     return pName;
+}
+
+void populateMangledName(core::GlobalState &gs, PackageName &pName) {
+    // Foo::Bar => Foo_Bar_Package
+    pName.mangledName = core::packages::MangledName::mangledNameFromParts(gs, pName.fullName.parts);
 }
 
 bool isReferenceToPackageSpec(core::Context ctx, const ast::ExpressionPtr &expr) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Commit summary

- **no-op: Store ImportType with 1 byte (not 4)** (fc81847b4)


- **Factor out populateMangledName helper** (b058e6090)

- **Use const GlobalState in PackageInfoFinder** (9b7342ccf)

  This defers the GlobalState mutations to run after the tree walk, which 
  lets the treewalk itself be used in places where we only have an 
  immutable GlobalState.

- **no-op: Assorted cleanups** (72cc99ff4)




### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This defers the GlobalState mutations to run after the tree walk, which 
lets the treewalk itself be used in places where we only have an immutable
GlobalState. I haven't actually made any changes which take advantage of this
yet--those changes will land in future changes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests