### PR TITLE
Stop showing definition results for literals

### DIFF
--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -91,7 +91,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
             }
             std::transform(locMapping.begin(), locMapping.end(), std::back_inserter(locations),
                            [](auto &p) { return std::move(p.second); });
-        } else if (resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
+        } else if (resp->isField() || (fileIsTyped && resp->isIdent())) {
             const auto &retType = resp->getTypeAndOrigins();
             for (auto &originLoc : retType.origins) {
                 addLocIfExists(gs, locations, originLoc);

--- a/test/testdata/lsp/def_literal.rb
+++ b/test/testdata/lsp/def_literal.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+x = 'foo/bar'
+#    ^ def: (nothing)
+p(x)


### PR DESCRIPTION
Other plugins typically try to associate definitions with things inside
string literals, e.g. by treating them as relative paths or something
like that.

Having Sorbet treat the "definition" of a string literal as the location
of the literal is not useful, and conflicts with other plugins that try
to provide their own definitions for string literals.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Requested by a developer of a Stripe-internal VS Code extension

cc @damolina-stripe


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.