### PR TITLE
Rename errorIfFileIsUntyped (it doesn't error)

### DIFF
--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -53,7 +53,7 @@ LSPQuery::filterAndDedup(const core::GlobalState &gs,
 }
 
 LSPQueryResult LSPQuery::byLoc(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker, string_view uri,
-                               const Position &pos, LSPMethod forMethod, bool errorIfFileIsUntyped) {
+                               const Position &pos, LSPMethod forMethod, bool emptyResultIfFileIsUntyped) {
     Timer timeit(config.logger, "setupLSPQueryByLoc");
     const core::GlobalState &gs = typechecker.state();
     auto fref = config.uri2FileRef(gs, uri);
@@ -72,7 +72,7 @@ LSPQueryResult LSPQuery::byLoc(const LSPConfiguration &config, LSPTypecheckerDel
         return LSPQueryResult{{}, move(error)};
     }
 
-    if (errorIfFileIsUntyped && fref.data(gs).strictLevel < core::StrictLevel::True) {
+    if (emptyResultIfFileIsUntyped && fref.data(gs).strictLevel < core::StrictLevel::True) {
         config.logger->info("Ignoring request on untyped file `{}`", uri);
         // Act as if the query returned no results.
         return LSPQueryResult{{}, nullptr};

--- a/main/lsp/LSPQuery.h
+++ b/main/lsp/LSPQuery.h
@@ -13,7 +13,7 @@ public:
 
     static LSPQueryResult byLoc(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
                                 std::string_view uri, const Position &pos, LSPMethod forMethod,
-                                bool errorIfFileIsUntyped = true);
+                                bool emptyResultIfFileIsUntyped = true);
     static LSPQueryResult bySymbolInFiles(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
                                           core::SymbolRef symbol, std::vector<core::FileRef> frefs);
     static LSPQueryResult bySymbol(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -17,9 +17,9 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
     const core::GlobalState &gs = typechecker.state();
     // To match the behavior of Go To Definition, we don't error in an untyped file, but instead
     // be okay with returning an empty result for certain queries.
-    auto errorIfFileIsUntyped = false;
+    auto emptyResultIfFileIsUntyped = false;
     auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
-                                  LSPMethod::SorbetShowSymbol, errorIfFileIsUntyped);
+                                  LSPMethod::SorbetShowSymbol, emptyResultIfFileIsUntyped);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I thought that this option being `true` meant that the query would return an `error`, but it actually returns a `result` that is empty.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.