### PR TITLE
apply grapheme encoding patch

### DIFF
--- a/third_party/ruby/fix_grapheme_clusters_3_3_only.patch
+++ b/third_party/ruby/fix_grapheme_clusters_3_3_only.patch
@@ -1,8 +1,8 @@
 diff --git a/regexec.c b/regexec.c
-index 9e6f503ed03f7f..95332915840e96 100644
+index 4b02e7f9b5..aa702028f9 100644
 --- a/regexec.c
 +++ b/regexec.c
-@@ -1943,6 +1943,19 @@ static int string_cmp_ic(OnigEncoding enc, int case_fold_flag,
+@@ -1890,6 +1890,19 @@ static int string_cmp_ic(OnigEncoding enc, int case_fold_flag,
  # define ABSENT_END_POS        end
  #endif /* USE_MATCH_RANGE_MUST_BE_INSIDE_OF_SPECIFIED_RANGE */
  
@@ -22,7 +22,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
  
  #ifdef USE_CAPTURE_HISTORY
  static int
-@@ -2923,7 +2936,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -2868,7 +2881,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  	int mb_len;
  
  	DATA_ENSURE(1);
@@ -31,7 +31,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
  	DATA_ENSURE(mb_len);
  	ss = s;
  	s += mb_len;
-@@ -3028,7 +3041,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -2973,7 +2986,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  
      CASE(OP_ANYCHAR)  MOP_IN(OP_ANYCHAR);
        DATA_ENSURE(1);
@@ -40,7 +40,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
        DATA_ENSURE(n);
        if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0)) goto fail;
        s += n;
-@@ -3037,7 +3050,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -2982,7 +2995,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  
      CASE(OP_ANYCHAR_ML)  MOP_IN(OP_ANYCHAR_ML);
        DATA_ENSURE(1);
@@ -49,7 +49,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
        DATA_ENSURE(n);
        s += n;
        MOP_OUT;
-@@ -3047,7 +3060,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -2992,7 +3005,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
        while (DATA_ENSURE_CHECK1) {
  	CHECK_MATCH_CACHE;
  	STACK_PUSH_ALT(p, s, sprev, pkeep);
@@ -58,7 +58,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
  	DATA_ENSURE(n);
  	if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
  	sprev = s;
-@@ -3060,7 +3073,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -3005,7 +3018,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
        while (DATA_ENSURE_CHECK1) {
  	CHECK_MATCH_CACHE;
  	STACK_PUSH_ALT(p, s, sprev, pkeep);
@@ -67,7 +67,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
  	if (n > 1) {
  	  DATA_ENSURE(n);
  	  sprev = s;
-@@ -3086,7 +3099,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -3031,7 +3044,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  	  msa->num_fails++;
  #endif
  	}
@@ -76,7 +76,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
  	DATA_ENSURE(n);
  	if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
  	sprev = s;
-@@ -3108,7 +3121,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -3053,7 +3066,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  	  msa->num_fails++;
  #endif
  	}
@@ -85,7 +85,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
  	if (n > 1) {
  	  DATA_ENSURE(n);
  	  sprev = s;
-@@ -3131,7 +3144,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -3076,7 +3089,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  	if (scv) goto fail;
  
  	STACK_PUSH_ALT_WITH_STATE_CHECK(p, s, sprev, mem, pkeep);
@@ -94,7 +94,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
  	DATA_ENSURE(n);
  	if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
  	sprev = s;
-@@ -3149,7 +3162,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -3094,7 +3107,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  	if (scv) goto fail;
  
  	STACK_PUSH_ALT_WITH_STATE_CHECK(p, s, sprev, mem, pkeep);
@@ -103,7 +103,7 @@ index 9e6f503ed03f7f..95332915840e96 100644
  	if (n > 1) {
  	  DATA_ENSURE(n);
  	  sprev = s;
-@@ -3491,7 +3504,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -3436,7 +3449,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  	DATA_ENSURE(n);
  	sprev = s;
  	STRING_CMP(pstart, s, n);
@@ -112,16 +112,16 @@ index 9e6f503ed03f7f..95332915840e96 100644
  	  sprev += len;
  
  	MOP_OUT;
-@@ -3522,7 +3535,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -3467,7 +3480,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  	DATA_ENSURE(n);
  	sprev = s;
- 	STRING_CMP_IC(case_fold_flag, pstart, &s, n, end);
+ 	STRING_CMP_IC(case_fold_flag, pstart, &s, (int)n, end);
 -	while (sprev + (len = enclen(encode, sprev, end)) < s)
 +	while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
  	  sprev += len;
  
  	MOP_OUT;
-@@ -3557,7 +3570,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+@@ -3502,7 +3515,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
  	  STRING_CMP_VALUE(pstart, swork, n, is_fail);
  	  if (is_fail) continue;
  	  s = swork;

--- a/third_party/ruby/fix_grapheme_clusters_3_3_only.patch
+++ b/third_party/ruby/fix_grapheme_clusters_3_3_only.patch
@@ -1,0 +1,132 @@
+diff --git a/regexec.c b/regexec.c
+index 9e6f503ed03f7f..95332915840e96 100644
+--- a/regexec.c
++++ b/regexec.c
+@@ -1943,6 +1943,19 @@ static int string_cmp_ic(OnigEncoding enc, int case_fold_flag,
+ # define ABSENT_END_POS        end
+ #endif /* USE_MATCH_RANGE_MUST_BE_INSIDE_OF_SPECIFIED_RANGE */
+ 
++int onigenc_mbclen_approximate(const OnigUChar* p,const OnigUChar* e, const struct OnigEncodingTypeST* enc);
++
++static inline int
++enclen_approx(OnigEncoding enc, const OnigUChar* p, const OnigUChar* e)
++{
++    if (enc->max_enc_len == enc->min_enc_len) {
++        return (p < e ? enc->min_enc_len : 0);
++    }
++    else {
++        return onigenc_mbclen_approximate(p, e, enc);
++    }
++}
++
+ 
+ #ifdef USE_CAPTURE_HISTORY
+ static int
+@@ -2923,7 +2936,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 	int mb_len;
+ 
+ 	DATA_ENSURE(1);
+-	mb_len = enclen(encode, s, end);
++	mb_len = enclen_approx(encode, s, end);
+ 	DATA_ENSURE(mb_len);
+ 	ss = s;
+ 	s += mb_len;
+@@ -3028,7 +3041,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 
+     CASE(OP_ANYCHAR)  MOP_IN(OP_ANYCHAR);
+       DATA_ENSURE(1);
+-      n = enclen(encode, s, end);
++      n = enclen_approx(encode, s, end);
+       DATA_ENSURE(n);
+       if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0)) goto fail;
+       s += n;
+@@ -3037,7 +3050,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 
+     CASE(OP_ANYCHAR_ML)  MOP_IN(OP_ANYCHAR_ML);
+       DATA_ENSURE(1);
+-      n = enclen(encode, s, end);
++      n = enclen_approx(encode, s, end);
+       DATA_ENSURE(n);
+       s += n;
+       MOP_OUT;
+@@ -3047,7 +3060,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+       while (DATA_ENSURE_CHECK1) {
+ 	CHECK_MATCH_CACHE;
+ 	STACK_PUSH_ALT(p, s, sprev, pkeep);
+-	n = enclen(encode, s, end);
++	n = enclen_approx(encode, s, end);
+ 	DATA_ENSURE(n);
+ 	if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
+ 	sprev = s;
+@@ -3060,7 +3073,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+       while (DATA_ENSURE_CHECK1) {
+ 	CHECK_MATCH_CACHE;
+ 	STACK_PUSH_ALT(p, s, sprev, pkeep);
+-	n = enclen(encode, s, end);
++	n = enclen_approx(encode, s, end);
+ 	if (n > 1) {
+ 	  DATA_ENSURE(n);
+ 	  sprev = s;
+@@ -3086,7 +3099,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 	  msa->num_fails++;
+ #endif
+ 	}
+-	n = enclen(encode, s, end);
++	n = enclen_approx(encode, s, end);
+ 	DATA_ENSURE(n);
+ 	if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
+ 	sprev = s;
+@@ -3108,7 +3121,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 	  msa->num_fails++;
+ #endif
+ 	}
+-	n = enclen(encode, s, end);
++	n = enclen_approx(encode, s, end);
+ 	if (n > 1) {
+ 	  DATA_ENSURE(n);
+ 	  sprev = s;
+@@ -3131,7 +3144,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 	if (scv) goto fail;
+ 
+ 	STACK_PUSH_ALT_WITH_STATE_CHECK(p, s, sprev, mem, pkeep);
+-	n = enclen(encode, s, end);
++	n = enclen_approx(encode, s, end);
+ 	DATA_ENSURE(n);
+ 	if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
+ 	sprev = s;
+@@ -3149,7 +3162,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 	if (scv) goto fail;
+ 
+ 	STACK_PUSH_ALT_WITH_STATE_CHECK(p, s, sprev, mem, pkeep);
+-	n = enclen(encode, s, end);
++	n = enclen_approx(encode, s, end);
+ 	if (n > 1) {
+ 	  DATA_ENSURE(n);
+ 	  sprev = s;
+@@ -3491,7 +3504,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 	DATA_ENSURE(n);
+ 	sprev = s;
+ 	STRING_CMP(pstart, s, n);
+-	while (sprev + (len = enclen(encode, sprev, end)) < s)
++	while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
+ 	  sprev += len;
+ 
+ 	MOP_OUT;
+@@ -3522,7 +3535,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 	DATA_ENSURE(n);
+ 	sprev = s;
+ 	STRING_CMP_IC(case_fold_flag, pstart, &s, n, end);
+-	while (sprev + (len = enclen(encode, sprev, end)) < s)
++	while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
+ 	  sprev += len;
+ 
+ 	MOP_OUT;
+@@ -3557,7 +3570,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
+ 	  STRING_CMP_VALUE(pstart, swork, n, is_fail);
+ 	  if (is_fail) continue;
+ 	  s = swork;
+-	  while (sprev + (len = enclen(encode, sprev, end)) < s)
++	  while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
+ 	    sprev += len;
+ 
+ 	  p += (SIZE_MEMNUM * (tlen - i - 1));

--- a/third_party/ruby/ldflags.patch
+++ b/third_party/ruby/ldflags.patch
@@ -1,7 +1,7 @@
 diff --git ext/fiddle/extconf.rb ext/fiddle/extconf.rb
 index 2d85b3eea5..eb03d3bfa6 100644
---- ext/fiddle/extconf.rb
-+++ ext/fiddle/extconf.rb
+--- a/ext/fiddle/extconf.rb
++++ b/ext/fiddle/extconf.rb
 @@ -96,7 +96,7 @@ def enable_debug_build_flag(flags)
 
    FileUtils.mkdir_p(libffi.dir)

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -137,8 +137,11 @@ def register_ruby_dependencies():
         sha256 = "96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d",
         strip_prefix = "ruby-3.3.0",
         build_file = ruby_3_3_build,
+        patch_tool = "patch",
+        patch_args = ["-p1"],
         patches = [
             "@com_stripe_ruby_typer//third_party/ruby:ldflags.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:fix_grapheme_clusters_3_3_only.patch",
         ],
     )
 


### PR DESCRIPTION
Applies patch that fixes grapheme encoding in pay-server


### Motivation
Ruby 3.3 upgrade


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
