### PR TITLE
Refactor `SorbetExtensionConfig` (part 1)

### DIFF
--- a/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
+++ b/vscode_extension/src/commands/showSorbetConfigurationPicker.ts
@@ -1,6 +1,6 @@
 import { QuickPickItem, window } from "vscode";
-import { SorbetLspConfig } from "../config";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
+import { SorbetLspConfig } from "../sorbetLspConfig";
 
 export interface LspConfigQuickPickItem extends QuickPickItem {
   lspConfig?: SorbetLspConfig;

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -10,74 +10,12 @@ import {
   WorkspaceFolder,
 } from "vscode";
 import * as fs from "fs";
+import { SorbetLspConfig, SorbetLspConfigData } from "./sorbetLspConfig";
+import { deepEqual } from "./utils";
 
-/**
- * Compare two `string` arrays for deep, in-order equality.
- */
-function deepEqual(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
-  return a.length === b.length && a.every((itemA, index) => itemA === b[index]);
-}
-
-interface ISorbetLspConfig {
-  readonly id: string;
-  /** Display name suitable for short-form fields like menu items or status fields. */
-  readonly name: string;
-  /** Human-readable long-form description suitable for hover text or help. */
-  readonly description: string;
-  readonly cwd: string;
-  readonly command: ReadonlyArray<string>;
-}
-
-export class SorbetLspConfig {
-  public readonly id: string;
-  public readonly name: string;
-  public readonly description: string;
-  public readonly cwd: string;
-  public readonly command: ReadonlyArray<string>;
-
-  constructor({ id, name, description, cwd, command }: ISorbetLspConfig) {
-    this.id = id;
-    this.name = name;
-    this.description = description;
-    this.cwd = cwd;
-    this.command = [...command];
-  }
-
-  public toString(): string {
-    return `${this.name}: ${this.description} [cmd: "${this.command.join(
-      " ",
-    )}"]`;
-  }
-
-  /** Deep equality. */
-  public isEqualTo(other: any): boolean {
-    if (
-      this !== other &&
-      (!(other instanceof SorbetLspConfig) ||
-        this.id !== other.id ||
-        this.name !== other.name ||
-        this.description !== other.description ||
-        this.cwd !== other.cwd ||
-        !deepEqual(this.command, other.command))
-    ) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /** Deep equality, suitable for use when left and/or right may be null or undefined. */
-  public static areEqual(
-    left: SorbetLspConfig | undefined | null,
-    right: SorbetLspConfig | undefined | null,
-  ) {
-    return left ? left.isEqualTo(right) : left === right;
-  }
-}
-
-export class SorbetLspConfigChangeEvent {
-  public readonly oldLspConfig: SorbetLspConfig | null | undefined;
-  public readonly newLspConfig: SorbetLspConfig | null | undefined;
+export interface SorbetLspConfigChangeEvent {
+  readonly oldLspConfig: SorbetLspConfig | undefined;
+  readonly newLspConfig: SorbetLspConfig | undefined;
 }
 
 /**
@@ -95,9 +33,6 @@ export interface ISorbetWorkspaceContext extends Disposable {
 
   /** See `vscode.workspace.onDidChangeConfiguration` */
   onDidChangeConfiguration: Event<ConfigurationChangeEvent>;
-
-  /** See `vscode.workspace.workspaceFolders` */
-  workspaceFolders(): ReadonlyArray<WorkspaceFolder> | undefined;
 
   initializeEnabled(enabled: boolean): void;
 }
@@ -226,10 +161,13 @@ export class SorbetExtensionConfig implements Disposable {
     this.wrappedTypedFalseCompletionNudges = true;
     this.wrappedRevealOutputOnError = false;
 
-    const workspaceFolders = this.sorbetWorkspaceContext.workspaceFolders();
-    this.wrappedEnabled = workspaceFolders?.length
-      ? fs.existsSync(`${workspaceFolders[0].uri.fsPath}/sorbet/config`)
-      : false;
+    // Any workspace with a `…/sorbet/config` file is considered Sorbet-enabled
+    // by default. This implementation does not work in the general case with
+    // multi-root workspaces.
+    const { workspaceFolders } = workspace;
+    this.wrappedEnabled =
+      !!workspaceFolders?.length &&
+      fs.existsSync(`${workspaceFolders[0].uri.fsPath}/sorbet/config`);
 
     this.disposables = [
       this.onLspConfigChangeEmitter,
@@ -298,11 +236,11 @@ export class SorbetExtensionConfig implements Disposable {
     });
 
     this.standardLspConfigs = this.sorbetWorkspaceContext
-      .get<ISorbetLspConfig[]>("lspConfigs", [])
+      .get<SorbetLspConfigData[]>("lspConfigs", [])
       .map((c) => new SorbetLspConfig(c));
 
     this.userLspConfigs = this.sorbetWorkspaceContext
-      .get<ISorbetLspConfig[]>("userLspConfigs", [])
+      .get<SorbetLspConfigData[]>("userLspConfigs", [])
       .map((c) => new SorbetLspConfig(c));
 
     this.selectedLspConfigId = this.sorbetWorkspaceContext.get<
@@ -334,6 +272,24 @@ export class SorbetExtensionConfig implements Disposable {
   }
 
   /**
+   * Get the active {@link SorbetLspConfig LSP config}.
+   *
+   * A {@link selectedLspConfig selected} config is only active when {@link enabled}
+   * is `true`.
+   */
+  public get activeLspConfig(): SorbetLspConfig | undefined {
+    return this.enabled ? this.selectedLspConfig : undefined;
+  }
+
+  public get enabled(): boolean {
+    return this.wrappedEnabled;
+  }
+
+  public get highlightUntyped(): boolean {
+    return this.wrappedHighlightUntyped;
+  }
+
+  /**
    * Returns a copy of the current SorbetLspConfig objects.
    */
   public get lspConfigs(): ReadonlyArray<SorbetLspConfig> {
@@ -348,79 +304,74 @@ export class SorbetExtensionConfig implements Disposable {
     return results;
   }
 
-  /**
-   * Returns the active `SorbetLspConfig`.
-   *
-   * If the Sorbet extension is disabled, returns `null`, otherwise
-   * returns a `SorbetLspConfig` or `undefined` as per `selectedLspConfig`.
-   */
-  public get activeLspConfig(): SorbetLspConfig | null | undefined {
-    return this.enabled ? this.selectedLspConfig : null;
-  }
-
-  /**
-   * Returns the selected `SorbetLspConfig`, even if the extension is disabled.
-   *
-   * If the configuration does not specify a `selectedLspConfigId`, or if
-   * the `id` refers to a `SorbetLspConfig` that does not exist, return `undefined`.
-   */
-  public get selectedLspConfig(): SorbetLspConfig | undefined {
-    return this.lspConfigs.find((c) => c.id === this.selectedLspConfigId);
-  }
-
-  /**
-   * Select the given `SorbetLspConfig`.
-   *
-   * (Note that if the extension is disabled, this does not *enable* the
-   * configuration.)
-   */
-  public async setSelectedLspConfigId(id: string): Promise<void> {
-    await this.sorbetWorkspaceContext.update("selectedLspConfigId", id);
-    this.refresh();
-  }
-
-  /**
-   * Select the given `SorbetLspConfig` and enable the extension, if
-   * the extension is disabled.
-   *
-   * This is equivalent to calling `selectedLspConfigId = id; enabled=true`.
-   */
-  public async setActiveLspConfigId(id: string): Promise<void> {
-    await Promise.all([
-      this.sorbetWorkspaceContext.update("selectedLspConfigId", id),
-      this.sorbetWorkspaceContext.update("enabled", true),
-    ]);
-    this.refresh();
-  }
-
   public get revealOutputOnError(): boolean {
     return this.wrappedRevealOutputOnError;
   }
 
-  public get highlightUntyped(): boolean {
-    return this.wrappedHighlightUntyped;
+  /**
+   * Get the currently selected {@link SorbetLspConfig LSP config}.
+   *
+   * Returns `undefined` if {@link selectedLspConfigId} has not been set or if
+   * its value does not map to a config in {@link lspConfigs}.
+   */
+  public get selectedLspConfig(): SorbetLspConfig | undefined {
+    return this.lspConfigs.find((c) => c.id === this.selectedLspConfigId);
   }
 
   public get typedFalseCompletionNudges(): boolean {
     return this.wrappedTypedFalseCompletionNudges;
   }
 
-  public get enabled(): boolean {
-    return this.wrappedEnabled;
+  /**
+   * Set active {@link SorbetLspConfig LSP config}.
+   *
+   * If {@link enabled} is `false`, this will change it to `true`.
+   */
+  public async setActiveLspConfigId(id: string): Promise<void> {
+    const updates: Array<Thenable<void>> = [];
+
+    if (this.activeLspConfig?.id !== id) {
+      updates.push(
+        this.sorbetWorkspaceContext.update("selectedLspConfigId", id),
+      );
+    }
+    if (!this.enabled) {
+      updates.push(this.sorbetWorkspaceContext.update("enabled", true));
+    }
+
+    if (updates.length) {
+      await Promise.all(updates);
+      this.refresh();
+    }
   }
 
-  public async setEnabled(b: boolean): Promise<void> {
-    await this.sorbetWorkspaceContext.update("enabled", b);
+  public async setEnabled(enabled: boolean): Promise<void> {
+    await this.sorbetWorkspaceContext.update("enabled", enabled);
     this.refresh();
   }
 
-  public async setHighlightUntyped(b: boolean): Promise<void> {
-    await this.sorbetWorkspaceContext.update("highlightUntyped", b);
+  public async setHighlightUntyped(enabled: boolean): Promise<void> {
+    await this.sorbetWorkspaceContext.update("highlightUntyped", enabled);
     this.refresh();
   }
 
-  public async setTypedFalseCompletionNudges(b: boolean): Promise<void> {
-    await this.sorbetWorkspaceContext.update("typedFalseCompletionNudges", b);
+  /**
+   * Set selected {@link SorbetLspConfig LSP config}.
+   *
+   * This does not change {@link enabled}.
+   */
+  public async setSelectedLspConfigId(id: string): Promise<void> {
+    if (this.selectedLspConfigId !== id) {
+      await this.sorbetWorkspaceContext.update("selectedLspConfigId", id);
+      this.refresh();
+    }
+  }
+
+  public async setTypedFalseCompletionNudges(enabled: boolean): Promise<void> {
+    await this.sorbetWorkspaceContext.update(
+      "typedFalseCompletionNudges",
+      enabled,
+    );
     this.refresh();
   }
 }

--- a/vscode_extension/src/sorbetLspConfig.ts
+++ b/vscode_extension/src/sorbetLspConfig.ts
@@ -1,0 +1,123 @@
+import { deepEqual } from "./utils";
+
+/**
+ * Sorbet LSP configuration (data-only).
+ */
+export interface SorbetLspConfigData {
+  /**
+   * Configuration Id.
+   */
+  readonly id: string;
+  /**
+   * Display name suitable for short-form fields like menu items or status fields.
+   */
+  readonly name: string;
+  /**
+   * Human-readable zlong-form description suitable for hover text or help.
+   */
+  readonly description: string;
+  /**
+   * Working directory for {@link command}.
+   */
+  readonly cwd: string;
+  /**
+   * Command and arguments to execute, e.g. `["srb", "typecheck", "--lsp"]`.
+   */
+  readonly command: ReadonlyArray<string>;
+}
+
+/**
+ * Sorbet LSP configuration.
+ */
+export class SorbetLspConfig implements SorbetLspConfigData {
+  /**
+   * Configuration Id.
+   */
+  public readonly id: string;
+  /**
+   * Display name suitable for short-form fields like menu items or status fields.
+   */
+  public readonly name: string;
+  /**
+   * Human-readable zlong-form description suitable for hover text or help.
+   */
+  public readonly description: string;
+  /**
+   * Working directory for {@link command}.
+   */
+  public readonly cwd: string;
+  /**
+   * Command and arguments to execute, e.g. `["srb", "typecheck", "--lsp"]`.
+   */
+  public readonly command: ReadonlyArray<string>;
+
+  constructor(data: SorbetLspConfigData);
+
+  constructor(id: string, name: string);
+  constructor(id: string, name: string, description: string);
+  constructor(id: string, name: string, description: string, cwd: string);
+  constructor(
+    id: string,
+    name: string,
+    description: string,
+    cwd: string,
+    command: ReadonlyArray<string>,
+  );
+
+  constructor(
+    idOrData: string | SorbetLspConfigData,
+    name: string = "",
+    description: string = "",
+    cwd: string = "",
+    command: ReadonlyArray<string> = [],
+  ) {
+    if (typeof idOrData === "string") {
+      this.id = idOrData;
+      this.name = name;
+      this.description = description;
+      this.cwd = cwd;
+      this.command = command;
+    } else {
+      this.id = idOrData.id;
+      this.name = idOrData.name;
+      this.description = idOrData.description;
+      this.cwd = idOrData.cwd;
+      this.command = [...idOrData.command];
+    }
+  }
+
+  public toString(): string {
+    return `${this.name}: ${this.description} [cmd: "${this.command.join(
+      " ",
+    )}"]`;
+  }
+
+  /**
+   * Deep equality.
+   */
+  public isEqualTo(other: any): boolean {
+    if (
+      this !== other &&
+      (!(other instanceof SorbetLspConfig) ||
+        this.id !== other.id ||
+        this.name !== other.name ||
+        this.description !== other.description ||
+        this.cwd !== other.cwd ||
+        !deepEqual(this.command, other.command))
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Deep equality, suitable for use when left and/or right may be null or undefined.
+   */
+  public static areEqual(
+    left: SorbetLspConfig | undefined | null,
+    right: SorbetLspConfig | undefined | null,
+  ) {
+    return left ? left.isEqualTo(right) : left === right;
+  }
+}

--- a/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
+++ b/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
@@ -5,8 +5,9 @@ import * as sinon from "sinon";
 
 import { createLogStub } from "../testUtils";
 import { showSorbetConfigurationPicker } from "../../commands/showSorbetConfigurationPicker";
-import { SorbetExtensionConfig, SorbetLspConfig } from "../../config";
+import { SorbetExtensionConfig } from "../../config";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
+import { SorbetLspConfig } from "../../sorbetLspConfig";
 
 suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
   let testRestorables: { restore: () => void }[];

--- a/vscode_extension/src/test/sorbetLspConfig.test.ts
+++ b/vscode_extension/src/test/sorbetLspConfig.test.ts
@@ -1,0 +1,74 @@
+import * as assert from "assert";
+import * as path from "path";
+
+import { SorbetLspConfig } from "../sorbetLspConfig";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  const config1 = new SorbetLspConfig(
+    "test_id",
+    "test_name",
+    "test_description",
+    "test_cwd",
+    ["test_command", "test_arg_1"],
+  );
+  const config2 = new SorbetLspConfig(
+    "test_id",
+    "test_name",
+    "test_description",
+    "test_cwd",
+    ["test_command", "test_arg_1"],
+  );
+  const differentConfigs = [
+    new SorbetLspConfig(
+      "different_test_id",
+      "test_name",
+      "test_description",
+      "test_cwd",
+      ["test_command", "test_arg_1"],
+    ),
+    new SorbetLspConfig(
+      "test_id",
+      "different_test_name",
+      "test_description",
+      "test_cwd",
+      ["test_command", "test_arg_1"],
+    ),
+    new SorbetLspConfig(
+      "test_id",
+      "test_name",
+      "different_test_description",
+      "test_cwd",
+      ["test_command", "test_arg_1"],
+    ),
+    new SorbetLspConfig(
+      "test_id",
+      "test_name",
+      "test_description",
+      "different_test_cwd",
+      ["test_command", "test_arg_1"],
+    ),
+    new SorbetLspConfig(
+      "test_id",
+      "test_name",
+      "test_description",
+      "test_cwd",
+      ["different_test_command", "test_arg_1"],
+    ),
+    undefined,
+    null,
+  ];
+
+  test("isEqualTo(other)", () => {
+    assert.ok(config1.isEqualTo(config2));
+    differentConfigs.forEach((c) =>
+      assert.ok(!config1.isEqualTo(c), `Should not equal: ${c}`),
+    );
+  });
+
+  test("toString", () => {
+    assert.strictEqual(
+      config1.toString(),
+      'test_name: test_description [cmd: "test_command test_arg_1"]',
+    );
+  });
+});

--- a/vscode_extension/src/test/utils.test.ts
+++ b/vscode_extension/src/test/utils.test.ts
@@ -1,0 +1,15 @@
+import * as assert from "assert";
+import * as path from "path";
+
+import { deepEqual } from "../utils";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  test("deepEqual", () => {
+    assert.ok(deepEqual([], []), "Empty");
+    assert.ok(deepEqual(["a", "b", "c"], ["a", "b", "c"]), "Simple");
+
+    assert.ok(!deepEqual(["a", "b", "c"], []), "Prefix");
+    assert.ok(!deepEqual(["a", "b", "c"], ["a", "b"]), "Prefix");
+    assert.ok(!deepEqual(["a", "b", "c"], ["c", "b", "a"]), "Out-of-order");
+  });
+});

--- a/vscode_extension/src/utils.ts
+++ b/vscode_extension/src/utils.ts
@@ -1,0 +1,6 @@
+/**
+ * Compare two `string` arrays for deep, in-order equality.
+ */
+export function deepEqual(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
+  return a.length === b.length && a.every((itemA, index) => itemA === b[index]);
+}


### PR DESCRIPTION
Refactor `SorbetExtensionConfig` by splitting some code out, adding tests for that code and cleaning-up code in general.
- Removes `ISorbetWorkspaceContext.workspaceFolders` as there is no reason to wrap VSCode's accessor here.
- No functional changes should be introduced by this PR.  All code changes are code clean-up.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://github.com/sorbet/sorbet/pull/7516 moves too much code around (and still not done), so breaking it apart into digestible changes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
