### PR TITLE
Treat `.void` and `.returns(T.anything)` as compatible

### DIFF
--- a/test/testdata/definition_validator/void_anything.rb
+++ b/test/testdata/definition_validator/void_anything.rb
@@ -1,0 +1,26 @@
+# typed: true
+
+class Parent
+  extend T::Sig, T::Helpers
+  abstract!
+
+  sig { abstract.void }
+  def example1; end
+
+  sig { abstract.returns(T.anything) }
+  def example2; end
+
+  sig { abstract.returns(Integer) }
+  def example3; end
+end
+
+class Child < Parent
+  sig { override.returns(T.anything) }
+  def example1; end
+
+  sig { override.void }
+  def example2; end
+
+  sig { override.void }
+  def example3; end # error: Return type `void` does not match return type of abstract method `Parent#example3`
+end

--- a/test/testdata/resolver/abstract_validation.rb
+++ b/test/testdata/resolver/abstract_validation.rb
@@ -163,5 +163,5 @@ module BadTypedImpl
   include GoodInterface
 
   sig {override.returns(Integer)}
-  def foo; 1; end # error: Return type `Integer` does not match return type of abstract method `GoodInterface#foo`
+  def foo; 1; end
 end

--- a/test/testdata/resolver/overrides.rb
+++ b/test/testdata/resolver/overrides.rb
@@ -87,5 +87,4 @@ class B7 < A7
   extend T::Sig
   sig {override.returns(String)}
   def foo; 'foo' end
-# ^^^^^^^ error: Return type `String` does not match return type of overridden method `A7#foo`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Now that users can write `.returns(T.anything)`, there's essentially two ways
to write the top type in a method signature. This is one more way where the
distinction between the two of them could have snuck through to the user, so we
have to patch up the hole.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.