### PR TITLE
Fix Ruby 3.4-dev compatibility

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/caller_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/caller_utils.rb
@@ -4,7 +4,13 @@
 module T::Private::CallerUtils
   if Thread.respond_to?(:each_caller_location) # RUBY_VERSION >= "3.2"
     def self.find_caller
+      skiped_first = false
       Thread.each_caller_location do |loc|
+        unless skiped_first
+          skiped_first = true
+          next
+        end
+
         next if loc.path&.start_with?("<internal:")
 
         return loc if yield(loc)

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -65,7 +65,7 @@ module T::Private::ClassUtils
     elsif mod.private_method_defined?(name)
       :private
     else
-      raise NameError.new("undefined method `#{name}` for `#{mod}`")
+      mod.method(name) # Raises
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -318,7 +318,7 @@ module T::Private::Methods::CallValidation
     elsif mod.private_method_defined?(name)
       :private
     else
-      raise NameError.new("undefined method `#{name}` for `#{mod}`")
+      mod.method(name) # Raises
     end
   end
 end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -261,16 +261,11 @@ module T::Props::Serializable::DecoratorMethods
   end
 
   def message_with_generated_source_context(error, generated_method, generate_source_method)
-    line_label = error.backtrace.find {|l| l.end_with?("in `#{generated_method}'")}
-    return unless line_label
+    generated_method = generated_method.to_s
+    line_loc = error.backtrace_locations.find {|l| l.base_label == generated_method}
+    return unless line_loc
 
-    line_num = if line_label.start_with?("(eval)")
-      # (eval):13:in `__t_props_generated_serialize'
-      line_label.split(':')[1]&.to_i
-    else
-      # (eval at /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb:65):13:in `__t_props_generated_serialize'
-      line_label.split(':')[2]&.to_i
-    end
+    line_num = line_loc.lineno
     return unless line_num
 
     source_lines = self.send(generate_source_method).split("\n")

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -302,7 +302,7 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
       e = assert_raises(NoMethodError) do
         m.immutable = 'world'
       end
-      assert_match(/undefined method `immutable='/, e.message)
+      assert_match(/undefined method [`']immutable='/, e.message)
     end
 
     it 'const creates an immutable prop' do
@@ -346,7 +346,7 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     e = assert_raises do
       MatrixStruct.new.c = nil
     end
-    assert_match(/undefined method `c='/, e.message)
+    assert_match(/undefined method [`']c='/, e.message)
     e = assert_raises do
       MatrixStruct.new.d = nil
     end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -261,7 +261,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         MySerializable.from_hash({'foo' => "Won't respond like hash"})
       end
 
-      assert_includes(e.message, "undefined method `transform_values'")
+      assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
       assert_includes(e.message, "foo")
       assert_includes(e.message, "val.transform_values {|v| T::Props::Utils.deep_clone_object(v)}")
     end
@@ -273,7 +273,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         m.serialize
       end
 
-      assert_includes(e.message, "undefined method `transform_values'")
+      assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
       assert_includes(e.message, 'h["foo"] = @foo.transform_values {|v| T::Props::Utils.deep_clone_object(v)}')
     end
   end
@@ -739,7 +739,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         struct.serialize
       end
 
-      assert_includes(e.message, "undefined method `serialize'")
+      assert_includes(e.message.tr("`", "'"), "undefined method 'serialize'")
     end
 
     it 'raises deserialize errors when props with a serializable subtype store the wrong datatype' do
@@ -763,7 +763,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         struct.serialize
       end
 
-      assert_includes(e.message, "undefined method `map'")
+      assert_includes(e.message.tr("`", "'"), "undefined method 'map'")
     end
 
     it 'raises deserialize errors when props with an array of a custom subtype store the wrong datatype' do
@@ -784,7 +784,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(CustomTypeStruct, storytime[:klass])
       assert_equal(:array, storytime[:prop])
       assert_equal(obj, storytime[:value])
-      assert_includes(storytime[:error], "undefined method `map'")
+      assert_includes(storytime[:error].tr("`", "'"), "undefined method 'map'")
     end
 
     it 'round trips as hash key' do
@@ -799,7 +799,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         struct.serialize
       end
 
-      assert_includes(e.message, "undefined method `transform_keys'")
+      assert_includes(e.message.tr("`", "'"), "undefined method 'transform_keys'")
     end
 
     it 'raises deserialize errors when props with a hash with keys of a custom subtype store the wrong datatype' do
@@ -820,7 +820,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(CustomTypeStruct, storytime[:klass])
       assert_equal(:hash_key, storytime[:prop])
       assert_equal(obj, storytime[:value])
-      assert_includes(storytime[:error], "undefined method `transform_keys'")
+      assert_includes(storytime[:error].tr("`", "'"), "undefined method 'transform_keys'")
     end
 
     it 'round trips as hash value' do
@@ -835,7 +835,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         struct.serialize
       end
 
-      assert_includes(e.message, "undefined method `transform_values'")
+      assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
     end
 
     it 'raises deserialize errors when props with a hash with values of a custom subtype store the wrong datatype' do
@@ -856,7 +856,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(CustomTypeStruct, storytime[:klass])
       assert_equal(:hash_value, storytime[:prop])
       assert_equal(obj, storytime[:value])
-      assert_includes(storytime[:error], "undefined method `transform_values'")
+      assert_includes(storytime[:error].tr("`", "'"), "undefined method 'transform_values'")
     end
 
     it 'round trips as hash key and value' do
@@ -871,7 +871,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
         struct.serialize
       end
 
-      assert_includes(e.message, "undefined method `each_with_object'")
+      assert_includes(e.message.tr("`", "'"), "undefined method 'each_with_object'")
     end
 
     it 'raises deserialize errors when props with a hash with keys/values of a custom subtype store the wrong datatype' do
@@ -892,7 +892,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(CustomTypeStruct, storytime[:klass])
       assert_equal(:hash_both, storytime[:prop])
       assert_equal(obj, storytime[:value])
-      assert_includes(storytime[:error], "undefined method `each_with_object'")
+      assert_includes(storytime[:error].tr("`", "'"), "undefined method 'each_with_object'")
     end
   end
 

--- a/gems/sorbet-runtime/test/types/sig.rb
+++ b/gems/sorbet-runtime/test/types/sig.rb
@@ -34,7 +34,7 @@ class Opus::Types::Test::SigTest < Critic::Unit::UnitTest
     e = assert_raises do
       klass.new.foo
     end
-    assert_match(/undefined method `sig' for/, e.message)
+    assert_match(/undefined method [`']sig' for/, e.message)
   end
 
   # Enable $VERBOSE and redirect stderr to a string for the duration of the


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/19117
Ref: https://bugs.ruby-lang.org/issues/16495

Now backtrace use constisten `'` quotes rather than a mix of backtick and quote.

Also the label include the class or module names.

But in most case dealing with `Backtrace::Location` objects is much more performant and clear than to match a regexp on the full rendered frame. So aside from Ruby compatibility, this is just better code.
