### PR TITLE
Stop shuffling classes around

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -974,8 +974,10 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             },
 
             [&](const ast::EmptyTree &n) { ret = current; },
-
-            [&](const ast::ClassDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
+            [&](const ast::ClassDef &c) {
+                // Nested classes and their methods will get handled later in CFGCollectorAndTyper. We can skip them.
+                ret = current;
+            },
             [&](const ast::MethodDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
 
             [&](const ast::ExpressionPtr &n) {

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -60,10 +60,13 @@ public:
         auto *classDef = ast::cast_tree<ast::ClassDef>(tree);
         auto inits = extractClassInit(ctx, classDef);
 
+        if (ast::isa_tree<ast::EmptyTree>(inits)) {
+            return;
+        }
+
         core::MethodRef sym;
         auto replacement = ast::MK::EmptyTree();
 
-        if (!ast::isa_tree<ast::EmptyTree>(inits)) {
             if (classDef->symbol == core::Symbols::root()) {
                 // Every file may have its own top-level code, so uniqify the names.
                 //
@@ -103,7 +106,6 @@ public:
             ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isSelfMethod = true;
 
             classDef->rhs.emplace_back(std::move(init));
-        }
     };
 };
 

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -67,45 +67,45 @@ public:
         core::MethodRef sym;
         auto replacement = ast::MK::EmptyTree();
 
-            if (classDef->symbol == core::Symbols::root()) {
-                // Every file may have its own top-level code, so uniqify the names.
-                //
-                // NOTE(nelhage): In general, we potentially need to do this for
-                // every class, since Ruby allows reopening classes. However, since
-                // pay-server bans that behavior, this should be OK here.
-                sym = ctx.state.lookupStaticInitForFile(ctx.file);
+        if (classDef->symbol == core::Symbols::root()) {
+            // Every file may have its own top-level code, so uniqify the names.
+            //
+            // NOTE(nelhage): In general, we potentially need to do this for
+            // every class, since Ruby allows reopening classes. However, since
+            // pay-server bans that behavior, this should be OK here.
+            sym = ctx.state.lookupStaticInitForFile(ctx.file);
 
-                // Skip emitting a place-holder for the root object.
-            } else {
-                sym = ctx.state.lookupStaticInitForClass(classDef->symbol);
+            // Skip emitting a place-holder for the root object.
+        } else {
+            sym = ctx.state.lookupStaticInitForClass(classDef->symbol);
 
-                // We only need a representation of the runtime definition of the class in the
-                // containing static-init if the file is compiled; such a definition is just
-                // noise otherwise.
-                if (ctx.file.data(ctx).compiledLevel == core::CompiledLevel::True) {
-                    replacement = ast::MK::DefineTopClassOrModule(classDef->declLoc, classDef->symbol);
-                }
+            // We only need a representation of the runtime definition of the class in the
+            // containing static-init if the file is compiled; such a definition is just
+            // noise otherwise.
+            if (ctx.file.data(ctx).compiledLevel == core::CompiledLevel::True) {
+                replacement = ast::MK::DefineTopClassOrModule(classDef->declLoc, classDef->symbol);
             }
-            ENFORCE(!sym.data(ctx)->arguments.empty(),
-                    "<static-init> method should already have a block arg symbol: {}", sym.show(ctx));
-            ENFORCE(sym.data(ctx)->arguments.back().flags.isBlock, "Last argument symbol is not a block arg: {}",
-                    sym.show(ctx));
+        }
+        ENFORCE(!sym.data(ctx)->arguments.empty(), "<static-init> method should already have a block arg symbol: {}",
+                sym.show(ctx));
+        ENFORCE(sym.data(ctx)->arguments.back().flags.isBlock, "Last argument symbol is not a block arg: {}",
+                sym.show(ctx));
 
-            // Synthesize a block argument for this <static-init> block. This is rather fiddly,
-            // because we have to know exactly what invariants desugar and namer set up about
-            // methods and block arguments before us.
-            auto blkLoc = core::LocOffsets::none();
-            core::LocalVariable blkLocalVar(core::Names::blkArg(), 0);
-            ast::MethodDef::ARGS_store args;
-            args.emplace_back(ast::make_expression<ast::Local>(blkLoc, blkLocalVar));
+        // Synthesize a block argument for this <static-init> block. This is rather fiddly,
+        // because we have to know exactly what invariants desugar and namer set up about
+        // methods and block arguments before us.
+        auto blkLoc = core::LocOffsets::none();
+        core::LocalVariable blkLocalVar(core::Names::blkArg(), 0);
+        ast::MethodDef::ARGS_store args;
+        args.emplace_back(ast::make_expression<ast::Local>(blkLoc, blkLocalVar));
 
-            auto init = ast::make_expression<ast::MethodDef>(classDef->declLoc, classDef->declLoc, sym,
-                                                             core::Names::staticInit(), std::move(args),
-                                                             std::move(inits), ast::MethodDef::Flags());
-            ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isRewriterSynthesized = false;
-            ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isSelfMethod = true;
+        auto init =
+            ast::make_expression<ast::MethodDef>(classDef->declLoc, classDef->declLoc, sym, core::Names::staticInit(),
+                                                 std::move(args), std::move(inits), ast::MethodDef::Flags());
+        ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isRewriterSynthesized = false;
+        ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isSelfMethod = true;
 
-            classDef->rhs.emplace_back(std::move(init));
+        classDef->rhs.emplace_back(std::move(init));
     };
 };
 

--- a/test/testdata/cfg/examples.rb.flatten-tree.exp
+++ b/test/testdata/cfg/examples.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Examples<<C Examples>> < (::<todo sym>)
     def i_like_ifs(<blk>)
       if true
@@ -104,5 +101,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
@@ -66,22 +66,6 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
 
 }
 
-method ::<Class:<root>>#<static-init> {
-
-bb0[rubyRegionId=0, firstDead=4]():
-    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
-    <statTemp>$6: T.untyped = <self>: T.class_of(<root>).foo()
-    <statTemp>$4: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$6: T.untyped)
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
-    <unconditional> -> bb1
-
-# backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
-    <unconditional> -> bb1
-
-}
-
 method ::MyClass#foo= {
 
 bb0[rubyRegionId=0, firstDead=2]():
@@ -102,6 +86,22 @@ bb0[rubyRegionId=0, firstDead=3]():
     <self>: T.class_of(MyClass) = cast(<self>: NilClass, T.class_of(MyClass));
     <returnMethodTemp>$2: Symbol(:foo=) = :foo=
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo=)
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+
+method ::<Class:<root>>#<static-init> {
+
+bb0[rubyRegionId=0, firstDead=4]():
+    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
+    <statTemp>$6: T.untyped = <self>: T.class_of(<root>).foo()
+    <statTemp>$4: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$6: T.untyped)
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -1,80 +1,3 @@
-method ::<Class:<root>>#<static-init> {
-
-bb0[rubyRegionId=0, firstDead=-1]():
-    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
-    <magic>$14: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
-
-# backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
-    <unconditional> -> bb1
-
-# backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$14: T.class_of(<Magic>)):
-    <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$21 -> (T::Boolean ? bb7 : bb8)
-
-# backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$14: T.class_of(<Magic>)):
-    <cfgAlias>$6: T.class_of(A) = alias <C A>
-    <statTemp>$4: A = <cfgAlias>$6: T.class_of(A).new()
-    <hashTemp>$8: Symbol(:z) = :z
-    <hashTemp>$9: Integer(3) = 3
-    <hashTemp>$10: Symbol(:w) = :w
-    <hashTemp>$11: String("string") = "string"
-    <magic>$12: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$7: {z: Integer(3), w: String("string")} = <magic>$12: T.class_of(<Magic>).<build-hash>(<hashTemp>$8: Symbol(:z), <hashTemp>$9: Integer(3), <hashTemp>$10: Symbol(:w), <hashTemp>$11: String("string"))
-    <statTemp>$13: TrueClass = true
-    <returnMethodTemp>$2: T.untyped = <statTemp>$4: A.f(<statTemp>$7: {z: Integer(3), w: String("string")}, <statTemp>$13: TrueClass)
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
-
-# backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$24: T.nilable(TrueClass)):
-    <cfgAlias>$16: T.class_of(T) = alias <C T>
-    e: T.untyped = <cfgAlias>$16: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
-    <statTemp>$27: String("done") = "done"
-    <throwAwayTemp>$25: NilClass = <self>: T.class_of(<root>).p(<statTemp>$27: String("done"))
-    <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb9)
-
-# backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$3: StandardError, <magic>$14: T.class_of(<Magic>)):
-    <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$14: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <statTemp>$23: String("whoops") = "whoops"
-    <returnMethodTemp>$2: NilClass = <self>: T.class_of(<root>).p(<statTemp>$23: String("whoops"))
-    <unconditional> -> bb6
-
-# backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
-    <gotoDeadTemp>$24: TrueClass = true
-    <unconditional> -> bb6
-
-# backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
-    <unconditional> -> bb1
-
-}
-
 method ::A#f {
 
 bb0[rubyRegionId=0, firstDead=-1]():
@@ -149,6 +72,83 @@ bb0[rubyRegionId=0, firstDead=2]():
 # backedges
 # - bb0(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+
+method ::<Class:<root>>#<static-init> {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
+    <magic>$14: T.class_of(<Magic>) = alias <C <Magic>>
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
+
+# backedges
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$14: T.class_of(<Magic>)):
+    <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$21 -> (T::Boolean ? bb7 : bb8)
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$14: T.class_of(<Magic>)):
+    <cfgAlias>$6: T.class_of(A) = alias <C A>
+    <statTemp>$4: A = <cfgAlias>$6: T.class_of(A).new()
+    <hashTemp>$8: Symbol(:z) = :z
+    <hashTemp>$9: Integer(3) = 3
+    <hashTemp>$10: Symbol(:w) = :w
+    <hashTemp>$11: String("string") = "string"
+    <magic>$12: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$7: {z: Integer(3), w: String("string")} = <magic>$12: T.class_of(<Magic>).<build-hash>(<hashTemp>$8: Symbol(:z), <hashTemp>$9: Integer(3), <hashTemp>$10: Symbol(:w), <hashTemp>$11: String("string"))
+    <statTemp>$13: TrueClass = true
+    <returnMethodTemp>$2: T.untyped = <statTemp>$4: A.f(<statTemp>$7: {z: Integer(3), w: String("string")}, <statTemp>$13: TrueClass)
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+
+# backedges
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: NilClass):
+    <unconditional> -> bb6
+
+# backedges
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$24: T.nilable(TrueClass)):
+    <cfgAlias>$16: T.class_of(T) = alias <C T>
+    e: T.untyped = <cfgAlias>$16: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
+    <statTemp>$27: String("done") = "done"
+    <throwAwayTemp>$25: NilClass = <self>: T.class_of(<root>).p(<statTemp>$27: String("done"))
+    <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb9)
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$3: StandardError, <magic>$14: T.class_of(<Magic>)):
+    <exceptionValue>$3: NilClass = nil
+    <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$14: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <statTemp>$23: String("whoops") = "whoops"
+    <returnMethodTemp>$2: NilClass = <self>: T.class_of(<root>).p(<statTemp>$23: String("whoops"))
+    <unconditional> -> bb6
+
+# backedges
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <gotoDeadTemp>$24: TrueClass = true
+    <unconditional> -> bb6
+
+# backedges
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 }

--- a/test/testdata/desugar/destructure.rb.flatten-tree.exp
+++ b/test/testdata/desugar/destructure.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Destructure<<C Destructure>> < (::<todo sym>)
     def f((x,y), z, <blk>)
       begin
@@ -34,5 +31,4 @@ begin
       <runtime method definition of f>
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/desugar/for.rb.cfg-text.exp
+++ b/test/testdata/desugar/for.rb.cfg-text.exp
@@ -1,19 +1,3 @@
-method ::<Class:<root>>#<static-init> {
-
-bb0[rubyRegionId=0, firstDead=4]():
-    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
-    <cfgAlias>$4: T.class_of(Main) = alias <C Main>
-    <returnMethodTemp>$2: T.untyped = <cfgAlias>$4: T.class_of(Main).main()
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
-    <unconditional> -> bb1
-
-# backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
-    <unconditional> -> bb1
-
-}
-
 method ::<Class:A>#each {
 
 bb0[rubyRegionId=0, firstDead=15]():
@@ -401,6 +385,22 @@ bb0[rubyRegionId=0, firstDead=3]():
     <self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));
     <returnMethodTemp>$2: Symbol(:main) = :main
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:main)
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+
+method ::<Class:<root>>#<static-init> {
+
+bb0[rubyRegionId=0, firstDead=4]():
+    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
+    <cfgAlias>$4: T.class_of(Main) = alias <C Main>
+    <returnMethodTemp>$2: T.untyped = <cfgAlias>$4: T.class_of(Main).main()
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges

--- a/test/testdata/desugar/op_eq.rb.flatten-tree.exp
+++ b/test/testdata/desugar/op_eq.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::OpEq<<C OpEq>> < (::<todo sym>)
     def b(<blk>)
       <emptyTree>
@@ -85,5 +82,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/desugar/sclass.rb.flatten-tree.exp
+++ b/test/testdata/desugar/sclass.rb.flatten-tree.exp
@@ -1,120 +1,104 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    def main(<blk>)
-      begin
-        <self>.puts(::A.a())
-        <self>.puts(::B.b())
-        <self>.puts($c.c())
-        <self>.puts(::D.singleton_class().d())
-        <self>.puts(::E.e())
-        <self>.puts(::F.f=(91))
-        <self>.puts(::G.new().wrapper())
-        <self>.puts(::T.untyped.h())
-      end
-    end
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      begin
-        $c = ::Object.new()
-        <runtime method definition of main>
-        <self>.main()
-        <emptyTree>
-      end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def main(<blk>)
+    begin
+      <self>.puts(::A.a())
+      <self>.puts(::B.b())
+      <self>.puts($c.c())
+      <self>.puts(::D.singleton_class().d())
+      <self>.puts(::E.e())
+      <self>.puts(::F.f=(91))
+      <self>.puts(::G.new().wrapper())
+      <self>.puts(::T.untyped.h())
     end
   end
+
   class ::A<<C A>> < (::<todo sym>)
   end
+
   class ::B<<C B>> < (::<todo sym>)
-    <emptyTree>
-  end
-  class <singleton class><<Class:B>> < ()
-    def b(<blk>)
-      "b"
-    end
+    class <singleton class><<Class:B>> < ()
+      def b(<blk>)
+        "b"
+      end
 
-    def self.<static-init>(<blk>)
-      <runtime method definition of b>
+      def self.<static-init>(<blk>)
+        <runtime method definition of b>
+      end
     end
   end
+
   class ::D<<C D>> < (::<todo sym>)
-    <emptyTree>
-  end
-  class <singleton class><<Class:D>> < ()
-    <emptyTree>
-  end
-  class <singleton class><<Class:<Class:D>>> < ()
-    def d(<blk>)
-      "d"
-    end
+    class <singleton class><<Class:D>> < ()
+      class <singleton class><<Class:<Class:D>>> < ()
+        def d(<blk>)
+          "d"
+        end
 
-    def self.<static-init>(<blk>)
-      <runtime method definition of d>
+        def self.<static-init>(<blk>)
+          <runtime method definition of d>
+        end
+      end
     end
   end
+
   class ::E<<C E>> < (::<todo sym>)
-    <emptyTree>
+    class <singleton class><<Class:E>> < ()
+      def wrapper(<blk>)
+        <runtime method definition of e>
+      end
+
+      def e(<blk>)
+        "e"
+      end
+
+      def self.<static-init>(<blk>)
+        <runtime method definition of wrapper>
+      end
+    end
 
     def self.<static-init>(<blk>)
       <self>.wrapper()
     end
   end
-  class <singleton class><<Class:E>> < ()
-    def wrapper(<blk>)
-      <runtime method definition of e>
-    end
 
-    def e(<blk>)
-      "e"
-    end
-
-    def self.<static-init>(<blk>)
-      <runtime method definition of wrapper>
-    end
-  end
   class ::F<<C F>> < (::<todo sym>)
-    <emptyTree>
-  end
-  class <singleton class><<Class:F>> < ()
-    def initialize(<blk>)
-      @f = <cast:let>(0, Integer, ::Integer)
-    end
+    class <singleton class><<Class:F>> < ()
+      def initialize(<blk>)
+        @f = <cast:let>(0, Integer, ::Integer)
+      end
 
-    def f=(f, <blk>)
-      @f = f
-    end
+      def f=(f, <blk>)
+        @f = f
+      end
 
-    def self.<static-init>(<blk>)
-      begin
-        ::Sorbet::Private::Static.sig(<self>) do ||
-          <self>.params(:f, ::Integer).returns(::Integer)
+      def self.<static-init>(<blk>)
+        begin
+          ::Sorbet::Private::Static.sig(<self>) do ||
+            <self>.params(:f, ::Integer).returns(::Integer)
+          end
+          <runtime method definition of initialize>
+          <self>.extend(::T::Sig)
+          <runtime method definition of f=>
+          <emptyTree>
         end
-        <runtime method definition of initialize>
-        <self>.extend(::T::Sig)
-        <runtime method definition of f=>
-        <emptyTree>
       end
     end
   end
+
   class ::G<<C G>> < (::<todo sym>)
     def wrapper(<blk>)
       <self>.inner()
     end
 
-    <emptyTree>
+    class <singleton class><<Class:G>> < ()
+      def inner(<blk>)
+        ::T.reveal_type(<self>)
+      end
+
+      def self.<static-init>(<blk>)
+        <runtime method definition of inner>
+      end
+    end
 
     def self.g(<blk>)
       "g"
@@ -128,29 +112,27 @@ begin
       end
     end
   end
-  class <singleton class><<Class:G>> < ()
-    def inner(<blk>)
-      ::T.reveal_type(<self>)
-    end
 
-    def self.<static-init>(<blk>)
-      <runtime method definition of inner>
-    end
-  end
   class ::H<<C H>> < (::<todo sym>)
-    <emptyTree>
-  end
-  class <singleton class><<Class:H>> < ()
-    <emptyTree>
-  end
-  class ::<Class:H>::H2<<C H2>> < (::<todo sym>)
-    def self.h(<blk>)
-      "h"
-    end
+    class <singleton class><<Class:H>> < ()
+      class ::<Class:H>::H2<<C H2>> < (::<todo sym>)
+        def self.h(<blk>)
+          "h"
+        end
 
-    def self.<static-init>(<blk>)
-      <runtime method definition of self.h>
+        def self.<static-init>(<blk>)
+          <runtime method definition of self.h>
+        end
+      end
     end
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    begin
+      $c = ::Object.new()
+      <runtime method definition of main>
+      <self>.main()
+      <emptyTree>
+    end
+  end
 end

--- a/test/testdata/desugar/sclass_inheritance.rb.flatten-tree.exp
+++ b/test/testdata/desugar/sclass_inheritance.rb.flatten-tree.exp
@@ -1,47 +1,31 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    def main(<blk>)
-      begin
-        <self>.puts(::A.newer())
-        <self>.puts(::B.newer())
-        <self>.puts(::C.newerer())
-      end
-    end
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      begin
-        <runtime method definition of main>
-        <self>.main()
-        <emptyTree>
-      end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def main(<blk>)
+    begin
+      <self>.puts(::A.newer())
+      <self>.puts(::B.newer())
+      <self>.puts(::C.newerer())
     end
   end
+
   module ::MM<<C MM>> < ()
   end
-  class ::A<<C A>> < (::<todo sym>)
-    <emptyTree>
-  end
-  class <singleton class><<Class:A>> < (::MM)
-    def newer(<blk>)
-      <self>.new()
-    end
 
-    def self.<static-init>(<blk>)
-      begin
-        <self>.include(::MM)
-        <runtime method definition of newer>
-        <emptyTree>
+  class ::A<<C A>> < (::<todo sym>)
+    class <singleton class><<Class:A>> < (::MM)
+      def newer(<blk>)
+        <self>.new()
+      end
+
+      def self.<static-init>(<blk>)
+        begin
+          <self>.include(::MM)
+          <runtime method definition of newer>
+          <emptyTree>
+        end
       end
     end
   end
+
   class ::B<<C B>> < (::<todo sym>)
     def self.newer(<blk>)
       <self>.new()
@@ -55,17 +39,24 @@ begin
       end
     end
   end
-  class ::C<<C C>> < (::A)
-    <emptyTree>
-  end
-  class <singleton class><<Class:C>> < ()
-    def newerer(<blk>)
-      <self>.newer()
-    end
 
-    def self.<static-init>(<blk>)
-      <runtime method definition of newerer>
+  class ::C<<C C>> < (::A)
+    class <singleton class><<Class:C>> < ()
+      def newerer(<blk>)
+        <self>.newer()
+      end
+
+      def self.<static-init>(<blk>)
+        <runtime method definition of newerer>
+      end
     end
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    begin
+      <runtime method definition of main>
+      <self>.main()
+      <emptyTree>
+    end
+  end
 end

--- a/test/testdata/deviations/non_ruby_names.rb.flatten-tree.exp
+++ b/test/testdata/deviations/non_ruby_names.rb.flatten-tree.exp
@@ -1,15 +1,9 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   module ::B<<C B>> < ()
   end
+
   module ::A<<C A>> < ()
-    <emptyTree>
+    class ::A::B::C<<C C>> < (::<todo sym>)
+    end
   end
-  class ::A::B::C<<C C>> < (::<todo sym>)
-  end
-  <emptyTree>
 end

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -1,52 +1,3 @@
-method ::<Class:<root>>#<static-init> {
-
-bb0[rubyRegionId=0, firstDead=-1]():
-    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
-    <cfgAlias>$5: T.class_of(B) = alias <C B>
-    <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(B).class_helper()
-    <selfRestore>$7: T.class_of(<root>) = <self>
-    <unconditional> -> bb2
-
-# backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
-    <unconditional> -> bb1
-
-# backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
-    # outerLoops: 1
-    <block-call> -> (NilClass ? bb5 : bb3)
-
-# backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=5](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
-    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$6, class_helper>
-    <self>: T.class_of(<root>) = <selfRestore>$7
-    <cfgAlias>$21: T.class_of(T) = alias <C T>
-    <statTemp>$19: T.class_of(<root>) = <cfgAlias>$21: T.class_of(T).reveal_type(<self>: T.class_of(<root>))
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
-    <unconditional> -> bb1
-
-# backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
-    # outerLoops: 1
-    <self>: T.class_of(<root>) = loadSelf(class_helper)
-    <cfgAlias>$11: T.class_of(B) = alias <C B>
-    keep_for_ide$10: T.class_of(B) = <cfgAlias>$11
-    keep_for_ide$10: T.untyped = <keep-alive> keep_for_ide$10
-    <castTemp>$12: T.class_of(<root>) = <self>
-    <self>: B = cast(<castTemp>$12: T.class_of(<root>), B);
-    <cfgAlias>$15: T.class_of(T) = alias <C T>
-    <statTemp>$13: B = <cfgAlias>$15: T.class_of(T).reveal_type(<self>: B)
-    <blockReturnTemp>$8: T.untyped = <self>: B.instance_helper()
-    <blockReturnTemp>$18: T.noreturn = blockreturn<class_helper> <blockReturnTemp>$8: T.untyped
-    <unconditional> -> bb2
-
-}
-
 method ::<Class:Base>#before_save {
 
 bb0[rubyRegionId=0, firstDead=2]():
@@ -1107,6 +1058,55 @@ bb0[rubyRegionId=0, firstDead=3]():
 # - bb0(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
+
+}
+
+method ::<Class:<root>>#<static-init> {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
+    <cfgAlias>$5: T.class_of(B) = alias <C B>
+    <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(B).class_helper()
+    <selfRestore>$7: T.class_of(<root>) = <self>
+    <unconditional> -> bb2
+
+# backedges
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb5 : bb3)
+
+# backedges
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=5](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
+    <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$6, class_helper>
+    <self>: T.class_of(<root>) = <selfRestore>$7
+    <cfgAlias>$21: T.class_of(T) = alias <C T>
+    <statTemp>$19: T.class_of(<root>) = <cfgAlias>$21: T.class_of(T).reveal_type(<self>: T.class_of(<root>))
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+# backedges
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
+    # outerLoops: 1
+    <self>: T.class_of(<root>) = loadSelf(class_helper)
+    <cfgAlias>$11: T.class_of(B) = alias <C B>
+    keep_for_ide$10: T.class_of(B) = <cfgAlias>$11
+    keep_for_ide$10: T.untyped = <keep-alive> keep_for_ide$10
+    <castTemp>$12: T.class_of(<root>) = <self>
+    <self>: B = cast(<castTemp>$12: T.class_of(<root>), B);
+    <cfgAlias>$15: T.class_of(T) = alias <C T>
+    <statTemp>$13: B = <cfgAlias>$15: T.class_of(T).reveal_type(<self>: B)
+    <blockReturnTemp>$8: T.untyped = <self>: B.instance_helper()
+    <blockReturnTemp>$18: T.noreturn = blockreturn<class_helper> <blockReturnTemp>$8: T.untyped
+    <unconditional> -> bb2
 
 }
 

--- a/test/testdata/infer/casts.rb.flatten-tree.exp
+++ b/test/testdata/infer/casts.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::TestCasts<<C TestCasts>> < (::<todo sym>)
     def untyped(<blk>)
       <emptyTree>
@@ -37,5 +34,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_methods.rb.flatten-tree.exp
@@ -1,9 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Parent<<C Parent>> < (::<todo sym>)
     def self.takes_integer_static(x, <blk>)
       <emptyTree>
@@ -28,6 +23,7 @@ begin
       end
     end
   end
+
   class ::Child<<C Child>> < (::Parent)
     def self.outer_static(<blk>)
       <self>.takes_integer_static(<runtime method definition of self.inner_static>)
@@ -53,5 +49,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/infer/flatten_private.rb.flatten-tree.exp
+++ b/test/testdata/infer/flatten_private.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::A<<C A>> < (::<todo sym>)
     def self.private(arg0, <blk>)
       <emptyTree>
@@ -44,5 +41,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -115,6 +115,70 @@ bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Base)):
 
 }
 
+method ::<Class:Base>#<static-init> {
+
+bb0[rubyRegionId=0, firstDead=7]():
+    <C Klass>$10: Runtime object representing type: T.class_of(Base)::Klass = alias <C Klass>
+    <self>: T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass] = cast(<self>: NilClass, T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass]);
+    <cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>
+    <cfgAlias>$8: T.class_of(T) = alias <C T>
+    <statTemp>$3: T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass] = <self>: T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass].extend(<cfgAlias>$6: T.class_of(T::Generic))
+    <C Klass>$10: T::Types::TypeTemplate = <self>: T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass].type_template()
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+
+method ::<Class:Concrete>#<static-init> {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <C Klass>$10: Runtime object representing type: String = alias <C Klass>
+    <self>: T.class_of(Concrete) = cast(<self>: NilClass, T.class_of(Concrete));
+    <cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>
+    <cfgAlias>$8: T.class_of(T) = alias <C T>
+    <statTemp>$3: T.class_of(Concrete) = <self>: T.class_of(Concrete).extend(<cfgAlias>$6: T.class_of(T::Generic))
+    <block-pre-call-temp>$12: Sorbet::Private::Static::Void = <self>: T.class_of(Concrete).type_template()
+    <selfRestore>$13: T.class_of(Concrete) = <self>
+    <unconditional> -> bb2
+
+# backedges
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb5 : bb3)
+
+# backedges
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
+    <C Klass>$10: T::Types::TypeTemplate = Solve<<block-pre-call-temp>$12, type_template>
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+# backedges
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
+    # outerLoops: 1
+    <self>: T.class_of(Concrete) = loadSelf(type_template)
+    <hashTemp>$15: Symbol(:fixed) = :fixed
+    <cfgAlias>$17: T.class_of(String) = alias <C String>
+    <magic>$18: T.class_of(<Magic>) = alias <C <Magic>>
+    <blockReturnTemp>$14: {fixed: T.class_of(String)} = <magic>$18: T.class_of(<Magic>).<build-hash>(<hashTemp>$15: Symbol(:fixed), <cfgAlias>$17: T.class_of(String))
+    <blockReturnTemp>$19: T.noreturn = blockreturn<type_template> <blockReturnTemp>$14: {fixed: T.class_of(String)}
+    <unconditional> -> bb2
+
+}
+
 method ::<Class:<root>>#<static-init> {
 
 bb0[rubyRegionId=0, firstDead=-1]():
@@ -193,70 +257,6 @@ bb9[rubyRegionId=2, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-tem
     <blockReturnTemp>$27: T::Private::Methods::DeclBuilder = <statTemp>$28: T::Private::Methods::DeclBuilder.void()
     <blockReturnTemp>$38: T.noreturn = blockreturn<sig> <blockReturnTemp>$27: T::Private::Methods::DeclBuilder
     <unconditional> -> bb6
-
-}
-
-method ::<Class:Base>#<static-init> {
-
-bb0[rubyRegionId=0, firstDead=7]():
-    <C Klass>$10: Runtime object representing type: T.class_of(Base)::Klass = alias <C Klass>
-    <self>: T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass] = cast(<self>: NilClass, T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass]);
-    <cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>
-    <cfgAlias>$8: T.class_of(T) = alias <C T>
-    <statTemp>$3: T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass] = <self>: T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass].extend(<cfgAlias>$6: T.class_of(T::Generic))
-    <C Klass>$10: T::Types::TypeTemplate = <self>: T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass].type_template()
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
-    <unconditional> -> bb1
-
-# backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
-    <unconditional> -> bb1
-
-}
-
-method ::<Class:Concrete>#<static-init> {
-
-bb0[rubyRegionId=0, firstDead=-1]():
-    <C Klass>$10: Runtime object representing type: String = alias <C Klass>
-    <self>: T.class_of(Concrete) = cast(<self>: NilClass, T.class_of(Concrete));
-    <cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>
-    <cfgAlias>$8: T.class_of(T) = alias <C T>
-    <statTemp>$3: T.class_of(Concrete) = <self>: T.class_of(Concrete).extend(<cfgAlias>$6: T.class_of(T::Generic))
-    <block-pre-call-temp>$12: Sorbet::Private::Static::Void = <self>: T.class_of(Concrete).type_template()
-    <selfRestore>$13: T.class_of(Concrete) = <self>
-    <unconditional> -> bb2
-
-# backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
-    <unconditional> -> bb1
-
-# backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
-    # outerLoops: 1
-    <block-call> -> (NilClass ? bb5 : bb3)
-
-# backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
-    <C Klass>$10: T::Types::TypeTemplate = Solve<<block-pre-call-temp>$12, type_template>
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
-    <unconditional> -> bb1
-
-# backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
-    # outerLoops: 1
-    <self>: T.class_of(Concrete) = loadSelf(type_template)
-    <hashTemp>$15: Symbol(:fixed) = :fixed
-    <cfgAlias>$17: T.class_of(String) = alias <C String>
-    <magic>$18: T.class_of(<Magic>) = alias <C <Magic>>
-    <blockReturnTemp>$14: {fixed: T.class_of(String)} = <magic>$18: T.class_of(<Magic>).<build-hash>(<hashTemp>$15: Symbol(:fixed), <cfgAlias>$17: T.class_of(String))
-    <blockReturnTemp>$19: T.noreturn = blockreturn<type_template> <blockReturnTemp>$14: {fixed: T.class_of(String)}
-    <unconditional> -> bb2
 
 }
 

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -12,107 +12,6 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 }
 
-method ::<Class:<root>>#<static-init> {
-
-bb0[rubyRegionId=0, firstDead=-1]():
-    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
-    <cfgAlias>$5: T.class_of(Normal) = alias <C Normal>
-    keep_for_ide$4: T.class_of(Normal) = <cfgAlias>$5
-    keep_for_ide$4: T.untyped = <keep-alive> keep_for_ide$4
-    <cfgAlias>$9: T.class_of(Normal) = alias <C Normal>
-    <statTemp>$7: Normal = <cfgAlias>$9: T.class_of(Normal).new()
-    <castTemp>$6: Normal = <statTemp>$7: Normal.returns_self()
-    <statTemp>$3: Normal = cast(<castTemp>$6: Normal, Normal);
-    <cfgAlias>$13: T.class_of(Generic) = alias <C Generic>
-    <cfgAlias>$15: T.class_of(String) = alias <C String>
-    keep_for_ide$11: Runtime object representing type: Generic[String] = <cfgAlias>$13: T.class_of(Generic).[](<cfgAlias>$15: T.class_of(String))
-    keep_for_ide$11: T.untyped = <keep-alive> keep_for_ide$11
-    <cfgAlias>$20: T.class_of(Generic) = alias <C Generic>
-    <cfgAlias>$22: T.class_of(String) = alias <C String>
-    <statTemp>$18: Runtime object representing type: Generic[String] = <cfgAlias>$20: T.class_of(Generic).[](<cfgAlias>$22: T.class_of(String))
-    <statTemp>$17: Generic[String] = <statTemp>$18: Runtime object representing type: Generic[String].new()
-    <castTemp>$16: Generic[String] = <statTemp>$17: Generic[String].returns_self()
-    <statTemp>$10: Generic[String] = cast(<castTemp>$16: Generic[String], Generic[String]);
-    <cfgAlias>$26: T.class_of(Generic) = alias <C Generic>
-    <cfgAlias>$28: T.class_of(String) = alias <C String>
-    <statTemp>$24: Runtime object representing type: Generic[String] = <cfgAlias>$26: T.class_of(Generic).[](<cfgAlias>$28: T.class_of(String))
-    a: Generic[String] = <statTemp>$24: Runtime object representing type: Generic[String].new()
-    <cfgAlias>$33: T.class_of(B) = alias <C B>
-    <ifTemp>$30: T::Boolean = a: Generic[String].is_a?(<cfgAlias>$33: T.class_of(B))
-    <ifTemp>$30 -> (T::Boolean ? bb2 : bb4)
-
-# backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
-    <unconditional> -> bb1
-
-# backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), a: T.all(Generic[String], B)):
-    <cfgAlias>$36: T.class_of(T) = alias <C T>
-    <cfgAlias>$39: T.class_of(Generic) = alias <C Generic>
-    <cfgAlias>$41: T.class_of(String) = alias <C String>
-    <statTemp>$37: Runtime object representing type: Generic[String] = <cfgAlias>$39: T.class_of(Generic).[](<cfgAlias>$41: T.class_of(String))
-    <cfgAlias>$43: T.class_of(B) = alias <C B>
-    keep_for_ide$34: Runtime object representing type: T.all(Generic[String], B) = <cfgAlias>$36: T.class_of(T).all(<statTemp>$37: Runtime object representing type: Generic[String], <cfgAlias>$43: T.class_of(B))
-    keep_for_ide$34: T.untyped = <keep-alive> keep_for_ide$34
-    <castTemp>$44: T.all(Generic[String], B) = a: T.all(Generic[String], B).returns_self()
-    <statTemp>$29: T.all(Generic[String], B) = cast(<castTemp>$44: T.all(Generic[String], B), T.all(Generic[String], B));
-    <unconditional> -> bb4
-
-# backedges
-# - bb0(rubyRegionId=0)
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
-    <cfgAlias>$49: T.class_of(Integer) = alias <C Integer>
-    <cfgAlias>$51: T.class_of(Integer) = alias <C Integer>
-    <magic>$52: T.class_of(<Magic>) = alias <C <Magic>>
-    keep_for_ide$47: [T.class_of(Integer), T.class_of(Integer)] = <magic>$52: T.class_of(<Magic>).<build-array>(<cfgAlias>$49: T.class_of(Integer), <cfgAlias>$51: T.class_of(Integer))
-    keep_for_ide$47: T.untyped = <keep-alive> keep_for_ide$47
-    <arrayTemp>$55: Integer(1) = 1
-    <arrayTemp>$56: Integer(2) = 2
-    <magic>$57: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$54: [Integer(1), Integer(2)] = <magic>$57: T.class_of(<Magic>).<build-array>(<arrayTemp>$55: Integer(1), <arrayTemp>$56: Integer(2))
-    <castTemp>$53: [Integer(1), Integer(2)] = <statTemp>$54: [Integer(1), Integer(2)].returns_self()
-    <statTemp>$46: [Integer, Integer] = cast(<castTemp>$53: [Integer(1), Integer(2)], [Integer, Integer]);
-    <cfgAlias>$60: T.class_of(A) = alias <C A>
-    s: A = <cfgAlias>$60: T.class_of(A).new()
-    <unconditional> -> bb5
-
-# backedges
-# - bb4(rubyRegionId=0)
-# - bb8(rubyRegionId=0)
-# - bb9(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
-    # outerLoops: 1
-    <whileTemp>$63: T.untyped = <self>: T.class_of(<root>).rnd()
-    <whileTemp>$63 -> (T.untyped ? bb8 : bb7)
-
-# backedges
-# - bb5(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=2](<self>: T.class_of(<root>), s: A):
-    <statTemp>$71: NilClass = <self>: T.class_of(<root>).puts(s: A)
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
-    <unconditional> -> bb1
-
-# backedges
-# - bb5(rubyRegionId=0)
-bb8[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
-    # outerLoops: 1
-    <cfgAlias>$69: T.class_of(B) = alias <C B>
-    <ifTemp>$66: T::Boolean = s: A.is_a?(<cfgAlias>$69: T.class_of(B))
-    <ifTemp>$66 -> (T::Boolean ? bb9 : bb5)
-
-# backedges
-# - bb8(rubyRegionId=0)
-bb9[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: T.all(A, B)):
-    # outerLoops: 1
-    <statTemp>$70: T.all(A, B) = s
-    s: T.all(A, B) = <statTemp>$70: T.all(A, B).returns_self()
-    <unconditional> -> bb5
-
-}
-
 method ::Parent#returns_self {
 
 bb0[rubyRegionId=0, firstDead=3]():
@@ -358,6 +257,107 @@ bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(B), <block-pre-call-temp>$7:
     <blockReturnTemp>$9: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<statTemp>$11: Runtime object representing type: T.untyped)
     <blockReturnTemp>$14: T.noreturn = blockreturn<sig> <blockReturnTemp>$9: T::Private::Methods::DeclBuilder
     <unconditional> -> bb2
+
+}
+
+method ::<Class:<root>>#<static-init> {
+
+bb0[rubyRegionId=0, firstDead=-1]():
+    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
+    <cfgAlias>$5: T.class_of(Normal) = alias <C Normal>
+    keep_for_ide$4: T.class_of(Normal) = <cfgAlias>$5
+    keep_for_ide$4: T.untyped = <keep-alive> keep_for_ide$4
+    <cfgAlias>$9: T.class_of(Normal) = alias <C Normal>
+    <statTemp>$7: Normal = <cfgAlias>$9: T.class_of(Normal).new()
+    <castTemp>$6: Normal = <statTemp>$7: Normal.returns_self()
+    <statTemp>$3: Normal = cast(<castTemp>$6: Normal, Normal);
+    <cfgAlias>$13: T.class_of(Generic) = alias <C Generic>
+    <cfgAlias>$15: T.class_of(String) = alias <C String>
+    keep_for_ide$11: Runtime object representing type: Generic[String] = <cfgAlias>$13: T.class_of(Generic).[](<cfgAlias>$15: T.class_of(String))
+    keep_for_ide$11: T.untyped = <keep-alive> keep_for_ide$11
+    <cfgAlias>$20: T.class_of(Generic) = alias <C Generic>
+    <cfgAlias>$22: T.class_of(String) = alias <C String>
+    <statTemp>$18: Runtime object representing type: Generic[String] = <cfgAlias>$20: T.class_of(Generic).[](<cfgAlias>$22: T.class_of(String))
+    <statTemp>$17: Generic[String] = <statTemp>$18: Runtime object representing type: Generic[String].new()
+    <castTemp>$16: Generic[String] = <statTemp>$17: Generic[String].returns_self()
+    <statTemp>$10: Generic[String] = cast(<castTemp>$16: Generic[String], Generic[String]);
+    <cfgAlias>$26: T.class_of(Generic) = alias <C Generic>
+    <cfgAlias>$28: T.class_of(String) = alias <C String>
+    <statTemp>$24: Runtime object representing type: Generic[String] = <cfgAlias>$26: T.class_of(Generic).[](<cfgAlias>$28: T.class_of(String))
+    a: Generic[String] = <statTemp>$24: Runtime object representing type: Generic[String].new()
+    <cfgAlias>$33: T.class_of(B) = alias <C B>
+    <ifTemp>$30: T::Boolean = a: Generic[String].is_a?(<cfgAlias>$33: T.class_of(B))
+    <ifTemp>$30 -> (T::Boolean ? bb2 : bb4)
+
+# backedges
+# - bb7(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), a: T.all(Generic[String], B)):
+    <cfgAlias>$36: T.class_of(T) = alias <C T>
+    <cfgAlias>$39: T.class_of(Generic) = alias <C Generic>
+    <cfgAlias>$41: T.class_of(String) = alias <C String>
+    <statTemp>$37: Runtime object representing type: Generic[String] = <cfgAlias>$39: T.class_of(Generic).[](<cfgAlias>$41: T.class_of(String))
+    <cfgAlias>$43: T.class_of(B) = alias <C B>
+    keep_for_ide$34: Runtime object representing type: T.all(Generic[String], B) = <cfgAlias>$36: T.class_of(T).all(<statTemp>$37: Runtime object representing type: Generic[String], <cfgAlias>$43: T.class_of(B))
+    keep_for_ide$34: T.untyped = <keep-alive> keep_for_ide$34
+    <castTemp>$44: T.all(Generic[String], B) = a: T.all(Generic[String], B).returns_self()
+    <statTemp>$29: T.all(Generic[String], B) = cast(<castTemp>$44: T.all(Generic[String], B), T.all(Generic[String], B));
+    <unconditional> -> bb4
+
+# backedges
+# - bb0(rubyRegionId=0)
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
+    <cfgAlias>$49: T.class_of(Integer) = alias <C Integer>
+    <cfgAlias>$51: T.class_of(Integer) = alias <C Integer>
+    <magic>$52: T.class_of(<Magic>) = alias <C <Magic>>
+    keep_for_ide$47: [T.class_of(Integer), T.class_of(Integer)] = <magic>$52: T.class_of(<Magic>).<build-array>(<cfgAlias>$49: T.class_of(Integer), <cfgAlias>$51: T.class_of(Integer))
+    keep_for_ide$47: T.untyped = <keep-alive> keep_for_ide$47
+    <arrayTemp>$55: Integer(1) = 1
+    <arrayTemp>$56: Integer(2) = 2
+    <magic>$57: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$54: [Integer(1), Integer(2)] = <magic>$57: T.class_of(<Magic>).<build-array>(<arrayTemp>$55: Integer(1), <arrayTemp>$56: Integer(2))
+    <castTemp>$53: [Integer(1), Integer(2)] = <statTemp>$54: [Integer(1), Integer(2)].returns_self()
+    <statTemp>$46: [Integer, Integer] = cast(<castTemp>$53: [Integer(1), Integer(2)], [Integer, Integer]);
+    <cfgAlias>$60: T.class_of(A) = alias <C A>
+    s: A = <cfgAlias>$60: T.class_of(A).new()
+    <unconditional> -> bb5
+
+# backedges
+# - bb4(rubyRegionId=0)
+# - bb8(rubyRegionId=0)
+# - bb9(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
+    # outerLoops: 1
+    <whileTemp>$63: T.untyped = <self>: T.class_of(<root>).rnd()
+    <whileTemp>$63 -> (T.untyped ? bb8 : bb7)
+
+# backedges
+# - bb5(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=2](<self>: T.class_of(<root>), s: A):
+    <statTemp>$71: NilClass = <self>: T.class_of(<root>).puts(s: A)
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+# backedges
+# - bb5(rubyRegionId=0)
+bb8[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
+    # outerLoops: 1
+    <cfgAlias>$69: T.class_of(B) = alias <C B>
+    <ifTemp>$66: T::Boolean = s: A.is_a?(<cfgAlias>$69: T.class_of(B))
+    <ifTemp>$66 -> (T::Boolean ? bb9 : bb5)
+
+# backedges
+# - bb8(rubyRegionId=0)
+bb9[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: T.all(A, B)):
+    # outerLoops: 1
+    <statTemp>$70: T.all(A, B) = s
+    s: T.all(A, B) = <statTemp>$70: T.all(A, B).returns_self()
+    <unconditional> -> bb5
 
 }
 

--- a/test/testdata/namer/alias_cross_file.flatten-tree.exp
+++ b/test/testdata/namer/alias_cross_file.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::TestSig<<C TestSig>> < (::<todo sym>)
     def test_resolve(<blk>)
       <emptyTree>
@@ -17,17 +14,12 @@ begin
       end
     end
   end
-  <emptyTree>
 end
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      ::T2 = ::T1
-    end
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::T1<<C T1>> < (::<todo sym>)
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    ::T2 = ::T1
+  end
 end

--- a/test/testdata/namer/ancestors.rb.flatten-tree.exp
+++ b/test/testdata/namer/ancestors.rb.flatten-tree.exp
@@ -1,33 +1,25 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   module ::Mixin1<<C Mixin1>> < ()
   end
+
   module ::Mixin2<<C Mixin2>> < ()
   end
+
   class ::Parent<<C Parent>> < (::<todo sym>, ::Mixin1)
     def self.<static-init>(<blk>)
       <self>.include(::Mixin1)
     end
   end
+
   class ::Child<<C Child>> < (::Parent, ::Mixin2)
     def self.<static-init>(<blk>)
       <self>.include(::Mixin2)
     end
   end
+
   class ::MultipleInclude<<C MultipleInclude>> < (::<todo sym>, ::Mixin2, ::Mixin1)
     def self.<static-init>(<blk>)
       <self>.include(::Mixin1, ::Mixin2)
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -1,17 +1,12 @@
-InsSeq{
-  stats = [
-    ClassDef{
-      kind = class
-      name = EmptyTree
-      symbol = <C <U <root>>>
-      ancestors = [ConstantLit{
-          symbol = (class ::<todo sym>)
-          orig = nullptr
-        }]
-      rhs = [
-        EmptyTree
-      ]
-    }
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
     ClassDef{
       kind = class
       name = ConstantLit{
@@ -170,6 +165,5 @@ InsSeq{
         }
       ]
     }
-  ],
-  expr = EmptyTree
+  ]
 }

--- a/test/testdata/namer/arguments.rb.flatten-tree.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::A<<C A>> < (::<todo sym>)
     def take_arguments(a, b, c, d, e, f, g)
       begin
@@ -17,5 +14,4 @@ begin
       <runtime method definition of take_arguments>
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/namer/class_and_alias.rb.flatten-tree.exp
+++ b/test/testdata/namer/class_and_alias.rb.flatten-tree.exp
@@ -1,20 +1,15 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      begin
-        ::A = 91
-        ::B = 91
-        <emptyTree>
-      end
-    end
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::A<<C A>> < (::<todo sym>)
   end
+
   class ::B<<C B>> < (::<todo sym>)
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    begin
+      ::A = 91
+      ::B = 91
+      <emptyTree>
+    end
+  end
 end

--- a/test/testdata/namer/conflicting_names.rb.flatten-tree.exp
+++ b/test/testdata/namer/conflicting_names.rb.flatten-tree.exp
@@ -1,19 +1,14 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   module ::A<<C A>> < ()
     def Foo(<blk>)
       <emptyTree>
     end
 
-    <emptyTree>
+    class ::A::Foo<<C Foo>> < (::<todo sym>)
+    end
 
     def self.<static-init>(<blk>)
       <runtime method definition of Foo>
     end
   end
-  class ::A::Foo<<C Foo>> < (::<todo sym>)
-  end
-  <emptyTree>
 end

--- a/test/testdata/namer/constants.rb.flatten-tree.exp
+++ b/test/testdata/namer/constants.rb.flatten-tree.exp
@@ -1,31 +1,26 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      begin
-        ::A::B::C
-        ::A::B::D
-        ::A
-        <emptyTree>
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module ::A<<C A>> < ()
+    module ::A::B<<C B>> < ()
+      def self.<static-init>(<blk>)
+        begin
+          ::A::B::C
+          ::A::B::D = 1
+          <emptyTree>
+        end
       end
     end
-  end
-  module ::A<<C A>> < ()
-    <emptyTree>
 
     def self.<static-init>(<blk>)
       ::A::B::C = 1
     end
   end
-  module ::A::B<<C B>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::A::B::C
-        ::A::B::D = 1
-        <emptyTree>
-      end
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    begin
+      ::A::B::C
+      ::A::B::D
+      ::A
+      <emptyTree>
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/namer/gvar.rb.flatten-tree.exp
+++ b/test/testdata/namer/gvar.rb.flatten-tree.exp
@@ -1,11 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      $a = 1
-    end
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::A<<C A>> < (::<todo sym>)
     def meth(<blk>)
       [$a, $b, $c]
@@ -20,5 +13,8 @@ begin
       end
     end
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    $a = 1
+  end
 end

--- a/test/testdata/namer/locals.rb.flatten-tree.exp
+++ b/test/testdata/namer/locals.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::TestLocals<<C TestLocals>> < (::<todo sym>)
     def method(<blk>)
       begin
@@ -27,5 +24,4 @@ begin
       <runtime method definition of method>
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/namer/nested_class.rb.flatten-tree.exp
+++ b/test/testdata/namer/nested_class.rb.flatten-tree.exp
@@ -1,15 +1,9 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   module ::A<<C A>> < ()
-    <emptyTree>
+    class ::A::B<<C B>> < (::<todo sym>)
+    end
   end
-  class ::A::B<<C B>> < (::<todo sym>)
-  end
+
   class ::C<<C C>> < (::<todo sym>)
   end
-  <emptyTree>
 end

--- a/test/testdata/namer/next_break.rb.flatten-tree.exp
+++ b/test/testdata/namer/next_break.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Test<<C Test>> < (::<todo sym>)
     def test_next_break(<blk>)
       <self>.each() do ||
@@ -24,5 +21,4 @@ begin
       <runtime method definition of test_next_break>
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/namer/redefinition_method.rb.flatten-tree.exp
+++ b/test/testdata/namer/redefinition_method.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Main<<C Main>> < (::<todo sym>)
     def foo<foo$1>(a, <blk>)
       a
@@ -28,5 +25,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/namer/simple.rb.flatten-tree.exp
+++ b/test/testdata/namer/simple.rb.flatten-tree.exp
@@ -1,19 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::NormalClass<<C NormalClass>> < (::<todo sym>)
     def normal_method(<blk>)
       <emptyTree>
@@ -23,9 +8,11 @@ begin
       <emptyTree>
     end
 
-    <emptyTree>
+    class ::NormalClass::InnerClass<<C InnerClass>> < (::<todo sym>)
+    end
 
-    <emptyTree>
+    module ::NormalClass::InnerModule<<C InnerModule>> < ()
+    end
 
     def self.<static-init>(<blk>)
       begin
@@ -35,23 +22,24 @@ begin
       end
     end
   end
-  class ::NormalClass::InnerClass<<C InnerClass>> < (::<todo sym>)
-  end
-  module ::NormalClass::InnerModule<<C InnerModule>> < ()
-  end
+
   module ::ANamespace<<C ANamespace>> < ()
-    <emptyTree>
+    class ::ANamespace::ObviousChild<<C ObviousChild>> < (::<todo sym>)
+    end
   end
-  class ::ANamespace::ObviousChild<<C ObviousChild>> < (::<todo sym>)
-  end
+
   class ::ANamespace::ClassInNamespace<<C ClassInNamespace>> < (::<todo sym>)
   end
+
   class ::Parent<<C Parent>> < (::<todo sym>)
   end
+
   module ::Mixin<<C Mixin>> < ()
   end
+
   module ::OtherMixin<<C OtherMixin>> < ()
   end
+
   class ::Child<<C Child>> < (::Parent, ::Mixin)
     def self.<static-init>(<blk>)
       begin
@@ -65,5 +53,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/namer/yield.rb.cfg-text.exp
+++ b/test/testdata/namer/yield.rb.cfg-text.exp
@@ -1,20 +1,3 @@
-method ::<Class:<root>>#<static-init> {
-
-bb0[rubyRegionId=0, firstDead=5]():
-    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
-    <cfgAlias>$5: T.class_of(Main) = alias <C Main>
-    <statTemp>$3: Main = <cfgAlias>$5: T.class_of(Main).new()
-    <returnMethodTemp>$2: T.untyped = <statTemp>$3: Main.main()
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
-    <unconditional> -> bb1
-
-# backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
-    <unconditional> -> bb1
-
-}
-
 method ::Main#yielder {
 
 bb0[rubyRegionId=0, firstDead=6]():
@@ -169,6 +152,23 @@ method ::<Class:Main>#<static-init> {
 bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+# backedges
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+
+method ::<Class:<root>>#<static-init> {
+
+bb0[rubyRegionId=0, firstDead=5]():
+    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
+    <cfgAlias>$5: T.class_of(Main) = alias <C Main>
+    <statTemp>$3: Main = <cfgAlias>$5: T.class_of(Main).new()
+    <returnMethodTemp>$2: T.untyped = <statTemp>$3: Main.main()
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges

--- a/test/testdata/namer/yield.rb.flatten-tree.exp
+++ b/test/testdata/namer/yield.rb.flatten-tree.exp
@@ -1,11 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      ::Main.new().main()
-    end
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Main<<C Main>> < (::<todo sym>)
     def yielder(<blk>)
       begin
@@ -60,5 +53,8 @@ begin
       end
     end
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    ::Main.new().main()
+  end
 end

--- a/test/testdata/resolver/ancestor_scope.rb.flatten-tree.exp
+++ b/test/testdata/resolver/ancestor_scope.rb.flatten-tree.exp
@@ -1,24 +1,13 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      begin
-        <cast:assert_type!>(::Test.new(), Test::Mixin, ::Test::Mixin)
-        <cast:assert_type!>(::Test.new(), Test::Other, ::Test::Other)
-        <cast:assert_type!>(::Test.new(), Other, ::Other)
-        <emptyTree>
-      end
-    end
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Other<<C Other>> < (::<todo sym>)
   end
-  class ::Test<<C Test>> < (::Other, ::Test::Mixin, ::Test::Other)
-    <emptyTree>
 
-    <emptyTree>
+  class ::Test<<C Test>> < (::Other, ::Test::Mixin, ::Test::Other)
+    module ::Test::Mixin<<C Mixin>> < ()
+    end
+
+    module ::Test::Other<<C Other>> < ()
+    end
 
     def self.<static-init>(<blk>)
       begin
@@ -28,9 +17,13 @@ begin
       end
     end
   end
-  module ::Test::Mixin<<C Mixin>> < ()
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    begin
+      <cast:assert_type!>(::Test.new(), Test::Mixin, ::Test::Mixin)
+      <cast:assert_type!>(::Test.new(), Test::Other, ::Test::Other)
+      <cast:assert_type!>(::Test.new(), Other, ::Other)
+      <emptyTree>
+    end
   end
-  module ::Test::Other<<C Other>> < ()
-  end
-  <emptyTree>
 end

--- a/test/testdata/resolver/class_instance_vars.rb.flatten-tree.exp
+++ b/test/testdata/resolver/class_instance_vars.rb.flatten-tree.exp
@@ -1,17 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      ::Alias = ::Parent
-    end
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Parent<<C Parent>> < (::<todo sym>)
     def initialize(<blk>)
       begin
@@ -36,6 +23,7 @@ begin
       end
     end
   end
+
   module ::Mixin<<C Mixin>> < ()
     def self.<static-init>(<blk>)
       begin
@@ -45,6 +33,7 @@ begin
       end
     end
   end
+
   class ::Child<<C Child>> < (::Parent, ::Mixin)
     def child_method(<blk>)
       begin
@@ -66,10 +55,14 @@ begin
       end
     end
   end
+
   class ::Child1<<C Child1>> < (::Alias)
     def self.<static-init>(<blk>)
       @@class_var
     end
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    ::Alias = ::Parent
+  end
 end

--- a/test/testdata/resolver/flatten.rb.flatten-tree.exp
+++ b/test/testdata/resolver/flatten.rb.flatten-tree.exp
@@ -1,25 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      begin
-        ::A.new().foo()
-        ::A.foo()
-        ::A.new().food()
-        ::A.food()
-        ::A.new().foos()
-        ::A.foos()
-        ::A.sfoo()
-        ::A.new().sfoo()
-        ::A.new().sfood()
-        ::A.sfood()
-        ::A.sfoos()
-        ::A.new().sfoos()
-        <emptyTree>
-      end
-    end
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::A<<C A>> < (::<todo sym>)
     def foo(<blk>)
       begin
@@ -59,5 +38,22 @@ begin
       end
     end
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    begin
+      ::A.new().foo()
+      ::A.foo()
+      ::A.new().food()
+      ::A.food()
+      ::A.new().foos()
+      ::A.foos()
+      ::A.sfoo()
+      ::A.new().sfoo()
+      ::A.new().sfood()
+      ::A.sfood()
+      ::A.sfoos()
+      ::A.new().sfoos()
+      <emptyTree>
+    end
+  end
 end

--- a/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
+++ b/test/testdata/resolver/optional_nil.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Test<<C Test>> < (::<todo sym>)
     def foo(x, <blk>)
       x
@@ -42,5 +39,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
@@ -1,17 +1,12 @@
-InsSeq{
-  stats = [
-    ClassDef{
-      kind = class
-      name = EmptyTree
-      symbol = <C <U <root>>>
-      ancestors = [ConstantLit{
-          symbol = (class ::<todo sym>)
-          orig = nullptr
-        }]
-      rhs = [
-        EmptyTree
-      ]
-    }
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
     ClassDef{
       kind = class
       name = ConstantLit{
@@ -202,6 +197,5 @@ InsSeq{
         }
       ]
     }
-  ],
-  expr = EmptyTree
+  ]
 }

--- a/test/testdata/resolver/simple.rb.flatten-tree.exp
+++ b/test/testdata/resolver/simple.rb.flatten-tree.exp
@@ -1,50 +1,39 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::Outer1<<C Outer1>> < (::<todo sym>)
   end
+
   class ::Outer2<<C Outer2>> < (::<todo sym>)
-    <emptyTree>
+    class ::Outer2::C<<C C>> < (::<todo sym>)
+    end
 
-    <emptyTree>
+    class ::Outer2::Inner1<<C Inner1>> < (::<todo sym>)
+      class ::Outer2::Inner1::A<<C A>> < (::<todo sym>)
+      end
 
-    <emptyTree>
-
-    <emptyTree>
-  end
-  class ::Outer2::C<<C C>> < (::<todo sym>)
-  end
-  class ::Outer2::Inner1<<C Inner1>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-  end
-  class ::Outer2::Inner1::A<<C A>> < (::<todo sym>)
-  end
-  class ::Outer2::Inner1::Inner2<<C Inner2>> < (::<todo sym>)
-    def self.<static-init>(<blk>)
-      begin
-        ::Outer2::Inner1::A
-        ::Outer2::Inner1
-        ::Outer2::Inner1::Inner2
-        ::Outer1
-        <emptyTree>
+      class ::Outer2::Inner1::Inner2<<C Inner2>> < (::<todo sym>)
+        def self.<static-init>(<blk>)
+          begin
+            ::Outer2::Inner1::A
+            ::Outer2::Inner1
+            ::Outer2::Inner1::Inner2
+            ::Outer1
+            <emptyTree>
+          end
+        end
       end
     end
-  end
-  class ::Outer2::Inner1::Inner2<<C Inner2>> < (::<todo sym>)
-    def self.<static-init>(<blk>)
-      begin
-        ::Outer2::C
-        Unresolved: <emptyTree>::<C A>
-        <emptyTree>
+
+    class ::Outer2::Inner1::Inner2<<C Inner2>> < (::<todo sym>)
+      def self.<static-init>(<blk>)
+        begin
+          ::Outer2::C
+          Unresolved: <emptyTree>::<C A>
+          <emptyTree>
+        end
       end
     end
+
+    class ::Outer2::Other<<C Other>> < (::Outer2::Inner1::Inner2)
+    end
   end
-  class ::Outer2::Other<<C Other>> < (::Outer2::Inner1::Inner2)
-  end
-  <emptyTree>
 end

--- a/test/testdata/resolver/stubs_typed_untyped.flatten-tree.exp
+++ b/test/testdata/resolver/stubs_typed_untyped.flatten-tree.exp
@@ -1,18 +1,14 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      begin
-        Unresolved: <emptyTree>::<C Bar>
-        Unresolved: ::Foo::<C Bar>
-        <emptyTree>
-      end
-    end
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   module ::Foo<<C Foo>> < ()
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    begin
+      Unresolved: <emptyTree>::<C Bar>
+      Unresolved: ::Foo::<C Bar>
+      <emptyTree>
+    end
+  end
 end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def self.<static-init><<static-init>$CENSORED>(<blk>)

--- a/test/testdata/rewriter/attr.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/attr.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::TestAttr<<C TestAttr>> < (::<todo sym>)
     def initialize(<blk>)
       begin
@@ -107,5 +104,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/rewriter/class_new_strict.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::A<<C A>> < (::<todo sym>)
     def self.make(<blk>)
       begin
@@ -41,5 +38,4 @@ begin
       end
     end
   end
-  <emptyTree>
 end

--- a/test/testdata/rewriter/flatten_nested.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/flatten_nested.rb.flatten-tree.exp
@@ -1,28 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    <emptyTree>
-
-    def self.<static-init><<static-init>$CENSORED>(<blk>)
-      begin
-        ::A.new().outer_method()
-        ::A.new().inner_method()
-        b = ::B.new()
-        b.outer_method()
-        b.inner_method()
-        ::C.outer_method()
-        ::C.new().inner_method()
-        ::D.outer_method()
-        ::D.inner_method()
-        <emptyTree>
-      end
-    end
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::A<<C A>> < (::<todo sym>)
     def outer_method(<blk>)
       <runtime method definition of inner_method>
@@ -36,6 +12,7 @@ begin
       <runtime method definition of outer_method>
     end
   end
+
   class ::B<<C B>> < (::<todo sym>)
     def outer_method(<blk>)
       <runtime method definition of self.inner_method>
@@ -49,6 +26,7 @@ begin
       <runtime method definition of outer_method>
     end
   end
+
   class ::C<<C C>> < (::<todo sym>)
     def self.outer_method(<blk>)
       <runtime method definition of inner_method>
@@ -62,6 +40,7 @@ begin
       <runtime method definition of self.outer_method>
     end
   end
+
   class ::D<<C D>> < (::<todo sym>)
     def self.outer_method(<blk>)
       <runtime method definition of self.inner_method>
@@ -75,5 +54,19 @@ begin
       <runtime method definition of self.outer_method>
     end
   end
-  <emptyTree>
+
+  def self.<static-init><<static-init>$CENSORED>(<blk>)
+    begin
+      ::A.new().outer_method()
+      ::A.new().inner_method()
+      b = ::B.new()
+      b.outer_method()
+      b.inner_method()
+      ::C.outer_method()
+      ::C.new().inner_method()
+      ::D.outer_method()
+      ::D.inner_method()
+      <emptyTree>
+    end
+  end
 end

--- a/test/testdata/todo/block_in_class.rb.flatten-tree.exp
+++ b/test/testdata/todo/block_in_class.rb.flatten-tree.exp
@@ -1,7 +1,4 @@
-begin
-  class <emptyTree><<C <root>>> < (::<todo sym>)
-    <emptyTree>
-  end
+class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::C<<C C>> < (::<todo sym>)
     def self.<static-init>(<blk>)
       ::C::L = <cast:let>(<self>.lambda() do |x$1|
@@ -15,5 +12,4 @@ begin
       }, ::T.proc().params(:x, ::Integer).returns(::Integer))
     end
   end
-  <emptyTree>
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Mostly I'm curious if we can get away with not doing this.

Maybe there's a bit of a performance win? Maybe there's a bit of a memory win,
because memory locality is a little better?

Anyways, mostly just trying to delete code.

We might want to rename this to something other than `class_flatten`, because
the only thing it's doing now is extracting `<static-init>` methods.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests