### PR TITLE
Only treat `.void` methods as returning `T.anything`

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1444,7 +1444,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
 
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(ctx, i.what);
-                if (core::Types::isSubType(ctx, core::Types::void_(), methodReturnType)) {
+                if (methodReturnType == core::Types::void_()) {
                     methodReturnType = core::Types::top();
                 }
                 if (!core::Types::isSubTypeUnderConstraint(ctx, constr, typeAndOrigin.type, methodReturnType,

--- a/test/testdata/infer/void_anything.rb
+++ b/test/testdata/infer/void_anything.rb
@@ -14,12 +14,12 @@ end
 
 sig { params(x: M).returns(Object) }
 def foo2(x)
-  x
+  x # error: Expected `Object` but found `M` for method result type
 end
 
 sig { params(x: M).returns(Kernel) }
 def foo3(x)
-  x
+  x # error: Expected `Kernel` but found `M` for method result type
 end
 
 sig { params(x: M).returns(BasicObject) }

--- a/test/testdata/infer/void_anything.rb
+++ b/test/testdata/infer/void_anything.rb
@@ -1,0 +1,30 @@
+# typed: strict
+extend T::Sig
+
+# We used to implement the logic to allow methods typed as `.void` to return
+# anything. The logic was buggy in such a way that methods returning `.void` or
+# *any superclass of void* would be treated as `.returns(T.anything)`.
+
+module M; end
+
+sig { params(x: M).void }
+def foo1(x)
+  x
+end
+
+sig { params(x: M).returns(Object) }
+def foo2(x)
+  x
+end
+
+sig { params(x: M).returns(Kernel) }
+def foo3(x)
+  x
+end
+
+sig { params(x: M).returns(BasicObject) }
+def foo4(x)
+  # Sorbet treats modules as descending from BasicObject
+  # We should fix that at some point, but that's unrelated to the `.void` bug
+  x
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet models `.void` as `returns(Sorbet::Private::Static::Void)` internally,
and it declares that with a normal class in an RBI (`rbi/sorbet/sorbet.rbi`).

The logic was backwards—it should have been `isSubType(methodReturnType,
void_())`, instead of the other way. So sorbet would implicitly treat any method
which returned a super type of .void if it returned top. Which meant:

- methods that return `.void`
- methods that return `Object`
- methods that return `Kernel`
- methods that return `BasicObject`

We could fix this by flipping the sign around, but then it would still be weird
because technically there's nothing stopping people from doing

```ruby
class MyVoid < Sorbet::Private::Static::Void
  # ...
end

sig { returns(MyVoid) }
def example; end
```

And then Sorbet would also treat this as a method that can return anything
(instead of only `MyVoid` instances). So let's just use `==` comparison.

This equality comparison works because ClassTypes are inlined types, which means
that all class types representing `.void` are byte-wise identical. This should
also be a marginal performance improvement.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.