### PR TITLE
Split overloads for `Array#sample` (help wanted)

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2261,12 +2261,13 @@ class Array < Object
   # a.sample(random: Random.new(1))     #=> 6
   # a.sample(4, random: Random.new(1))  #=> [6, 10, 9, 2]
   # ```
+  sig {params(random: Random::Formatter).returns(T.nilable(Elem))}
   sig do
     params(
         arg0: Integer,
         random: Random::Formatter,
     )
-    .returns(T.any(T.nilable(Elem), T::Array[Elem]))
+    .returns(T::Array[Elem])
   end
   def sample(arg0=T.unsafe(nil), random: T.unsafe(nil)); end
 


### PR DESCRIPTION
### Motivation

Similar to [`Array#first`](https://github.com/sorbet/sorbet/blob/1d4e6f159c69e13f990a3a1d39eec5a84d8afde2/rbi/core/array.rbi#L1369-L1376), `Array#sample` has 2 overloads:

```ruby
[].sample # => nil
[1, 2, 3].sample # => 1

[].sample(1) # => []
[1, 2, 3].sample(1) # => [1]
```

but the RBI only has one, which returns `T.any(T.nilable(Elem), T::Array[Elem])`, requiring you to cast all the time.

This PR splits these 2 overloads, so we no longer have to cast the results:

```diff
-result = T.cast(input.sample(5), T::Array[Integer])
+result = input.sample(5)
```

### Test plan

- [ ] TODO: Are there automated tests that cover this behaviour?

### Other

- [ ] TODO: `Array#sample` is currently being used as an example in the FAQ:

    https://github.com/sorbet/sorbet/blob/1d4e6f159c69e13f990a3a1d39eec5a84d8afde2/website/docs/faq.md?plain=1#L249-L278

    Is there another example we could use, instead?