### PR TITLE
Introduce core::packages::MangledName

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2384,7 +2384,7 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTe
     packageDB_.extraPackageFilesDirectorySlashPrefixes_ = extraPackageFilesDirectorySlashPrefixes;
     packageDB_.skipRBIExportEnforcementDirs_ = packageSkipRBIExportEnforcementDirs;
 
-    std::vector<core::NameRef> allowRelaxedPackagerChecksFor_;
+    std::vector<core::packages::MangledName> allowRelaxedPackagerChecksFor_;
     for (const string &pkgName : allowRelaxedPackagerChecksFor) {
         std::vector<string_view> pkgNameParts = absl::StrSplit(pkgName, "::");
         auto mangledName = core::packages::MangledName::mangledNameFromParts(*this, pkgNameParts);

--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -1,26 +1,47 @@
 #include "core/packages/MangledName.h"
 #include "absl/strings/str_join.h"
+#include "absl/strings/str_replace.h"
 #include "core/GlobalState.h"
 #include "core/Names.h"
 
 using namespace std;
 
 namespace sorbet::core::packages {
-core::NameRef MangledName::mangledNameFromParts(core::GlobalState &gs, std::vector<std::string_view> &parts) {
+MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, std::vector<std::string_view> &parts) {
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(parts, "_"), core::PACKAGE_SUFFIX);
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
     auto packagerName = gs.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-    return gs.enterNameConstant(packagerName);
+    return MangledName(gs.enterNameConstant(packagerName));
 }
 
-core::NameRef MangledName::mangledNameFromParts(core::GlobalState &gs, std::vector<core::NameRef> &parts) {
+MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, std::vector<core::NameRef> &parts) {
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(gs)), core::PACKAGE_SUFFIX);
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
     auto packagerName = gs.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-    return gs.enterNameConstant(packagerName);
+    return MangledName(gs.enterNameConstant(packagerName));
+}
+
+MangledName MangledName::mangledNameFromHuman(const core::GlobalState &gs, string_view nameStr) {
+    auto mangled = absl::StrCat(absl::StrReplaceAll(nameStr, {{"::", "_"}}), core::PACKAGE_SUFFIX);
+    auto utf8Name = gs.lookupNameUTF8(mangled);
+    if (!utf8Name.exists()) {
+        return MangledName();
+    }
+
+    auto packagerName = gs.lookupNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
+    if (!packagerName.exists()) {
+        return MangledName();
+    }
+
+    auto cnst = gs.lookupNameConstant(packagerName);
+    if (!cnst.exists()) {
+        return MangledName();
+    }
+
+    return MangledName(cnst);
 }
 } // namespace sorbet::core::packages

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -22,17 +22,17 @@ class PackageDB final {
     friend class core::GlobalState;
 
 public:
-    NameRef enterPackage(std::unique_ptr<PackageInfo> pkg);
+    MangledName enterPackage(std::unique_ptr<PackageInfo> pkg);
 
-    // Fetch the mangled package name for a file, returning a core::NameRef::noName() that doesn't exist if there is no
+    // Fetch the mangled package name for a file, returning a MangledName that doesn't exist if there is no
     // associated packge for the file.
-    const NameRef getPackageNameForFile(FileRef file) const;
+    const MangledName getPackageNameForFile(FileRef file) const;
 
     // Set the associated package for the file.
-    void setPackageNameForFile(FileRef file, NameRef mangledName);
+    void setPackageNameForFile(FileRef file, MangledName mangledName);
 
     const PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
-    const PackageInfo &getPackageInfo(core::NameRef mangledName) const;
+    const PackageInfo &getPackageInfo(MangledName mangledName) const;
 
     // Lookup `PackageInfo` from the string representation of the un-mangled package name.
     const PackageInfo &getPackageInfo(const core::GlobalState &gs, std::string_view str) const;
@@ -41,7 +41,7 @@ public:
     // Get mangled names for all packages.
     // Packages are ordered lexicographically with respect to the NameRef's that make up their
     // namespaces.
-    const std::vector<core::NameRef> &packages() const;
+    const std::vector<MangledName> &packages() const;
 
     PackageDB deepCopy() const;
 
@@ -59,7 +59,7 @@ public:
     const std::vector<std::string> &skipRBIExportEnforcementDirs() const;
 
     const std::string_view errorHint() const;
-    bool allowRelaxedPackagerChecksFor(const core::NameRef mangledName) const;
+    bool allowRelaxedPackagerChecksFor(const MangledName mangledName) const;
 
 private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
@@ -67,16 +67,16 @@ private:
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes_;
     std::string errorHint_;
     std::vector<std::string> skipRBIExportEnforcementDirs_;
-    std::vector<NameRef> allowRelaxedPackagerChecksFor_;
+    std::vector<MangledName> allowRelaxedPackagerChecksFor_;
 
     // This vector is kept in sync with the size of the file table in the global state by
     // `Packager::setPackageNameOnFiles`. A `FileRef` being out of bounds in this vector is treated as the file having
     // no associated package.
-    std::vector<NameRef> packageForFile_;
+    std::vector<MangledName> packageForFile_;
 
-    UnorderedMap<core::NameRef, std::unique_ptr<packages::PackageInfo>> packages_;
-    UnorderedMap<std::string, core::NameRef> packagesByPathPrefix;
-    std::vector<NameRef> mangledNames;
+    UnorderedMap<MangledName, std::unique_ptr<packages::PackageInfo>> packages_;
+    UnorderedMap<std::string, MangledName> packagesByPathPrefix;
+    std::vector<MangledName> mangledNames;
 
     bool frozen = true;
     std::thread::id writerThread;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -3,6 +3,7 @@
 
 #include "core/NameRef.h"
 #include "core/SymbolRef.h"
+#include "core/packages/MangledName.h"
 #include <optional>
 #include <vector>
 
@@ -23,7 +24,7 @@ enum class ImportType {
 
 class PackageInfo {
 public:
-    virtual core::NameRef mangledName() const = 0;
+    virtual MangledName mangledName() const = 0;
     virtual const std::vector<core::NameRef> &fullName() const = 0;
     virtual const std::vector<std::string> &pathPrefixes() const = 0;
     virtual std::vector<std::vector<core::NameRef>> exports() const = 0;
@@ -41,7 +42,7 @@ public:
     core::ClassOrModuleRef getPackageScope(const core::GlobalState &gs) const;
     core::ClassOrModuleRef getPackageTestScope(const core::GlobalState &gs) const;
 
-    virtual std::optional<ImportType> importsPackage(core::NameRef mangledName) const = 0;
+    virtual std::optional<ImportType> importsPackage(MangledName mangledName) const = 0;
 
     // autocorrects
     virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
@@ -78,15 +79,15 @@ public:
 class ImportInfo final {
 public:
     // The mangled name of the package whose imports are described.
-    core::NameRef package;
+    MangledName package;
 
     // Imported packages whose name is a prefix of `package`. For example, if the package `Foo::Bar` imports `Foo` that
     // package's name would be in `parentImports` because its name is a prefix of `Foo::Bar`.
-    std::vector<core::NameRef> parentImports;
+    std::vector<MangledName> parentImports;
 
     // The mangled names of packages that are imported by this package, minus any imports that fall in the parent
     // namespace of this package.
-    std::vector<core::NameRef> regularImports;
+    std::vector<MangledName> regularImports;
 
     static ImportInfo fromPackage(const core::GlobalState &gs, const PackageInfo &info);
 };

--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -97,7 +97,7 @@ LSPQueryResult LSPQuery::LSPQuery::bySymbolInFiles(const LSPConfiguration &confi
 }
 
 LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
-                                  core::SymbolRef symbol, core::NameRef pkgName) {
+                                  core::SymbolRef symbol, core::packages::MangledName pkgName) {
     Timer timeit(config.logger, "setupLSPQueryBySymbol");
     ENFORCE(symbol.exists());
     vector<core::FileRef> frefs;

--- a/main/lsp/LSPQuery.h
+++ b/main/lsp/LSPQuery.h
@@ -17,7 +17,8 @@ public:
     static LSPQueryResult bySymbolInFiles(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
                                           core::SymbolRef symbol, std::vector<core::FileRef> frefs);
     static LSPQueryResult bySymbol(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
-                                   core::SymbolRef symbol, core::NameRef pkgName = core::NameRef::noName());
+                                   core::SymbolRef symbol,
+                                   core::packages::MangledName pkgName = core::packages::MangledName());
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -301,7 +301,7 @@ LSPTask::getReferencesToSymbol(LSPTypecheckerDelegate &typechecker, core::Symbol
 }
 
 vector<unique_ptr<core::lsp::QueryResponse>>
-LSPTask::getReferencesToSymbolInPackage(LSPTypecheckerDelegate &typechecker, core::NameRef packageName,
+LSPTask::getReferencesToSymbolInPackage(LSPTypecheckerDelegate &typechecker, core::packages::MangledName packageName,
                                         core::SymbolRef symbol,
                                         vector<unique_ptr<core::lsp::QueryResponse>> &&priorRefs) const {
     if (symbol.exists()) {

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -41,7 +41,7 @@ protected:
                           std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
-    getReferencesToSymbolInPackage(LSPTypecheckerDelegate &typechecker, core::NameRef packageName,
+    getReferencesToSymbolInPackage(LSPTypecheckerDelegate &typechecker, core::packages::MangledName packageName,
                                    core::SymbolRef symbol,
                                    std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -19,7 +19,7 @@ bool ReferencesTask::needsMultithreading(const LSPIndexer &indexer) const {
 
 vector<core::SymbolRef> ReferencesTask::getSymsToCheckWithinPackage(const core::GlobalState &gs,
                                                                     core::SymbolRef symInPackage,
-                                                                    core::NameRef packageName) {
+                                                                    core::packages::MangledName packageName) {
     std::vector<core::NameRef> fullName;
 
     auto sym = symInPackage;

--- a/main/lsp/requests/references.h
+++ b/main/lsp/requests/references.h
@@ -8,7 +8,7 @@ class ReferenceParams;
 class ReferencesTask final : public LSPRequestTask {
     std::unique_ptr<ReferenceParams> params;
     std::vector<core::SymbolRef> getSymsToCheckWithinPackage(const core::GlobalState &gs, core::SymbolRef symInPackage,
-                                                             core::NameRef packageName);
+                                                             core::packages::MangledName packageName);
     core::SymbolRef findSym(const core::GlobalState &gs, const std::vector<core::NameRef> &fullName,
                             core::SymbolRef underNamespace);
 

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1208,7 +1208,7 @@ public:
 
     RBIGenerator::RBIOutput emit() {
         RBIGenerator::RBIOutput output;
-        output.baseFilePath = pkg.mangledName().show(gs);
+        output.baseFilePath = pkg.mangledName().mangledName.show(gs);
 
         vector<core::SymbolRef> exports;
         vector<core::SymbolRef> testExports;
@@ -1289,7 +1289,7 @@ UnorderedSet<core::ClassOrModuleRef> RBIGenerator::buildPackageNamespace(core::G
     return packageNamespaces;
 }
 
-RBIGenerator::RBIOutput RBIGenerator::runOnce(const core::GlobalState &gs, core::NameRef pkgName,
+RBIGenerator::RBIOutput RBIGenerator::runOnce(const core::GlobalState &gs, core::packages::MangledName pkgName,
                                               const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces) {
     auto &pkg = gs.packageDB().getPackageInfo(pkgName);
     ENFORCE(pkg.exists());
@@ -1303,14 +1303,14 @@ void RBIGenerator::run(core::GlobalState &gs, const UnorderedSet<core::ClassOrMo
 
     const auto &packageDB = gs.packageDB();
     auto &packages = packageDB.packages();
-    auto inputq = make_shared<ConcurrentBoundedQueue<core::NameRef>>(packages.size());
+    auto inputq = make_shared<ConcurrentBoundedQueue<core::packages::MangledName>>(packages.size());
     for (auto package : packages) {
         inputq->push(move(package), 1);
     }
 
     workers.multiplexJob(
         "RBIGenerator", [inputq, outputDir, &threadBarrier, &rogs = std::as_const(gs), &packageNamespaces]() {
-            core::NameRef job;
+            core::packages::MangledName job;
             for (auto result = inputq->try_pop(job); !result.done(); result = inputq->try_pop(job)) {
                 if (result.gotItem()) {
                     auto output = runOnce(rogs, job, packageNamespaces);
@@ -1335,7 +1335,7 @@ void RBIGenerator::run(core::GlobalState &gs, const UnorderedSet<core::ClassOrMo
 
 void RBIGenerator::runSinglePackage(core::GlobalState &gs,
                                     const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
-                                    core::NameRef package, string outputDir, WorkerPool &workers) {
+                                    core::packages::MangledName package, string outputDir, WorkerPool &workers) {
     auto output = runOnce(gs, package, packageNamespaces);
     if (!output.rbi.empty()) {
         FileOps::write(absl::StrCat(outputDir, "/", output.baseFilePath, ".package.rbi"), output.rbi);

--- a/packager/rbi_gen.h
+++ b/packager/rbi_gen.h
@@ -20,7 +20,7 @@ public:
 
     // Exposed for testing.
     static UnorderedSet<core::ClassOrModuleRef> buildPackageNamespace(core::GlobalState &gs, WorkerPool &workers);
-    static RBIOutput runOnce(const core::GlobalState &gs, core::NameRef pkg,
+    static RBIOutput runOnce(const core::GlobalState &gs, core::packages::MangledName pkg,
                              const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces);
 
     // Generate RBIs for all packages present in the package database of `gs`.
@@ -29,7 +29,7 @@ public:
 
     // Generate RBIs for a single package, provided as the mangled package name `package`.
     static void runSinglePackage(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
-                                 core::NameRef package, std::string outputDir, WorkerPool &workers);
+                                 core::packages::MangledName package, std::string outputDir, WorkerPool &workers);
 };
 } // namespace sorbet::packager
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -391,7 +391,7 @@ private:
     static const int MAX_SUGGESTION_COUNT = 10;
 
     struct PackageStub {
-        core::NameRef packageId;
+        core::packages::MangledName packageId;
         vector<core::NameRef> fullName;
 
         PackageStub(const core::packages::PackageInfo &info)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This will be the first step towards identifying packages by a
`PackageRef` ID instead of by these special mangled names.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests
