### PR TITLE
Allow some overlapping edits in `lsp_test_runner`

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1787,10 +1787,20 @@ std::unique_ptr<TextDocumentEdit> ApplyCodeActionAssertion::sortEdits(std::uniqu
     // First, sort the edits by increasing starting location and verify that none overlap.
     fast_sort(changes->edits, [](const auto &l, const auto &r) -> bool { return l->range->cmp(*r->range) < 0; });
     for (uint32_t i = 1; i < changes->edits.size(); i++) {
+        auto &first = changes->edits[i - 1];
+        auto &second = changes->edits[i];
+
+        // VSCode allows two overlapping edits if:
+        // 1) One edit is contained inside another
+        // 2) One of edits is empty string
+        if ((first->range->contains(*second->range) || second->range->contains(*first->range)) && (first->newText == "" || second->newText == "")) {
+            continue;
+        }
+
         INFO(fmt::format("Received quick fix edit\n{}\nthat overlaps edit\n{}\nThe test runner does not support "
                          "overlapping autocomplete edits, and it's likely that this is a bug.",
-                         changes->edits[i - 1]->toJSON(), changes->edits[i]->toJSON()));
-        REQUIRE_LT(changes->edits[i - 1]->range->end->cmp(*changes->edits[i]->range->start), 0);
+                         first->toJSON(), second->toJSON()));
+        REQUIRE_LT(first->range->end->cmp(*second->range->start), 0);
     }
 
     // Now, apply the edits in the reverse order so that the indices don't change.


### PR DESCRIPTION


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Overlapping edits are not allowed in `lsp_test_runner`, because VSCode doesn't allow that, and we try to mimic it.
Turns out if one edit is an empty string and included in the other edit, VSCode is okay with that

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
I found this out while working on https://github.com/sorbet/sorbet/pull/7573

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
