### PR TITLE
Fix packager_suggest_nested_crash test

### DIFF
--- a/test/cli/packager_suggest_nested_crash/test.out
+++ b/test/cli/packager_suggest_nested_crash/test.out
@@ -1,25 +1,11 @@
-test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb:4: Tests in the `Project::ConsumerAuth::Data` package must define tests in the `Test::Project::ConsumerAuth::Data` namespace https://srb.help/3713
-     4 |class Project::ConsumerAuth::Data
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test/cli/packager_suggest_nested_crash/consumer_auth/data/__package.rb:4: Enclosing package declared here
-     4 |class Project::ConsumerAuth::Data < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierType` resolves but is not exported from `Project::ConsumerAuth` https://srb.help/3717
+consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierType` resolves but is not exported from `Project::ConsumerAuth` https://srb.help/3717
      6 |    puts(Project::ConsumerAuth::IdentifierType)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb:5: Defined here
+    consumer_auth/identity_type.rb:5: Defined here
      5 |  class IdentifierType
           ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/packager_suggest_nested_crash/consumer_auth/__package.rb:6: Insert `export Project::ConsumerAuth::IdentifierType`
+    consumer_auth/__package.rb:6: Insert `export Project::ConsumerAuth::IdentifierType`
      6 |  import Project::ConsumerAuth::Data
                                             ^
-
-test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb:4: Tests in the `Project::ConsumerAuth` package must define tests in the `Test::Project::ConsumerAuth` namespace https://srb.help/3713
-     4 |class Project::ConsumerAuth
-              ^^^^^^^^^^^^^^^^^^^^^
-    test/cli/packager_suggest_nested_crash/consumer_auth/__package.rb:5: Enclosing package declared here
-     5 |class Project::ConsumerAuth < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 3
+Errors: 1

--- a/test/cli/packager_suggest_nested_crash/test.sh
+++ b/test/cli/packager_suggest_nested_crash/test.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+cd test/cli/packager_suggest_nested_crash || exit 0
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This test had two extra errors which said something about "package must
define tests in the Test::" namespace.

But these errors were spurious--the CLI test was not trying to have
these files be packged test files, it just so happened that it didn't
`cd` into its specific `test/cli` subfolder before running Sorbet.

Changing into that directory makes it so that Sorbet doesn't see
`/test/` in the path name anymore, and thus doesn't report those
unrelated errors.

We already use this technique in other CLI tests where it's important to
distinguish between test and non-test packaged files.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test-only change