### PR TITLE
Fix error-reference.md for error 7019

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3710,7 +3710,7 @@ sig {params(xs: Integer).void}
 def foo(*xs); end
 
 xs = Array.new(3) {|i| i}
-T.unsafe(self).foo(xs)
+T.unsafe(self).foo(*xs)
 # ---------------------------------------------
 ```
 


### PR DESCRIPTION
### Motivation

Typo, when using T.unsafe and not changing the method to expect an array, the call is done with `*` same as the first example above.