### PR TITLE
Remove the last use of getPackageForFile on symbols

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -257,6 +257,15 @@ const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, cor
     return NONE_PKG;
 }
 
+const PackageInfo &PackageDB::getPackageForSymbol(const core::GlobalState &gs, core::SymbolRef sym) const {
+    auto name = this->getPackageNameForSymbol(gs, sym);
+    if (!name.exists()) {
+        return NONE_PKG;
+    }
+
+    return this->getPackageInfo(name);
+}
+
 const PackageInfo &PackageDB::getPackageInfo(const core::GlobalState &gs, std::string_view nameStr) const {
     auto cnst = core::packages::MangledName::mangledNameFromHuman(gs, nameStr);
     if (!cnst.exists()) {

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -46,6 +46,7 @@ public:
     void setPackageNameForFile(FileRef file, MangledName mangledName);
 
     const PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
+    const PackageInfo &getPackageForSymbol(const core::GlobalState &gs, core::SymbolRef sym) const;
     const PackageInfo &getPackageInfo(MangledName mangledName) const;
 
     // Lookup `PackageInfo` from the string representation of the un-mangled package name.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1380,8 +1380,7 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
 
         writer.String("package");
         if (sym.exists() && sym.loc(gs).exists()) {
-            const auto file = sym.loc(gs).file();
-            const auto &pkg = gs.packageDB().getPackageForFile(gs, file);
+            const auto &pkg = gs.packageDB().getPackageForSymbol(gs, sym);
             if (!pkg.exists()) {
                 writer.String("<none>");
             } else {


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is the last place where we were using `sym.loc().file()` to get the package that owns the symbol, rather than using symbol information to lookup the package directly.

There are still a handful of `getPackageNameForFile` calls (which get the `MangledName` for the package instead of the full `PackageInfo`), and removing all the rest of these should mean that we can remove the part of `VisibilityChecker` that calls `addLoc` to ensure that a symbol's canonical loc matches the owning package.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
