### PR TITLE
Remove getenv from GC debug patches

### DIFF
--- a/third_party/ruby/gc-more-t-none-context.patch
+++ b/third_party/ruby/gc-more-t-none-context.patch
@@ -9,7 +9,7 @@ index 346a77ec63..6e025cb200 100644
 -        gc_mark(data->objspace, (VALUE)ccs->cme);
 +        VALUE cme_obj = (VALUE)ccs->cme;
 +
-+        if (getenv("STRIPE_DEBUG_T_NONE") && UNLIKELY(RB_TYPE_P(cme_obj, T_NONE))) {
++        if (UNLIKELY(RB_TYPE_P(cme_obj, T_NONE))) {
 +            VALUE class_path = rb_class_path_cached(data->klass);
 +            if (!NIL_P(class_path)) {
 +                char *objname = rb_id2name(id);

--- a/third_party/ruby/gc-t-none-context.patch
+++ b/third_party/ruby/gc-t-none-context.patch
@@ -61,7 +61,7 @@ index 6f4ae3a397..033a89f8f3 100644
 +/***** BEGIN Stripe debugging code ***/
 +            // Note: rgengc.parent_object will be set if we followed a reference from an old-gen object to
 +            // get here.
-+            if (getenv("STRIPE_DEBUG_T_NONE") && objspace->rgengc.parent_object) {
++            if (objspace->rgengc.parent_object) {
 +                char buff[0x200];
 +                rb_bug(
 +                    "try to mark T_NONE object -- %s",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Removes `getenv` from `T_NONE` debug patches. Keying off an env-var isn't necessary -- we know the checks work, and in any case they only fire on `T_NONE`s.

The downside of using raw `getenv` is it can lead to undefined behavior under multithreading -- a canonical Ruby env check in fact is done in a synchronized [way](https://github.com/ruby/ruby/blob/366b14c0cd850d07f11b7c2f13d0456ece1c1036/hash.c#L4972-L4990).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Remove code that could potentially segfault.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Stripe CI