### PR TITLE
Add `base64digest` methods for `OpenSSL::HMAC`

### DIFF
--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -4442,6 +4442,10 @@ class OpenSSL::HMAC
   sig {returns(::T.untyped)}
   def hexdigest(); end
 
+  # Returns the authentication code as a Base64-encoded string.
+  sig {returns(::T.untyped)}
+  def base64digest(); end
+
   sig do
     params(
       arg0: ::T.untyped,
@@ -4554,6 +4558,28 @@ class OpenSSL::HMAC
     .returns(::T.untyped)
   end
   def self.hexdigest(arg0, arg1, arg2); end
+
+  # Returns the authentication code as a Base64-encoded string. The *digest*
+  # parameter specifies the digest algorithm to use. This may be a
+  # [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html) representing the
+  # algorithm name or an instance of
+  # [`OpenSSL::Digest`](https://docs.ruby-lang.org/en/2.7.0/OpenSSL/Digest.html).
+  #
+  # === Example
+  #  key = 'key'
+  #  data = 'The quick brown fox jumps over the lazy dog'
+  #
+  #  hmac = OpenSSL::HMAC.base64digest('SHA1', key, data)
+  #  #=> "3nybhbi3iqa8ino29wqQcBydtNk="
+  sig do
+    params(
+      arg0: ::T.untyped,
+      arg1: ::T.untyped,
+      arg2: ::T.untyped,
+    )
+    .returns(::T.untyped)
+  end
+  def self.base64digest(arg0, arg1, arg2); end
 end
 
 # Document-class:


### PR DESCRIPTION
### Motivation

Two `base64digest` methods were added to `OpenSSL::HMAC` in Ruby 3.1.0, but Sorbet does not have them ([docs here](https://ruby-doc.org/stdlib-3.1.0/libdoc/openssl/rdoc/OpenSSL/HMAC.html#method-c-base64digest), [source here](https://github.com/ruby/ruby/blob/4300c42a7eb12a0aa81e4ec79891cdba1cfdf3aa/ext/openssl/lib/openssl/hmac.rb)). I'm not sure what version Sorbet supports for these rbi files, but figured I'd open a PR in case they'd be helpful.

Everything else in the tweaked file is untyped, so I kept that convention rather than returning `String` and using the proper parameters.

### Test plan

Not sure that tests would add a whole lot of value here, so I didn't include any. I can add some if they should be added.