### PR TITLE
complain if `rubyfmt` cannot be found for LSP

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -729,9 +729,13 @@ void readOptions(Options &opts,
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-highlight"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
         opts.rubyfmtPath = raw["rubyfmt-path"].as<string>();
-        opts.lspDocumentFormatRubyfmtEnabled =
-            FileOps::exists(opts.rubyfmtPath) &&
-            (enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>());
+        if (enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>()) {
+            if (!FileOps::exists(opts.rubyfmtPath)) {
+                logger->error("`{}` does not exist, LSP rubyfmt integration will not be enabled", opts.rubyfmtPath);
+            } else {
+                opts.lspDocumentFormatRubyfmtEnabled = true;
+            }
+        }
         opts.outOfOrderReferenceChecksEnabled = raw["check-out-of-order-constant-references"].as<bool>();
         opts.trackUntyped = raw["track-untyped"].as<bool>();
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Request from a user for debugging help.

Using `error` here without exiting feels a little weird, but there is precedent for this later in `options.cc`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
