### PR TITLE
Add native_thread_id method to Thread

### DIFF
--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -495,6 +495,25 @@ class Thread < Object
   sig {params(name: T.untyped).returns(T.untyped)}
   def name=(name); end
 
+  # Return the native thread ID which is used by the Ruby thread.
+  #
+  # The ID depends on the OS. (not POSIX thread ID returned by pthread_self(3))
+  # * On Linux it is TID returned by gettid(2).
+  # * On macOS it is the system-wide unique integral ID of thread returned
+  #   by pthread_threadid_np(3).
+  # * On FreeBSD it is the unique integral ID of the thread returned by
+  #   pthread_getthreadid_np(3).
+  # * On Windows it is the thread identifier returned by GetThreadId().
+  # * On other platforms, it raises NotImplementedError.
+  #
+  # NOTE:
+  # If the thread is not associated yet or already deassociated with a native
+  # thread, it returns _nil_.
+  # If the Ruby implementation uses M:N thread model, the ID may change
+  # depending on the timing.
+  sig { returns(Integer) }
+  def native_thread_id; end;
+
   # Returns whether or not the asynchronous queue is empty for the target
   # thread.
   #


### PR DESCRIPTION
Adding a missing definition for `native_thread_id`: https://docs.ruby-lang.org/en/3.2/Thread.html#method-i-native_thread_id

I tried to put it in alphabetical order with the rest of the methods, and I copied [the comment from thread.c in the MRI source](https://git.ruby-lang.org/ruby.git/tree/thread.c?h=ruby_3_2#n3301) since that's where it seemed like the other comments came from.

Let me know if anything looks amiss!