### PR TITLE
Make Packager::runIncremental use a const GlobalState

### DIFF
--- a/packager/packager.h
+++ b/packager/packager.h
@@ -47,7 +47,7 @@ public:
     static void run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
-    static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files);
+    static std::vector<ast::ParsedFile> runIncremental(const core::GlobalState &gs, std::vector<ast::ParsedFile> files);
 
     static void dumpPackageInfo(const core::GlobalState &gs, std::string output);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Currently, `Packager::runIncremental` only runs when package files are
identical, so it never makes changes to `GlobalState`. In the future we hope to
change that, to where making certain changes to `__package.rb` files can take
the fast path and update `GlobalState` along the way.

Being explicit about where we are and are not mutating `GlobalState` today makes
those changes easier in the future.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.