### PR TITLE
Add image hint to pipeline configuration

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -14,6 +14,10 @@ steps:
         queue: elastic
       plugins:
         - docker#0d9b114b0ca8ec7167787285274aa3842392374d:
+            # This image needs to be a [manifest list][0] with constituent images for all of the
+            # supported linux architectures.
+            #
+            # [0]: https://docs.docker.com/reference/cli/docker/manifest/#create-and-push-a-manifest-list
             image: "sorbetruby/sorbet-build-image:latest"
             workdir: /app
             always-pull: false


### PR DESCRIPTION
An omission from #7718, adds an in-line hint about how this image ref needs to be setup. If and when there exists arm64 hardware in GitHub actions (or nested virtualisation support on the M series Mac runners), we can setup https://github.com/sorbet/sorbet-build-image to do this automatically for `linux-x86_64` and `linux-aarch64`.