### PR TITLE
Make type initialization happen lazily

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -431,7 +431,7 @@ module T::Private::Methods
     run_sig_block_for_key(method_to_key(method))
   end
 
-  private_class_method def self.run_sig_block_for_key(key)
+  private_class_method def self.run_sig_block_for_key(key, force_type_init: false)
     blk = @sig_wrappers[key]
     if !blk
       sig = @signatures_by_method[key]
@@ -454,14 +454,17 @@ module T::Private::Methods
     end
 
     @sig_wrappers.delete(key)
+
+    sig.force_type_init if force_type_init
+
     sig
   end
 
-  def self.run_all_sig_blocks
+  def self.run_all_sig_blocks(force_type_init: true)
     loop do
       break if @sig_wrappers.empty?
       key, = @sig_wrappers.first
-      run_sig_block_for_key(key)
+      run_sig_block_for_key(key, force_type_init: force_type_init)
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -246,11 +246,11 @@ class T::Private::Methods::Signature
   end
 
   def force_type_init
-    @arg_types.each { |_, type| type.build_type }
-    @kwarg_types.each { |_, type| type.build_type }
-    @block_type.build_type if @block_type
-    @rest_type.build_type if @rest_type
-    @keyrest_type.build_type if @keyrest_type
+    @arg_types.each {|_, type| type.build_type}
+    @kwarg_types.each {|_, type| type.build_type}
+    @block_type&.build_type
+    @rest_type&.build_type
+    @keyrest_type&.build_type
     @return_type.build_type
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -245,6 +245,15 @@ class T::Private::Methods::Signature
     "#{@method} at #{loc}"
   end
 
+  def force_type_init
+    @arg_types.each { |_, type| type.build_type }
+    @kwarg_types.each { |_, type| type.build_type }
+    @block_type.build_type if @block_type
+    @rest_type.build_type if @rest_type
+    @keyrest_type.build_type if @keyrest_type
+    @return_type.build_type
+  end
+
   EMPTY_LIST = [].freeze
   EMPTY_HASH = {}.freeze
 end

--- a/gems/sorbet-runtime/lib/types/private/types/not_typed.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/not_typed.rb
@@ -6,6 +6,10 @@
 class T::Private::Types::NotTyped < T::Types::Base
   ERROR_MESSAGE = "Validation is being done on a `NotTyped`. Please report this bug at https://github.com/sorbet/sorbet/issues"
 
+  def build_type
+    nil
+  end
+
   # overrides Base
   def name
     "<NOT-TYPED>"

--- a/gems/sorbet-runtime/lib/types/private/types/string_holder.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/string_holder.rb
@@ -9,6 +9,10 @@ class T::Private::Types::StringHolder < T::Types::Base
     @string = string
   end
 
+  def build_type
+    nil
+  end
+
   # overrides Base
   def name
     string

--- a/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
@@ -9,6 +9,10 @@ module T::Private::Types
       @callable = callable
     end
 
+    def build_type
+      nil
+    end
+
     def aliased_type
       @aliased_type ||= T::Utils.coerce(@callable.call)
     end

--- a/gems/sorbet-runtime/lib/types/private/types/void.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/void.rb
@@ -18,6 +18,10 @@ module T::Private::Types
       freeze
     end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def name
       "<VOID>"

--- a/gems/sorbet-runtime/lib/types/private/types/void.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/void.rb
@@ -19,7 +19,7 @@ module T::Private::Types
     end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/anything.rb
+++ b/gems/sorbet-runtime/lib/types/types/anything.rb
@@ -7,7 +7,7 @@ module T::Types
     def initialize; end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/anything.rb
+++ b/gems/sorbet-runtime/lib/types/types/anything.rb
@@ -6,6 +6,10 @@ module T::Types
   class Anything < Base
     def initialize; end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def name
       "T.anything"

--- a/gems/sorbet-runtime/lib/types/types/attached_class.rb
+++ b/gems/sorbet-runtime/lib/types/types/attached_class.rb
@@ -10,6 +10,10 @@ module T::Types
 
     def initialize(); end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def name
       "T.attached_class"

--- a/gems/sorbet-runtime/lib/types/types/attached_class.rb
+++ b/gems/sorbet-runtime/lib/types/types/attached_class.rb
@@ -11,7 +11,7 @@ module T::Types
     def initialize(); end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -33,7 +33,8 @@ module T::Types
       raise NotImplementedError
     end
 
-    # Force the lazy type initialization
+    # Force any lazy initialization that this type might need to do
+    # It's unusual to call this directly; you probably want to call it indirectly via `T::Utils.run_all_sig_blocks`.
     def build_type
       raise NotImplementedError
     end

--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -33,6 +33,11 @@ module T::Types
       raise NotImplementedError
     end
 
+    # Force the lazy type initialization
+    def build_type
+      raise NotImplementedError
+    end
+
     # Equality is based on name, so be sure the name reflects all relevant state when implementing.
     def name
       raise NotImplementedError

--- a/gems/sorbet-runtime/lib/types/types/class_of.rb
+++ b/gems/sorbet-runtime/lib/types/types/class_of.rb
@@ -10,6 +10,10 @@ module T::Types
       @type = type
     end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def name
       "T.class_of(#{@type})"

--- a/gems/sorbet-runtime/lib/types/types/class_of.rb
+++ b/gems/sorbet-runtime/lib/types/types/class_of.rb
@@ -11,7 +11,7 @@ module T::Types
     end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/enum.rb
@@ -13,7 +13,7 @@ module T::Types
     end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/enum.rb
@@ -12,6 +12,10 @@ module T::Types
       @values = values
     end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def valid?(obj)
       @values.member?(obj)

--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -6,23 +6,25 @@ module T::Types
   # Takes a list of types. Validates each item in an array using the type in the same position
   # in the list.
   class FixedArray < Base
-    attr_reader :types
-
     def initialize(types)
-      @types = types.map {|type| T::Utils.coerce(type)}
+      @inner_types = types
+    end
+
+    def types
+      @types ||= @inner_types.map {|type| T::Utils.coerce(type)}
     end
 
     # overrides Base
     def name
-      "[#{@types.join(', ')}]"
+      "[#{types.join(', ')}]"
     end
 
     # overrides Base
     def recursively_valid?(obj)
-      if obj.is_a?(Array) && obj.length == @types.length
+      if obj.is_a?(Array) && obj.length == types.length
         i = 0
-        while i < @types.length
-          if !@types[i].recursively_valid?(obj[i])
+        while i < types.length
+          if !types[i].recursively_valid?(obj[i])
             return false
           end
           i += 1
@@ -35,10 +37,10 @@ module T::Types
 
     # overrides Base
     def valid?(obj)
-      if obj.is_a?(Array) && obj.length == @types.length
+      if obj.is_a?(Array) && obj.length == types.length
         i = 0
-        while i < @types.length
-          if !@types[i].valid?(obj[i])
+        while i < types.length
+          if !types[i].valid?(obj[i])
             return false
           end
           i += 1
@@ -56,7 +58,7 @@ module T::Types
         # Properly speaking, covariance here is unsound since arrays
         # can be mutated, but sorbet implements covariant tuples for
         # ease of adoption.
-        @types.size == other.types.size && @types.zip(other.types).all? do |t1, t2|
+        types.size == other.types.size && types.zip(other.types).all? do |t1, t2|
           t1.subtype_of?(t2)
         end
       when TypedArray
@@ -85,7 +87,7 @@ module T::Types
     # overrides Base
     def describe_obj(obj)
       if obj.is_a?(Array)
-        if obj.length == @types.length
+        if obj.length == types.length
           item_classes = obj.map(&:class).join(', ')
           "type [#{item_classes}]"
         else

--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -14,6 +14,10 @@ module T::Types
       @types ||= @inner_types.map {|type| T::Utils.coerce(type)}
     end
 
+    def build_type
+      types
+    end
+
     # overrides Base
     def name
       "[#{types.join(', ')}]"

--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -16,6 +16,7 @@ module T::Types
 
     def build_type
       types
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -5,30 +5,32 @@ module T::Types
   # Takes a hash of types. Validates each item in a hash using the type in the same position
   # in the list.
   class FixedHash < Base
-    attr_reader :types
-
     def initialize(types)
-      @types = types.transform_values {|v| T::Utils.coerce(v)}
+      @inner_types = types
+    end
+
+    def types
+      @types ||= @inner_types.transform_values {|v| T::Utils.coerce(v)}
     end
 
     # overrides Base
     def name
-      serialize_hash(@types)
+      serialize_hash(types)
     end
 
     # overrides Base
     def recursively_valid?(obj)
       return false unless obj.is_a?(Hash)
-      return false if @types.any? {|key, type| !type.recursively_valid?(obj[key])}
-      return false if obj.any? {|key, _| !@types[key]}
+      return false if types.any? {|key, type| !type.recursively_valid?(obj[key])}
+      return false if obj.any? {|key, _| !types[key]}
       true
     end
 
     # overrides Base
     def valid?(obj)
       return false unless obj.is_a?(Hash)
-      return false if @types.any? {|key, type| !type.valid?(obj[key])}
-      return false if obj.any? {|key, _| !@types[key]}
+      return false if types.any? {|key, type| !type.valid?(obj[key])}
+      return false if obj.any? {|key, _| !types[key]}
       true
     end
 
@@ -37,7 +39,7 @@ module T::Types
       case other
       when FixedHash
         # Using `subtype_of?` here instead of == would be unsound
-        @types == other.types
+        types == other.types
       when TypedHash
         # warning: covariant hashes
 

--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -13,6 +13,10 @@ module T::Types
       @types ||= @inner_types.transform_values {|v| T::Utils.coerce(v)}
     end
 
+    def build_type
+      types
+    end
+
     # overrides Base
     def name
       serialize_hash(types)

--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -15,6 +15,7 @@ module T::Types
 
     def build_type
       types
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/intersection.rb
+++ b/gems/sorbet-runtime/lib/types/types/intersection.rb
@@ -4,10 +4,12 @@
 module T::Types
   # Takes a list of types. Validates that an object matches all of the types.
   class Intersection < Base
-    attr_reader :types
-
     def initialize(types)
-      @types = types.flat_map do |type|
+      @inner_types = types
+    end
+
+    def types
+      @types ||= @inner_types.flat_map do |type|
         type = T::Utils.resolve_alias(type)
         if type.is_a?(Intersection)
           # Simplify nested intersections (mostly so `name` returns a nicer value)
@@ -20,17 +22,17 @@ module T::Types
 
     # overrides Base
     def name
-      "T.all(#{@types.map(&:name).compact.sort.join(', ')})"
+      "T.all(#{types.map(&:name).compact.sort.join(', ')})"
     end
 
     # overrides Base
     def recursively_valid?(obj)
-      @types.all? {|type| type.recursively_valid?(obj)}
+      types.all? {|type| type.recursively_valid?(obj)}
     end
 
     # overrides Base
     def valid?(obj)
-      @types.all? {|type| type.valid?(obj)}
+      types.all? {|type| type.valid?(obj)}
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/intersection.rb
+++ b/gems/sorbet-runtime/lib/types/types/intersection.rb
@@ -22,6 +22,7 @@ module T::Types
 
     def build_type
       types
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/intersection.rb
+++ b/gems/sorbet-runtime/lib/types/types/intersection.rb
@@ -20,6 +20,10 @@ module T::Types
       end.uniq
     end
 
+    def build_type
+      types
+    end
+
     # overrides Base
     def name
       "T.all(#{types.map(&:name).compact.sort.join(', ')})"

--- a/gems/sorbet-runtime/lib/types/types/noreturn.rb
+++ b/gems/sorbet-runtime/lib/types/types/noreturn.rb
@@ -6,6 +6,10 @@ module T::Types
   class NoReturn < Base
     def initialize; end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def name
       "T.noreturn"

--- a/gems/sorbet-runtime/lib/types/types/noreturn.rb
+++ b/gems/sorbet-runtime/lib/types/types/noreturn.rb
@@ -7,7 +7,7 @@ module T::Types
     def initialize; end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/proc.rb
+++ b/gems/sorbet-runtime/lib/types/types/proc.rb
@@ -8,21 +8,25 @@ module T::Types
   # At present, we only support fixed-arity procs with no optional or
   # keyword arguments.
   class Proc < Base
-    attr_reader :arg_types
-    attr_reader :returns
-
     def initialize(arg_types, returns)
-      @arg_types = {}
-      arg_types.each do |key, raw_type|
-        @arg_types[key] = T::Utils.coerce(raw_type)
-      end
-      @returns = T::Utils.coerce(returns)
+      @inner_arg_types = arg_types
+      @inner_returns = returns
+    end
+
+    def arg_types
+      @arg_types ||= @inner_arg_types.map do |key, raw_type|
+        [key, T::Utils.coerce(raw_type)]
+      end.to_h
+    end
+
+    def returns
+      @returns ||= T::Utils.coerce(@inner_returns)
     end
 
     # overrides Base
     def name
       args = []
-      @arg_types.each do |k, v|
+      arg_types.each do |k, v|
         args << "#{k}: #{v.name}"
       end
       "T.proc.params(#{args.join(', ')}).returns(#{returns})"

--- a/gems/sorbet-runtime/lib/types/types/proc.rb
+++ b/gems/sorbet-runtime/lib/types/types/proc.rb
@@ -23,6 +23,11 @@ module T::Types
       @returns ||= T::Utils.coerce(@inner_returns)
     end
 
+    def build_type
+      arg_types
+      returns
+    end
+
     # overrides Base
     def name
       args = []

--- a/gems/sorbet-runtime/lib/types/types/proc.rb
+++ b/gems/sorbet-runtime/lib/types/types/proc.rb
@@ -26,6 +26,7 @@ module T::Types
     def build_type
       arg_types
       returns
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/self_type.rb
+++ b/gems/sorbet-runtime/lib/types/types/self_type.rb
@@ -9,7 +9,7 @@ module T::Types
     def initialize(); end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/self_type.rb
+++ b/gems/sorbet-runtime/lib/types/types/self_type.rb
@@ -8,6 +8,10 @@ module T::Types
 
     def initialize(); end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def name
       "T.self_type"

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -14,7 +14,7 @@ module T::Types
     end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -13,6 +13,10 @@ module T::Types
       @raw_type = raw_type
     end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def name
       # Memoize to mitigate pathological performance with anonymous modules (https://bugs.ruby-lang.org/issues/11119)

--- a/gems/sorbet-runtime/lib/types/types/t_enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/t_enum.rb
@@ -10,6 +10,10 @@ module T::Types
       @val = val
     end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def name
       # Strips the #<...> off, just leaving the ...

--- a/gems/sorbet-runtime/lib/types/types/t_enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/t_enum.rb
@@ -11,7 +11,7 @@ module T::Types
     end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/type_parameter.rb
+++ b/gems/sorbet-runtime/lib/types/types/type_parameter.rb
@@ -20,6 +20,10 @@ module T::Types
       @name = name
     end
 
+    def build_type
+      nil
+    end
+
     def self.make(name)
       cached = Private.cached_entry(name)
       return cached if cached

--- a/gems/sorbet-runtime/lib/types/types/type_variable.rb
+++ b/gems/sorbet-runtime/lib/types/types/type_variable.rb
@@ -19,6 +19,10 @@ module T::Types
       @variance = variance
     end
 
+    def build_type
+      # no-op
+    end
+
     def valid?(obj)
       true
     end

--- a/gems/sorbet-runtime/lib/types/types/type_variable.rb
+++ b/gems/sorbet-runtime/lib/types/types/type_variable.rb
@@ -20,7 +20,7 @@ module T::Types
     end
 
     def build_type
-      # no-op
+      nil
     end
 
     def valid?(obj)

--- a/gems/sorbet-runtime/lib/types/types/typed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_array.rb
@@ -61,7 +61,7 @@ module T::Types
       end
 
       def freeze
-        type # force lazy initialization before freezing the object
+        build_type # force lazy initialization before freezing the object
         super
       end
 

--- a/gems/sorbet-runtime/lib/types/types/typed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_array.rb
@@ -5,7 +5,7 @@ module T::Types
   class TypedArray < TypedEnumerable
     # overrides Base
     def name
-      "T::Array[#{@type.name}]"
+      "T::Array[#{type.name}]"
     end
 
     def underlying_class
@@ -58,6 +58,11 @@ module T::Types
 
       def valid?(obj)
         obj.is_a?(Array)
+      end
+
+      def freeze
+        type # force lazy initialization before freezing the object
+        super
       end
 
       module Private

--- a/gems/sorbet-runtime/lib/types/types/typed_class.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_class.rb
@@ -3,15 +3,17 @@
 
 module T::Types
   class TypedClass < T::Types::Base
-    attr_reader :type
-
     def initialize(type)
-      @type = T::Utils.coerce(type)
+      @inner_type = type
+    end
+
+    def type
+      @type ||= T::Utils.coerce(@inner_type)
     end
 
     # overrides Base
     def name
-      "T::Class[#{@type.name}]"
+      "T::Class[#{type.name}]"
     end
 
     def underlying_class
@@ -67,6 +69,11 @@ module T::Types
         super(T.untyped)
       end
 
+      def freeze
+        type # force lazy initialization before freezing the object
+        super
+      end
+
       module Private
         INSTANCE = Untyped.new.freeze
       end
@@ -75,6 +82,11 @@ module T::Types
     class Anything < TypedClass
       def initialize
         super(T.anything)
+      end
+
+      def freeze
+        type # force lazy initialization before freezing the object
+        super
       end
 
       module Private

--- a/gems/sorbet-runtime/lib/types/types/typed_class.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_class.rb
@@ -75,7 +75,7 @@ module T::Types
       end
 
       def freeze
-        type # force lazy initialization before freezing the object
+        build_type # force lazy initialization before freezing the object
         super
       end
 
@@ -90,7 +90,7 @@ module T::Types
       end
 
       def freeze
-        type # force lazy initialization before freezing the object
+        build_type # force lazy initialization before freezing the object
         super
       end
 

--- a/gems/sorbet-runtime/lib/types/types/typed_class.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_class.rb
@@ -11,6 +11,10 @@ module T::Types
       @type ||= T::Utils.coerce(@inner_type)
     end
 
+    def build_type
+      type
+    end
+
     # overrides Base
     def name
       "T::Class[#{type.name}]"

--- a/gems/sorbet-runtime/lib/types/types/typed_class.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_class.rb
@@ -13,6 +13,7 @@ module T::Types
 
     def build_type
       type
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -16,6 +16,7 @@ module T::Types
 
     def build_type
       type
+      nil
     end
 
     def underlying_class

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -14,6 +14,10 @@ module T::Types
       @type ||= T::Utils.coerce(@inner_type)
     end
 
+    def build_type
+      type
+    end
+
     def underlying_class
       Enumerable
     end

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
@@ -3,15 +3,13 @@
 
 module T::Types
   class TypedEnumerator < TypedEnumerable
-    attr_reader :type
-
     def underlying_class
       Enumerator
     end
 
     # overrides Base
     def name
-      "T::Enumerator[#{@type.name}]"
+      "T::Enumerator[#{type.name}]"
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerator_chain.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerator_chain.rb
@@ -3,15 +3,13 @@
 
 module T::Types
   class TypedEnumeratorChain < TypedEnumerable
-    attr_reader :type
-
     def underlying_class
       Enumerator::Chain
     end
 
     # overrides Base
     def name
-      "T::Enumerator::Chain[#{@type.name}]"
+      "T::Enumerator::Chain[#{type.name}]"
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerator_lazy.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerator_lazy.rb
@@ -3,15 +3,13 @@
 
 module T::Types
   class TypedEnumeratorLazy < TypedEnumerable
-    attr_reader :type
-
     def underlying_class
       Enumerator::Lazy
     end
 
     # overrides Base
     def name
-      "T::Enumerator::Lazy[#{@type.name}]"
+      "T::Enumerator::Lazy[#{type.name}]"
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -3,22 +3,32 @@
 
 module T::Types
   class TypedHash < TypedEnumerable
-    # Technically we don't need these, but they are a nice api
-    attr_reader :keys, :values
-
     def underlying_class
       Hash
     end
 
     def initialize(keys:, values:)
-      @keys = T::Utils.coerce(keys)
-      @values = T::Utils.coerce(values)
-      @type = T::Utils.coerce([keys, values])
+      @inner_keys = keys
+      @inner_values = values
+    end
+
+    # Technically we don't need these, but they is a nice api
+    def keys
+      @keys ||= T::Utils.coerce(@inner_keys)
+    end
+
+    # Technically we don't need these, but they is a nice api
+    def values
+      @values ||= T::Utils.coerce(@inner_values)
+    end
+
+    def type
+      @type ||= T::Utils.coerce([@inner_keys, @inner_values])
     end
 
     # overrides Base
     def name
-      "T::Hash[#{@keys.name}, #{@values.name}]"
+      "T::Hash[#{keys.name}, #{values.name}]"
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -23,7 +23,7 @@ module T::Types
     end
 
     def type
-      @type ||= T::Utils.coerce([@inner_keys, @inner_values])
+      @type ||= T::Utils.coerce([keys, values])
     end
 
     def build_type

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -26,6 +26,12 @@ module T::Types
       @type ||= T::Utils.coerce([@inner_keys, @inner_values])
     end
 
+    def build_type
+      super
+      keys
+      values
+    end
+
     # overrides Base
     def name
       "T::Hash[#{keys.name}, #{values.name}]"

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -27,9 +27,9 @@ module T::Types
     end
 
     def build_type
-      super
       keys
       values
+      super
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -12,12 +12,12 @@ module T::Types
       @inner_values = values
     end
 
-    # Technically we don't need these, but they is a nice api
+    # Technically we don't need this, but it is a nice api
     def keys
       @keys ||= T::Utils.coerce(@inner_keys)
     end
 
-    # Technically we don't need these, but they is a nice api
+    # Technically we don't need this, but it is a nice api
     def values
       @values ||= T::Utils.coerce(@inner_values)
     end

--- a/gems/sorbet-runtime/lib/types/types/typed_range.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_range.rb
@@ -3,15 +3,13 @@
 
 module T::Types
   class TypedRange < TypedEnumerable
-    attr_reader :type
-
     def underlying_class
       Hash
     end
 
     # overrides Base
     def name
-      "T::Range[#{@type.name}]"
+      "T::Range[#{type.name}]"
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/typed_set.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_set.rb
@@ -3,15 +3,13 @@
 
 module T::Types
   class TypedSet < TypedEnumerable
-    attr_reader :type
-
     def underlying_class
       Hash
     end
 
     # overrides Base
     def name
-      "T::Set[#{@type.name}]"
+      "T::Set[#{type.name}]"
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -4,12 +4,14 @@
 module T::Types
   # Takes a list of types. Validates that an object matches at least one of the types.
   class Union < Base
-    attr_reader :types
-
     # Don't use Union.new directly, use `Private::Pool.union_of_types`
     # inside sorbet-runtime and `T.any` elsewhere.
     def initialize(types)
-      @types = types.flat_map do |type|
+      @inner_types = types
+    end
+
+    def types
+      @types ||= @inner_types.flat_map do |type|
         type = T::Utils.coerce(type)
         if type.is_a?(Union)
           # Simplify nested unions (mostly so `name` returns a nicer value)
@@ -51,12 +53,12 @@ module T::Types
 
     # overrides Base
     def recursively_valid?(obj)
-      @types.any? {|type| type.recursively_valid?(obj)}
+      types.any? {|type| type.recursively_valid?(obj)}
     end
 
     # overrides Base
     def valid?(obj)
-      @types.any? {|type| type.valid?(obj)}
+      types.any? {|type| type.valid?(obj)}
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -24,6 +24,7 @@ module T::Types
 
     def build_type
       types
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -22,6 +22,10 @@ module T::Types
       end.uniq
     end
 
+    def build_type
+      types
+    end
+
     # overrides Base
     def name
       # Use the attr_reader here so we can override it in SimplePairUnion

--- a/gems/sorbet-runtime/lib/types/types/untyped.rb
+++ b/gems/sorbet-runtime/lib/types/types/untyped.rb
@@ -8,7 +8,7 @@ module T::Types
     def initialize; end
 
     def build_type
-      # no-op
+      nil
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/untyped.rb
+++ b/gems/sorbet-runtime/lib/types/types/untyped.rb
@@ -7,6 +7,10 @@ module T::Types
 
     def initialize; end
 
+    def build_type
+      # no-op
+    end
+
     # overrides Base
     def name
       "T.untyped"

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -79,8 +79,8 @@ module T::Utils
   end
 
   # Unwraps all the sigs.
-  def self.run_all_sig_blocks
-    T::Private::Methods.run_all_sig_blocks
+  def self.run_all_sig_blocks(force_type_init: true)
+    T::Private::Methods.run_all_sig_blocks(force_type_init: force_type_init)
   end
 
   # Return the underlying type for a type alias. Otherwise returns type.

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1123,7 +1123,7 @@ module Opus::Types::Test
 
     describe 'TypeAlias' do
       it 'builds properly' do
-        type = T.type_alias { String }
+        type = T.type_alias {String}
         type.build_type
         assert_equal('String', type.name)
       end

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -233,6 +233,10 @@ module Opus::Types::Test
 
         it 'valid? does not allocate' do
           skip unless check_alloc_counts
+
+          # Call a method on the type to trigger the lazy initialization
+          assert_equal("T.nilable(T.any(Integer, T::Boolean))", @type.name)
+
           allocs_when_valid = counting_allocations {@type.valid?(0)}
           assert_equal(0, allocs_when_valid)
 
@@ -372,6 +376,9 @@ module Opus::Types::Test
         @klass.include(Mixin1)
         @klass.include(Mixin2)
 
+        # Call a method on the type to trigger the lazy initialization
+        assert_equal("T.all(Opus::Types::Test::TypesTest::Mixin1, Opus::Types::Test::TypesTest::Mixin2)", @type.name)
+
         allocs_when_valid = counting_allocations {@type.valid?(@klass)}
         assert_equal(0, allocs_when_valid)
 
@@ -407,6 +414,10 @@ module Opus::Types::Test
 
       it 'valid? does not allocate' do
         skip unless check_alloc_counts
+
+        # Call a method on the type to trigger the lazy initialization
+        assert_equal("[String, T::Boolean]", @type.name)
+
         arr = ["foo", false]
         allocs_when_valid = counting_allocations {@type.valid?(arr)}
         assert_equal(0, allocs_when_valid)
@@ -459,6 +470,10 @@ module Opus::Types::Test
 
       it 'valid? does not allocate' do
         skip unless check_alloc_counts
+
+        # Call a method on the type to trigger the lazy initialization
+        assert_equal("{a: String, b: T::Boolean, c: T.nilable(Numeric)}", @type.name)
+
         h = {a: 'foo', b: false, c: nil}
         allocs_when_valid = counting_allocations {@type.valid?(h)}
         assert_equal(0, allocs_when_valid)

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1105,7 +1105,29 @@ module Opus::Types::Test
       end
     end
 
+    describe 'NotTyped' do
+      it 'builds properly' do
+        type = T::Private::Types::NotTyped.new
+        type.build_type
+        assert_equal('<NOT-TYPED>', type.name)
+      end
+    end
+
+    describe 'StringHolder' do
+      it 'builds properly' do
+        type = T::Private::Types::StringHolder.new("String")
+        type.build_type
+        assert_equal('String', type.name)
+      end
+    end
+
     describe 'TypeAlias' do
+      it 'builds properly' do
+        type = T.type_alias { String }
+        type.build_type
+        assert_equal('String', type.name)
+      end
+
       it 'delegates name' do
         type = T.type_alias {T.any(Integer, String)}
         assert_equal('T.any(Integer, String)', type.name)
@@ -1690,6 +1712,12 @@ module Opus::Types::Test
       end
 
       describe 'type variables' do
+        it 'builds properly' do
+          type = T::Types::TypeParameter.new(:FOO)
+          type.build_type
+          assert_equal('T.type_parameter(:FOO)', type.name)
+        end
+
         it 'type members are subtypes of everything' do
           assert_subtype(T::Types::TypeMember.new(:in), T.untyped)
           assert_subtype(T::Types::TypeMember.new(:in), String)

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -443,7 +443,7 @@ module T::Utils
   def self.coerce(val); end
 
   def self.resolve_alias(type); end
-  def self.run_all_sig_blocks; end
+  def self.run_all_sig_blocks(force_type_init: true); end
   def self.signature_for_method(method); end
   def self.signature_for_instance_method(mod, method_name); end
   def self.unwrap_nilable(type); end


### PR DESCRIPTION
### Motivation

For performance reasons, in production, we remove as much as `sorbet-runtime` overhead as possible. One of the changes we apply is no-op'ing `T` annotations such as `T.let(x, Type)` by monkey patching the `T` module:

```ruby
module InlineTypeAssertions
  def let(value, type, checked: true)
    value
  end
end

T.singleton_class.prepend(InlineTypeAssertions)
```

This effectively negates the overhead of the inline assertion `let` but the cost of type `Type` construction is still present.

Here's a very simple example using the patch above:

```rb
100_000.times do
  x = T.let([], T::Array[T::Hash[Integer, String]])
end
```

Profiling this snippet with our `InlineTypeAssertions` patch shows that while `T.let` is not doing anything, we still spend a considerable amount of time into initializing `Type` mostly due to `T::Utils.coerce`:

<img width="1318" alt="image" src="https://github.com/sorbet/sorbet/assets/583144/e332da3f-37b2-4706-9f6d-3225d35ca0a0">

This PR proposes to move the type coercion outside of the initializer to let it happen lazily. In a normal execution context, this doesn't modify the behavior at all. The type construction is just moved to the first call involving the type rather than when the type is instantiated. But in a context where inline type assertions are no-op'ed, this drastically simplifies the type initialization and since nothing ever calls inside the type in that case, the lazy construction is never executed, resulting in a considerable speed-up and less pressure on the garbage collector. 

<img width="1318" alt="image" src="https://github.com/sorbet/sorbet/assets/583144/bab77fbd-54db-471a-a739-c343edbd14f2">

There is no extra performance cost for this change but we require an additional instance variable for each type to store the original type passed to the constructor before we lazily coerce it.

### Test plan

See included automated tests.
