### PR TITLE
Show better error for failed equivalence

### DIFF
--- a/test/cli/detailed-errors/test.out
+++ b/test/cli/detailed-errors/test.out
@@ -18,6 +18,21 @@ type_members.rb:36: Argument does not have asserted type `Integer` https://srb.h
   Detailed explanation:
     `Box1` does not derive from `Integer`
 
+type_members.rb:49: Expected `Box[T.any(Integer, String)]` but found `Box[Integer]` for argument `box` https://srb.help/7002
+    49 |  takes_box_int_str(box)
+                            ^^^
+  Expected `Box[T.any(Integer, String)]` for argument `box` of method `Object#takes_box_int_str`:
+    type_members.rb:44:
+    44 |sig { params(box: Box[T.any(Integer, String)]).void }
+                     ^^^
+  Got `Box[Integer]` originating from:
+    type_members.rb:48:
+    48 |def takes_box_integer(box)
+                              ^^^
+  Detailed explanation:
+    `Integer` is not equivalent to `T.any(Integer, String)` for invariant type member `Box::Elem`
+      `Integer` is a subtype of `T.any(Integer, String)` but not the reverse, so they are not equivalent
+
 type_members.rb:21: Argument does not have asserted type `A[Middle, Middle, Middle]` https://srb.help/7007
     21 |T.let(A[String, Lower, Upper].new, A[Middle, Middle, Middle])
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,4 +200,4 @@ tuples.rb:18: Expected `[Integer, String]` but found `[String("")]` for argument
     tuples.rb:18:
     18 |takes_tuple([''])
                     ^^^^
-Errors: 15
+Errors: 16

--- a/test/cli/detailed-errors/type_members.rb
+++ b/test/cli/detailed-errors/type_members.rb
@@ -35,3 +35,16 @@ def takes_box1(box1)
   T.let(box1, Box2[Integer])
   T.let(box1, Integer)
 end
+
+class Box
+  extend T::Generic
+  Elem = type_member
+end
+
+sig { params(box: Box[T.any(Integer, String)]).void }
+def takes_box_int_str(box); end
+
+sig { params(box: Box[Integer]).void }
+def takes_box_integer(box)
+  takes_box_int_str(box)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This should help explain errors around invariant type members and
equivalence much better than we currently do.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.