### PR TITLE
Allow hover in `typed: false` files if possible

### DIFF
--- a/test/testdata/lsp/hover_typed_false.rb
+++ b/test/testdata/lsp/hover_typed_false.rb
@@ -1,15 +1,18 @@
 # typed: false
 
 class Foo
-    # ^ hover: This file is `# typed: false`.
-    # ^ hover: Hover, Go To Definition, and other features are disabled in this file.
+    # ^ hover: T.class_of(Foo)
 
   def foo
-    # ^ hover: This file is `# typed: false`.
-    # ^ hover: Hover, Go To Definition, and other features are disabled in this file.
+    # ^ hover: sig { returns(T.untyped) }
+    # ^ hover: def foo; end
     x = 10
   # ^ hover: This file is `# typed: false`.
-  # ^ hover: Hover, Go To Definition, and other features are disabled in this file.
+  # ^ hover: Most Hover results will not appear until the file is `# typed: true` or higher.
     x
   end
+
+  X = 1
+  p(X)
+  # ^ hover: Integer
 end

--- a/test/testdata/lsp/hover_typed_ignore.rb
+++ b/test/testdata/lsp/hover_typed_ignore.rb
@@ -2,14 +2,14 @@
 
 class Foo
     # ^ hover: This file is `# typed: ignore`.
-    # ^ hover: Hover, Go To Definition, and other features are disabled in this file.
+    # ^ hover: No Sorbet IDE features will work in this file.
 
   def foo
     # ^ hover: This file is `# typed: ignore`.
-    # ^ hover: Hover, Go To Definition, and other features are disabled in this file.
+    # ^ hover: No Sorbet IDE features will work in this file.
     x = 10
   # ^ hover: This file is `# typed: ignore`.
-  # ^ hover: Hover, Go To Definition, and other features are disabled in this file.
+    # ^ hover: No Sorbet IDE features will work in this file.
     x
   end
 end

--- a/test/testdata/lsp/hover_typed_no_sigil.rb
+++ b/test/testdata/lsp/hover_typed_no_sigil.rb
@@ -1,13 +1,16 @@
 class Foo
-    # ^ hover: This file is `# typed: false`.
-    # ^ hover: Hover, Go To Definition, and other features are disabled in this file.
+    # ^ hover: T.class_of(Foo)
 
   def foo
-    # ^ hover: This file is `# typed: false`.
-    # ^ hover: Hover, Go To Definition, and other features are disabled in this file.
+    # ^ hover: sig { returns(T.untyped) }
+    # ^ hover: def foo; end
     x = 10
   # ^ hover: This file is `# typed: false`.
-  # ^ hover: Hover, Go To Definition, and other features are disabled in this file.
+  # ^ hover: Most Hover results will not appear until the file is `# typed: true` or higher.
     x
   end
+
+  X = 1
+  p(X)
+  # ^ hover: Integer
 end


### PR DESCRIPTION
cc @vinistock

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This matches the behavior of go to definition, which has worked that way
since 99f0ffe9a559f75072dabe3c138ca64ebe8165f5.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.