### PR TITLE
patch configure for aarch64 branch protection backport

### DIFF
--- a/third_party/ruby/9385-aarch64-fibers-crash-backport.patch
+++ b/third_party/ruby/9385-aarch64-fibers-crash-backport.patch
@@ -25,3 +25,34 @@ index 9286946fc1..18b4247991 100644
                  break
              ])
          ])
+--- a/configure	2024-04-16 14:03:03.035215032 +0000
++++ b/configure	2024-04-16 16:43:00.603560413 +0000
+@@ -10964,9 +9969,10 @@
+ 
+ fi
+ 
+-            if test "x$branch_protection" = xyes
+-then :
++            if test "x$branch_protection" = xyes; then :
+ 
++                # C compiler and assembler must be consistent for -mbranch-protection
++                # since they both check `__ARM_FEATURE_PAC_DEFAULT` definition.
+                 # RUBY_APPEND_OPTION(XCFLAGS)
+ 	case " ${XCFLAGS-} " in #(
+   *" $opt "*) :
+@@ -10976,6 +10005,15 @@
+   *) :
+      XCFLAGS="$XCFLAGS $opt" ;;
+ esac
++                # RUBY_APPEND_OPTION(ASFLAGS)
++	case " ${ASFLAGS-} " in #(
++  *" $opt "*) :
++     ;; #(
++  '  ') :
++     ASFLAGS="$opt" ;; #(
++  *) :
++     ASFLAGS="$ASFLAGS $opt" ;;
++esac
+                 break
+ 
+ fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In #7830, we backported a patch from upstream to fix a crash on aarch64, which patched `configure.ac`.  For upstream, this is fine; development regenerates `configure` as-needed.  For `sorbet_ruby` builds, however, `configure` comes pre-generated in the tarball, and we do not automatically regenerate it.

Ergo, the patch was ineffective.  With this PR, we are also patching the generated file to do what it's supposed to.

cc @jd-stripe

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Going to verify this builds on Stripe's infrastructure, and compare the aarch64 ruby builds from before and after.