### PR TITLE
More robust way of checking whether the packager is enabled

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2380,6 +2380,7 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &extraPackag
                                      std::string errorHint) {
     ENFORCE(!packageDB_.frozen);
 
+    packageDB_.enabled_ = true;
     packageDB_.extraPackageFilesDirectoryUnderscorePrefixes_ = extraPackageFilesDirectoryUnderscorePrefixes;
     packageDB_.extraPackageFilesDirectorySlashPrefixes_ = extraPackageFilesDirectorySlashPrefixes;
     packageDB_.skipRBIExportEnforcementDirs_ = packageSkipRBIExportEnforcementDirs;

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -205,10 +205,6 @@ const PackageInfo &PackageDB::getPackageInfo(MangledName mangledName) const {
     return *it->second;
 }
 
-bool PackageDB::empty() const {
-    return packages_.empty();
-}
-
 const vector<MangledName> &PackageDB::packages() const {
     return mangledNames;
 }

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -236,6 +236,7 @@ PackageDB PackageDB::deepCopy() const {
     for (auto const &[nr, pkgInfo] : this->packages_) {
         result.packages_[nr] = pkgInfo->deepCopy();
     }
+    result.enabled_ = this->enabled_;
     result.extraPackageFilesDirectoryUnderscorePrefixes_ = this->extraPackageFilesDirectoryUnderscorePrefixes_;
     result.extraPackageFilesDirectorySlashPrefixes_ = this->extraPackageFilesDirectorySlashPrefixes_;
     result.packagesByPathPrefix = this->packagesByPathPrefix;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -39,7 +39,6 @@ public:
     // Lookup `PackageInfo` from the string representation of the un-mangled package name.
     const PackageInfo &getPackageInfo(const core::GlobalState &gs, std::string_view str) const;
 
-    bool empty() const;
     // Get mangled names for all packages.
     // Packages are ordered lexicographically with respect to the NameRef's that make up their
     // namespaces.
@@ -62,12 +61,17 @@ public:
     const std::string_view errorHint() const;
     bool allowRelaxedPackagerChecksFor(const MangledName mangledName) const;
 
+    bool enabled() const {
+        return this->enabled_;
+    }
+
 private:
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes_;
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes_;
     std::string errorHint_;
     std::vector<std::string> skipRBIExportEnforcementDirs_;
     std::vector<MangledName> allowRelaxedPackagerChecksFor_;
+    bool enabled_ = false;
 
     // This vector is kept in sync with the size of the file table in the global state by
     // `Packager::setPackageNameOnFiles`. A `FileRef` being out of bounds in this vector is treated as the file having

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -54,6 +54,11 @@ public:
     PackageDB &operator=(const PackageDB &) = delete;
     PackageDB &operator=(PackageDB &&) = default;
 
+    // Whether the --stripe-packages mode is active.
+    bool enabled() const {
+        return this->enabled_;
+    }
+
     const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes() const;
     const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes() const;
     const std::vector<std::string> &skipRBIExportEnforcementDirs() const;
@@ -61,17 +66,13 @@ public:
     const std::string_view errorHint() const;
     bool allowRelaxedPackagerChecksFor(const MangledName mangledName) const;
 
-    bool enabled() const {
-        return this->enabled_;
-    }
-
 private:
+    bool enabled_ = false;
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes_;
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes_;
     std::string errorHint_;
     std::vector<std::string> skipRBIExportEnforcementDirs_;
     std::vector<MangledName> allowRelaxedPackagerChecksFor_;
-    bool enabled_ = false;
 
     // This vector is kept in sync with the size of the file table in the global state by
     // `Packager::setPackageNameOnFiles`. A `FileRef` being out of bounds in this vector is treated as the file having

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -394,7 +394,7 @@ com::stripe::rubytyper::FileTable Proto::filesToProto(const GlobalState &gs,
                                                       const UnorderedMap<long, long> &untypedUsages, bool showFull) {
     com::stripe::rubytyper::FileTable files;
     const auto &packageDB = gs.packageDB();
-    auto stripePackages = !packageDB.empty();
+    auto stripePackages = !packageDB.enabled();
     for (int i = 1; i < gs.filesUsed(); ++i) {
         core::FileRef file(i);
         if (file.data(gs).isPayload()) {

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -394,7 +394,7 @@ com::stripe::rubytyper::FileTable Proto::filesToProto(const GlobalState &gs,
                                                       const UnorderedMap<long, long> &untypedUsages, bool showFull) {
     com::stripe::rubytyper::FileTable files;
     const auto &packageDB = gs.packageDB();
-    auto stripePackages = !packageDB.enabled();
+    auto stripePackages = packageDB.enabled();
     for (int i = 1; i < gs.filesUsed(); ++i) {
         core::FileRef file(i);
         if (file.data(gs).isPayload()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, we would use `packageDB().empty()` in a handful of places as
a proxy for whether `--stripe-packages` had been passed.

That only worked because the places that we needed to check this option
ran after the packager had already created packages--packager itself
used the command line option to determine whether to run the packager in
the first place.

As I start to move more of packager into namer, I need a reliable way to
determine whether `--stripe-packages` had been passed. Storing a boolean
explicitly is the easiest way to manager that.

Also, by setting it in the `setPackagerOptions` function, we ensure that
it's already going to be set in all the places that we'd need it to be
set, like in tests and in LSP, without having to go flip this bit on in
a bunch of places manually.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests