### PR TITLE
Add patch to make WeakMap write-barrier protected, and a write barrier for WeakMap finalizer

### DIFF
--- a/third_party/ruby/gc-weakmap-finalizer-write-barrier.patch
+++ b/third_party/ruby/gc-weakmap-finalizer-write-barrier.patch
@@ -1,0 +1,22 @@
+diff --git gc.c gc.c
+index 7d884efe17..ad641886b0 100644
+--- gc.c
++++ gc.c
+@@ -12092,7 +12092,7 @@ static const rb_data_type_t weakmap_type = {
+ 	wmap_memsize,
+         wmap_compact,
+     },
+-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
++    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+ };
+ 
+ static VALUE wmap_finalize(RB_BLOCK_CALL_FUNC_ARGLIST(objid, self));
+@@ -12104,7 +12104,7 @@ wmap_allocate(VALUE klass)
+     VALUE obj = TypedData_Make_Struct(klass, struct weakmap, &weakmap_type, w);
+     w->obj2wmap = rb_init_identtable();
+     w->wmap2obj = rb_init_identtable();
+-    w->final = rb_func_lambda_new(wmap_finalize, obj, 1, 1);
++    RB_OBJ_WRITE(obj, &w->final, rb_func_lambda_new(wmap_finalize, obj, 1, 1));
+     return obj;
+ }
+ 

--- a/third_party/ruby/ruby-versions.txt
+++ b/third_party/ruby/ruby-versions.txt
@@ -1,4 +1,5 @@
 sorbet_ruby_2_7
 sorbet_ruby_3_1
+sorbet_ruby_3_1_experimental
 sorbet_ruby_3_2
 sorbet_ruby_3_3_preview

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -95,6 +95,21 @@ def register_ruby_dependencies():
             "@com_stripe_ruby_typer//third_party/ruby:gc-t-none-context.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-more-t-none-context.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-write-barrier-cme.patch",
+        ],
+    )
+
+    http_archive(
+        name = "EXPERIMENTAL_sorbet_ruby_3_1",
+        urls = _ruby_urls("3.1/ruby-3.1.4.tar.gz"),
+        sha256 = "a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6",
+        strip_prefix = "ruby-3.1.4",
+        build_file = "@com_stripe_ruby_typer//third_party/ruby:ruby.BUILD",
+        patches = [
+            "@com_stripe_ruby_typer//third_party/ruby:gc-add-need-major-by-3_1.patch",  # https://github.com/ruby/ruby/pull/6791
+            "@com_stripe_ruby_typer//third_party/ruby:thp.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:gc-t-none-context.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:gc-more-t-none-context.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:gc-write-barrier-cme.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-weakmap-finalizer-write-barrier.patch",
         ],
     )

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -95,6 +95,7 @@ def register_ruby_dependencies():
             "@com_stripe_ruby_typer//third_party/ruby:gc-t-none-context.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-more-t-none-context.patch",
             "@com_stripe_ruby_typer//third_party/ruby:gc-write-barrier-cme.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:gc-weakmap-finalizer-write-barrier.patch",
         ],
     )
 

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -99,7 +99,7 @@ def register_ruby_dependencies():
     )
 
     http_archive(
-        name = "EXPERIMENTAL_sorbet_ruby_3_1",
+        name = "sorbet_ruby_3_1_experimental",
         urls = _ruby_urls("3.1/ruby-3.1.4.tar.gz"),
         sha256 = "a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6",
         strip_prefix = "ruby-3.1.4",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
[Subset of patch in Ruby 3.3](https://github.com/ruby/ruby/commit/9bb43978759ca86ba09d9ca6cf24506621f5bcbe#diff-14642ca05e367c9201974b1641f91730c15bde48eebe09f9494f5b7ecb42b2fbR89)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
`WeakMap` defines a finalizer on every value inserted into it. When this finalizer runs, it removes the correpsonding entry from the map. However, if this finalizer does not run we may have a dangling pointer. That is, the VM may allocate the empty slot corresponding to the value to a new object. Then, on performing a WeakMap lookup , we might get some random Ruby value.

This change adds a write barrier to the finalizer defined by WeakMap, which is Ruby lambda (and hence which might get garbage collected since there's no other reference to it)

The following is a minimal repro:
```c

// foo.c

#include "ruby.h"
#include "ruby/st.h"
#include "ruby/encoding.h"
#include "ruby/thread.h"
#include "ruby/debug.h"
#include "ruby/util.h"
#include "stdio.h"

typedef struct {
} Foo;

static void foo_mark(Foo* foo) {
}

static void foo_free(Foo* foo) {
  xfree(foo);
}

static const rb_data_type_t foo_type = {
  .wrap_struct_name = "foo",
  .function =
  {
    .dfree = foo_free,
    .dmark = foo_mark,
    .dsize = NULL,
  },
  .data = NULL,
  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
};

VALUE wmp = Qnil; 
ID item_get;
ID item_set;
VALUE val = Qnil;

static VALUE foo_alloc(VALUE klass) {
  Foo* foo = ALLOC(Foo);
  rb_gc_register_address(&wmp);
  VALUE wmp_klass = rb_eval_string("ObjectSpace::WeakMap");
  wmp = rb_class_new_instance(0, NULL, wmp_klass);
  item_get = rb_intern("[]");
  item_set = rb_intern("[]=");
  val = Qnil;
  return TypedData_Wrap_Struct(klass, &foo_type, foo);
}

static VALUE foo_getit(VALUE self, VALUE x) {
  Foo* foo;
  TypedData_Get_Struct(self, Foo, &foo_type, foo);
  return rb_funcall(wmp, item_get, 1, x);
}

static VALUE foo_insert_internal(VALUE self, VALUE k) {
  Foo* foo;
  TypedData_Get_Struct(self, Foo, &foo_type, foo);
  VALUE new_string = rb_str_new_cstr("insert_internal");
  val = new_string;
  // rb_objspace;
  return rb_funcall(wmp, item_set, 2, k, new_string);
}

static VALUE foo_womp(VALUE self) {
  Foo* foo;
  TypedData_Get_Struct(self, Foo, &foo_type, foo);
  VALUE new_string = rb_str_new_cstr("WOMP");
  memcpy(val, new_string, 40);
  return INT2NUM(1);
}

void Init_foo() {
  VALUE cFoo = rb_define_class("Foo", rb_cObject);
  rb_define_alloc_func(cFoo, foo_alloc);
  rb_define_method(cFoo, "insert_internal", foo_insert_internal, 1);
  rb_define_method(cFoo, "getit", foo_getit, 1);
  rb_define_method(cFoo, "womp", foo_womp, 0);
}
```

```ruby
require_relative 'foo'

foo = Foo.new
foo.insert_internal(2)

puts "foo.getit(2) #{foo.getit(2)}"
ObjectSpace.undefine_finalizer(foo.getit(2))
GC.start

puts "foo.getit(2) #{foo.getit(2)}"

foo.womp
puts "foo #{foo.getit(2)}"
```

**output:**
```
foo.getit(2) insert_internal
foo.getit(2) 
foo WOMP
```

To run yourself, put `foo.c` and `test.rb` in a single directory, and add the following `extconf.rb`file as well
```ruby
require 'mkmf'
create_makefile('foo')
```

- Run `ruby extconf.rb`
- Run `make`
- Run `ruby test.rb`

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
