### PR TITLE
fix issues when `Exception#backtrace_locations` returns `nil`

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -261,11 +261,16 @@ module T::Props::Serializable::DecoratorMethods
   end
 
   def message_with_generated_source_context(error, generated_method, generate_source_method)
-    generated_method = generated_method.to_s
-    line_loc = error.backtrace_locations.find {|l| l.base_label == generated_method}
-    return unless line_loc
+    line_label = error.backtrace.find {|l| l.end_with?("in `#{generated_method}'")}
+    return unless line_label
 
-    line_num = line_loc.lineno
+    line_num = if line_label.start_with?("(eval)")
+      # (eval):13:in `__t_props_generated_serialize'
+      line_label.split(':')[1]&.to_i
+    else
+      # (eval at /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb:65):13:in `__t_props_generated_serialize'
+      line_label.split(':')[2]&.to_i
+    end
     return unless line_num
 
     source_lines = self.send(generate_source_method).split("\n")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This reverts parts of #7710.

cc @casperisfine 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The changes to this file in #7710 cause errors when `backtrace_locations` is `nil`.  It's not obvious to me why `backtrace_locations` is `nil`, but it is on a number of Stripe's internal tests.  I see [references in the Ruby source](https://github.com/ruby/ruby/blob/35fe4b048034a8568cd2a2dc34f59dc12f644d21/error.c#L3322-L3343) to setting `backtrace_locations` to `nil` when exceptions are marshaled (!), but AFAICT we are not going through marshaling in the codepaths that are erroring.

This is error-handling code, so I'm not too concerned with the efficiency win from iterating over `backtrace_locations` rather than taking apart the backtrace itself.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I was not able to write a reproducible test case for this.