### PR TITLE
Truncate "Value returned from method is untyped" to one line

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -384,4 +384,16 @@ pair<Loc, uint32_t> Loc::findStartOfLine(const GlobalState &gs) const {
     return make_pair(Loc(this->file(), startOffset, startOffset), padding);
 }
 
+Loc Loc::truncateToFirstLine(const GlobalState &gs) const {
+    auto [beginPos, endPos] = this->position(gs);
+    if (beginPos.line == endPos.line) {
+        return *this;
+    }
+
+    const auto &lineBreaks = this->file().data(gs).lineBreaks();
+    // Detail::line is 1-indexed. We want one after the 0-indexed line, so line - 1 + 1 = line
+    auto firstNewline = lineBreaks[beginPos.line];
+    return Loc(this->file(), this->beginPos(), firstNewline);
+}
+
 } // namespace sorbet::core

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -134,6 +134,12 @@ public:
     // - how many characters of the start of this line are whitespace.
     //
     std::pair<Loc, uint32_t> findStartOfLine(const GlobalState &gs) const;
+
+    // If the given loc spans multiple lines, return a new location which has been truncated to
+    // one line (excluding the newline character which ends the first line).
+    //
+    // Otherwise, return the current loc unchanged.
+    Loc truncateToFirstLine(const GlobalState &gs) const;
 };
 CheckSize(Loc, 12, 4);
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1467,7 +1467,8 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 } else if (!methodReturnType.isUntyped() && !methodReturnType.isTop() &&
                            typeAndOrigin.type.isUntyped()) {
                     auto what = core::errors::Infer::errorClassForUntyped(ctx, ctx.file, typeAndOrigin.type);
-                    if (auto e = ctx.beginError(bind.loc, what)) {
+                    auto errLoc = ctx.locAt(bind.loc).truncateToFirstLine(ctx);
+                    if (auto e = ctx.state.beginError(errLoc, what)) {
                         e.setHeader("Value returned from method is `{}`", "T.untyped");
                         core::TypeErrorDiagnostics::explainUntyped(ctx, e, what, typeAndOrigin, ownerLoc);
                     }

--- a/test/testdata/infer/untyped_return_multiline.rb
+++ b/test/testdata/infer/untyped_return_multiline.rb
@@ -1,0 +1,39 @@
+# typed: strong
+extend T::Sig
+
+sig do
+  type_parameters(:Return)
+    .params(blk: T.proc.returns(T.type_parameter(:Return)))
+    .returns(T.type_parameter(:Return))
+end
+def with_block(&blk)
+  yield
+end
+
+sig { params(blk: T.proc.returns(T.untyped)).returns(T.untyped) }
+def with_block_untyped(&blk)
+  yield
+end
+
+sig { params(x: Integer, y: String).returns(T.untyped) }
+def returns_untyped(x, y)
+end
+
+# ---
+
+sig { returns(Integer) }
+def example1
+  with_block_untyped do
+# ^^^^^^^^^^^^^^^^^^^^^ error: Value returned from method is `T.untyped`
+    0
+  end
+end
+
+sig { returns(Integer) }
+def example2
+  returns_untyped(
+# ^^^^^^^^^^^^^^^^ error: Value returned from method is `T.untyped`
+    0,
+    ''
+  )
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


The current behavior makes it noisy, because wrapping a method body in a
block that returns untyped will make the whole method blue, which
disguises most real errors.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.