### PR TITLE
Rewrite namer to operate on absl::Span

### DIFF
--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -41,7 +41,8 @@ void processSource(core::GlobalState &cb, string str) {
     trees.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
     core::FoundDefHashes foundHashes; // compute this just for test coverage
-    trees = move(namer::Namer::run(cb, move(trees), *workers, &foundHashes).result());
+    auto cancelled = namer::Namer::run(cb, absl::Span<ast::ParsedFile>(trees), *workers, &foundHashes);
+    ENFORCE(!cancelled);
     auto resolved = resolver::Resolver::run(cb, move(trees), *workers);
     for (auto &tree : resolved.result()) {
         sorbet::core::MutableContext ctx(cb, core::Symbols::root(), tree.file);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -266,13 +266,13 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
             core::UnfreezeSymbolTable symbolTable(gs);
             core::UnfreezeNameTable nameTable(gs);
 
-            auto result = runIncrementalNamer ? sorbet::namer::Namer::runIncremental(
-                                                    gs, move(what), std::move(foundHashesForFiles.value()), workers)
-                                              : sorbet::namer::Namer::run(gs, move(what), workers, nullptr);
+            auto canceled = runIncrementalNamer
+                                ? sorbet::namer::Namer::runIncremental(gs, absl::Span<ast::ParsedFile>(what),
+                                                                       std::move(foundHashesForFiles.value()), workers)
+                                : sorbet::namer::Namer::run(gs, absl::Span<ast::ParsedFile>(what), workers, nullptr);
 
             // Cancellation cannot occur during incremental namer.
-            ENFORCE(result.hasResult());
-            what = move(result.result());
+            ENFORCE(!canceled);
 
             // Required for autogen tests, which need to control which phase to stop after.
             if (opts.stopAfterPhase == options::Phase::NAMER) {
@@ -773,15 +773,14 @@ void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const opti
 #endif
 }
 
-ast::ParsedFilesOrCancelled name(core::GlobalState &gs, vector<ast::ParsedFile> what, const options::Options &opts,
-                                 WorkerPool &workers, core::FoundDefHashes *foundHashes) {
+[[nodiscard]] bool name(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
+                        WorkerPool &workers, core::FoundDefHashes *foundHashes) {
     Timer timeit(gs.tracer(), "name");
     core::UnfreezeNameTable nameTableAccess(gs);     // creates singletons and class names
     core::UnfreezeSymbolTable symbolTableAccess(gs); // enters symbols
-    auto result = namer::Namer::run(gs, move(what), workers, foundHashes);
-
-    return result;
+    return namer::Namer::run(gs, what, workers, foundHashes);
 }
+
 class GatherUnresolvedConstantsWalk {
 public:
     vector<string> unresolvedConstants;
@@ -862,11 +861,10 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                                     const options::Options &opts, WorkerPool &workers,
                                     core::FoundDefHashes *foundHashes) {
     try {
-        auto result = name(*gs, move(what), opts, workers, foundHashes);
-        if (!result.hasResult()) {
-            return result;
+        auto canceled = name(*gs, absl::Span<ast::ParsedFile>(what), opts, workers, foundHashes);
+        if (canceled) {
+            return ast::ParsedFilesOrCancelled::cancel(move(what), workers);
         }
-        what = move(result.result());
 
         for (auto &named : what) {
             if (opts.print.NameTree.enabled) {

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -46,8 +46,8 @@ incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                    std::optional<UnorderedMap<core::FileRef, core::FoundDefHashes>> &&foundHashesForFiles,
                    const options::Options &opts, WorkerPool &workers);
 
-ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
-                                 WorkerPool &workers, core::FoundDefHashes *foundHashes);
+[[nodiscard]] bool name(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
+                        WorkerPool &workers, core::FoundDefHashes *foundHashes);
 
 std::vector<ast::ParsedFile> autogenWriteCacheFile(const core::GlobalState &gs, const std::string &cachePath,
                                                    std::vector<ast::ParsedFile> what, WorkerPool &workers);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -777,7 +777,9 @@ int realmain(int argc, char *argv[]) {
 
             // Only need to compute FoundMethodHashes when running to compute a FileHash
             auto foundMethodHashes = nullptr;
-            indexed = move(pipeline::name(*gs, move(indexed), opts, *workers, foundMethodHashes).result());
+            auto canceled =
+                pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers, foundMethodHashes);
+            ENFORCE(!canceled);
 
             {
                 core::UnfreezeNameTable nameTableAccess(*gs);

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -11,10 +11,9 @@ class WorkerPool;
 namespace sorbet::namer {
 
 class Namer final {
-    static ast::ParsedFilesOrCancelled
-    runInternal(core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers,
-                UnorderedMap<core::FileRef, core::FoundDefHashes> &&oldFoundDefHashesForFiles,
-                core::FoundDefHashes *foundHashesOut);
+    [[nodiscard]] static bool runInternal(core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, WorkerPool &workers,
+                                          UnorderedMap<core::FileRef, core::FoundDefHashes> &&oldFoundDefHashesForFiles,
+                                          core::FoundDefHashes *foundHashesOut);
 
 public:
     // Note: foundHashes is an optional out parameter.
@@ -22,8 +21,8 @@ public:
     // Setting it to a non-nullptr requests that Namer compute a fingerprint of the FoundDefinitions
     // it found while running. (Thus, it's usually nullptr except when pipeline::resolve is called
     // for the purpose of computing a FileHash.)
-    static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
-                                           WorkerPool &workers, core::FoundDefHashes *foundHashesOut);
+    [[nodiscard]] static bool run(core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, WorkerPool &workers,
+                                  core::FoundDefHashes *foundHashesOut);
 
     // Version of Namer that accepts the old FoundDefHashes for each file to run Namer, which
     // it uses to figure out how to mutate the already-populated GlobalState into the right shape
@@ -33,8 +32,8 @@ public:
     // `foundDefHashesForFiles[i]` should be the `FoundDefHashes` for `trees[i]`.
     // (Done this way, instead of using something like a `std::pair`, to avoid intermediate
     // allocations for phases that don't actually need to operate on the `FoundDefHashes`.)
-    static ast::ParsedFilesOrCancelled
-    runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
+    [[nodiscard]] static bool
+    runIncremental(core::GlobalState &gs, absl::Span<ast::ParsedFile> trees,
                    UnorderedMap<core::FileRef, core::FoundDefHashes> &&oldFoundDefHashesForFiles, WorkerPool &workers);
 
     Namer() = delete;

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -46,7 +46,9 @@ vector<ast::ParsedFile> runNamer(core::GlobalState &gs, ast::ParsedFile tree) {
     v.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
     core::FoundDefHashes foundHashes; // compute this just for test coverage
-    return move(namer::Namer::run(gs, move(v), *workers, &foundHashes).result());
+    auto canceled = namer::Namer::run(gs, absl::Span<ast::ParsedFile>(v), *workers, &foundHashes);
+    ENFORCE(!canceled);
+    return v;
 }
 
 } // namespace

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -446,7 +446,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 core::UnfreezeNameTable nameTableAccess(*rbiGenGs);     // creates singletons and class names
                 core::UnfreezeSymbolTable symbolTableAccess(*rbiGenGs); // enters symbols
                 auto foundHashes = nullptr;
-                trees = move(namer::Namer::run(*rbiGenGs, move(trees), *workers, foundHashes).result());
+                auto canceled = namer::Namer::run(*rbiGenGs, absl::Span<ast::ParsedFile>(trees), *workers, foundHashes);
+                ENFORCE(!canceled);
             }
 
             // Resolver
@@ -479,7 +480,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         core::UnfreezeNameTable nameTableAccess(*gs);     // creates singletons and class names
         core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters symbols
         auto foundHashes = nullptr;
-        trees = move(namer::Namer::run(*gs, move(trees), *workers, foundHashes).result());
+        auto canceled = namer::Namer::run(*gs, absl::Span<ast::ParsedFile>(trees), *workers, foundHashes);
+        ENFORCE(!canceled);
     }
 
     for (auto &tree : trees) {
@@ -809,7 +811,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             // to stress the codepath where Namer is not tasked with deleting anything when run for
             // the fast path.
             ENFORCE(!ranIncrementalNamer);
-            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundHashes).result());
+            auto canceled = namer::Namer::run(*gs, absl::Span<ast::ParsedFile>(vTmp), *workers, &foundHashes);
+            ENFORCE(!canceled);
             tree = testSerialize(*gs, move(vTmp[0]));
 
             handler.addObserved(*gs, "name-tree", [&]() { return tree.tree.toString(*gs); });


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In the future, namer will be in charge of defining packages. When this happens,
we want to be able to run namer on **only** the package files, before we've even
so much as indexed the rest of the files. The easiest way to run namer on a
subset of the files is going to be by making a subspan of the list of parsed
files and passing that to namer.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests