### PR TITLE
Compare edited files against appropriate *.rbedited file

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -13,6 +13,7 @@
 #include "test/helpers/position_assertions.h"
 #include <iterator>
 #include <regex>
+#include <string.h>
 
 using namespace std;
 
@@ -1760,8 +1761,8 @@ ApplyCodeActionAssertion::ApplyCodeActionAssertion(string_view filename, unique_
 string ApplyCodeActionAssertion::toString() const {
     return fmt::format("apply-code-action: [{}] {}", version, title);
 }
-optional<pair<string, string>> ApplyCodeActionAssertion::expectedFile() {
-    auto expectedUpdatedFilePath = updatedFilePath(this->filename, this->version);
+optional<pair<string, string>> ApplyCodeActionAssertion::expectedFile(string filename, string version) {
+    auto expectedUpdatedFilePath = updatedFilePath(filename, version);
     string expectedEditedFileContents;
     try {
         expectedEditedFileContents = FileOps::read(expectedUpdatedFilePath);
@@ -1814,11 +1815,6 @@ getFileByUri(const LSPConfiguration &config,
 
 void ApplyCodeActionAssertion::check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
                                      LSPWrapper &wrapper, const CodeAction &codeAction) {
-    auto maybeFile = expectedFile();
-    if (!maybeFile.has_value()) {
-        return;
-    }
-    auto [expectedUpdatedFilePath, expectedEditedFileContents] = maybeFile.value();
     const auto &config = wrapper.config();
     for (auto &c : *codeAction.edit.value()->documentChanges) {
         auto file = getFileByUri(config, sourceFileContents, c->textDocument->uri);
@@ -1826,6 +1822,12 @@ void ApplyCodeActionAssertion::check(const UnorderedMap<std::string, std::shared
         string actualEditedFileContents = string(file->source());
         c = sortEdits(move(c));
 
+        auto maybeFile = expectedFile(uriToFilePath(config, c->textDocument->uri), this->version);
+        if (!maybeFile.has_value()) {
+            return;
+        }
+
+        auto [expectedUpdatedFilePath, expectedEditedFileContents] = maybeFile.value();
         for (auto &e : c->edits) {
             auto reindent = false;
             actualEditedFileContents = applyEdit(actualEditedFileContents, *file, *e->range, e->newText, reindent);
@@ -1839,12 +1841,11 @@ void ApplyCodeActionAssertion::checkAll(
     const CodeAction &codeAction) {
     const auto &config = wrapper.config();
     UnorderedMap<string, string> accumulatedOriginalEditedContents{};
+
+    // actualEditedFileContents -> (expectedUpdatedFilePath, expectedEditedFileContents)
+    // Maps original file contents to a edited filename and contents
+    UnorderedMap<string, std::pair<std::string, std::string>> fileToUpdatedFile;
     string actualEditedFileContents;
-    auto maybeFile = expectedFile();
-    if (!maybeFile.has_value()) {
-        return;
-    }
-    auto [expectedUpdatedFilePath, expectedEditedFileContents] = maybeFile.value();
     for (auto &c : *codeAction.edit.value()->documentChanges) {
         auto file = getFileByUri(config, sourceFileContents, c->textDocument->uri);
 
@@ -1852,6 +1853,12 @@ void ApplyCodeActionAssertion::checkAll(
         actualEditedFileContents = string(file->source());
 
         for (auto &e : c->edits) {
+            auto maybeFile = expectedFile(uriToFilePath(config, c->textDocument->uri), this->version);
+            if (!maybeFile.has_value()) {
+                continue;
+            }
+            fileToUpdatedFile.insert_or_assign(actualEditedFileContents, maybeFile.value());
+
             string oldSource = accumulatedOriginalEditedContents.contains(actualEditedFileContents)
                                    ? accumulatedOriginalEditedContents[actualEditedFileContents]
                                    : actualEditedFileContents;
@@ -1863,6 +1870,7 @@ void ApplyCodeActionAssertion::checkAll(
     }
 
     for (auto pair : accumulatedOriginalEditedContents) {
+        auto [expectedUpdatedFilePath, expectedEditedFileContents] = fileToUpdatedFile[pair.first];
         assertResults(expectedUpdatedFilePath, expectedEditedFileContents, pair.second);
     }
 }

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -425,7 +425,7 @@ public:
     std::string toString() const override;
 
 private:
-    std::optional<std::pair<std::string, std::string>> expectedFile();
+    std::optional<std::pair<std::string, std::string>> expectedFile(std::string filename, std::string version);
     void assertResults(std::string expectedPath, std::string expectedContents, std::string actualContents);
     std::unique_ptr<TextDocumentEdit> sortEdits(std::unique_ptr<TextDocumentEdit> changes);
 };


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Before this commit LSP test runner, would compare edited file against `<original_file>.*.rbedited.`
That is not always a right thing to do, because code action might edit something in a different file.

For example, if the error in file `a.rb` has a code action assertion with an autocorrect in `package.rb`, then LSP test harness would apply the autocorrect, and compare `a.rb` with `a.1.rbedited`. The right thing to do is to apply autocorrect and compare `package.rb` with `package.1.rbedited`, because this is the file where autocorrect is actually applied. The PR fixes that bug.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The issue was found while working on https://github.com/sorbet/sorbet/pull/7573

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
