### PR TITLE
Accept a list of classes in dropSubtypesOf

### DIFF
--- a/compiler/IREmitter/sends.cc
+++ b/compiler/IREmitter/sends.cc
@@ -151,7 +151,7 @@ InlinedVector<ApplicableIntrinsic, NUM_INTRINSICS> applicableIntrinsics(MethodCa
 
         auto potentialClasses = symbolBasedIntrinsic->applicableClasses(mcctx.cs);
         for (auto &c : potentialClasses) {
-            InlinedVector<ClassOrModuleRef, 1> toDrop{c};
+            auto toDrop = absl::MakeSpan(&c, 1);
             auto leftType = core::Types::dropSubtypesOf(mcctx.cs, remainingType, toDrop);
 
             if (leftType == remainingType) {

--- a/compiler/IREmitter/sends.cc
+++ b/compiler/IREmitter/sends.cc
@@ -151,7 +151,8 @@ InlinedVector<ApplicableIntrinsic, NUM_INTRINSICS> applicableIntrinsics(MethodCa
 
         auto potentialClasses = symbolBasedIntrinsic->applicableClasses(mcctx.cs);
         for (auto &c : potentialClasses) {
-            auto leftType = core::Types::dropSubtypesOf(mcctx.cs, remainingType, c);
+            InlinedVector<ClassOrModuleRef, 1> toDrop{c};
+            auto leftType = core::Types::dropSubtypesOf(mcctx.cs, remainingType, toDrop);
 
             if (leftType == remainingType) {
                 continue;

--- a/core/Types.h
+++ b/core/Types.h
@@ -116,9 +116,11 @@ public:
     static TypePtr nilableProcClass();
     static TypePtr declBuilderForProcsSingletonClass();
     static TypePtr falsyTypes();
+    static absl::Span<const ClassOrModuleRef> falsySymbols();
     static TypePtr todo();
 
-    static TypePtr dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassOrModuleRef klass);
+    static TypePtr dropSubtypesOf(const GlobalState &gs, const TypePtr &from,
+                                  absl::Span<const ClassOrModuleRef> klasses);
     static TypePtr approximateSubtract(const GlobalState &gs, const TypePtr &from, const TypePtr &what);
     static bool canBeTruthy(const GlobalState &gs, const TypePtr &what);
     static bool canBeFalsy(const GlobalState &gs, const TypePtr &what);
@@ -714,7 +716,8 @@ private:
     friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<TypePtr, 4> &typeFilter);
-    friend TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassOrModuleRef klass);
+    friend TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from,
+                                         absl::Span<const ClassOrModuleRef> klasses);
     friend TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &t1);
     friend class ClassOrModule; // the actual method is `recordSealedSubclass(Mutableconst GlobalState &gs, SymbolRef
                                 // subclass)`, but referring to it introduces a cycle

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3694,7 +3694,7 @@ void digImplementation(const GlobalState &gs, const DispatchArgs &args, Dispatch
         return;
     }
 
-    auto newSelfType = Types::dropSubtypesOf(gs, dispatched.returnType, core::Symbols::NilClass());
+    auto newSelfType = Types::dropNil(gs, dispatched.returnType);
 
     if (newSelfType.isBottom()) {
         // The result was `nil` (or maybe `T.nilable(T.noreturn)` == `nil`, or maybe just plain `T.noreturn`)

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -2,6 +2,7 @@
 #include "absl/base/casts.h"
 #include "absl/strings/match.h"
 #include "common/common.h"
+#include "common/strings/formatting.h"
 #include "common/typecase.h"
 #include "core/Context.h"
 #include "core/GlobalState.h"
@@ -147,11 +148,16 @@ TypePtr Types::falsyTypes() {
     return res;
 }
 
+absl::Span<const ClassOrModuleRef> Types::falsySymbols() {
+    static InlinedVector<ClassOrModuleRef, 2> res{Symbols::NilClass(), Symbols::FalseClass()};
+    return res;
+}
+
 TypePtr Types::todo() {
     return make_type<ClassType>(Symbols::todo());
 }
 
-TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassOrModuleRef klass) {
+TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, absl::Span<const ClassOrModuleRef> klasses) {
     TypePtr result;
 
     if (from.isUntyped()) {
@@ -161,8 +167,8 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassO
     typecase(
         from,
         [&](const OrType &o) {
-            auto lhs = dropSubtypesOf(gs, o.left, klass);
-            auto rhs = dropSubtypesOf(gs, o.right, klass);
+            auto lhs = dropSubtypesOf(gs, o.left, klasses);
+            auto rhs = dropSubtypesOf(gs, o.right, klasses);
             if (lhs == o.left && rhs == o.right) {
                 result = from;
             } else if (lhs.isBottom()) {
@@ -174,8 +180,8 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassO
             }
         },
         [&](const AndType &a) {
-            auto lhs = dropSubtypesOf(gs, a.left, klass);
-            auto rhs = dropSubtypesOf(gs, a.right, klass);
+            auto lhs = dropSubtypesOf(gs, a.left, klasses);
+            auto rhs = dropSubtypesOf(gs, a.right, klasses);
             if (lhs != a.left || rhs != a.right) {
                 result = Types::all(gs, lhs, rhs);
             } else {
@@ -186,10 +192,12 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassO
             auto cdata = c.symbol.data(gs);
             if (c.symbol == core::Symbols::untyped()) {
                 result = from;
-            } else if (c.symbol == klass || c.derivesFrom(gs, klass)) {
+            } else if (absl::c_any_of(klasses,
+                                      [&](auto klass) { return c.symbol == klass || c.derivesFrom(gs, klass); })) {
                 result = Types::bottom();
-            } else if (c.symbol.data(gs)->isClass() && klass.data(gs)->isClass() &&
-                       !klass.data(gs)->derivesFrom(gs, c.symbol)) {
+            } else if (c.symbol.data(gs)->isClass() && absl::c_all_of(klasses, [&](auto klass) {
+                           return klass.data(gs)->isClass() && !klass.data(gs)->derivesFrom(gs, c.symbol);
+                       })) {
                 // We have two classes (not modules), and if the class we're
                 // removing doesn't derive from `c`, there's nothing to do,
                 // because of ruby having single inheritance.
@@ -197,17 +205,18 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassO
             } else if (cdata->flags.isSealed && (cdata->flags.isAbstract || cdata->isModule())) {
                 auto subclasses = cdata->sealedSubclassesToUnion(gs);
                 ENFORCE(!Types::equiv(gs, subclasses, from), "sealedSubclassesToUnion about to cause infinite loop");
-                result = dropSubtypesOf(gs, subclasses, klass);
+                result = dropSubtypesOf(gs, subclasses, klasses);
             } else {
                 result = from;
             }
         },
         [&](const AppliedType &a) {
             auto adata = a.klass.data(gs);
-            if (a.klass == klass || a.derivesFrom(gs, klass)) {
+            if (absl::c_any_of(klasses, [&](auto klass) { return a.klass == klass || a.derivesFrom(gs, klass); })) {
                 result = Types::bottom();
-            } else if (a.klass.data(gs)->isClass() && klass.data(gs)->isClass() &&
-                       !klass.data(gs)->derivesFrom(gs, a.klass)) {
+            } else if (a.klass.data(gs)->isClass() && absl::c_all_of(klasses, [&](auto klass) {
+                           return klass.data(gs)->isClass() && !klass.data(gs)->derivesFrom(gs, a.klass);
+                       })) {
                 // We have two classes (not modules), and if the class we're
                 // removing doesn't derive from `a`, there's nothing to do,
                 // because of ruby having single inheritance.
@@ -215,22 +224,22 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassO
             } else if (adata->flags.isSealed && (adata->flags.isAbstract || adata->isModule())) {
                 auto subclasses = adata->sealedSubclassesToUnion(gs);
                 ENFORCE(!Types::equiv(gs, subclasses, from), "sealedSubclassesToUnion about to cause infinite loop");
-                result = dropSubtypesOf(gs, subclasses, klass);
+                result = dropSubtypesOf(gs, subclasses, klasses);
                 result = Types::all(gs, from, result);
             } else {
                 result = from;
             }
         },
         [&](const TypePtr &) {
-            if (is_proxy_type(from) && dropSubtypesOf(gs, from.underlying(gs), klass).isBottom()) {
+            if (is_proxy_type(from) && dropSubtypesOf(gs, from.underlying(gs), klasses).isBottom()) {
                 result = Types::bottom();
             } else {
                 result = from;
             }
         });
     SLOW_ENFORCE(Types::isSubType(gs, result, from),
-                 "dropSubtypesOf({}, {}) returned {}, which is not a subtype of the input", from.toString(gs),
-                 klass.showFullName(gs), result.toString(gs));
+                 "dropSubtypesOf({}, [{}]) returned {}, which is not a subtype of the input", from.toString(gs),
+                 fmt::map_join(klasses, ", ", [&](auto klass) { return klass.showFullName(gs); }), result.toString(gs));
     return result;
 }
 
@@ -272,8 +281,13 @@ bool Types::canBeFalsy(const GlobalState &gs, const TypePtr &what) {
 TypePtr Types::approximateSubtract(const GlobalState &gs, const TypePtr &from, const TypePtr &what) {
     TypePtr result;
     typecase(
-        what, [&](const ClassType &c) { result = Types::dropSubtypesOf(gs, from, c.symbol); },
-        [&](const AppliedType &c) { result = Types::dropSubtypesOf(gs, from, c.klass); },
+        what,
+        [&](const ClassType &c) {
+            result = Types::dropSubtypesOf(gs, from, InlinedVector<ClassOrModuleRef, 1>{c.symbol});
+        },
+        [&](const AppliedType &c) {
+            result = Types::dropSubtypesOf(gs, from, InlinedVector<ClassOrModuleRef, 1>{c.klass});
+        },
         [&](const OrType &o) {
             result = Types::approximateSubtract(gs, Types::approximateSubtract(gs, from, o.left), o.right);
         },
@@ -333,7 +347,8 @@ TypePtr Types::tClass(const TypePtr &attachedClass) {
 }
 
 TypePtr Types::dropNil(const GlobalState &gs, const TypePtr &from) {
-    return Types::dropSubtypesOf(gs, from, Symbols::NilClass());
+    static InlinedVector<ClassOrModuleRef, 1> toDrop{core::Symbols::NilClass()};
+    return Types::dropSubtypesOf(gs, from, toDrop);
 }
 
 std::optional<int> Types::getProcArity(const AppliedType &type) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -786,8 +786,7 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
     } else {
         core::TypeAndOrigins tp = getTypeAndOrigin(ctx, cond);
         tp.origins.emplace_back(loc);
-        tp.type = core::Types::dropSubtypesOf(ctx, core::Types::dropSubtypesOf(ctx, tp.type, core::Symbols::NilClass()),
-                                              core::Symbols::FalseClass());
+        tp.type = core::Types::dropSubtypesOf(ctx, tp.type, core::Types::falsySymbols());
         if (tp.type.isBottom()) {
             isDead = true;
             return;

--- a/test/testdata/infer/no_eager_expand_sealed.rb
+++ b/test/testdata/infer/no_eager_expand_sealed.rb
@@ -1,0 +1,25 @@
+# typed: true
+extend T::Sig
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+  end
+end
+
+sig { params(enums: T::Array[MyEnum], orig: T.nilable(MyEnum)).void }
+def exmaple(enums, orig)
+  current_enum = orig
+  if current_enum.nil?
+    return
+  end
+  T.reveal_type(current_enum) # error: `MyEnum`
+
+  enums.each do |enum|
+    # If we don't short circuit in dropSubtypesOf, we might eagerly expand
+    # sealed subclasses, causing `current_enum` expand to `T.any(...)` instead
+    # of remaining as `MyEnum`, which would cause a pinning error here.
+    current_enum = enum
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Should improve performance slightly, because dropSubtypesOf is called for
every conditional branch which follows the truthy case in Sorbet, and now
that we accept a list of types, we only have to descend into large types
once, instead of twice.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.