### PR TITLE
Explicitly mark drainErrors [[nodiscard]]

### DIFF
--- a/core/ErrorCollector.cc
+++ b/core/ErrorCollector.cc
@@ -16,7 +16,7 @@ void ErrorCollector::flushErrors(spdlog::logger &logger, const core::GlobalState
     }
 }
 
-vector<unique_ptr<core::Error>> ErrorCollector::drainErrors() {
+[[nodiscard]] vector<unique_ptr<core::Error>> ErrorCollector::drainErrors() {
     return move(collectedErrors);
 }
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -179,7 +179,7 @@ public:
     void clear(const core::GlobalState &gs) {
         got.clear();
         errorQueue->flushAllErrors(gs);
-        errorCollector->drainErrors();
+        auto _newErrors = errorCollector->drainErrors();
     }
 };
 
@@ -731,7 +731,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     // Allow later phases to have errors that we didn't test for
     errorQueue->flushAllErrors(*gs);
-    errorCollector->drainErrors();
+    { auto _ = errorCollector->drainErrors(); }
 
     // now we test the incremental resolver
 
@@ -833,7 +833,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     // and drain all the remaining errors
     errorQueue->flushAllErrors(*gs);
-    errorCollector->drainErrors();
+    { auto _ = errorCollector->drainErrors(); }
 
     {
         INFO("the incremental resolver should not add new symbols");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Makes it more explicit when the user is calling this method to drop
errors vs to pass the errors somewhere else.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.