### PR TITLE
Allow ConstantAssumeType rewriter to work with class aliases

### DIFF
--- a/test/testdata/resolver/assume_type_class_alias.rb
+++ b/test/testdata/resolver/assume_type_class_alias.rb
@@ -1,7 +1,15 @@
 # typed: strict
 
 class A; end
-AliasToX = A
 
-X = AliasToX.new
+AliasToA = A
+X = AliasToA.new
 T.reveal_type(X) # error: `A`
+
+TypeAliasToA = T.type_alias { A }
+
+# There should also be a type error on the call to `.new`, but that's also broken.
+# See test/testdata/infer/metatype_new.rb for more.
+Y = TypeAliasToA.new # error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+T.reveal_type(Y) # error: `T.untyped`
+

--- a/test/testdata/resolver/assume_type_class_alias.rb
+++ b/test/testdata/resolver/assume_type_class_alias.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class A; end
+AliasToX = A
+
+X = AliasToX.new # error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+T.reveal_type(X) # error: `T.untyped`

--- a/test/testdata/resolver/assume_type_class_alias.rb
+++ b/test/testdata/resolver/assume_type_class_alias.rb
@@ -3,5 +3,5 @@
 class A; end
 AliasToX = A
 
-X = AliasToX.new # error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
-T.reveal_type(X) # error: `T.untyped`
+X = AliasToX.new
+T.reveal_type(X) # error: `A`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

You can put class aliases in normal type syntax (as evidenced by the fact that
this `<cast:<assume type>>(...)` node works when made to simply not early exit).

Fixes #7560


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.