### PR TITLE
Fix broken compiler test by using exponentiation (int_plus)

### DIFF
--- a/test/testdata/compiler/intrinsics/int_plus.rb
+++ b/test/testdata/compiler/intrinsics/int_plus.rb
@@ -15,4 +15,4 @@ puts(1 + T.unsafe(Float::INFINITY))
 puts(1 + T.unsafe(-Float::INFINITY))
 
 # T_BIGNUM, *
-puts(T.cast(100*100, Integer) + 1)
+puts(T.cast(100**100, Integer) + 1)


### PR DESCRIPTION
### Motivation
The comment says what we should be doing, but the cast is redundant with the current code.  Let's fix that.

This is similar to [[sorbet/pr/7490] fix broken compiler test by using exponentiation](https://github.com/sorbet/sorbet/pull/7490)

### Test plan
The test itself