### PR TITLE
drop some unneeded ruby versions

### DIFF
--- a/third_party/ruby/ruby-versions.txt
+++ b/third_party/ruby/ruby-versions.txt
@@ -1,5 +1,2 @@
-sorbet_ruby_2_7
 sorbet_ruby_3_1
-sorbet_ruby_3_2
-sorbet_ruby_3_3_preview
 sorbet_ruby_3_3


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't need 2.7 now that Stripe has upgraded.

We don't need 3.2 because 3.3 is a better upgrade target.

We don't need the 3.3 preview because 3.3 is officially released.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
