### PR TITLE
Add support for `Set#initialize` with block

### DIFF
--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -643,12 +643,13 @@ class Set < Object
   def flatten!(); end
 
   sig do
-    params(
-        enum: T.nilable(T::Enumerable[BasicObject]),
+    type_parameters(:U).params(
+      enum: T.nilable(T::Enumerable[T.type_parameter(:U)]),
+      blk: T.nilable(T.proc.params(arg0: T.type_parameter(:U)).returns(Elem))
     )
     .void
   end
-  def initialize(enum=nil); end
+  def initialize(enum=nil, &blk); end
 
   # Returns true if the set and the given enumerable have at least
   # one

--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -642,6 +642,19 @@ class Set < Object
   sig {returns(T.nilable(T.self_type))}
   def flatten!(); end
 
+  # Creates a new set containing the elements of the given
+  # enumerable object.
+  #
+  # If a block is given, the elements of enum are preprocessed by
+  # the given block.
+  #
+  # ```ruby
+  # Set.new([1, 2])                    #=> #<Set: {1, 2}>
+  # Set.new([1, 2, 1])                 #=> #<Set: {1, 2}>
+  # Set.new([1, 'c', :s])              #=> #<Set: {1, "c", :s}>
+  # Set.new(1..5)                      #=> #<Set: {1, 2, 3, 4, 5}>
+  # Set.new([1, 2, 3]) { |x| x * x }   #=> #<Set: {1, 4, 9}>
+  # ```
   sig do
     type_parameters(:U).params(
       enum: T.nilable(T::Enumerable[T.type_parameter(:U)]),


### PR DESCRIPTION
- Adds support for `Set#initialize` with a block (https://github.com/sorbet/sorbet/commit/7ad16a10d7dd03b5419130fd051ebf44448efe73).
- Also adds missing docs (https://github.com/sorbet/sorbet/pull/7714/commits/75c65280c22046db3b8a021d75a9cf67c24a7e13).

### Motivation

Ruby has supported `Set#initialize` with a block to preprocess the input elements since at least [version 1.9.1](https://ruby-doc.org/stdlib-1.9.1/libdoc/set/rdoc/Set.html#method-c-new). This change adds support for that.

### Test plan

```sh
bazel-bin/main/sorbet -e "Set.new(Set.new([[:a, :b], [:c]], &:first))"
```