### PR TITLE
Correctly log the extension version

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/src/metricsClient.ts
+++ b/vscode_extension/src/metricsClient.ts
@@ -69,9 +69,12 @@ export class MetricClient {
   constructor(context: SorbetExtensionContext, api?: Api) {
     this.apiPromise = api ? Promise.resolve(api) : this.initSorbetMetricsApi();
     this.context = context;
-    const sorbetExtension = extensions.getExtension("sorbet-vscode-extension");
+    const sorbetExtension = extensions.getExtension(
+      "sorbet.sorbet-vscode-extension",
+    );
     this.sorbetExtensionVersion =
       sorbetExtension?.packageJSON.version ?? "unknown";
+    this.emitCountMetric("metrics_client_initialized", 1);
   }
 
   /**

--- a/vscode_extension/src/test/metricsClient.test.ts
+++ b/vscode_extension/src/test/metricsClient.test.ts
@@ -38,17 +38,15 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       new NoOpApi(),
     );
 
-    incrementStub.resetHistory();
-
     await client.emitCountMetric(
       expectedMetricName,
       expectedCount,
       expectedTags,
     );
 
-    sinon.assert.calledOnce(incrementStub);
+    sinon.assert.calledTwice(incrementStub);
     sinon.assert.calledWithMatch(
-      incrementStub,
+      incrementStub.secondCall,
       `${METRIC_PREFIX}${expectedMetricName}`,
       expectedCount,
       expectedTags,

--- a/vscode_extension/src/test/metricsClient.test.ts
+++ b/vscode_extension/src/test/metricsClient.test.ts
@@ -38,6 +38,8 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       new NoOpApi(),
     );
 
+    incrementStub.resetHistory();
+
     await client.emitCountMetric(
       expectedMetricName,
       expectedCount,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The extension identifier was wrong, so it was always reporting
`"unknown"` for the version.

Also, I'd like an explicit count metric for this, instead of having to
pick an unrelated LSP task that happens to report timing information
tagged with the version.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested that the extension identifier change is correct by looking in the
debugger. I did not test that the new metric was reported.