### PR TITLE
Fix spelling of 'overridden'

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1469,7 +1469,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     auto *intrinsic = method.data(gs)->getIntrinsic();
     if (intrinsic != nullptr) {
         intrinsic->apply(gs, args, result);
-        // the call could have overriden constraint
+        // the call could have overridden constraint
         if (result.main.constr || constr != &core::TypeConstraint::EmptyFrozenConstraint) {
             constr = result.main.constr.get();
         }

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -151,7 +151,7 @@ module T::Private::Methods::SignatureValidation
         # This is a one-off hack, and we should think carefully before adding more methods here.
         nil
       else
-        raise "You marked `#{signature.method_name}` as #{pretty_mode(signature)}, but that method doesn't already exist in this class/module to be overriden.\n" \
+        raise "You marked `#{signature.method_name}` as #{pretty_mode(signature)}, but that method doesn't already exist in this class/module to be overridden.\n" \
           "  Either check for typos and for missing includes or super classes to make the parent method shows up\n" \
           "  ... or remove #{pretty_mode(signature)} here: #{method_loc_str(signature.method)}\n"
       end

--- a/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
+++ b/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
@@ -55,7 +55,7 @@ module T::Props::PrettyPrintable
     end
 
     # Overridable method to specify how the first part of a `pretty_print`d object's class should look like
-    # NOTE: This is just to support Stripe's `PrettyPrintableModel` case, and not recommended to be overriden
+    # NOTE: This is just to support Stripe's `PrettyPrintableModel` case, and not recommended to be overridden
     sig {params(instance: T::Props::PrettyPrintable).returns(String)}
     def inspect_class_with_decoration(instance)
       T.unsafe(instance).class.to_s

--- a/gems/sorbet-runtime/test/types/method_modes.rb
+++ b/gems/sorbet-runtime/test/types/method_modes.rb
@@ -202,7 +202,7 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
 
       assert_includes(
         err.message,
-        "You marked `foo` as .override, but that method doesn't already exist in this class/module to be overriden"
+        "You marked `foo` as .override, but that method doesn't already exist in this class/module to be overridden"
       )
     end
 

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -385,7 +385,7 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
       prop :a, String
     end
 
-    it 'errors if a prop is overriden without override => true' do
+    it 'errors if a prop is overridden without override => true' do
       error = assert_raises(ArgumentError) do
         class OverrideProps1 < OverrideProps
           prop :a, Integer

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -262,7 +262,7 @@ UnorderedMap<core::NameRef, core::TypePtr> guessArgumentTypes(core::Context ctx,
 }
 
 core::MethodRef closestOverriddenMethod(core::Context ctx, core::ClassOrModuleRef enclosingClassSymbol,
-                                       core::NameRef name) {
+                                        core::NameRef name) {
     auto enclosingClass = enclosingClassSymbol.data(ctx);
     ENFORCE(enclosingClass->flags.isLinearizationComputed, "Should have been linearized by resolver");
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -261,7 +261,7 @@ UnorderedMap<core::NameRef, core::TypePtr> guessArgumentTypes(core::Context ctx,
     return argTypesForBBToPass[cfg->deadBlock()->id];
 }
 
-core::MethodRef closestOverridenMethod(core::Context ctx, core::ClassOrModuleRef enclosingClassSymbol,
+core::MethodRef closestOverriddenMethod(core::Context ctx, core::ClassOrModuleRef enclosingClassSymbol,
                                        core::NameRef name) {
     auto enclosingClass = enclosingClassSymbol.data(ctx);
     ENFORCE(enclosingClass->flags.isLinearizationComputed, "Should have been linearized by resolver");
@@ -282,7 +282,7 @@ core::MethodRef closestOverridenMethod(core::Context ctx, core::ClassOrModuleRef
     if (superMethod.exists()) {
         return superMethod;
     } else {
-        return closestOverridenMethod(ctx, superClass, name);
+        return closestOverriddenMethod(ctx, superClass, name);
     }
 }
 
@@ -360,7 +360,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     auto guessedArgumentTypes = guessArgumentTypes(ctx, methodSymbol, cfg);
 
     auto enclosingClass = methodSymbol.enclosingClass(ctx);
-    auto closestMethod = closestOverridenMethod(ctx, enclosingClass, methodSymbol.data(ctx)->name);
+    auto closestMethod = closestOverriddenMethod(ctx, enclosingClass, methodSymbol.data(ctx)->name);
 
     fmt::memory_buffer ss;
     if (closestMethod.exists()) {

--- a/main/lsp/ConvertToSingletonClassMethod.cc
+++ b/main/lsp/ConvertToSingletonClassMethod.cc
@@ -163,7 +163,7 @@ public:
         // This doesn't make any attempt to handle methods that are overridden.
         //
         // Technically speaking, this code action doesn't make a ton of sense if the method is
-        // overriden, because converting to a singleton method will kill dynamic dispatch.
+        // overridden, because converting to a singleton method will kill dynamic dispatch.
         //
         // We have two options:
         // 1.  Assume that there are no overrides of this method.

--- a/test/cli/suggest-sig-override-edge/suggest-sig-override-edge.rb
+++ b/test/cli/suggest-sig-override-edge/suggest-sig-override-edge.rb
@@ -1,6 +1,6 @@
 # typed: strict
 
-# initialize can be overriden without overridable/override
+# initialize can be overridden without overridable/override
 class ParentInitialize
   extend T::Sig
   sig {void}

--- a/test/cli/suggest-sig-override-edge/test.out
+++ b/test/cli/suggest-sig-override-edge/test.out
@@ -1,6 +1,6 @@
 # typed: strict
 
-# initialize can be overriden without overridable/override
+# initialize can be overridden without overridable/override
 class ParentInitialize
   extend T::Sig
   sig {void}


### PR DESCRIPTION
I noticed the misspelling in some error output from `gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb`, then found a bunch of other places.

(Prior to this change, the split was 31 for 'overriden', and 131 for 'overridden')