### PR TITLE
`SorbetExtensionConfig` does not duplicate `workspaceState` and configuration values

### DIFF
--- a/vscode_extension/src/sorbetLspConfig.ts
+++ b/vscode_extension/src/sorbetLspConfig.ts
@@ -47,7 +47,7 @@ export class SorbetLspConfig implements SorbetLspConfigData {
    */
   public readonly cwd: string;
   /**
-   * Command and arguments to execute, e.g. `["srb", "typecheck", "--lsp"]`.
+   * Command and arguments to execute, e.g. `["bundle", "exec", "srb", "typecheck", "--lsp"]`.
    */
   public readonly command: ReadonlyArray<string>;
 

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -64,7 +64,7 @@ class FakeWorkspaceConfiguration implements ISorbetWorkspaceContext {
     section: string,
     value: any,
     configurationTarget?: boolean | ConfigurationTarget | undefined,
-  ): Thenable<void> {
+  ): Promise<void> {
     if (configurationTarget) {
       assert.fail(
         `fake does not (yet) support ConfigurationTarget, given: ${configurationTarget}`,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`SorbetExtensionConfig` has a particular design that always tries to read a setting from the  `workspaceState` first, and if not found, it falls back to `workspace.getConfiguration("sorbet")`'s  configuration. But when updating a setting value, it always writes to `workspaceState`. This means settings could unexpectedly be "pinned" to the "default" value, so if they are changed (via `settings.json`), the new value is not read.

This PR updates the `update` logic so when saving a value it will only update/keep a value in `workspaceState` if it does not match the default already provided via configuration.  Goal is to clean-up `workspaceState` and reduce some confusion when debugging issues (note that `workspaceState` is normally not visible to users).

This DOES NOT fix issues related to changing configuration values from the `Settings` page and behaviors not being enabled/disabled as expected (reason being, `workspaceState` values might still take precedence), but at least should help cleaning-up conflicting values.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Follow-up to https://github.com/sorbet/sorbet/pull/7519 as a series of changes to improve handling/behavior of settings.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
