### PR TITLE
Revert "Pre-resolve the PackageSpec superclass in a package file (#7737)"

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1228,13 +1228,6 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
         // value in going that far (even namer mutates the trees; the packager fills a similar role).
         packageSpecClass->name = prependName(move(packageSpecClass->name));
 
-        // Pre-resolve the super class. This makes it easier to detect that this is a package
-        // spec-related class def in later passes without having to recursively walk up the constant
-        // lit's scope to find if it starts with <PackageSpecRegistry>.
-        auto superClassLoc = packageSpecClass->ancestors[0].loc();
-        packageSpecClass->ancestors[0] = ast::make_expression<ast::ConstantLit>(
-            superClassLoc, core::Symbols::PackageSpec(), move(packageSpecClass->ancestors[0]));
-
         info = make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree), ctx.locAt(packageSpecClass->loc),
                                             ctx.locAt(packageSpecClass->declLoc));
     }

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/deeply_nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
 
     <self>.export(::<root>::<C Package>::<C PackageClass>)
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Package>)
 
     <self>.export(::<root>::<C Package>::<C Subpackage>::<C SubpackageClass>)

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -1,11 +1,11 @@
 # -- test/testdata/packager/export_for_test/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPkg><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C RootPkg><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
   end
 end
 # -- test/testdata/packager/export_for_test/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Opus>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar>)
 
     <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Util>)
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/foo/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
 
     <self>.export(::<root>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/test_imported/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C TestImported><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Opus>::<C TestImported><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Opus>::<C TestImported>::<C TIClass>)
 
     <self>.export(::<root>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Util><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Opus>::<C Util><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Opus>::<C Util>::<C UtilClass>)
 
     <self>.export(::<root>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/export_imported/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C B>)
 
     <self>.export(::<root>::<C B>::<C BClass>)
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_imported/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C B>::<C BClass>)
   end
 end

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/extra_package_paths/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
 
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package>)
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/baz/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C C>)
 
     <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C E>)
@@ -18,7 +18,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Foo>::<C B>)
 
     <self>.export(::<root>::<C Project>::<C Foo>::<C D>)
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo_bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C FooBar><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C FooBar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C FooBar>::<C Z>)
   end
 end

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -1,12 +1,12 @@
 # -- test/testdata/packager/import_subpackage/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Root><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Root><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Root>::<C B>)
   end
 end
 # -- test/testdata/packager/import_subpackage/a/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Root>::<C B><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Root>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Root>::<C B>::<C Foo>)
   end
 end

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/invalid_imports_and_exports/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(123)
 
     <self>.import("hello")
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/invalid_imports_and_exports/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C A>)
 
     <self>.export(::<root>::<C B>::<C BClass>)

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -2,7 +2,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C SomeConstant> = <emptyTree>::<C PackageSpec>
 
-  class ::<PackageSpecRegistry>::<C MyPackage><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C MyPackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -1,12 +1,12 @@
 # -- test/testdata/packager/nested_inner_namespaces/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPackage><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C RootPackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C RootPackage>::<C Foo>)
   end
 end
 # -- test/testdata/packager/nested_inner_namespaces/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPackage>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C RootPackage>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C RootPackage>::<C Foo>::<C Constant>)
 
     <self>.export(::<root>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
 
     <self>.export(::<root>::<C Package>::<C PackageClass>)
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/nested_packages/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Package>)
 
     <self>.export(::<root>::<C Package>::<C Subpackage>::<C SubpackageClass>)

--- a/test/testdata/packager/shared_prefix/pass.package-tree.exp
+++ b/test/testdata/packager/shared_prefix/pass.package-tree.exp
@@ -1,18 +1,18 @@
 # -- test/testdata/packager/shared_prefix/bar/that/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C That><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C That><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Bar>::<C That>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/this/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C This><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C This><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Bar>::<C This>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/that/that.rb --

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/simple_package/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
 
     <self>.export(::<root>::<C Project>::<C Bar>::<C Bar>)
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Bar>)
 
     <self>.export(::<root>::<C Project>::<C Foo>::<C Foo>)

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/simple_test_import/main_lib/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C MainLib><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C MainLib><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Util>)
 
     <self>.test_import(::<PackageSpecRegistry>::<C Project>::<C TestOnly>)
@@ -10,13 +10,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_test_import/test_only/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C TestOnly><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C TestOnly><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C TestOnly>::<C SomeHelper>)
   end
 end
 # -- test/testdata/packager/simple_test_import/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Util><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Util><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Util>::<C MyUtil>)
 
     <self>.export(::<root>::<C Test>::<C Project>::<C Util>::<C UtilHelper>)

--- a/test/testdata/packager/unimported_namespace/pass.package-tree.exp
+++ b/test/testdata/packager/unimported_namespace/pass.package-tree.exp
@@ -1,18 +1,18 @@
 # -- test/testdata/packager/unimported_namespace/aaa/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C AAA><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C AAA><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C AAA>::<C AClass>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/bbb/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C BBB><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C BBB><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(::<PackageSpecRegistry>::<C AAA>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/ccc/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C CCC><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C CCC><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/aaa/a_class.rb --


### PR DESCRIPTION
This reverts commit a75ce501d1f897d914136019fa8a5b95fe5fa466.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is causing problems with caches, because the contents of the cache depends on the value of the `--stripe-packages` option, but the cache key does not include --stripe-packages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.