### PR TITLE
Add corresponding type to the block in  `IO.pipe`

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -1821,9 +1821,17 @@ class IO < Object
     params(
       ext_enc: T.nilable(T.any(String, Encoding)),
       int_enc: T.nilable(T.any(String, Encoding)),
-      opt: T.nilable(T::Hash[Symbol, String]),
-      blk: T.nilable(T.proc.params(read_io: IO, write_io: IO).void)
+      opt: T.nilable(T::Hash[Symbol, String])
     ).returns([IO, IO])
+  end
+  sig do
+    type_parameters(:T)
+    .params(
+      ext_enc: T.nilable(T.any(String, Encoding)),
+      int_enc: T.nilable(T.any(String, Encoding)),
+      opt: T.nilable(T::Hash[Symbol, String]),
+      blk: T.nilable(T.proc.params(read_io: IO, write_io: IO).returns(T.type_parameter(:T)))
+    ).returns(T.type_parameter(:T))
   end
   def self.pipe(ext_enc = nil, int_enc = nil, opt = nil, &blk); end
 

--- a/test/testdata/rbi/io.rb
+++ b/test/testdata/rbi/io.rb
@@ -31,3 +31,11 @@ def test_io_read_return(io)
   T.assert_type!(io.read(1), T.nilable(String))
   T.assert_type!(io.read, String)
 end
+
+sig {void}
+def test_io_pipe
+  result = IO.pipe do
+    1
+  end
+  T.assert_type!(result, Integer)
+end


### PR DESCRIPTION
### Motivation
Fixes #7799

### Test plan
See included automated tests.
