### PR TITLE
Bug in simultaneous import and export suggestion

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -69,8 +69,8 @@ static void reportMissingImport(const core::Context &ctx, core::SymbolRef symbol
     }
 }
 
-static std::optional<core::AutocorrectSuggestion>
-addImport(const core::Context &ctx, core::FileRef file, core::SymbolRef symbol) {
+static std::optional<core::AutocorrectSuggestion> addImport(const core::Context &ctx, core::FileRef file,
+                                                            core::SymbolRef symbol) {
     // pkgName => importing to this package
     // otherPackage => importing this package
     auto pkgName = ctx.state.packageDB().getPackageNameForFile(file);

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -541,11 +541,15 @@ public:
                         const auto &package = gs.packageDB().getPackageInfo(pkgName);
                         VisibilityCheckerPass pass{ctx, package};
                         ast::TreeWalk::apply(ctx, pass, f.tree);
-                        for (const auto &[symbol, loc] : pass.imports) {
-                            reportMissingImport(ctx, package, symbol, loc);
+                        for (auto &[symbol, locs] : pass.imports) {
+                            fast_sort(locs,
+                                      [](const auto a, const auto b) -> bool { return a.beginPos() < b.beginPos(); });
+                            reportMissingImport(ctx, package, symbol, locs);
                         }
-                        for (const auto &[symbol, loc] : pass.testImports) {
-                            reportMissingTestImport(ctx, package, symbol, loc);
+                        for (auto &[symbol, locs] : pass.testImports) {
+                            fast_sort(locs,
+                                      [](const auto a, const auto b) -> bool { return a.beginPos() < b.beginPos(); });
+                            reportMissingTestImport(ctx, package, symbol, locs);
                         }
                     }
                 }

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -410,7 +410,7 @@ class VisibilityCheckerPass final {
 
 public:
     UnorderedMap<core::SymbolRef, std::vector<core::LocOffsets>> imports;
-    UnorderedMap<core::SymbolRef, std::vector<core::LocOffsets>> testImports;
+    UnorderedMap<core::SymbolRef, std::vector<core::LocOffsets>> testImportsToReplace;
     const core::packages::PackageInfo &package;
     const bool insideTestFile;
 
@@ -512,7 +512,7 @@ public:
             imports[lit.symbol].emplace_back(lit.loc);
         } else if (*importType == core::packages::ImportType::Test && !this->insideTestFile) {
             // We used a symbol from a `test_import` in a non-test context
-            testImports[lit.symbol].emplace_back(lit.loc);
+            testImportsToReplace[lit.symbol].emplace_back(lit.loc);
         }
     }
 
@@ -554,7 +554,7 @@ public:
                                 outputq->push(std::move(suggestion), 1);
                             }
                         }
-                        for (auto &[symbol, locs] : pass.testImports) {
+                        for (auto &[symbol, locs] : pass.testImportsToReplace) {
                             fast_sort(locs,
                                       [](const auto a, const auto b) -> bool { return a.beginPos() > b.beginPos(); });
                             for (auto loc : locs) {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -543,12 +543,12 @@ public:
                         ast::TreeWalk::apply(ctx, pass, f.tree);
                         for (auto &[symbol, locs] : pass.imports) {
                             fast_sort(locs,
-                                      [](const auto a, const auto b) -> bool { return a.beginPos() < b.beginPos(); });
+                                      [](const auto a, const auto b) -> bool { return a.beginPos() > b.beginPos(); });
                             reportMissingImport(ctx, package, symbol, locs);
                         }
                         for (auto &[symbol, locs] : pass.testImports) {
                             fast_sort(locs,
-                                      [](const auto a, const auto b) -> bool { return a.beginPos() < b.beginPos(); });
+                                      [](const auto a, const auto b) -> bool { return a.beginPos() > b.beginPos(); });
                             reportMissingTestImport(ctx, package, symbol, locs);
                         }
                     }

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -52,9 +52,9 @@ foo_class.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package i
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
-     6 |  Foo::Bar::OtherPackage::ImportMeTestOnly
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+     4 |  Test::Foo::Bar::OtherPackage::TestUtil
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Exported from package here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,9 +63,9 @@ foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its packa
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
 
-foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
-     4 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
+     6 |  Foo::Bar::OtherPackage::ImportMeTestOnly
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Exported from package here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -23,6 +23,10 @@ foo_class.rb:15: Unable to resolve constant `MyClass` https://srb.help/5002
       NN |class Digest::Class
           ^^^^^^^^^^^^^^^^^^^
 
+foo_class.rb:17: `Test::Foo::Bar::OtherPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    17 |  Test::Foo::Bar::OtherPackage::TestUtil
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 foo_class.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,10 +44,6 @@ foo_class.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is
     other/__package.rb:3: Exported from package here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
-     6 |  # import Foo::Bar::OtherPackage ## MISSING!
-                                                     ^
 
 foo_class.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
     14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
@@ -51,18 +51,10 @@ foo_class.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package i
     other/__package.rb:3: Exported from package here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
-     6 |  # import Foo::Bar::OtherPackage ## MISSING!
-                                                     ^
 
-foo_class.rb:17: `Test::Foo::Bar::OtherPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
-    17 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
-     4 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
+     6 |  Foo::Bar::OtherPackage::ImportMeTestOnly
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Exported from package here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,9 +63,9 @@ foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
 
-foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
-     6 |  Foo::Bar::OtherPackage::ImportMeTestOnly
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+     4 |  Test::Foo::Bar::OtherPackage::TestUtil
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Exported from package here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/package-double-import-autocorrect/a/__package.rb
+++ b/test/cli/package-double-import-autocorrect/a/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class A < PackageSpec
+  export A::Foo
+end

--- a/test/cli/package-double-import-autocorrect/a/a.rb
+++ b/test/cli/package-double-import-autocorrect/a/a.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module A
+  class Foo; end
+end

--- a/test/cli/package-double-import-autocorrect/different-files/__package.rb
+++ b/test/cli/package-double-import-autocorrect/different-files/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class C < PackageSpec
+end

--- a/test/cli/package-double-import-autocorrect/different-files/c1.rb
+++ b/test/cli/package-double-import-autocorrect/different-files/c1.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+module C
+  extend T::Sig
+
+  sig{returns(A::Foo)}
+  def first_reference
+    T.unsafe(nil)
+  end
+end

--- a/test/cli/package-double-import-autocorrect/different-files/c2.rb
+++ b/test/cli/package-double-import-autocorrect/different-files/c2.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+module C
+  extend T::Sig
+
+  sig{returns(A::Foo)}
+  def second_reference
+    T.unsafe(nil)
+  end
+end

--- a/test/cli/package-double-import-autocorrect/same-file/__package.rb
+++ b/test/cli/package-double-import-autocorrect/same-file/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class B < PackageSpec
+  import A
+end

--- a/test/cli/package-double-import-autocorrect/same-file/__package.rb
+++ b/test/cli/package-double-import-autocorrect/same-file/__package.rb
@@ -1,5 +1,4 @@
 # typed: strict
 
 class B < PackageSpec
-  import A
 end

--- a/test/cli/package-double-import-autocorrect/same-file/b.rb
+++ b/test/cli/package-double-import-autocorrect/same-file/b.rb
@@ -1,0 +1,11 @@
+# typed: strict
+
+module B
+  extend T::Sig
+
+  sig {returns(A::Foo)}
+  def use_a
+    x = A::Foo.new
+    T.unsafe(x)
+  end
+end

--- a/test/cli/package-double-import-autocorrect/test.out
+++ b/test/cli/package-double-import-autocorrect/test.out
@@ -22,10 +22,6 @@ different-files/c2.rb:6: `A::Foo` resolves but its package is not imported https
     a/__package.rb:3: Exported from package here
      3 |class A < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    different-files/__package.rb:3: Inserted `import A`
-     3 |class C < PackageSpec
-                             ^
 
 different-files/c1.rb:6: `A::Foo` resolves but its package is not imported https://srb.help/3718
      6 |  sig{returns(A::Foo)}

--- a/test/cli/package-double-import-autocorrect/test.out
+++ b/test/cli/package-double-import-autocorrect/test.out
@@ -1,0 +1,56 @@
+same-file/b.rb:6: `A::Foo` resolves but its package is not imported https://srb.help/3718
+     6 |  sig {returns(A::Foo)}
+                       ^^^^^^
+    a/__package.rb:3: Exported from package here
+     3 |class A < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    same-file/__package.rb:3: Inserted `import A`
+     3 |class B < PackageSpec
+                             ^
+
+same-file/b.rb:8: `A::Foo` resolves but its package is not imported https://srb.help/3718
+     8 |    x = A::Foo.new
+                ^^^^^^
+    a/__package.rb:3: Exported from package here
+     3 |class A < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+
+different-files/c2.rb:6: `A::Foo` resolves but its package is not imported https://srb.help/3718
+     6 |  sig{returns(A::Foo)}
+                      ^^^^^^
+    a/__package.rb:3: Exported from package here
+     3 |class A < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    different-files/__package.rb:3: Inserted `import A`
+     3 |class C < PackageSpec
+                             ^
+
+different-files/c1.rb:6: `A::Foo` resolves but its package is not imported https://srb.help/3718
+     6 |  sig{returns(A::Foo)}
+                      ^^^^^^
+    a/__package.rb:3: Exported from package here
+     3 |class A < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    different-files/__package.rb:3: Inserted `import A`
+     3 |class C < PackageSpec
+                             ^
+Errors: 4
+
+====================
+
+# typed: strict
+
+class B < PackageSpec
+  import A
+end
+
+====================
+
+# typed: strict
+
+class C < PackageSpec
+  import A
+end

--- a/test/cli/package-double-import-autocorrect/test.sh
+++ b/test/cli/package-double-import-autocorrect/test.sh
@@ -1,0 +1,22 @@
+cwd="$(pwd)"
+tmp="$(mktemp -d)"
+cd test/cli/package-double-import-autocorrect || exit 1
+for file in $(find . -name '*.rb' | sort); do
+    mkdir -p "$tmp/$(dirname "$file")"
+    cp "$file" "$tmp/$file"
+done
+cd "$tmp" || exit 1
+
+"$cwd/main/sorbet" --silence-dev-message --stripe-packages --max-threads=0 --autocorrect . 2>&1
+
+echo
+echo "===================="
+echo
+
+cat same-file/__package.rb
+
+echo
+echo "===================="
+echo
+
+cat different-files/__package.rb

--- a/test/cli/package-error-missing-import/test.out
+++ b/test/cli/package-error-missing-import/test.out
@@ -17,10 +17,6 @@ foo_class.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is
     other/__package.rb:3: Exported from package here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    __package.rb:6: Insert `import Foo::Bar::OtherPackage`
-     6 |  # import Foo::Bar::OtherPackage ## MISSING!
-                                                     ^
   Note:
     Try running generate-packages.sh
 
@@ -30,10 +26,6 @@ foo_class.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package i
     other/__package.rb:3: Exported from package here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    __package.rb:6: Insert `import Foo::Bar::OtherPackage`
-     6 |  # import Foo::Bar::OtherPackage ## MISSING!
-                                                     ^
   Note:
     Try running generate-packages.sh
 

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1854,7 +1854,6 @@ void ApplyCodeActionAssertion::checkAll(
         actualEditedFileContents = string(file->source());
 
         for (auto &e : c->edits) {
-
             auto &td = c->textDocument;
             auto filename = td->uri;
             auto version = td->version;

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -13,6 +13,7 @@
 #include "test/helpers/position_assertions.h"
 #include <iterator>
 #include <regex>
+#include <string.h>
 
 using namespace std;
 
@@ -1752,8 +1753,8 @@ ApplyCodeActionAssertion::ApplyCodeActionAssertion(string_view filename, unique_
 string ApplyCodeActionAssertion::toString() const {
     return fmt::format("apply-code-action: [{}] {}", version, title);
 }
-optional<pair<string, string>> ApplyCodeActionAssertion::expectedFile() {
-    auto expectedUpdatedFilePath = updatedFilePath(this->filename, this->version);
+optional<pair<string, string>> ApplyCodeActionAssertion::expectedFile(string filename, string version) {
+    auto expectedUpdatedFilePath = updatedFilePath(filename, version);
     string expectedEditedFileContents;
     try {
         expectedEditedFileContents = FileOps::read(expectedUpdatedFilePath);
@@ -1806,11 +1807,6 @@ getFileByUri(const LSPConfiguration &config,
 
 void ApplyCodeActionAssertion::check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
                                      LSPWrapper &wrapper, const CodeAction &codeAction) {
-    auto maybeFile = expectedFile();
-    if (!maybeFile.has_value()) {
-        return;
-    }
-    auto [expectedUpdatedFilePath, expectedEditedFileContents] = maybeFile.value();
     const auto &config = wrapper.config();
     for (auto &c : *codeAction.edit.value()->documentChanges) {
         auto file = getFileByUri(config, sourceFileContents, c->textDocument->uri);
@@ -1818,6 +1814,21 @@ void ApplyCodeActionAssertion::check(const UnorderedMap<std::string, std::shared
         string actualEditedFileContents = string(file->source());
         c = sortEdits(move(c));
 
+        auto &td = c->textDocument;
+        auto filename = td->uri;
+        auto version = td->version;
+
+        if (!std::holds_alternative<double>(version)) {
+            continue;
+        }
+
+        const double *v = std::get_if<double>(&version);
+        auto maybeFile = expectedFile(filename, to_string(*v));
+        if (!maybeFile.has_value()) {
+            return;
+        }
+
+        auto [expectedUpdatedFilePath, expectedEditedFileContents] = maybeFile.value();
         for (auto &e : c->edits) {
             auto reindent = false;
             actualEditedFileContents = applyEdit(actualEditedFileContents, *file, *e->range, e->newText, reindent);
@@ -1831,12 +1842,11 @@ void ApplyCodeActionAssertion::checkAll(
     const CodeAction &codeAction) {
     const auto &config = wrapper.config();
     UnorderedMap<string, string> accumulatedOriginalEditedContents{};
+
+    // actualEditedFileContents -> (expectedUpdatedFilePath, expectedEditedFileContents)
+    // Maps original file contents to a edited filename and contents
+    UnorderedMap<string, std::pair<std::string, std::string>> fileToUpdatedFile;
     string actualEditedFileContents;
-    auto maybeFile = expectedFile();
-    if (!maybeFile.has_value()) {
-        return;
-    }
-    auto [expectedUpdatedFilePath, expectedEditedFileContents] = maybeFile.value();
     for (auto &c : *codeAction.edit.value()->documentChanges) {
         auto file = getFileByUri(config, sourceFileContents, c->textDocument->uri);
 
@@ -1844,6 +1854,22 @@ void ApplyCodeActionAssertion::checkAll(
         actualEditedFileContents = string(file->source());
 
         for (auto &e : c->edits) {
+
+            auto &td = c->textDocument;
+            auto filename = td->uri;
+            auto version = td->version;
+
+            if (!std::holds_alternative<double>(version)) {
+                continue;
+            }
+
+            const double *v = std::get_if<double>(&version);
+            auto maybeFile = expectedFile(filename, to_string(*v));
+            if (!maybeFile.has_value()) {
+                continue;
+            }
+            fileToUpdatedFile.insert_or_assign(actualEditedFileContents, maybeFile.value());
+
             string oldSource = accumulatedOriginalEditedContents.contains(actualEditedFileContents)
                                    ? accumulatedOriginalEditedContents[actualEditedFileContents]
                                    : actualEditedFileContents;
@@ -1855,6 +1881,7 @@ void ApplyCodeActionAssertion::checkAll(
     }
 
     for (auto pair : accumulatedOriginalEditedContents) {
+        auto [expectedUpdatedFilePath, expectedEditedFileContents] = fileToUpdatedFile[pair.first];
         assertResults(expectedUpdatedFilePath, expectedEditedFileContents, pair.second);
     }
 }

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -425,7 +425,7 @@ public:
     std::string toString() const override;
 
 private:
-    std::optional<std::pair<std::string, std::string>> expectedFile();
+    std::optional<std::pair<std::string, std::string>> expectedFile(std::string filename, std::string version);
     void assertResults(std::string expectedPath, std::string expectedContents, std::string actualContents);
     std::unique_ptr<TextDocumentEdit> sortEdits(std::unique_ptr<TextDocumentEdit> changes);
 };

--- a/test/testdata/packager/export-autocorrect/__package.rb
+++ b/test/testdata/packager/export-autocorrect/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Package < PackageSpec
+
+end

--- a/test/testdata/packager/export-autocorrect/a.rb
+++ b/test/testdata/packager/export-autocorrect/a.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# typed: strict
+# selective-apply-code-action: source.fixAll.sorbet
+
+class Package::A
+  extend T::Sig
+
+  sig {void}
+  def self.get_exported_item
+    Dep::ExportedItem.new
+  # ^^^               apply-code-action: [1] Apply all Sorbet fixes for file
+  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but is not exported from `Dep`
+
+    Dep::ExportedItem.new
+  # ^^^               apply-code-action: [1] Apply all Sorbet fixes for file
+  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but is not exported from `Dep`
+
+  end
+end

--- a/test/testdata/packager/export-autocorrect/dep/__package.1.rbedited
+++ b/test/testdata/packager/export-autocorrect/dep/__package.1.rbedited
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Dep < PackageSpec
+  export Dep::ExportedItem
+end

--- a/test/testdata/packager/export-autocorrect/dep/__package.rb
+++ b/test/testdata/packager/export-autocorrect/dep/__package.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Dep < PackageSpec
+end

--- a/test/testdata/packager/export-autocorrect/dep/exported.rb
+++ b/test/testdata/packager/export-autocorrect/dep/exported.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Dep::ExportedItem
+
+end

--- a/test/testdata/packager/import-autocorrect/__package.1.rbedited 
+++ b/test/testdata/packager/import-autocorrect/__package.1.rbedited 
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Package < PackageSpec
+  import Dep
+end

--- a/test/testdata/packager/import-autocorrect/__package.rb
+++ b/test/testdata/packager/import-autocorrect/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Package < PackageSpec
+
+end

--- a/test/testdata/packager/import-autocorrect/a.rb
+++ b/test/testdata/packager/import-autocorrect/a.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# typed: strict
+# selective-apply-code-action: source.fixAll.sorbet
+
+class Package::A
+  extend T::Sig
+
+  sig {void}
+  def self.get_exported_item
+    Dep::ExportedItem.new
+  # ^^^               apply-code-action: [1] Apply all Sorbet fixes for file
+  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but its package is not imported (fix available)
+    Dep::ExportedItem.new
+  # ^^^               apply-code-action: [1] Apply all Sorbet fixes for file
+  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but its package is not imported (fix available)
+
+  end
+end

--- a/test/testdata/packager/import-autocorrect/a.rb
+++ b/test/testdata/packager/import-autocorrect/a.rb
@@ -9,10 +9,10 @@ class Package::A
   def self.get_exported_item
     Dep::ExportedItem.new
   # ^^^               apply-code-action: [1] Apply all Sorbet fixes for file
-  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but its package is not imported (fix available)
+  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but its package is not imported
     Dep::ExportedItem.new
   # ^^^               apply-code-action: [1] Apply all Sorbet fixes for file
-  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but its package is not imported (fix available)
+  # ^^^^^^^^^^^^^^^^^ error: `Dep::ExportedItem` resolves but its package is not imported
 
   end
 end

--- a/test/testdata/packager/import-autocorrect/dep/__package.rb
+++ b/test/testdata/packager/import-autocorrect/dep/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Dep < PackageSpec
+  export Dep::ExportedItem
+end

--- a/test/testdata/packager/import-autocorrect/dep/exported.rb
+++ b/test/testdata/packager/import-autocorrect/dep/exported.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Dep::ExportedItem
+
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

**Issue:**
- A package has a constant which requires an import, and a constant requires an export. Sorbet with `--autocorrects` will apply only one autocorrect. Most likely it's caused by logic in `hasSeen` function in `AutcorrectSuggestion.cc`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
