### PR TITLE
Update locations of overloaded methods on a fast path

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3976,8 +3976,11 @@ public:
             i++;
             core::MethodRef overloadSym;
             if (isOverloaded) {
+                auto loc = ctx.locAt(sig.loc);
                 overloadSym =
-                    ctx.state.enterNewMethodOverload(ctx.locAt(sig.loc), mdef.symbol, originalName, i, sig.argsToKeep);
+                    ctx.state.enterNewMethodOverload(loc, mdef.symbol, originalName, i, sig.argsToKeep);
+                overloadSym.data(ctx)->addLoc(ctx, loc);
+
                 overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());
                 overloadSym.data(ctx)->intrinsicOffset = mdef.symbol.data(ctx)->intrinsicOffset;
                 if (i != sigs.size() - 1) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3977,8 +3977,7 @@ public:
             core::MethodRef overloadSym;
             if (isOverloaded) {
                 auto loc = ctx.locAt(sig.loc);
-                overloadSym =
-                    ctx.state.enterNewMethodOverload(loc, mdef.symbol, originalName, i, sig.argsToKeep);
+                overloadSym = ctx.state.enterNewMethodOverload(loc, mdef.symbol, originalName, i, sig.argsToKeep);
                 overloadSym.data(ctx)->addLoc(ctx, loc);
 
                 overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());

--- a/test/testdata/lsp/fast_path/location_updates/overloads_test.1.rbupdate
+++ b/test/testdata/lsp/fast_path/location_updates/overloads_test.1.rbupdate
@@ -1,0 +1,15 @@
+# typed: true
+
+
+class I; end
+class S; end
+class A
+  extend T::Sig
+  sig {params(x: I).void}
+  sig {params(x: S).void}
+  def my_method(x); end
+end
+
+
+A.new.my_metho # error: does not exist
+#             ^ completion: my_method, my_method

--- a/test/testdata/lsp/fast_path/location_updates/overloads_test.rb
+++ b/test/testdata/lsp/fast_path/location_updates/overloads_test.rb
@@ -1,0 +1,51 @@
+# typed: true
+
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+# This is a rather large comment at the start of the file so that when we
+# delete it on the fast path, it will make it very likely that we have an array
+# access that's out of bounds when reporting errors.
+
+class I; end
+class S; end
+class A
+  extend T::Sig
+  sig {params(x: I).void}
+  sig {params(x: S).void}
+  def my_method(x); end
+end
+
+
+A.new.my_metho # error: does not exist
+#             ^ completion: my_method, my_method


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The PR is a continuation of an effort to eliminate all crashes caused by faulty locations (https://github.com/sorbet/sorbet/pull/7398, https://github.com/sorbet/sorbet/pull/7407, https://github.com/sorbet/sorbet/pull/7381, https://github.com/sorbet/sorbet/pull/7411, https://github.com/sorbet/sorbet/pull/7414, https://github.com/sorbet/sorbet/pull/7418, https://github.com/sorbet/sorbet/pull/7419, https://github.com/sorbet/sorbet/pull/7424, https://github.com/sorbet/sorbet/pull/7434, https://github.com/sorbet/sorbet/pull/7470)

When Sorbet encounters an overloaded method, it will create a symbol for each signature the method has. It happens in the resolver in the `ResolveMultiSignatureJob`. The symbols are created by calling `enterNewMethodOverload`, which leverages `enterMethodSymbol`. This method has [a shortcut for already existing symbols](https://github.com/sorbet/sorbet/blob/c9c2cbde9915dfac98ae36d038dcc09e6aa267c9/core/GlobalState.cc#L1323-L1327). On a fast path Sorbet will take the shortcut code path and wouldn't update the location of the overloaded symbol. 
The PR introduces a patch to fix the issue.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Less LSP crashes

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
