### PR TITLE
Don't suggest `Kernel` methods which are "private"

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -811,10 +811,15 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     auto alternatives = symbol.data(gs)->findMemberFuzzyMatch(gs, targetName);
                     for (auto alternative : alternatives) {
                         auto possibleSymbol = alternative.symbol;
-                        if (!possibleSymbol.isClassOrModule() &&
-                            (!possibleSymbol.isMethod() ||
-                             (possibleSymbol.asMethodRef().data(gs)->flags.isPrivate && !args.isPrivateOk))) {
+                        if (!possibleSymbol.isClassOrModule() && !possibleSymbol.isMethod()) {
                             continue;
+                        }
+
+                        if (possibleSymbol.isMethod()) {
+                            auto possibleMethod = possibleSymbol.asMethodRef().data(gs);
+                            if (possibleMethod->flags.isPrivate && !args.isPrivateOk) {
+                                continue;
+                            }
                         }
 
                         if (isSetter && possibleSymbol.name(gs).lookupWithEq(gs) == args.name) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -817,7 +817,11 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
 
                         if (possibleSymbol.isMethod()) {
                             auto possibleMethod = possibleSymbol.asMethodRef().data(gs);
-                            if (possibleMethod->flags.isPrivate && !args.isPrivateOk) {
+                            if ((possibleMethod->flags.isPrivate || possibleMethod->owner == Symbols::Kernel()) &&
+                                !args.isPrivateOk) {
+                                // Special-case Kernel methods, which should be treated as private, but aren't due to
+                                // this bug: https://github.com/sorbet/sorbet/issues/4434
+                                // (If we fix that bug, we can delete the `Kernel` reference above.)
                                 continue;
                             }
                         }

--- a/test/cli/autocorrect/test.out
+++ b/test/cli/autocorrect/test.out
@@ -93,9 +93,6 @@ autocorrect.rb:12: Setter method `bar=` does not exist on `String` component of 
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Did you mean: `Kernel#warn`
-      NN |  def warn(*msg); end
-            ^^^^^^^^^^^^^^
 
 autocorrect.rb:12: Setter method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     12 |foo.bar ||= "a"
@@ -136,9 +133,6 @@ autocorrect.rb:13: Setter method `bar=` does not exist on `String` component of 
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Did you mean: `Kernel#warn`
-      NN |  def warn(*msg); end
-            ^^^^^^^^^^^^^^
 
 autocorrect.rb:13: Setter method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     13 |foo.bar &&= "a"
@@ -179,9 +173,6 @@ autocorrect.rb:14: Setter method `bar=` does not exist on `String` component of 
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Did you mean: `Kernel#warn`
-      NN |  def warn(*msg); end
-            ^^^^^^^^^^^^^^
 
 autocorrect.rb:14: Setter method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     14 |foo.bar |= "a"
@@ -222,9 +213,6 @@ autocorrect.rb:15: Setter method `bar=` does not exist on `String` component of 
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Did you mean: `Kernel#warn`
-      NN |  def warn(*msg); end
-            ^^^^^^^^^^^^^^
 
 autocorrect.rb:15: Setter method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     15 |foo.bar &= "a"

--- a/test/cli/struct_fuzz/test.out
+++ b/test/cli/struct_fuzz/test.out
@@ -37,7 +37,6 @@ test/cli/struct_fuzz/struct_fuzz.rb:2: Method `raise` does not exist on `T.class
     test/cli/struct_fuzz/struct_fuzz.rb:2:
      2 |::B=Struct.new:x
         ^^^^^^^^^^^^^^^^
-    ???: Did you mean: `Kernel#raise`
 
 test/cli/struct_fuzz/struct_fuzz.rb:2: Method `raise` does not exist on `T.class_of(Kernel)` https://srb.help/7003
      2 |::B=Struct.new:x
@@ -46,7 +45,6 @@ test/cli/struct_fuzz/struct_fuzz.rb:2: Method `raise` does not exist on `T.class
     test/cli/struct_fuzz/struct_fuzz.rb:2:
      2 |::B=Struct.new:x
         ^^^^^^^^^^^^^^^^
-    ???: Did you mean: `Kernel#raise`
 
 test/cli/struct_fuzz/struct_fuzz.rb:2: Method `raise` does not exist on `T.class_of(Kernel)` https://srb.help/7003
      2 |::B=Struct.new:x
@@ -55,7 +53,6 @@ test/cli/struct_fuzz/struct_fuzz.rb:2: Method `raise` does not exist on `T.class
     test/cli/struct_fuzz/struct_fuzz.rb:2: Possibly uninitialized (`NilClass`) in:
      2 |::B=Struct.new:x
         ^^^^^^^^^^^^^^^^
-    ???: Did you mean: `Kernel#raise`
 
 test/cli/struct_fuzz/struct_fuzz.rb:2: Method `returns` does not exist on `T.class_of(B)` https://srb.help/7003
      2 |::B=Struct.new:x


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Due to <https://github.com/sorbet/sorbet/issues/4434>, Sorbet does not see
certain `Kernel` methods as `private`. Since most `Kernel` methods have
short names, and because `Kernel` is included in ~every class, these "did
you mean" suggestions come up a lot when they're unwanted.

Until we fix the underlying issue, this is a simple enough bandaid for the
problem.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.