### PR TITLE
Upgrade to rubygems 3.5.4 (bundler 2.5.4)

### DIFF
--- a/third_party/ruby/ruby-versions.txt
+++ b/third_party/ruby/ruby-versions.txt
@@ -1,4 +1,3 @@
-sorbet_ruby_2_7
 sorbet_ruby_3_1
 sorbet_ruby_3_2
 sorbet_ruby_3_3_preview

--- a/third_party/ruby/ruby.BUILD
+++ b/third_party/ruby/ruby.BUILD
@@ -60,12 +60,12 @@ ruby(
     rubygems = "@rubygems_update_stripe//file",
     deps = select({
         "@platforms//os:osx": [
-            "@system_ssl_darwin//:ssl",
             "@system_ssl_darwin//:crypto",
+            "@system_ssl_darwin//:ssl",
         ],
         "@platforms//os:linux": [
-            "@system_ssl_linux//:ssl",
             "@system_ssl_linux//:crypto",
+            "@system_ssl_linux//:ssl",
         ],
     }),
 )

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -25,8 +25,8 @@ def register_ruby_dependencies():
 
     http_file(
         name = "rubygems_update_stripe",
-        urls = _rubygems_urls("rubygems-update-3.3.3.gem"),
-        sha256 = "610aef544e0c15ff3cd5492dff3f5f46bd2062896f4f62c7191432c6f1d681c9",
+        urls = _rubygems_urls("rubygems-update-3.5.4.gem"),
+        sha256 = "41d4c93a79426a7e034080cc367c696ee0ae5c26fcfef20bb58f950031c95924",
     )
 
     ruby_build = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD"

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -29,7 +29,15 @@ def register_ruby_dependencies():
         sha256 = "41d4c93a79426a7e034080cc367c696ee0ae5c26fcfef20bb58f950031c95924",
     )
 
+    # Pre Ruby 3.0 needs an older rubygems
+    http_file(
+        name = "rubygems_update_stripe_ruby2",
+        urls = _rubygems_urls("rubygems-update-3.3.3.gem"),
+        sha256 = "610aef544e0c15ff3cd5492dff3f5f46bd2062896f4f62c7191432c6f1d681c9",
+    )
+
     ruby_build = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD"
+    ruby_2_build = "@com_stripe_ruby_typer//third_party/ruby:ruby_2.BUILD"
     ruby_3_3_build = "@com_stripe_ruby_typer//third_party/ruby:ruby_3_3.BUILD"
     ruby_for_compiler_build = "@com_stripe_ruby_typer//third_party/ruby:ruby_for_compiler.BUILD"
 
@@ -38,7 +46,7 @@ def register_ruby_dependencies():
         urls = _ruby_urls("2.6/ruby-2.6.5.tar.gz"),
         sha256 = "66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d",
         strip_prefix = "ruby-2.6.5",
-        build_file = ruby_build,
+        build_file = ruby_2_build,
     )
 
     urls = _ruby_urls("2.7/ruby-2.7.2.tar.gz")
@@ -50,7 +58,7 @@ def register_ruby_dependencies():
         urls = urls,
         sha256 = sha256,
         strip_prefix = strip_prefix,
-        build_file = ruby_build,
+        build_file = ruby_2_build,
     )
 
     http_archive(
@@ -58,7 +66,7 @@ def register_ruby_dependencies():
         urls = urls,
         sha256 = sha256,
         strip_prefix = strip_prefix,
-        build_file = ruby_build,
+        build_file = ruby_2_build,
         patches = [
             "@com_stripe_ruby_typer//third_party/ruby:gc-remove-write-barrier.patch",
             "@com_stripe_ruby_typer//third_party/ruby:dtoa.patch",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Lining up a rubygems 3.5.4 (https://rubygems.org/gems/rubygems-update/versions/3.5.4) (bundler 2.5.4) update.

Bundler 2.5.4 is significantly faster than 2.3.3


### Test plan

- [x] Test against stripe's codebase

Note: we cannot merge this change until the changes in Stripe's codebase are ready to go

<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
