### PR TITLE
ensure that `T::Enum#to_s` returns values in sorted order

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/enum.rb
@@ -33,7 +33,7 @@ module T::Types
 
     # overrides Base
     def name
-      @name ||= "T.deprecated_enum([#{@values.map(&:inspect).join(', ')}])"
+      @name ||= "T.deprecated_enum([#{@values.map(&:inspect).sort.join(', ')}])"
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1209,21 +1209,21 @@ module Opus::Types::Test
 
       it 'fails validation with a value not from the enum' do
         msg = check_error_message_for_obj(@type, :baz)
-        assert_equal("Expected type T.deprecated_enum([:foo, :bar]), got :baz", msg)
+        assert_equal("Expected type T.deprecated_enum([:bar, :foo]), got :baz", msg)
       end
 
       it 'does not coerce types' do
         msg = check_error_message_for_obj(@type, 'foo')
-        assert_equal('Expected type T.deprecated_enum([:foo, :bar]), got "foo"', msg)
+        assert_equal('Expected type T.deprecated_enum([:bar, :foo]), got "foo"', msg)
 
         type = T.deprecated_enum(%w[foo bar])
         msg = check_error_message_for_obj(type, :foo)
-        assert_equal('Expected type T.deprecated_enum(["foo", "bar"]), got :foo', msg)
+        assert_equal('Expected type T.deprecated_enum(["bar", "foo"]), got :foo', msg)
       end
 
       it 'fails validation with a nil value' do
         msg = check_error_message_for_obj(@type, nil)
-        assert_equal("Expected type T.deprecated_enum([:foo, :bar]), got nil", msg)
+        assert_equal("Expected type T.deprecated_enum([:bar, :foo]), got nil", msg)
       end
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

cc @jd-stripe 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We do this for union and intersection types, we should do it for `T.deprecated_enum` types too.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  We know that there are tests at Stripe that depend on the ordering of these enum values in the stringified type, so those tests will have to be updated when sorbet-runtime is imported internally.

🤞  that this change doesn't cause other things to blow up in weird ways.
