### PR TITLE
Forcibly segfault for uncaught exception

### DIFF
--- a/main/main.cc
+++ b/main/main.cc
@@ -12,6 +12,6 @@ int main(int argc, char *argv[]) {
 
         // Forcibly exit with a segfault signal for uncaught exceptions, which makes it easier to
         // use `catchsegv.sh` to report these errors.
-        kill(0, SIGSEGV);
+        kill(getpid(), SIGSEGV);
     }
 };

--- a/main/main.cc
+++ b/main/main.cc
@@ -1,6 +1,7 @@
 #include "common/common.h"
 #include "main/options/options.h"
 #include "main/realmain.h"
+#include <signal.h>
 int main(int argc, char *argv[]) {
     try {
         return sorbet::realmain::realmain(argc, argv);
@@ -8,6 +9,9 @@ int main(int argc, char *argv[]) {
         return c.returnCode;
     } catch (sorbet::SorbetException &e) {
         fprintf(stderr, "caught %s: %s\n", typeid(e).name(), e.what());
-        return 1;
+
+        // Forcibly exit with a segfault signal for uncaught exceptions, which makes it easier to
+        // use `catchsegv.sh` to report these errors.
+        kill(0, SIGSEGV);
     }
 };


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This means that uncaught exceptions will look like segfaults. Stripe's
crash reporting mechanisms already look for segfaults, so this saves
some work having to integrate a different way to report uncaught
top-level exceptions.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The `--simulate-crash` flag uses `Exception::raise` to simulate a crash, which
means that it will go through this code path. I verified that when I used that flag,
the shell showed me that the process died with a segfault.