### PR TITLE
RBI: make Pathname#mkdir match Dir.mkdir's signature for the optional mode argument

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -971,7 +971,7 @@ class Pathname < Object
     )
     .returns(Integer)
   end
-  def mkdir(p1); end
+  def mkdir(p1=T.unsafe(nil)); end
 
   # Creates a full path, including any intermediate directories that don't yet
   # exist.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
I updated the RBI signature to allow the optional `mode` parameter to not be supplied, matching how the same call is set in `Dir.mkdir` in `core/dir.rbi` (which Pathname defers to).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Sorbet was reporting an error when it is actually a valid usage. 

e.g.

```
irb(main):002:0> p = Pathname.new("/tmp/foo")
=> #<Pathname:/tmp/foo>
irb(main):003:0> p.mkdir
=> 0
irb(main):004:0> p.exist?
=> true
```

While in vscode with latest sorbet, this reports:

```
Not enough arguments provided for method `Pathname#mkdir`. Expected: `1`, got: `0`
```

### Test plan

I looked at the most recent RBI change (https://github.com/sorbet/sorbet/pull/7639 at the time of writing) and it looks like you run some internal testing. Let me know if you want me to do anything on my end for this PR. 