### PR TITLE
Stop catching top-level SorbetException exceptions

### DIFF
--- a/common/backtrace.cc
+++ b/common/backtrace.cc
@@ -46,7 +46,7 @@ void sorbet::Exception::printBacktrace() noexcept {
 
     string res = addr2line(programName, stackTraces, traceSize);
     filter_unnecessary(res);
-    fatalLogger->error("Backtrace from terminate:\n{}", res.c_str());
+    fatalLogger->error("Backtrace:\n{}", res.c_str());
 
     if (messages != nullptr) {
         free(messages);

--- a/common/common.cc
+++ b/common/common.cc
@@ -492,12 +492,8 @@ public:
                 // Aparently this is the only way to convert a std::exception_ptr to std::exception
                 std::rethrow_exception(eptr);
             } catch (const std::exception &e) {
-                int status;
-                // nullptr to request that __cxa_demangle allocate the string on our behalf,
-                // instead of populating a pre-allocated buffer.
-                auto demangled = abi::__cxa_demangle(typeid(e).name(), nullptr, nullptr, &status);
-                sorbet::fatalLogger->error("Sorbet raised uncaught exception type={} what={}", demangled, e.what());
-                std::free(demangled);
+                sorbet::fatalLogger->error("Sorbet raised uncaught exception type={} what={}",
+                                           demangle(typeid(e).name()), e.what());
             } catch (const std::string &s) {
                 sorbet::fatalLogger->error("Sorbet raised uncaught exception type=std::string what={}", s);
             } catch (const char *s) {

--- a/common/common.cc
+++ b/common/common.cc
@@ -1,4 +1,5 @@
 #include "common/common.h"
+#include "absl/strings/escaping.h"
 #include "common/FileOps.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "common/concurrency/WorkerPool.h"
@@ -492,12 +493,14 @@ public:
                 // Aparently this is the only way to convert a std::exception_ptr to std::exception
                 std::rethrow_exception(eptr);
             } catch (const std::exception &e) {
-                sorbet::fatalLogger->error("Sorbet raised uncaught exception type={} what={}",
-                                           demangle(typeid(e).name()), e.what());
+                sorbet::fatalLogger->error("Sorbet raised uncaught exception type=\"{}\" what=\"{}\"",
+                                           demangle(typeid(e).name()), absl::CEscape(e.what()));
             } catch (const std::string &s) {
-                sorbet::fatalLogger->error("Sorbet raised uncaught exception type=std::string what={}", s);
+                sorbet::fatalLogger->error("Sorbet raised uncaught exception type=std::string what=\"{}\"",
+                                           absl::CEscape(s));
             } catch (const char *s) {
-                sorbet::fatalLogger->error("Sorbet raised uncaught exception type=\"char *\" what={}", s);
+                sorbet::fatalLogger->error("Sorbet raised uncaught exception type=\"char *\" what=\"{}\"",
+                                           absl::CEscape(s));
             } catch (...) {
                 sorbet::fatalLogger->error("Sorbet raised uncaught exception type=<unknown> what=\"\"");
             }

--- a/main/main.cc
+++ b/main/main.cc
@@ -6,8 +6,5 @@ int main(int argc, char *argv[]) {
         return sorbet::realmain::realmain(argc, argv);
     } catch (sorbet::EarlyReturnWithCode &c) {
         return c.returnCode;
-    } catch (sorbet::SorbetException &e) {
-        fprintf(stderr, "caught %s: %s\n", typeid(e).name(), e.what());
-        return 1;
     }
 };

--- a/test/cli/statsd-invalid-link/test.out
+++ b/test/cli/statsd-invalid-link/test.out
@@ -1,2 +1,2 @@
 Exception::raise(): statsd initialization failed: host=f4K#l1N&.com port=8200 prefix=foo.bar.counters
-caught N6sorbet15SorbetExceptionE: statsd initialization failed: host=f4K#l1N&.com port=8200 prefix=foo.bar.counters
+Sorbet raised uncaught exception type="sorbet::SorbetException" what="statsd initialization failed: host=f4K#l1N&.com port=8200 prefix=foo.bar.counters"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Also:

- Use `std::current_exception` to print the name of all uncaught
  exceptions, not just `SorbetException` and subclasses.
- Use `abort` at the end of our `terminate_handler` to be sure the
  process is aborted (avoid undefined behavior).
- Use `abi::__cxa_demangle` to print a better (demangled) exception name


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

So that we can include uncaught C++ exceptions in Stripe's crash monitoring
(previously, only the non-`SorbetException` exceptions would get caught by our
crash monitoring).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested locally to see that things like

```
Sorbet raised uncaught exception type=std::bad_optional_access what=bad_optional_access
```

do get printed.

Testing manually on Stripe's codebase to make sure that the `SIGABRT` signal
that the `on_terminate` function exits with is enough to trigger a monitor.