### PR TITLE
Add code in Ruby GC to give contextual info on parent object for rare T_NONE errors

### DIFF
--- a/third_party/ruby/t-none-context.patch
+++ b/third_party/ruby/t-none-context.patch
@@ -1,5 +1,5 @@
 diff --git gc.c gc.c
-index 6f4ae3a397..48f05f55fc 100644
+index 6f4ae3a397..346a77ec63 100644
 --- gc.c
 +++ gc.c
 @@ -6709,6 +6709,119 @@ gc_aging(rb_objspace_t *objspace, VALUE obj)
@@ -122,13 +122,15 @@ index 6f4ae3a397..48f05f55fc 100644
  static void
  gc_mark_ptr(rb_objspace_t *objspace, VALUE obj)
  {
-@@ -6729,8 +6842,20 @@ gc_mark_ptr(rb_objspace_t *objspace, VALUE obj)
+@@ -6729,8 +6842,22 @@ gc_mark_ptr(rb_objspace_t *objspace, VALUE obj)
  
          if (UNLIKELY(RB_TYPE_P(obj, T_NONE))) {
              rp(obj);
 -            rb_bug("try to mark T_NONE object"); /* check here will help debugging */
 +
 +/***** BEGIN Stripe debugging code ***/
++            // Note: rgengc.parent_object will be set if we followed a reference from an old-gen object to
++            // get here.
 +            if (getenv("STRIPE_DEBUG_T_NONE") && objspace->rgengc.parent_object) {
 +                char buff[0x200];
 +                rb_bug(

--- a/third_party/ruby/t-none-context.patch
+++ b/third_party/ruby/t-none-context.patch
@@ -1,5 +1,5 @@
 diff --git gc.c gc.c
-index 6f4ae3a397..567cc31240 100644
+index 6f4ae3a397..48f05f55fc 100644
 --- gc.c
 +++ gc.c
 @@ -6709,6 +6709,119 @@ gc_aging(rb_objspace_t *objspace, VALUE obj)
@@ -129,7 +129,7 @@ index 6f4ae3a397..567cc31240 100644
 -            rb_bug("try to mark T_NONE object"); /* check here will help debugging */
 +
 +/***** BEGIN Stripe debugging code ***/
-+            if (objspace->rgengc.parent_object) {
++            if (getenv("STRIPE_DEBUG_T_NONE") && objspace->rgengc.parent_object) {
 +                char buff[0x200];
 +                rb_bug(
 +                    "try to mark T_NONE object -- %s",

--- a/third_party/ruby/t-none-context.patch
+++ b/third_party/ruby/t-none-context.patch
@@ -1,0 +1,146 @@
+diff --git gc.c gc.c
+index 6f4ae3a397..d4666b1406 100644
+--- gc.c
++++ gc.c
+@@ -6709,6 +6709,119 @@ gc_aging(rb_objspace_t *objspace, VALUE obj)
+ NOINLINE(static void gc_mark_ptr(rb_objspace_t *objspace, VALUE obj));
+ static void reachable_objects_from_callback(VALUE obj);
+ 
++/**
++ * BEGIN Stripe debugging code. 
++ *
++ * Context: We are seeing instances of "try to mark T_NONE" crashes at Stripe, at times tied to T_HASH parent object.
++ * In these cases, we want to print contextual information about the parent object at the time of the crash.
++ *
++*/
++typedef struct {
++  rb_objspace_t *objspace;
++  char *buff;
++  const int buff_size;
++  int* pos;
++} hash_debug_args_STRIPE;
++
++static int
++gc_debug_hash_entry_STRIPE(st_data_t key, st_data_t value, st_data_t args) {
++    #define BUFF_ARGS buff + *pos, buff_size - *pos
++    #define APPENDF(f) if ((*pos += snprintf f) >= buff_size) goto end
++    
++    // Destructure args
++    hash_debug_args_STRIPE *debug_args = (hash_debug_args_STRIPE*)args;
++    rb_objspace_t *objspace = debug_args->objspace;
++    char *buff = debug_args->buff;
++    int buff_size = debug_args->buff_size;
++    int *pos = debug_args->pos;
++
++    VALUE k_obj = (VALUE)key;
++    VALUE v_obj = (VALUE)value;
++
++    // Skip the entry that has T_NONEs, it probably caused the error condition.
++    // We care about surrounding context.
++    if (UNLIKELY(RB_TYPE_P(k_obj, T_NONE) || RB_TYPE_P(k_obj, T_NONE))) {
++        return ST_CONTINUE;
++    }
++
++    if (is_markable_object(objspace, k_obj)) {
++        if (BUILTIN_TYPE(k_obj) == T_OBJECT && !internal_object_p(k_obj) && RBASIC(k_obj)->klass && RTEST(RBASIC(k_obj)->klass)) {
++            // If the key is a "real" object, add information about its class
++            VALUE class_path = rb_class_path_cached(RBASIC(k_obj)->klass);
++            if (!NIL_P(class_path)) {
++                APPENDF((BUFF_ARGS, "k:T_OBJECT(%s),", RSTRING_PTR(class_path)));
++            } else {
++                APPENDF((BUFF_ARGS, "k:T_OBJECT,"));
++            }
++        } else {
++            APPENDF((BUFF_ARGS, "k:%s,", obj_type_name(k_obj)));
++        }
++    }
++
++    if (is_markable_object(objspace, v_obj)) {
++        if (BUILTIN_TYPE(v_obj) == T_OBJECT && !internal_object_p(v_obj) && RBASIC(v_obj)->klass && RTEST(RBASIC(v_obj)->klass)) {
++            // If the value is a "real" object, add information about its class
++            VALUE class_path = rb_class_path_cached(RBASIC(v_obj)->klass);
++            if (!NIL_P(class_path)) {
++                APPENDF((BUFF_ARGS, "v:T_OBJECT(%s),", RSTRING_PTR(class_path)));
++            } else {
++                APPENDF((BUFF_ARGS, "k:T_OBJECT,"));
++            }
++        } else {
++            APPENDF((BUFF_ARGS, "v:%s; ", obj_type_name(v_obj)));
++        }
++    }
++
++  end:
++    return ST_CONTINUE;
++
++    #undef BUFF_ARGS
++    #undef APPENDF
++}
++
++const char *
++gc_debug_parent_object_STRIPE(rb_objspace_t *objspace, VALUE parent, char *buff, const int buff_size) {
++    int pos = 0;
++
++    #define BUFF_ARGS buff + pos, buff_size - pos
++    #define APPENDF(f) if ((pos += snprintf f) >= buff_size) goto end
++
++    // "P" is for parent object
++    APPENDF((BUFF_ARGS, "P:%s", obj_type_name(parent)));
++
++    switch (BUILTIN_TYPE(parent)) {
++        case T_CLASS:
++        case T_MODULE: {
++          // If the parent object is a class or module, print its fully qualified name.
++          VALUE class_path = rb_class_path_cached(parent);
++          if (!NIL_P(class_path)) {
++              APPENDF((BUFF_ARGS, "(%s)", RSTRING_PTR(class_path)));
++          }
++          break;
++        }
++        case T_HASH: {
++          // If the parent object is a hash, print information about its keys.
++          APPENDF((BUFF_ARGS, "[ "));
++          hash_debug_args_STRIPE args = {objspace, buff, buff_size, &pos};
++          rb_hash_stlike_foreach(parent, gc_debug_hash_entry_STRIPE, (st_data_t)(&args));
++          APPENDF((BUFF_ARGS, " ]"));
++          break;
++        }
++        // No special handling for other types
++    }
++
++    APPENDF((BUFF_ARGS, "\n"));
++
++  end:
++
++    return buff;
++
++    #undef BUFF_ARGS
++    #undef APPENDF
++}
++
++/***** END Stripe debugging code ***/
++
+ static void
+ gc_mark_ptr(rb_objspace_t *objspace, VALUE obj)
+ {
+@@ -6729,8 +6842,20 @@ gc_mark_ptr(rb_objspace_t *objspace, VALUE obj)
+ 
+         if (UNLIKELY(RB_TYPE_P(obj, T_NONE))) {
+             rp(obj);
+-            rb_bug("try to mark T_NONE object"); /* check here will help debugging */
++
++/***** BEGIN Stripe debugging code ***/
++            if (objspace->rgengc.parent_object) {
++                char buff[0x200];
++                rb_bug(
++                    "try to mark T_NONE object -- %s",
++                    gc_debug_parent_object_STRIPE(objspace, objspace->rgengc.parent_object, buff, 0x200)
++                ); /* check here will help debugging */
++            } else {
++/***** END Stripe debugging code ***/
++                rb_bug("try to mark T_NONE object"); /* check here will help debugging */
++            }
+         }
++
+ 	gc_aging(objspace, obj);
+ 	gc_grey(objspace, obj);
+     }

--- a/third_party/ruby/t-none-context.patch
+++ b/third_party/ruby/t-none-context.patch
@@ -1,5 +1,5 @@
 diff --git gc.c gc.c
-index 6f4ae3a397..d4666b1406 100644
+index 6f4ae3a397..567cc31240 100644
 --- gc.c
 +++ gc.c
 @@ -6709,6 +6709,119 @@ gc_aging(rb_objspace_t *objspace, VALUE obj)
@@ -37,7 +37,7 @@ index 6f4ae3a397..d4666b1406 100644
 +
 +    // Skip the entry that has T_NONEs, it probably caused the error condition.
 +    // We care about surrounding context.
-+    if (UNLIKELY(RB_TYPE_P(k_obj, T_NONE) || RB_TYPE_P(k_obj, T_NONE))) {
++    if (UNLIKELY(RB_TYPE_P(k_obj, T_NONE) || RB_TYPE_P(v_obj, T_NONE))) {
 +        return ST_CONTINUE;
 +    }
 +
@@ -62,7 +62,7 @@ index 6f4ae3a397..d4666b1406 100644
 +            if (!NIL_P(class_path)) {
 +                APPENDF((BUFF_ARGS, "v:T_OBJECT(%s),", RSTRING_PTR(class_path)));
 +            } else {
-+                APPENDF((BUFF_ARGS, "k:T_OBJECT,"));
++                APPENDF((BUFF_ARGS, "v:T_OBJECT,"));
 +            }
 +        } else {
 +            APPENDF((BUFF_ARGS, "v:%s; ", obj_type_name(v_obj)));

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -92,6 +92,7 @@ def register_ruby_dependencies():
         patches = [
             "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by-3_1.patch",  # https://github.com/ruby/ruby/pull/6791
             "@com_stripe_ruby_typer//third_party/ruby:thp.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:t-none-context.patch",
         ],
     )
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds logging about the "parent object" surrounding a `try to mark T_NONE` error in the Ruby GC.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
At Stripe, we are occasionally seeing `try to mark T_NONE` errors in GC which are leading to crashes -- this is a pathological, hard-to-debug case which is probably triggered by a bad interaction with some gem extension, however, we are not sure. Adding more contextual information about the parent object currently being marked will likely help us debug these issues better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

* Tested by calling the new code paths in some test scripts (outside of `rb_bug`, ie just printing to stdout).
* Prints information like:
```
P:T_HASH[ k:T_OBJECT(BClass),v:T_OBJECT(AClass), ]
P:T_HASH[ k:T_OBJECT(BClass),v:T_OBJECT(AClass), ]
```
when the parent object is a hash, or
```
P:T_CLASS(AClass)
```
when the parent object is a class.

* CI builds at Stripe.

See included automated tests.