### PR TITLE
Give ARGV the T::Array[String] type

### DIFF
--- a/rbi/core/constants.rbi
+++ b/rbi/core/constants.rbi
@@ -6,7 +6,7 @@
 # A library like
 # [`OptionParser`](https://docs.ruby-lang.org/en/2.7.0/OptionParser.html) can be
 # used to process command-line arguments.
-::ARGV = T.let(T.unsafe(nil), T::Array[T.untyped])
+::ARGV = T.let(T.unsafe(nil), T::Array[String])
 ::CROSS_COMPILING = T.let(T.unsafe(nil), NilClass)
 # An obsolete alias of `false`
 ::FALSE = T.let(T.unsafe(nil), FalseClass)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
I have some basic argument processing code that I want to switch to `typed: strong`.

### Test plan
The only docs I could find weren't 100% definitive that these are strings: https://docs.ruby-lang.org/en/3.3/globals_rdoc.html#label-ARGV

But bug report appears confirm that they are frozen strings: https://bugs.ruby-lang.org/issues/12128

Any pointers on what tests would apply here?

Also, should there be types for the related globals [$0](https://docs.ruby-lang.org/en/3.3/globals_rdoc.html#label-240) and [$*](https://docs.ruby-lang.org/en/3.3/globals_rdoc.html#label-24-2A+-28ARGV-29)?
