### PR TITLE
printLocs: Take a Span instead of InlinedVector

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1088,7 +1088,7 @@ bool isHiddenFromPrinting(const GlobalState &gs, SymbolRef symbol) {
     return false;
 }
 
-void printLocs(const GlobalState &gs, fmt::memory_buffer &buf, const InlinedVector<Loc, 2> &locs, bool showRaw) {
+void printLocs(const GlobalState &gs, fmt::memory_buffer &buf, absl::Span<const Loc> locs, bool showRaw) {
     if (!locs.empty()) {
         fmt::format_to(std::back_inserter(buf), " @ ");
         if (locs.size() > 1) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on a change on another branch where I will only have one `Loc` to print, and I don't want to be able to use `absl::MakeSpan` instead of making a whole vector and passing that.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.