### PR TITLE
highlightUntyped: Make VS Code extension use nowhere/everywhere

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -261,7 +261,7 @@
           "default": false
         },
         "sorbet.highlightUntyped": {
-          "type": "string",
+          "enum": ["nowhere", "everywhere"],
           "description": "Shows warning for untyped values.",
           "default": "nowhere"
         },

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -261,9 +261,9 @@
           "default": false
         },
         "sorbet.highlightUntyped": {
-          "type": "boolean",
+          "type": "string",
           "description": "Shows warning for untyped values.",
-          "default": false
+          "default": "nowhere"
         },
         "sorbet.typedFalseCompletionNudges": {
           "type": "boolean",

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -1,4 +1,18 @@
+import { TrackUntyped } from "../config";
+import { Log } from "../log";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
+
+function toggle(log: Log, trackWhere: TrackUntyped): TrackUntyped {
+  switch (trackWhere) {
+    case "nowhere":
+      return "everywhere";
+    case "everywhere":
+      return "nowhere";
+    default:
+      log.warning(`Got unexpected state: ${trackWhere}`);
+      return "nowhere";
+  }
+}
 
 /**
  * Toggle highlighting of untyped code.
@@ -7,14 +21,10 @@ import { SorbetExtensionContext } from "../sorbetExtensionContext";
  */
 export async function toggleUntypedCodeHighlighting(
   context: SorbetExtensionContext,
-): Promise<boolean> {
-  const targetState = !context.configuration.highlightUntyped;
+): Promise<TrackUntyped> {
+  const targetState = toggle(context.log, context.configuration.highlightUntyped);
   await context.configuration.setHighlightUntyped(targetState);
-  context.log.info(
-    `ToggleUntyped: Untyped code highlighting: ${
-      targetState ? "enabled" : "disabled"
-    }`,
-  );
+  context.log.info(`ToggleUntyped: Untyped code highlighting: ${targetState}`);
 
   const { activeLanguageClient: client } = context.statusProvider;
   if (client) {

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -22,7 +22,10 @@ function toggle(log: Log, trackWhere: TrackUntyped): TrackUntyped {
 export async function toggleUntypedCodeHighlighting(
   context: SorbetExtensionContext,
 ): Promise<TrackUntyped> {
-  const targetState = toggle(context.log, context.configuration.highlightUntyped);
+  const targetState = toggle(
+    context.log,
+    context.configuration.highlightUntyped,
+  );
   await context.configuration.setHighlightUntyped(targetState);
   context.log.info(`ToggleUntyped: Untyped code highlighting: ${targetState}`);
 

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -39,20 +39,20 @@ function backwardsCompatibleValue(
 export async function toggleUntypedCodeHighlighting(
   context: SorbetExtensionContext,
 ): Promise<TrackUntyped> {
-  const toggled = toggle(context.log, context.configuration.highlightUntyped);
-  await context.configuration.setHighlightUntyped(toggled);
-  context.log.info(`ToggleUntyped: Untyped code highlighting: ${toggled}`);
+  const targetState = toggle(context.log, context.configuration.highlightUntyped);
+  await context.configuration.setHighlightUntyped(targetState);
+  context.log.info(`ToggleUntyped: Untyped code highlighting: ${targetState}`);
 
   const { activeLanguageClient: client } = context.statusProvider;
   if (client) {
     client.sendNotification("workspace/didChangeConfiguration", {
       settings: {
-        highlightUntyped: backwardsCompatibleValue(context.log, toggled),
+        highlightUntyped: backwardsCompatibleValue(context.log, targetState),
       },
     });
   } else {
     context.log.debug("ToggleUntyped: No active Sorbet LSP to notify.");
   }
 
-  return toggled;
+  return targetState;
 }

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -39,7 +39,10 @@ function backwardsCompatibleValue(
 export async function toggleUntypedCodeHighlighting(
   context: SorbetExtensionContext,
 ): Promise<TrackUntyped> {
-  const targetState = toggle(context.log, context.configuration.highlightUntyped);
+  const targetState = toggle(
+    context.log,
+    context.configuration.highlightUntyped,
+  );
   await context.configuration.setHighlightUntyped(targetState);
   context.log.info(`ToggleUntyped: Untyped code highlighting: ${targetState}`);
 

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -9,8 +9,25 @@ function toggle(log: Log, trackWhere: TrackUntyped): TrackUntyped {
     case "everywhere":
       return "nowhere";
     default:
-      log.warning(`Got unexpected state: ${trackWhere}`);
+      const exhaustiveCheck: never = trackWhere;
+      log.warning(`Got unexpected state: ${exhaustiveCheck}`);
       return "nowhere";
+  }
+}
+
+function backwardsCompatibleValue(
+  log: Log,
+  trackWhere: TrackUntyped,
+): boolean | TrackUntyped {
+  switch (trackWhere) {
+    case "nowhere":
+      return false;
+    case "everywhere":
+      return true;
+    default:
+      const exhaustiveCheck: never = trackWhere;
+      log.warning(`Got unexpected state: ${exhaustiveCheck}`);
+      return false;
   }
 }
 
@@ -22,23 +39,20 @@ function toggle(log: Log, trackWhere: TrackUntyped): TrackUntyped {
 export async function toggleUntypedCodeHighlighting(
   context: SorbetExtensionContext,
 ): Promise<TrackUntyped> {
-  const targetState = toggle(
-    context.log,
-    context.configuration.highlightUntyped,
-  );
-  await context.configuration.setHighlightUntyped(targetState);
-  context.log.info(`ToggleUntyped: Untyped code highlighting: ${targetState}`);
+  const toggled = toggle(context.log, context.configuration.highlightUntyped);
+  await context.configuration.setHighlightUntyped(toggled);
+  context.log.info(`ToggleUntyped: Untyped code highlighting: ${toggled}`);
 
   const { activeLanguageClient: client } = context.statusProvider;
   if (client) {
     client.sendNotification("workspace/didChangeConfiguration", {
       settings: {
-        highlightUntyped: targetState,
+        highlightUntyped: backwardsCompatibleValue(context.log, toggled),
       },
     });
   } else {
     context.log.debug("ToggleUntyped: No active Sorbet LSP to notify.");
   }
 
-  return targetState;
+  return toggled;
 }

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -12,16 +12,19 @@ import * as fs from "fs";
 import { SorbetLspConfig, SorbetLspConfigData } from "./sorbetLspConfig";
 import { deepEqual } from "./utils";
 
-function maybeUpgradeHighlightUntyped(
-  value: boolean | TrackUntyped,
+function coerceTrackUntypedSetting(
+  value: boolean | string,
 ): TrackUntyped {
   switch (value) {
     case true:
       return "everywhere";
     case false:
       return "nowhere";
-    default:
+    case "nowhere":
+    case "everywhere":
       return value;
+    default:
+      return "nowhere";
   }
 }
 
@@ -244,7 +247,7 @@ export class SorbetExtensionConfig implements Disposable {
       "highlightUntyped",
       this.highlightUntyped,
     );
-    this.wrappedHighlightUntyped = maybeUpgradeHighlightUntyped(
+    this.wrappedHighlightUntyped = coerceTrackUntypedSetting(
       highlightUntyped,
     );
     this.wrappedTypedFalseCompletionNudges = this.sorbetWorkspaceContext.get(

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -12,9 +12,9 @@ import * as fs from "fs";
 import { SorbetLspConfig, SorbetLspConfigData } from "./sorbetLspConfig";
 import { deepEqual } from "./utils";
 
-function coerceTrackUntypedSetting(
-  value: boolean | string,
-): TrackUntyped {
+export type TrackUntyped = "nowhere" | "everywhere";
+
+function coerceTrackUntypedSetting(value: boolean | string): TrackUntyped {
   switch (value) {
     case true:
       return "everywhere";
@@ -160,8 +160,6 @@ export class DefaultSorbetWorkspaceContext implements ISorbetWorkspaceContext {
   }
 }
 
-export type TrackUntyped = "nowhere" | "everywhere";
-
 export class SorbetExtensionConfig implements Disposable {
   private configFilePatterns: ReadonlyArray<string>;
   private configFileWatchers: ReadonlyArray<FileSystemWatcher>;
@@ -247,9 +245,7 @@ export class SorbetExtensionConfig implements Disposable {
       "highlightUntyped",
       this.highlightUntyped,
     );
-    this.wrappedHighlightUntyped = coerceTrackUntypedSetting(
-      highlightUntyped,
-    );
+    this.wrappedHighlightUntyped = coerceTrackUntypedSetting(highlightUntyped);
     this.wrappedTypedFalseCompletionNudges = this.sorbetWorkspaceContext.get(
       "typedFalseCompletionNudges",
       this.typedFalseCompletionNudges,

--- a/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
+++ b/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
@@ -4,7 +4,7 @@ import * as sinon from "sinon";
 
 import { createLogStub } from "../testUtils";
 import { toggleUntypedCodeHighlighting } from "../../commands/toggleUntypedCodeHighlighting";
-import { SorbetExtensionConfig, TrackUntyped  } from "../../config";
+import { SorbetExtensionConfig, TrackUntyped } from "../../config";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
 import { SorbetStatusProvider } from "../../sorbetStatusProvider";
 import { RestartReason } from "../../types";

--- a/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
+++ b/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
@@ -47,10 +47,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       statusProvider,
     };
 
-    assert.strictEqual(
-      await toggleUntypedCodeHighlighting(context),
-      !initialState,
-    );
+    assert.strictEqual(await toggleUntypedCodeHighlighting(context), "nowhere");
 
     sinon.assert.calledOnce(setHighlightUntypedSpy);
     sinon.assert.calledWithExactly(setHighlightUntypedSpy, "nowhere");

--- a/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
+++ b/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
@@ -4,7 +4,7 @@ import * as sinon from "sinon";
 
 import { createLogStub } from "../testUtils";
 import { toggleUntypedCodeHighlighting } from "../../commands/toggleUntypedCodeHighlighting";
-import { SorbetExtensionConfig } from "../../config";
+import { SorbetExtensionConfig, TrackUntyped  } from "../../config";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
 import { SorbetStatusProvider } from "../../sorbetStatusProvider";
 import { RestartReason } from "../../types";
@@ -21,12 +21,12 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
   });
 
   test("toggleUntypedCodeHighlighting", async () => {
-    const initialState = true;
+    const initialState = "everywhere";
     let currentState = initialState;
 
     const log = createLogStub();
 
-    const setHighlightUntypedSpy = sinon.spy((value: boolean) => {
+    const setHighlightUntypedSpy = sinon.spy((value: TrackUntyped) => {
       currentState = value;
     });
     const configuration = <SorbetExtensionConfig>(<unknown>{
@@ -53,6 +53,6 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     );
 
     sinon.assert.calledOnce(setHighlightUntypedSpy);
-    sinon.assert.calledWithExactly(setHighlightUntypedSpy, !initialState);
+    sinon.assert.calledWithExactly(setHighlightUntypedSpy, "nowhere");
   });
 });

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -378,17 +378,23 @@ suite("SorbetExtensionConfig", async () => {
 
       suite("sorbet.highlightUntyped", async () => {
         test("true instead of a string", async () => {
-          const workspaceConfig = new FakeWorkspaceConfiguration([["highlightUntyped", true]]);
+          const workspaceConfig = new FakeWorkspaceConfiguration([
+            ["highlightUntyped", true],
+          ]);
           const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
           assert.strictEqual(sorbetConfig.highlightUntyped, "everywhere");
         });
         test("false instead of a string", async () => {
-          const workspaceConfig = new FakeWorkspaceConfiguration([["highlightUntyped", false]]);
+          const workspaceConfig = new FakeWorkspaceConfiguration([
+            ["highlightUntyped", false],
+          ]);
           const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
           assert.strictEqual(sorbetConfig.highlightUntyped, "nowhere");
         });
         test("unrecognized string", async () => {
-          const workspaceConfig = new FakeWorkspaceConfiguration([["highlightUntyped", "nope"]]);
+          const workspaceConfig = new FakeWorkspaceConfiguration([
+            ["highlightUntyped", "nope"],
+          ]);
           const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
           assert.strictEqual(sorbetConfig.highlightUntyped, "nowhere");
         });

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -376,6 +376,24 @@ suite("SorbetExtensionConfig", async () => {
         );
       });
 
+      suite("sorbet.highlightUntyped", async () => {
+        test("true instead of a string", async () => {
+          const workspaceConfig = new FakeWorkspaceConfiguration([["highlightUntyped", true]]);
+          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
+          assert.strictEqual(sorbetConfig.highlightUntyped, "everywhere");
+        });
+        test("false instead of a string", async () => {
+          const workspaceConfig = new FakeWorkspaceConfiguration([["highlightUntyped", false]]);
+          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
+          assert.strictEqual(sorbetConfig.highlightUntyped, "nowhere");
+        });
+        test("unrecognized string", async () => {
+          const workspaceConfig = new FakeWorkspaceConfiguration([["highlightUntyped", "nope"]]);
+          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
+          assert.strictEqual(sorbetConfig.highlightUntyped, "nowhere");
+        });
+      });
+
       test("multiple instances of SorbetExtensionConfig stay in sync with each other", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration([
           ["enabled", true],


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a follow up to #7569, which converted from using `bool` to using an enum
for the `--track-untyped` setting, in anticipation of making it no longer be a
boolean.

In this PR, we make the same changes to the VS Code extension.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

I've also tested manually in VS Code to ensure that the first time you use this
version of the extension, it gracefully upgrades you to use the new value,
instead of keeping the setting defined as a boolean.