### PR TITLE
Add a mention of canTakeFastPath for SEO

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -75,6 +75,9 @@ void LSPIndexer::computeFileHashes(const vector<shared_ptr<core::File>> &files) 
     computeFileHashes(files, *emptyWorkers);
 }
 
+// This function was prevously called canTakeFastPath, but we changed it in ancitipation of adding
+// incremental mode(s) that lied between the original fast and slow path. Leaving this comment here
+// because old habits die hard and I still can only remember the name "canTakeFastPath"
 TypecheckingPath
 LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &changedFiles,
                                         const UnorderedMap<core::FileRef, shared_ptr<core::File>> &evictedFiles) const {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I can never remember `getTypecheckingPathInternal` despite it having
been added ages ago.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a