### PR TITLE
Reimplement a4a06f8016 in terms of symbol ownership

### DIFF
--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -573,12 +573,6 @@ public:
         return show(gs, {});
     };
     std::string show(const GlobalState &gs, ShowOptions options) const;
-
-    /*
-     * Returns true if symbol is under the namespace of otherClass. Foo::Bar::A is under its own namespace, also is
-     * under the namespace of Foo::Bar and Foo.
-     */
-    bool isUnderNamespace(const GlobalState &gs, core::ClassOrModuleRef otherClass) const;
 };
 CheckSize(SymbolRef, 4, 4);
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -853,28 +853,6 @@ vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findMemberFuzzyMatch(con
     return res;
 }
 
-bool SymbolRef::isUnderNamespace(const GlobalState &gs, ClassOrModuleRef otherClass) const {
-    if (isClassOrModule() && otherClass == asClassOrModuleRef()) {
-        return true;
-    }
-
-    // if we are checking for nesting under root itself, which is always true
-    if (otherClass == core::Symbols::root()) {
-        return true;
-    }
-
-    auto curOwner = owner(gs).asClassOrModuleRef();
-    while (curOwner != core::Symbols::root()) {
-        if (curOwner == otherClass) {
-            return true;
-        }
-
-        curOwner = curOwner.data(gs)->owner;
-    }
-
-    return false;
-}
-
 vector<ClassOrModule::FuzzySearchResult>
 ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name, int betterThan) const {
     // Performance of this method is bad, to say the least.

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -49,8 +49,6 @@ public:
     virtual core::Loc declLoc() const = 0;
     virtual bool exists() const final;
     std::string show(const core::GlobalState &gs) const;
-    core::ClassOrModuleRef getRootSymbolForAutocorrectSearch(const core::GlobalState &gs,
-                                                             core::SymbolRef suggestionScope) const;
 
     core::ClassOrModuleRef getPackageScope(const core::GlobalState &gs) const;
     core::ClassOrModuleRef getPackageTestScope(const core::GlobalState &gs) const;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -225,9 +225,8 @@ public:
     }
 
     bool ownsSymbol(const core::GlobalState &gs, core::SymbolRef symbol) const {
-        auto file = symbol.loc(gs).file();
-        auto &pkg = gs.packageDB().getPackageForFile(gs, file);
-        return this->mangledName() == pkg.mangledName();
+        auto &pkg = gs.packageDB().getPackageNameForSymbol(gs, symbol);
+        return this->mangledName() == pkg;
     }
 
     PackageInfoImpl(PackageName name, core::Loc loc, core::Loc declLoc_) : name(name), loc(loc), declLoc_(declLoc_) {}

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -803,16 +803,10 @@ private:
                         // export statement. Currently (1/9/23) this happens to work because export statements are the
                         // only part of the packager DSL that do not prepend PackageSpec to the relevant constant.
 
-                        // Can't use pkg.ownsSymbol since it uses symbol definition locs, which have an edge case that
-                        // isn't handled until the VisibilityChecker pass.
-                        const auto pkgRootSymbol = ctx.state.packageDB()
-                                                       .getPackageForFile(ctx.state, ctx.file)
-                                                       .getRootSymbolForAutocorrectSearch(ctx.state, suggestScope);
-
-                        auto it = std::remove_if(suggested.begin(), suggested.end(),
-                                                 [&pkgRootSymbol, &gs](auto &suggestion) -> bool {
-                                                     return !suggestion.symbol.isUnderNamespace(gs, pkgRootSymbol);
-                                                 });
+                        const auto &curPkg = ctx.state.packageDB().getPackageForFile(ctx.state, ctx.file);
+                        auto it = std::remove_if(suggested.begin(), suggested.end(), [&](auto &suggestion) {
+                            return !curPkg.ownsSymbol(gs, suggestion.symbol);
+                        });
                         suggested.erase(it, suggested.end());
                     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


Now that we have proper symbol-based package ownership, we don't need to
use this hack which relies on the canonical loc of a Symbol being the
source of truth for that symbol's package.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The test included in a4a06f8016 covers this refactor.