### PR TITLE
add a test for no-prop constructors

### DIFF
--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -21,6 +21,9 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
     prop :untyped_prop, T.untyped, default: nil
   end
 
+  class NoProps < T::Struct
+  end
+
   it "raises when omitting a required prop" do
     err = assert_raises(ArgumentError) do
       MyStruct.new(foo: 'foo')
@@ -33,6 +36,13 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
       MyStruct.new(name: 'Alex', foo: {}, bar1: 'bar1', bar2: 'bar2')
     end
     assert_equal("Opus::Types::Test::Props::ConstructorTest::MyStruct: Unrecognized properties: bar1, bar2", err.message)
+  end
+
+  it "raises when giving unknown props to a no-prop class" do
+    err = assert_raises(ArgumentError) do
+      NoProps.new(bar1: 'bar1', bar2: 'bar2')
+    end
+    assert_equal("Opus::Types::Test::Props::ConstructorTest::NoProps: Unrecognized properties: bar1, bar2", err.message)
   end
 
   it 'allows required props to be omitted if they have a default value' do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a distillation of a test that failed on Stripe's codebase with #6693 applied.

cc @jeffcarbs 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
