### PR TITLE
Make sure to use `config.cwd` as the `cwd` of the language server

### DIFF
--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -287,8 +287,8 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
   private startSorbetProcess(): Promise<ChildProcess> {
     this.status = ServerStatus.INITIALIZING;
     this.context.log.info("Running Sorbet LSP.");
-    const [command, ...args] =
-      this.context.configuration.activeLspConfig?.command ?? [];
+    const activeConfig = this.context.configuration.activeLspConfig;
+    const [command, ...args] = activeConfig?.command ?? [];
     if (!command) {
       const msg = `Missing command-line data to start Sorbet. ConfigId:${this.context.configuration.activeLspConfig?.id}`;
       this.context.log.error(msg);
@@ -297,7 +297,7 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
 
     this.context.log.debug(` > ${command} ${args.join(" ")}`);
     this.sorbetProcess = spawn(command, args, {
-      cwd: workspace.rootPath,
+      cwd: activeConfig?.cwd ?? workspace.rootPath,
     });
     // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
     // So, we need to handle both events. ¯\_(ツ)_/¯

--- a/vscode_extension/src/sorbetLspConfig.ts
+++ b/vscode_extension/src/sorbetLspConfig.ts
@@ -19,7 +19,7 @@ export interface SorbetLspConfigData {
   /**
    * Working directory for {@link command}.
    */
-  readonly cwd: string;
+  readonly cwd: string | undefined;
   /**
    * Command and arguments to execute, e.g. `["srb", "typecheck", "--lsp"]`.
    */
@@ -45,7 +45,7 @@ export class SorbetLspConfig implements SorbetLspConfigData {
   /**
    * Working directory for {@link command}.
    */
-  public readonly cwd: string;
+  public readonly cwd: string | undefined;
   /**
    * Command and arguments to execute, e.g. `["bundle", "exec", "srb", "typecheck", "--lsp"]`.
    */
@@ -55,12 +55,27 @@ export class SorbetLspConfig implements SorbetLspConfigData {
 
   constructor(id: string, name: string);
   constructor(id: string, name: string, description: string);
-  constructor(id: string, name: string, description: string, cwd: string);
   constructor(
     id: string,
     name: string,
     description: string,
-    cwd: string,
+    cwd: string | undefined,
+  );
+
+  constructor(
+    id: string,
+    name: string,
+    description: string,
+    cwd: string | undefined,
+    env: NodeJS.ProcessEnv,
+  );
+
+  constructor(
+    id: string,
+    name: string,
+    description: string,
+    cwd: string | undefined,
+    env: NodeJS.ProcessEnv,
     command: ReadonlyArray<string>,
   );
 
@@ -68,7 +83,7 @@ export class SorbetLspConfig implements SorbetLspConfigData {
     idOrData: string | SorbetLspConfigData,
     name: string = "",
     description: string = "",
-    cwd: string = "",
+    cwd: string | undefined = undefined,
     command: ReadonlyArray<string> = [],
   ) {
     if (typeof idOrData === "string") {


### PR DESCRIPTION
It seems the `cwd` of the language server was never being set correctly, and it would always default to `workspace.rootPath`. This makes any setup that uses `config.cwd` to not be respected.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fix what I assume is a bug, but @froydnj's comment [here](https://github.com/sorbet/sorbet/pull/7763#issuecomment-1997802046) might mean this is intentional.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
