### PR TITLE
Revert "Move extract to variable to beta (#7640)"

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -367,7 +367,7 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "Enable experimental `requires_ancestor` annotation");
 
     options.add_options("advanced")("enable-experimental-lsp-extract-to-variable",
-                                    "Enable beta LSP feature: Extract To Variable");
+                                    "Enable experimental LSP feature: Extract To Variable");
 
     options.add_options("advanced")(
         "enable-all-experimental-lsp-features",
@@ -742,13 +742,13 @@ void readOptions(Options &opts,
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
         opts.lspAllBetaFeaturesEnabled = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();
-        opts.lspExtractToVariableEnabled =
-            opts.lspAllBetaFeaturesEnabled || raw["enable-experimental-lsp-extract-to-variable"].as<bool>();
         opts.lspDocumentSymbolEnabled =
             opts.lspAllBetaFeaturesEnabled || raw["enable-experimental-lsp-document-symbol"].as<bool>();
         opts.lspDocumentHighlightEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-highlight"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
+        opts.lspExtractToVariableEnabled =
+            enableAllLSPFeatures || raw["enable-experimental-lsp-extract-to-variable"].as<bool>();
         opts.rubyfmtPath = raw["rubyfmt-path"].as<string>();
         if (enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>()) {
             if (!FileOps::exists(opts.rubyfmtPath)) {


### PR DESCRIPTION
This reverts commit 7fc8defc078d1e6e77601cfc3dace5c7bc48d68d.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Move Extract to Variable back to experimental.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's not stable enough to be in beta; too many crashes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
