### PR TITLE
Handle `Empty` CodeActionKind

### DIFF
--- a/main/lsp/tools/generate_lsp_messages.h
+++ b/main/lsp/tools/generate_lsp_messages.h
@@ -474,6 +474,10 @@ private:
     static std::string toIdentifier(std::string_view val) {
         // Split string into components.
         auto components = absl::StrSplit(val, absl::ByAnyChar("._/"));
+        // Handle empty string.
+        if (val.empty()) {
+            return "Empty";
+        }
         // Capitalize each component.
         return fmt::format("{}", fmt::map_join(components, "", [](auto component) -> std::string {
                                if (component.length() == 0) {

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -416,7 +416,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                    classTypes);
 
     auto CodeActionKind = makeStrEnum("CodeActionKind",
-                                      {"quickfix", "refactor", "refactor.extract", "refactor.inline",
+                                      {"", "quickfix", "refactor", "refactor.extract", "refactor.inline",
                                        "refactor.rewrite", "source", "source.organizeImports", "source.fixAll.sorbet"},
                                       enumTypes);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This PR makes sorbet-lsp supports `Empty` CodeActionKind.
spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind

For example, vim-lsp sends `Empty` CodeActionKind in `only` property of CodeActionContext.
code: https://github.com/prabirshrestha/vim-lsp/blob/3af8f3b38effc4a631a15bb283a4b701c251275d/autoload/lsp/ui/vim/code_action.vim#L55

Related slack thread: https://sorbet-ruby.slack.com/archives/CFT8Y4909/p1701997597443059

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Vim with vim-lsp users cannot use Sorbet's CodeAction because sorbet-lsp returns the following error message when vim-lsp requests CodeAction.

```
Unable to deserialize LSP request: Error deserializing JSON message: Invalid value for enum type `CodeActionKind`: 
```

This error message looks like truncated because the error is caused by an empty string (`""`), which represents `Empty` CodeActionKind.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I am sorry but I don't have good idea to write code to check make_lsp_types.cc follows the spec.
I would like to have some advice to do that if I need to write test in this case.
