### PR TITLE
Remove an extra for in an error message

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2575,7 +2575,7 @@ private:
         ENFORCE(!methodArgs.empty());
         const auto &bspec = methodArgs.back();
         ENFORCE(bspec.flags.isBlock);
-        auto for_ = ErrorColors::format("for block argument `{}` of method `{}`", bspec.argumentName(gs),
+        auto for_ = ErrorColors::format("block argument `{}` of method `{}`", bspec.argumentName(gs),
                                         dispatchComp.method.show(gs));
         e.addErrorSection(TypeAndOrigins::explainExpected(gs, blockType, bspec.loc, for_));
     }

--- a/test/cli/expected-got/test.out
+++ b/test/cli/expected-got/test.out
@@ -40,7 +40,7 @@ test/cli/expected-got/expected-got.rb:27: Expected `Integer` but found `T.any(In
 test/cli/expected-got/expected-got.rb:42: Expected `T.proc.returns(Integer)` but found `T.proc.returns(String)` for block argument https://srb.help/7002
     42 |  takes_int_block(&blk)
           ^^^^^^^^^^^^^^^^^^^^^
-  Expected `T.proc.returns(Integer)` for for block argument `blk` of method `Object#takes_int_block`:
+  Expected `T.proc.returns(Integer)` for block argument `blk` of method `Object#takes_int_block`:
     test/cli/expected-got/expected-got.rb:32:
     32 |sig {params(blk: T.proc.returns(Integer)).void}
                     ^^^


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`explainExpected` already add a "for"

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Grammar.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
