### PR TITLE
Make findSymbols work in-place

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -386,7 +386,7 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
             }
         }
     }
-    return !epochManager.wasTypecheckingCanceled();
+    return epochManager.wasTypecheckingCanceled();
 }
 
 bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
@@ -437,7 +437,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
         // We use `gs` rather than the moved `finalGS` from this point forward.
 
         // Copy the indexes of unchanged files.
-        if (!copyIndexed(workers, updatedFiles, indexedCopies)) {
+        if (copyIndexed(workers, updatedFiles, indexedCopies)) {
             // Canceled.
             return;
         }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -386,6 +386,10 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
             }
         }
     }
+    if (epochManager.wasTypecheckingCanceled()) {
+        return true;
+    }
+    fast_sort(out, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
     return epochManager.wasTypecheckingCanceled();
 }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2370,10 +2370,6 @@ ast::ParsedFilesOrCancelled defineSymbols(core::GlobalState &gs, vector<SymbolFi
     return output;
 }
 
-struct SymbolizeTreesResult {
-    vector<ast::ParsedFile> trees;
-};
-
 vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::ParsedFile> trees,
                                        WorkerPool &workers) {
     Timer timeit(gs.tracer(), "naming.symbolizeTrees");
@@ -2387,7 +2383,6 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
     workers.multiplexJob("symbolizeTrees", [&gs, fileq, resultq]() {
         Timer timeit(gs.tracer(), "naming.symbolizeTreesWorker");
         TreeSymbolizer inserter;
-        SymbolizeTreesResult output;
         ParsedFileWithIdx job;
         for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
             if (result.gotItem()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2185,8 +2185,7 @@ vector<SymbolFinderResult> findSymbols(const core::GlobalState &gs, vector<ast::
     Timer timeit(gs.tracer(), "naming.findSymbols");
     auto resultq = make_shared<BlockingBoundedQueue<pair<size_t, SymbolFinderResult>>>(trees.size());
     auto fileq = make_shared<ConcurrentBoundedQueue<SymbolFinderJob>>(trees.size());
-    vector<SymbolFinderResult> allFoundDefinitions;
-    allFoundDefinitions.reserve(trees.size());
+    vector<SymbolFinderResult> allFoundDefinitions(trees.size());
     size_t idx = 0;
     for (auto &tree : trees) {
         fileq->push(SymbolFinderJob(move(tree), idx++), 1);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -30,7 +30,7 @@ struct SymbolFinderJob {
     ast::ParsedFile parsedFile;
     size_t idx;
 
-    SymbolFinderJob();
+    SymbolFinderJob() = default;
     SymbolFinderJob(ast::ParsedFile &&parsedFile, size_t idx) : parsedFile(move(parsedFile)), idx(idx) {}
     SymbolFinderJob(const SymbolFinderJob &job) = delete;
     SymbolFinderJob &operator=(const SymbolFinderJob &job) = delete;
@@ -42,7 +42,7 @@ struct SymbolFinderResult {
     ast::ParsedFile tree;
     unique_ptr<core::FoundDefinitions> names;
 
-    SymbolFinderResult();
+    SymbolFinderResult() = default;
     SymbolFinderResult(ast::ParsedFile &&tree, unique_ptr<core::FoundDefinitions> names)
         : tree(move(tree)), names(move(names)) {}
     SymbolFinderResult(const SymbolFinderResult &result) = delete;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This both allows us to remove a `fast_sort` at the end of findSymbols
(update: two `fast_sort`, from symbolFinder and treeSymbolizer)
and also sets this methd up to operate on `absl::Span`, which will make
implementing parts of the upcoming packager refactors more easily.

This could potentially adversely affect performance if this causes worse
cache locality, but I think that locality should be ~mostly fine as long
as the amount of work per file is approximately similar?

Another thing: before this change, we would not attempt to start merging
index results until the first thread had completed all its work, which
meant that merging the `allFoundDefinitions` was frequently the long
poll. Now, the merging happens as soon as the thread finishes, which
means it's keeping the main thread busier.

**Update**: it's not quite two, because one of them was load bearing for LSP:

LSP runSlowPath was relying on namer sorting files.
That meant that in the batch pipeline, which already sorts the input
earlier, namer was doing a redundant sort, but in LSP it was the only
sort.

We could ENFORCE this, except that we don't actually have the full list
sorted--`__package.rb` files are generally first, but only in the
pipeline, not LSP. So for now I'm just going to leave this new
`fast_sort` call here without an additional ENFORCE.

So in the batch pipeline, we net drop two sorts, and in LSP we net drop one.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests