### PR TITLE
Treat `.void` and `.returns(T.anything)` as compatible

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1444,7 +1444,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
 
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(ctx, i.what);
-                if (core::Types::isSubType(ctx, core::Types::void_(), methodReturnType)) {
+                if (methodReturnType == core::Types::void_()) {
                     methodReturnType = core::Types::top();
                 }
                 if (!core::Types::isSubTypeUnderConstraint(ctx, constr, typeAndOrigin.type, methodReturnType,

--- a/test/testdata/definition_validator/void_anything.rb
+++ b/test/testdata/definition_validator/void_anything.rb
@@ -1,0 +1,26 @@
+# typed: true
+
+class Parent
+  extend T::Sig, T::Helpers
+  abstract!
+
+  sig { abstract.void }
+  def example1; end
+
+  sig { abstract.returns(T.anything) }
+  def example2; end
+
+  sig { abstract.returns(Integer) }
+  def example3; end
+end
+
+class Child < Parent
+  sig { override.returns(T.anything) }
+  def example1; end
+
+  sig { override.void }
+  def example2; end
+
+  sig { override.void }
+  def example3; end # error: Return type `void` does not match return type of abstract method `Parent#example3`
+end

--- a/test/testdata/infer/void_anything.rb
+++ b/test/testdata/infer/void_anything.rb
@@ -14,12 +14,12 @@ end
 
 sig { params(x: M).returns(Object) }
 def foo2(x)
-  x
+  x # error: Expected `Object` but found `M` for method result type
 end
 
 sig { params(x: M).returns(Kernel) }
 def foo3(x)
-  x
+  x # error: Expected `Kernel` but found `M` for method result type
 end
 
 sig { params(x: M).returns(BasicObject) }

--- a/test/testdata/infer/void_anything.rb
+++ b/test/testdata/infer/void_anything.rb
@@ -1,0 +1,30 @@
+# typed: strict
+extend T::Sig
+
+# We used to implement the logic to allow methods typed as `.void` to return
+# anything. The logic was buggy in such a way that methods returning `.void` or
+# *any superclass of void* would be treated as `.returns(T.anything)`.
+
+module M; end
+
+sig { params(x: M).void }
+def foo1(x)
+  x
+end
+
+sig { params(x: M).returns(Object) }
+def foo2(x)
+  x
+end
+
+sig { params(x: M).returns(Kernel) }
+def foo3(x)
+  x
+end
+
+sig { params(x: M).returns(BasicObject) }
+def foo4(x)
+  # Sorbet treats modules as descending from BasicObject
+  # We should fix that at some point, but that's unrelated to the `.void` bug
+  x
+end

--- a/test/testdata/resolver/abstract_validation.rb
+++ b/test/testdata/resolver/abstract_validation.rb
@@ -163,5 +163,5 @@ module BadTypedImpl
   include GoodInterface
 
   sig {override.returns(Integer)}
-  def foo; 1; end # error: Return type `Integer` does not match return type of abstract method `GoodInterface#foo`
+  def foo; 1; end
 end

--- a/test/testdata/resolver/overrides.rb
+++ b/test/testdata/resolver/overrides.rb
@@ -87,5 +87,4 @@ class B7 < A7
   extend T::Sig
   sig {override.returns(String)}
   def foo; 'foo' end
-# ^^^^^^^ error: Return type `String` does not match return type of overridden method `A7#foo`
 end


### PR DESCRIPTION
This is the same as #7557 but I somehow messed up my git commands and closed the
other one prematurely.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Now that users can write `.returns(T.anything)`, there's essentially two ways
to write the top type in a method signature. This is one more way where the
distinction between the two of them could have snuck through to the user, so we
have to patch up the hole.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.