### PR TITLE
Add additional test coverage for `T::Props::Constructor` - Part 2

### DIFF
--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -578,6 +578,8 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
     prop :array_of_substruct, T::Array[MySerializable]
     prop :hash_of_substruct, T::Hash[String, MySerializable]
     prop :infinity_float, Float, default: Float::INFINITY
+    prop :negative_infinity_float, Float, default: -Float::INFINITY
+    prop :nan_float, Float, default: Float::NAN
     prop :enum, MyEnum
     prop :nilable_enum, T.nilable(MyEnum)
     prop :default_enum, MyEnum, default: MyEnum::FooOne
@@ -616,6 +618,8 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
         "array_of_substruct" => [{"name" => "foo2"}],
         "hash_of_substruct" => {"3" => {"name" => "foo3"}},
         "infinity_float" => Float::INFINITY,
+        "negative_infinity_float" => -Float::INFINITY,
+        "nan_float" => Float::NAN,
         "enum" => "fooone",
         "default_enum" => "fooone",
         "deprecated_enum" => :foo_one,

--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -470,6 +470,11 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
     prop :required, String, raise_on_nil_write: true
   end
 
+  class UntypedStruct < T::Struct
+    prop :untyped, T.untyped
+    prop :untyped_with_raise_on_nil_write, T.untyped, raise_on_nil_write: true
+  end
+
   it 'forbids nil in constructor if raise_on_nil_write=true' do
     err = assert_raises(ArgumentError) do
       NilFieldStruct.new
@@ -485,6 +490,13 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
       NilFieldStruct.new(foo: 1, bar: 'hey', required: nil)
     end
     assert_includes(err.message, "Can't set Opus::Types::Test::Props::ConstructorTest::NilFieldStruct.required to nil (instance of NilClass) - need a String")
+  end
+
+  it 'does not forbid nil in constructor for T.untyped' do
+    UntypedStruct.new
+    UntypedStruct.new(untyped: nil)
+    UntypedStruct.new(untyped_with_raise_on_nil_write: nil)
+    UntypedStruct.new(untyped: nil, untyped_with_raise_on_nil_write: nil)
   end
 
   class SetterValidate < T::Struct

--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -472,6 +472,7 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
 
   class UntypedStruct < T::Struct
     prop :untyped, T.untyped
+    prop :untyped_with_default, T.untyped, default: 123
     prop :untyped_with_raise_on_nil_write, T.untyped, raise_on_nil_write: true
   end
 
@@ -495,8 +496,16 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
   it 'does not forbid nil in constructor for T.untyped' do
     UntypedStruct.new
     UntypedStruct.new(untyped: nil)
+    UntypedStruct.new(untyped_with_default: true)
     UntypedStruct.new(untyped_with_raise_on_nil_write: nil)
-    UntypedStruct.new(untyped: nil, untyped_with_raise_on_nil_write: nil)
+    UntypedStruct.new(untyped: nil, untyped_with_default: nil, untyped_with_raise_on_nil_write: nil)
+  end
+
+  it 'returns the right required props for T.untyped' do
+    assert_equal(
+      Set[:untyped, :untyped_with_default, :untyped_with_raise_on_nil_write],
+      UntypedStruct.decorator.required_props.to_set
+    )
   end
 
   class SetterValidate < T::Struct


### PR DESCRIPTION
Follow-up to #7626 , add additional tests for T::Props::Constructor` for:
- special values of `Float`
- behavior around fields being required/optional for untyped fields in T::Struct

### Motivation

While working on #6693, I noticed a spec breaking due a missing required prop that was `T.untyped` with no default. In the current world, the way we check for a missing required prop when there is no default is by running a type check on the value (happens in the `setter_proc`) and if it fails, then checking if the prop was in the provided hash. Here's the code: https://github.com/sorbet/sorbet/blob/a4457bfc25b26f8953eef8e529ec5a7488f2e1ac/gems/sorbet-runtime/lib/types/props/constructor.rb#L23-L37

With `T.untyped`, the typecheck will never fail so we'll never get into the rescue block and thus would never raise an error. Statically, sorbet considers this an error, so this seems like a runtime bug: https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20Foo%20%3C%20T%3A%3AStruct%0A%20%20prop%20%3Abar%2C%20T.untyped%0Aend%0A%0AFoo.new%20%23%20Error%3A%20Missing%20required%20keyword%20argument%20bar%0AFoo.new%28bar%3A%20nil%29

This likely isn't a safe bug to fix since there's probably a ton of production code "accidentally" relying on this behavior. In that PR, I'm going to plan to add some special handling for this case, but I first wanted to capture the behavior in a dedicated test to lock it in as expected.

### Test plan

See included automated tests.
