### PR TITLE
IO#write accepts multiple objects

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -2718,11 +2718,11 @@ class IO < Object
   # ```
   sig do
     params(
-        arg0: Object,
+        args: Object,
     )
     .returns(Integer)
   end
-  def write(arg0); end
+  def write(*args); end
 
   # Opens the file, optionally seeks to the given *offset*, then returns
   # *length* bytes (defaulting to the rest of the file). binread ensures the


### PR DESCRIPTION
As per the docs in comment above, `IO#write` accepts a splat of objects.