### PR TITLE
Allow completion on typed: false files for constants

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1239,7 +1239,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
     }
     auto queryLoc = maybeQueryLoc.value();
 
-    auto result = LSPQuery::byLoc(config, typechecker, uri, pos, LSPMethod::TextDocumentCompletion);
+    auto result = LSPQuery::byLoc(config, typechecker, uri, pos, LSPMethod::TextDocumentCompletion, false);
 
     if (result.error) {
         // An error happened while setting up the query.

--- a/test/testdata/lsp/completion/ignored_file.rb
+++ b/test/testdata/lsp/completion/ignored_file.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 class AnImportantClass
   def important_method(important_parameter)
@@ -7,8 +7,8 @@ class AnImportantClass
   end
 end
 
-An # error: Unable to resolve constant
-# ^ completion: AnImportantClass
+An
+# ^ completion: (file is not `# typed: true` or higher)
 
 AnImportantClass.n
 #                 ^ completion: (file is not `# typed: true` or higher)

--- a/test/testdata/lsp/completion/typed_false_completion_nudges_disabled.rb
+++ b/test/testdata/lsp/completion/typed_false_completion_nudges_disabled.rb
@@ -10,8 +10,7 @@ class AnImportantClass
 end
 
 An # error: Unable to resolve constant
-# ^ completion: (nothing)
+# ^ completion: AnImportantClass
 
 AnImportantClass.n
 #                 ^ completion: (nothing)
-


### PR DESCRIPTION
Allow completion results in `typed: false` files so that we can complete constants, which can be properly typechecked by Sorbet.

### Motivation

Similar to https://github.com/sorbet/sorbet/pull/7535. Sorbet can accurately find constants even in `typed: false` files, so enabling completion improves the developer experience.


### Test plan

Updated existing tests and added one for ignored files.