### PR TITLE
Don't dup documentationLocations when not aliased

### DIFF
--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -88,9 +88,12 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
                 documentationLocations.emplace_back(loc);
             }
         }
-        for (auto loc : c->symbolBeforeDealias.dealias(gs).locs(gs)) {
-            if (loc.exists()) {
-                documentationLocations.emplace_back(loc);
+        auto dealiased = c->symbolBeforeDealias.dealias(gs);
+        if (dealiased != c->symbolBeforeDealias) {
+            for (auto loc : dealiased.locs(gs)) {
+                if (loc.exists()) {
+                    documentationLocations.emplace_back(loc);
+                }
             }
         }
     } else if (auto d = resp->isMethodDef()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The changes in 9c90faa74 accidentally made all documentation for
constants that were not constant aliases duplicated.

We should definitely include both the pre- and post-dealiased
documentation locations if the symbols are different, but if they're the
same, then it's just going to mean showing two copies of the
documentation.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

It's hard to write a test for this, because our `hover` assertions are just
"does the documentation include this text" which makes it hard to say that the
hovered text **doesn't** contain something, and is also why none of our existing
tests caught this regression.

I'm going to punt on changing the test suite for that because I don't think this
issue is so pressing that we want to make sure that it never gets reintroduced.

To that end, I tested this manually in my editor, sending a hover request, observing that before this change there were two copies of the documentation, and after there was not.

**Before**
<img width="186" alt="Screenshot 2024-05-06 at 2 34 28 PM" src="https://github.com/sorbet/sorbet/assets/5544532/a8e6eb5b-aa47-4dd5-8104-02571f9a0399">
**After**
<img width="226" alt="Screenshot 2024-05-06 at 2 35 14 PM" src="https://github.com/sorbet/sorbet/assets/5544532/ca101b38-0095-46f6-b39e-e6728cb81702">
