### PR TITLE
Use `Concurrent::Hash`, if available, for sig related storage

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -3,8 +3,13 @@
 
 module T::Private::Methods
   @installed_hooks = {}
-  @signatures_by_method = {}
-  @sig_wrappers = {}
+  if defined?(Concurrent::Hash)
+    @signatures_by_method = Concurrent::Hash.new
+    @sig_wrappers = Concurrent::Hash.new
+  else
+    @signatures_by_method = {}
+    @sig_wrappers = {}
+  end
   @sigs_that_raised = {}
   # stores method names that were declared final without regard for where.
   # enables early rejection of names that we know can't induce final method violations.

--- a/gems/sorbet-runtime/test/concurrent-ruby-shims.rbi
+++ b/gems/sorbet-runtime/test/concurrent-ruby-shims.rbi
@@ -1,0 +1,7 @@
+# typed: __STDLIB_INTERNAL
+
+class Concurrent::Hash < Hash
+  K = type_member(:out)
+  V = type_member(:out)
+  Elem = type_member(:out)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This PR makes access to `@sig_wrappers` and `@signatures_by_method` ivars of `T::Private::Methods` class less racy for alternative Ruby implementations by making them be `Concurrent::Hash` instances if `Concurrent::Hash` is defined.

Even if they have the constant defined for an unrelated reason, this should ensure that common users of the library who run on CRuby have no performance penalty for using `Concurrent::Hash`, since the [implementation of that class on CRuby is exactly the built-in `Hash` class](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent-ruby/concurrent/hash.rb#L16-L24).

/cc @nirvdrum @rwstauner 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Unlike the case on CRuby, alternative Ruby implementations like JRuby/TruffleRuby do not have a GVL, which makes access to shared data structure inherently racy. In most cases, these races are not visible, but concurrent access to `@sig_wrappers` has already been problematic in Sorbet runtime on CRuby [before](https://github.com/sorbet/sorbet/pull/1397). Depending on access patterns and/or implementation of the underlying `Hash` implementation, errors can exhibit themselves in strange ways, especially on alternative Ruby implementations.

We've recently been seeing hash related crashes while accessing `@sig_wrappers.delete(key)` inside `T::Private::Methods.run_sig_block_for_key` when running one of our applications on TruffleRuby with the [new `CompactHashStore` Hash implementation](https://github.com/oracle/truffleruby/pull/3172).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
