### PR TITLE
propagate changes to the config as well as the cache

### DIFF
--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -147,6 +147,7 @@ export class DefaultSorbetWorkspaceContext implements ISorbetWorkspaceContext {
   public async update(section: string, value: any): Promise<void> {
     const key = `sorbet.${section}`;
     await this.workspaceState.update(key, value);
+    await this.cachedSorbetConfiguration.update(section, value);
     this.onDidChangeConfigurationEmitter.fire({
       affectsConfiguration: () => true,
     });


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think this solves some issues that users has with changing things through VSCode itself, rather than the extension?  Or do we instead have to listen for changes being made on the workspace configuration, and propagate those into the `workspaceState`?

Or...why do we have this layer of caching between VSCode's configuration anyway?  Would things be simpler and less error-prone if we just removed `DefaultSorbetWorkspaceContext`'s caching entirely?

cc @damolina-stripe 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
