### PR TITLE
runtime: Treat .void and .returns(T.anything) as compatible

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -262,7 +262,14 @@ module T::Private::Methods::SignatureValidation
     end
 
     # return types must be covariant
-    if !signature.return_type.subtype_of?(super_signature.return_type)
+    super_signature_return_type = super_signature.return_type
+
+    if super_signature_return_type == T::Private::Types::Void::Private::INSTANCE
+      # Treat `.void` as `T.anything` (see corresponding comment in definition_valitor for more)
+      super_signature_return_type = T::Types::Anything::Private::INSTANCE
+    end
+
+    if !signature.return_type.subtype_of?(super_signature_return_type)
       raise "Incompatible return type in signature for #{mode_noun} of method `#{signature.method_name}`:\n" \
             "* Base: `#{super_signature.return_type}` (in #{method_loc_str(super_signature.method)})\n" \
             "* #{mode_noun.capitalize}: `#{signature.return_type}` (in #{method_loc_str(signature.method)})\n" \

--- a/gems/sorbet-runtime/test/types/interface_validation.rb
+++ b/gems/sorbet-runtime/test/types/interface_validation.rb
@@ -144,7 +144,7 @@ class Opus::Types::Test::InterfacesTest < Critic::Unit::UnitTest
     T::Private::Abstract::Validate.validate_abstract_module(base)
   end
 
-  it "raises an error if a void method has an incompatible implementation" do
+  it "does not raise an error if a void method does not have a void implementation" do
     base = Module.new do
       extend T::Sig
       extend T::Helpers
@@ -169,10 +169,7 @@ class Opus::Types::Test::InterfacesTest < Critic::Unit::UnitTest
       include mod
     end
 
-    err = assert_raises(RuntimeError) do
-      klass.new.foo
-    end
-    assert_includes(err.message, "Incompatible return type in signature for implementation of method")
+    klass.new.foo
   end
 
 end

--- a/gems/sorbet-runtime/test/types/validate_override_types.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_types.rb
@@ -172,5 +172,21 @@ module Opus::Types::Test
       child.new.example
     end
 
+    it "allows returns(T.anything) to be compatible with .void" do
+      parent = Class.new do
+        extend T::Sig
+        sig {overridable.void}
+        def example; end
+      end
+
+      child = Class.new(parent) do
+        extend T::Sig
+        sig {override.returns(T.anything)}
+        def example; end
+      end
+
+      child.new.example
+    end
+
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Runtime changes corresponding to #7557


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.