### PR TITLE
Re-enable out-of-order checks for unknown classes and modules

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1329,8 +1329,7 @@ private:
             const bool possibleGenericType = false;
             if (resolveConstantJob(ctx, nesting_, constant, resolutionFailed, possibleGenericType)) {
                 categoryCounterInc("resolve.constants.nonancestor", "firstpass");
-                if (loadScopeDepth_ == 0 && (!constant->symbol.isClassOrModule() ||
-                                             constant->symbol.asClassOrModuleRef().data(ctx)->isDeclared())) {
+                if (loadScopeDepth_ == 0) {
                     // While Sorbet treats class A::B; end like an implicit definition of A, it's actually a
                     // reference of A--Ruby will require a proper definition of A elsewhere. Long term,
                     // Sorbet should be taught to emit errors when these references are not actually defined,


### PR DESCRIPTION
This feature was turned off in commit 25448a2ddcc6e926f2ae2bcb5a5a60cd7417ecc9 in the PR #6842

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
