### PR TITLE
sorbet-runtime: Speed up methods with no meaningful return type

### DIFF
--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -166,6 +166,11 @@ module SorbetBenchmarks
         application_class_param(example)
       end
 
+      time_block("sig {params(x: Example).returns(T.anything)}") do
+        application_class_param_returns_anything(example)
+        application_class_param_returns_anything(example)
+      end
+
       time_block("T.let(..., T.nilable(Example))") do
         T.let(nil, T.nilable(Example))
         T.let(example, T.nilable(Example))
@@ -174,6 +179,11 @@ module SorbetBenchmarks
       time_block("sig {params(x: T.nilable(Example)).void}") do
         nilable_application_class_param(nil)
         nilable_application_class_param(example)
+      end
+
+      time_block("sig {params(x: T.nilable(Example)).returns(T.anything)}") do
+        nilable_application_class_param_returns_anything(nil)
+        nilable_application_class_param_returns_anything(example)
       end
 
       time_block("sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs)") do
@@ -220,8 +230,14 @@ module SorbetBenchmarks
     sig {params(x: Example).void}
     def self.application_class_param(x); end
 
+    sig {params(x: Example).returns(T.anything)}
+    def self.application_class_param_returns_anything(x); end
+
     sig {params(x: T.nilable(Example)).void}
     def self.nilable_application_class_param(x); end
+
+    sig {params(x: T.nilable(Example)).returns(T.anything)}
+    def self.nilable_application_class_param_returns_anything(x); end
 
     sig {params(s: Symbol, x: Integer, y: Integer).void}
     def self.arg_plus_kwargs(s, x:, y: 0); end

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -75,7 +75,7 @@ module T::Private::Methods::CallValidation
        method_sig.return_type.eql?(T::Types::SelfType::Private::INSTANCE) ||
        method_sig.return_type.is_a?(T::Types::TypeParameter) ||
        method_sig.return_type.is_a?(T::Types::TypeVariable) ||
-       (method_sig.return_type.is_a?(T::Types::Simple) && method_sig.return_type.raw_type == BasicObject))
+       (method_sig.return_type.is_a?(T::Types::Simple) && method_sig.return_type.raw_type.eql?(BasicObject)))
 
     returns_anything_method = all_args_are_simple && return_is_ignorable
 

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -69,12 +69,12 @@ module T::Private::Methods::CallValidation
 
     # All the types for which valid? unconditionally returns `true`
     return_is_ignorable =
-      (method_sig.return_type == T::Types::Untyped::Private::INSTANCE ||
-       method_sig.return_type == T::Types::Anything::Private::INSTANCE ||
+      (method_sig.return_type.eql?(T::Types::Untyped::Private::INSTANCE) ||
+       method_sig.return_type.eql?(T::Types::Anything::Private::INSTANCE) ||
        method_sig.return_type.is_a?(T::Types::TypeParameter) ||
        method_sig.return_type.is_a?(T::Types::TypeVariable) ||
-       method_sig.return_type.is_a?(T::Types::AttachedClassType) ||
-       method_sig.return_type.is_a?(T::Types::SelfType) ||
+       method_sig.return_type.is_a?(T::Types::AttachedClassType::Private::INSTANCE) ||
+       method_sig.return_type.is_a?(T::Types::SelfType::Private::INSTANCE) ||
        (method_sig.return_type.is_a?(T::Types::Simple) && method_sig.return_type.raw_type == BasicObject))
 
     returns_anything_method = all_args_are_simple && return_is_ignorable

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -71,10 +71,10 @@ module T::Private::Methods::CallValidation
     return_is_ignorable =
       (method_sig.return_type.eql?(T::Types::Untyped::Private::INSTANCE) ||
        method_sig.return_type.eql?(T::Types::Anything::Private::INSTANCE) ||
+       method_sig.return_type.eql?(T::Types::AttachedClassType::Private::INSTANCE) ||
+       method_sig.return_type.eql?(T::Types::SelfType::Private::INSTANCE) ||
        method_sig.return_type.is_a?(T::Types::TypeParameter) ||
        method_sig.return_type.is_a?(T::Types::TypeVariable) ||
-       method_sig.return_type.is_a?(T::Types::AttachedClassType::Private::INSTANCE) ||
-       method_sig.return_type.is_a?(T::Types::SelfType::Private::INSTANCE) ||
        (method_sig.return_type.is_a?(T::Types::Simple) && method_sig.return_type.raw_type == BasicObject))
 
     returns_anything_method = all_args_are_simple && return_is_ignorable

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -69,13 +69,13 @@ module T::Private::Methods::CallValidation
 
     # All the types for which valid? unconditionally returns `true`
     return_is_ignorable =
-      (method_sig.return_type.eql?(T::Types::Untyped::Private::INSTANCE) ||
-       method_sig.return_type.eql?(T::Types::Anything::Private::INSTANCE) ||
-       method_sig.return_type.eql?(T::Types::AttachedClassType::Private::INSTANCE) ||
-       method_sig.return_type.eql?(T::Types::SelfType::Private::INSTANCE) ||
+      (method_sig.return_type.equal?(T::Types::Untyped::Private::INSTANCE) ||
+       method_sig.return_type.equal?(T::Types::Anything::Private::INSTANCE) ||
+       method_sig.return_type.equal?(T::Types::AttachedClassType::Private::INSTANCE) ||
+       method_sig.return_type.equal?(T::Types::SelfType::Private::INSTANCE) ||
        method_sig.return_type.is_a?(T::Types::TypeParameter) ||
        method_sig.return_type.is_a?(T::Types::TypeVariable) ||
-       (method_sig.return_type.is_a?(T::Types::Simple) && method_sig.return_type.raw_type.eql?(BasicObject)))
+       (method_sig.return_type.is_a?(T::Types::Simple) && method_sig.return_type.raw_type.equal?(BasicObject)))
 
     returns_anything_method = all_args_are_simple && return_is_ignorable
 

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation_2_6.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation_2_6.rb
@@ -343,6 +343,265 @@ module T::Private::Methods::CallValidation
     end
   end
 
+  def self.create_validator_method_skip_return_fast(mod, original_method, method_sig, original_visibility)
+    # trampoline to reduce stack frame size
+    arg_types = method_sig.arg_types
+    case arg_types.length
+    when 0
+      create_validator_method_skip_return_fast0(mod, original_method, method_sig, original_visibility)
+    when 1
+      create_validator_method_skip_return_fast1(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1].raw_type)
+    when 2
+      create_validator_method_skip_return_fast2(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1].raw_type,
+                                    arg_types[1][1].raw_type)
+    when 3
+      create_validator_method_skip_return_fast3(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1].raw_type,
+                                    arg_types[1][1].raw_type,
+                                    arg_types[2][1].raw_type)
+    when 4
+      create_validator_method_skip_return_fast4(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1].raw_type,
+                                    arg_types[1][1].raw_type,
+                                    arg_types[2][1].raw_type,
+                                    arg_types[3][1].raw_type)
+    else
+      raise 'should not happen'
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast0(mod, original_method, method_sig, original_visibility)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |&blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(&blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast1(mod, original_method, method_sig, original_visibility, arg0_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0.is_a?(arg0_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(arg0, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast2(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0.is_a?(arg0_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1.is_a?(arg1_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(arg0, arg1, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast3(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type, arg2_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0.is_a?(arg0_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1.is_a?(arg1_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      unless arg2.is_a?(arg2_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(arg0, arg1, arg2, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast4(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type, arg2_type, arg3_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, arg3, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0.is_a?(arg0_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1.is_a?(arg1_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      unless arg2.is_a?(arg2_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+
+      unless arg3.is_a?(arg3_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[3][1].error_message_for_obj(arg3),
+          'Parameter',
+          method_sig.arg_types[3][0],
+          arg3_type,
+          arg3,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(arg0, arg1, arg2, arg3, &blk)
+    end
+  end
+
   def self.create_validator_procedure_fast(mod, original_method, method_sig, original_visibility)
     # trampoline to reduce stack frame size
     arg_types = method_sig.arg_types
@@ -941,6 +1200,265 @@ module T::Private::Methods::CallValidation
         end
       end
       return_value
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium(mod, original_method, method_sig, original_visibility)
+    # trampoline to reduce stack frame size
+    arg_types = method_sig.arg_types
+    case arg_types.length
+    when 0
+      create_validator_method_skip_return_medium0(mod, original_method, method_sig, original_visibility)
+    when 1
+      create_validator_method_skip_return_medium1(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1])
+    when 2
+      create_validator_method_skip_return_medium2(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1],
+                                    arg_types[1][1])
+    when 3
+      create_validator_method_skip_return_medium3(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1],
+                                    arg_types[1][1],
+                                    arg_types[2][1])
+    when 4
+      create_validator_method_skip_return_medium4(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1],
+                                    arg_types[1][1],
+                                    arg_types[2][1],
+                                    arg_types[3][1])
+    else
+      raise 'should not happen'
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium0(mod, original_method, method_sig, original_visibility)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |&blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(&blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium1(mod, original_method, method_sig, original_visibility, arg0_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(arg0, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium2(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1_type.valid?(arg1)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(arg0, arg1, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium3(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type, arg2_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1_type.valid?(arg1)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      unless arg2_type.valid?(arg2)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(arg0, arg1, arg2, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium4(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type, arg2_type, arg3_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, arg3, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1_type.valid?(arg1)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      unless arg2_type.valid?(arg2)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+
+      unless arg3_type.valid?(arg3)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[3][1].error_message_for_obj(arg3),
+          'Parameter',
+          method_sig.arg_types[3][0],
+          arg3_type,
+          arg3,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind(self).call(arg0, arg1, arg2, arg3, &blk)
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation_2_7.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation_2_7.rb
@@ -343,6 +343,265 @@ module T::Private::Methods::CallValidation
     end
   end
 
+  def self.create_validator_method_skip_return_fast(mod, original_method, method_sig, original_visibility)
+    # trampoline to reduce stack frame size
+    arg_types = method_sig.arg_types
+    case arg_types.length
+    when 0
+      create_validator_method_skip_return_fast0(mod, original_method, method_sig, original_visibility)
+    when 1
+      create_validator_method_skip_return_fast1(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1].raw_type)
+    when 2
+      create_validator_method_skip_return_fast2(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1].raw_type,
+                                    arg_types[1][1].raw_type)
+    when 3
+      create_validator_method_skip_return_fast3(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1].raw_type,
+                                    arg_types[1][1].raw_type,
+                                    arg_types[2][1].raw_type)
+    when 4
+      create_validator_method_skip_return_fast4(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1].raw_type,
+                                    arg_types[1][1].raw_type,
+                                    arg_types[2][1].raw_type,
+                                    arg_types[3][1].raw_type)
+    else
+      raise 'should not happen'
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast0(mod, original_method, method_sig, original_visibility)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |&blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast1(mod, original_method, method_sig, original_visibility, arg0_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0.is_a?(arg0_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, arg0, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast2(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0.is_a?(arg0_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1.is_a?(arg1_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, arg0, arg1, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast3(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type, arg2_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0.is_a?(arg0_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1.is_a?(arg1_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      unless arg2.is_a?(arg2_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, arg0, arg1, arg2, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_fast4(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type, arg2_type, arg3_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, arg3, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0.is_a?(arg0_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1.is_a?(arg1_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      unless arg2.is_a?(arg2_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+
+      unless arg3.is_a?(arg3_type)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[3][1].error_message_for_obj(arg3),
+          'Parameter',
+          method_sig.arg_types[3][0],
+          arg3_type,
+          arg3,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, arg0, arg1, arg2, arg3, &blk)
+    end
+  end
+
   def self.create_validator_procedure_fast(mod, original_method, method_sig, original_visibility)
     # trampoline to reduce stack frame size
     arg_types = method_sig.arg_types
@@ -941,6 +1200,265 @@ module T::Private::Methods::CallValidation
         end
       end
       return_value
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium(mod, original_method, method_sig, original_visibility)
+    # trampoline to reduce stack frame size
+    arg_types = method_sig.arg_types
+    case arg_types.length
+    when 0
+      create_validator_method_skip_return_medium0(mod, original_method, method_sig, original_visibility)
+    when 1
+      create_validator_method_skip_return_medium1(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1])
+    when 2
+      create_validator_method_skip_return_medium2(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1],
+                                    arg_types[1][1])
+    when 3
+      create_validator_method_skip_return_medium3(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1],
+                                    arg_types[1][1],
+                                    arg_types[2][1])
+    when 4
+      create_validator_method_skip_return_medium4(mod, original_method, method_sig, original_visibility,
+                                    arg_types[0][1],
+                                    arg_types[1][1],
+                                    arg_types[2][1],
+                                    arg_types[3][1])
+    else
+      raise 'should not happen'
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium0(mod, original_method, method_sig, original_visibility)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |&blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium1(mod, original_method, method_sig, original_visibility, arg0_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, arg0, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium2(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1_type.valid?(arg1)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, arg0, arg1, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium3(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type, arg2_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1_type.valid?(arg1)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      unless arg2_type.valid?(arg2)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, arg0, arg1, arg2, &blk)
+    end
+  end
+
+  def self.create_validator_method_skip_return_medium4(mod, original_method, method_sig, original_visibility, arg0_type, arg1_type, arg2_type, arg3_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, arg3, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+
+      unless arg1_type.valid?(arg1)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+
+      unless arg2_type.valid?(arg2)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+
+      unless arg3_type.valid?(arg3)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[3][1].error_message_for_obj(arg3),
+          'Parameter',
+          method_sig.arg_types[3][0],
+          arg3_type,
+          arg3,
+          caller_offset: -1
+        )
+      end
+
+      # The following line breaks are intentional to show nice pry message
+
+
+
+
+
+
+
+
+
+
+      # PRY note:
+      # this code is sig validation code.
+      # Please issue `finish` to step out of it
+
+      original_method.bind_call(self, arg0, arg1, arg2, arg3, &blk)
     end
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm trying to build a rubocop that prevents people from using
`.void.checked(:tests)`.

The suggestion is to use `.returns(T.anything).checked(:tests)` instead, but
that currently comes with a performance penalty, because there is a special case
in the runtime for methods that return `.void`.

In the process of speeding up `.returns(T.anything)` methods, I realized that we
can apply the same thing to all methods which Sorbet will skip runtime checking
for, including `T.untyped`, `T.attached_class`, `T.self_type`,
`T.type_parameter`, `BasicObject` and type members/templates.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Before:

    sig {params(x: Example).void}: 139.688 ns
    sig {params(x: Example).returns(T.anything)}: 188.611 ns

    sig {params(x: T.nilable(Example)).void}: 180.063 ns
    sig {params(x: T.nilable(Example)).returns(T.anything)}: 200.054 ns

After:

    sig {params(x: Example).void}: 139.103 ns
    sig {params(x: Example).returns(T.anything)}: 139.717 ns

    sig {params(x: T.nilable(Example)).void}: 178.575 ns
    sig {params(x: T.nilable(Example)).returns(T.anything)}: 179.478 ns

Full output after:

    ❯ bex rake bench:typecheck
    Vanilla Ruby method call: 19.518 ns
    Vanilla Ruby is_a?: 22.928 ns
    T.unsafe: 20.456 ns
    T.must on non-nil: 27.755 ns
    T::Types::Simple#valid?: 35.288 ns
    T.nilable(Integer).valid?: 50.812 ns
    T.any(Integer, Float, T::Boolean).valid?: 178.889 ns
    T.let(..., Integer): 181.623 ns
    sig {params(x: Integer).void}: 143.413 ns
    sig {params(x: Integer, blk: T.proc.void)} -- block literal: 583.669 ns
    sig {params(x: Integer, blk: T.proc.void)} -- block pass: 504.053 ns
    sig {params(x: Integer, blk: T.nilable(T.proc.void))} -- block literal: 207.812 ns
    sig {params(x: Integer, blk: T.nilable(T.proc.void))} -- block pass: 156.218 ns
    T.let(..., T.nilable(Integer)): 633.972 ns
    sig {params(x: T.nilable(Integer)).void}: 177.717 ns
    T.let(..., Example): 169.639 ns
    sig {params(x: Example).void}: 139.103 ns
    sig {params(x: Example).returns(T.anything)}: 139.717 ns
    T.let(..., T.nilable(Example)): 636.255 ns
    sig {params(x: T.nilable(Example)).void}: 178.575 ns
    sig {params(x: T.nilable(Example)).returns(T.anything)}: 179.478 ns
    sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs): 1.016 μs
    direct call Object#class: 20.054 ns
    .bind(example).call Object#class: 108.268 ns
    .bind_call(example) Object#class: 64.995 ns