### PR TITLE
Comment why we can't type x in Kernel#tap

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -692,6 +692,7 @@ module Kernel
   # ```
   sig do
     params(
+      # `x` should be `T.self_type`, but it's blocked by https://github.com/sorbet/sorbet/issues/5632
       blk: T.proc.params(x: T.untyped).void
     )
     .returns(T.self_type)


### PR DESCRIPTION
### Motivation
We've tried to type this method a couple of times, and we always end up failing because of [[sorbet/issues/5632] Cannot write the natural type for `Object#yield_self`](https://github.com/sorbet/sorbet/issues/5632).

Last time was in [[sorbet/pr/7551] Type Kernel#tap](https://github.com/sorbet/sorbet/pull/7551)

### Test plan
None, this is just a comment