### PR TITLE
Replace `--secondary-test-package-namespace` with "test-only packages"

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2373,18 +2373,13 @@ const packages::PackageDB &GlobalState::packageDB() const {
     return packageDB_;
 }
 
-void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
-                                     const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
+void GlobalState::setPackagerOptions(const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                                      const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
                                      const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
                                      const std::vector<std::string> &allowRelaxedPackagerChecksFor,
                                      std::string errorHint) {
     ENFORCE(packageDB_.secondaryTestPackageNamespaceRefs_.size() == 0);
     ENFORCE(!packageDB_.frozen);
-
-    for (const string &ns : secondaryTestPackageNamespaces) {
-        packageDB_.secondaryTestPackageNamespaceRefs_.emplace_back(enterNameConstant(ns));
-    }
 
     packageDB_.extraPackageFilesDirectoryUnderscorePrefixes_ = extraPackageFilesDirectoryUnderscorePrefixes;
     packageDB_.extraPackageFilesDirectorySlashPrefixes_ = extraPackageFilesDirectorySlashPrefixes;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -162,8 +162,7 @@ public:
     FileRef findFileByPath(std::string_view path) const;
 
     const packages::PackageDB &packageDB() const;
-    void setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
-                            const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
+    void setPackagerOptions(const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                             const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
                             const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
                             const std::vector<std::string> &skipImportVisibilityCheckFor, std::string errorHint);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -969,22 +969,6 @@ void readOptions(Options &opts,
             }
         }
 
-        if (raw.count("secondary-test-package-namespaces")) {
-            if (!opts.stripePackages) {
-                logger->error("--secondary-test-package-namespaces can only be specified in --stripe-packages mode");
-                throw EarlyReturnWithCode(1);
-            }
-            std::regex nsValid("[A-Z][a-zA-Z0-9]+");
-            for (const string &ns : raw["secondary-test-package-namespaces"].as<vector<string>>()) {
-                if (!std::regex_match(ns, nsValid)) {
-                    logger->error("--secondary-test-package-namespaces must contain items that start with a capital "
-                                  "letter and are alphanumeric.");
-                    throw EarlyReturnWithCode(1);
-                }
-                opts.secondaryTestPackageNamespaces.emplace_back(ns);
-            }
-        }
-
         if (raw.count("allow-relaxed-packager-checks-for")) {
             if (!opts.stripePackages) {
                 logger->error("--allow-relaxed-packager-checks-for can only be specified in --stripe-packages mode");

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -164,7 +164,6 @@ struct Options {
     std::string stripePackagesHint = "";
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes;
-    std::vector<std::string> secondaryTestPackageNamespaces;
     std::vector<std::string> allowRelaxedPackagerChecksFor;
     std::string typedSource = "";
     std::string cacheDir = "";

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -742,7 +742,7 @@ void setPackagerOptions(core::GlobalState &gs, const options::Options &opts) {
     {
         core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
-        gs.setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes,
+        gs.setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,
                               opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
                               opts.allowRelaxedPackagerChecksFor, opts.stripePackagesHint);
     }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -658,10 +658,10 @@ int realmain(int argc, char *argv[]) {
             {
                 core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
                 core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-                gs->setPackagerOptions(
-                    opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes,
-                    opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
-                    opts.allowRelaxedPackagerChecksFor, opts.stripePackagesHint);
+                gs->setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                                       opts.extraPackageFilesDirectorySlashPrefixes,
+                                       opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor,
+                                       opts.stripePackagesHint);
             }
 
             packager::Packager::findPackages(*gs, absl::Span<ast::ParsedFile>(packages));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -31,13 +31,8 @@ bool isPrimaryTestNamespace(const core::NameRef ns) {
     return ns == core::packages::PackageDB::TEST_NAMESPACE;
 }
 
-bool isSecondaryTestNamespace(const core::GlobalState &gs, const core::NameRef ns) {
-    const vector<core::NameRef> &secondaryTestPackageNamespaceRefs = gs.packageDB().secondaryTestPackageNamespaceRefs();
-    return absl::c_find(secondaryTestPackageNamespaceRefs, ns) != secondaryTestPackageNamespaceRefs.end();
-}
-
 bool isTestNamespace(const core::GlobalState &gs, const core::NameRef ns) {
-    return isPrimaryTestNamespace(ns) || isSecondaryTestNamespace(gs, ns);
+    return isPrimaryTestNamespace(ns);
 }
 
 struct FullyQualifiedName {
@@ -879,8 +874,7 @@ private:
         }
 
         if (prevDepth == 0 && isTestFile && namespaces.depth() > 0) {
-            useTestNamespace = isPrimaryTestNamespace(tmpNameParts.back().first) ||
-                               !isSecondaryTestNamespace(ctx, pkg.name.fullName.parts[0]);
+            useTestNamespace = isPrimaryTestNamespace(tmpNameParts.back().first);
         }
 
         tmpNameParts.clear();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -704,7 +704,16 @@ public:
 // prefix.
 class EnforcePackagePrefix final {
     const PackageInfoImpl &pkg;
+
+    // Whether code in this file must use the `Test::` namespace.
+    //
+    // Obviously tests *can* use the `Test::` namespace, but tests in test-only packages don't have to.
+    //
+    // (This is a wart of the original implementation, not an intentional design choice. It would
+    // probably be good in the future to require that runnable tests live in the `Test::` namespace
+    // for the package.)
     const bool mustUseTestNamespace;
+
     PackageNamespaces namespaces;
     // Counter to avoid duplicate errors:
     // - Only emit errors when depth is 0

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -876,7 +876,7 @@ private:
         }
 
         if (prevDepth == 0 && mustUseTestNamespace && namespaces.depth() > 0) {
-            useTestNamespace = isPrimaryTestNamespace(tmpNameParts.back().first);
+            useTestNamespace = true;
         }
 
         tmpNameParts.clear();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -27,12 +27,8 @@ namespace {
 
 constexpr string_view PACKAGE_FILE_NAME = "__package.rb"sv;
 
-bool isPrimaryTestNamespace(const core::NameRef ns) {
+bool isTestNamespace(const core::NameRef ns) {
     return ns == core::packages::PackageDB::TEST_NAMESPACE;
-}
-
-bool isTestNamespace(const core::GlobalState &gs, const core::NameRef ns) {
-    return isPrimaryTestNamespace(ns);
 }
 
 struct FullyQualifiedName {
@@ -593,11 +589,11 @@ public:
         bool boundsEmpty = bounds.empty();
 
         if (isTestFile && boundsEmpty && !foundTestNS.exists()) {
-            if (isPrimaryTestNamespace(name)) {
+            if (isTestNamespace(name)) {
                 foundTestNS = name;
                 foundTestNSLoc = loc;
                 return;
-            } else if (!isTestNamespace(ctx, name) && !filePkg.loc.file().data(ctx).isPackagedTest()) {
+            } else if (!filePkg.loc.file().data(ctx).isPackagedTest()) {
                 // Inside a test file, but not inside a test namespace. Set bounds such that
                 // begin == end, stopping any subsequent search.
                 bounds.emplace_back(begin, end);

--- a/test/cli/package-prefix-enforcement/test.out
+++ b/test/cli/package-prefix-enforcement/test.out
@@ -91,7 +91,21 @@ nested/nested.test.rb:16: Tests in the `Root::Nested` package must define tests 
      3 |class Root::Nested < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-critic_prefix/real.test.rb:13: File belongs to package `Critic::SomePkg` but defines a constant that does not match this namespace https://srb.help/3713
+critic_prefix/real.test.rb:3: Tests in the `Critic::SomePkg` package must define tests in the `Test::Critic::SomePkg` namespace https://srb.help/3713
+     3 |module Critic::SomePkg::Real
+               ^^^^^^^^^^^^^^^^^^^^^
+    critic_prefix/__package.rb:3: Enclosing package declared here
+     3 |class Critic::SomePkg < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+critic_prefix/real.test.rb:7: Tests in the `Critic::SomePkg` package must define tests in the `Test::Critic::SomePkg` namespace https://srb.help/3713
+     7 |Critic::SomePkg::RealConst = 2
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    critic_prefix/__package.rb:3: Enclosing package declared here
+     3 |class Critic::SomePkg < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+critic_prefix/real.test.rb:13: Tests in the `Critic::SomePkg` package must define tests in the `Test::Critic::SomePkg` namespace https://srb.help/3713
     13 |SomeOtherNamespace::SomePkg::SomeConst = 4
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     critic_prefix/__package.rb:3: Enclosing package declared here
@@ -107,4 +121,4 @@ commands/foo_command.rb:4: File belongs to package `Root::Commands::Foo` but def
     __package.rb:3: Must belong to this package, given constant name `Root::Commands::Baz::Ban`
      3 |class Root < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 11
+Errors: 13

--- a/test/cli/package-secondary-test-namespace-invalid/__package.rb
+++ b/test/cli/package-secondary-test-namespace-invalid/__package.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-# typed: strict
-# enable-packager: true
-
-class Critic < PackageSpec
-end

--- a/test/cli/package-secondary-test-namespace-invalid/test.out
+++ b/test/cli/package-secondary-test-namespace-invalid/test.out
@@ -1,3 +1,0 @@
---secondary-test-package-namespaces must contain items that start with a capital letter and are alphanumeric.
---secondary-test-package-namespaces must contain items that start with a capital letter and are alphanumeric.
---secondary-test-package-namespaces must contain items that start with a capital letter and are alphanumeric.

--- a/test/cli/package-secondary-test-namespace-invalid/test.sh
+++ b/test/cli/package-secondary-test-namespace-invalid/test.sh
@@ -1,5 +1,0 @@
-cd test/cli/package-secondary-test-namespace-invalid || exit 1
-
-../../../main/sorbet --silence-dev-message --stripe-packages --secondary-test-package-namespaces=Critic:: --stripe-mode . 2>&1
-../../../main/sorbet --silence-dev-message --stripe-packages --secondary-test-package-namespaces=critic --stripe-mode . 2>&1
-../../../main/sorbet --silence-dev-message --stripe-packages --secondary-test-package-namespaces=^ --stripe-mode . 2>&1

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -569,13 +569,11 @@ TEST_CASE("LSPTest") {
             if (extraDirSlash.has_value()) {
                 opts->extraPackageFilesDirectorySlashPrefixes.emplace_back(extraDirSlash.value());
             }
-            opts->secondaryTestPackageNamespaces.emplace_back("Critic");
             auto skipImportVisibility =
                 StringPropertyAssertion::getValue("allow-relaxed-packager-checks-for", assertions);
             if (skipImportVisibility.has_value()) {
                 opts->allowRelaxedPackagerChecksFor.emplace_back(skipImportVisibility.value());
             }
-            opts->secondaryTestPackageNamespaces.emplace_back("Critic");
         }
         opts->disableWatchman = true;
         opts->rubyfmtPath = "test/testdata/lsp/rubyfmt-stub/rubyfmt";

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -259,7 +259,6 @@ vector<ast::ParsedFile> index(unique_ptr<core::GlobalState> &gs, absl::Span<core
 void setupPackager(unique_ptr<core::GlobalState> &gs, vector<shared_ptr<RangeAssertion>> &assertions) {
     vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
     vector<std::string> extraPackageFilesDirectorySlashPrefixes;
-    vector<std::string> secondaryTestPackageNamespaces;
     vector<std::string> skipRBIExportEnforcementDirs;
     vector<std::string> allowRelaxedPackagerChecksFor;
 
@@ -282,9 +281,8 @@ void setupPackager(unique_ptr<core::GlobalState> &gs, vector<shared_ptr<RangeAss
     {
         core::UnfreezeNameTable packageNS(*gs);
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-        gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryUnderscorePrefixes,
-                               extraPackageFilesDirectorySlashPrefixes, {}, allowRelaxedPackagerChecksFor,
-                               "PACKAGE_ERROR_HINT");
+        gs->setPackagerOptions(extraPackageFilesDirectoryUnderscorePrefixes, extraPackageFilesDirectorySlashPrefixes,
+                               {}, allowRelaxedPackagerChecksFor, "PACKAGE_ERROR_HINT");
     }
 }
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -259,7 +259,7 @@ vector<ast::ParsedFile> index(unique_ptr<core::GlobalState> &gs, absl::Span<core
 void setupPackager(unique_ptr<core::GlobalState> &gs, vector<shared_ptr<RangeAssertion>> &assertions) {
     vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
     vector<std::string> extraPackageFilesDirectorySlashPrefixes;
-    vector<std::string> secondaryTestPackageNamespaces = {"Critic"};
+    vector<std::string> secondaryTestPackageNamespaces;
     vector<std::string> skipRBIExportEnforcementDirs;
     vector<std::string> allowRelaxedPackagerChecksFor;
 

--- a/test/testdata/packager/package-prefix-enforcement/critic_prefix/real.test.rb
+++ b/test/testdata/packager/package-prefix-enforcement/critic_prefix/real.test.rb
@@ -1,10 +1,12 @@
 # typed: strict
 
 module Critic::SomePkg::Real
+  #    ^^^^^^^^^^^^^^^^^^^^^ error: Tests in the `Critic::SomePkg` package must define tests in the `Test::Critic::SomePkg` namespace
   FOO = 1
 end
 
-Critic::SomePkg::RealConst = 2
+ Critic::SomePkg::RealConst = 2
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Tests in the `Critic::SomePkg` package must define tests in the `Test::Critic::SomePkg` namespace
 
 # Allowed
 Test::Critic::SomePkg::SomeTestConst = 3


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`--secondary-test-package-namespaces` is obsolete, and we can replace with a concept of test-only packages.

I suspect that we could even go one step further and say that only code in `.test.rb` files can and needs to use the `Test::` prefix, meaning that we would not need to special case test-only packages. But that'd be a change for the future, and would be more restrictive than what currently exists.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.