### PR TITLE
Use the loc of the expression when desugaring multiple return 

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1929,6 +1929,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::Return *ret) {
                 if (ret->exprs.size() > 1) {
+                    auto arrayLoc = ret->exprs.front()->loc.join(ret->exprs.back()->loc);
                     Array::ENTRY_store elems;
                     elems.reserve(ret->exprs.size());
                     for (auto &stat : ret->exprs) {
@@ -1940,7 +1941,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         }
                         elems.emplace_back(node2TreeImpl(dctx, std::move(stat)));
                     };
-                    ExpressionPtr arr = MK::Array(loc, std::move(elems));
+                    ExpressionPtr arr = MK::Array(arrayLoc, std::move(elems));
                     ExpressionPtr res = MK::Return(loc, std::move(arr));
                     result = std::move(res);
                 } else if (ret->exprs.size() == 1) {
@@ -1961,6 +1962,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::Break *ret) {
                 if (ret->exprs.size() > 1) {
+                    auto arrayLoc = ret->exprs.front()->loc.join(ret->exprs.back()->loc);
                     Array::ENTRY_store elems;
                     elems.reserve(ret->exprs.size());
                     for (auto &stat : ret->exprs) {
@@ -1972,7 +1974,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         }
                         elems.emplace_back(node2TreeImpl(dctx, std::move(stat)));
                     };
-                    ExpressionPtr arr = MK::Array(loc, std::move(elems));
+                    ExpressionPtr arr = MK::Array(arrayLoc, std::move(elems));
                     ExpressionPtr res = MK::Break(loc, std::move(arr));
                     result = std::move(res);
                 } else if (ret->exprs.size() == 1) {
@@ -1993,6 +1995,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::Next *ret) {
                 if (ret->exprs.size() > 1) {
+                    auto arrayLoc = ret->exprs.front()->loc.join(ret->exprs.back()->loc);
                     Array::ENTRY_store elems;
                     elems.reserve(ret->exprs.size());
                     for (auto &stat : ret->exprs) {
@@ -2004,7 +2007,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         }
                         elems.emplace_back(node2TreeImpl(dctx, std::move(stat)));
                     };
-                    ExpressionPtr arr = MK::Array(loc, std::move(elems));
+                    ExpressionPtr arr = MK::Array(arrayLoc, std::move(elems));
                     ExpressionPtr res = MK::Next(loc, std::move(arr));
                     result = std::move(res);
                 } else if (ret->exprs.size() == 1) {

--- a/test/cli/multiple-return-loc/test.out
+++ b/test/cli/multiple-return-loc/test.out
@@ -1,0 +1,20 @@
+test.rb:6: Expected `T::Array[Integer]` but found `[Integer(1), String("")]` for method result type https://srb.help/7005
+     6 |  return 1, ""
+          ^^^^^^^^^^^^
+  Expected `T::Array[Integer]` for result type of method `foo`:
+    test.rb:5:
+     5 |def foo
+        ^^^^^^^
+  Got `[Integer(1), String("")] (2-tuple)` originating from:
+    test.rb:6:
+     6 |  return 1, ""
+          ^^^^^^^^^^^^
+
+test.rb:13: Revealed type: `[Integer(1), Integer(2)] (2-tuple)` https://srb.help/7014
+    13 |T.reveal_type(x)
+        ^^^^^^^^^^^^^^^^
+  Got `[Integer(1), Integer(2)] (2-tuple)` originating from:
+    test.rb:10:
+    10 |  break 1, 2
+          ^^^^^^^^^^
+Errors: 2

--- a/test/cli/multiple-return-loc/test.out
+++ b/test/cli/multiple-return-loc/test.out
@@ -8,7 +8,7 @@ test.rb:6: Expected `T::Array[Integer]` but found `[Integer(1), String("")]` for
   Got `[Integer(1), String("")] (2-tuple)` originating from:
     test.rb:6:
      6 |  return 1, ""
-          ^^^^^^^^^^^^
+                 ^^^^^
 
 test.rb:13: Revealed type: `[Integer(1), Integer(2)] (2-tuple)` https://srb.help/7014
     13 |T.reveal_type(x)
@@ -16,5 +16,5 @@ test.rb:13: Revealed type: `[Integer(1), Integer(2)] (2-tuple)` https://srb.help
   Got `[Integer(1), Integer(2)] (2-tuple)` originating from:
     test.rb:10:
     10 |  break 1, 2
-          ^^^^^^^^^^
+                ^^^^
 Errors: 2

--- a/test/cli/multiple-return-loc/test.rb
+++ b/test/cli/multiple-return-loc/test.rb
@@ -1,0 +1,13 @@
+# typed: true
+extend T::Sig
+
+sig { returns(T::Array[Integer]) }
+def foo
+  return 1, ""
+end
+
+x = loop do
+  break 1, 2
+end
+
+T.reveal_type(x)

--- a/test/cli/multiple-return-loc/test.sh
+++ b/test/cli/multiple-return-loc/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main/sorbet --silence-dev-message test/cli/multiple-return-loc 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Split off from https://github.com/sorbet/sorbet/pull/7475; the tree walk looks for a node with the exact same loc to decide whether a given expression should be allowed to be extracted or not. Without this change, if the user selects the entire return expression, it will match on the "fake" array, even though what was actually selected was more than just the array.

This also improves error messages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
