### PR TITLE
Remove rubydbg from --config=dbg

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,7 +60,6 @@ build --copt=-Wno-macro-redefined
 build:dbg --copt=-O0
 build:dbg --compilation_mode=dbg
 build:dbg --config=debugsymbols
-build:dbg --config=rubydbg
 
 build:rubydbg --copt=-DRUBY_DEBUG --copt=-DVM_CHECK_MODE=1 --copt=-DTRANSIENT_HEAP_CHECK_MODE --copt=-DRGENGC_CHECK_MODE --copt=-DENC_DEBUG
 


### PR DESCRIPTION
We can remove the rubydbg build configuration itself when we finally
delete all Ruby bazel configurations from Sorbet (we can't do that until
we vendor them into Stripe's codebase).


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed we were passing some C preprocessor defines to every C++ target we
build in debug mode.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.