### PR TITLE
Kernel#method accepts Symbol or String

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -552,7 +552,7 @@ module Kernel
 
   sig do
     params(
-        arg0: Symbol,
+        arg0: T.any(Symbol, String)
     )
     .returns(Method)
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://rubyapi.org/3.3/o/object#method-i-method

```rb
>> 42.method(:abs)
=> #<Method: Integer#abs()>
>> 42.method("abs")
=> #<Method: Integer#abs()>
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Kernel%0Aextend%20T%3A%3ASig%0A%0A%20%20sig%20do%0A%20%20%20%20params%28%0A%20%20%20%20%20%20arg0%3A%20T.any%28Symbol%2C%20String%29%0A%20%20%20%20%29%0A%20%20%20%20.returns%28Method%29%0A%20%20end%0A%20%20def%20method%28arg0%29%3B%20Method.new%20end%0Aend%0A%0A42.method%28%3Aabs%29%0A42.method%28%22abs%22%29
