### PR TITLE
Split packager into definePackage and rewritePackageSpec

### DIFF
--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -18,7 +18,7 @@ constexpr ErrorClass InvalidPackageExpression{3710, StrictLevel::False};
 constexpr ErrorClass PackageFileMustBeStrict{3711, StrictLevel::False};
 constexpr ErrorClass InvalidPackageName{3712, StrictLevel::False};
 constexpr ErrorClass DefinitionPackageMismatch{3713, StrictLevel::False};
-constexpr ErrorClass ImportConflict{3714, StrictLevel::False};
+// constexpr ErrorClass ImportConflict{3714, StrictLevel::False};
 // constexpr ErrorClass InvalidExportForTest{3715, StrictLevel::False};
 constexpr ErrorClass ExportConflict{3716, StrictLevel::False};
 constexpr ErrorClass UsedPackagePrivateName{3717, StrictLevel::False};

--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -11,7 +11,7 @@ constexpr ErrorClass RedefinitionOfPackage{3703, StrictLevel::False};
 constexpr ErrorClass PackageNotFound{3704, StrictLevel::False};
 constexpr ErrorClass UnpackagedFile{3705, StrictLevel::False};
 constexpr ErrorClass InvalidConfiguration{3706, StrictLevel::False};
-// constexpr ErrorClass MultiplePackagesInOneFile{3707, StrictLevel::False};
+constexpr ErrorClass MultiplePackagesInOneFile{3707, StrictLevel::False};
 // 3708 MultipleExportMethodsCalls
 constexpr ErrorClass NoSelfImport{3709, StrictLevel::False};
 constexpr ErrorClass InvalidPackageExpression{3710, StrictLevel::False};

--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -11,7 +11,7 @@ constexpr ErrorClass RedefinitionOfPackage{3703, StrictLevel::False};
 constexpr ErrorClass PackageNotFound{3704, StrictLevel::False};
 constexpr ErrorClass UnpackagedFile{3705, StrictLevel::False};
 constexpr ErrorClass InvalidConfiguration{3706, StrictLevel::False};
-constexpr ErrorClass MultiplePackagesInOneFile{3707, StrictLevel::False};
+// constexpr ErrorClass MultiplePackagesInOneFile{3707, StrictLevel::False};
 // 3708 MultipleExportMethodsCalls
 constexpr ErrorClass NoSelfImport{3709, StrictLevel::False};
 constexpr ErrorClass InvalidPackageExpression{3710, StrictLevel::False};

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -18,9 +18,11 @@ public:
 
     MangledName() = default;
 
+    // ["Foo", "Bar"] => :Foo_Bar_Package
     static MangledName mangledNameFromParts(core::GlobalState &gs, std::vector<std::string_view> &parts);
+    // [:Foo, :Bar] => :Foo_Bar_Package
     static MangledName mangledNameFromParts(core::GlobalState &gs, std::vector<core::NameRef> &parts);
-    // Opus::Foo::Bar -> Opus_Foo_Bar__Package
+    // "Foo::Bar" -> :Foo_Bar_Package
     static MangledName mangledNameFromHuman(const core::GlobalState &gs, std::string_view human);
 
     bool operator==(const MangledName &rhs) const {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1222,15 +1222,13 @@ unique_ptr<PackageInfoImpl> runPackageInfoFinder(core::GlobalState &gs, ast::Par
         populateMangledName(gs, visibleTo);
 
         if (visibleTo.mangledName == info->name.mangledName) {
-            if (auto e =
-                    gs.beginError(core::Loc(package.file, visibleTo.loc), core::errors::Packager::NoSelfImport)) {
+            if (auto e = gs.beginError(core::Loc(package.file, visibleTo.loc), core::errors::Packager::NoSelfImport)) {
                 e.setHeader("Useless `{}`, because {} cannot import itself", "visible_to", info->name.toString(gs));
             }
         }
     }
 
-    auto extraPackageFilesDirectoryUnderscorePrefixes =
-        gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes();
+    auto extraPackageFilesDirectoryUnderscorePrefixes = gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes();
     auto extraPackageFilesDirectorySlashPrefixes = gs.packageDB().extraPackageFilesDirectorySlashPrefixes();
 
     const auto numPrefixes =

--- a/test/testdata/packager/invalid_package_name/__package.rb
+++ b/test/testdata/packager/invalid_package_name/__package.rb
@@ -1,4 +1,3 @@
-# error: Package file must contain a package definition of form
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true

--- a/test/testdata/packager/package-no-spec/__package.rb
+++ b/test/testdata/packager/package-no-spec/__package.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
-# error: Package file must contain a package definition
+# error: `__package.rb` file must contain a package definition
 # typed: strict
 # enable-packager: true


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Mostly reviewable by commit.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Splitting things this way is a stepping stone to being able to run namer on
`__package.rb` files to define `Package` symbols, and then running the packager
to discover imports and exports.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Close to no behavior changes, so covered by existing tests. Some of the errors
double up, because it's easier to structure things that way, and two errors for
one problem is mostly fine.