### PR TITLE
gitignore: Add another clangd cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,9 @@ compiler/IREmitter/Intrinsics/PayloadIntrinsics.formatted.c
 compiler/IREmitter/Intrinsics/WrappedIntrinsics.h
 compiler/IREmitter/Intrinsics/WrappedIntrinsics.formatted.h
 
-# clangd caches data in this folder.
+# clangd caches data in these folders
 /.clangd
+/.cache/clangd
 
 # for YARD documentation
 .yardoc/


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It looks like a new version of `clangd` starts caching data in a
different folder. Let's ignore both of them.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a