### PR TITLE
Detect and fix certain kinds of broken links

### DIFF
--- a/.buildkite/linters.sh
+++ b/.buildkite/linters.sh
@@ -65,7 +65,7 @@ if ! ./tools/scripts/format_website.sh -t &> format_website; then
     buildkite-agent annotate --context tools/scripts/format_website.sh --style error --append < format_website
 fi
 
-if grep -r '^  \w*\.md' website &> lint_docusaurus_md; then
+if grep -n -r '^  \w*\.md' website &> lint_docusaurus_md; then
   globalErr=1
   echo "^^^ +++"
   buildkite-agent annotate --context "Docusaurus Link Reference Definitions" --style error --append <<EOF

--- a/.buildkite/linters.sh
+++ b/.buildkite/linters.sh
@@ -65,6 +65,23 @@ if ! ./tools/scripts/format_website.sh -t &> format_website; then
     buildkite-agent annotate --context tools/scripts/format_website.sh --style error --append < format_website
 fi
 
+if grep -r '^  \w*\.md' website &> lint_docusaurus_md; then
+  globalErr=1
+  echo "^^^ +++"
+  buildkite-agent annotate --context "Docusaurus Link Reference Definitions" --style error --append <<EOF
+These markdown files have link reference definitions which split onto multiple lines.
+
+Prettier insists on splitting long link reference definitions onto multiple lines,
+but Docusaurus fails to linkify these definitions.
+
+Rewrite these link reference definitions to be inline links to avoid broken links:
+
+\`\`\`
+$(< lint_docusaurus_md)
+\`\`\`
+EOF
+fi
+
 echo "~~~ Checking the vscode extension"
 pushd vscode_extension
 yarn install

--- a/website/docs/server-status.md
+++ b/website/docs/server-status.md
@@ -266,13 +266,11 @@ option during the [`initialize` request].
 }
 ```
 
-Different language clients will have [different ways to specify
-`initializationOptions`] when starting a language server. Consult the
-documentation of your editor or language client for how to pass this option on
-startup in the `initialize` request.
-
-[different ways to specify `initializationOptions`]:
-  lsp.md#instructions-for-specific-language-clients
+Different language clients will have
+[different ways to specify `initializationOptions`](lsp.md#instructions-for-specific-language-clients)
+when starting a language server. Consult the documentation of your editor or
+language client for how to pass this option on startup in the `initialize`
+request.
 
 As a reference, it may be helpful to consult the implementation in the Sorbet VS
 Code extension:

--- a/website/docs/sorbet-uris.md
+++ b/website/docs/sorbet-uris.md
@@ -69,13 +69,11 @@ pass the `supportsSorbetURIs` property:
 }
 ```
 
-Different language clients will have [different ways to specify
-`initializationOptions`] when starting a language server. Consult the
-documentation of your editor or language client for how to pass this option on
-startup in the `initialize` request.
-
-[different ways to specify `initializationOptions`]:
-  lsp.md#instructions-for-specific-language-clients
+Different language clients will have
+[different ways to specify `initializationOptions`](lsp.md#instructions-for-specific-language-clients)
+when starting a language server. Consult the documentation of your editor or
+language client for how to pass this option on startup in the `initialize`
+request.
 
 Setting `supportsSorbetURIs` to `true` informs Sorbet that it can use `sorbet:`
 URIs. Whenever a Go to Definition request would attempt to jump into a synthetic


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Docusaurus does some heuristics to rewrite `foo.md` links to `/docs/foo.html`
links. It's doesn't work when the link is a Markdown reference link definition
that's been split onto two lines.

These typically surface as warnings to show up in our Algolia crawler, but in
every case it means that there's a broken link in our website.

I don't know whether this is fixed in a newer Docusaurus version. Docusaurus v1
is unmaintained, and Docusaurus v2 introduces backwards incompatible changes so
I've put off upgrading.

Instead, let's just fix with `grep`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

This is what the new failing test looks like when it fails:

<https://buildkite.com/sorbet/sorbet/builds/30813#018e9bcd-4d27-46f6-8a87-ebf3c8bc54ba>

<img width="742" alt="Screenshot 2024-04-01 at 3 43 45 PM" src="https://github.com/sorbet/sorbet/assets/5544532/7be3777a-3c2b-4c12-9db6-31c2e47b75ba">
