### PR TITLE
Redefinition of parent should error for payload

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1062,21 +1062,13 @@ private:
                        job.klass.data(ctx)->superClass() == core::Symbols::todo() ||
                        job.klass.data(ctx)->superClass() == resolvedClass) {
                 job.klass.data(ctx)->setSuperClass(resolvedClass);
-            } else if (!ctx.file.data(ctx).isPayload() && absl::c_any_of(job.klass.data(ctx)->locs(), [&](auto &loc) {
-                           return loc.file().data(ctx).isPayload();
-                       })) {
-                job.klass.data(ctx)->setSuperClass(resolvedClass);
-                job.klass.data(ctx)->unsetClassOrModuleLinearizationComputed();
             } else {
                 auto fileIsPayload = ctx.file.data(ctx).isPayload();
                 auto klassDefinedInPayload = absl::c_any_of(
                     job.klass.data(ctx)->locs(), [&](auto &loc) { return loc.file().data(ctx).isPayload(); });
                 auto allowsPayloadParentOverride = suppressPayloadSuperclassRedefinitionFor.contains(job.klass);
 
-                if (!fileIsPayload && klassDefinedInPayload && allowsPayloadParentOverride) {
-                    job.klass.data(ctx)->setSuperClass(resolvedClass);
-                    job.klass.data(ctx)->unsetClassOrModuleLinearizationComputed();
-                } else {
+                if (!allowsPayloadParentOverride) {
                     if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::RedefinitionOfParents)) {
                         e.setHeader("Parent of class `{}` redefined from `{}` to `{}`", job.klass.show(ctx),
                                     job.klass.data(ctx)->superClass().show(ctx), resolvedClass.show(ctx));

--- a/test/testdata/resolver/payload_superclass_redefinition.rb
+++ b/test/testdata/resolver/payload_superclass_redefinition.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class Parent
+end
+
+class IRB::RelineInputMethod < Parent
+                             # ^^^^^^ error: Parent of class `IRB::RelineInputMethod` redefined from `IRB::InputMethod` to `Parent`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
I believe https://github.com/sorbet/sorbet/pull/7587 introduced a bug. This is my initial attempt at fixing it. 

The test I added is not outputting a typecheck error in `master`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
