### PR TITLE
Move <PackageSpecRegistry> to the end of the class name, not the beginning

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -591,9 +591,6 @@ void GlobalState::initEmpty() {
                  .build();
     ENFORCE(method == Symbols::SorbetPrivateStaticSingleton_sig());
 
-    klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpecRegistry());
-    ENFORCE(klass == Symbols::PackageSpecRegistry());
-
     // PackageSpec is a class that can be subclassed.
     klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpec());
     klass.data(*this)->setIsModule(false);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -163,9 +163,10 @@ public:
 
     bool isOnlyDefinedInFile(const GlobalState &gs, core::FileRef file) const;
 
-    // Given a symbol like <PackageSpecRegistry>::Project::Foo, returns true.
+    // Given a symbol like Project::Foo::<PackageSpecRegistry>, returns true.
     // Given any other symbol, returns false.
     // Also returns false if called on core::Symbols::noClassOrModule().
+    // TODO(jez) Can we remove this method once we have packages in the symbol table?
     bool isPackageSpecSymbol(const GlobalState &gs) const;
 
     // Certain classes that need to be generic in the standard library already have a definition for
@@ -1005,16 +1006,12 @@ public:
         return MethodRef::fromRaw(9);
     }
 
-    static ClassOrModuleRef PackageSpecRegistry() {
+    static ClassOrModuleRef PackageSpec() {
         return ClassOrModuleRef::fromRaw(85);
     }
 
-    static ClassOrModuleRef PackageSpec() {
-        return ClassOrModuleRef::fromRaw(86);
-    }
-
     static ClassOrModuleRef PackageSpecSingleton() {
-        return ClassOrModuleRef::fromRaw(87);
+        return ClassOrModuleRef::fromRaw(86);
     }
 
     static MethodRef PackageSpec_import() {
@@ -1034,11 +1031,11 @@ public:
     }
 
     static ClassOrModuleRef Encoding() {
-        return ClassOrModuleRef::fromRaw(88);
+        return ClassOrModuleRef::fromRaw(87);
     }
 
     static ClassOrModuleRef Thread() {
-        return ClassOrModuleRef::fromRaw(89);
+        return ClassOrModuleRef::fromRaw(88);
     }
 
     static MethodRef Class_new() {
@@ -1062,43 +1059,43 @@ public:
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
-        return ClassOrModuleRef::fromRaw(90);
+        return ClassOrModuleRef::fromRaw(89);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSigSingleton() {
-        return ClassOrModuleRef::fromRaw(91);
+        return ClassOrModuleRef::fromRaw(90);
     }
 
     static ClassOrModuleRef T_Private_Compiler() {
-        return ClassOrModuleRef::fromRaw(92);
+        return ClassOrModuleRef::fromRaw(91);
     }
 
     static ClassOrModuleRef T_Private_CompilerSingleton() {
-        return ClassOrModuleRef::fromRaw(93);
+        return ClassOrModuleRef::fromRaw(92);
     }
 
     static ClassOrModuleRef MagicBindToAttachedClass() {
-        return ClassOrModuleRef::fromRaw(94);
+        return ClassOrModuleRef::fromRaw(93);
     }
 
     static ClassOrModuleRef MagicBindToSelfType() {
-        return ClassOrModuleRef::fromRaw(95);
+        return ClassOrModuleRef::fromRaw(94);
     }
 
     static ClassOrModuleRef T_Types() {
-        return ClassOrModuleRef::fromRaw(96);
+        return ClassOrModuleRef::fromRaw(95);
     }
 
     static ClassOrModuleRef T_Types_Base() {
-        return ClassOrModuleRef::fromRaw(97);
+        return ClassOrModuleRef::fromRaw(96);
     }
 
     static ClassOrModuleRef Data() {
-        return ClassOrModuleRef::fromRaw(98);
+        return ClassOrModuleRef::fromRaw(97);
     }
 
     static ClassOrModuleRef T_Class() {
-        return ClassOrModuleRef::fromRaw(99);
+        return ClassOrModuleRef::fromRaw(98);
     }
 
     static MethodRef T_Generic_squareBrackets() {
@@ -1106,7 +1103,7 @@ public:
     }
 
     static ClassOrModuleRef Magic_UntypedSource() {
-        return ClassOrModuleRef::fromRaw(101);
+        return ClassOrModuleRef::fromRaw(100);
     }
 
     static FieldRef Magic_UntypedSource_super() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -22,7 +22,7 @@ namespace sorbet::core {
 
 using namespace std;
 
-const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
+const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 214;
 const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 53;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
@@ -33,10 +33,13 @@ constexpr string_view COLON_SEPARATOR = "::"sv;
 constexpr string_view HASH_SEPARATOR = "#"sv;
 
 string showInternal(const GlobalState &gs, core::SymbolRef owner, core::NameRef name, string_view separator) {
-    if (!owner.exists() || owner == Symbols::root() || owner == core::Symbols::PackageSpecRegistry()) {
+    if (!owner.exists() || owner == Symbols::root()) {
         return name.show(gs);
+    } else if (name == core::Names::Constants::PackageSpecRegistry()) {
+        return owner.show(gs);
+    } else {
+        return absl::StrCat(owner.show(gs), separator, name.show(gs));
     }
-    return absl::StrCat(owner.show(gs), separator, name.show(gs));
 }
 } // namespace
 
@@ -625,16 +628,11 @@ bool ClassOrModuleRef::isOnlyDefinedInFile(const GlobalState &gs, core::FileRef 
 
 // Documented in SymbolRef.h
 bool ClassOrModuleRef::isPackageSpecSymbol(const GlobalState &gs) const {
-    auto sym = *this;
-    while (sym.exists() && sym != core::Symbols::root()) {
-        if (sym == core::Symbols::PackageSpecRegistry()) {
-            return true;
-        }
-
-        sym = sym.data(gs)->owner;
+    if (!this->exists()) {
+        return false;
     }
 
-    return false;
+    return this->data(gs)->name == core::Names::Constants::PackageSpecRegistry();
 }
 
 bool ClassOrModuleRef::isBuiltinGenericForwarder() const {
@@ -2699,7 +2697,6 @@ void ClassOrModule::addLoc(const core::GlobalState &gs, core::Loc loc) {
     // We shouldn't add locs for <root>, otherwise it'll end up with a massive loc list (O(number
     // of files)). Those locs aren't useful, either.
     ENFORCE(ref(gs) != Symbols::root());
-    ENFORCE(ref(gs) != Symbols::PackageSpecRegistry());
 
     addLocInternal(gs, loc, this->loc(), locs_);
 }

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -23,8 +23,13 @@ vector<core::SymbolRef> ReferencesTask::getSymsToCheckWithinPackage(const core::
     std::vector<core::NameRef> fullName;
 
     auto sym = symInPackage;
-    while (sym.exists() && sym != core::Symbols::PackageSpecRegistry() && sym != core::Symbols::root()) {
-        fullName.emplace_back(sym.name(gs));
+    while (sym.exists() && sym != core::Symbols::root()) {
+        auto name = sym.name(gs);
+        if (name == core::Names::Constants::PackageSpecRegistry()) {
+            continue;
+        }
+
+        fullName.emplace_back(name);
         sym = sym.owner(gs);
     }
     reverse(fullName.begin(), fullName.end());

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -454,7 +454,7 @@ void mustContainPackageDef(core::Context ctx, core::LocOffsets loc) {
     }
 }
 
-ast::ExpressionPtr prependName(ast::ExpressionPtr scope, core::NameRef prefix) {
+ast::ExpressionPtr prependName(ast::ExpressionPtr scope) {
     auto lastConstLit = ast::cast_tree<ast::UnresolvedConstantLit>(scope);
     ENFORCE(lastConstLit != nullptr);
     while (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(lastConstLit->scope)) {
@@ -992,7 +992,7 @@ struct PackageSpecBodyWalk {
                 auto importArg = move(send.getPosArg(0));
                 send.removePosArg(0);
                 ENFORCE(send.numPosArgs() == 0);
-                send.addPosArg(prependName(move(importArg), core::Names::Constants::PackageSpecRegistry()));
+                send.addPosArg(prependName(move(importArg)));
 
                 info.importedPackageNames.emplace_back(getPackageName(ctx, target), method2ImportType(send));
             }
@@ -1003,7 +1003,7 @@ struct PackageSpecBodyWalk {
             auto importArg = move(send.getPosArg(0));
             send.removePosArg(0);
             ENFORCE(send.numPosArgs() == 0);
-            send.addPosArg(prependName(move(importArg), core::Names::Constants::PackageSpecRegistry()));
+            send.addPosArg(prependName(move(importArg)));
         }
 
         if (send.fun == core::Names::exportAll() && send.numPosArgs() == 0) {
@@ -1025,7 +1025,7 @@ struct PackageSpecBodyWalk {
                 auto importArg = move(send.getPosArg(0));
                 send.removePosArg(0);
                 ENFORCE(send.numPosArgs() == 0);
-                send.addPosArg(prependName(move(importArg), core::Names::Constants::PackageSpecRegistry()));
+                send.addPosArg(prependName(move(importArg)));
 
                 info.visibleTo_.emplace_back(getPackageName(ctx, target));
             }
@@ -1219,8 +1219,7 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
         //
         // Other than being able to say "we don't mutate the trees in packager" there's not much
         // value in going that far (even namer mutates the trees; the packager fills a similar role).
-        packageSpecClass->name =
-            prependName(move(packageSpecClass->name), core::Names::Constants::PackageSpecRegistry());
+        packageSpecClass->name = prependName(move(packageSpecClass->name));
 
         info = make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree), ctx.locAt(packageSpecClass->loc),
                                             ctx.locAt(packageSpecClass->declLoc));

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -1,7 +1,7 @@
 # -- test/testdata/packager/deeply_nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
+  class <emptyTree>::<C Package>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Package>::<C Subpackage>::<C <PackageSpecRegistry>>)
 
     <self>.export(::<root>::<C Package>::<C PackageClass>)
 
@@ -10,8 +10,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Package>)
+  class <emptyTree>::<C Package>::<C Subpackage>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Package>::<C <PackageSpecRegistry>>)
 
     <self>.export(::<root>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -1,16 +1,16 @@
 # -- test/testdata/packager/export_for_test/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPkg><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C RootPkg>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
   end
 end
 # -- test/testdata/packager/export_for_test/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar>)
+  class <emptyTree>::<C Opus>::<C Foo>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C <PackageSpecRegistry>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Util>)
+    <self>.import(<emptyTree>::<C Opus>::<C Util>::<C <PackageSpecRegistry>>)
 
-    <self>.test_import(::<PackageSpecRegistry>::<C Opus>::<C TestImported>)
+    <self>.test_import(<emptyTree>::<C Opus>::<C TestImported>::<C <PackageSpecRegistry>>)
 
     <self>.export(::<root>::<C Opus>::<C Foo>::<C FooClass>)
 
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/foo/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
 
     <self>.export(::<root>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/test_imported/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C TestImported><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Opus>::<C TestImported>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Opus>::<C TestImported>::<C TIClass>)
 
     <self>.export(::<root>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Util><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Opus>::<C Util>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Opus>::<C Util>::<C UtilClass>)
 
     <self>.export(::<root>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -1,14 +1,14 @@
 # -- test/testdata/packager/export_imported/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C B>)
+  class <emptyTree>::<C A>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C B>::<C <PackageSpecRegistry>>)
 
     <self>.export(::<root>::<C B>::<C BClass>)
   end
 end
 # -- test/testdata/packager/export_imported/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C B>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C B>::<C BClass>)
   end
 end

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -1,16 +1,16 @@
 # -- test/testdata/packager/extra_package_paths/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
+  class <emptyTree>::<C Project>::<C Bar>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Project>::<C Foo>::<C <PackageSpecRegistry>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package>)
+    <self>.import(<emptyTree>::<C Project>::<C Baz>::<C Package>::<C <PackageSpecRegistry>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C FooBar>)
+    <self>.import(<emptyTree>::<C Project>::<C FooBar>::<C <PackageSpecRegistry>>)
   end
 end
 # -- test/testdata/packager/extra_package_paths/baz/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Project>::<C Baz>::<C Package>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C C>)
 
     <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C E>)
@@ -18,7 +18,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Project>::<C Foo>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Foo>::<C B>)
 
     <self>.export(::<root>::<C Project>::<C Foo>::<C D>)
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo_bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C FooBar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Project>::<C FooBar>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C FooBar>::<C Z>)
   end
 end

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -1,12 +1,12 @@
 # -- test/testdata/packager/import_subpackage/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Root><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Root>::<C B>)
+  class <emptyTree>::<C Root>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Root>::<C B>::<C <PackageSpecRegistry>>)
   end
 end
 # -- test/testdata/packager/import_subpackage/a/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Root>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Root>::<C B>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Root>::<C B>::<C Foo>)
   end
 end

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -1,17 +1,17 @@
 # -- test/testdata/packager/invalid_imports_and_exports/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C A>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(123)
 
     <self>.import("hello")
 
     <self>.import(<self>.method())
 
-    <self>.import(::<PackageSpecRegistry>::<C REFERENCE>)
+    <self>.import(<emptyTree>::<C REFERENCE>::<C <PackageSpecRegistry>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C B>)
+    <self>.import(<emptyTree>::<C B>::<C <PackageSpecRegistry>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C B>)
+    <self>.import(<emptyTree>::<C B>::<C <PackageSpecRegistry>>)
 
     <self>.export(123)
 
@@ -28,8 +28,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/invalid_imports_and_exports/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C A>)
+  class <emptyTree>::<C B>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C A>::<C <PackageSpecRegistry>>)
 
     <self>.export(::<root>::<C B>::<C BClass>)
 

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -2,7 +2,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C SomeConstant> = <emptyTree>::<C PackageSpec>
 
-  class ::<PackageSpecRegistry>::<C MyPackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C MyPackage>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -1,12 +1,12 @@
 # -- test/testdata/packager/nested_inner_namespaces/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C RootPackage>::<C Foo>)
+  class <emptyTree>::<C RootPackage>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C RootPackage>::<C Foo>::<C <PackageSpecRegistry>>)
   end
 end
 # -- test/testdata/packager/nested_inner_namespaces/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPackage>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C RootPackage>::<C Foo>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C RootPackage>::<C Foo>::<C Constant>)
 
     <self>.export(::<root>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -1,15 +1,15 @@
 # -- test/testdata/packager/nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
+  class <emptyTree>::<C Package>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Package>::<C Subpackage>::<C <PackageSpecRegistry>>)
 
     <self>.export(::<root>::<C Package>::<C PackageClass>)
   end
 end
 # -- test/testdata/packager/nested_packages/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Package>)
+  class <emptyTree>::<C Package>::<C Subpackage>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Package>::<C <PackageSpecRegistry>>)
 
     <self>.export(::<root>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end

--- a/test/testdata/packager/shared_prefix/pass.package-tree.exp
+++ b/test/testdata/packager/shared_prefix/pass.package-tree.exp
@@ -1,18 +1,18 @@
 # -- test/testdata/packager/shared_prefix/bar/that/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C That><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Project>::<C Bar>::<C That>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Bar>::<C That>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/this/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C This><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Project>::<C Bar>::<C This>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Bar>::<C This>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Project>::<C Foo>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/that/that.rb --

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -1,7 +1,7 @@
 # -- test/testdata/packager/simple_package/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
+  class <emptyTree>::<C Project>::<C Bar>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Project>::<C Foo>::<C <PackageSpecRegistry>>)
 
     <self>.export(::<root>::<C Project>::<C Bar>::<C Bar>)
 
@@ -10,8 +10,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Bar>)
+  class <emptyTree>::<C Project>::<C Foo>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Project>::<C Bar>::<C <PackageSpecRegistry>>)
 
     <self>.export(::<root>::<C Project>::<C Foo>::<C Foo>)
 

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -1,22 +1,22 @@
 # -- test/testdata/packager/simple_test_import/main_lib/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C MainLib><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Util>)
+  class <emptyTree>::<C Project>::<C MainLib>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C Project>::<C Util>::<C <PackageSpecRegistry>>)
 
-    <self>.test_import(::<PackageSpecRegistry>::<C Project>::<C TestOnly>)
+    <self>.test_import(<emptyTree>::<C Project>::<C TestOnly>::<C <PackageSpecRegistry>>)
 
     <self>.export_for_test(<emptyTree>::<C Project>::<C MainLib>::<C Lib>)
   end
 end
 # -- test/testdata/packager/simple_test_import/test_only/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C TestOnly><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Project>::<C TestOnly>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C TestOnly>::<C SomeHelper>)
   end
 end
 # -- test/testdata/packager/simple_test_import/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Util><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C Project>::<C Util>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Util>::<C MyUtil>)
 
     <self>.export(::<root>::<C Test>::<C Project>::<C Util>::<C UtilHelper>)

--- a/test/testdata/packager/unimported_namespace/pass.package-tree.exp
+++ b/test/testdata/packager/unimported_namespace/pass.package-tree.exp
@@ -1,18 +1,18 @@
 # -- test/testdata/packager/unimported_namespace/aaa/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C AAA><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C AAA>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C AAA>::<C AClass>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/bbb/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C BBB><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.import(::<PackageSpecRegistry>::<C AAA>)
+  class <emptyTree>::<C BBB>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.import(<emptyTree>::<C AAA>::<C <PackageSpecRegistry>>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/ccc/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C CCC><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+  class <emptyTree>::<C CCC>::<C <PackageSpecRegistry>><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/aaa/a_class.rb --


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.