### PR TITLE
prework: Ensure that symbol table is frozen

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1294,6 +1294,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     auto ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->typeArguments().size());
 
+    ENFORCE(!symbolTableFrozen);
     for (auto typeArg : ownerScope->typeArguments()) {
         if (typeArg.dataAllowingNone(*this)->name == name) {
             ENFORCE(typeArg.dataAllowingNone(*this)->flags.hasFlags(flags), "existing symbol has wrong flags");
@@ -1303,7 +1304,6 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
         }
     }
 
-    ENFORCE(!symbolTableFrozen);
     auto result = TypeArgumentRef(*this, this->typeArguments.size());
     this->typeArguments.emplace_back();
 
@@ -1422,6 +1422,8 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
+    ENFORCE(!symbolTableFrozen);
+
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
         ENFORCE(store.isStaticField(*this), "existing symbol is not a static field");
@@ -1432,8 +1434,6 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
         fieldRef.data(*this)->addLoc(*this, loc);
         return fieldRef;
     }
-
-    ENFORCE(!symbolTableFrozen);
 
     auto ret = FieldRef(*this, fields.size());
     store = ret; // DO NOT MOVE this assignment down. emplace_back on fields invalidates `store`

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1303,7 +1303,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
             } else {
                 // Sometimes this method is called when the symbol table is frozen for the purposes of sanity
                 // checking. Don't mutate the symbol table in those cases. This loc should already be there.
-                ENFORCE(absl::c_count(typeArg.data(*this)->locs(), loc) == 1);
+                ENFORCE(!loc.exists() || absl::c_count(typeArg.data(*this)->locs(), loc) == 1);
             }
             return typeArg;
         }
@@ -1440,7 +1440,7 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
         } else {
             // Sometimes this method is called when the symbol table is frozen for the purposes of sanity
             // checking. Don't mutate the symbol table in those cases. This loc should already be there.
-            ENFORCE(absl::c_count(fieldRef.data(*this)->locs(), loc) == 1);
+            ENFORCE(!loc.exists() || absl::c_count(fieldRef.data(*this)->locs(), loc) == 1);
         }
         return fieldRef;
     }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -818,7 +818,11 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     // resolver
-    trees = move(resolver::Resolver::runIncremental(*gs, move(trees), ranIncrementalNamer, *workers).result());
+    {
+        core::UnfreezeNameTable nameTableAccess(*gs);
+        core::UnfreezeSymbolTable symbolTableAccess(*gs);
+        trees = move(resolver::Resolver::runIncremental(*gs, move(trees), ranIncrementalNamer, *workers).result());
+    }
 
     if (enablePackager) {
         trees = packager::VisibilityChecker::run(*gs, *workers, move(trees));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These two calls were actually mutating GlobalState without potentially
checking this. I think that luckily we don't have any bugs because of
this, but let's hoist these checks earlier just to be sure.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests