### PR TITLE
Make LSPTypechecker::getResolved use thread pool

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -639,7 +639,7 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const std::vecto
     ENFORCE(gs->errorQueue->isEmpty());
     ENFORCE(gs->lspQuery.isEmpty());
     gs->lspQuery = q;
-    auto resolved = getResolved(filesForQuery);
+    auto resolved = getResolved(filesForQuery, workers);
     tryApplyDefLocSaver(*gs, resolved);
     tryApplyLocalVarSaver(*gs, resolved);
 
@@ -690,7 +690,7 @@ const ast::ParsedFile &LSPTypechecker::getIndexed(core::FileRef fref) const {
     return indexed[id];
 }
 
-vector<ast::ParsedFile> LSPTypechecker::getResolved(const vector<core::FileRef> &frefs) const {
+vector<ast::ParsedFile> LSPTypechecker::getResolved(const vector<core::FileRef> &frefs, WorkerPool &workers) const {
     ENFORCE(this_thread::get_id() == typecheckerThreadId, "Typechecker can only be used from the typechecker thread.");
     vector<ast::ParsedFile> updatedIndexed;
 
@@ -780,7 +780,7 @@ const ast::ParsedFile &LSPTypecheckerDelegate::getIndexed(core::FileRef fref) co
 }
 
 std::vector<ast::ParsedFile> LSPTypecheckerDelegate::getResolved(const std::vector<core::FileRef> &frefs) const {
-    return typechecker.getResolved(frefs);
+    return typechecker.getResolved(frefs, workers);
 }
 
 ast::ExpressionPtr LSPTypecheckerDelegate::getDesugared(core::FileRef fref) const {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -311,10 +311,10 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     }
 
     ENFORCE(gs->lspQuery.isEmpty());
-    auto resolved =
-        shouldRunIncrementalNamer
-            ? pipeline::incrementalResolve(*gs, move(updatedIndexed), std::move(oldFoundHashesForFiles), config->opts)
-            : pipeline::incrementalResolve(*gs, move(updatedIndexed), nullopt, config->opts);
+    auto resolved = shouldRunIncrementalNamer
+                        ? pipeline::incrementalResolve(*gs, move(updatedIndexed), std::move(oldFoundHashesForFiles),
+                                                       config->opts, workers)
+                        : pipeline::incrementalResolve(*gs, move(updatedIndexed), nullopt, config->opts, workers);
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
     const auto presorted = true;
     const auto cancelable = false;
@@ -706,7 +706,7 @@ vector<ast::ParsedFile> LSPTypechecker::getResolved(const vector<core::FileRef> 
     // In getResolved, we want the LSP query behavior, not the file update behavior, which we get by passing nullopt.
     auto foundHashesForFiles = nullopt;
 
-    return pipeline::incrementalResolve(*gs, move(updatedIndexed), move(foundHashesForFiles), config->opts);
+    return pipeline::incrementalResolve(*gs, move(updatedIndexed), move(foundHashesForFiles), config->opts, workers);
 }
 
 const core::GlobalState &LSPTypechecker::state() const {

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -125,7 +125,7 @@ public:
     /**
      * Returns the parsed files for the given files, including resolver.
      */
-    std::vector<ast::ParsedFile> getResolved(const std::vector<core::FileRef> &frefs) const;
+    std::vector<ast::ParsedFile> getResolved(const std::vector<core::FileRef> &frefs, WorkerPool &workers) const;
 
     /**
      * Returns the currently active GlobalState.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -243,7 +243,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
 vector<ast::ParsedFile>
 incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
                    optional<UnorderedMap<core::FileRef, core::FoundDefHashes>> &&foundHashesForFiles,
-                   const options::Options &opts) {
+                   const options::Options &opts, WorkerPool &workers) {
     try {
 #ifndef SORBET_REALMAIN_MIN
         if (opts.stripePackages) {
@@ -916,7 +916,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                     // We don't compute file hashes when running for incrementalResolve.
                     auto foundHashesForFiles = nullopt;
                     auto reresolved =
-                        pipeline::incrementalResolve(*gs, move(toBeReResolved), foundHashesForFiles, opts);
+                        pipeline::incrementalResolve(*gs, move(toBeReResolved), foundHashesForFiles, opts, workers);
                     ENFORCE(reresolved.size() == 1);
                     f = checkNoDefinitionsInsideProhibitedLines(*gs, move(reresolved[0]), 0, prohibitedLines);
                 }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -256,6 +256,7 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
             // split `pipeline::package` into something like "populate the package DB" and "verify
             // the package prefixes" with the later living in `pipeline::resolve` once again (thus
             // restoring the symmetry).
+            // TODO(jez) Parallelize this
             what = packager::Packager::runIncremental(gs, move(what));
         }
 #endif
@@ -264,12 +265,10 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
             Timer timeit(gs.tracer(), "incremental_naming");
             core::UnfreezeSymbolTable symbolTable(gs);
             core::UnfreezeNameTable nameTable(gs);
-            auto emptyWorkers = WorkerPool::create(0, gs.tracer());
 
-            auto result = runIncrementalNamer
-                              ? sorbet::namer::Namer::runIncremental(
-                                    gs, move(what), std::move(foundHashesForFiles.value()), *emptyWorkers)
-                              : sorbet::namer::Namer::run(gs, move(what), *emptyWorkers, nullptr);
+            auto result = runIncrementalNamer ? sorbet::namer::Namer::runIncremental(
+                                                    gs, move(what), std::move(foundHashesForFiles.value()), workers)
+                                              : sorbet::namer::Namer::run(gs, move(what), workers, nullptr);
 
             // Cancellation cannot occur during incremental namer.
             ENFORCE(result.hasResult());
@@ -287,7 +286,7 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
             core::UnfreezeSymbolTable symbolTable(gs);
             core::UnfreezeNameTable nameTable(gs);
 
-            auto result = sorbet::resolver::Resolver::runIncremental(gs, move(what), runIncrementalNamer);
+            auto result = sorbet::resolver::Resolver::runIncremental(gs, move(what), runIncrementalNamer, workers);
             // incrementalResolve is not cancelable.
             ENFORCE(result.hasResult());
             what = move(result.result());
@@ -300,8 +299,7 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
 
 #ifndef SORBET_REALMAIN_MIN
         if (opts.stripePackages) {
-            auto emptyWorkers = WorkerPool::create(0, gs.tracer());
-            what = packager::VisibilityChecker::run(gs, *emptyWorkers, std::move(what));
+            what = packager::VisibilityChecker::run(gs, workers, std::move(what));
         }
 #endif
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -44,7 +44,7 @@ ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std:
 std::vector<ast::ParsedFile>
 incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                    std::optional<UnorderedMap<core::FileRef, core::FoundDefHashes>> &&foundHashesForFiles,
-                   const options::Options &opts);
+                   const options::Options &opts, WorkerPool &workers);
 
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
                                  WorkerPool &workers, core::FoundDefHashes *foundHashes);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1622,6 +1622,7 @@ void Packager::run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::P
     }
 }
 
+// TODO(jez) Parallelize this
 vector<ast::ParsedFile> Packager::runIncremental(const core::GlobalState &gs, vector<ast::ParsedFile> files) {
     // Note: This will only run if packages have not been changed (byte-for-byte equality).
     // TODO(nroman-stripe) This could be further incrementalized to avoid processing all packages by

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -22,7 +22,7 @@ public:
      * These two versions are explicitly instantiated in resolver.cc
      */
     static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
-                                                      bool ranIncrementalNamer);
+                                                      bool ranIncrementalNamer, WorkerPool &workers);
 
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The `LSPTypechecker::getResolved` method is used by `LSPTypechecker::query`,
which is used by `LSPQuery::bySymbol`, which powers things like find all
references and move method and convert to singleton class method.

Based on our strategy of searching for references in files that have a reference
to _any_ symbol with the name of the current symbol, `bySymbol` can run the
query over many files. In particular, a common case in Stripe's codebase is
finding references on methods called `call`, where there are thousands of files.

Currently, Sorbet resolves all of these files single threaded, even when it
would use the worker pool for running inference on those files (i.e., there was
a worker pool in scope already).

There's no reason to do this, and in fact all of the things inside `getResolved`
(namer and resolver) already work in parallel if given a `WorkerPool`. (Well,
almost all the things--packager does not run the incremental version in
parallel, but that can be a future change, and/or might just go away as we move
more packager into namer/resolver).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The code compiles.

I'm not adding any new parallelism, which means there's no worry about
potentially racing on shared state--this change just takes advantage of the
existing parallelism already present in the pipeline, so there's no reason to
expect anything to break because of this.

Separately, I'm working on testing the performance of this for a few Find All
References queries on Stripe's codebase.