### PR TITLE
Fix untyped blame tracking

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -844,7 +844,7 @@ void readOptions(Options &opts,
                 raw["autogen-behavior-allowed-in-rbi-files-paths"].as<vector<string>>();
         }
 
-        if (opts.print.UntypedBlame.enabled && opts.trackUntyped != core::TrackUntyped::Nowhere) {
+        if (opts.print.UntypedBlame.enabled && opts.trackUntyped == core::TrackUntyped::Nowhere) {
             logger->error("-p untyped-blame:<output-path> must also include --track-untyped");
             throw EarlyReturnWithCode(1);
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


I accidentally negated this condition when I made the changes in #7569.

We don't test the untyped-blame printing in CI because it depends on a
custom build of Sorbet, and we don't build that configuration in CI.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.