### PR TITLE
Early exit if checkPackageName fails

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -376,8 +376,8 @@ public:
     }
 };
 
-[[nodiscard]] bool checkPackageName(core::Context ctx, const ast::UnresolvedConstantLit *constLit) {
-    bool hasError = false;
+[[nodiscard]] bool validatePackageName(core::Context ctx, const ast::UnresolvedConstantLit *constLit) {
+    bool valid = true;
     while (constLit != nullptr) {
         if (absl::StrContains(constLit->cnst.shortName(ctx), "_")) {
             // By forbidding package names to have an underscore, we can trivially convert between
@@ -397,12 +397,12 @@ public:
                     fmt::format("Replace `{}` with `{}`", constLit->cnst.shortName(ctx), replacement),
                     {core::AutocorrectSuggestion::Edit{ctx.locAt(nameLoc), replacement}}});
             }
-            hasError = true;
+            valid = false;
         }
         constLit = ast::cast_tree<ast::UnresolvedConstantLit>(constLit->scope);
     }
 
-    return hasError;
+    return valid;
 }
 
 FullyQualifiedName getFullyQualifiedName(core::Context ctx, const ast::UnresolvedConstantLit *constantLit) {
@@ -1042,7 +1042,7 @@ struct PackageInfoFinder {
         }
 
         auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
-        if (!checkPackageName(ctx, nameTree)) {
+        if (!validatePackageName(ctx, nameTree)) {
             return;
         }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -376,11 +376,16 @@ public:
     }
 };
 
-void checkPackageName(core::Context ctx, const ast::UnresolvedConstantLit *constLit) {
+[[nodiscard]] bool checkPackageName(core::Context ctx, const ast::UnresolvedConstantLit *constLit) {
+    bool hasError = false;
     while (constLit != nullptr) {
         if (absl::StrContains(constLit->cnst.shortName(ctx), "_")) {
-            // By forbidding package names to have an underscore, we can trivially convert between mangled names and
-            // unmangled names by replacing `_` with `::`.
+            // By forbidding package names to have an underscore, we can trivially convert between
+            // mangled names and unmangled names by replacing `_` with `::`.
+            //
+            // Even with packages into the symbol table this restriction is useful, because we have
+            // a lot of tooling that will create directory structures like Foo_Bar to store
+            // generated files associated with package Foo::Bar
             if (auto e = ctx.beginError(constLit->loc, core::errors::Packager::InvalidPackageName)) {
                 e.setHeader("Package names cannot contain an underscore");
                 auto replacement = absl::StrReplaceAll(constLit->cnst.shortName(ctx), {{"_", ""}});
@@ -392,9 +397,12 @@ void checkPackageName(core::Context ctx, const ast::UnresolvedConstantLit *const
                     fmt::format("Replace `{}` with `{}`", constLit->cnst.shortName(ctx), replacement),
                     {core::AutocorrectSuggestion::Edit{ctx.locAt(nameLoc), replacement}}});
             }
+            hasError = true;
         }
         constLit = ast::cast_tree<ast::UnresolvedConstantLit>(constLit->scope);
     }
+
+    return hasError;
 }
 
 FullyQualifiedName getFullyQualifiedName(core::Context ctx, const ast::UnresolvedConstantLit *constantLit) {
@@ -1020,24 +1028,33 @@ struct PackageInfoFinder {
             if (auto e = ctx.beginError(classDef.declLoc, core::errors::Packager::InvalidPackageDefinition)) {
                 e.setHeader("Expected package definition of form `Foo::Bar < PackageSpec`");
             }
-        } else if (info == nullptr) {
-            auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
-            info = make_unique<PackageInfoImpl>();
-            checkPackageName(ctx, nameTree);
 
-            info->name = getPackageName(ctx, nameTree);
-            info->loc = ctx.locAt(classDef.loc);
-            info->declLoc_ = ctx.locAt(classDef.declLoc);
+            return;
+        }
 
-            // `class Foo < PackageSpec` -> `class <PackageSpecRegistry>::Foo < PackageSpec`
-            // This removes the PackageSpec's themselves from the top-level namespace
-            classDef.name = prependName(move(classDef.name), core::Names::Constants::PackageSpecRegistry());
-        } else {
+        if (info != nullptr) {
             if (auto e = ctx.beginError(classDef.declLoc, core::errors::Packager::MultiplePackagesInOneFile)) {
                 e.setHeader("Package files can only declare one package");
                 e.addErrorLine(info->loc, "Previous package declaration found here");
             }
+
+            return;
         }
+
+        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
+        if (!checkPackageName(ctx, nameTree)) {
+            return;
+        }
+
+        info = make_unique<PackageInfoImpl>();
+
+        info->name = getPackageName(ctx, nameTree);
+        info->loc = ctx.locAt(classDef.loc);
+        info->declLoc_ = ctx.locAt(classDef.declLoc);
+
+        // `class Foo < PackageSpec` -> `class <PackageSpecRegistry>::Foo < PackageSpec`
+        // This removes the PackageSpec's themselves from the top-level namespace
+        classDef.name = prependName(move(classDef.name), core::Names::Constants::PackageSpecRegistry());
     }
 
     void postTransformClassDef(core::Context ctx, const ast::ExpressionPtr &tree) {

--- a/test/testdata/packager/invalid_package_name/__package.rb
+++ b/test/testdata/packager/invalid_package_name/__package.rb
@@ -1,3 +1,4 @@
+# error: Package file must contain a package definition of form
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true


### PR DESCRIPTION
Right now we would actually enter a package with the underscore in it.
Sorbet should be able to ENFORCE that there are no underscores in
package names, so it's better to completely early exit here.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Enforcing invariants that I'd like to be able to use in the new packager.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests