### PR TITLE
Upgrade Rubocop to 1.57.1

### DIFF
--- a/gems/sorbet-runtime/.rubocop.yml
+++ b/gems/sorbet-runtime/.rubocop.yml
@@ -3,6 +3,7 @@ require: rubocop-performance
 
 AllCops:
   NewCops: disable
+  SuggestExtensions: false
 
 
 # Stripe in-house styles that are prevalent in the codebase already.
@@ -84,6 +85,11 @@ Performance/CollectionLiteralInLoop:
   Exclude:
     # Ok to prioritize brevity over perf in tests
     - 'test/**/*'
+Performance/BindCall:
+  Exclude:
+    # Only runs when `bind_call` is not built into the stdlib
+    - 'lib/types/private/methods/call_validation_2_6.rb'
+    - 'lib/types/private/methods/call_validation.rb'
 
 # We frequently care about the exact type of values, not just truthiness
 Style/DoubleNegation:
@@ -109,3 +115,29 @@ Layout/ArgumentAlignment:
     # matters more than the readability of the result
     - 'lib/types/private/methods/call_validation_2_6.rb'
     - 'lib/types/private/methods/call_validation_2_7.rb'
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+Layout/RescueEnsureAlignment:
+  Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Style/YodaCondition:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
+Style/MixinUsage:
+  Enabled: false
+Style/CommentAnnotation:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Style/ClassEqualityComparison:
+  Enabled: false
+Style/AccessorGrouping:
+  Enabled: false
+Style/BisectedAttrAccessor:
+  Exclude:
+    - 'lib/types/private/methods/signature.rb'

--- a/gems/sorbet-runtime/Rakefile
+++ b/gems/sorbet-runtime/Rakefile
@@ -25,9 +25,13 @@ task :test_vm_serde do
   require_tests
 end
 
-require 'rubocop/rake_task'
-RuboCop::RakeTask.new(:rubocop) do |t|
-  t.requires << 'rubocop-performance'
+task :rubocop do
+  # For some reason, using RuboCop::RakeTask causes our test suite to run a
+  # bazillion times. I'm guessing that something about RuboCop::RakeTask is
+  # causing a file to be required that shouldn't be getting required? I have
+  # lost patience trying to debug it and am simply going to use a Suprocess.
+  require 'subprocess'
+  Subprocess.check_call(['rubocop'])
 end
 
 begin

--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -198,8 +198,10 @@ module SorbetBenchmarks
 
       class_method = Object.instance_method(:class)
       time_block(".bind(example).call Object#class") do
+        # rubocop:disable Performance/BindCall
         class_method.bind(example).call
         class_method.bind(example).call
+        # rubocop:enable Performance/BindCall
       end
 
       if T::Configuration::AT_LEAST_RUBY_2_7

--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -38,7 +38,7 @@ if defined? ::RSpec::Mocks
 
         module MethodDoubleExtensions
           def initialize(object, method_name, proxy)
-            if ::Kernel.instance_method(:respond_to?).bind(object).call(method_name, true)
+            if ::Kernel.instance_method(:respond_to?).bind(object).call(method_name, true) # rubocop:disable Performance/BindCall
               method = ::RSpec::Support.method_handle_for(object, method_name)
               T::Private::Methods.maybe_run_sig_block_for_method(method)
             end

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -451,7 +451,7 @@ module T::Configuration
   @default_module_name_mangler = if T::Configuration::AT_LEAST_RUBY_2_7
     ->(type) {MODULE_NAME.bind_call(type)}
   else
-    ->(type) {MODULE_NAME.bind(type).call}
+    ->(type) {MODULE_NAME.bind(type).call} # rubocop:disable Performance/BindCall
   end
 
   @module_name_mangler = nil

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -273,7 +273,7 @@ module T::Private::Methods
         elsif T::Configuration::AT_LEAST_RUBY_2_7
           original_method.bind_call(self, *args, &blk)
         else
-          original_method.bind(self).call(*args, &blk)
+          original_method.bind(self).call(*args, &blk) # rubocop:disable Performance/BindCall
         end
       end
     end
@@ -514,7 +514,7 @@ module T::Private::Methods
         if T::Configuration::AT_LEAST_RUBY_2_7
           old_included.bind_call(self, arg)
         else
-          old_included.bind(self).call(arg)
+          old_included.bind(self).call(arg) # rubocop:disable Performance/BindCall
         end
         ::T::Private::Methods._hook_impl(arg, false, self)
       end
@@ -522,7 +522,7 @@ module T::Private::Methods
         if T::Configuration::AT_LEAST_RUBY_2_7
           old_extended.bind_call(self, arg)
         else
-          old_extended.bind(self).call(arg)
+          old_extended.bind(self).call(arg) # rubocop:disable Performance/BindCall
         end
         ::T::Private::Methods._hook_impl(arg, true, self)
       end
@@ -530,7 +530,7 @@ module T::Private::Methods
         if T::Configuration::AT_LEAST_RUBY_2_7
           old_inherited.bind_call(self, arg)
         else
-          old_inherited.bind(self).call(arg)
+          old_inherited.bind(self).call(arg) # rubocop:disable Performance/BindCall
         end
         ::T::Private::Methods._hook_impl(arg, false, self)
       end

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -73,8 +73,7 @@ class T::Private::Methods::Signature
       param_names = parameters.map {|_, name| name}
       missing_names = param_names - raw_arg_types.keys
       raise "The declaration for `#{method.name}` is missing parameter(s): #{missing_names.join(', ')}"
-    elsif parameters.length == raw_arg_types.size
-    else
+    elsif parameters.length != raw_arg_types.size
       param_names = parameters.map {|_, name| name}
       has_extra_names = parameters.count {|_, name| raw_arg_types.key?(name)} < raw_arg_types.size
       if has_extra_names

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -59,10 +59,9 @@ module T::Private::Methods::SignatureValidation
     # `{ new(): AbstractClass }`. We may want to consider building some
     # analogue to `T.class_of` in the future that works like this `{new():
     # ...}` type.
-    if signature.method_name == :initialize && signature.method.owner.is_a?(Class)
-      if signature.mode == Modes.standard
-        return
-      end
+    if signature.method_name == :initialize && signature.method.owner.is_a?(Class) &&
+        signature.mode == Modes.standard
+      return
     end
 
     super_method = signature.method.super_method

--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -117,7 +117,9 @@ module T::Props
       def eagerly_define_lazy_methods!
         return if lazily_defined_methods.empty?
 
+        # rubocop:disable Style/StringConcatenation
         source = "# frozen_string_literal: true\n" + lazily_defined_methods.values.map(&:call).map(&:to_s).join("\n\n")
+        # rubocop:enable Style/StringConcatenation
 
         cls = decorated_class
         cls.class_eval(source)

--- a/gems/sorbet-runtime/lib/types/types/proc.rb
+++ b/gems/sorbet-runtime/lib/types/types/proc.rb
@@ -14,9 +14,9 @@ module T::Types
     end
 
     def arg_types
-      @arg_types ||= @inner_arg_types.map do |key, raw_type|
-        [key, T::Utils.coerce(raw_type)]
-      end.to_h
+      @arg_types ||= @inner_arg_types.transform_values do |raw_type|
+        T::Utils.coerce(raw_type)
+      end
     end
 
     def returns

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -23,7 +23,12 @@ module T::Types
       #
       # `name` isn't normally a hot path for types, but it is used in initializing a T::Types::Union,
       # and so in `T.nilable`, and so in runtime constructions like `x = T.let(nil, T.nilable(Integer))`.
+      #
+      # Care more about back compat than we do about performance here.
+      # Once 2.6 is well in the rear view mirror, we can replace this.
+      # rubocop:disable Performance/BindCall
       @name ||= (NAME_METHOD.bind(@raw_type).call || @raw_type.name).freeze
+      # rubocop:enable Performance/BindCall
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -172,7 +172,7 @@ module T::Types
         if T::Configuration::AT_LEAST_RUBY_2_7
           Object.instance_method(:class).bind_call(obj)
         else
-          Object.instance_method(:class).bind(obj).call
+          Object.instance_method(:class).bind(obj).call # rubocop:disable Performance/BindCall
         end
       end
     end

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -4,6 +4,7 @@
 module T::Utils
   module Private
     def self.coerce_and_check_module_types(val, check_val, check_module_type)
+      # rubocop:disable Style/CaseLikeIf
       if val.is_a?(T::Types::Base)
         if val.is_a?(T::Private::Types::TypeAlias)
           val.aliased_type
@@ -31,6 +32,7 @@ module T::Utils
         raise "Invalid value for type constraint. Must be an #{T::Types::Base}, a " \
               "class/module, or an array. Got a `#{val.class}`."
       end
+      # rubocop:enable Style/CaseLikeIf
     end
   end
 
@@ -173,7 +175,7 @@ module T::Utils
     def self.get_type_info(prop_type)
       if prop_type.is_a?(T::Types::Union)
         non_nilable_type = prop_type.unwrap_nilable
-        if non_nilable_type&.is_a?(T::Types::Simple)
+        if non_nilable_type.is_a?(T::Types::Simple)
           non_nilable_type = non_nilable_type.raw_type
         end
         TypeInfo.new(true, non_nilable_type)
@@ -188,7 +190,7 @@ module T::Utils
     def self.get_underlying_type(prop_type)
       if prop_type.is_a?(T::Types::Union)
         non_nilable_type = prop_type.unwrap_nilable
-        if non_nilable_type&.is_a?(T::Types::Simple)
+        if non_nilable_type.is_a?(T::Types::Simple)
           non_nilable_type = non_nilable_type.raw_type
         end
         non_nilable_type || prop_type

--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'concurrent-ruby', '~> 1.1.5'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-byebug'
-  # for validating generated code
-  s.add_development_dependency 'parser', '~> 2.7.1'
   # for running ruby subprocesses
   s.add_development_dependency 'subprocess', '~> 1.5.3'
 end

--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 2.1'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rubocop', '~> 0.90.0'
-  s.add_development_dependency 'rubocop-performance', '~> 1.8.0'
+  s.add_development_dependency 'rubocop', '1.57.1'
+  s.add_development_dependency 'rubocop-performance', '1.13.2'
   # for reproducing race conditions in tests
   s.add_development_dependency 'concurrent-ruby', '~> 1.1.5'
   s.add_development_dependency 'pry'

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -881,7 +881,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
       mutex = Mutex.new
       replaced = T::Private::ClassUtils.replace_method(T::Private::Methods.singleton_class, :run_sig_block_for_method) do |*args|
         barrier.wait
-        mutex.synchronize {replaced.bind(T::Private::Methods).call(*args)}
+        mutex.synchronize {replaced.bind_call(T::Private::Methods, *args)}
       end
 
       klass = Class.new do

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -383,7 +383,9 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
 
     it 'raises an assertion if to_str is called (implicitly) and also returns the serialized value' do
       ex = assert_raises(NoMethodError) do
-        'foo ' + CardSuit::HEART
+        # rubocop:disable Style/StringConcatenation
+        "foo " + CardSuit::HEART
+        # rubocop:enable Style/StringConcatenation
       end
       assert_match(ENUM_CONVERSION_MSG, ex.message)
     end
@@ -407,13 +409,13 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     end
 
     it 'raises an assertion if to_str is called (implicitly) and also returns the serialized value' do
+      # rubocop:disable Style/StringConcatenation
       assert_equal('foo heart', 'foo ' + CardSuit::HEART)
+      # rubocop:enable Style/StringConcatenation
     end
   end
 
   describe 'string value comparison assertions' do
-    # rubocop:disable Style/YodaCondition
-
     it 'returns false if the types mismatch for ==' do
       assert_equal(false, 'spade' == CardSuit::SPADE)
       assert_equal(false, 'diamond' == CardSuit::SPADE)
@@ -427,8 +429,6 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
       assert_equal(false, CardSuit::SPADE === 'spade')
       assert_equal(false, CardSuit::CLUB === 'spade')
     end
-
-    # rubocop:enable Style/YodaCondition
 
     it 'returns false for a string in a `when` compared to an enum value' do
       val = CardSuit::SPADE
@@ -465,8 +465,6 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
       T::Configuration.disable_legacy_t_enum_migration_mode
     end
 
-    # rubocop:disable Style/YodaCondition
-
     it 'raises an assertion if string is lhs of comparison' do
       assert_equal(true, 'spade' == CardSuit::SPADE)
 
@@ -490,8 +488,6 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
 
       assert_equal(false, CardSuit::CLUB === 'spade')
     end
-
-    # rubocop:enable Style/YodaCondition
 
     it 'raises an assertion for a string in a `when` compared to an enum value' do
       val = CardSuit::SPADE

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -120,7 +120,7 @@ module Opus::Types::Test
           mod = Module.new do
             extend T::Sig
             sig {params(a: Integer, b: Integer).returns(Integer)}
-            def self.foo(a: 1, b:)
+            def self.foo(a: 1, b:) # rubocop:disable Style/KeywordParametersOrder
               a + b
             end
           end
@@ -318,7 +318,7 @@ module Opus::Types::Test
       it "accepts T.proc" do
         @mod.sig {params(blk: T.proc.params(i: Integer).returns(Integer)).returns(Integer)}
         def @mod.foo(&blk)
-          blk.call(4)
+          yield 4
         end
 
         @mod.foo {|i| i**2}

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 require_relative '../../test_helper'
 
-require 'parser/current'
-
 class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
   def assert_prop_error(match, &blk)
     ex = assert_raises(ArgumentError) do

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1134,11 +1134,13 @@ module Opus::Types::Test
       end
 
       it 'delegates equality' do
+        # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
         assert(T.any(Integer, String) == T.type_alias {T.any(Integer, String)})
         assert(T.type_alias {T.any(Integer, String)} == T.any(Integer, String))
         assert(T.type_alias {T.any(Integer, String)} == T.type_alias {T.any(Integer, String)})
 
         refute(T.type_alias {T.any(Integer, Float)} == T.type_alias {T.any(Integer, String)})
+        # rubocop:enable Lint/BinaryOperatorWithIdenticalOperands
       end
 
       it 'passes a validation' do

--- a/gems/sorbet-runtime/test/types/validate_override_shape.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_shape.rb
@@ -219,7 +219,7 @@ module Opus::Types::Test
       klass = Class.new(AbstractBase) do
         extend T::Sig
         sig {override.void}
-        def initialize; end
+        def initialize; super; end
 
         def foo
           0
@@ -236,7 +236,7 @@ module Opus::Types::Test
           .params(x: Integer)
           .void
         end
-        def initialize(x); end
+        def initialize(x); super; end
       end
       err = assert_raises(RuntimeError) do
         klass.new(0)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This unblocks testing sorbet-runtime on Ruby 3.3.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested that introducing a RuboCop failure still makes the `rake` command exit
with a failure.

### For posterity

If you ever want to try to reproduce the issue I was seeing with
RuboCop::RakeTask, you can try reverting the changes to the Rakefile in this PR
and then running

```
bundle install
bundle exec rake
```

The behavior I was seeing was this:

<details>
<summary>
Click to expand rake output
</summary>

```
❯ bex rake
/Users/jez/stripe/sorbet/gems/sorbet-runtime/test/types/method_validation.rb:573: warning: key :_ is duplicated and overwritten on line 573
Running RuboCop...
Run options: --seed 18573

# Running:

Run options: --seed 38551

# Running:

Run options: --seed 34258

# Running:

Run options: --seed 2818

# Running:

Run options: --seed 19900

# Running:

Run options: --seed 25615

# Running:

Run options: --seed 21120

# Running:

Run options: --seed 31207

# Running:

.Run options: --seed 8684

# Running:

...........................................................................................................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
..............Run options: --seed 56795

# Running:

.........................................................................................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
.....................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
..........................................................................................................................................................................................................................................................................................................................S................................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
.....................................................................................................................................................................................................................S.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................S.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
.................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
.........................................................................................................................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
.....................................................................................................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
....................................................................................................................................................................................................................................warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................S......................................................................................................................................................................................................................................................................................................................................................................................S.........................................................................................................................................................................................................................................................................................................................................................................................................S................................................................................................................................................................................................................................................................................................................................S............................
....
Finished in 0.666688s, 1340.9571 runs/s, 4253.8639 assertions/s.

..894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
...............................................................................S............................................................................................................................................................................................................................................................................................................................................................................................................................................................................

..Finished in 0.686921s, 1301.4597 runs/s, 4128.5679 assertions/s.
..
.894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
..................................................................................................................................................................................................S.............................................................

.Finished in 0.695320s, 1285.7389 runs/s, 4078.6976 assertions/s.
..
894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
............

Finished in 0.691012s, 1293.7547 runs/s, 4104.1255 assertions/s.

894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
...............................................................................................

Finished in 0.700632s, 1275.9908 runs/s, 4047.7740 assertions/s.

.894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
....................................................................................................................................................................................................................................................................................

Finished in 0.713513s, 1252.9554 runs/s, 3974.6998 assertions/s.

894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
...................................................................................................................................................

Finished in 0.720598s, 1240.6362 runs/s, 3935.6201 assertions/s.

894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
...................................................

Finished in 0.723012s, 1236.4940 runs/s, 3922.4798 assertions/s.

894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
....

Finished in 0.723053s, 1236.4239 runs/s, 3922.2574 assertions/s.

894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
.................................................................................................................................................................................................S...................................

Finished in 0.746098s, 1198.2340 runs/s, 3801.1092 assertions/s.

894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
Inspecting 161 files
.................................................................................................................................................................

161 files inspected, no offenses detected
Run options: --seed 30442

# Running:

..................................................................................................................................................................................................................................................................................................S...warning: parser/current is loading parser/ruby27, which recognizes 2.7.8-compliant syntax, but you are running 2.7.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 0.404301s, 2211.2238 runs/s, 7014.5758 assertions/s.

894 runs, 2836 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
```
</details>

As you can see, it seems like the tests were getting run about 11 times instead
of just once. I don't know what caused that, but it seems to have gone away when
we use the `rubocop` executable instead of the `RakeTask` abstraction.