### PR TITLE
Improve perf of T::Enum when not using enable_legacy_t_enum_migration_mode

### DIFF
--- a/gems/sorbet-runtime/bench/enum.rb
+++ b/gems/sorbet-runtime/bench/enum.rb
@@ -38,6 +38,8 @@ module SorbetBenchmarks
 
     def self.all_comparisons
       time_block("T::Enum == T::Enum", iterations_of_block: 100_000, iterations_in_block: 9) do
+        # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
+        # rubocop:disable Lint/Void
         MyEnum::X == MyEnum::X
         MyEnum::X == MyEnum::X
         MyEnum::X == MyEnum::X
@@ -49,9 +51,12 @@ module SorbetBenchmarks
         MyEnum::Z == MyEnum::Z
         MyEnum::Z == MyEnum::Z
         MyEnum::Z == MyEnum::Z
+        # rubocop:enable Lint/Void
+        # rubocop:enable Lint/BinaryOperatorWithIdenticalOperands
       end
 
       time_block("T::Enum == String", iterations_of_block: 100_000, iterations_in_block: 9) do
+        # rubocop:disable Lint/Void
         MyEnum::X == 'x'
         MyEnum::X == 'x'
         MyEnum::X == 'x'
@@ -63,6 +68,7 @@ module SorbetBenchmarks
         MyEnum::Z == 'z'
         MyEnum::Z == 'z'
         MyEnum::Z == 'z'
+        # rubocop:enable Lint/Void
       end
     end
 
@@ -72,7 +78,7 @@ module SorbetBenchmarks
       all_comparisons
 
       T::Configuration.enable_legacy_t_enum_migration_mode
-      T::Configuration.soft_assert_handler = -> (str, extra) do
+      T::Configuration.soft_assert_handler = lambda do |str, extra|
         # Empty
         # (Not trying to benchmark the performance of the soft_assert_handler)
       end

--- a/gems/sorbet-runtime/bench/enum.rb
+++ b/gems/sorbet-runtime/bench/enum.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module Enum
+    extend T::Sig
+
+    class Example; end
+
+    class MyEnum < T::Enum
+      enums do
+        X = new
+        Y = new
+        Z = new
+      end
+    end
+
+    def self.time_block(name, iterations_of_block: 1_000_000, iterations_in_block: 2, &blk)
+      1_000.times(&blk) # warmup
+
+      GC.start
+      GC.disable
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      iterations_of_block.times(&blk)
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+
+      GC.enable
+
+      ns_per_iter = duration_s * 1_000_000_000 / (iterations_of_block * iterations_in_block)
+      duration_str = ns_per_iter >= 1000 ? "#{(ns_per_iter / 1000).round(3)} μs" : "#{ns_per_iter.round(3)} ns"
+      puts "#{name}: #{duration_str}"
+    end
+
+    def self.all_comparisons
+      time_block("T::Enum == T::Enum", iterations_of_block: 100_000, iterations_in_block: 9) do
+        MyEnum::X == MyEnum::X
+        MyEnum::X == MyEnum::X
+        MyEnum::X == MyEnum::X
+
+        MyEnum::Y == MyEnum::Y
+        MyEnum::Y == MyEnum::Y
+        MyEnum::Y == MyEnum::Y
+
+        MyEnum::Z == MyEnum::Z
+        MyEnum::Z == MyEnum::Z
+        MyEnum::Z == MyEnum::Z
+      end
+
+      time_block("T::Enum == String", iterations_of_block: 100_000, iterations_in_block: 9) do
+        MyEnum::X == 'x'
+        MyEnum::X == 'x'
+        MyEnum::X == 'x'
+
+        MyEnum::Y == 'y'
+        MyEnum::Y == 'y'
+        MyEnum::Y == 'y'
+
+        MyEnum::Z == 'z'
+        MyEnum::Z == 'z'
+        MyEnum::Z == 'z'
+      end
+    end
+
+    def self.run
+      puts("before T::Configuration.enable_legacy_t_enum_migration_mode")
+
+      all_comparisons
+
+      T::Configuration.enable_legacy_t_enum_migration_mode
+      T::Configuration.soft_assert_handler = -> (str, extra) do
+        # Empty
+        # (Not trying to benchmark the performance of the soft_assert_handler)
+      end
+      puts("\nafter T::Configuration.enable_legacy_t_enum_migration_mode")
+
+      all_comparisons
+    end
+  end
+end

--- a/gems/sorbet-runtime/bench/tasks.rb
+++ b/gems/sorbet-runtime/bench/tasks.rb
@@ -12,6 +12,7 @@ require_relative 'sigs'
 require_relative 'tutils'
 require_relative 'typecheck'
 require_relative 'typecheck_kwargs_splat'
+require_relative 'enum'
 
 namespace :bench do
   task :getters do
@@ -56,6 +57,10 @@ namespace :bench do
 
   task :tutils do
     SorbetBenchmarks::TUtils.run
+  end
+
+  task :enum do
+    SorbetBenchmarks::Enum.run
   end
 
   task all: %i[getters setters constructor deserialize prop_definition serialize_custom_type sigs tutils typecheck]

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -536,6 +536,7 @@ module T::Configuration
 
   @legacy_t_enum_migration_mode = false
   def self.enable_legacy_t_enum_migration_mode
+    T::Enum.public_send(:include, T::Enum::LegacyMigrationMode)
     @legacy_t_enum_migration_mode = true
   end
   def self.disable_legacy_t_enum_migration_mode

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -536,7 +536,7 @@ module T::Configuration
 
   @legacy_t_enum_migration_mode = false
   def self.enable_legacy_t_enum_migration_mode
-    T::Enum.public_send(:include, T::Enum::LegacyMigrationMode)
+    T::Enum.include(T::Enum::LegacyMigrationMode)
     @legacy_t_enum_migration_mode = true
   end
   def self.disable_legacy_t_enum_migration_mode

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -186,6 +186,17 @@ class T::Enum
   end
 
   module LegacyMigrationMode
+    include Kernel
+    extend T::Helpers
+    abstract!
+
+    if T.unsafe(false)
+      # Declare to the type system that the `serialize` method for sure exists
+      # on whatever we mix this into.
+      T::Sig::WithoutRuntime.sig {abstract.returns(T.untyped)}
+      def serialize; end
+    end
+
     # NB: Do not call this method. This exists to allow for a safe migration path in places where enum
     # values are compared directly against string values.
     #
@@ -201,12 +212,12 @@ class T::Enum
           msg,
           storytime: {
             class: self.class.name,
-            caller_location: caller_locations(1..1)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
+            caller_location: Kernel.caller_locations(1..1)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
           },
         )
         serialize.to_s
       else
-        raise NoMethodError.new(msg)
+        Kernel.raise NoMethodError.new(msg)
       end
     end
 
@@ -254,7 +265,7 @@ class T::Enum
           other: other,
           other_class: other.class.name,
           method: method,
-          caller_location: caller_locations(2..2)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
+          caller_location: Kernel.caller_locations(2..2)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
         }
       )
     end

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -185,6 +185,7 @@ class T::Enum
     end
   end
 
+  module LegacyMigrationMode
   # NB: Do not call this method. This exists to allow for a safe migration path in places where enum
   # values are compared directly against string values.
   #
@@ -256,6 +257,7 @@ class T::Enum
         caller_location: caller_locations(2..2)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
       }
     )
+  end
   end
 
   ### Private implementation ###

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -186,78 +186,78 @@ class T::Enum
   end
 
   module LegacyMigrationMode
-  # NB: Do not call this method. This exists to allow for a safe migration path in places where enum
-  # values are compared directly against string values.
-  #
-  # Ruby's string has a weird quirk where `'my_string' == obj` calls obj.==('my_string') if obj
-  # responds to the `to_str` method. It does not actually call `to_str` however.
-  #
-  # See https://ruby-doc.org/core-2.4.0/String.html#method-i-3D-3D
-  T::Sig::WithoutRuntime.sig {returns(String)}
-  def to_str
-    msg = 'Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead.'
-    if T::Configuration.legacy_t_enum_migration_mode?
+    # NB: Do not call this method. This exists to allow for a safe migration path in places where enum
+    # values are compared directly against string values.
+    #
+    # Ruby's string has a weird quirk where `'my_string' == obj` calls obj.==('my_string') if obj
+    # responds to the `to_str` method. It does not actually call `to_str` however.
+    #
+    # See https://ruby-doc.org/core-2.4.0/String.html#method-i-3D-3D
+    T::Sig::WithoutRuntime.sig {returns(String)}
+    def to_str
+      msg = 'Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead.'
+      if T::Configuration.legacy_t_enum_migration_mode?
+        T::Configuration.soft_assert_handler(
+          msg,
+          storytime: {
+            class: self.class.name,
+            caller_location: caller_locations(1..1)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
+          },
+        )
+        serialize.to_s
+      else
+        raise NoMethodError.new(msg)
+      end
+    end
+
+    # WithoutRuntime so that comparison_assertion_failed can assume a constant stack depth
+    T::Sig::WithoutRuntime.sig {params(other: BasicObject).returns(T::Boolean)}
+    def ==(other)
+      case other
+      when String
+        if T::Configuration.legacy_t_enum_migration_mode?
+          comparison_assertion_failed(:==, other)
+          self.serialize == other
+        else
+          false
+        end
+      else
+        super(other)
+      end
+    end
+
+    # WithoutRuntime so that comparison_assertion_failed can assume a constant stack depth
+    T::Sig::WithoutRuntime.sig {params(other: BasicObject).returns(T::Boolean)}
+    def ===(other)
+      case other
+      when String
+        if T::Configuration.legacy_t_enum_migration_mode?
+          comparison_assertion_failed(:===, other)
+          self.serialize == other
+        else
+          false
+        end
+      else
+        super(other)
+      end
+    end
+
+    # WithoutRuntime so that caller_locations can assume a constant stack depth
+    # (Otherwise, the first call would be the method with the wrapping, which would have a different stack depth.)
+    T::Sig::WithoutRuntime.sig {params(method: Symbol, other: T.untyped).void}
+    private def comparison_assertion_failed(method, other)
       T::Configuration.soft_assert_handler(
-        msg,
+        'Enum to string comparison not allowed. Compare to the Enum instance directly instead. See go/enum-migration',
         storytime: {
           class: self.class.name,
-          caller_location: caller_locations(1..1)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
-        },
+          self: self.inspect,
+          other: other,
+          other_class: other.class.name,
+          method: method,
+          caller_location: caller_locations(2..2)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
+        }
       )
-      serialize.to_s
-    else
-      raise NoMethodError.new(msg)
     end
-  end
-
-  # WithoutRuntime so that comparison_assertion_failed can assume a constant stack depth
-  T::Sig::WithoutRuntime.sig {params(other: BasicObject).returns(T::Boolean)}
-  def ==(other)
-    case other
-    when String
-      if T::Configuration.legacy_t_enum_migration_mode?
-        comparison_assertion_failed(:==, other)
-        self.serialize == other
-      else
-        false
-      end
-    else
-      super(other)
-    end
-  end
-
-  # WithoutRuntime so that comparison_assertion_failed can assume a constant stack depth
-  T::Sig::WithoutRuntime.sig {params(other: BasicObject).returns(T::Boolean)}
-  def ===(other)
-    case other
-    when String
-      if T::Configuration.legacy_t_enum_migration_mode?
-        comparison_assertion_failed(:===, other)
-        self.serialize == other
-      else
-        false
-      end
-    else
-      super(other)
-    end
-  end
-
-  # WithoutRuntime so that caller_locations can assume a constant stack depth
-  # (Otherwise, the first call would be the method with the wrapping, which would have a different stack depth.)
-  T::Sig::WithoutRuntime.sig {params(method: Symbol, other: T.untyped).void}
-  private def comparison_assertion_failed(method, other)
-    T::Configuration.soft_assert_handler(
-      'Enum to string comparison not allowed. Compare to the Enum instance directly instead. See go/enum-migration',
-      storytime: {
-        class: self.class.name,
-        self: self.inspect,
-        other: other,
-        other_class: other.class.name,
-        method: method,
-        caller_location: caller_locations(2..2)&.[](0)&.then {"#{_1.path}:#{_1.lineno}"},
-      }
-    )
-  end
   end
 
   ### Private implementation ###

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -369,7 +369,6 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
   end
 
   describe 'string value conversion assertions' do
-    ENUM_CONVERSION_MSG = /Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead./.freeze
     before do
       T::Configuration.expects(:soft_assert_handler).never
     end
@@ -378,16 +377,16 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
       ex = assert_raises(NoMethodError) do
         CardSuit::HEART.to_str
       end
-      assert_match(ENUM_CONVERSION_MSG, ex.message)
+      assert_match(/undefined method `to_str' for #<T::Enum::Test::EnumTest::CardSuit::HEART>/, ex.message)
     end
 
     it 'raises an assertion if to_str is called (implicitly) and also returns the serialized value' do
-      ex = assert_raises(NoMethodError) do
+      ex = assert_raises(TypeError) do
         # rubocop:disable Style/StringConcatenation
         "foo " + CardSuit::HEART
         # rubocop:enable Style/StringConcatenation
       end
-      assert_match(ENUM_CONVERSION_MSG, ex.message)
+      assert_match(/no implicit conversion of T::Enum::Test::EnumTest::CardSuit into String/, ex.message)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -379,10 +379,10 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
       # once before, even if it's been undone with
       # T::Configuration.disable_legacy_t_enum_migration_mode, unfortunately.
       # Hopefully no one depended on the old behavior.
-      if T::Enum < T::Enum::LegacyMigrationMode
-        exn_message = /Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead./
+      exn_message = if T::Enum < T::Enum::LegacyMigrationMode
+        /Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead./
       else
-        exn_message = /undefined method `to_str'/
+        /undefined method `to_str'/
       end
 
       ex = assert_raises(NoMethodError) do

--- a/rbi/core/enum.rbi
+++ b/rbi/core/enum.rbi
@@ -3,6 +3,23 @@
 class T::Enum
   extend T::Props::CustomType
 
+  # Assume that this is always included (even if it isn't) so that it never
+  # shows up in RBI files generated from reflection.
+  module LegacyMigrationMode
+    sig {returns(String)}
+    def to_str; end
+
+    sig {params(other: T.anything).returns(T::Boolean)}
+    def ==(other); end
+
+    sig {params(other: T.anything).returns(T::Boolean)}
+    def ===(other); end
+
+    sig {params(method: Symbol, other: T.untyped).void}
+    private def comparison_assertion_failed(method, other); end
+  end
+  include LegacyMigrationMode
+
   ## Enum class methods ##
 
   # All the values defined in the Enum class


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

h/t @egiurleo / @Morriar (and possibly others at Shopify) for finding and
reporting this performance opportunity.

### Commit summary

- **Conditionally define T::Enum <> String methods** (30645b06c)

  These methods should not incur a performance overhead for anyone who 
  never calls `enable_legacy_t_enum_migration_mode`.

- **no-op: Reindent** (69284ed2a)


- **no-op: Get it to typecheck** (76177b67a)


- **Add a benchmark for T::Enum ==** (8d3d3ec22)





### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

**master:**

```
❯ bex rake bench:enum
before T::Configuration.enable_legacy_t_enum_migration_mode
T::Enum == T::Enum: 68.176 ns
T::Enum == String: 79.956 ns

after T::Configuration.enable_legacy_t_enum_migration_mode
T::Enum == T::Enum: 68.173 ns
T::Enum == String: 3.654 μs
```

**branch:**

```
❯ bex rake bench:enum
before T::Configuration.enable_legacy_t_enum_migration_mode
T::Enum == T::Enum: 16.291 ns
T::Enum == String: 14.887 ns

after T::Configuration.enable_legacy_t_enum_migration_mode
T::Enum == T::Enum: 73.553 ns
T::Enum == String: 3.875 μs
```

This suggests three things:

1.  This change makes `==` comparison on `T::Enum` ~4x faster for
    codebases that don't use `enable_legacy_t_enum_migration_mode`.

2.  This change does not regress performance on codebases that do use
    `enable_legacy_t_enum_migration_mode`.

3.  This suggests Stripe may want to invest in fixing legacy enum
    migration soft assertions so that Stripe can benefit from the
    improved performance.

    The benchmark script above does not even consider the performance of
    calling `soft_assert_handler`--Stripe's `soft_assert_handler` is
    substantially slower than the one in this benchmark.