### PR TITLE
Fix uncaught metrics API errors

### DIFF
--- a/vscode_extension/src/metricsClient.ts
+++ b/vscode_extension/src/metricsClient.ts
@@ -98,6 +98,7 @@ export class MetricClient {
         sorbetMetricsApi = api as Api;
         if (!sorbetMetricsApi.metricsEmitter.timing) {
           this.context.log.info("Timer metrics disabled (unsupported API).");
+          sorbetMetricsApi = NoOpApi.INSTANCE;
         }
       } else {
         this.context.log.info("Metrics-gathering disabled (no API)");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was showing up in development. I don't know why the
`sorbet.metrics.getExportedApi` command is defined but returning
something with an interface that doesn't match what's expected. This
doesn't appear to happen in Stripe's codebase so we're probably setting
things up correctly there.

It looks like the intention was to gracefully fail for this anyways, so
let's gracefully fail.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I verified that this made one of the two uncaught errors that happen on shutdown
go away when running the extension locally.