### PR TITLE
backport ruby/ruby#9385 to fix aarch64 crashes

### DIFF
--- a/third_party/ruby/9385-aarch64-fibers-crash-backport.patch
+++ b/third_party/ruby/9385-aarch64-fibers-crash-backport.patch
@@ -1,0 +1,27 @@
+commit 7f97e3540ce448b501bcbee15afac5f94bb22dd9
+Author: Yuta Saito <kateinoigakukun@gmail.com>
+Date:   Mon Feb 5 23:50:20 2024 +0900
+
+    [Backport 3.3] [Bug #20085] Use consistent default options for `-mbranch-protection` (#9385)
+    
+    [Bug #20085] Use consistent default options for `-mbranch-protection`
+    
+    We need to use the same options for both C compiler and assembler
+    when `-mbranch-protection` is guessed by configure. Otherwise,
+    `coroutine/arm64/Context.{h,S}` will use incompatible PAC strategies.
+
+diff --git a/configure.ac b/configure.ac
+index 9286946fc1..18b4247991 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -830,7 +830,10 @@ AS_IF([test "$GCC" = yes], [
+ 	AS_FOR(option, opt, [-mbranch-protection=pac-ret -msign-return-address=all], [
+             RUBY_TRY_CFLAGS(option, [branch_protection=yes], [branch_protection=no])
+             AS_IF([test "x$branch_protection" = xyes], [
++                # C compiler and assembler must be consistent for -mbranch-protection
++                # since they both check `__ARM_FEATURE_PAC_DEFAULT` definition.
+                 RUBY_APPEND_OPTION(XCFLAGS, option)
++                RUBY_APPEND_OPTION(ASFLAGS, option)
+                 break
+             ])
+         ])

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -144,6 +144,7 @@ def register_ruby_dependencies():
             "@com_stripe_ruby_typer//third_party/ruby:fix_grapheme_clusters_3_3_only.patch",
             "@com_stripe_ruby_typer//third_party/ruby:10151_no_hash_allocate_static_kwargs_3_3_only.patch",
             "@com_stripe_ruby_typer//third_party/ruby:10306_no_hash_allocate_static_kwargs_3_3_only.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:9385-aarch64-fibers-crash-backport.patch",
         ],
     )
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is going to be in the Ruby 3.3.1 release, but until that time...

Special thanks to @paracycle for pointing out the PR!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
