### PR TITLE
Use different way to find LHS loc for && autocorrect

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3081,6 +3081,7 @@ public:
                                         // nodes. In these cases, we know that there are two origins and that the first
                                         // origin is the call on the LHS.
                                         auto lhsLoc = selfTyAndAnd.origins[0];
+                                        ENFORCE(lhsLoc.beginPos() < selfTyAndAnd.origins[1].beginPos());
                                         newErr.addAutocorrect(AutocorrectSuggestion{
                                             "Refactor to use `&.`",
                                             {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3075,14 +3075,17 @@ public:
                                         "&.");
 
                                     auto funLoc = core::Loc(args.locs.file, args.locs.fun);
-                                    if (funLoc.exists() && !funLoc.empty() &&
+                                    if (selfTyAndAnd.origins.size() == 2 && funLoc.exists() && !funLoc.empty() &&
                                         funLoc.adjustLen(gs, -1, 1).source(gs) == ".") {
-                                        auto andAndLoc = args.locs.args[2];
+                                        // Our checkAndAnd desugarer only fires if the LHS and RHS have matching Send
+                                        // nodes. In these cases, we know that there are two origins and that the first
+                                        // origin is the call on the LHS.
+                                        auto lhsLoc = selfTyAndAnd.origins[0];
                                         newErr.addAutocorrect(AutocorrectSuggestion{
                                             "Refactor to use `&.`",
                                             {
                                                 AutocorrectSuggestion::Edit{
-                                                    core::Loc(args.locs.file, andAndLoc.beginPos(), recvLoc.beginPos()),
+                                                    core::Loc(args.locs.file, lhsLoc.beginPos(), recvLoc.beginPos()),
                                                     "",
                                                 },
                                                 AutocorrectSuggestion::Edit{funLoc.adjustLen(gs, -1, 1), "&."},

--- a/test/cli/autocorrect_and_and/autocorrect_and_and.rb
+++ b/test/cli/autocorrect_and_and/autocorrect_and_and.rb
@@ -39,3 +39,19 @@ class A
 
   end
 end
+
+extend T::Sig
+
+class Auth
+  extend T::Sig
+  sig { returns(T::Boolean) }
+  def livemode
+    true
+  end
+end
+
+sig { returns(T.nilable(Auth))}
+def auth
+end
+
+(auth && auth.livemode)

--- a/test/cli/autocorrect_and_and/test.out
+++ b/test/cli/autocorrect_and_and/test.out
@@ -1,3 +1,28 @@
+autocorrect_and_and.rb:57: Call to method `livemode` after `&&` assumes result type doesn't change https://srb.help/7037
+    57 |(auth && auth.livemode)
+                      ^^^^^^^^
+  Got `T.nilable(Auth)` originating from:
+    autocorrect_and_and.rb:57:
+    57 |(auth && auth.livemode)
+                 ^^^^
+  Type had been narrowed to `Auth` before `&&`:
+    autocorrect_and_and.rb:57:
+    57 |(auth && auth.livemode)
+         ^^^^
+    autocorrect_and_and.rb:57:
+    57 |(auth && auth.livemode)
+             ^^^^
+  Note:
+    Sorbet never assumes that a method called twice returns the same result both times.
+    Either factor out a variable or use `&.`
+  Autocorrect: Done
+    autocorrect_and_and.rb:57: Deleted
+    57 |(auth && auth.livemode)
+        ^^^^^^^^^
+    autocorrect_and_and.rb:57: Replaced with `&.`
+    57 |(auth && auth.livemode)
+                     ^
+
 autocorrect_and_and.rb:12: Call to method `even?` after `&&` assumes result type doesn't change https://srb.help/7037
     12 |    if a.foo && a.foo.even?
                               ^^^^^
@@ -102,7 +127,7 @@ autocorrect_and_and.rb:36: Call to method `even?` after `&&` assumes result type
   Note:
     Sorbet never assumes that a method called twice returns the same result both times.
     Either factor out a variable or use `&.`
-Errors: 5
+Errors: 6
 
 --------------------------------------------------------------------------
 
@@ -145,3 +170,19 @@ class A
 
   end
 end
+
+extend T::Sig
+
+class Auth
+  extend T::Sig
+  sig { returns(T::Boolean) }
+  def livemode
+    true
+  end
+end
+
+sig { returns(T.nilable(Auth))}
+def auth
+end
+
+auth&.livemode)

--- a/test/cli/autocorrect_and_and/test.out
+++ b/test/cli/autocorrect_and_and/test.out
@@ -18,7 +18,7 @@ autocorrect_and_and.rb:57: Call to method `livemode` after `&&` assumes result t
   Autocorrect: Done
     autocorrect_and_and.rb:57: Deleted
     57 |(auth && auth.livemode)
-        ^^^^^^^^^
+         ^^^^^^^^
     autocorrect_and_and.rb:57: Replaced with `&.`
     57 |(auth && auth.livemode)
                      ^
@@ -185,4 +185,4 @@ sig { returns(T.nilable(Auth))}
 def auth
 end
 
-auth&.livemode)
+(auth&.livemode)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This broke after #7345, which we made in service of other autocorrects,
meaning that we couldn't assume `andAndLoc.beginPos()` pointed to the right
place (because it would technically include the enclosing parens).

Had we used the loc for the sake of wrapping the call to the `&&` or for
deleting the whole `&&`, we would have been able to do so. But we were
trying to find the start of the LHS operand to the `&&` by assuming that
the start of the `&&` operand is the start of the LHS inside it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.