### PR TITLE
Add caller_location to T::Enum soft assertion storytime

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -192,13 +192,16 @@ class T::Enum
   # responds to the `to_str` method. It does not actually call `to_str` however.
   #
   # See https://ruby-doc.org/core-2.4.0/String.html#method-i-3D-3D
-  sig {returns(String)}
+  T::Sig::WithoutRuntime.sig {returns(String)}
   def to_str
     msg = 'Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead.'
     if T::Configuration.legacy_t_enum_migration_mode?
       T::Configuration.soft_assert_handler(
         msg,
-        storytime: {class: self.class.name},
+        storytime: {
+          class: self.class.name,
+          caller_location: caller_locations(1..1)&.[](0)&.then { "#{_1.path}:#{_1.lineno}" },
+        },
       )
       serialize.to_s
     else
@@ -206,7 +209,8 @@ class T::Enum
     end
   end
 
-  sig {params(other: BasicObject).returns(T::Boolean).checked(:never)}
+  # WithoutRuntime so that comparison_assertion_failed can assume a constant stack depth
+  T::Sig::WithoutRuntime.sig {params(other: BasicObject).returns(T::Boolean)}
   def ==(other)
     case other
     when String
@@ -221,7 +225,8 @@ class T::Enum
     end
   end
 
-  sig {params(other: BasicObject).returns(T::Boolean).checked(:never)}
+  # WithoutRuntime so that comparison_assertion_failed can assume a constant stack depth
+  T::Sig::WithoutRuntime.sig {params(other: BasicObject).returns(T::Boolean)}
   def ===(other)
     case other
     when String
@@ -236,7 +241,9 @@ class T::Enum
     end
   end
 
-  sig {params(method: Symbol, other: T.untyped).void}
+  # WithoutRuntime so that caller_locations can assume a constant stack depth
+  # (Otherwise, the first call would be the method with the wrapping, which would have a different stack depth.)
+  T::Sig::WithoutRuntime.sig {params(method: Symbol, other: T.untyped).void}
   private def comparison_assertion_failed(method, other)
     T::Configuration.soft_assert_handler(
       'Enum to string comparison not allowed. Compare to the Enum instance directly instead. See go/enum-migration',
@@ -246,6 +253,7 @@ class T::Enum
         other: other,
         other_class: other.class.name,
         method: method,
+        caller_location: caller_locations(2..2)&.[](0)&.then { "#{_1.path}:#{_1.lineno}" },
       }
     )
   end

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -200,7 +200,7 @@ class T::Enum
         msg,
         storytime: {
           class: self.class.name,
-          caller_location: caller_locations(1..1)&.[](0)&.then { "#{_1.path}:#{_1.lineno}" },
+          caller_location: caller_locations(1..1)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
         },
       )
       serialize.to_s
@@ -253,7 +253,7 @@ class T::Enum
         other: other,
         other_class: other.class.name,
         method: method,
-        caller_location: caller_locations(2..2)&.[](0)&.then { "#{_1.path}:#{_1.lineno}" },
+        caller_location: caller_locations(2..2)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
       }
     )
   end

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -395,8 +395,9 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     ENUM_CONVERSION_MSG_LEGACY = 'Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead.'
     before do
       T::Configuration.enable_legacy_t_enum_migration_mode
-      T::Configuration.expects(:soft_assert_handler).at_least_once.with do |message|
+      T::Configuration.expects(:soft_assert_handler).at_least_once.with do |message, storytime:|
         assert_equal(ENUM_CONVERSION_MSG_LEGACY, message)
+        assert_includes(storytime[:caller_location], __FILE__)
       end
     end
 
@@ -456,8 +457,9 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     ENUM_COMPARE_MSG = 'Enum to string comparison not allowed. Compare to the Enum instance directly instead. See go/enum-migration'
     before do
       T::Configuration.enable_legacy_t_enum_migration_mode
-      T::Configuration.expects(:soft_assert_handler).at_least_once.with do |message|
+      T::Configuration.expects(:soft_assert_handler).at_least_once.with do |message, storytime:|
         assert_equal(ENUM_COMPARE_MSG, message)
+        assert_includes(storytime[:caller_location], __FILE__)
       end
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have a ton of these assertions and even it's particularly hard for
well-meaning people to go in and try to clean them up with the limited
information we currently report.

There is technically a `backtrace` keyword argument (peer to
`storytime`), but I'm worried about spamming large backtraces into the logs
(this assertion is tripped frequently) and I think that the immediate caller
location is likely good enough to debug.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested manually to make sure that the correct frame is chosen with
`caller_locations()`.

```ruby
# typed: true

require_relative './gems/sorbet-runtime/lib/sorbet-runtime'
T::Configuration.enable_legacy_t_enum_migration_mode

class MyEnum < T::Enum
  enums do
    X = new
  end
end

MyEnum::X == 'x'
```

```
Enum to string comparison not allowed. Compare to the Enum instance directly instead. See go/enum-migration, extra: {:storytime=>{:class=>"MyEnum", :self=>"#<MyEnum::X>", :other=>"x", :other_class=>"String", :method=>:==, :caller_location=>"foo.rb:12"}}
```

Wrote an automated test to verify that it doesn't break horribly, but it won't
catch all possible regressions.