### PR TITLE
Teach merchant_token_prop about the `name` field

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -208,6 +208,7 @@ NameDef names[] = {
     {"updatedProp", "updated_prop"},
     {"merchantProp", "merchant_prop"},
     {"merchantTokenProp", "merchant_token_prop"},
+    {"name"},
     {"encryptedProp", "encrypted_prop"},
     {"array"},
     {"defDelegator", "def_delegator"},

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -334,6 +334,18 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
         if (ifunset != nullptr) {
             ret.ifunset = std::move(ifunset);
         }
+
+        if (send->fun == core::Names::merchantTokenProp()) {
+            auto [_nameKey, nameValue] = ASTUtil::extractHashValue(ctx, *rules, core::Names::name());
+            if (nameValue != nullptr) {
+                if (auto lit = ast::cast_tree<ast::Literal>(nameValue)) {
+                    if (lit->isSymbol()) {
+                        ret.name = lit->asSymbol();
+                        ret.nameLoc = nameValue.loc();
+                    }
+                }
+            }
+        }
     }
 
     if (ret.default_ == nullptr && isTNilable(ret.type)) {

--- a/test/testdata/rewriter/shard_by_merchant_prop.rb
+++ b/test/testdata/rewriter/shard_by_merchant_prop.rb
@@ -39,8 +39,20 @@ class MerchantTokenPropModel
   merchant_token_prop
 end
 
+class MerchantTokenPropModelCustomName
+  include T::Props
+  extend ShardByMerchantBase
+
+  merchant_token_prop name: :linked_merchant
+end
+
 T.reveal_type(MerchantPropModel.new.merchant) # error: Revealed type: `String`
 MerchantPropModel.new.merchant = "hi" # error: Setter method `merchant=` does not exist
 
 T.reveal_type(MerchantTokenPropModel.new.merchant) # error: Revealed type: `Opus::Autogen::Tokens::AccountModelMerchant::Token`
 MerchantTokenPropModel.new.merchant = nil # error: Setter method `merchant=` does not exist
+
+MerchantTokenPropModelCustomName.new.merchant
+#                                    ^^^^^^^^ error: does not exist
+
+T.reveal_type(MerchantTokenPropModelCustomName.new.linked_merchant) # error: `Opus::Autogen::Tokens::AccountModelMerchant::Token`

--- a/test/testdata/rewriter/shard_by_merchant_prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/shard_by_merchant_prop.rb.rewrite-tree.exp
@@ -81,6 +81,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of merchant>
   end
 
+  class <emptyTree>::<C MerchantTokenPropModelCustomName><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C Opus>::<C Autogen>::<C Tokens>::<C AccountModelMerchant>::<C Token>)
+    end
+
+    def linked_merchant<<todo method>>(&<blk>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    <self>.include(<emptyTree>::<C T>::<C Props>)
+
+    <self>.extend(<emptyTree>::<C ShardByMerchantBase>)
+
+    <self>.merchant_token_prop(:name, :linked_merchant, :without_accessors, true)
+
+    <runtime method definition of linked_merchant>
+  end
+
   <emptyTree>::<C T>.reveal_type(<emptyTree>::<C MerchantPropModel>.new().merchant())
 
   <emptyTree>::<C MerchantPropModel>.new().merchant=("hi")
@@ -88,4 +106,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(<emptyTree>::<C MerchantTokenPropModel>.new().merchant())
 
   <emptyTree>::<C MerchantTokenPropModel>.new().merchant=(nil)
+
+  <emptyTree>::<C MerchantTokenPropModelCustomName>.new().merchant()
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C MerchantTokenPropModelCustomName>.new().linked_merchant())
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were not handling the fact that this method accepts an optional `name`
keyword parameter, which can be used to customize the name to something that's
not `merchant`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Those at Stripe can see that this is how this method works by looking at
this code:

<http://go/GnhimGWM>