### PR TITLE
Add alternative Array#sample sig when no arg0 is passed in

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2268,6 +2268,15 @@ class Array < Object
     )
     .returns(T.any(T.nilable(Elem), T::Array[Elem]))
   end
+  sig do
+    params(
+        random: Random::Formatter,
+    )
+    .returns(T.nilable(Elem))
+  end
+  sig do
+    returns(T.nilable(Elem))
+  end
   def sample(arg0=T.unsafe(nil), random: T.unsafe(nil)); end
 
   # Returns a new array containing all elements of `ary` for which the given

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -79,3 +79,8 @@ x = [[3.4], [1, "a"]]
 T.reveal_type(x.transpose) # error: Revealed type: `T::Array[T::Array[T.untyped]]`
 x = [[3.4, "a"], [:a, 5]]
 T.reveal_type(x.transpose) # error: Revealed type: `[T::Array[T.any(Float, Symbol)], T::Array[T.any(Integer, String)]] (2-tuple)`
+
+# sample
+array = T.let([1, 2, 3], T::Array[Integer])
+T.reveal_type(array.sample) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type(array.sample(1)) # error: Revealed type: `T.nilable(T.any(Integer, T::Array[Integer]))


### PR DESCRIPTION
### Motivation
When no argument is passed in, the result is just `T.nilable(Elem)`, which simplifies not having to deal with the `T.any`

### Test plan
See included automated tests.
