### PR TITLE
Update `with_index` signature to remove `T.untyped`

### DIFF
--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -398,11 +398,11 @@ class Enumerator < Object
   # `offset`
   # :   the starting index to use
   sig do
-    params(
+    type_parameters(:U).params(
       offset: Integer,
-      blk: T.proc.params(arg0: Elem, arg1: Integer).returns(BasicObject)
+      blk: T.proc.params(arg0: Elem, arg1: Integer).returns(T.type_parameter(:U))
     )
-      .returns(T.untyped)
+                       .returns(T::Enumerator[T.type_parameter(:U)])
   end
   sig do
     params(
@@ -813,7 +813,7 @@ class Enumerator::Lazy < Enumerator
   def grep_v(_); end
 
   # Returns self.
-  sig {returns(T.self_type)}
+  sig { returns(T.self_type) }
   def lazy; end
 
   # Like
@@ -1033,7 +1033,7 @@ class Enumerator::Chain < Enumerator
 
   sig do
     type_parameters(:U).params(
-      arg0: T::Enumerable[T.type_parameter(:U)],
+      arg0: T::Enumerable[T.type_parameter(:U)]
     ).returns(
       T::Enumerator::Chain[T.type_parameter(:U)]
     )


### PR DESCRIPTION
Update `with_index` signature to remove `T.untyped`.
- Misc. formatting changes (including the odd long spaces before `.returns`)

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Found `with_index` usages in our codebase that lead to `T.untyped` highlighting.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
