### PR TITLE
prework: Upgrade zlib to fix warnings

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -46,10 +46,10 @@ def register_sorbet_dependencies():
     # `@zlib` if it's present.
     http_archive(
         name = "zlib",
-        urls = _github_public_urls("madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.zip"),
+        urls = _github_public_urls("madler/zlib/archive/v1.3.1.zip"),
         build_file = "@com_stripe_ruby_typer//third_party:zlib.BUILD",
-        sha256 = "1cce3828ec2ba80ff8a4cac0ab5aa03756026517154c4b450e617ede751d41bd",
-        strip_prefix = "zlib-cacf7f1d4e3d44d871b605da3b647f07d718623f",
+        sha256 = "50b24b47bf19e1f35d2a21ff36d2a366638cdf958219a66f30ce0861201760e6",
+        strip_prefix = "zlib-1.3.1",
     )
 
     # proto_library, cc_proto_library, and java_proto_library rules implicitly
@@ -207,6 +207,7 @@ def register_sorbet_dependencies():
     )
 
     # optimized version of blake2 hashing algorithm
+    # TODO(jez) Add something to use the neon implementation on Apple Silicon
     http_archive(
         name = "com_github_blake2_libb2",
         urls = _github_public_urls("BLAKE2/libb2/archive/fa83ddbe179912e9a7a57edf0333b33f6ff83056.zip"),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are some problems relating to new Clang warnings which can be
fixed by upgrading the version of zlib. Doing that first before
upgrading the compiler (in a stacked change).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests