### PR TITLE
Make GC patch for CME debugging null-safe

### DIFF
--- a/third_party/ruby/gc-more-t-none-context.patch
+++ b/third_party/ruby/gc-more-t-none-context.patch
@@ -1,8 +1,8 @@
 diff --git gc.c gc.c
-index 346a77ec63..172373e40d 100644
+index 346a77ec63..6e025cb200 100644
 --- gc.c
 +++ gc.c
-@@ -2935,7 +2935,27 @@ cc_table_mark_i(ID id, VALUE ccs_ptr, void *data_ptr)
+@@ -2935,7 +2935,33 @@ cc_table_mark_i(ID id, VALUE ccs_ptr, void *data_ptr)
          return ID_TABLE_DELETE;
      }
      else {
@@ -12,18 +12,24 @@ index 346a77ec63..172373e40d 100644
 +        if (getenv("STRIPE_DEBUG_T_NONE") && UNLIKELY(RB_TYPE_P(cme_obj, T_NONE))) {
 +            VALUE class_path = rb_class_path_cached(data->klass);
 +            if (!NIL_P(class_path)) {
-+                fprintf(
-+                    stdout,
-+                    "ERROR (cc_table_mark_i): will fail shortly with try to mark T_NONE object -- obj:%s, P:%s\n",
-+                    rb_id2name(id),
-+                    RSTRING_PTR(class_path)
-+                );
++                char *objname = rb_id2name(id);
++                if (objname) {
++                    fprintf(
++                        stdout,
++                        "ERROR (cc_table_mark_i): will fail shortly with try to mark T_NONE object -- obj:%s, P:%s\n",
++                        objname,
++                        RSTRING_PTR(class_path)
++                    );
++                }
 +            } else {
-+                fprintf(
-+                    stdout,
-+                    "ERROR (cc_table_mark_i): will fail shortly fail with try to mark T_NONE object -- obj:%s\n",
-+                    rb_id2name(id)
-+                );
++                char *objname = rb_id2name(id);
++                if (objname) {
++                    fprintf(
++                        stdout,
++                        "ERROR (cc_table_mark_i): will fail shortly with try to mark T_NONE object -- obj:%s\n",
++                        objname
++                    );
++                }
 +            }
 +        }
 +


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In https://github.com/sorbet/sorbet/pull/7592, I shipped a patch to Ruby to add more context to `T_NONE` errors encountered in GC. However, there is a small null safety concern with this patch, re the call to `rb_id2name`. It might not actually be a problem, but just fixing it anyway for posterity.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on Stripe codebase.
