### PR TITLE
🔊 Make combinedLogger use the same time format as debug loggers [retry]

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -414,6 +414,7 @@ int realmain(int argc, char *argv[]) {
             vector<spdlog::sink_ptr> sinks{stderrColorSink, fileSink};
             auto combinedLogger = make_shared<spdlog::logger>("consoleAndFile", begin(sinks), end(sinks));
             combinedLogger->flush_on(spdlog::level::err);
+            combinedLogger->set_pattern("[%Y-%m-%dT%T.%f] [%n] [%l] %v");
             combinedLogger->set_level(spdlog::level::trace); // pass through everything, let the sinks decide
 
             spdlog::register_logger(combinedLogger);

--- a/test/cli/logging/test.sh
+++ b/test/cli/logging/test.sh
@@ -2,7 +2,7 @@ LOG_FILE=$(mktemp)
 main/sorbet --silence-dev-message -e '1' -q --debug-log-file="$LOG_FILE"
 echo LOG BEGINS
 # only keep message parts, drop timings and the entire counter section
-sed -E "s/\\[[0-9]+\\-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+.[0-9]+\\]/TIMESTAMP/"< "$LOG_FILE" |  # replace timestamps
+sed -E "s/\\[[0-9]+\\-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+.[0-9]+\\]/TIMESTAMP/"< "$LOG_FILE" | # replace timestamps
   grep 'TIMESTAMP'                                                                       |  # Only give first lines
   grep -Eve ': [0-9]+\.?[0-9]*(e(-|\+))?[0-9]*ms$'                                                       |  # remove timings
   grep -v debug-log-file                                                                     # remove header line that contains generated log name


### PR DESCRIPTION
This is a retry of [[sorbet/pr/7301] 🔊 Make combinedLogger use the same time format as debug loggers](https://github.com/sorbet/sorbet/pull/7301), which got reverted on https://github.com/sorbet/sorbet/pull/7307, as it inadvertently changed more logging than expected. 

### Motivation
- When setting the verbosity, log messages look like: `[T1802318][2023-09-06T17:57:38.322303] whatever`
- When no verbosity is set, messages look like: `[2023-09-07 23:48:51.229] [consoleAndFile] [debug] whatever`

Note the missing `T` separator in the time. This `T` is part of [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601), and intended as a separator between the date and the time, to avoid ambiguities.

### Test plan
Ran sorbet with and without my changes by running ` bazel-bin/main/sorbet --debug-log-file=my_log -e "1 + false"`

With the changes, `my_log` looks like:
```
[2023-09-08 12:32:31.417] [typeDiagnosticsAndFile] [error] -e:1: Expected Integer but found FalseClass for argument arg0 https://srb.help/7002
     1 |1 + false
            ^^^^^
  Expected Integer for argument arg0 of method Integer#+:
    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
     148 |        arg0: Integer,
                  ^^^^
  Got FalseClass originating from:
    -e:1:
     1 |1 + false
            ^^^^^
[2023-09-08 12:32:31.418] [typeDiagnosticsAndFile] [error] Errors: 1
```

Without:
```
[2023-09-08 12:33:32.659] [typeDiagnosticsAndFile] [error] -e:1: Expected Integer but found FalseClass for argument arg0 https://srb.help/7002
     1 |1 + false
            ^^^^^
  Expected Integer for argument arg0 of method Integer#+:
    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
     148 |        arg0: Integer,
                  ^^^^
  Got FalseClass originating from:
    -e:1:
     1 |1 + false
            ^^^^^
[2023-09-08 12:33:32.661] [typeDiagnosticsAndFile] [error] Errors: 1
```

In both cases, the immediate output of Sorbet is the same:

```
-e:1: Expected Integer but found FalseClass for argument arg0 https://srb.help/7002
     1 |1 + false
            ^^^^^
  Expected Integer for argument arg0 of method Integer#+:
    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#L148:
     148 |        arg0: Integer,
                  ^^^^
  Got FalseClass originating from:
    -e:1:
     1 |1 + false
            ^^^^^
Errors: 1
```
