### PR TITLE
Allow specifying --track-untyped={everywhere,nowhere}

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -8,6 +8,7 @@
 #include "core/Loc.h"
 #include "core/Names.h"
 #include "core/Symbols.h"
+#include "core/TrackUntyped.h"
 #include "core/lsp/Query.h"
 #include "core/packages/PackageDB.h"
 #include "core/packages/PackageInfo.h"
@@ -232,7 +233,7 @@ public:
     bool silenceErrors = false;
     bool autocorrect = false;
     bool didYouMean = true;
-    bool trackUntyped = false;
+    TrackUntyped trackUntyped = TrackUntyped::Nowhere;
     bool printingFileTable = false;
 
     // We have a lot of internal names of form `<something>` that's chosen with `<` and `>` as you can't make

--- a/core/TrackUntyped.h
+++ b/core/TrackUntyped.h
@@ -1,0 +1,13 @@
+#ifndef SORBET_CORE_TRACK_UNTYPED_H
+#define SORBET_CORE_TRACK_UNTYPED_H
+
+#include <stdint.h>
+
+namespace sorbet::core {
+enum class TrackUntyped : uint8_t {
+    Nowhere,
+    Everywhere,
+};
+} // namespace sorbet::core
+
+#endif

--- a/core/errors/infer.cc
+++ b/core/errors/infer.cc
@@ -5,7 +5,7 @@ namespace sorbet::core::errors::Infer {
 
 ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file, const TypePtr &untyped) {
     prodCounterInc("types.input.untyped.usages");
-    if (!gs.trackUntyped) {
+    if (gs.trackUntyped == TrackUntyped::Nowhere) {
         return UntypedValue;
     }
 

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -54,6 +54,22 @@ void LSPConfiguration::assertHasClientConfig() const {
     }
 }
 
+core::TrackUntyped LSPClientConfiguration::parseEnableHighlightUntyped(const SorbetInitializationOptions &options,
+                                                                       core::TrackUntyped defaultIfUnset) {
+    if (!options.highlightUntyped.has_value()) {
+        return defaultIfUnset;
+    } else if (auto *enabled = get_if<bool>(&options.highlightUntyped.value())) {
+        return enabled ? core::TrackUntyped::Everywhere : core::TrackUntyped::Nowhere;
+    } else {
+        auto &highlightUntyped = get<string>(options.highlightUntyped.value());
+        if (highlightUntyped == "" || highlightUntyped == "everywhere") {
+            return core::TrackUntyped::Everywhere;
+        } else {
+            return core::TrackUntyped::Nowhere;
+        }
+    }
+}
+
 LSPClientConfiguration::LSPClientConfiguration(const InitializeParams &params) {
     // Note: Default values for fields are set in class definition.
     if (auto rootUriString = get_if<string>(&params.rootUri)) {
@@ -103,7 +119,7 @@ LSPClientConfiguration::LSPClientConfiguration(const InitializeParams &params) {
         enableOperationNotifications = initOptions->supportsOperationNotifications.value_or(false);
         enableTypecheckInfo = initOptions->enableTypecheckInfo.value_or(false);
         enableSorbetURIs = initOptions->supportsSorbetURIs.value_or(false);
-        enableHighlightUntyped = initOptions->highlightUntyped.value_or(false);
+        enableHighlightUntyped = parseEnableHighlightUntyped(*initOptions, core::TrackUntyped::Nowhere);
         enableTypedFalseCompletionNudges = initOptions->enableTypedFalseCompletionNudges.value_or(true);
     }
 }

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -9,6 +9,7 @@ namespace sorbet::realmain::lsp {
 
 class LSPOutput;
 class InitializeParams;
+class SorbetInitializationOptions;
 class Position;
 class Location;
 
@@ -34,8 +35,8 @@ public:
     /** If true, then LSP sends metadata to the client every time it typechecks files. Used in tests. */
     bool enableTypecheckInfo = false;
 
-    /** If true, then LSP outputs a warning for untyped values */
-    bool enableHighlightUntyped = false;
+    /** Where LSP should output an information diagnostic for untyped values */
+    core::TrackUntyped enableHighlightUntyped = core::TrackUntyped::Nowhere;
 
     /** If false, nudges in `typed: false` files are disabled */
     bool enableTypedFalseCompletionNudges = true;
@@ -56,6 +57,9 @@ public:
     bool clientCodeActionDataSupport = false;
 
     LSPClientConfiguration(const InitializeParams &initializeParams);
+
+    static core::TrackUntyped parseEnableHighlightUntyped(const SorbetInitializationOptions &options,
+                                                          core::TrackUntyped defaultIfUnset);
 };
 
 /**

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -399,7 +399,8 @@ const core::File &LSPIndexer::getFile(core::FileRef fref) const {
 }
 
 void LSPIndexer::updateGsFromOptions(const DidChangeConfigurationParams &options) const {
-    initialGS->trackUntyped = options.settings->highlightUntyped.value_or(initialGS->trackUntyped);
+    initialGS->trackUntyped =
+        LSPClientConfiguration::parseEnableHighlightUntyped(*options.settings, initialGS->trackUntyped);
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -722,7 +722,8 @@ void LSPTypechecker::setSlowPathBlocked(bool blocked) {
 }
 
 void LSPTypechecker::updateGsFromOptions(const DidChangeConfigurationParams &options) const {
-    this->gs->trackUntyped = options.settings->highlightUntyped.value_or(this->gs->trackUntyped);
+    this->gs->trackUntyped =
+        LSPClientConfiguration::parseEnableHighlightUntyped(*options.settings, this->gs->trackUntyped);
 
     if (options.settings->enableTypecheckInfo.has_value() ||
         options.settings->enableTypedFalseCompletionNudges.has_value() ||

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1256,7 +1256,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        makeField("supportsOperationNotifications", makeOptional(JSONBool)),
                        makeField("supportsSorbetURIs", makeOptional(JSONBool)),
                        makeField("enableTypecheckInfo", makeOptional(JSONBool)),
-                       makeField("highlightUntyped", makeOptional(JSONBool)),
+                       makeField("highlightUntyped", makeOptional(makeVariant({JSONBool, JSONString}))),
                        makeField("enableTypedFalseCompletionNudges", makeOptional(JSONBool)),
                    },
                    classTypes);

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -5,6 +5,7 @@
 #include "common/common.h"
 #include "common/strings/ConstExprStr.h"
 #include "core/StrictLevel.h"
+#include "core/TrackUntyped.h"
 #include "main/pipeline/semantic_extension/SemanticExtension.h"
 #include "spdlog/spdlog.h"
 #include <optional>
@@ -251,7 +252,7 @@ struct Options {
     bool lspSignatureHelpEnabled = false;
     // Enables out-of-order reference checking
     bool outOfOrderReferenceChecksEnabled = false;
-    bool trackUntyped = false;
+    core::TrackUntyped trackUntyped = core::TrackUntyped::Nowhere;
 
     // Experimental feature `requires_ancestor`
     bool requiresAncestorEnabled = false;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


This converts from a `bool` to an `enum class` with two entries, and
changes the option parsing to parse string names like

    --track-untyped
    --track-untyped=everywhere
    --track-untyped=nowhere

and also LSP configuration like

    "highlightUntyped": false,
    "highlightUntyped": true,
    "highlightUntyped": "",
    "highlightUntyped": "nowhere",
    "highlightUntyped": "everywhere",
    // and omitted

In the future, I plan to add an option like "EverywhereButTests" which
will use the `isPackagedTest` flag on `core::File` to decide whether to
show untyped highlights there.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.