### PR TITLE
Fix crash in extract variable

### DIFF
--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -55,7 +55,7 @@ public:
             // It's not valid to extract the following node types
             if (!ast::isa_tree<ast::Break>(tree) && !ast::isa_tree<ast::Next>(tree) &&
                 !ast::isa_tree<ast::Return>(tree) && !ast::isa_tree<ast::Retry>(tree) &&
-                !ast::isa_tree<ast::RescueCase>(tree)) {
+                !ast::isa_tree<ast::RescueCase>(tree) && !ast::isa_tree<ast::InsSeq>(tree)) {
                 matchingLoc = tree.loc();
             }
         }

--- a/test/testdata/lsp/code_actions/extract_variable/invalid.rb
+++ b/test/testdata/lsp/code_actions/extract_variable/invalid.rb
@@ -120,6 +120,15 @@ end
 def endless_method = 1 + 123
 #                        ^^^ apply-code-action: [A] Extract Variable
 
+# The actual issue we saw causing crashes was the following, the selection is the entire method body:
+# def foo
+#   1 + 1
+#   2 + 2
+# end
+# However, our tests don't support mutli-line assertions, so this test case is approximating that
+# by joining the lines with a ; (the parse result will be the same for both cases).
+# TODO(neil): add a multiline test case here once we have multiline assertions.
+
 def multi_stat_selection
   1 + 1; 2 + 2
 # ^^^^^^^^^^^^ apply-code-action: [A] Extract Variable

--- a/test/testdata/lsp/code_actions/extract_variable/invalid.rb
+++ b/test/testdata/lsp/code_actions/extract_variable/invalid.rb
@@ -119,3 +119,8 @@ end
 
 def endless_method = 1 + 123
 #                        ^^^ apply-code-action: [A] Extract Variable
+
+def multi_stat_selection
+  1 + 1; 2 + 2
+# ^^^^^^^^^^^^ apply-code-action: [A] Extract Variable
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Selecting the entire method body was causing crashes in the extract to variable logic, because the selection would be a node (InsSeq), but our logic to find the matching statement would fail (since we would walk through each statement in the InsSeq). It doesn't make sense to extract multiple lines to a variable, so we can just disallow extracting of InsSeqs.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fix crashes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
