### PR TITLE
Change CFG entrypoint shape: invhouse → cds

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -222,7 +222,7 @@ string CFG::toString(const core::GlobalState &gs) const {
         auto text = basicBlock->toString(gs, *this);
         auto lines = absl::StrSplit(text, "\n");
 
-        auto shape = basicBlock->id == 0 ? "invhouse" : basicBlock->id == 1 ? "parallelogram" : "rectangle";
+        auto shape = basicBlock->id == 0 ? "cds" : basicBlock->id == 1 ? "parallelogram" : "rectangle";
         // whole block red if whole block is dead
         auto color = basicBlock->firstDeadInstructionIdx == 0 ? "red" : "black";
         fmt::format_to(std::back_inserter(buf),
@@ -276,7 +276,7 @@ string CFG::showRaw(core::Context ctx) const {
         auto text = basicBlock->showRaw(ctx, *this);
         auto lines = absl::StrSplit(text, "\n");
 
-        auto shape = basicBlock->id == 0 ? "invhouse" : basicBlock->id == 1 ? "parallelogram" : "rectangle";
+        auto shape = basicBlock->id == 0 ? "cds" : basicBlock->id == 1 ? "parallelogram" : "rectangle";
         // whole block red if whole block is dead
         auto color = basicBlock->firstDeadInstructionIdx == 0 ? "red" : "black";
         fmt::format_to(std::back_inserter(buf),

--- a/test/cli/phases/test.out
+++ b/test/cli/phases/test.out
@@ -203,7 +203,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     color = blue;
 
     "bb::<Class:<root>>#<static-init>_0" [
-        shape = invhouse;
+        shape = cds;
         color = black;
         label = "block[id=0, rubyRegionId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));\l<returnMethodTemp>$2: Integer(1) = 1\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
     ];
@@ -231,7 +231,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     color = blue;
 
     "bb::<Class:<root>>#<static-init>_0" [
-        shape = invhouse;
+        shape = cds;
         color = black;
         label = "block[id=0]()\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <self>>,\l&nbsp;&nbsp;type = T.class_of(<root>),\l&nbsp;},\l&nbsp;value = Cast {\l&nbsp;&nbsp;cast = T.cast,\l&nbsp;&nbsp;value = VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <self>>,\l&nbsp;&nbsp;&nbsp;type = NilClass,\l&nbsp;&nbsp;},\l&nbsp;&nbsp;type = T.class_of(<root>),\l&nbsp;},\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <returnMethodTemp>>$2,\l&nbsp;&nbsp;type = Integer(1),\l&nbsp;},\l&nbsp;value = Literal { value = Integer(1) },\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <finalReturn>>,\l&nbsp;&nbsp;type = T.noreturn,\l&nbsp;},\l&nbsp;value = Return {\l&nbsp;&nbsp;what = VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <returnMethodTemp>>$2,\l&nbsp;&nbsp;&nbsp;type = Integer(1),\l&nbsp;&nbsp;},\l&nbsp;},\l}\lVariableUseSite { variable = <U <unconditional>> }\l"
     ];

--- a/test/testdata/cfg/raw_test.rb.cfg-raw.exp
+++ b/test/testdata/cfg/raw_test.rb.cfg-raw.exp
@@ -7,7 +7,7 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     color = blue;
 
     "bb::<Class:<root>>#<static-init>_0" [
-        shape = invhouse;
+        shape = cds;
         color = black;
         label = "block[id=0]()\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <self>>,\l&nbsp;&nbsp;type = T.class_of(<root>),\l&nbsp;},\l&nbsp;value = Cast {\l&nbsp;&nbsp;cast = T.cast,\l&nbsp;&nbsp;value = VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <self>>,\l&nbsp;&nbsp;&nbsp;type = NilClass,\l&nbsp;&nbsp;},\l&nbsp;&nbsp;type = T.class_of(<root>),\l&nbsp;},\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <statTemp>>$4,\l&nbsp;&nbsp;type = Integer(0),\l&nbsp;},\l&nbsp;value = Literal { value = Integer(0) },\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <returnMethodTemp>>$2,\l&nbsp;&nbsp;type = NilClass,\l&nbsp;},\l&nbsp;value = Send {\l&nbsp;&nbsp;recv = <self>: T.class_of(<root>),\l&nbsp;&nbsp;fun = <U puts>,\l&nbsp;&nbsp;args = (VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <statTemp>>$4,\l&nbsp;&nbsp;&nbsp;type = Integer(0),\l&nbsp;&nbsp;}),\l&nbsp;},\l}\lBinding {\l&nbsp;bind = VariableUseSite {\l&nbsp;&nbsp;variable = <U <finalReturn>>,\l&nbsp;&nbsp;type = T.noreturn,\l&nbsp;},\l&nbsp;value = Return {\l&nbsp;&nbsp;what = VariableUseSite {\l&nbsp;&nbsp;&nbsp;variable = <U <returnMethodTemp>>$2,\l&nbsp;&nbsp;&nbsp;type = NilClass,\l&nbsp;&nbsp;},\l&nbsp;},\l}\lVariableUseSite { variable = <U <unconditional>> }\l"
     ];


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a pentagon with the point on the right side. I don't know what
`cds` stands for. But it has the effect of making the default graphviz
layouting much better at conserving horizontal space.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

**Before**

<img width="1988" alt="Screenshot 2024-02-06 at 3 13 16 PM" src="https://github.com/sorbet/sorbet/assets/5544532/17859f68-f6e7-4ac4-b482-c5655de1ff3f">

**After**

<img width="1152" alt="Screenshot 2024-02-06 at 3 13 27 PM" src="https://github.com/sorbet/sorbet/assets/5544532/48ca9bfc-a77f-49a5-a143-038837d25c53">

