### PR TITLE
Remove useless `TypedHash#build_type` override

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -26,12 +26,6 @@ module T::Types
       @type ||= T::Utils.coerce([keys, values])
     end
 
-    def build_type
-      keys
-      values
-      super
-    end
-
     # overrides Base
     def name
       "T::Hash[#{keys.name}, #{values.name}]"


### PR DESCRIPTION
As pointed in https://github.com/sorbet/sorbet/pull/7534#discussion_r1442192689, the super method from `TypedEnumerable` is already calling `type` which will then build the `keys` and `values`.
