### PR TITLE
Revert "highlightUntyped: Make VS Code extension use nowhere/everywhere"

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -261,9 +261,9 @@
           "default": false
         },
         "sorbet.highlightUntyped": {
-          "enum": ["nowhere", "everywhere"],
+          "type": "boolean",
           "description": "Shows warning for untyped values.",
-          "default": "nowhere"
+          "default": false
         },
         "sorbet.typedFalseCompletionNudges": {
           "type": "boolean",

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -1,35 +1,4 @@
-import { TrackUntyped } from "../config";
-import { Log } from "../log";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
-
-function toggle(log: Log, trackWhere: TrackUntyped): TrackUntyped {
-  switch (trackWhere) {
-    case "nowhere":
-      return "everywhere";
-    case "everywhere":
-      return "nowhere";
-    default:
-      const exhaustiveCheck: never = trackWhere;
-      log.warning(`Got unexpected state: ${exhaustiveCheck}`);
-      return "nowhere";
-  }
-}
-
-function backwardsCompatibleValue(
-  log: Log,
-  trackWhere: TrackUntyped,
-): boolean | TrackUntyped {
-  switch (trackWhere) {
-    case "nowhere":
-      return false;
-    case "everywhere":
-      return true;
-    default:
-      const exhaustiveCheck: never = trackWhere;
-      log.warning(`Got unexpected state: ${exhaustiveCheck}`);
-      return false;
-  }
-}
 
 /**
  * Toggle highlighting of untyped code.
@@ -38,19 +7,20 @@ function backwardsCompatibleValue(
  */
 export async function toggleUntypedCodeHighlighting(
   context: SorbetExtensionContext,
-): Promise<TrackUntyped> {
-  const targetState = toggle(
-    context.log,
-    context.configuration.highlightUntyped,
-  );
+): Promise<boolean> {
+  const targetState = !context.configuration.highlightUntyped;
   await context.configuration.setHighlightUntyped(targetState);
-  context.log.info(`ToggleUntyped: Untyped code highlighting: ${targetState}`);
+  context.log.info(
+    `ToggleUntyped: Untyped code highlighting: ${
+      targetState ? "enabled" : "disabled"
+    }`,
+  );
 
   const { activeLanguageClient: client } = context.statusProvider;
   if (client) {
     client.sendNotification("workspace/didChangeConfiguration", {
       settings: {
-        highlightUntyped: backwardsCompatibleValue(context.log, targetState),
+        highlightUntyped: targetState,
       },
     });
   } else {

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -12,22 +12,6 @@ import * as fs from "fs";
 import { SorbetLspConfig, SorbetLspConfigData } from "./sorbetLspConfig";
 import { deepEqual } from "./utils";
 
-export type TrackUntyped = "nowhere" | "everywhere";
-
-function coerceTrackUntypedSetting(value: boolean | string): TrackUntyped {
-  switch (value) {
-    case true:
-      return "everywhere";
-    case false:
-      return "nowhere";
-    case "nowhere":
-    case "everywhere":
-      return value;
-    default:
-      return "nowhere";
-  }
-}
-
 export interface SorbetLspConfigChangeEvent {
   readonly oldLspConfig?: SorbetLspConfig;
   readonly newLspConfig?: SorbetLspConfig;
@@ -175,7 +159,7 @@ export class SorbetExtensionConfig implements Disposable {
   /** "Custom" LSP configs that override/supplement "standard" LSP configs. */
   private userLspConfigs: ReadonlyArray<SorbetLspConfig>;
   private wrappedEnabled: boolean;
-  private wrappedHighlightUntyped: TrackUntyped;
+  private wrappedHighlightUntyped: boolean;
   private wrappedTypedFalseCompletionNudges: boolean;
   private wrappedRevealOutputOnError: boolean;
 
@@ -188,7 +172,7 @@ export class SorbetExtensionConfig implements Disposable {
     this.sorbetWorkspaceContext = sorbetWorkspaceContext;
     this.standardLspConfigs = [];
     this.userLspConfigs = [];
-    this.wrappedHighlightUntyped = "nowhere";
+    this.wrappedHighlightUntyped = false;
     this.wrappedTypedFalseCompletionNudges = true;
     this.wrappedRevealOutputOnError = false;
 
@@ -241,11 +225,10 @@ export class SorbetExtensionConfig implements Disposable {
       "revealOutputOnError",
       this.revealOutputOnError,
     );
-    const highlightUntyped = this.sorbetWorkspaceContext.get(
+    this.wrappedHighlightUntyped = this.sorbetWorkspaceContext.get(
       "highlightUntyped",
       this.highlightUntyped,
     );
-    this.wrappedHighlightUntyped = coerceTrackUntypedSetting(highlightUntyped);
     this.wrappedTypedFalseCompletionNudges = this.sorbetWorkspaceContext.get(
       "typedFalseCompletionNudges",
       this.typedFalseCompletionNudges,
@@ -317,7 +300,7 @@ export class SorbetExtensionConfig implements Disposable {
     return this.wrappedEnabled;
   }
 
-  public get highlightUntyped(): TrackUntyped {
+  public get highlightUntyped(): boolean {
     return this.wrappedHighlightUntyped;
   }
 
@@ -382,8 +365,8 @@ export class SorbetExtensionConfig implements Disposable {
     this.refresh();
   }
 
-  public async setHighlightUntyped(trackWhere: TrackUntyped): Promise<void> {
-    await this.sorbetWorkspaceContext.update("highlightUntyped", trackWhere);
+  public async setHighlightUntyped(enabled: boolean): Promise<void> {
+    await this.sorbetWorkspaceContext.update("highlightUntyped", enabled);
     this.refresh();
   }
 

--- a/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
+++ b/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
@@ -4,7 +4,7 @@ import * as sinon from "sinon";
 
 import { createLogStub } from "../testUtils";
 import { toggleUntypedCodeHighlighting } from "../../commands/toggleUntypedCodeHighlighting";
-import { SorbetExtensionConfig, TrackUntyped } from "../../config";
+import { SorbetExtensionConfig } from "../../config";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
 import { SorbetStatusProvider } from "../../sorbetStatusProvider";
 import { RestartReason } from "../../types";
@@ -21,12 +21,12 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
   });
 
   test("toggleUntypedCodeHighlighting", async () => {
-    const initialState = "everywhere";
+    const initialState = true;
     let currentState = initialState;
 
     const log = createLogStub();
 
-    const setHighlightUntypedSpy = sinon.spy((value: TrackUntyped) => {
+    const setHighlightUntypedSpy = sinon.spy((value: boolean) => {
       currentState = value;
     });
     const configuration = <SorbetExtensionConfig>(<unknown>{
@@ -47,9 +47,12 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       statusProvider,
     };
 
-    assert.strictEqual(await toggleUntypedCodeHighlighting(context), "nowhere");
+    assert.strictEqual(
+      await toggleUntypedCodeHighlighting(context),
+      !initialState,
+    );
 
     sinon.assert.calledOnce(setHighlightUntypedSpy);
-    sinon.assert.calledWithExactly(setHighlightUntypedSpy, "nowhere");
+    sinon.assert.calledWithExactly(setHighlightUntypedSpy, !initialState);
   });
 });

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -376,30 +376,6 @@ suite("SorbetExtensionConfig", async () => {
         );
       });
 
-      suite("sorbet.highlightUntyped", async () => {
-        test("true instead of a string", async () => {
-          const workspaceConfig = new FakeWorkspaceConfiguration([
-            ["highlightUntyped", true],
-          ]);
-          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
-          assert.strictEqual(sorbetConfig.highlightUntyped, "everywhere");
-        });
-        test("false instead of a string", async () => {
-          const workspaceConfig = new FakeWorkspaceConfiguration([
-            ["highlightUntyped", false],
-          ]);
-          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
-          assert.strictEqual(sorbetConfig.highlightUntyped, "nowhere");
-        });
-        test("unrecognized string", async () => {
-          const workspaceConfig = new FakeWorkspaceConfiguration([
-            ["highlightUntyped", "nope"],
-          ]);
-          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
-          assert.strictEqual(sorbetConfig.highlightUntyped, "nowhere");
-        });
-      });
-
       test("multiple instances of SorbetExtensionConfig stay in sync with each other", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration([
           ["enabled", true],


### PR DESCRIPTION
Reverts sorbet/sorbet#7571