### PR TITLE
Remove `package:` argument from `non_forcing_is_a?`

### DIFF
--- a/gems/sorbet-runtime/test/types/non_forcing_constants.rb
+++ b/gems/sorbet-runtime/test/types/non_forcing_constants.rb
@@ -95,21 +95,5 @@ class Opus::Types::Test::NonForcingConstantsTest < Critic::Unit::UnitTest
       end
       assert_match(/is not a class or module/, exn.message)
     end
-
-    describe 'packaged form' do
-      it "when exists and is_a? of something not in the package" do
-        # 0 is an Integer, but we're trying to find out if it's a
-        # `PkgRegistry::SomePackage::Integer` here, so this should be
-        # false
-        res = T::NonForcingConstants.non_forcing_is_a?(0, 'Integer', package: "SomePackage")
-        assert_equal(false, res)
-      end
-
-      it "when exists and is_a? of something that IS in the 'package' (i.e. in the right namespace)" do
-        # This relies on the constants we've set up elsewhere
-        res = T::NonForcingConstants.non_forcing_is_a?(SomePackage::Thing.new, 'Thing', package: "SomePackage")
-        assert_equal(true, res)
-      end
-    end
   end
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -470,6 +470,6 @@ end
 
 module T::NonForcingConstants
   # See <https://sorbet.org/docs/non-forcing-constants> for full docs.
-  sig {params(val: BasicObject, klass: String, package: T.nilable(String)).returns(T::Boolean)}
-  def self.non_forcing_is_a?(val, klass, package: nil); end
+  sig {params(val: BasicObject, klass: String).returns(T::Boolean)}
+  def self.non_forcing_is_a?(val, klass); end
 end

--- a/test/testdata/infer/non_forcing_is_a.rb
+++ b/test/testdata/infer/non_forcing_is_a.rb
@@ -56,15 +56,6 @@ if T::NonForcingConstants.non_forcing_is_a?(i_or_s, '::String')
 end
 
 oni = T.unsafe(Outer::Nested::Inner.new)
-# in non-package mode, the following are all identical and should all resolve
-T::NonForcingConstants.non_forcing_is_a?(oni, "::Outer::Nested::Inner")
-T::NonForcingConstants.non_forcing_is_a?(oni, "Inner", package: "Outer::Nested")
-T::NonForcingConstants.non_forcing_is_a?(oni, "Nested::Inner", package: "Outer")
 
 # these, that reference non-existing constants, should all yield the same error
 T::NonForcingConstants.non_forcing_is_a?(oni, "::Outer::Nested::Other") # error: Unable to resolve constant `::Outer::Nested::Other`
-T::NonForcingConstants.non_forcing_is_a?(oni, "Other", package: "Outer::Nested") # error: Unable to resolve constant `::Outer::Nested::Other`
-T::NonForcingConstants.non_forcing_is_a?(oni, "Nested::Other", package: "Outer") # error: Unable to resolve constant `::Outer::Nested::Other`
-
-pkg = "Outer"
-T::NonForcingConstants.non_forcing_is_a?(oni, "Nested::Other", package: pkg) # error: only accepts string literals

--- a/test/testdata/packager/non_forcing_constants/foo/foo_no_forcing.rb
+++ b/test/testdata/packager/non_forcing_constants/foo/foo_no_forcing.rb
@@ -15,7 +15,8 @@ module Project::Foo::FooNonForcing
 
   sig {params(arg: T.untyped).returns(T::Boolean)}
   def self.bad_not_keyword_arg(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Bar", "Project::Bar") # error: Too many positional arguments
+    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Bar", "Project::Bar")
+      #                                                       ^^^^^^^^^^^^^^ error: Too many arguments
       true
     else
       false
@@ -24,7 +25,9 @@ module Project::Foo::FooNonForcing
 
   sig {params(arg: T.untyped).returns(T::Boolean)}
   def self.bad_wrong_keyword_arg(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Bar", pakige: "Project::Bar") # error: Unrecognized keyword argument
+    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Bar", pakige: "Project::Bar")
+      #                                              ^^^^^^^ error: Unable to resolve constant
+      #                                                       ^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments
       true
     else
       false
@@ -33,7 +36,18 @@ module Project::Foo::FooNonForcing
 
   sig {params(arg: T.untyped).returns(T::Boolean)}
   def self.bad_package(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Bar", package: 5) # error: Unrecognized keyword argument
+    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Bar", package: 5)
+      #                                              ^^^^^^^ error: Unable to resolve constant
+      #                                                       ^^^^^^^^^^ error: Too many arguments
+      true
+    else
+      false
+    end
+  end
+
+  sig {params(arg: T.untyped).returns(T::Boolean)}
+  def self.good_check_is_bar(arg)
+    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Project::Bar::Bar")
       true
     else
       false

--- a/test/testdata/packager/non_forcing_constants/foo/foo_no_forcing.rb
+++ b/test/testdata/packager/non_forcing_constants/foo/foo_no_forcing.rb
@@ -32,44 +32,8 @@ module Project::Foo::FooNonForcing
   end
 
   sig {params(arg: T.untyped).returns(T::Boolean)}
-  def self.bad_package_not_a_string(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Bar", package: 5) # error: Expected `T.nilable(String)` but found `Integer(5)`
-      true
-    else
-      false
-    end
-  end
-
-  sig {params(arg: T.untyped).returns(T::Boolean)}
-  def self.bad_check_for_global_bar(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Bar", package: "Project::Bar") # error: should not be an absolute constant reference
-      true
-    else
-      false
-    end
-  end
-
-  sig {params(arg: T.untyped).returns(T::Boolean)}
-  def self.bad_non_existent_package(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "Bar", package: "Project::Quux") # error: Unable to resolve constant `::Project::Quux`
-      true
-    else
-      false
-    end
-  end
-
-  sig {params(arg: T.untyped).returns(T::Boolean)}
-  def self.check_for_non_existing_bar(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "Quux", package: "Project::Bar") # error: Unable to resolve constant `::Project::Bar::Quux`
-      true
-    else
-      false
-    end
-  end
-
-  sig {params(arg: T.untyped).returns(T::Boolean)}
-  def self.good_check_is_bar(arg)
-    if T::NonForcingConstants.non_forcing_is_a?(arg, "Bar", package: "Project::Bar")
+  def self.bad_package(arg)
+    if T::NonForcingConstants.non_forcing_is_a?(arg, "::Bar", package: 5) # error: Unrecognized keyword argument
       true
     else
       false


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was a remnant of our earlier intention of making the package system
enforced at runtime. We ended up abandoning that approach, and you can
see because the implementation of `non_forcing_is_a?` says as much in a
comment (now deleted).

I'm going to codemod Stripe's codebase to no longer use the `package:`
argument (i.e., prepend it to the second argument) and then land this
static and runtime change.

I doubt that anyone outside of Stripe is using this.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Mostly deleted the tests that mentioned a `package:` keyword arg, but I did
leave two behind to prove that we now report an error in infer when the keyword
arg (or any keyword arg) is passed.