### PR TITLE
Apply ruby performance patches #10151 and #10306

### DIFF
--- a/third_party/ruby/10151_no_hash_allocate_static_kwargs_3_3_only.patch
+++ b/third_party/ruby/10151_no_hash_allocate_static_kwargs_3_3_only.patch
@@ -1,0 +1,136 @@
+diff --git a/vm_args.c b/vm_args.c
+index 14ae550d2f..79e4b2e0a1 100644
+--- a/vm_args.c
++++ b/vm_args.c
+@@ -396,6 +396,109 @@ args_setup_kw_parameters(rb_execution_context_t *const ec, const rb_iseq_t *cons
+     locals[key_num] = unspecified_bits_value;
+ }
+ 
++static void
++args_setup_kw_parameters_from_kwsplat(rb_execution_context_t *const ec, const rb_iseq_t *const iseq,
++                         VALUE keyword_hash, VALUE *const locals, bool remove_hash_value)
++{
++    const ID *acceptable_keywords = ISEQ_BODY(iseq)->param.keyword->table;
++    const int req_key_num = ISEQ_BODY(iseq)->param.keyword->required_num;
++    const int key_num = ISEQ_BODY(iseq)->param.keyword->num;
++    const VALUE * const default_values = ISEQ_BODY(iseq)->param.keyword->default_values;
++    VALUE missing = 0;
++    int i, di;
++    int unspecified_bits = 0;
++    size_t keyword_size = RHASH_SIZE(keyword_hash);
++    VALUE unspecified_bits_value = Qnil;
++
++    for (i=0; i<req_key_num; i++) {
++        VALUE key = ID2SYM(acceptable_keywords[i]);
++        VALUE value;
++        if (remove_hash_value) {
++            value = rb_hash_delete_entry(keyword_hash, key);
++        }
++        else {
++            value = rb_hash_lookup2(keyword_hash, key, Qundef);
++        }
++
++        if (!UNDEF_P(value)) {
++            keyword_size--;
++            locals[i] = value;
++        }
++        else {
++            if (!missing) missing = rb_ary_hidden_new(1);
++            rb_ary_push(missing, key);
++        }
++    }
++
++    if (missing) argument_kw_error(ec, iseq, "missing", missing);
++
++    for (di=0; i<key_num; i++, di++) {
++        VALUE key = ID2SYM(acceptable_keywords[i]);
++        VALUE value;
++        if (remove_hash_value) {
++            value = rb_hash_delete_entry(keyword_hash, key);
++        }
++        else {
++            value = rb_hash_lookup2(keyword_hash, key, Qundef);
++        }
++
++        if (!UNDEF_P(value)) {
++            keyword_size--;
++            locals[i] = value;
++        }
++        else {
++            if (UNDEF_P(default_values[di])) {
++                locals[i] = Qnil;
++
++                if (LIKELY(i < KW_SPECIFIED_BITS_MAX)) {
++                    unspecified_bits |= 0x01 << di;
++                }
++                else {
++                    if (NIL_P(unspecified_bits_value)) {
++                        /* fixnum -> hash */
++                        int j;
++                        unspecified_bits_value = rb_hash_new();
++
++                        for (j=0; j<KW_SPECIFIED_BITS_MAX; j++) {
++                            if (unspecified_bits & (0x01 << j)) {
++                                rb_hash_aset(unspecified_bits_value, INT2FIX(j), Qtrue);
++                            }
++                        }
++                    }
++                    rb_hash_aset(unspecified_bits_value, INT2FIX(di), Qtrue);
++                }
++            }
++            else {
++                locals[i] = default_values[di];
++            }
++        }
++    }
++
++    if (ISEQ_BODY(iseq)->param.flags.has_kwrest) {
++        const int rest_hash_index = key_num + 1;
++        locals[rest_hash_index] = keyword_hash;
++    }
++    else {
++        if (!remove_hash_value) {
++            if (keyword_size != 0) {
++                /* Recurse with duplicated keyword hash in remove mode.
++                 * This is simpler than writing code to check which entries in the hash do not match.
++                 * This will raise an exception, so the additional performance impact shouldn't be material.
++                 */
++                args_setup_kw_parameters_from_kwsplat(ec, iseq, rb_hash_dup(keyword_hash), locals, true);
++            }
++        }
++        else if (!RHASH_EMPTY_P(keyword_hash)) {
++            argument_kw_error(ec, iseq, "unknown", rb_hash_keys(keyword_hash));
++        }
++    }
++
++    if (NIL_P(unspecified_bits_value)) {
++        unspecified_bits_value = INT2FIX(unspecified_bits);
++    }
++    locals[key_num] = unspecified_bits_value;
++}
++
+ static inline void
+ args_setup_kw_rest_parameter(VALUE keyword_hash, VALUE *locals, int kw_flag)
+ {
+@@ -720,15 +823,12 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
+             args_setup_kw_parameters(ec, iseq, args->kw_argv, kw_arg->keyword_len, kw_arg->keywords, klocals);
+         }
+         else if (!NIL_P(keyword_hash)) {
+-            int kw_len = rb_long2int(RHASH_SIZE(keyword_hash));
+-            struct fill_values_arg arg;
+-            /* copy kw_argv */
+-            arg.keys = args->kw_argv = ALLOCA_N(VALUE, kw_len * 2);
+-            arg.vals = arg.keys + kw_len;
+-            arg.argc = 0;
+-            rb_hash_foreach(keyword_hash, fill_keys_values, (VALUE)&arg);
+-            VM_ASSERT(arg.argc == kw_len);
+-            args_setup_kw_parameters(ec, iseq, arg.vals, kw_len, arg.keys, klocals);
++            bool remove_hash_value = false;
++            if (ISEQ_BODY(iseq)->param.flags.has_kwrest) {
++                keyword_hash = check_kwrestarg(keyword_hash, &kw_flag);
++                remove_hash_value = true;
++            }
++            args_setup_kw_parameters_from_kwsplat(ec, iseq, keyword_hash, klocals, remove_hash_value);
+         }
+         else {
+             VM_ASSERT(args_argc(args) == 0);

--- a/third_party/ruby/10306_no_hash_allocate_static_kwargs_3_3_only.patch
+++ b/third_party/ruby/10306_no_hash_allocate_static_kwargs_3_3_only.patch
@@ -1,0 +1,15 @@
+diff --git a/vm_args.c b/vm_args.c
+index 79e4b2e0a1..3e95fe50c0 100644
+--- a/vm_args.c
++++ b/vm_args.c
+@@ -714,8 +714,9 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
+                 kw_flag &= ~(VM_CALL_KW_SPLAT | VM_CALL_KW_SPLAT_MUT);
+             }
+             else {
+-                if (!(kw_flag & VM_CALL_KW_SPLAT_MUT)) {
++                if (!(kw_flag & VM_CALL_KW_SPLAT_MUT) && !ISEQ_BODY(iseq)->param.flags.has_kw) {
+                     converted_keyword_hash = rb_hash_dup(converted_keyword_hash);
++                    kw_flag |= VM_CALL_KW_SPLAT_MUT;
+                 }
+ 
+                 if (last_arg != converted_keyword_hash) {

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -142,6 +142,8 @@ def register_ruby_dependencies():
         patches = [
             "@com_stripe_ruby_typer//third_party/ruby:ldflags.patch",
             "@com_stripe_ruby_typer//third_party/ruby:fix_grapheme_clusters_3_3_only.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:10151_no_hash_allocate_static_kwargs_3_3_only.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:10306_no_hash_allocate_static_kwargs_3_3_only.patch",
         ],
     )
 


### PR DESCRIPTION
Before:
```
bazel-bin/external/sorbet_ruby_3_3/ruby -e 'def foo(x:);end; b=GC.stat[:total_allocated_objects]; kwargs={x:1}; 1000.times { foo(**kwargs) }; a=GC.stat[:total_allocated_objects]; p a-b'
1005
```
after:
```
6
```

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Ruby performance


### Test plan
passes ruby make check run manually

See included automated tests.
