### PR TITLE
Reapply "highlightUntyped: Make VS Code extension use nowhere/everywhere" (#7579)

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.28",
+  "version": "0.3.27",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {
@@ -261,9 +261,9 @@
           "default": false
         },
         "sorbet.highlightUntyped": {
-          "type": "boolean",
+          "enum": ["nowhere", "everywhere"],
           "description": "Shows warning for untyped values.",
-          "default": false
+          "default": "nowhere"
         },
         "sorbet.typedFalseCompletionNudges": {
           "type": "boolean",

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.27",
+  "version": "0.3.29",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -1,4 +1,4 @@
-import { TrackUntyped } from "../config";
+import { TrackUntyped, backwardsCompatibleTrackUntyped } from "../config";
 import { Log } from "../log";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
 
@@ -12,22 +12,6 @@ function toggle(log: Log, trackWhere: TrackUntyped): TrackUntyped {
       const exhaustiveCheck: never = trackWhere;
       log.warning(`Got unexpected state: ${exhaustiveCheck}`);
       return "nowhere";
-  }
-}
-
-function backwardsCompatibleValue(
-  log: Log,
-  trackWhere: TrackUntyped,
-): boolean | TrackUntyped {
-  switch (trackWhere) {
-    case "nowhere":
-      return false;
-    case "everywhere":
-      return true;
-    default:
-      const exhaustiveCheck: never = trackWhere;
-      log.warning(`Got unexpected state: ${exhaustiveCheck}`);
-      return false;
   }
 }
 
@@ -50,7 +34,10 @@ export async function toggleUntypedCodeHighlighting(
   if (client) {
     client.sendNotification("workspace/didChangeConfiguration", {
       settings: {
-        highlightUntyped: backwardsCompatibleValue(context.log, targetState),
+        highlightUntyped: backwardsCompatibleTrackUntyped(
+          context.log,
+          targetState,
+        ),
       },
     });
   } else {

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -15,6 +15,7 @@ import { stopProcess } from "./connections";
 import { Tags } from "./metricsClient";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { ServerStatus, RestartReason } from "./types";
+import { backwardsCompatibleTrackUntyped } from "./config";
 
 const VALID_STATE_TRANSITIONS: ReadonlyMap<
   ServerStatus,
@@ -58,7 +59,10 @@ function createClient(
       supportsOperationNotifications: true,
       // Let Sorbet know that we can handle sorbet:// URIs for generated files.
       supportsSorbetURIs: true,
-      highlightUntyped: context.configuration.highlightUntyped,
+      highlightUntyped: backwardsCompatibleTrackUntyped(
+        context.log,
+        context.configuration.highlightUntyped,
+      ),
       enableTypedFalseCompletionNudges:
         context.configuration.typedFalseCompletionNudges,
     },

--- a/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
+++ b/vscode_extension/src/test/commands/toggleUntypedCodeHighlighting.test.ts
@@ -4,7 +4,7 @@ import * as sinon from "sinon";
 
 import { createLogStub } from "../testUtils";
 import { toggleUntypedCodeHighlighting } from "../../commands/toggleUntypedCodeHighlighting";
-import { SorbetExtensionConfig } from "../../config";
+import { SorbetExtensionConfig, TrackUntyped } from "../../config";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
 import { SorbetStatusProvider } from "../../sorbetStatusProvider";
 import { RestartReason } from "../../types";
@@ -21,12 +21,12 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
   });
 
   test("toggleUntypedCodeHighlighting", async () => {
-    const initialState = true;
+    const initialState = "everywhere";
     let currentState = initialState;
 
     const log = createLogStub();
 
-    const setHighlightUntypedSpy = sinon.spy((value: boolean) => {
+    const setHighlightUntypedSpy = sinon.spy((value: TrackUntyped) => {
       currentState = value;
     });
     const configuration = <SorbetExtensionConfig>(<unknown>{
@@ -47,12 +47,9 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       statusProvider,
     };
 
-    assert.strictEqual(
-      await toggleUntypedCodeHighlighting(context),
-      !initialState,
-    );
+    assert.strictEqual(await toggleUntypedCodeHighlighting(context), "nowhere");
 
     sinon.assert.calledOnce(setHighlightUntypedSpy);
-    sinon.assert.calledWithExactly(setHighlightUntypedSpy, !initialState);
+    sinon.assert.calledWithExactly(setHighlightUntypedSpy, "nowhere");
   });
 });

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -376,6 +376,30 @@ suite("SorbetExtensionConfig", async () => {
         );
       });
 
+      suite("sorbet.highlightUntyped", async () => {
+        test("true instead of a string", async () => {
+          const workspaceConfig = new FakeWorkspaceConfiguration([
+            ["highlightUntyped", true],
+          ]);
+          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
+          assert.strictEqual(sorbetConfig.highlightUntyped, "everywhere");
+        });
+        test("false instead of a string", async () => {
+          const workspaceConfig = new FakeWorkspaceConfiguration([
+            ["highlightUntyped", false],
+          ]);
+          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
+          assert.strictEqual(sorbetConfig.highlightUntyped, "nowhere");
+        });
+        test("unrecognized string", async () => {
+          const workspaceConfig = new FakeWorkspaceConfiguration([
+            ["highlightUntyped", "nope"],
+          ]);
+          const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
+          assert.strictEqual(sorbetConfig.highlightUntyped, "nowhere");
+        });
+      });
+
       test("multiple instances of SorbetExtensionConfig stay in sync with each other", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration([
           ["enabled", true],

--- a/website/docs/vscode.md
+++ b/website/docs/vscode.md
@@ -142,31 +142,40 @@ your preferred LSP client using the [`sorbet/showSymbol` LSP request].)
 [`sorbet/showsymbol` lsp request]:
   https://github.com/sorbet/sorbet/blob/ec02be89e3d1895ea51bc72464538073d27b812c/vscode_extension/src/LanguageClient.ts#L154-L179
 
-Highlight `T.untyped` code. This feature is in beta.
+Highlight `T.untyped` code.
 
 This feature reports diagnostics to the editor for occurrences of `T.untyped`
 code. Note that it is not yet perfect and may miss occurrences of such values.
 
 It can be enabled by adding the following to your VS Code `settings.json` and
-either reopening VS Code or restarting Sorbet.
+either reopening VS Code or restarting Sorbet:
 
 ```json
-"sorbet.highlightUntyped": true
+"sorbet.highlightUntyped": "everywhere"
 ```
 
-or by using the `Sorbet: Toggle Highlight untyped values` command from the
-command palette (note this causes a full restart of Sorbet).
+> **Note**: In versions of the Sorbet VS Code extension before v0.3.29, this
+> option was a simple `true`/`false` setting. If you had specified it as a
+> boolean in your config, you will want to convert `true` to `"everywhere"` or
+> `false` to `"nowhere"`, though the legacy boolean option remains supported.
+> The default (`false` / `"nowhere"`) remains the same.
+
+You can also using the `Sorbet: Toggle Highlight untyped values` command from
+the command palette (note this causes a full restart of Sorbet).
 
 To enable this feature in other language clients, configure your language client
-to send
+to send this when sending the LSP initialize request to the Sorbet language
+server:
 
 ```json
 "initializationOptions": {
-  "highlightUntyped": true
+  "highlightUntyped": "everywhere"
 }
 ```
 
-when sending the LSP initialize request to the Sorbet language server.
+> **Note**: In versions of the Sorbet language server before `v0.5.11175`, this
+> option was a simple `true`/`false` setting. The legacy boolean option remains
+> supported.
 
 <img src="/img/lsp/highlight_untyped.png" />
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Commit summary

- **Reapply "highlightUntyped: Make VS Code extension use nowhere/everywhere" (#7579)** (1bc2a45b5)

  This reverts commit df85067a910ffbac32afd4447f63e3946ff8dc07.

- **Bump VS Code extension version** (0b57bf3f1)

  Bump by two, because we need to undo the downgrade from the revert commit.

- **Also apply backcompat to initialization** (7dcd9036c)

  Fix the bug causing the previous change to be reverted.
  Previously, the backcompat logic only applied to the toggle message, not the
  server initialization message.

- **Update website for highlightUntyped** (d7424ddf5)

  Users looked at the website when trying to debug this, and were greeted with
  out-of-date documentation that only made debugging worse.





### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This reverts commit df85067a910ffbac32afd4447f63e3946ff8dc07.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

For the previous version, I had only tested locally with a newer version of
Sorbet, which supported the new string options.

This time, I was sure to check out a version of Sorbet that did not have that
change, and both reproduced the crash that users were seeing and verified that
this change fixes the crash.