### PR TITLE
Add Gem::BUNDLED_GEMS to rubygems.rbi

### DIFF
--- a/rbi/stdlib/rubygems.rbi
+++ b/rbi/stdlib/rubygems.rbi
@@ -7515,6 +7515,18 @@ module Gem::Util
   def self.traverse_parents(directory, &block); end
 end
 
+# The `BUNDLED_GEMS` (undocumented) module was introduced in Ruby 3.3.
+module Gem::BUNDLED_GEMS
+  SINCE = ::T.let(nil, T::Hash[String, String])
+  EXACT = ::T.let(nil, T::Hash[String, T::Boolean])
+  PREFIXED = ::T.let(nil, T::Hash[String, T::Boolean])
+  WARNED = ::T.let(nil, T::Hash[String, T::Boolean])
+  LIBDIR = ::T.let(nil, String)
+  ARCHDIR = ::T.let(nil, String)
+  DLEXT = ::T.let(nil, Regexp)
+  LIBEXT = ::T.let(nil, Regexp)
+end
+
 module Kernel
   # Use
   # [`Kernel#gem`](https://docs.ruby-lang.org/en/2.7.0/Kernel.html#method-i-gem)


### PR DESCRIPTION
### Motivation
The `Gem::BUNDLED_GEMS` module introduced in Ruby 3.3 is currently unknown to sorbet and causes "unable to resolve constant ..." errors.
This module is currently undocumented, but its implementation can be seen [here](https://github.com/ruby/ruby/blob/master/lib/bundled_gems.rb).
cc @2rba who noticed and raised this with me.