### PR TITLE
Cache files before pipeline::package

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1230,7 +1230,7 @@ void printFileTable(unique_ptr<core::GlobalState> &gs, const options::Options &o
 #endif
 }
 
-bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, const vector<ast::ParsedFile> &parsedFiles,
+bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::Span<const ast::ParsedFile> parsedFiles,
                         const unique_ptr<OwnedKeyValueStore> &kvstore) {
     if (kvstore == nullptr) {
         return false;

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -67,8 +67,7 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
                                     const options::Options &opts);
 
 // Caches any uncached trees and files. Returns true if it modifies kvstore.
-bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers,
-                        const std::vector<ast::ParsedFile> &parsedFiles,
+bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::Span<const ast::ParsedFile> parsedFiles,
                         const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 // Exported for tests only.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The call to `pipeline::package` will do some rewrites that only apply if
the `--stripe-packages` option was passed.

What this would mean is that the later call to
`maybeCacheGlobalStateAndFiles` would accidentally add ASTs produced by
phases later than indexer to the cache, which could then sometimes get
read back out in contexts where that flag hadn't been passed.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I don't have a way to test this, and I'm only 99% sure that this is the root
cause of the problems we were seeing. That's good enough for me to roll forward
with this.