### PR TITLE
Add option to highlight untyped everywhere but tests

### DIFF
--- a/core/TrackUntyped.h
+++ b/core/TrackUntyped.h
@@ -6,6 +6,7 @@
 namespace sorbet::core {
 enum class TrackUntyped : uint8_t {
     Nowhere,
+    EverywhereButTests,
     Everywhere,
 };
 } // namespace sorbet::core

--- a/core/errors/infer.cc
+++ b/core/errors/infer.cc
@@ -9,7 +9,12 @@ ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file, const TypeP
         return UntypedValue;
     }
 
-    auto isOpenInClient = file.data(gs).isOpenInClient();
+    const auto &fileData = file.data(gs);
+    if (gs.trackUntyped == TrackUntyped::EverywhereButTests && fileData.isPackagedTest()) {
+        return UntypedValue;
+    }
+
+    auto isOpenInClient = fileData.isOpenInClient();
     if (gs.printingFileTable) {
         // Note: this metric, despite being a prod metric, will not get reported in the normal way
         // to the metrics file, the web trace file, nor statsd. We call getAndClearHistogram BEFORE
@@ -32,7 +37,7 @@ ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file, const TypeP
         prodHistogramInc("untyped.blames", untyped.untypedBlame().rawId());
     }
 
-    if (isOpenInClient && file.data(gs).strictLevel < core::StrictLevel::Strong) {
+    if (isOpenInClient && fileData.strictLevel < core::StrictLevel::Strong) {
         return UntypedValueInformation;
     } else {
         return UntypedValue;

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -64,6 +64,8 @@ core::TrackUntyped LSPClientConfiguration::parseEnableHighlightUntyped(const Sor
         auto &highlightUntyped = get<string>(options.highlightUntyped.value());
         if (highlightUntyped == "" || highlightUntyped == "everywhere") {
             return core::TrackUntyped::Everywhere;
+        } else if (highlightUntyped == "everywhere-but-tests") {
+            return core::TrackUntyped::EverywhereButTests;
         } else {
             return core::TrackUntyped::Nowhere;
         }

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -180,6 +180,8 @@ core::TrackUntyped text2TrackUntyped(string_view key, spdlog::logger &logger) {
         return core::TrackUntyped::Everywhere;
     } else if (key == "nowhere") {
         return core::TrackUntyped::Nowhere;
+    } else if (key == "everywhere-but-tests") {
+        return core::TrackUntyped::EverywhereButTests;
     } else if (key == "everywhere") {
         return core::TrackUntyped::Everywhere;
     } else {
@@ -430,7 +432,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("check-out-of-order-constant-references",
                                     "Enable out-of-order constant reference checks (error 5027)");
     options.add_options("advanced")("track-untyped", "Track untyped usage statistics in the file-table output",
-                                    cxxopts::value<string>()->implicit_value("everywhere"), "{[nowhere],everywhere}");
+                                    cxxopts::value<string>()->implicit_value("everywhere"),
+                                    "{[nowhere],everywhere,everywhere-but-tests}");
 
     // Developer options
     options.add_options("dev")("p,print", to_string(all_prints), cxxopts::value<vector<string>>(), "type");

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -24,13 +24,13 @@
   ],
   "activationEvents": [
     "onCommand:sorbet.configure",
+    "onCommand:sorbet.configureHighlightUntyped",
     "onCommand:sorbet.disable",
     "onCommand:sorbet.enable",
     "onCommand:sorbet.restart",
     "onCommand:sorbet.setLogLevel",
     "onCommand:sorbet.showOutput",
     "onCommand:sorbet.toggleHighlightUntyped",
-    "onCommand:sorbet.configureHighlightUntyped",
     "onCommand:sorbet.toggleTypedFalseCompletionNudges",
     "onLanguage:ruby",
     "workspaceContains:sorbet/*"

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -30,6 +30,7 @@
     "onCommand:sorbet.setLogLevel",
     "onCommand:sorbet.showOutput",
     "onCommand:sorbet.toggleHighlightUntyped",
+    "onCommand:sorbet.configureHighlightUntyped",
     "onCommand:sorbet.toggleTypedFalseCompletionNudges",
     "onLanguage:ruby",
     "workspaceContains:sorbet/*"
@@ -95,6 +96,12 @@
       {
         "command": "sorbet.toggleHighlightUntyped",
         "title": "Toggle highlighting untyped code",
+        "category": "Sorbet",
+        "enablement": "workbenchState != empty"
+      },
+      {
+        "command": "sorbet.configureHighlightUntyped",
+        "title": "Configure untyped code highlighting",
         "category": "Sorbet",
         "enablement": "workbenchState != empty"
       },

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -57,6 +57,12 @@
         "category": "Sorbet"
       },
       {
+        "command": "sorbet.configureHighlightUntyped",
+        "title": "Configure untyped code highlighting",
+        "category": "Sorbet",
+        "enablement": "workbenchState != empty"
+      },
+      {
         "command": "sorbet.copySymbolToClipboard",
         "title": "Copy Symbol to Clipboard",
         "category": "Sorbet",
@@ -96,12 +102,6 @@
       {
         "command": "sorbet.toggleHighlightUntyped",
         "title": "Toggle highlighting untyped code",
-        "category": "Sorbet",
-        "enablement": "workbenchState != empty"
-      },
-      {
-        "command": "sorbet.configureHighlightUntyped",
-        "title": "Configure untyped code highlighting",
         "category": "Sorbet",
         "enablement": "workbenchState != empty"
       },

--- a/vscode_extension/src/commandIds.ts
+++ b/vscode_extension/src/commandIds.ts
@@ -55,6 +55,12 @@ export const TOGGLE_HIGHLIGHT_UNTYPED_COMMAND_ID =
   "sorbet.toggleHighlightUntyped";
 
 /**
+ * Configure highlighting of untyped code.
+ */
+export const CONFIGURE_HIGHLIGHT_UNTYPED_COMMAND_ID =
+  "sorbet.configureHighlightUntyped";
+
+/**
  * Toggle the auto-complete nudge in `typed: false` files.
  */
 export const TOGGLE_TYPED_FALSE_COMPLETION_NUDGES_COMMAND_ID =

--- a/vscode_extension/src/commandIds.ts
+++ b/vscode_extension/src/commandIds.ts
@@ -1,4 +1,10 @@
 /**
+ * Configure highlighting of untyped code.
+ */
+export const CONFIGURE_HIGHLIGHT_UNTYPED_COMMAND_ID =
+  "sorbet.configureHighlightUntyped";
+
+/**
  * Copy Symbol to Clipboard.
  */
 export const COPY_SYMBOL_COMMAND_ID = "sorbet.copySymbolToClipboard";
@@ -53,13 +59,6 @@ export const SORBET_SAVE_PACKAGE_FILES = "sorbet.savePackageFiles";
  */
 export const TOGGLE_HIGHLIGHT_UNTYPED_COMMAND_ID =
   "sorbet.toggleHighlightUntyped";
-
-/**
- * Configure highlighting of untyped code.
- */
-export const CONFIGURE_HIGHLIGHT_UNTYPED_COMMAND_ID =
-  "sorbet.configureHighlightUntyped";
-
 /**
  * Toggle the auto-complete nudge in `typed: false` files.
  */

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -1,15 +1,26 @@
-import { TrackUntyped, backwardsCompatibleTrackUntyped } from "../config";
+import { QuickPickItem, window } from "vscode";
+import { TrackUntyped, backwardsCompatibleTrackUntyped, SorbetExtensionConfig } from "../config";
 import { Log } from "../log";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
 
-function toggle(log: Log, trackWhere: TrackUntyped): TrackUntyped {
-  switch (trackWhere) {
+export interface TrackUntypedQuickPickItem extends QuickPickItem {
+  trackWhere: TrackUntyped;
+}
+
+function toggle(log: Log, configuration: SorbetExtensionConfig): TrackUntyped {
+  if (configuration.oldHighlightUntyped != null) {
+    return configuration.oldHighlightUntyped;
+  }
+
+  switch (configuration.highlightUntyped) {
     case "nowhere":
       return "everywhere";
+    case "everywhere-but-tests":
+      return "nowhere";
     case "everywhere":
       return "nowhere";
     default:
-      const exhaustiveCheck: never = trackWhere;
+      const exhaustiveCheck: never = configuration.highlightUntyped;
       log.warning(`Got unexpected state: ${exhaustiveCheck}`);
       return "nowhere";
   }
@@ -18,15 +29,12 @@ function toggle(log: Log, trackWhere: TrackUntyped): TrackUntyped {
 /**
  * Toggle highlighting of untyped code.
  * @param context Sorbet extension context.
- * @returns `true` if highlighting is now enabled, `false` otherwise.
+ * @returns The new TrackUntyped setting
  */
 export async function toggleUntypedCodeHighlighting(
   context: SorbetExtensionContext,
 ): Promise<TrackUntyped> {
-  const targetState = toggle(
-    context.log,
-    context.configuration.highlightUntyped,
-  );
+  const targetState = toggle(context.log, context.configuration);
   await context.configuration.setHighlightUntyped(targetState);
   context.log.info(`ToggleUntyped: Untyped code highlighting: ${targetState}`);
 
@@ -45,4 +53,53 @@ export async function toggleUntypedCodeHighlighting(
   }
 
   return targetState;
+}
+
+/**
+ * Set highlighting of untyped code to sepcific setting.
+ * @param context Sorbet extension context.
+ */
+export async function configureUntypedCodeHighlighting(
+  context: SorbetExtensionContext,
+): Promise<void> {
+  const items: TrackUntypedQuickPickItem[] = [
+    {
+      label: "Nowhere",
+      trackWhere: "nowhere",
+    },
+    {
+      label: "Everywhere but tests",
+      trackWhere: "everywhere-but-tests",
+    },
+    {
+      label: "Everywhere",
+      trackWhere: "everywhere",
+    },
+  ];
+
+  const selectedItem = await window.showQuickPick(items, {
+    placeHolder: "Select where to highlight untyped code",
+  });
+
+  if (selectedItem) {
+    const oldHighlightUntyped = context.configuration.highlightUntyped;
+    context.configuration.oldHighlightUntyped = oldHighlightUntyped;
+
+    const targetState = selectedItem.trackWhere;
+    await context.configuration.setHighlightUntyped(targetState);
+    context.log.info(
+      `ToggleUntyped: Untyped code highlighting: ${targetState}`,
+    );
+
+    const { activeLanguageClient: client } = context.statusProvider;
+    if (client) {
+      client.sendNotification("workspace/didChangeConfiguration", {
+        settings: {
+          highlightUntyped: targetState,
+        },
+      });
+    } else {
+      context.log.debug("ToggleUntyped: No active Sorbet LSP to notify.");
+    }
+  }
 }

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -1,5 +1,9 @@
 import { QuickPickItem, window } from "vscode";
-import { TrackUntyped, backwardsCompatibleTrackUntyped, SorbetExtensionConfig } from "../config";
+import {
+  TrackUntyped,
+  backwardsCompatibleTrackUntyped,
+  SorbetExtensionConfig,
+} from "../config";
 import { Log } from "../log";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
 

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -88,7 +88,7 @@ export async function configureUntypedCodeHighlighting(
     const targetState = selectedItem.trackWhere;
     await context.configuration.setHighlightUntyped(targetState);
     context.log.info(
-      `ToggleUntyped: Untyped code highlighting: ${targetState}`,
+      `ConfigureUntyped: Untyped code highlighting: ${targetState}`,
     );
 
     const { activeLanguageClient: client } = context.statusProvider;
@@ -99,7 +99,7 @@ export async function configureUntypedCodeHighlighting(
         },
       });
     } else {
-      context.log.debug("ToggleUntyped: No active Sorbet LSP to notify.");
+      context.log.debug("ConfigureUntyped: No active Sorbet LSP to notify.");
     }
   }
 }

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -13,7 +13,7 @@ import { Log } from "./log";
 import { SorbetLspConfig, SorbetLspConfigData } from "./sorbetLspConfig";
 import { deepEqual } from "./utils";
 
-export type TrackUntyped = "nowhere" | "everywhere";
+export type TrackUntyped = "nowhere" | "everywhere-but-tests" | "everywhere";
 
 function coerceTrackUntypedSetting(value: boolean | string): TrackUntyped {
   switch (value) {
@@ -22,6 +22,7 @@ function coerceTrackUntypedSetting(value: boolean | string): TrackUntyped {
     case false:
       return "nowhere";
     case "nowhere":
+    case "everywhere-but-tests":
     case "everywhere":
       return value;
     default:
@@ -38,6 +39,8 @@ export function backwardsCompatibleTrackUntyped(
       return false;
     case "everywhere":
       return true;
+    case "everywhere-but-tests":
+      return trackWhere;
     default:
       const exhaustiveCheck: never = trackWhere;
       log.warning(`Got unexpected state: ${exhaustiveCheck}`);
@@ -339,6 +342,8 @@ export class SorbetExtensionConfig implements Disposable {
   public get highlightUntyped(): TrackUntyped {
     return this.wrappedHighlightUntyped;
   }
+
+  public oldHighlightUntyped: TrackUntyped | undefined = undefined;
 
   /**
    * Returns a copy of the current SorbetLspConfig objects.

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -7,7 +7,10 @@ import { savePackageFiles } from "./commands/savePackageFiles";
 import { setLogLevel } from "./commands/setLogLevel";
 import { showSorbetActions } from "./commands/showSorbetActions";
 import { showSorbetConfigurationPicker } from "./commands/showSorbetConfigurationPicker";
-import { toggleUntypedCodeHighlighting } from "./commands/toggleUntypedCodeHighlighting";
+import {
+  toggleUntypedCodeHighlighting,
+  configureUntypedCodeHighlighting,
+} from "./commands/toggleUntypedCodeHighlighting";
 import { toggleTypedFalseCompletionNudges } from "./commands/toggleTypedFalseCompletionNudges";
 import { getLogLevelFromEnvironment, LogLevel } from "./log";
 import { SorbetContentProvider, SORBET_SCHEME } from "./sorbetContentProvider";
@@ -89,6 +92,10 @@ export function activate(context: ExtensionContext) {
     ),
     commands.registerCommand(cmdIds.TOGGLE_HIGHLIGHT_UNTYPED_COMMAND_ID, () =>
       toggleUntypedCodeHighlighting(sorbetExtensionContext),
+    ),
+    commands.registerCommand(
+      cmdIds.CONFIGURE_HIGHLIGHT_UNTYPED_COMMAND_ID,
+      () => configureUntypedCodeHighlighting(sorbetExtensionContext),
     ),
     commands.registerCommand(
       cmdIds.TOGGLE_TYPED_FALSE_COMPLETION_NUDGES_COMMAND_ID,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In Stripe's codebase, usages of untyped in tests vastly outnumber usages in
non-test files. Put another way: usages of untyped in non-test files are rare
enough that you might conceivably want Sorbet to highlight all of them, all the
time.

The only way you can do that right now is by highlighting untyped in test files
too. While many tests use very little untyped, other tests are nearly completely
untyped, which is very noisy.

This setting allows people to opt in to a sort of "always on in non-test file"
style of development. In particular, it updates the **Toggle** command to toggle
between the last two values of the setting. So if you want to toggle between "on
except in tests" and "off" you can. Or you can toggle between "on except in
tests" and "on everywhere." Or, like today, you can toggle between
everywhere/nowhere.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

I have tested this manually, but I need to do more testing to make sure that new
VS Code extension versions work with old Sorbet versions (also the case for
#7571)