### PR TITLE
Fix signature of `Thread.each_caller_location`

### DIFF
--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -1230,7 +1230,7 @@ class Thread < Object
 
   # Yields each frame of the current execution stack as a
   # backtrace location object.
-  sig {params(blk: T.proc.void).returns(T.untyped)}
+  sig {params(blk: T.proc.params(location: Thread::Backtrace::Location).void).returns(T.untyped)}
   def self.each_caller_location(&blk); end
 end
 


### PR DESCRIPTION
Followup: https://github.com/sorbet/sorbet/pull/7293 (cc @nate-at-gusto)

It always yields a `Backtrace::Location` ~~and always returns `nil`~~. Actually if you `break something` in the block, it returns that. 

This save having to use `T.must` or something in the block.
