### PR TITLE
Add a `Numeric` signature for Integer/Float arithmetic methods

### DIFF
--- a/rbi/core/float.rbi
+++ b/rbi/core/float.rbi
@@ -117,6 +117,12 @@ class Float < Numeric
     )
     .returns(BigDecimal)
   end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
+  end
   def %(arg0); end
 
   # Returns a new [`Float`](https://docs.ruby-lang.org/en/2.7.0/Float.html)
@@ -157,6 +163,12 @@ class Float < Numeric
     )
     .returns(Float)
   end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
+  end
   def *(arg0); end
 
   # Raises `float` to the power of `other`.
@@ -193,6 +205,12 @@ class Float < Numeric
         arg0: Complex,
     )
     .returns(Complex)
+  end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
   end
   def **(arg0); end
 
@@ -233,6 +251,12 @@ class Float < Numeric
         arg0: T.any(Integer, Float),
     )
     .returns(Float)
+  end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
   end
   def +(arg0); end
 
@@ -277,6 +301,12 @@ class Float < Numeric
     )
     .returns(Float)
   end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
+  end
   def -(arg0); end
 
   # Returns `float`, negated.
@@ -320,6 +350,12 @@ class Float < Numeric
         arg0: T.any(Integer, Float),
     )
     .returns(Float)
+  end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
   end
   def /(arg0); end
 

--- a/rbi/core/integer.rbi
+++ b/rbi/core/integer.rbi
@@ -41,6 +41,12 @@ class Integer < Numeric
     )
     .returns(T.any(Integer, Float))
   end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
+  end
   def %(arg0); end
 
   # Bitwise AND.
@@ -89,6 +95,12 @@ class Integer < Numeric
         arg0: T.any(Integer, Float),
     )
     .returns(T.any(Integer, Float))
+  end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
   end
   def *(arg0); end
 
@@ -139,6 +151,12 @@ class Integer < Numeric
     )
     .returns(Complex)
   end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
+  end
   def **(arg0); end
 
   # Performs addition: the class of the resulting object depends on the class of
@@ -178,6 +196,12 @@ class Integer < Numeric
         arg0: T.any(Integer, Float),
     )
     .returns(T.any(Integer, Float))
+  end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
   end
   def +(arg0); end
 
@@ -222,6 +246,12 @@ class Integer < Numeric
     )
     .returns(T.any(Integer, Float))
   end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
+  end
   def -(arg0); end
 
   # Returns `int`, negated.
@@ -265,6 +295,12 @@ class Integer < Numeric
         arg0: T.any(Integer, Float),
     )
     .returns(T.any(Integer, Float))
+  end
+  sig do
+    params(
+        arg0: Numeric,
+    )
+    .returns(Numeric)
   end
   def /(arg0); end
 


### PR DESCRIPTION
### Motivation
This is part of [[sorbet/issues/7582] Potential improvements to make `Integer#+` overload resolution better](https://github.com/sorbet/sorbet/issues/7582)

Basically, we want for this to be fine:

```ruby
sig {params(x: Numeric).returns(Numeric)}
def foo(x)
  1 + x
end

```

### Test plan
Existing tests