### PR TITLE
Update Set#intersect? signature to accept enumerator

### DIFF
--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -663,7 +663,7 @@ class Set < Object
   # ```
   sig do
     params(
-        set: T::Set[Elem],
+        set: T::Enumerable[Elem],
     )
     .returns(T::Boolean)
   end


### PR DESCRIPTION
### Motivation
In 3.0 and below, `Set#intersect?` only accepted a `Set` as a parameter. However, since 3.1, any `Enumerable` is accepted.

- https://docs.ruby-lang.org/en/3.0/Set.html#method-i-intersect-3F
- https://docs.ruby-lang.org/en/3.1/Set.html#method-i-intersect-3F

### Test plan
Tried calling `Set.new.intersect?([])`, `Set.new.intersect?({})` in Ruby 3.1