### PR TITLE
prework: Delete addNonClassConstant

### DIFF
--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -229,22 +229,6 @@ class FoundDefinitions final {
     // Contains all class and instance variables defined in the file.
     std::vector<FoundField> _fields;
 
-    FoundDefinitionRef addNonClassConstant(FoundDefinitionRef ref) {
-        DEBUG_ONLY(switch (ref.kind()) {
-            case FoundDefinitionRef::Kind::StaticField:
-            case FoundDefinitionRef::Kind::TypeMember:
-                break;
-            case FoundDefinitionRef::Kind::Class:
-            case FoundDefinitionRef::Kind::Method:
-            case FoundDefinitionRef::Kind::Field:
-            case FoundDefinitionRef::Kind::Empty:
-            case FoundDefinitionRef::Kind::Symbol:
-                ENFORCE(false, "Attempted to give unexpected FoundDefinitionRef kind to addDefinition");
-        });
-        _nonClassConstants.emplace_back(ref);
-        return ref;
-    }
-
 public:
     FoundDefinitions() = default;
     FoundDefinitions(FoundDefinitions &&names) = default;
@@ -266,13 +250,17 @@ public:
     FoundDefinitionRef addStaticField(FoundStaticField &&staticField) {
         const uint32_t idx = _staticFields.size();
         _staticFields.emplace_back(std::move(staticField));
-        return addNonClassConstant(FoundDefinitionRef(FoundDefinitionRef::Kind::StaticField, idx));
+        auto ref = FoundDefinitionRef(FoundDefinitionRef::Kind::StaticField, idx);
+        _nonClassConstants.emplace_back(ref);
+        return ref;
     }
 
     FoundDefinitionRef addTypeMember(FoundTypeMember &&typeMember) {
         const uint32_t idx = _typeMembers.size();
         _typeMembers.emplace_back(std::move(typeMember));
-        return addNonClassConstant(FoundDefinitionRef(FoundDefinitionRef::Kind::TypeMember, idx));
+        auto ref = FoundDefinitionRef(FoundDefinitionRef::Kind::TypeMember, idx);
+        _nonClassConstants.emplace_back(ref);
+        return ref;
     }
 
     FoundDefinitionRef addField(FoundField &&field) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It looks like this function only has two call sites, plus a big switch
statement that enforces that it's only called from those two call sites.
There was probably value in that in the past but it doesn't seem
valuable anymore.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests