### PR TITLE
`hexdigest` accepts a `String` and returns a `String`

### DIFF
--- a/rbi/stdlib/digest.rbi
+++ b/rbi/stdlib/digest.rbi
@@ -222,9 +222,9 @@ class Digest::Class
   # [`Digest.hexencode`](https://docs.ruby-lang.org/en/2.7.0/Digest.html#method-c-hexencode)([`Digest::Class.new(*parameters)`](https://docs.ruby-lang.org/en/2.7.0/Digest/Instance.html#method-i-new).digest(string)).
   sig do
     params(
-      _: ::T.untyped,
+      _: String,
     )
-    .returns(::T.untyped)
+    .returns(String)
   end
   def self.hexdigest(*_); end
 end
@@ -324,9 +324,9 @@ module Digest::Instance
   # the process.
   sig do
     params(
-      _: ::T.untyped,
+      _: String,
     )
-    .returns(::T.untyped)
+    .returns(String)
   end
   def hexdigest(*_); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

According to the official Ruby documentation both the class and instance methods only accept `String` parameters and return a `String` result.

- https://ruby-doc.org/3.2.2/exts/digest/Digest/Class.html#method-c-hexdigest
- https://ruby-doc.org/3.2.2/exts/digest/Digest/Instance.html#method-i-hexdigest


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Improve the stdlib definitions.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->