### PR TITLE
Deduplicate export suggestions

### DIFF
--- a/test/testdata/packager/export-autocorrect/__package.rb
+++ b/test/testdata/packager/export-autocorrect/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Package < PackageSpec
+
+end

--- a/test/testdata/packager/export-autocorrect/a.rb
+++ b/test/testdata/packager/export-autocorrect/a.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# typed: strict
+# selective-apply-code-action: source.fixAll.sorbet
+
+class Package::A
+  extend T::Sig
+
+  sig {void}
+  def self.get_exported_item
+    Dep::ExportedItem.new
+  # ^^^               apply-code-action: [1] Apply all Sorbet fixes for file
+  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but is not exported from `Dep`
+
+    Dep::ExportedItem.new
+  # ^^^               apply-code-action: [1] Apply all Sorbet fixes for file
+  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but is not exported from `Dep`
+
+  end
+end

--- a/test/testdata/packager/export-autocorrect/dep/__package.1.rbedited
+++ b/test/testdata/packager/export-autocorrect/dep/__package.1.rbedited
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Dep < PackageSpec
+  export Dep::ExportedItem
+end

--- a/test/testdata/packager/export-autocorrect/dep/__package.rb
+++ b/test/testdata/packager/export-autocorrect/dep/__package.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Dep < PackageSpec
+end

--- a/test/testdata/packager/export-autocorrect/dep/exported.rb
+++ b/test/testdata/packager/export-autocorrect/dep/exported.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Dep::ExportedItem
+
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The PR fixes a bug when an autocorrect for adding `export <PackageName>` was applied twice.

**Issue:**
In certain condition an autocorrect to add a package export might be applied twice, see included test for more details.

**Solution:**
Similar to https://github.com/sorbet/sorbet/pull/7573. I've introduced a queue, which collects information about the errors and autocorrects to be reported. Potential autocorrects are deduplicated by using set. Before my change, errors were reported straight away.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
