### PR TITLE
Fix `new` in subclasses of abstract classes when `tap` is redeclared

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/declare.rb
@@ -35,11 +35,11 @@ module T::Private::Abstract::Declare
       # define_method because of the guard above
 
       mod.send(:define_singleton_method, :new) do |*args, &blk|
-        super(*args, &blk).tap do |result|
-          if result.instance_of?(mod)
-            raise "#{mod} is declared as abstract; it cannot be instantiated"
-          end
+        result = super(*args, &blk)
+        if result.instance_of?(mod)
+          raise "#{mod} is declared as abstract; it cannot be instantiated"
         end
+        result
       end
 
       # Ruby doesn not emit "method redefined" warnings for aliased methods

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -637,6 +637,19 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     assert_instance_of(String, klass.new(type: String))
   end
 
+  it 'allows abstract classes to redclare tap' do
+    superclass = Class.new do
+      extend T::Helpers
+      abstract!
+
+      attr_reader :tap
+    end
+
+    klass = Class.new(superclass)
+
+    assert_instance_of(klass, klass.new)
+  end
+
   it 'handles class scope change when already hooked' do
     klass = Class.new do
       extend T::Sig


### PR DESCRIPTION
### Motivation
I have an abstract class that happened to redeclare the `tap` method to be something else entirely. This used to work until 544f173782921ded834d925c5b86084326be244d. Sorbet seems to generally work around tampering like this (see `Object.instance_method(:method)` a few lines prior) so I reckon the same should happen here.

I could have done:

```rb
Object.instance_method(:tap).bind_call(super(*args, &blk)) do |result|
  if result.instance_of?(mod)
    raise "#{mod} is declared as abstract; it cannot be instantiated"
  end
end
```

but the code-readability benefits from `tap` are largely lost so it's IMO clearer to just avoid it entirely.

### Test plan
See included test.
