### PR TITLE
Tighten signature of Enumerable#inject

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -855,17 +855,17 @@ module Enumerable
     .returns(T.untyped)
   end
   sig do
-    params(
-        initial: T.untyped,
-        blk: T.proc.params(arg0: T.untyped, arg1: Elem).returns(T.untyped),
+    type_parameters(:U).params(
+        initial: T.type_parameter(:U),
+        blk: T.proc.params(arg0: T.type_parameter(:U), arg1: Elem).returns(T.type_parameter(:U)),
     )
-    .returns(T.untyped)
+    .returns(T.type_parameter(:U))
   end
   sig do
-    params(
-        blk: T.proc.params(arg0: T.untyped, arg1: Elem).returns(T.untyped),
+    type_parameters(:U).params(
+        blk: T.proc.params(arg0: T.any(Elem, T.type_parameter(:U)), arg1: Elem).returns(T.type_parameter(:U)),
     )
-    .returns(T.untyped)
+    .returns(T.nilable(T.type_parameter(:U)))
   end
   def inject(initial=T.unsafe(nil), arg0=T.unsafe(nil), &blk); end
 

--- a/test/testdata/infer/takes_no_block_inject.rb
+++ b/test/testdata/infer/takes_no_block_inject.rb
@@ -1,4 +1,0 @@
-# typed: strict
-
-foo = T::Array[Integer].new
-foo.inject(nil) {|sum, x| sum ? sum + x : x}

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -76,11 +76,27 @@ def example(xs)
   end
   T.reveal_type(res) # error: `String`
 
+  res = xs.reduce do |acc, x|
+    T.reveal_type(acc) # error: `Integer`
+    T.reveal_type(x) # error: `Integer`
+    new_acc = acc + x
+    T.reveal_type(new_acc) # error: `Integer`
+  end
+  T.reveal_type(res) # error: `T.nilable(Integer)`
+
   res = xs.inject('') do |acc, x|
-    T.reveal_type(acc) # error: `T.untyped`
+    T.reveal_type(acc) # error: `String`
     T.reveal_type(x) # error: `Integer`
     new_acc = acc + x.to_s
-    T.reveal_type(new_acc) # error: `T.untyped`
+    T.reveal_type(new_acc) # error: `String`
   end
-  T.reveal_type(res) # error: `T.untyped`
+  T.reveal_type(res) # error: `String`
+
+  res = xs.inject do |acc, x|
+    T.reveal_type(acc) # error: `Integer`
+    T.reveal_type(x) # error: `Integer`
+    new_acc = acc + x
+    T.reveal_type(new_acc) # error: `Integer`
+  end
+  T.reveal_type(res) # error: `T.nilable(Integer)`
 end


### PR DESCRIPTION
### Motivation
`inject` is an alias for `reduce`, so they can have the same signature

### Test plan
Added tests, and expanded existing ones (to cover the case without an initial value)
