### PR TITLE
Comment out error without any usages

### DIFF
--- a/core/errors/namer.h
+++ b/core/errors/namer.h
@@ -17,7 +17,7 @@ constexpr ErrorClass InvalidTypeDefinition{4011, StrictLevel::False};
 constexpr ErrorClass ModuleKindRedefinition{4012, StrictLevel::False};
 constexpr ErrorClass InterfaceClass{4013, StrictLevel::False};
 constexpr ErrorClass DynamicConstant{4014, StrictLevel::False};
-constexpr ErrorClass InvalidClassOwner{4015, StrictLevel::False};
+// constexpr ErrorClass InvalidClassOwner{4015, StrictLevel::False};
 constexpr ErrorClass RootTypeMember{4016, StrictLevel::False};
 // constexpr ErrorClass DynamicConstantAssignment{4017, StrictLevel::False};
 // constexpr ErrorClass RepeatedArgument{4018, StrictLevel::False};

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -769,7 +769,6 @@ int realmain(int argc, char *argv[]) {
             }
 
             gs->suppressErrorClass(core::errors::Namer::RedefinitionOfMethod.code);
-            gs->suppressErrorClass(core::errors::Namer::InvalidClassOwner.code);
             gs->suppressErrorClass(core::errors::Namer::ModuleKindRedefinition.code);
             gs->suppressErrorClass(core::errors::Namer::ConstantKindRedefinition.code);
             gs->suppressErrorClass(core::errors::Resolver::StubConstant.code);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Per the tin. 

Looks like the last usage of that error was removed in this PR in namer.cc https://github.com/sorbet/sorbet/pull/6534
### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
