### PR TITLE
Remove `secondaryTestPackageNamespaceRefs_`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2378,7 +2378,6 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &extraPackag
                                      const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
                                      const std::vector<std::string> &allowRelaxedPackagerChecksFor,
                                      std::string errorHint) {
-    ENFORCE(packageDB_.secondaryTestPackageNamespaceRefs_.size() == 0);
     ENFORCE(!packageDB_.frozen);
 
     packageDB_.extraPackageFilesDirectoryUnderscorePrefixes_ = extraPackageFilesDirectoryUnderscorePrefixes;

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -213,10 +213,6 @@ const vector<MangledName> &PackageDB::packages() const {
     return mangledNames;
 }
 
-const std::vector<core::NameRef> &PackageDB::secondaryTestPackageNamespaceRefs() const {
-    return secondaryTestPackageNamespaceRefs_;
-}
-
 const std::vector<std::string> &PackageDB::skipRBIExportEnforcementDirs() const {
     return skipRBIExportEnforcementDirs_;
 }
@@ -244,7 +240,6 @@ PackageDB PackageDB::deepCopy() const {
     for (auto const &[nr, pkgInfo] : this->packages_) {
         result.packages_[nr] = pkgInfo->deepCopy();
     }
-    result.secondaryTestPackageNamespaceRefs_ = this->secondaryTestPackageNamespaceRefs_;
     result.extraPackageFilesDirectoryUnderscorePrefixes_ = this->extraPackageFilesDirectoryUnderscorePrefixes_;
     result.extraPackageFilesDirectorySlashPrefixes_ = this->extraPackageFilesDirectorySlashPrefixes_;
     result.packagesByPathPrefix = this->packagesByPathPrefix;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -55,7 +55,6 @@ public:
     PackageDB &operator=(const PackageDB &) = delete;
     PackageDB &operator=(PackageDB &&) = default;
 
-    const std::vector<core::NameRef> &secondaryTestPackageNamespaceRefs() const;
     const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes() const;
     const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes() const;
     const std::vector<std::string> &skipRBIExportEnforcementDirs() const;
@@ -64,7 +63,6 @@ public:
     bool allowRelaxedPackagerChecksFor(const MangledName mangledName) const;
 
 private:
-    std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes_;
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes_;
     std::string errorHint_;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I removed all usages of this in `8ba8dd0dd` and removed the command line
option in `fb09bed28`. I forgot to actually remove the storage for this
from `PackageDB` itself.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not used.