### PR TITLE
Build and release on linux-aarch64

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -107,6 +107,9 @@ build:untyped-blame --copt=-DTRACK_UNTYPED_BLAME_MODE
 # harden: mark relocation sections read-only
 build:release-linux --linkopt=-Wl,-z,relro,-z,now
 build:release-linux --config=lto-linux --config=release-common
+# Separate config for aarch64, so x86_64 can be differently optimized
+build:release-linux-aarch64 --linkopt=-Wl,-z,relro,-z,now
+build:release-linux-aarch64 --config=lto-linux --config=release-common
 
 # This is to turn on vector instructions where available.
 # We used to do this unconditionally, but Rosetta 2 doesn't translate all vector instructions well.

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -10,8 +10,11 @@ processor_name="$(uname -m)"
 
 platform="${kernel_name}-${processor_name}"
 case "$platform" in
-  linux-x86_64|linux-aarch64)
+  linux-x86_64)
     CONFIG_OPTS="--config=release-linux"
+    ;;
+  linux-aarch64)
+    CONFIG_OPTS="--config=release-${platform}"
     ;;
   darwin-x86_64|darwin-arm64)
     CONFIG_OPTS="--config=release-mac"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -80,6 +80,14 @@ steps:
     artifact_paths: _out_/**/*
     <<: *elastic
 
+  - label: ":linux: (arm64) build-static-release.sh"
+    command: .buildkite/build-static-release.sh
+    artifact_paths: _out_/**/*
+    <<: *elastic
+    agents:
+      os: linux
+      queue: elastic-arm64
+
   - label: ":linux: build-sorbet-static-and-runtime.sh"
     command: .buildkite/build-sorbet-static-and-runtime.sh
     artifact_paths: _out_/**/*


### PR DESCRIPTION
Closes #4119 

Build and release on aarch64 linux, uses a dedicated target so the x86_64 build keeps its optimisations.