### PR TITLE
fix find all references for the `Command` rewriter

### DIFF
--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -95,11 +95,8 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     // method, there are no calls to it, which will frustrate the user.  Erase
     // the location(s) on the non-synthetic method so that LSP only sees the
     // synthetic method.
-    auto hiddenCall = ast::MK::Method(call->loc.copyWithZeroLength(),
-                                      call->declLoc.copyWithZeroLength(),
-                                      call->name,
-                                      std::move(call->args), std::move(call->rhs),
-                                      call->flags);
+    auto hiddenCall = ast::MK::Method(call->loc.copyWithZeroLength(), call->declLoc.copyWithZeroLength(), call->name,
+                                      std::move(call->args), std::move(call->rhs), call->flags);
 
     // We need to make sure we assign into `callptr` prior to inserting into
     // `klass->rhs`, otherwise our pointer might not be live anymore.

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -91,9 +91,10 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
 
     // We are now in the weird situation where we have an actual method that
     // the user has written, but we have a synthetic method that lives at the
-    // same location.  If we try to jump-to-def from the actual method, there
-    // are no calls to it, which will frustrate the user.  Erase the location(s)
-    // on the non-synthetic method so that LSP only sees the synthetic method.
+    // same location.  If we try to find all references from the actual
+    // method, there are no calls to it, which will frustrate the user.  Erase
+    // the location(s) on the non-synthetic method so that LSP only sees the
+    // synthetic method.
     auto hiddenCall = ast::MK::Method(call->loc.copyWithZeroLength(),
                                       call->declLoc.copyWithZeroLength(),
                                       call->name,

--- a/test/testdata/lsp/command_find_refs.rb
+++ b/test/testdata/lsp/command_find_refs.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+class Opus::Command
+  extend T::Sig
+  def self.call(*args, **kwargs, &blk)
+  end
+end
+
+class MyCommand < Opus::Command
+  sig { params(x: Integer, y: Integer).void }
+  def call(x, y)
+    # ^ def: MyCommand.call
+  end
+end
+
+MyCommand.call(1, 2)
+#         ^ usage: MyCommand.call
+MyCommand.call(3, 4)
+#         ^ usage: MyCommand.call


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #7858 

This is admittedly kind of a weird thing to do, but it is consistent with how we hide other things from LSP -- even though the other things we are hiding are usually synthesized methods, rather than the real thing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
