### PR TITLE
Rework hover/def/ref w.r.t. constant aliases

### DIFF
--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -78,7 +78,7 @@ public:
     const core::MethodRef enclosingMethod;
     const core::TypeAndOrigins retType;
 };
-CheckSize(ConstantResponse, 88, 8);
+CheckSize(ConstantResponse, 80, 8);
 
 class FieldResponse final {
 public:

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -67,18 +67,10 @@ CheckSize(LiteralResponse, 48, 8);
 class ConstantResponse final {
 public:
     using Scopes = InlinedVector<core::SymbolRef, 1>;
-    ConstantResponse(core::SymbolRef symbol, core::SymbolRef symbolBeforeDealias, core::Loc termLoc, Scopes scopes,
-                     core::NameRef name, core::TypeAndOrigins retType, core::MethodRef enclosingMethod)
-        : symbol(symbol), symbolBeforeDealias(symbolBeforeDealias), termLoc(termLoc), scopes(scopes), name(name),
+    ConstantResponse(core::SymbolRef symbolBeforeDealias, core::Loc termLoc, Scopes scopes, core::NameRef name,
+                     core::TypeAndOrigins retType, core::MethodRef enclosingMethod)
+        : symbolBeforeDealias(symbolBeforeDealias), termLoc(termLoc), scopes(scopes), name(name),
           enclosingMethod(enclosingMethod), retType(std::move(retType)) {}
-    const core::SymbolRef symbol;
-    // You probably don't want this. Almost all of Sorbet's type system operates on dealiased
-    // symbols transparently (e.g., for a constant like `X = Integer`, Sorbet reports that `''` is
-    // not an `Integer`, not that `''` is not an `X`).
-    //
-    // But for some interactive features, it's important to respond using names the user typed.
-    // If you're thinking about using this, probably just use `symbol` instead, and if you still
-    // think you need this, double check with a Sorbet contributor.
     const core::SymbolRef symbolBeforeDealias;
     const core::Loc termLoc;
     const Scopes scopes;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -126,8 +126,8 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             }
 
             auto enclosingMethod = enclosingMethodFromContext(ctx);
-            auto resp = core::lsp::ConstantResponse(symbol, symbolBeforeDealias, ctx.locAt(lit->loc), scopes,
-                                                    unresolved.cnst, tp, enclosingMethod);
+            auto resp = core::lsp::ConstantResponse(symbolBeforeDealias, ctx.locAt(lit->loc), scopes, unresolved.cnst,
+                                                    tp, enclosingMethod);
             core::lsp::QueryResponse::pushQueryResponse(ctx, resp);
         }
         lit = ast::cast_tree<ast::ConstantLit>(unresolved.scope);

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -65,11 +65,14 @@ unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, string_view ru
 
 string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant) {
     if (constant == core::Symbols::StubModule()) {
-        return "This constant is not defined";
+        return "(unable to resolve constant)";
     }
 
     if (constant.isClassAlias(gs)) {
-        return fmt::format("{} = {}", constant.name(gs).show(gs), constant.dealias(gs).show(gs));
+        auto dealiased = constant.dealias(gs);
+        auto dealiasedShow =
+            dealiased == core::Symbols::StubModule() ? "(unable to resolve constant)" : dealiased.show(gs);
+        return fmt::format("{} = {}", constant.name(gs).show(gs), dealiasedShow);
     }
 
     core::TypePtr result;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -64,12 +64,12 @@ unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, string_view ru
 }
 
 string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant) {
-    // Request that the constant already be dealiased, rather than dealias here to avoid defensively dealiasing.
-    // We should understand where dealias calls go.
-    ENFORCE(constant == constant.dealias(gs));
-
     if (constant == core::Symbols::StubModule()) {
         return "This constant is not defined";
+    }
+
+    if (constant.isClassAlias(gs)) {
+        return fmt::format("{} = {}", constant.name(gs).show(gs), constant.dealias(gs).show(gs));
     }
 
     core::TypePtr result;

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -71,7 +71,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
 
         // Only support go-to-definition on constants and fields in untyped files.
         if (auto c = resp->isConstant()) {
-            auto sym = c->symbol;
+            auto sym = c->symbolBeforeDealias;
             vector<pair<core::Loc, unique_ptr<Location>>> locMapping;
             for (auto loc : sym.locs(gs)) {
                 locMapping.emplace_back(loc, config.loc2Location(gs, loc));

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -65,8 +65,8 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
 
         // If file is untyped, only supports find reference requests from constants and class definitions.
         if (auto constResp = resp->isConstant()) {
-            response->result =
-                getHighlights(typechecker, getReferencesToSymbolInFile(typechecker, fref, constResp->symbol));
+            response->result = getHighlights(
+                typechecker, getReferencesToSymbolInFile(typechecker, fref, constResp->symbolBeforeDealias));
         } else if (auto fieldResp = resp->isField()) {
             // This could be a `prop` or `attr_*`, which have multiple associated symbols.
             response->result = getHighlights(

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -83,7 +83,12 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
             }
         }
     } else if (auto c = resp->isConstant()) {
-        for (auto loc : c->symbol.locs(gs)) {
+        for (auto loc : c->symbolBeforeDealias.locs(gs)) {
+            if (loc.exists()) {
+                documentationLocations.emplace_back(loc);
+            }
+        }
+        for (auto loc : c->symbolBeforeDealias.dealias(gs).locs(gs)) {
             if (loc.exists()) {
                 documentationLocations.emplace_back(loc);
             }
@@ -121,7 +126,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         typeString = core::source_generator::prettyTypeForMethod(gs, defResp->symbol, nullptr, defResp->retType.type,
                                                                  nullptr, options);
     } else if (auto constResp = resp->isConstant()) {
-        typeString = prettyTypeForConstant(gs, constResp->symbol);
+        typeString = prettyTypeForConstant(gs, constResp->symbolBeforeDealias);
     } else {
         core::TypePtr retType = resp->getRetType();
         // Some untyped arguments have null types.

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -100,7 +100,7 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
         }
     } else if (auto constant = queryResponse->isConstant()) {
         // User called "Go to Implementation" from the abstract class reference
-        auto classSymbol = constant->symbol.asClassOrModuleRef();
+        auto classSymbol = constant->symbolBeforeDealias.dealias(gs).asClassOrModuleRef();
 
         if (!classSymbol.data(gs)->flags.isAbstract) {
             response->error = makeInvalidRequestError(classSymbol, gs);

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -120,7 +120,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
                 //  Returns all global usages of Foo::A
 
                 auto packageName = gs.packageDB().getPackageNameForFile(fref);
-                auto symsToCheck = getSymsToCheckWithinPackage(gs, constResp->symbol, packageName);
+                auto symsToCheck = getSymsToCheckWithinPackage(gs, constResp->symbolBeforeDealias, packageName);
 
                 if (!symsToCheck.empty()) {
                     std::vector<std::unique_ptr<Location>> locations;
@@ -137,13 +137,13 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
                 } else {
                     // Fall back to normal case when we are not querying for an external symbol, e.g. class Foo <
                     // PackageSpec declarations, or export statements.
-                    response->result =
-                        extractLocations(typechecker.state(), getReferencesToSymbol(typechecker, constResp->symbol));
+                    response->result = extractLocations(
+                        typechecker.state(), getReferencesToSymbol(typechecker, constResp->symbolBeforeDealias));
                 }
             } else {
                 // Normal handling for non-package files
-                response->result =
-                    extractLocations(typechecker.state(), getReferencesToSymbol(typechecker, constResp->symbol));
+                response->result = extractLocations(typechecker.state(),
+                                                    getReferencesToSymbol(typechecker, constResp->symbolBeforeDealias));
             }
         } else if (auto fieldResp = resp->isField()) {
             // This could be a `prop` or `attr_*`, which have multiple associated symbols.

--- a/test/testdata/lsp/definition_alias.rb
+++ b/test/testdata/lsp/definition_alias.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+class A; end
+class Scope
+  X = A
+# ^ def: X
+end
+
+class Scope
+  puts(X)
+  #    ^ usage: X
+end
+
+puts(A)

--- a/test/testdata/lsp/hover_alias.rb
+++ b/test/testdata/lsp/hover_alias.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+# The documentation for `A` itself
+class A; end
+class Scope
+  # The documentation for this alias
+  X = A
+end
+
+class Scope
+  puts(X)
+  #    ^ hover: The documentation for this alias
+  #    ^ hover: The documentation for `A` itself
+end

--- a/test/testdata/lsp/hover_static_field_alias_to_nothing.rb
+++ b/test/testdata/lsp/hover_static_field_alias_to_nothing.rb
@@ -4,4 +4,4 @@ SomeConstant = DoesNotExist
 #              ^^^^^^^^^^^^ error: Unable to resolve constant `DoesNotExist`
 
 p(SomeConstant)
-#  ^ hover: This constant is not defined
+#  ^ hover: SomeConstant = (unable to resolve constant)

--- a/test/testdata/lsp/hover_undefined_constant.rb
+++ b/test/testdata/lsp/hover_undefined_constant.rb
@@ -3,6 +3,6 @@
 class MyClass
   def foo(x)
     x + THE_CONSTANT # error: Unable to resolve constant
-      # ^ hover: This constant is not defined
+      # ^ hover: (unable to resolve constant)
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This started as simply "Make Go to Definition on constant alias go to the alias
definition" but then I realized that there's a similar "bug" with references,
and at that point it made sense to get rid of `ConstantResponse::symbol`
entirely, in favor of `ConstantResponse::symbolBeforeDealias`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.