### PR TITLE
Add a type for T.deprecated_enum's parameter

### DIFF
--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -127,7 +127,7 @@ module T
   # Deprecated. Use `T::Enum` instead.
   #
   # For more information, see https://sorbet.org/docs/tenum
-  sig { params(values: T::Array[T.anything]).returns(T.untyped) }
+  sig { params(values: T.any(T::Set[T.anything], T::Array[T.anything])).returns(T.untyped) }
   def self.deprecated_enum(values); end
 
   # Type syntax to opt out of static type checking.

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -127,6 +127,7 @@ module T
   # Deprecated. Use `T::Enum` instead.
   #
   # For more information, see https://sorbet.org/docs/tenum
+  sig { params(values: T::Array[T.anything]).returns(T.untyped) }
   def self.deprecated_enum(values); end
 
   # Type syntax to opt out of static type checking.

--- a/test/cli/autocorrect-t-combinator-kwargs/test.out
+++ b/test/cli/autocorrect-t-combinator-kwargs/test.out
@@ -70,18 +70,19 @@ autocorrect-t-combinator-kwargs.rb:10: Unexpected bare `Symbol(:b)` value found 
     10 |      any: T.any(Integer, String, a: Integer, b: String),
                                                       ^
 
-autocorrect-t-combinator-kwargs.rb:12: Expected `T::Array[T.anything]` but found `{a: T.class_of(Integer)}` for argument `values` https://srb.help/7002
+autocorrect-t-combinator-kwargs.rb:12: Expected `T.any(T::Set[T.anything], T::Array[T.anything])` but found `{a: T.class_of(Integer)}` for argument `values` https://srb.help/7002
     12 |      enum: T.deprecated_enum(a: Integer),
                                       ^^^^^^^^^^
-  Expected `T::Array[T.anything]` for argument `values` of method `T.deprecated_enum`:
+  Expected `T.any(T::Set[T.anything], T::Array[T.anything])` for argument `values` of method `T.deprecated_enum`:
     https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L130:
-     130 |  sig { params(values: T::Array[T.anything]).returns(T.untyped) }
+     130 |  sig { params(values: T.any(T::Set[T.anything], T::Array[T.anything])).returns(T.untyped) }
                          ^^^^^^
   Got `{a: T.class_of(Integer)} (shape of T::Hash[T.untyped, T.untyped])` originating from:
     autocorrect-t-combinator-kwargs.rb:12:
     12 |      enum: T.deprecated_enum(a: Integer),
                                       ^^^^^^^^^^
   Detailed explanation:
+    `Hash` does not derive from `Set`
     `Hash` does not derive from `Array`
 Errors: 13
 

--- a/test/cli/autocorrect-t-combinator-kwargs/test.out
+++ b/test/cli/autocorrect-t-combinator-kwargs/test.out
@@ -69,7 +69,21 @@ autocorrect-t-combinator-kwargs.rb:10: Unexpected bare `Symbol(:a)` value found 
 autocorrect-t-combinator-kwargs.rb:10: Unexpected bare `Symbol(:b)` value found in type position https://srb.help/7009
     10 |      any: T.any(Integer, String, a: Integer, b: String),
                                                       ^
-Errors: 12
+
+autocorrect-t-combinator-kwargs.rb:12: Expected `T::Array[T.anything]` but found `{a: T.class_of(Integer)}` for argument `values` https://srb.help/7002
+    12 |      enum: T.deprecated_enum(a: Integer),
+                                      ^^^^^^^^^^
+  Expected `T::Array[T.anything]` for argument `values` of method `T.deprecated_enum`:
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L130:
+     130 |  sig { params(values: T::Array[T.anything]).returns(T.untyped) }
+                         ^^^^^^
+  Got `{a: T.class_of(Integer)} (shape of T::Hash[T.untyped, T.untyped])` originating from:
+    autocorrect-t-combinator-kwargs.rb:12:
+    12 |      enum: T.deprecated_enum(a: Integer),
+                                      ^^^^^^^^^^
+  Detailed explanation:
+    `Hash` does not derive from `Array`
+Errors: 13
 
 --------------------------------------------------------------------------
 

--- a/test/testdata/resolver/sig_bad.rb
+++ b/test/testdata/resolver/sig_bad.rb
@@ -38,10 +38,10 @@ class A
       #          ^^^^^^^^^^^   error: Unsupported type literal
       #    ^^^^                error: Method `enum` does not exist on `T.class_of(T)`
       b1: T.deprecated_enum, # error: Not enough arguments provided for method `T.deprecated_enum`. Expected: `1`, got: `0`
-      c11: T.deprecated_enum(1), # error: Expected `T::Array[T.anything]`
-      c12: T.deprecated_enum(1.0), # error: Expected `T::Array[T.anything]`
-      c13: T.deprecated_enum("d"), # error: Expected `T::Array[T.anything]`
-      c14: T.deprecated_enum(:e), # error: Expected `T::Array[T.anything]`
+      c11: T.deprecated_enum(1), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
+      c12: T.deprecated_enum(1.0), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
+      c13: T.deprecated_enum("d"), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
+      c14: T.deprecated_enum(:e), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
       d1: T.deprecated_enum([]), # error: enum([]) is invalid
       e1: T.deprecated_enum([unsupported]), # error: Unsupported type literal
       f: 0, # error: Unsupported literal in type syntax

--- a/test/testdata/resolver/sig_bad.rb
+++ b/test/testdata/resolver/sig_bad.rb
@@ -38,10 +38,10 @@ class A
       #          ^^^^^^^^^^^   error: Unsupported type literal
       #    ^^^^                error: Method `enum` does not exist on `T.class_of(T)`
       b1: T.deprecated_enum, # error: Not enough arguments provided for method `T.deprecated_enum`. Expected: `1`, got: `0`
-      c11: T.deprecated_enum(1),
-      c12: T.deprecated_enum(1.0),
-      c13: T.deprecated_enum("d"),
-      c14: T.deprecated_enum(:e),
+      c11: T.deprecated_enum(1), # error: Expected `T::Array[T.anything]`
+      c12: T.deprecated_enum(1.0), # error: Expected `T::Array[T.anything]`
+      c13: T.deprecated_enum("d"), # error: Expected `T::Array[T.anything]`
+      c14: T.deprecated_enum(:e), # error: Expected `T::Array[T.anything]`
       d1: T.deprecated_enum([]), # error: enum([]) is invalid
       e1: T.deprecated_enum([unsupported]), # error: Unsupported type literal
       f: 0, # error: Unsupported literal in type syntax

--- a/test/testdata/resolver/t_combinator_kwargs.rb
+++ b/test/testdata/resolver/t_combinator_kwargs.rb
@@ -18,7 +18,7 @@ module M
       param: T.type_parameter(a: Integer),
       #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter` does not accept keyword arguments
       enum: T.deprecated_enum(a: Integer),
-      #                       ^^^^^^^^^^ error: Expected `T::Array[T.anything]`
+      #                       ^^^^^^^^^^ error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
       #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.deprecated_enum` does not accept keyword arguments
       klass: T.class_of(a: Integer),
       #      ^^^^^^^^^^^^^^^^^^^^^^ error: `T.class_of` does not accept keyword arguments

--- a/test/testdata/resolver/t_combinator_kwargs.rb
+++ b/test/testdata/resolver/t_combinator_kwargs.rb
@@ -18,6 +18,7 @@ module M
       param: T.type_parameter(a: Integer),
       #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter` does not accept keyword arguments
       enum: T.deprecated_enum(a: Integer),
+      #                       ^^^^^^^^^^ error: Expected `T::Array[T.anything]`
       #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.deprecated_enum` does not accept keyword arguments
       klass: T.class_of(a: Integer),
       #      ^^^^^^^^^^^^^^^^^^^^^^ error: `T.class_of` does not accept keyword arguments


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This should catch people trying to do something silly when converting a
legacy enum to a `T::Enum` with a dumb find and replace.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

RBI change