### PR TITLE
Allow `everywhere-but-tests` in settings.json

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -268,7 +268,7 @@
           "default": false
         },
         "sorbet.highlightUntyped": {
-          "enum": ["nowhere", "everywhere"],
+          "enum": ["nowhere", "everywhere-but-tests", "everywhere"],
           "description": "Shows warning for untyped values.",
           "default": "nowhere"
         },


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This doesn't actually enable any new functionality, it just lets VS Code
show the option in the dropdown picker in the settings UI view, and
doesn't show a yellow warning squiggle in the settings textual view.

The actual logic landed in 1adc5d649.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a