### PR TITLE
Make `locs` methods return `absl::Span`

### DIFF
--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -542,7 +542,7 @@ public:
     core::Loc loc(const GlobalState &gs) const;
     bool isPrintable(const GlobalState &gs) const;
     using LOC_store = InlinedVector<Loc, 2>;
-    const LOC_store &locs(const GlobalState &gs) const;
+    absl::Span<const Loc> locs(const GlobalState &gs) const;
     void removeLocsForFile(GlobalState &gs, core::FileRef file) const;
     const TypePtr &resultType(const GlobalState &gs) const;
     void setResultType(GlobalState &gs, const TypePtr &typePtr) const;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1890,10 +1890,10 @@ void ClassOrModule::recordSealedSubclass(GlobalState &gs, ClassOrModuleRef subcl
     }
 }
 
-const InlinedVector<Loc, 2> &ClassOrModule::sealedLocs(const GlobalState &gs) const {
+absl::Span<const Loc> ClassOrModule::sealedLocs(const GlobalState &gs) const {
     ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(gs).show(gs));
     auto sealedSubclasses = this->lookupSingletonClass(gs).data(gs)->findMethod(gs, core::Names::sealedSubclasses());
-    auto &result = sealedSubclasses.data(gs)->locs();
+    auto result = sealedSubclasses.data(gs)->locs();
     ENFORCE(result.size() > 0);
     return result;
 }
@@ -2599,19 +2599,19 @@ Loc TypeParameter::loc() const {
     return Loc::none();
 }
 
-const InlinedVector<Loc, 2> &Method::locs() const {
+absl::Span<const Loc> Method::locs() const {
     return locs_;
 }
 
-const InlinedVector<Loc, 2> &ClassOrModule::locs() const {
+absl::Span<const Loc> ClassOrModule::locs() const {
     return locs_;
 }
 
-const InlinedVector<Loc, 2> &Field::locs() const {
+absl::Span<const Loc> Field::locs() const {
     return locs_;
 }
 
-const InlinedVector<Loc, 2> &TypeParameter::locs() const {
+absl::Span<const Loc> TypeParameter::locs() const {
     return locs_;
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -587,7 +587,7 @@ MethodRef ClassOrModule::findParentMethodTransitive(const GlobalState &gs, NameR
     return Symbols::noMethod();
 }
 
-bool singleFileDefinition(const GlobalState &gs, const core::SymbolRef::LOC_store &locs, core::FileRef file) {
+bool singleFileDefinition(const GlobalState &gs, absl::Span<const Loc> locs, core::FileRef file) {
     bool result = false;
 
     for (auto &loc : locs) {
@@ -1607,7 +1607,7 @@ bool SymbolRef::isPrintable(const GlobalState &gs) const {
     }
 }
 
-const InlinedVector<Loc, 2> &SymbolRef::locs(const GlobalState &gs) const {
+absl::Span<const Loc> SymbolRef::locs(const GlobalState &gs) const {
     switch (kind()) {
         case SymbolRef::Kind::ClassOrModule:
             return asClassOrModuleRef().data(gs)->locs();

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -95,7 +95,7 @@ public:
     CheckSize(Flags, 2, 1);
 
     Loc loc() const;
-    const SymbolRef::LOC_store &locs() const;
+    absl::Span<const Loc> locs() const;
     void addLoc(const core::GlobalState &gs, core::Loc loc);
     void removeLocsForFile(core::FileRef file);
     uint32_t hash(const GlobalState &gs) const;
@@ -243,7 +243,7 @@ public:
     CheckSize(Flags, 1, 1);
 
     Loc loc() const;
-    const SymbolRef::LOC_store &locs() const;
+    absl::Span<const Loc> locs() const;
     void addLoc(const core::GlobalState &gs, core::Loc loc);
     void removeLocsForFile(core::FileRef file);
 
@@ -320,7 +320,7 @@ public:
     CheckSize(Flags, 1, 1);
 
     Loc loc() const;
-    const SymbolRef::LOC_store &locs() const;
+    absl::Span<const Loc> locs() const;
     void addLoc(const core::GlobalState &gs, core::Loc loc);
     void removeLocsForFile(core::FileRef file);
 
@@ -398,7 +398,7 @@ public:
     CheckSize(Flags, 2, 1);
 
     Loc loc() const;
-    const SymbolRef::LOC_store &locs() const;
+    absl::Span<const Loc> locs() const;
     void addLoc(const core::GlobalState &gs, core::Loc loc);
     void removeLocsForFile(core::FileRef file);
 
@@ -555,7 +555,7 @@ public:
     void recordSealedSubclass(GlobalState &gs, ClassOrModuleRef subclass);
 
     // Returns the locations that are allowed to subclass the sealed class.
-    const SymbolRef::LOC_store &sealedLocs(const GlobalState &gs) const;
+    absl::Span<const Loc> sealedLocs(const GlobalState &gs) const;
 
     TypePtr sealedSubclassesToUnion(const GlobalState &ctx) const;
 

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -183,7 +183,7 @@ TypeErrorDiagnostics::editForDSLMethod(const GlobalState &gs, FileRef fileToEdit
     }
 
     auto inCurrentFile = [&](const auto &loc) { return loc.file() == fileToEdit; };
-    auto &classLocs = inWhat->locs();
+    auto classLocs = inWhat->locs();
     auto classLoc = absl::c_find_if(classLocs, inCurrentFile);
 
     if (classLoc == classLocs.end()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Package symbols will not have a list of locs, so it's a little easier if I can
get away with just storing a `Loc` instead of having to store an
`InlinedVector<Loc, 1>`, because all `SymbolRef` kinds need to implement the
`locs` method, and right now that has to return a reference to a vector, which
would have to outlive the reference to the `Package` symbol (and thus be managed
by the `Package` symbol itself).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests