### PR TITLE
Allow passing env variables to LSP configuration

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -236,6 +236,15 @@
                 "format": "uri-reference",
                 "default": "${workspaceFolder}"
               },
+              "env": {
+                "description": "Environment variables to set when launching sorbet",
+                "type": "object",
+                "minItems": 1,
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "default": {}
+              },
               "command": {
                 "description": "Full command line to invoke sorbet",
                 "type": "array",
@@ -250,6 +259,9 @@
               "name": "My Custom Sorbet Configuration",
               "description": "A longer description of this Sorbet Configuration for use in hover text",
               "cwd": "${workspaceFolder}",
+              "env": {
+                "MY_ENV_VAR": "my-value"
+              },
               "command": [
                 "bundle",
                 "exec",

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -287,8 +287,8 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
   private startSorbetProcess(): Promise<ChildProcess> {
     this.status = ServerStatus.INITIALIZING;
     this.context.log.info("Running Sorbet LSP.");
-    const [command, ...args] =
-      this.context.configuration.activeLspConfig?.command ?? [];
+    const activeConfig = this.context.configuration.activeLspConfig;
+    const [command, ...args] = activeConfig?.command ?? [];
     if (!command) {
       const msg = `Missing command-line data to start Sorbet. ConfigId:${this.context.configuration.activeLspConfig?.id}`;
       this.context.log.error(msg);
@@ -298,6 +298,7 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
     this.context.log.debug(` > ${command} ${args.join(" ")}`);
     this.sorbetProcess = spawn(command, args, {
       cwd: workspace.rootPath,
+      env: activeConfig?.env ?? process.env,
     });
     // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
     // So, we need to handle both events. ¯\_(ツ)_/¯

--- a/vscode_extension/src/sorbetLspConfig.ts
+++ b/vscode_extension/src/sorbetLspConfig.ts
@@ -1,4 +1,4 @@
-import { deepEqual } from "./utils";
+import { deepEqual, deepEqualEnv } from "./utils";
 
 /**
  * Sorbet LSP configuration (data-only).
@@ -20,6 +20,10 @@ export interface SorbetLspConfigData {
    * Working directory for {@link command}.
    */
   readonly cwd: string;
+  /**
+   * Environment variables to set when executing {@link command}.
+   */
+  readonly env: NodeJS.ProcessEnv;
   /**
    * Command and arguments to execute, e.g. `["srb", "typecheck", "--lsp"]`.
    */
@@ -47,6 +51,10 @@ export class SorbetLspConfig implements SorbetLspConfigData {
    */
   public readonly cwd: string;
   /**
+   * Environment variables to set when executing {@link command}.
+   */
+  public readonly env: NodeJS.ProcessEnv;
+  /**
    * Command and arguments to execute, e.g. `["bundle", "exec", "srb", "typecheck", "--lsp"]`.
    */
   public readonly command: ReadonlyArray<string>;
@@ -61,6 +69,15 @@ export class SorbetLspConfig implements SorbetLspConfigData {
     name: string,
     description: string,
     cwd: string,
+    env: NodeJS.ProcessEnv,
+  );
+
+  constructor(
+    id: string,
+    name: string,
+    description: string,
+    cwd: string,
+    env: NodeJS.ProcessEnv,
     command: ReadonlyArray<string>,
   );
 
@@ -69,6 +86,7 @@ export class SorbetLspConfig implements SorbetLspConfigData {
     name: string = "",
     description: string = "",
     cwd: string = "",
+    env: NodeJS.ProcessEnv = {},
     command: ReadonlyArray<string> = [],
   ) {
     if (typeof idOrData === "string") {
@@ -76,12 +94,14 @@ export class SorbetLspConfig implements SorbetLspConfigData {
       this.name = name;
       this.description = description;
       this.cwd = cwd;
+      this.env = { ...process.env, ...env };
       this.command = command;
     } else {
       this.id = idOrData.id;
       this.name = idOrData.name;
       this.description = idOrData.description;
       this.cwd = idOrData.cwd;
+      this.env = { ...process.env, ...idOrData.env };
       this.command = [...idOrData.command];
     }
   }
@@ -103,6 +123,7 @@ export class SorbetLspConfig implements SorbetLspConfigData {
         this.name !== other.name ||
         this.description !== other.description ||
         this.cwd !== other.cwd ||
+        !deepEqualEnv(this.env, other.env) ||
         !deepEqual(this.command, other.command))
     ) {
       return false;

--- a/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
+++ b/vscode_extension/src/test/commands/showSorbetConfigurationPicker.test.ts
@@ -26,6 +26,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       name: "test-config-id-active",
       description: "",
       cwd: "",
+      env: {},
       command: [],
     });
     const otherLspConfig = new SorbetLspConfig({
@@ -33,6 +34,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       name: "test-config-id",
       description: "",
       cwd: "",
+      env: {},
       command: [],
     });
 

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -98,6 +98,7 @@ const fooLspConfig = new SorbetLspConfig({
   name: "FooFoo",
   description: "The foo config",
   cwd: "${workspaceFolder}", // eslint-disable-line no-template-curly-in-string
+  env: {},
   command: ["foo", "on", "you"],
 });
 
@@ -106,6 +107,7 @@ const barLspConfig = new SorbetLspConfig({
   name: "BarBar",
   description: "The bar config",
   cwd: "${workspaceFolder}/bar", // eslint-disable-line no-template-curly-in-string
+  env: {},
   command: ["I", "heart", "bar", "bee", "que"],
 });
 
@@ -116,6 +118,7 @@ suite("SorbetLspConfig", () => {
       name: "two",
       description: "three",
       cwd: "four",
+      env: {},
       command: ["five", "six"],
     };
     const lspConfig = new SorbetLspConfig(ctorArg);
@@ -157,6 +160,7 @@ suite("SorbetLspConfig", () => {
       name: "two",
       description: "three",
       cwd: "four",
+      env: {},
       command: ["five", "six"],
     };
     const config1 = new SorbetLspConfig(json);
@@ -167,6 +171,7 @@ suite("SorbetLspConfig", () => {
       new SorbetLspConfig({ ...json, description: "different description" }),
       new SorbetLspConfig({ ...json, cwd: "different cwd" }),
       new SorbetLspConfig({ ...json, command: ["different", "command"] }),
+      new SorbetLspConfig({ ...json, env: { different: "value" } }),
       undefined,
     ];
 

--- a/vscode_extension/src/test/sorbetLspConfig.test.ts
+++ b/vscode_extension/src/test/sorbetLspConfig.test.ts
@@ -9,6 +9,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     "test_name",
     "test_description",
     "test_cwd",
+    {},
     ["test_command", "test_arg_1"],
   );
   const config2 = new SorbetLspConfig(
@@ -16,6 +17,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     "test_name",
     "test_description",
     "test_cwd",
+    {},
     ["test_command", "test_arg_1"],
   );
   const differentConfigs = [
@@ -24,6 +26,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       "test_name",
       "test_description",
       "test_cwd",
+      {},
       ["test_command", "test_arg_1"],
     ),
     new SorbetLspConfig(
@@ -31,6 +34,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       "different_test_name",
       "test_description",
       "test_cwd",
+      {},
       ["test_command", "test_arg_1"],
     ),
     new SorbetLspConfig(
@@ -38,6 +42,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       "test_name",
       "different_test_description",
       "test_cwd",
+      {},
       ["test_command", "test_arg_1"],
     ),
     new SorbetLspConfig(
@@ -45,6 +50,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       "test_name",
       "test_description",
       "different_test_cwd",
+      {},
       ["test_command", "test_arg_1"],
     ),
     new SorbetLspConfig(
@@ -52,7 +58,18 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       "test_name",
       "test_description",
       "test_cwd",
+      {},
       ["different_test_command", "test_arg_1"],
+    ),
+    new SorbetLspConfig(
+      "test_id",
+      "test_name",
+      "test_description",
+      "test_cwd",
+      {
+        different_env_key: "different_env_value",
+      },
+      ["test_command", "test_arg_1"],
     ),
     undefined,
     null,

--- a/vscode_extension/src/utils.ts
+++ b/vscode_extension/src/utils.ts
@@ -4,3 +4,17 @@
 export function deepEqual(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
   return a.length === b.length && a.every((itemA, index) => itemA === b[index]);
 }
+
+export function deepEqualEnv(
+  a: Readonly<NodeJS.ProcessEnv>,
+  b: Readonly<NodeJS.ProcessEnv>,
+) {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  return (
+    keysA.length === keysB.length &&
+    keysA.every((key) => a[key] === b[key]) &&
+    keysB.every((key) => a[key] === b[key])
+  );
+}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This PR adds the ability to pass environment variables to the language server via an `env` setting in the LSP config.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
I was trying to run a very non-standard Sorbet configuration in https://github.com/ruby/prism/pull/2561 and wanted to use the LSP server to help with fixing the type errors.

However, I needed to pass the `BUNDLE_GEMFILE` env variable to make `bundle exec srb` use the correct gemfile. I realized that there was no way to pass env variables to the language server process and decided to add support for them.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
