### PR TITLE
Fix signature for `String#slice`.

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -290,7 +290,7 @@ class String < Object
   sig do
     params(
         arg0: Regexp,
-        arg1: String,
+        arg1: T.any(String, Symbol),
     )
     .returns(T.nilable(String))
   end
@@ -2037,7 +2037,7 @@ class String < Object
   sig do
     params(
         arg0: Regexp,
-        arg1: String,
+        arg1: T.any(String, Symbol),
     )
     .returns(T.nilable(String))
   end

--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -2945,7 +2945,7 @@ class String < Object
   sig do
     params(
         arg0: Regexp,
-        arg1: String,
+        arg1: T.any(String, Symbol),
     )
     .returns(T.nilable(String))
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When using named capture groups, using a `Symbol` also works.


https://ruby-doc.org/3.2.2/String.html#class-String-label-String+Slices


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A