### PR TITLE
Extract `to_str` to T::Enum

### DIFF
--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -369,48 +369,26 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
   end
 
   describe 'string value conversion assertions' do
+    ENUM_CONVERSION_MSG = /Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead./.freeze
+
     before do
       T::Configuration.expects(:soft_assert_handler).never
     end
 
     it 'raises an assertion if to_str is called and also returns the serialized value' do
-      # The exception messages change depending on whether
-      # T::Configuration.enable_legacy_t_enum_migration_mode has been called
-      # once before, even if it's been undone with
-      # T::Configuration.disable_legacy_t_enum_migration_mode, unfortunately.
-      # Hopefully no one depended on the old behavior.
-      exn_message = if T::Enum < T::Enum::LegacyMigrationMode
-        /Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead./
-      else
-        /undefined method `to_str'/
-      end
-
       ex = assert_raises(NoMethodError) do
         CardSuit::HEART.to_str
       end
-      assert_match(exn_message, ex.message)
+      assert_match(ENUM_CONVERSION_MSG, ex.message)
     end
 
     it 'raises an assertion if to_str is called (implicitly) and also returns the serialized value' do
-      # The exception messages change depending on whether
-      # T::Configuration.enable_legacy_t_enum_migration_mode has been called
-      # once before, even if it's been undone with
-      # T::Configuration.disable_legacy_t_enum_migration_mode, unfortunately.
-      # Hopefully no one depended on the old behavior.
-      if T::Enum < T::Enum::LegacyMigrationMode
-        exn_class = NoMethodError
-        exn_message = /Implicit conversion of Enum instances to strings is not allowed. Call #serialize instead./
-      else
-        exn_class = TypeError
-        exn_message = /no implicit conversion of .* into String/
-      end
-
-      ex = assert_raises(exn_class) do
+      ex = assert_raises(NoMethodError) do
         # rubocop:disable Style/StringConcatenation
         "foo " + CardSuit::HEART
         # rubocop:enable Style/StringConcatenation
       end
-      assert_match(exn_message, ex.message)
+      assert_match(ENUM_CONVERSION_MSG, ex.message)
     end
   end
 

--- a/rbi/core/enum.rbi
+++ b/rbi/core/enum.rbi
@@ -6,9 +6,6 @@ class T::Enum
   # Assume that this is always included (even if it isn't) so that it never
   # shows up in RBI files generated from reflection.
   module LegacyMigrationMode
-    sig {returns(String)}
-    def to_str; end
-
     sig {params(other: T.anything).returns(T::Boolean)}
     def ==(other); end
 
@@ -81,6 +78,9 @@ class T::Enum
 
   sig {returns(String)}
   def to_s; end
+
+  sig {returns(String)}
+  def to_str; end
 
   sig {returns(String)}
   def inspect; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Responding to `to_str` allows ruby to call `T::Enum#==` during string comparisons. This feature was used by T::Enum's before the recent `LegacyMigrationMode` mixin change and I think there's value in keeping it so that all T::Enum's can define their own `==` method.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I can add one if it's helpful.

