### PR TITLE
Restore Ruby 3.4 compatibility in T::Props::Serializable

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -261,15 +261,30 @@ module T::Props::Serializable::DecoratorMethods
   end
 
   def message_with_generated_source_context(error, generated_method, generate_source_method)
-    line_label = error.backtrace.find {|l| l.end_with?("in `#{generated_method}'")}
-    return unless line_label
+    generated_method = generated_method.to_s
+    if error.backtrace_locations
+      line_loc = error.backtrace_locations.find {|l| l.base_label == generated_method}
+      return unless line_loc
 
-    line_num = if line_label.start_with?("(eval)")
-      # (eval):13:in `__t_props_generated_serialize'
-      line_label.split(':')[1]&.to_i
+      line_num = line_loc.lineno
     else
-      # (eval at /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb:65):13:in `__t_props_generated_serialize'
-      line_label.split(':')[2]&.to_i
+      label = if RUBY_VERSION >= "3.4"
+        # in 'ClassName#__t_props_generated_serialize'"
+        "##{generated_method}'"
+      else
+        # in `__t_props_generated_serialize'"
+        "in `#{generated_method}'"
+      end
+      line_label = error.backtrace.find {|l| l.end_with?(label)}
+      return unless line_label
+
+      line_num = if line_label.start_with?("(eval)")
+        # (eval):13:in ...
+        line_label.split(':')[1]&.to_i
+      else
+        # (eval at /Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb:65):13:in ...
+        line_label.split(':')[2]&.to_i
+      end
     end
     return unless line_num
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -276,6 +276,22 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
       assert_includes(e.message, 'h["foo"] = @foo.transform_values {|v| T::Props::Utils.deep_clone_object(v)}')
     end
+
+    it 'handles exceptions without a #backtrace_locations' do
+      mock = Object.new
+      def mock.transform_values(...)
+        raise NoMethodError, "undefined method 'transform_values'", caller # rubocop:disable Style/RaiseArgs
+      end
+
+      m = a_serializable
+      m.instance_variable_set(:@foo, mock)
+      e = assert_raises(NoMethodError) do
+        m.serialize
+      end
+
+      assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
+      assert_includes(e.message, 'h["foo"] = @foo.transform_values {|v| T::Props::Utils.deep_clone_object(v)}')
+    end
   end
 
   class HasUnstoredProp < T::Struct


### PR DESCRIPTION
Followup: https://github.com/sorbet/sorbet/pull/7778
Followup: https://github.com/sorbet/sorbet/pull/7710

Exceptions are not guaranteed to have a `#backtrace_locations` because of `Exception#set_backtrace` and `Kernel#raise(error, message, backtrace)`.

It's still prefereable to use `#backtrace_location` when present as it requires much less string parsing.

But if it's missing we can fallback to parse backtraces the old way, however we need to account for Ruby 3.4 newer format.

@froydnj @jez @paracycle 