### PR TITLE
Hoist `pipeline::name` to after `pipeline::package`

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -49,7 +49,7 @@ where what the phases of Sorbet actually do are documented.
                                           ▼
              ┌─────────────────────────────────────────────────────────┐
              │  ┌─────────────┐                                        │
-             │  │ GlobalState │        resolve                         │
+             │  │ GlobalState │    nameAndResolve                      │
              │  └─────────────┘                                        │
              ├─────────────────────────────────────────────────────────┤
              │                   ┌─────────────────┐                   │
@@ -124,7 +124,7 @@ Some notes:
   about it amongst ourselves) into three big chunks:
 
   1.  index
-  2.  resolve
+  2.  nameAndResolve
   3.  typecheck
 
 - The "index" chunk works at the file level and involves largely syntactic
@@ -163,12 +163,13 @@ Some notes:
   For more information on what's parallelized, see [Namer & Resolver
   Pipeline](namer-resolver-pipeline.md).
 
-  The sequential parts of resolve were originally designed to be whole-program,
-  which makes it tricky to make incremental. Our current trick is to separate
-  changes into "local changes" (fast path) and "non-local changes" (slow path).
-  It's easy to run resolve in a mode where it assumes it's on the fast path but
-  checks to see if it needs to take the slow path. The details are a bit hairy,
-  but you can see them if you look for `incrementalResolve` in the code.
+  The sequential parts of nameAndResolve were originally designed to be
+  whole-program, which makes it tricky to make incremental. Our current trick is
+  to separate changes into "local changes" (fast path) and "non-local changes"
+  (slow path). It's easy to run nameAndResolve in a mode where it assumes it's
+  on the fast path but checks to see if it needs to take the slow path. The
+  details are a bit hairy, but you can see them if you look for
+  `incrementalResolve` in the code.
 
 - The "typecheck" chunk operates on an immutable GlobalState. Because we don't
   do global type inference, type checking one method can't affect the result of

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -80,7 +80,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
 
     auto workers = WorkerPool::create(0, lgs->tracer());
     core::FoundDefHashes foundHashes; // out parameter
-    realmain::pipeline::resolve(lgs, move(single), opts(), *workers, &foundHashes);
+    realmain::pipeline::nameAndResolve(lgs, move(single), opts(), *workers, &foundHashes);
 
     return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash), move(foundHashes));
 }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -472,7 +472,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
 
         // Only need to compute FoundDefHashes when running to compute a FileHash
         auto foundHashes = nullptr;
-        auto maybeResolved = pipeline::resolve(gs, move(indexedCopies), config->opts, workers, foundHashes);
+        auto maybeResolved = pipeline::nameAndResolve(gs, move(indexedCopies), config->opts, workers, foundHashes);
         if (!maybeResolved.hasResult()) {
             return;
         }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -472,7 +472,14 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
 
         // Only need to compute FoundDefHashes when running to compute a FileHash
         auto foundHashes = nullptr;
-        auto maybeResolved = pipeline::nameAndResolve(gs, move(indexedCopies), config->opts, workers, foundHashes);
+        auto canceled =
+            pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexedCopies), config->opts, workers, foundHashes);
+        if (canceled) {
+            ast::ParsedFilesOrCancelled::cancel(move(indexedCopies), workers);
+            return;
+        }
+
+        auto maybeResolved = pipeline::resolve(gs, move(indexedCopies), config->opts, workers);
         if (!maybeResolved.hasResult()) {
             return;
         }

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -424,7 +424,7 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
 
     // Only need to compute FoundDefHashes when running to compute a FileHash
     auto foundHashes = nullptr;
-    rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers, foundHashes).result());
+    rbiIndexed = move(pipeline::nameAndResolve(rbiGS, move(rbiIndexed), opts, workers, foundHashes).result());
     if (rbiGS->hadCriticalError()) {
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -421,10 +421,12 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
 
     pipeline::setPackagerOptions(*rbiGS, opts);
     pipeline::package(*rbiGS, absl::Span<ast::ParsedFile>(rbiIndexed), opts, workers);
-
     // Only need to compute FoundDefHashes when running to compute a FileHash
     auto foundHashes = nullptr;
-    rbiIndexed = move(pipeline::nameAndResolve(rbiGS, move(rbiIndexed), opts, workers, foundHashes).result());
+    auto canceled = pipeline::name(*rbiGS, absl::Span<ast::ParsedFile>(rbiIndexed), opts, workers, foundHashes);
+    ENFORCE(!canceled, "Can only cancel in LSP mode");
+
+    rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers).result());
     if (rbiGS->hadCriticalError()) {
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -720,15 +720,15 @@ size_t partitionPackageFiles(const core::GlobalState &gs, absl::Span<core::FileR
     return numPackageFiles;
 }
 
-void unpartitionPackageFiles(vector<ast::ParsedFile> &indexed, vector<ast::ParsedFile> &&nonPackageIndexed) {
-    if (indexed.empty()) {
+void unpartitionPackageFiles(vector<ast::ParsedFile> &packageFiles, vector<ast::ParsedFile> &&nonPackageFiles) {
+    if (packageFiles.empty()) {
         // Performance optimization--if it's already empty, no need to move one-by-one
-        indexed = move(nonPackageIndexed);
+        packageFiles = move(nonPackageFiles);
     } else {
         // In this case, all the __package.rb files will have been sorted before non-__package.rb files,
         // and within each subsequence, the parsed files will be sorted (pipeline::index sorts its result)
-        indexed.reserve(indexed.size() + nonPackageIndexed.size());
-        absl::c_move(nonPackageIndexed, back_inserter(indexed));
+        packageFiles.reserve(packageFiles.size() + nonPackageFiles.size());
+        absl::c_move(nonPackageFiles, back_inserter(packageFiles));
     }
 }
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -887,6 +887,12 @@ ast::ParsedFilesOrCancelled nameAndResolve(unique_ptr<core::GlobalState> &gs, ve
         return ast::ParsedFilesOrCancelled::cancel(move(what), workers);
     }
 
+    return resolve(gs, move(what), opts, workers, foundHashes);
+}
+
+ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
+                                    const options::Options &opts, WorkerPool &workers,
+                                    core::FoundDefHashes *foundHashes) {
     try {
         if (opts.stopAfterPhase != options::Phase::NAMER) {
             ProgressIndicator namingProgress(opts.showProgress, "Resolving", 1);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -249,13 +249,13 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
         if (opts.stripePackages) {
             Timer timeit(gs.tracer(), "incremental_packager");
             // For simplicity, we still call Packager::runIncremental here, even though
-            // pipeline::resolve no longer calls Packager::run.
+            // pipeline::nameAndResolve no longer calls Packager::run.
             //
             // TODO(jez) We may want to revisit this. At the moment, the only thing that
             // runIncremental does is validate that files have the right package prefix. We could
             // split `pipeline::package` into something like "populate the package DB" and "verify
-            // the package prefixes" with the later living in `pipeline::resolve` once again (thus
-            // restoring the symmetry).
+            // the package prefixes" with the later living in `pipeline::nameAndResolve` once again
+            // (thus restoring the symmetry).
             // TODO(jez) Parallelize this
             what = packager::Packager::runIncremental(gs, move(what));
         }
@@ -879,9 +879,9 @@ ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, a
     return what;
 }
 
-ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers,
-                                    core::FoundDefHashes *foundHashes) {
+ast::ParsedFilesOrCancelled nameAndResolve(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
+                                           const options::Options &opts, WorkerPool &workers,
+                                           core::FoundDefHashes *foundHashes) {
     auto canceled = name(*gs, absl::Span<ast::ParsedFile>(what), opts, workers, foundHashes);
     if (canceled) {
         return ast::ParsedFilesOrCancelled::cancel(move(what), workers);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -887,12 +887,11 @@ ast::ParsedFilesOrCancelled nameAndResolve(unique_ptr<core::GlobalState> &gs, ve
         return ast::ParsedFilesOrCancelled::cancel(move(what), workers);
     }
 
-    return resolve(gs, move(what), opts, workers, foundHashes);
+    return resolve(gs, move(what), opts, workers);
 }
 
 ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers,
-                                    core::FoundDefHashes *foundHashes) {
+                                    const options::Options &opts, WorkerPool &workers) {
     try {
         if (opts.stopAfterPhase != options::Phase::NAMER) {
             ProgressIndicator namingProgress(opts.showProgress, "Resolving", 1);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -784,10 +784,10 @@ void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const opti
     if (!canceled) {
         for (auto &named : what) {
             if (opts.print.NameTree.enabled) {
-                opts.print.NameTree.fmt("{}\n", named.tree.toStringWithTabs(*gs, 0));
+                opts.print.NameTree.fmt("{}\n", named.tree.toStringWithTabs(gs, 0));
             }
             if (opts.print.NameTreeRaw.enabled) {
-                opts.print.NameTreeRaw.fmt("{}\n", named.tree.showRaw(*gs));
+                opts.print.NameTreeRaw.fmt("{}\n", named.tree.showRaw(gs));
             }
         }
     }

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -50,6 +50,10 @@ incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
 [[nodiscard]] bool name(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
                         WorkerPool &workers, core::FoundDefHashes *foundHashes);
 
+ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
+                                    const options::Options &opts, WorkerPool &workers,
+                                    core::FoundDefHashes *foundHashes);
+
 std::vector<ast::ParsedFile> autogenWriteCacheFile(const core::GlobalState &gs, const std::string &cachePath,
                                                    std::vector<ast::ParsedFile> what, WorkerPool &workers);
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -25,7 +25,8 @@ std::vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileR
                                    WorkerPool &workers, const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 
 size_t partitionPackageFiles(const core::GlobalState &gs, absl::Span<core::FileRef> files);
-void unpartitionPackageFiles(std::vector<ast::ParsedFile> &indexed, std::vector<ast::ParsedFile> &&nonPackageIndexed);
+void unpartitionPackageFiles(std::vector<ast::ParsedFile> &packageFiles,
+                             std::vector<ast::ParsedFile> &&nonPackageFiles);
 
 void setPackagerOptions(core::GlobalState &gs, const options::Options &opts);
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -32,9 +32,9 @@ void setPackagerOptions(core::GlobalState &gs, const options::Options &opts);
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers);
 
-ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers,
-                                    core::FoundDefHashes *foundHashes);
+ast::ParsedFilesOrCancelled nameAndResolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
+                                           const options::Options &opts, WorkerPool &workers,
+                                           core::FoundDefHashes *foundHashes);
 
 // If `foundMethodHashesForFiles` is non-nullopt, incrementalResolve invokes Namer in runIncremental mode.
 //

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -51,8 +51,7 @@ incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                         WorkerPool &workers, core::FoundDefHashes *foundHashes);
 
 ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers,
-                                    core::FoundDefHashes *foundHashes);
+                                    const options::Options &opts, WorkerPool &workers);
 
 std::vector<ast::ParsedFile> autogenWriteCacheFile(const core::GlobalState &gs, const std::string &cachePath,
                                                    std::vector<ast::ParsedFile> what, WorkerPool &workers);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -531,6 +531,14 @@ int realmain(int argc, char *argv[]) {
     }
     gs->suggestUnsafe = opts.suggestUnsafe;
 
+    if (gs->runningUnderAutogen) {
+        gs->suppressErrorClass(core::errors::Namer::RedefinitionOfMethod.code);
+        gs->suppressErrorClass(core::errors::Namer::ModuleKindRedefinition.code);
+        gs->suppressErrorClass(core::errors::Namer::ConstantKindRedefinition.code);
+        gs->suppressErrorClass(core::errors::Resolver::StubConstant.code);
+        gs->suppressErrorClass(core::errors::Resolver::RecursiveTypeAlias.code);
+    }
+
     logger->trace("done building initial global state");
 
     if (opts.print.PayloadSources.enabled) {
@@ -767,12 +775,6 @@ int realmain(int argc, char *argv[]) {
                 indexed = pipeline::autogenWriteCacheFile(*gs, opts.autogenConstantCacheConfig.cacheFile, move(indexed),
                                                           *workers);
             }
-
-            gs->suppressErrorClass(core::errors::Namer::RedefinitionOfMethod.code);
-            gs->suppressErrorClass(core::errors::Namer::ModuleKindRedefinition.code);
-            gs->suppressErrorClass(core::errors::Namer::ConstantKindRedefinition.code);
-            gs->suppressErrorClass(core::errors::Resolver::StubConstant.code);
-            gs->suppressErrorClass(core::errors::Resolver::RecursiveTypeAlias.code);
 
             // Only need to compute FoundMethodHashes when running to compute a FileHash
             auto foundMethodHashes = nullptr;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -741,6 +741,10 @@ int realmain(int argc, char *argv[]) {
                 // First run: only the __package.rb files. This populates the packageDB
                 pipeline::setPackagerOptions(*gs, opts);
                 pipeline::package(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers);
+                // Only need to compute hashes when running to compute a FileHash
+                auto foundHashes = nullptr;
+                auto canceled = pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers, foundHashes);
+                ENFORCE(!canceled, "There's no cancellation in batch mode");
             }
 
             auto nonPackageIndexed =
@@ -757,7 +761,14 @@ int realmain(int argc, char *argv[]) {
             // Second run: all the other files (the packageDB shouldn't change)
             pipeline::package(*gs, absl::Span<ast::ParsedFile>(nonPackageIndexed), opts, *workers);
 
+            // Only need to compute hashes when running to compute a FileHash
+            auto foundHashes = nullptr;
+            auto canceled =
+                pipeline::name(*gs, absl::Span<ast::ParsedFile>(nonPackageIndexed), opts, *workers, foundHashes);
+            ENFORCE(!canceled, "There's no cancellation in batch mode");
+
             pipeline::unpartitionPackageFiles(indexed, move(nonPackageIndexed));
+            // TODO(jez) At this point, it's not correct to call it `indexed` anymore: we've run namer too
 
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
@@ -769,18 +780,15 @@ int realmain(int argc, char *argv[]) {
             logger->warn("Autogen is disabled in sorbet-orig for faster builds");
             return 1;
 #else
-
+            // TODO(jez) Make sure that it's still okay to run this phase after namer, otherwise
+            // you'll have to adjust the non-autogen pipeline code. At first read, it seems like it
+            // unwraps ConstantLit to UnresolvedConstantLit and proceeds as normal, so I think it
+            // should be fine.
             if (!opts.autogenConstantCacheConfig.cacheFile.empty()) {
                 // we should regenerate the constant cache here
                 indexed = pipeline::autogenWriteCacheFile(*gs, opts.autogenConstantCacheConfig.cacheFile, move(indexed),
                                                           *workers);
             }
-
-            // Only need to compute FoundMethodHashes when running to compute a FileHash
-            auto foundMethodHashes = nullptr;
-            auto canceled =
-                pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers, foundMethodHashes);
-            ENFORCE(!canceled);
 
             {
                 core::UnfreezeNameTable nameTableAccess(*gs);
@@ -795,9 +803,7 @@ int realmain(int argc, char *argv[]) {
             runAutogen(*gs, opts, autogenCfg, *workers, indexed, opts.autogenConstantCacheConfig.changedFiles);
 #endif
         } else {
-            // Only need to compute hashes when running to compute a FileHash
-            auto foundHashes = nullptr;
-            indexed = move(pipeline::nameAndResolve(gs, move(indexed), opts, *workers, foundHashes).result());
+            indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers).result());
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -795,7 +795,7 @@ int realmain(int argc, char *argv[]) {
         } else {
             // Only need to compute hashes when running to compute a FileHash
             auto foundHashes = nullptr;
-            indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers, foundHashes).result());
+            indexed = move(pipeline::nameAndResolve(gs, move(indexed), opts, *workers, foundHashes).result());
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -19,7 +19,7 @@ public:
     // Note: foundHashes is an optional out parameter.
     //
     // Setting it to a non-nullptr requests that Namer compute a fingerprint of the FoundDefinitions
-    // it found while running. (Thus, it's usually nullptr except when pipeline::resolve is called
+    // it found while running. (Thus, it's usually nullptr except when pipeline::nameAndResolve is called
     // for the purpose of computing a FileHash.)
     [[nodiscard]] static bool run(core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, WorkerPool &workers,
                                   core::FoundDefHashes *foundHashesOut);

--- a/payload/text/populate.cc
+++ b/payload/text/populate.cc
@@ -33,7 +33,8 @@ void populateRBIsInto(unique_ptr<core::GlobalState> &gs) {
     // '[0].to_set' will typecheck (using text-based payload) but never calculate hashes for the
     // payload files (because neither `--lsp` nor `--store-state` was passed).
     auto foundMethodHashes = nullptr;
-    realmain::pipeline::nameAndResolve(gs, move(indexed), emptyOpts, *workers, foundMethodHashes); // result is thrown away
+    realmain::pipeline::nameAndResolve(gs, move(indexed), emptyOpts, *workers, foundMethodHashes);
+    // ^ result is thrown away
     gs->ensureCleanStrings = false;
 }
 

--- a/payload/text/populate.cc
+++ b/payload/text/populate.cc
@@ -33,7 +33,7 @@ void populateRBIsInto(unique_ptr<core::GlobalState> &gs) {
     // '[0].to_set' will typecheck (using text-based payload) but never calculate hashes for the
     // payload files (because neither `--lsp` nor `--store-state` was passed).
     auto foundMethodHashes = nullptr;
-    realmain::pipeline::resolve(gs, move(indexed), emptyOpts, *workers, foundMethodHashes); // result is thrown away
+    realmain::pipeline::nameAndResolve(gs, move(indexed), emptyOpts, *workers, foundMethodHashes); // result is thrown away
     gs->ensureCleanStrings = false;
 }
 

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -72,7 +72,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     indexed = realmain::pipeline::index(*gs, absl::Span<core::FileRef>(inputFiles), *opts, *workers, kvstore);
     // We don't run this fuzzer with any packager options, so we can skip pipeline::package()
     auto foundHashes = nullptr;
-    indexed = move(realmain::pipeline::resolve(gs, move(indexed), *opts, *workers, foundHashes).result());
+    indexed = move(realmain::pipeline::nameAndResolve(gs, move(indexed), *opts, *workers, foundHashes).result());
     realmain::pipeline::typecheck(*gs, move(indexed), *opts, *workers);
     return 0;
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After this change, we have the situation that every call to `pipeline::package`
is immediately followed by a call to `pipeline::name`.

In a future change, we'll basically merge most of `pipeline::package` into
`pipeline::name`, but when we do so, the package database will still have been
populated at the same point in the pipeline.

### Commit summary

- **no-op: Rename arguments in unpartitionPackageFiles** (fa2d41f90)

  `indexed` → `packageFiles`
  `nonPackageIndexed` → `nonPackageFiles`

  Soon we'll hoist the namer call up for `__package.rb` files, so the
  variable names will no longer mean what they should.

- **no-op: Move opts.print.NameTree into pipeline::name** (0df6ee9ba)

  `pipeline::name` is only called by `pipeline::resolve`

- **no-op: Fixup moved code** (40636130d)


- **no-op: Hoist pipeline::name out of try/catch** (b40f0ffb7)

  This way, when we start calling `pipeline::name` in places where it's
  currently being called via `pipeline::resolve`, it'll get the same
  behavior.

- **pipeline::resolve → pipeline::nameAndResolve** (48ca1cfa3)

  This changes the name one of the core pipeline functions, because we're
  going to start to exercise more control around when the `name` portion
  of it is called.

  We could technically speaking leave it as a function and add a boolean
  parameter indicating whether to call `name()` or not, but I figure
  making new top-level functions is better.

- **Add `pipeline::resolve` back, without `name`** (2d1a9b732)


- **Remove unused foundHashes from pipeline::resolve** (313b30ea4)

  This is only used by `pipeline::name` (and thus `nameAndResolve`), so we
  can drop it from the new `pipeline::resolve` function.

- **no-op: Move autogen suppressErrorClass calls earlier** (a700642f8)

  This is kind of nice, because it means that they're all set at the same
  point. And also, we're going to replace autogen's call to
  `pipeline::name` with the rest of the batch pipeline's call to
  `pipeline::name` after packager.

- **Hoist `pipeline::name` to right after package** (1c686657c)

  So now, we have the situation that every call to `pipeline::package` is
  immediately followed by a call to `pipeline::name`.

  In a future change, we'll basically merge most of `pipeline::package`
  into `pipeline::name`, but in doing so, the package database will still
  have been populated at the same point in the pipeline.

- **Do the same to the slow path and --minimize-for-rbi** (a7c27f4ea)

  At the moment, I'm not giving this treatment to incrementalResolve, but
  that shouldn't matter for the time being, because the fast path cannot
  modify the package database yet.

- **Do the same to pipeline_test_runner.cc** (099ac2f49)


- **Format** (c4f49ef15)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests