### PR TITLE
Update `Kernel#Integer` sig to allow arg to be of type `NilClass`

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -974,7 +974,7 @@ module Kernel
   # ```
   sig do
     params(
-        arg: T.any(Numeric, String),
+        arg: T.any(Numeric, String, NilClass),
         base: Integer,
         exception: T::Boolean
     )


### PR DESCRIPTION
Update `Kernel#Integer` sig to allow arg to be of type `NilClass`

### Motivation
According to ruby's RBS definition for `Kernel#Integer`, if `exception` is `false`, all errors raised by `#Integer` are suppressed and `nil` is returned. This is true even if `arg` is nil:
https://github.com/ruby/rbs/blob/c3e4171e64a8c03c3d52279c206318db595970d1/core/kernel.rbs#L619-L635
```ruby
> Integer(nil, exception: false)
=> nil
```

`sorbet`'s signature for `Kernel#Integer` forces `arg` to be either `Numeric` or `String`, which is not consistent with the actual behaviour

### Test plan
If there's any tests I can introduce, please let me know and I'll work on it 👍 

See included automated tests.
