### PR TITLE
Prefer exact match on singleton class to fuzzy match instance method

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -761,6 +761,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                                        fmt::format("include {}", objMeth.data(gs)->owner.data(gs)->name.show(gs)));
                     }
                 }
+                auto canSkipFuzzyMatch = false;
+                if (!canSkipFuzzyMatch) {
                 auto alternatives = symbol.data(gs)->findMemberFuzzyMatch(gs, targetName);
                 for (auto alternative : alternatives) {
                     auto possibleSymbol = alternative.symbol;
@@ -826,6 +828,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         }
                         e.addErrorLine(possibleSymbol.loc(gs), "`{}` defined here", toReplace);
                     }
+                }
                 }
             }
         }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -790,9 +790,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                                              move(eitherLine),
                                          }));
 
-                        if (args.receiverLoc().empty()) {
+                        if (args.receiverLoc().exists() && args.receiverLoc().empty()) {
                             e.replaceWith("Insert `self.class.`", args.funLoc().copyWithZeroLength(), "self.class.");
-                        } else {
+                        } else if (args.receiverLoc().exists()) {
                             e.replaceWith("Insert `.class`", args.receiverLoc().copyEndWithZeroLength(), ".class");
                         }
                         canSkipFuzzyMatch = true;

--- a/test/cli/suggest-singleton/test.out
+++ b/test/cli/suggest-singleton/test.out
@@ -19,15 +19,17 @@ suggest-singleton.rb:13: Method `bar` does not exist on `A` https://srb.help/700
     suggest-singleton.rb:13:
     13 |A.new.bar
         ^^^^^
-  Note:
-    Did you mean to call `A.bar` which is a singleton class method?
+  There is a singleton class method with the same name:
+    suggest-singleton.rb:5: Defined here
+     5 |  def self.bar
+          ^^^^^^^^^^^^
+    Either:
+    - use `.class` to call it, or
+    - remove `self.` from its definition to make it an instance method
   Autocorrect: Done
     suggest-singleton.rb:13: Inserted `.class`
     13 |A.new.bar
              ^
-    suggest-singleton.rb:5: `bar` defined here
-     5 |  def self.bar
-          ^^^^^^^^^^^^
 
 suggest-singleton.rb:14: Method `my_attribute` does not exist on `T.class_of(A)` https://srb.help/7003
     14 |A.my_attribute

--- a/test/cli/suggest_static/test.out
+++ b/test/cli/suggest_static/test.out
@@ -5,15 +5,17 @@ suggest_static.rb:11: Method `foo` does not exist on `A` https://srb.help/7003
     suggest_static.rb:11:
     11 |A.new.foo
         ^^^^^
-  Note:
-    Did you mean to call `A.foo` which is a singleton class method?
+  There is a singleton class method with the same name:
+    suggest_static.rb:3: Defined here
+     3 |  def self.foo
+          ^^^^^^^^^^^^
+    Either:
+    - use `.class` to call it, or
+    - remove `self.` from its definition to make it an instance method
   Autocorrect: Done
     suggest_static.rb:11: Inserted `.class`
     11 |A.new.foo
              ^
-    suggest_static.rb:3: `foo` defined here
-     3 |  def self.foo
-          ^^^^^^^^^^^^
 
 suggest_static.rb:21: Method `on_both` does not exist on `Left` component of `T.any(Left, Right)` https://srb.help/7003
     21 |left_or_right.on_both
@@ -22,15 +24,17 @@ suggest_static.rb:21: Method `on_both` does not exist on `Left` component of `T.
     suggest_static.rb:20:
     20 |left_or_right = T.let(Left.new, T.any(Left, Right))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Did you mean to call `Left.on_both` which is a singleton class method?
+  There is a singleton class method with the same name:
+    suggest_static.rb:14: Defined here
+    14 |  def self.on_both; end
+          ^^^^^^^^^^^^^^^^
+    Either:
+    - use `.class` to call it, or
+    - remove `self.` from its definition to make it an instance method
   Autocorrect: Done
     suggest_static.rb:21: Inserted `.class`
     21 |left_or_right.on_both
                      ^
-    suggest_static.rb:14: `on_both` defined here
-    14 |  def self.on_both; end
-          ^^^^^^^^^^^^^^^^
 
 suggest_static.rb:21: Method `on_both` does not exist on `Right` component of `T.any(Left, Right)` https://srb.help/7003
     21 |left_or_right.on_both
@@ -39,28 +43,33 @@ suggest_static.rb:21: Method `on_both` does not exist on `Right` component of `T
     suggest_static.rb:20:
     20 |left_or_right = T.let(Left.new, T.any(Left, Right))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Did you mean to call `Right.on_both` which is a singleton class method?
+  There is a singleton class method with the same name:
+    suggest_static.rb:17: Defined here
+    17 |  def self.on_both; end
+          ^^^^^^^^^^^^^^^^
+    Either:
+    - use `.class` to call it, or
+    - remove `self.` from its definition to make it an instance method
   Autocorrect: Done
     suggest_static.rb:21: Inserted `.class`
     21 |left_or_right.on_both
                      ^
-    suggest_static.rb:17: `on_both` defined here
-    17 |  def self.on_both; end
-          ^^^^^^^^^^^^^^^^
 
 suggest_static.rb:7: Method `foo` does not exist on `A` https://srb.help/7003
      7 |    foo
             ^^^
-  Note:
-    Did you mean to call `A.foo` which is a singleton class method?
+  There is a singleton class method with the same name:
+    suggest_static.rb:3: Defined here
+     3 |  def self.foo
+          ^^^^^^^^^^^^
+    Either:
+    - use `.class` to call it,
+    - remove `self.` from its definition to make it an instance method, or
+    - define the current method as a singleton class method using `def self.`
   Autocorrect: Done
     suggest_static.rb:7: Inserted `self.class.`
      7 |    foo
             ^
-    suggest_static.rb:3: `foo` defined here
-     3 |  def self.foo
-          ^^^^^^^^^^^^
 Errors: 4
 
 --------------------------------------------------------------------------

--- a/test/testdata/infer/constructors.rb.autocorrects.exp
+++ b/test/testdata/infer/constructors.rb.autocorrects.exp
@@ -33,7 +33,7 @@ end
 class InstanceMethod
   def test_imethod_new
     o = Object.new
-    o.new # error: Method `new` does not exist
+    o.class.new # error: Method `new` does not exist
   end
 
   def _; end

--- a/test/testdata/infer/suggest_dot_class.rb
+++ b/test/testdata/infer/suggest_dot_class.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class A
+  def self.my_singleton_class_method; end
+
+  def example
+    my_singleton_class_method # error: does not exist
+    self.my_singleton_class_method # error: does not exist
+    a = A.new
+    a.my_singleton_class_method # error: does not exist
+  end
+end

--- a/test/testdata/infer/suggest_dot_class.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_dot_class.rb.autocorrects.exp
@@ -5,10 +5,10 @@ class A
   def self.my_singleton_class_method; end
 
   def example
-    singleton_method # error: does not exist
-    self.singleton_method # error: does not exist
+    self.class.my_singleton_class_method # error: does not exist
+    self.class.my_singleton_class_method # error: does not exist
     a = A.new
-    a.singleton_method # error: does not exist
+    a.class.my_singleton_class_method # error: does not exist
   end
 end
 # ------------------------------

--- a/test/testdata/infer/suggest_dot_class.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_dot_class.rb.autocorrects.exp
@@ -1,0 +1,14 @@
+# -- test/testdata/infer/suggest_dot_class.rb --
+# typed: true
+
+class A
+  def self.my_singleton_class_method; end
+
+  def example
+    singleton_method # error: does not exist
+    self.singleton_method # error: does not exist
+    a = A.new
+    a.singleton_method # error: does not exist
+  end
+end
+# ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More context when something isn't quite right, also help new Ruby users
understand Ruby's object model better.

### Commit summary

- **prework: Nest this code in an if** (731ceea4d)

  This is going to mess up the whitespace in a bit

- **prework: clang-format the previous commit** (d429555b0)

  This commit is just whitespace changes.

- **Add failing test** (ecf274c1c)

  This commit shows the test file before implementing an autocorrect.

- **Show suggestion to use `.class` to call singleton class method** (2a5a14ccb)

  This commit shows the new changes, and the new autocorrect test changes.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

**Before:**

<img width="645" alt="Screenshot 2024-01-03 at 1 49 40 PM" src="https://github.com/sorbet/sorbet/assets/5544532/48e545b2-fab7-4a55-9282-54dc880e42f3">

**After:**

<img width="611" alt="image" src="https://github.com/sorbet/sorbet/assets/5544532/f694e827-062d-40fe-ac73-823b1f772f0f">
