### PR TITLE
Add detailed error for classSymbolIsAsGoodAs

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1204,7 +1204,6 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         if (!result) {
             return result;
         }
-        if (result) {
         InlinedVector<TypeMemberRef, 4> indexes = Types::alignBaseTypeArgs(gs, a1->klass, a1->targs, a2->klass);
         // code below inverts permutation of type params
         int j = 0;
@@ -1272,7 +1271,6 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             j++;
         }
         // alight type params.
-        }
         return result;
     }
     if (isa_type<AppliedType>(t2)) {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1201,6 +1201,9 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         } else {
             result = classSymbolIsAsGoodAs(gs, a1->klass, a2->klass);
         }
+        if (!result) {
+            return result;
+        }
         if (result) {
             InlinedVector<TypeMemberRef, 4> indexes = Types::alignBaseTypeArgs(gs, a1->klass, a1->targs, a2->klass);
             // code below inverts permutation of type params

--- a/test/cli/detailed-errors/test.out
+++ b/test/cli/detailed-errors/test.out
@@ -1,3 +1,35 @@
+type_members.rb:35: Argument does not have asserted type `Box2[Integer]` https://srb.help/7007
+    35 |  T.let(box1, Box2[Integer])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `Box1[Integer]` originating from:
+    type_members.rb:34:
+    34 |def takes_box1(box1)
+                       ^^^^
+  Detailed explanation:
+    `Box1` does not derive from `Box2`
+
+type_members.rb:36: Argument does not have asserted type `Integer` https://srb.help/7007
+    36 |  T.let(box1, Integer)
+          ^^^^^^^^^^^^^^^^^^^^
+  Got `Box1[Integer]` originating from:
+    type_members.rb:34:
+    34 |def takes_box1(box1)
+                       ^^^^
+  Detailed explanation:
+    `Box1` does not derive from `Integer`
+
+type_members.rb:21: Argument does not have asserted type `A[Middle, Middle, Middle]` https://srb.help/7007
+    21 |T.let(A[String, Lower, Upper].new, A[Middle, Middle, Middle])
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `A[String, Lower, Upper]` originating from:
+    type_members.rb:21:
+    21 |T.let(A[String, Lower, Upper].new, A[Middle, Middle, Middle])
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Detailed explanation:
+    `String` is not equivalent to `Middle` for invariant type member `A::X`
+    `Lower` is not a supertype of `Middle` for contravariant type member `A::Y`
+    `Upper` is not a subtype of `Middle` for covariant type member `A::Z`
+
 shapes.rb:10: Expected `{a: Integer, b: String}` but found `{}` for argument `x` https://srb.help/7002
     10 |takes_shape({})
                     ^^
@@ -153,16 +185,4 @@ tuples.rb:18: Expected `[Integer, String]` but found `[String("")]` for argument
     tuples.rb:18:
     18 |takes_tuple([''])
                     ^^^^
-
-type_members.rb:21: Argument does not have asserted type `A[Middle, Middle, Middle]` https://srb.help/7007
-    21 |T.let(A[String, Lower, Upper].new, A[Middle, Middle, Middle])
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Got `A[String, Lower, Upper]` originating from:
-    type_members.rb:21:
-    21 |T.let(A[String, Lower, Upper].new, A[Middle, Middle, Middle])
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Detailed explanation:
-    `String` is not equivalent to `Middle` for invariant type member `A::X`
-    `Lower` is not a supertype of `Middle` for contravariant type member `A::Y`
-    `Upper` is not a subtype of `Middle` for covariant type member `A::Z`
-Errors: 13
+Errors: 15

--- a/test/cli/detailed-errors/test.sh
+++ b/test/cli/detailed-errors/test.sh
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-main/sorbet --silence-dev-message test/cli/detailed-errors 2>&1
+main/sorbet --silence-dev-message --max-threads=0 test/cli/detailed-errors 2>&1

--- a/test/cli/detailed-errors/type_members.rb
+++ b/test/cli/detailed-errors/type_members.rb
@@ -20,3 +20,18 @@ end
 
 T.let(A[String, Lower, Upper].new, A[Middle, Middle, Middle])
 
+class Box1
+  extend T::Generic
+  Elem = type_member
+end
+
+class Box2
+  extend T::Generic
+  Elem = type_member
+end
+
+sig { params(box1: Box1[Integer]).void }
+def takes_box1(box1)
+  T.let(box1, Box2[Integer])
+  T.let(box1, Integer)
+end

--- a/test/cli/invariant_type_parameter/test.out
+++ b/test/cli/invariant_type_parameter/test.out
@@ -37,6 +37,8 @@ test/cli/invariant_type_parameter/test.rb:75: Expected `Box[T.type_parameter(:U)
     test/cli/invariant_type_parameter/test.rb:71:
     71 |ibox_m = T.let(Box[M].new, IBox[M])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Detailed explanation:
+    `IBox` does not derive from `Box`
 
 test/cli/invariant_type_parameter/test.rb:76: Revealed type: `Box[T.noreturn]` https://srb.help/7014
     76 |  T.reveal_type(box)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already have some errors explaining when the type arguments of two applied
types don't match, but we didn't have an error when it was the `klass` symbols
of the applied types themselves that cause the problem.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.