### PR TITLE
Don't run all `test/testdata/packager/` tests twice

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -247,17 +247,6 @@ pipeline_tests(
 )
 
 pipeline_tests(
-    "test_packager",
-    glob(
-        [
-            "testdata/packager/**/*.rb",
-            "testdata/packager/**/*.exp",
-        ],
-    ),
-    "PackagerTests",
-)
-
-pipeline_tests(
     "whitequark_parser_corpus",
     glob([
         "whitequark/**/*.rb",

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -113,8 +113,7 @@ _TEST_RUNNERS = {
 }
 
 def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], tags = []):
-    tests = {}  # test_name-> {"path": String, "prefix": String, "sentinel": String}
-    package_tests = {}  # ^ ditto
+    tests = {}  # test_name-> {"path": String, "prefix": String, "sentinel": String, "isPackage": bool}
 
     # The packager step needs folder-based steps since folder structure dictates package membership.
     # All immediate subdirs of `/packager/` are individual tests.
@@ -139,9 +138,9 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
                         "isMultiFile": False,
                         "isDirectory": True,
                         "disabled": "disabled" in test_name,
+                        "isPackage": True,
                     }
                     tests[test_name] = data
-                    package_tests[test_name] = data
                 continue
 
         # This is not a folder test (common case)
@@ -158,6 +157,7 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
                 "isMultiFile": "__" in path,
                 "isDirectory": False,
                 "disabled": "disabled" in path,
+                "isPackage": False,
             }
             tests[test_name] = data
 
@@ -166,6 +166,7 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
         fail(msg = "Unknown pipeline test type: {}".format(test_name_prefix))
 
     enabled_tests = []
+    enabled_packager_tests = []
     disabled_tests = []
     for name in tests.keys():
         test_name = "test_{}/{}".format(test_name_prefix, name)
@@ -180,6 +181,8 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
             disabled_tests.append(test_name)
         else:
             enabled_tests.append(test_name)
+            if tests[name]["isPackage"]:
+                enabled_packager_tests.append(test_name)
 
         data = []
         data += extra_files
@@ -209,10 +212,10 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
         tests = enabled_tests,
     )
 
-    if len(package_tests) > 0:
+    if len(enabled_packager_tests) > 0:
         native.test_suite(
             name = "{}_packager".format(suite_name),
-            tests = package_tests,
+            tests = enabled_packager_tests,
         )
 
     if len(disabled_tests) > 0:

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -114,6 +114,7 @@ _TEST_RUNNERS = {
 
 def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], tags = []):
     tests = {}  # test_name-> {"path": String, "prefix": String, "sentinel": String}
+    package_tests = {}  # ^ ditto
 
     # The packager step needs folder-based steps since folder structure dictates package membership.
     # All immediate subdirs of `/packager/` are individual tests.
@@ -140,6 +141,7 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
                         "disabled": "disabled" in test_name,
                     }
                     tests[test_name] = data
+                    package_tests[test_name] = data
                 continue
 
         # This is not a folder test (common case)
@@ -206,6 +208,12 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
         name = suite_name,
         tests = enabled_tests,
     )
+
+    if len(package_tests) > 0:
+        native.test_suite(
+            name = "{}_packager".format(suite_name),
+            tests = package_tests,
+        )
 
     if len(disabled_tests) > 0:
         native.test_suite(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was needlessly making our test times slow. We instantiate two
identical-except-in-name test targets for each `test/testdata/packager`
subfolder.

I noticed this while I was looking to see if there was a convenient Bazel target
for a test suite contained with only the `test/testdata/packager/` tests.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This could potentially be deleting tests if we're not sure we know how this
works, so the test plan is Feynman method.