### PR TITLE
Create the folder if cache-dir doesn't exist

### DIFF
--- a/test/cli/cache-dir-dne/test.out
+++ b/test/cli/cache-dir-dne/test.out
@@ -1,1 +1,3 @@
-'nope2' does not exist. When using --cache-dir, create the directory before hand.
+No errors! Great job.
+'nope3/subdir' is not a directory, and so cannot store the Sorbet disk cache.
+'nope4/subdir' does not exist and could not be created. When using --cache-dir, create the directory before hand.

--- a/test/cli/cache-dir-dne/test.out
+++ b/test/cli/cache-dir-dne/test.out
@@ -1,3 +1,2 @@
 No errors! Great job.
 'nope3/subdir' is not a directory, and so cannot store the Sorbet disk cache.
-'nope4/subdir' does not exist and could not be created. When using --cache-dir, create the directory before hand.

--- a/test/cli/cache-dir-dne/test.sh
+++ b/test/cli/cache-dir-dne/test.sh
@@ -1,2 +1,19 @@
 #!/bin/bash
+set -euo pipefail
+
+trap 'rm -rf nope2 nope3 nope4' EXIT
+
 main/sorbet --silence-dev-message --cache-dir=nope2 -e '0' 2>&1
+
+touch nope3
+if main/sorbet --silence-dev-message --cache-dir=nope3/subdir -e 0 2>&1; then
+  2>&1 echo 'Expected to fail!'
+  exit 1
+fi
+
+mkdir nope4
+chmod -w nope4
+if main/sorbet --silence-dev-message --cache-dir=nope4/subdir -e 0 2>&1; then
+  2>&1 echo 'Expected to fail!'
+  exit 1
+fi

--- a/test/cli/cache-dir-dne/test.sh
+++ b/test/cli/cache-dir-dne/test.sh
@@ -15,5 +15,6 @@ mkdir nope4
 chmod -w nope4
 if main/sorbet --silence-dev-message --cache-dir=nope4/subdir -e 0 2>&1; then
   2>&1 echo 'Expected to fail!'
+  2>&1 ls -l
   exit 1
 fi

--- a/test/cli/cache-dir-dne/test.sh
+++ b/test/cli/cache-dir-dne/test.sh
@@ -1,20 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-trap 'rm -rf nope2 nope3 nope4' EXIT
+trap 'rm -rf nope2 nope3' EXIT
 
 main/sorbet --silence-dev-message --cache-dir=nope2 -e '0' 2>&1
 
 touch nope3
 if main/sorbet --silence-dev-message --cache-dir=nope3/subdir -e 0 2>&1; then
   2>&1 echo 'Expected to fail!'
-  exit 1
-fi
-
-mkdir nope4
-chmod -w nope4
-if main/sorbet --silence-dev-message --cache-dir=nope4/subdir -e 0 2>&1; then
-  2>&1 echo 'Expected to fail!'
-  2>&1 ls -l
   exit 1
 fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was writing a doc for how to use `--cache-dir`, but it's annoying to have to
explain both having to create the directory ahead of time and also how to work
around it (create a bash script that wraps `srb tc`).

It's a lot easier to just create the directory if it doesn't exist.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.