### PR TITLE
Add missing `sort:` argument to Dir.[]

### DIFF
--- a/rbi/core/dir.rbi
+++ b/rbi/core/dir.rbi
@@ -589,9 +589,10 @@ class Dir < Object
     params(
         pattern: T.any(String, Pathname),
         base: T.nilable(T.any(String, Pathname)),
+        sort: T::Boolean,
         blk: T.nilable(T.proc.params(arg0: String).returns(BasicObject))
     )
     .returns(T::Array[String])
   end
-  def self.[](*pattern, base: nil, &blk); end
+  def self.[](*pattern, base: nil, sort: true, &blk); end
 end


### PR DESCRIPTION
This was added in Ruby 3.0.
