### PR TITLE
don't cargo-cult `:setter_proc` for prop value validation

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -103,7 +103,7 @@ class T::Props::Decorator
     # We call `setter_proc` here without binding to an instance, so it'll run
     # `instance_variable_set` if validation passes, but nothing will care.
     # We only care about the validation.
-    prop_rules(prop).fetch(:setter_proc).call(val)
+    prop_rules(prop).fetch(:value_validate_proc).call(val)
   end
 
   # For performance, don't use named params here.
@@ -378,7 +378,11 @@ class T::Props::Decorator
       end
     end
 
-    rules[:setter_proc] = T::Props::Private::SetterFactory.build_setter_proc(@class, name, rules).freeze
+    setter_proc, value_validate_proc = T::Props::Private::SetterFactory.build_setter_proc(@class, name, rules)
+    setter_proc.freeze
+    value_validate_proc.freeze
+    rules[:setter_proc] = setter_proc
+    rules[:value_validate_proc] = value_validate_proc
 
     add_prop_definition(name, rules)
 

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -100,9 +100,6 @@ class T::Props::Decorator
   # checked(:never) - potentially O(prop accesses) depending on usage pattern
   sig {params(prop: Symbol, val: T.untyped).void.checked(:never)}
   def validate_prop_value(prop, val)
-    # We call `setter_proc` here without binding to an instance, so it'll run
-    # `instance_variable_set` if validation passes, but nothing will care.
-    # We only care about the validation.
     prop_rules(prop).fetch(:value_validate_proc).call(val)
   end
 

--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -80,7 +80,7 @@ module T::Props
                 val,
               )
             end
-          end
+          end,
         ]
       end
 
@@ -130,7 +130,7 @@ module T::Props
                 val,
               )
             end
-          end
+          end,
         ]
       end
 
@@ -165,7 +165,7 @@ module T::Props
                 val,
               )
             end
-          end
+          end,
         ]
       end
 
@@ -219,7 +219,7 @@ module T::Props
                 val,
               )
             end
-          end
+          end,
         ]
       end
 

--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -59,27 +59,29 @@ module T::Props
         .returns([SetterProc, ValueValidationProc])
       end
       private_class_method def self.simple_non_nil_proc(prop, accessor_key, non_nil_type, klass)
-        return proc do |val|
-          unless val.is_a?(non_nil_type)
-            T::Props::Private::SetterFactory.raise_pretty_error(
-              klass,
-              prop,
-              T::Utils.coerce(non_nil_type),
-              val,
-            )
+        [
+          proc do |val|
+            unless val.is_a?(non_nil_type)
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                T::Utils.coerce(non_nil_type),
+                val,
+              )
+            end
+            instance_variable_set(accessor_key, val)
+          end,
+          proc do |val|
+            unless val.is_a?(non_nil_type)
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                T::Utils.coerce(non_nil_type),
+                val,
+              )
+            end
           end
-          instance_variable_set(accessor_key, val)
-        end,
-        proc do |val|
-          unless val.is_a?(non_nil_type)
-            T::Props::Private::SetterFactory.raise_pretty_error(
-              klass,
-              prop,
-              T::Utils.coerce(non_nil_type),
-              val,
-            )
-          end
-        end
+        ]
       end
 
       sig do
@@ -93,41 +95,43 @@ module T::Props
         .returns([SetterProc, ValueValidationProc])
       end
       private_class_method def self.non_nil_proc(prop, accessor_key, non_nil_type, klass, validate)
-        return proc do |val|
-          # this use of recursively_valid? is intentional: unlike for
-          # methods, we want to make sure data at the 'edge'
-          # (e.g. models that go into databases or structs serialized
-          # from disk) are correct, so we use more thorough runtime
-          # checks there
-          if non_nil_type.recursively_valid?(val)
-            validate&.call(prop, val)
-          else
-            T::Props::Private::SetterFactory.raise_pretty_error(
-              klass,
-              prop,
-              non_nil_type,
-              val,
-            )
+        [
+          proc do |val|
+            # this use of recursively_valid? is intentional: unlike for
+            # methods, we want to make sure data at the 'edge'
+            # (e.g. models that go into databases or structs serialized
+            # from disk) are correct, so we use more thorough runtime
+            # checks there
+            if non_nil_type.recursively_valid?(val)
+              validate&.call(prop, val)
+            else
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                non_nil_type,
+                val,
+              )
+            end
+            instance_variable_set(accessor_key, val)
+          end,
+          proc do |val|
+            # this use of recursively_valid? is intentional: unlike for
+            # methods, we want to make sure data at the 'edge'
+            # (e.g. models that go into databases or structs serialized
+            # from disk) are correct, so we use more thorough runtime
+            # checks there
+            if non_nil_type.recursively_valid?(val)
+              validate&.call(prop, val)
+            else
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                non_nil_type,
+                val,
+              )
+            end
           end
-          instance_variable_set(accessor_key, val)
-        end,
-        proc do |val|
-          # this use of recursively_valid? is intentional: unlike for
-          # methods, we want to make sure data at the 'edge'
-          # (e.g. models that go into databases or structs serialized
-          # from disk) are correct, so we use more thorough runtime
-          # checks there
-          if non_nil_type.recursively_valid?(val)
-            validate&.call(prop, val)
-          else
-            T::Props::Private::SetterFactory.raise_pretty_error(
-              klass,
-              prop,
-              non_nil_type,
-              val,
-            )
-          end
-        end
+        ]
       end
 
       sig do
@@ -140,27 +144,29 @@ module T::Props
         .returns([SetterProc, ValueValidationProc])
       end
       private_class_method def self.simple_nilable_proc(prop, accessor_key, non_nil_type, klass)
-        return proc do |val|
-          unless val.nil? || val.is_a?(non_nil_type)
-            T::Props::Private::SetterFactory.raise_pretty_error(
-              klass,
-              prop,
-              T::Utils.coerce(non_nil_type),
-              val,
-            )
+        [
+          proc do |val|
+            unless val.nil? || val.is_a?(non_nil_type)
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                T::Utils.coerce(non_nil_type),
+                val,
+              )
+            end
+            instance_variable_set(accessor_key, val)
+          end,
+          proc do |val|
+            unless val.nil? || val.is_a?(non_nil_type)
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                T::Utils.coerce(non_nil_type),
+                val,
+              )
+            end
           end
-          instance_variable_set(accessor_key, val)
-        end,
-        proc do |val|
-          unless val.nil? || val.is_a?(non_nil_type)
-            T::Props::Private::SetterFactory.raise_pretty_error(
-              klass,
-              prop,
-              T::Utils.coerce(non_nil_type),
-              val,
-            )
-          end
-        end
+        ]
       end
 
       sig do
@@ -174,45 +180,47 @@ module T::Props
         .returns([SetterProc, ValueValidationProc])
       end
       private_class_method def self.nilable_proc(prop, accessor_key, non_nil_type, klass, validate)
-        return proc do |val|
-          if val.nil?
-            instance_variable_set(accessor_key, nil)
-          # this use of recursively_valid? is intentional: unlike for
-          # methods, we want to make sure data at the 'edge'
-          # (e.g. models that go into databases or structs serialized
-          # from disk) are correct, so we use more thorough runtime
-          # checks there
-          elsif non_nil_type.recursively_valid?(val)
-            validate&.call(prop, val)
-            instance_variable_set(accessor_key, val)
-          else
-            T::Props::Private::SetterFactory.raise_pretty_error(
-              klass,
-              prop,
-              non_nil_type,
-              val,
-            )
-            instance_variable_set(accessor_key, val)
+        [
+          proc do |val|
+            if val.nil?
+              instance_variable_set(accessor_key, nil)
+            # this use of recursively_valid? is intentional: unlike for
+            # methods, we want to make sure data at the 'edge'
+            # (e.g. models that go into databases or structs serialized
+            # from disk) are correct, so we use more thorough runtime
+            # checks there
+            elsif non_nil_type.recursively_valid?(val)
+              validate&.call(prop, val)
+              instance_variable_set(accessor_key, val)
+            else
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                non_nil_type,
+                val,
+              )
+              instance_variable_set(accessor_key, val)
+            end
+          end,
+          proc do |val|
+            if val.nil?
+            # this use of recursively_valid? is intentional: unlike for
+            # methods, we want to make sure data at the 'edge'
+            # (e.g. models that go into databases or structs serialized
+            # from disk) are correct, so we use more thorough runtime
+            # checks there
+            elsif non_nil_type.recursively_valid?(val)
+              validate&.call(prop, val)
+            else
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                non_nil_type,
+                val,
+              )
+            end
           end
-        end,
-        proc do |val|
-          if val.nil?
-          # this use of recursively_valid? is intentional: unlike for
-          # methods, we want to make sure data at the 'edge'
-          # (e.g. models that go into databases or structs serialized
-          # from disk) are correct, so we use more thorough runtime
-          # checks there
-          elsif non_nil_type.recursively_valid?(val)
-            validate&.call(prop, val)
-          else
-            T::Props::Private::SetterFactory.raise_pretty_error(
-              klass,
-              prop,
-              non_nil_type,
-              val,
-            )
-          end
-        end
+        ]
       end
 
       sig do

--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -113,19 +113,15 @@ module T::Props
       end
       private_class_method def self.simple_nilable_proc(prop, accessor_key, non_nil_type, klass)
         proc do |val|
-          if val.nil?
-            instance_variable_set(accessor_key, nil)
-          elsif val.is_a?(non_nil_type)
-            instance_variable_set(accessor_key, val)
-          else
+          unless val.nil? || val.is_a?(non_nil_type)
             T::Props::Private::SetterFactory.raise_pretty_error(
               klass,
               prop,
               T::Utils.coerce(non_nil_type),
               val,
             )
-            instance_variable_set(accessor_key, val)
           end
+          instance_variable_set(accessor_key, val)
         end
       end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The code for `validate_prop_value` contains this pearl:

```
    # We call `setter_proc` here without binding to an instance, so it'll run
    # `instance_variable_set` if validation passes, but nothing will care.
```

Something very much does care, namely, the instance variables of `SetterFactory`:

```
[dev] main:0> class A < T::Struct
[dev] main:0>   prop :example, String
[dev] main:0> end
=> T::Private::Types::Void::VOID
[dev] main:0> T::Props::Private::SetterFactory.instance_variables
=> []
[dev] main:0> A.validate_prop_value(:example, "a")
=> "a"
[dev] main:0> T::Props::Private::SetterFactory.instance_variables
=> [:@example]
```

It seems bad to have `SetterFactory` slowly accumulate instance variables for every prop that gets validated, never mind the GC implications.

I don't love the duplication here, but I don't want to slow down the setter path by introducing an extra block invocation.  I should try benchmarking the non-duplication change, though.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
