### PR TITLE
Add missing `Gem::Security::Exception` type

### DIFF
--- a/rbi/stdlib/rubygems.rbi
+++ b/rbi/stdlib/rubygems.rbi
@@ -7044,6 +7044,10 @@ class Gem::Security::DIGEST_ALGORITHM < OpenSSL::Digest
   def self.hexdigest(data); end
 end
 
+# [`Gem::Security`](https://docs.ruby-lang.org/en/2.7.0/Gem/Security.html)
+# default exception type
+class Gem::Security::Exception < Gem::Exception; end
+
 class Gem::Security::Policy
   include Gem::UserInteraction
 


### PR DESCRIPTION
### Motivation
`Gem::Secutity::Exception`, which could be thrown from some RubyGems methods (e.g. `Gem::Package` API), was missing.

### Test plan
Documented: https://docs.ruby-lang.org/en/3.2/Gem/Security/Exception.html
Validated: https://github.com/rubygems/rubygems/blob/599fa578c55ae1a94cb6225bdddf71e212201cfc/lib/rubygems/security.rb#L332
Tested: in my own project for a little while.