### PR TITLE
Allow `T.let` types to affect lambda inference

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -169,6 +169,20 @@ InstructionPtr maybeMakeTypeParameterAlias(CFGContext &cctx, ast::Send &s) {
     return make_insn<Alias>(typeParam);
 }
 
+ast::Send *isKernelLambda(ast::ExpressionPtr &expr) {
+    auto *send = ast::cast_tree<ast::Send>(expr);
+    if (send == nullptr || send->fun != core::Names::lambda() || send->hasNonBlockArgs()) {
+        return nullptr;
+    }
+
+    auto *recv = ast::cast_tree<ast::ConstantLit>(send->recv);
+    if (recv == nullptr || recv->symbol != core::Symbols::Kernel()) {
+        return nullptr;
+    }
+
+    return send;
+}
+
 } // namespace
 
 void CFGBuilder::jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc) {
@@ -924,12 +938,18 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             },
 
             [&](ast::Cast &c) {
-                // This is kind of gross, but it is the only way to ensure that the bits in the
-                // type expression make it into the CFG for LSP to hit on their locations.
-                LocalRef deadSym = cctx.newTemporary(core::Names::keepForIde());
-                current = walk(cctx.withTarget(deadSym), c.typeExpr, current);
-                // Ensure later passes don't delete the results of the typeExpr.
-                current->exprs.emplace_back(deadSym, core::LocOffsets::none(), make_insn<KeepAlive>(deadSym));
+                if (auto *kernelLambda = isKernelLambda(c.arg)) {
+                    kernelLambda->fun = core::Names::lambdaTLet();
+                    kernelLambda->addPosArg(move(c.typeExpr));
+                    // TODO(jez) Do we need to gate this on the Cast type?
+                } else {
+                    // This is kind of gross, but it is the only way to ensure that the bits in the
+                    // type expression make it into the CFG for LSP to hit on their locations.
+                    LocalRef deadSym = cctx.newTemporary(core::Names::keepForIde());
+                    current = walk(cctx.withTarget(deadSym), c.typeExpr, current);
+                    // Ensure later passes don't delete the results of the typeExpr.
+                    current->exprs.emplace_back(deadSym, core::LocOffsets::none(), make_insn<KeepAlive>(deadSym));
+                }
                 LocalRef tmp = cctx.newTemporary(core::Names::castTemp());
                 core::LocOffsets argLoc = c.arg.loc();
                 current = walk(cctx.withTarget(tmp), c.arg, current);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -680,6 +680,9 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::T_Generic(), Names::squareBrackets()).repeatedTopArg(Names::args()).build();
     ENFORCE(method == Symbols::T_Generic_squareBrackets());
 
+    method = enterMethod(*this, Symbols::Kernel(), Names::lambdaTLet()).typedArg(Names::type(), Types::top()).build();
+    ENFORCE(method == Symbols::Kernel_lambdaTLet());
+
     typeArgument =
         enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::TodoTypeArgument(), Variance::CoVariant);
     ENFORCE(typeArgument == Symbols::todoTypeArgument());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1105,6 +1105,10 @@ public:
         return MethodRef::fromRaw(19);
     }
 
+    static MethodRef Kernel_lambdaTLet() {
+        return MethodRef::fromRaw(20);
+    }
+
     static ClassOrModuleRef Magic_UntypedSource() {
         return ClassOrModuleRef::fromRaw(101);
     }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,7 +23,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 53;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 54;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 73;

--- a/core/Types.h
+++ b/core/Types.h
@@ -1056,7 +1056,8 @@ struct DispatchComponent {
     TypePtr sendTp;
     TypePtr blockReturnType;
     TypePtr blockPreType;
-    ArgInfo blockSpec; // used only by LoadSelf to change type of self inside method.
+    ClassOrModuleRef rebind;
+    Loc rebindLoc;
     std::unique_ptr<TypeConstraint> constr;
 };
 
@@ -1071,7 +1072,7 @@ struct DispatchResult {
     DispatchResult(TypePtr returnType, TypePtr receiverType, core::MethodRef method)
         : returnType(returnType),
           main(DispatchComponent{
-              std::move(receiverType), method, {}, std::move(returnType), nullptr, nullptr, ArgInfo{}, nullptr}){};
+              std::move(receiverType), method, {}, std::move(returnType), nullptr, nullptr, {}, {}, nullptr}){};
     DispatchResult(TypePtr returnType, DispatchComponent comp)
         : returnType(std::move(returnType)), main(std::move(comp)){};
     DispatchResult(TypePtr returnType, DispatchComponent comp, std::unique_ptr<DispatchResult> secondary,

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -357,6 +357,7 @@ NameDef names[] = {
     {"destructureArg", "<destructure>"},
 
     {"lambda"},
+    {"lambdaTLet", "<lambda T.let>"},
     {"nil_p", "nil?"},
     {"blank_p", "blank?"},
     {"present_p", "present?"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -134,7 +134,7 @@ DispatchResult ShapeType::dispatchCall(const GlobalState &gs, const DispatchArgs
     if (method.exists()) {
         auto *intrinsic = method.data(gs)->getIntrinsic();
         if (intrinsic != nullptr) {
-            DispatchComponent comp{args.selfType, method, {}, nullptr, nullptr, nullptr, ArgInfo{}, nullptr};
+            DispatchComponent comp{args.selfType, method, {}, nullptr, nullptr, nullptr, {}, {}, nullptr};
             DispatchResult res{nullptr, std::move(comp)};
             intrinsic->apply(gs, args, res);
             if (res.returnType != nullptr) {
@@ -151,7 +151,7 @@ DispatchResult TupleType::dispatchCall(const GlobalState &gs, const DispatchArgs
     if (method.exists()) {
         auto *intrinsic = method.data(gs)->getIntrinsic();
         if (intrinsic != nullptr) {
-            DispatchComponent comp{args.selfType, method, {}, nullptr, nullptr, nullptr, ArgInfo{}, nullptr};
+            DispatchComponent comp{args.selfType, method, {}, nullptr, nullptr, nullptr, {}, {}, nullptr};
             DispatchResult res{nullptr, std::move(comp)};
             intrinsic->apply(gs, args, res);
             if (res.returnType != nullptr) {
@@ -1508,7 +1508,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         blockType = constr->isSolved() ? Types::instantiate(gs, blockType, *constr)
                                        : Types::approximate(gs, blockType, *constr);
         component.blockPreType = blockType;
-        component.blockSpec = bspec.deepCopy();
+        component.rebind = bspec.rebind;
+        component.rebindLoc = bspec.loc;
     }
 
     TypePtr &resultType = result.returnType;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1822,7 +1822,7 @@ void Environment::cloneFrom(const Environment &rhs) {
 
 core::TypeAndOrigins Environment::getTypeFromRebind(core::Context ctx, const core::DispatchComponent &main,
                                                     cfg::LocalRef fallback) {
-    auto rebind = main.blockSpec.rebind;
+    auto rebind = main.rebind;
 
     if (rebind.exists()) {
         core::TypeAndOrigins result;
@@ -1840,7 +1840,7 @@ core::TypeAndOrigins Environment::getTypeFromRebind(core::Context ctx, const cor
             result.type = rebind.data(ctx)->selfType(ctx);
         }
 
-        result.origins.emplace_back(main.blockSpec.loc);
+        result.origins.emplace_back(main.rebindLoc);
         return result;
     } else {
         return getTypeAndOrigin(ctx, fallback);

--- a/test/testdata/infer/t_let_lambda.rb
+++ b/test/testdata/infer/t_let_lambda.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+f = T.let(
+  -> (x) do
+    T.reveal_type(x)
+  end,
+  T.proc.params(x: Integer).returns(Integer)
+)
+T.reveal_type(f)
+
+# Should we error if this is not a proc type?
+# (What would have happened if you put `blk: Integer` in a sig somewhere?)
+f = T.let(
+  -> (x) do
+    T.reveal_type(x)
+  end,
+  Integer
+)
+T.reveal_type(f)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This lets `T.let` annotations affect the inference of lambdas.

Right now it ignores `proc` and `lambda` methods, and only works for `->(){}`
lambda syntax, but I think we could expand support to include those.

Before this PR, when you wrap a lambda in a `T.let`, it doesn't affect how the
body of the lambda is type checked. The arguments are still assumed to be
untyped, and the result is also untyped. Then the `T.let` comes along and
ascribes a type, which might be out of sync with what the lambda's true type
actually is.

After this PR, we allow the body of the lambda to be typechecked assuming that
the `T.let` type holds, and report errors if that assumption doesn't hold. It's
powered by the exact same mechanism that powers type checking for blocks, which
makes the implementation very simple.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.