### PR TITLE
Add example showing load_iseq interaction

### DIFF
--- a/gems/sorbet-runtime/entry.rb
+++ b/gems/sorbet-runtime/entry.rb
@@ -1,0 +1,20 @@
+require_relative './lib/sorbet-runtime'
+
+def (::RubyVM::InstructionSequence).load_iseq(path)
+  return nil unless ENV["PATCH_LOAD_ISEQ"]
+  return nil if path.end_with?('_transformed.rb')
+  return nil unless path.end_with?('_untransformed.rb')
+
+  transformed_src = File.read(path).gsub(/LAZY_CONSTANT = .*$/, "autoload :LAZY_CONSTANT, '#{path.gsub(/_untransformed\.rb$/, "_transformed.rb")}'")
+  puts("-- transformed_src for path=#{path} --", transformed_src, "-----")
+  return nil if transformed_src.nil?
+  RubyVM::InstructionSequence.compile(transformed_src, path)
+end
+
+puts '-- before require --'
+require_relative './example_untransformed.rb'
+
+puts("LAZY_CONSTANT=#{Example::LAZY_CONSTANT}")
+
+puts '-- before Example.main --'
+Example.main

--- a/gems/sorbet-runtime/example_transformed.rb
+++ b/gems/sorbet-runtime/example_transformed.rb
@@ -1,0 +1,3 @@
+module Example
+  LAZY_CONSTANT = begin puts '-- forcing LAZY_CONSTANT! --'; 0 end
+end

--- a/gems/sorbet-runtime/example_untransformed.rb
+++ b/gems/sorbet-runtime/example_untransformed.rb
@@ -1,0 +1,7 @@
+module Example
+  LAZY_CONSTANT = begin puts '-- forcing LAZY_CONSTANT! --'; 0 end
+
+  def self.main
+    T.must(nil)
+  end
+end

--- a/gems/sorbet-runtime/run.sh
+++ b/gems/sorbet-runtime/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+bundle exec ruby entry.rb
+echo $'\n\n^unpatched ---------- patched:\n\n'
+PATCH_LOAD_ISEQ=1 bundle exec ruby entry.rb


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

```
❯ ./run.sh
-- before require --
-- forcing LAZY_CONSTANT! --
LAZY_CONSTANT=0
-- before Example.main --
/Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/_types.rb:222:in `must': Passed `nil` into T.must (T::MustTypeError)

    T.must(nil)
           ^^^
        from /Users/jez/stripe/sorbet/gems/sorbet-runtime/example_untransformed.rb:5:in `main'
        from entry.rb:20:in `<main>'


^unpatched ---------- patched:


-- before require --
-- transformed_src for path=/Users/jez/stripe/sorbet/gems/sorbet-runtime/example_untransformed.rb --
module Example
  autoload :LAZY_CONSTANT, '/Users/jez/stripe/sorbet/gems/sorbet-runtime/example_transformed.rb'

  def self.main
    T.must(nil)
  end
end
-----
-- forcing LAZY_CONSTANT! --
LAZY_CONSTANT=0
-- before Example.main --
/Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/_types.rb:222:in `must': Passed `nil` into T.must (T::MustTypeError)

    T.must(nil)
    ^
        from /Users/jez/stripe/sorbet/gems/sorbet-runtime/example_untransformed.rb:5:in `main'
        from entry.rb:20:in `<main>'
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.