### PR TITLE
Upgrade to Clang 15

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,7 @@ common:test --test_env=GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1
 ##
 ##  Custom toolchain.
 ##
-build --crosstool_top=@llvm_toolchain_12_0_0//:toolchain --copt=-D_LIBCPP_ENABLE_NODISCARD
+build --crosstool_top=@llvm_toolchain_15_0_7//:toolchain --copt=-D_LIBCPP_ENABLE_NODISCARD
 
 ##
 ##  Common build options across all build configurations
@@ -44,8 +44,6 @@ build --host_cxxopt=-Wno-pass-failed # host build doesn't have enough optimizati
 # <command line>:1:9: and <built-in>:355:9: so sadly we turn them all off
 build --copt=-Wno-macro-redefined
 
-# Clang 12.0.0 has warnings when compiling LLVM 12.0.0 on C++20, sadly.
-# TODO(jez) When we upgrade to LLVM 13.0.0+ can we delete this?
 # TODO(jez) We will need these to build C++20, but emscripten doesn't even know about these options yet.
 # Leaving them commented out so we can uncomment them after upgrading emscripten.
 # build --host_cxxopt=-Wno-deprecated-anon-enum-enum-conversion
@@ -212,9 +210,9 @@ build:ubsan --define unsanitized=false
 build:ubsan --copt=-DHAS_SANITIZER
 
 # Bazel links C++ files with $CC, not $CXX, this breaks UBSan
-build:sanitize-linux --linkopt=external/llvm_toolchain_12_0_0/lib/clang/12.0.0/lib/linux/libclang_rt.asan_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain_12_0_0/lib/clang/12.0.0/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain_12_0_0/lib/clang/12.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_15_0_7/lib/clang/15.0.7/lib/linux/libclang_rt.asan_cxx-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_15_0_7/lib/clang/15.0.7/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_15_0_7/lib/clang/15.0.7/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
 build:sanitize-linux --config=sanitize
 
 build:sanitize-mac --config=sanitize
@@ -263,7 +261,7 @@ build:webasm --compilation_mode=opt
 build:webasm --copt=-DNDEBUG --linkopt=-DNDEBUG # for some reason emscripten doesn't pass those when -O2\-Oz are specified
 build:webasm --copt=--llvm-lto --copt=3 --linkopt=--llvm-lto --linkopt=3
 # Specify a "sane" C++ toolchain for the host platform.
-build:webasm --host_crosstool_top=@llvm_toolchain_12_0_0//:toolchain
+build:webasm --host_crosstool_top=@llvm_toolchain_15_0_7//:toolchain
 
 ##
 ## Stripe's ci passes --config=ci, we need it to exist

--- a/.bazelrc
+++ b/.bazelrc
@@ -80,7 +80,6 @@ build:dbg-linux --config=dbg --platforms=@//tools/platforms:linux_x86_64
 ##
 # release version: optimized, with debug symbols and version information
 build:release-common --define release=true
-build:release-common --define mimalloc=true
 build:release-common --compilation_mode=opt
 build:release-common --config=backtracesymbols
 build:release-common --config=static-libs
@@ -106,6 +105,15 @@ build:release-linux --config=lto-linux --config=release-common
 # Separate config for aarch64, so x86_64 can be differently optimized
 build:release-linux-aarch64 --linkopt=-Wl,-z,relro,-z,now
 build:release-linux-aarch64 --config=lto-linux --config=release-common
+
+# It would be nice to move this back to release-common, but there is a build
+# failure when using clang 15 on macOS to build GNU make via rules_foreign_cc:
+# <https://github.com/bazelbuild/rules_foreign_cc/issues/1186>
+# We only use rules_foreign_cc for mimalloc and we only use mimalloc in release
+# builds, so I'm moving this here until we can figure out a better workaround,
+# or a fix lands upstream.
+build:release-linux --define mimalloc=true
+build:release-linux-aarch64 --define mimalloc=true
 
 # This is to turn on vector instructions where available.
 # We used to do this unconditionally, but Rosetta 2 doesn't translate all vector instructions well.

--- a/.bazelrc
+++ b/.bazelrc
@@ -284,6 +284,9 @@ build:webasm-darwin --crosstool_top=//tools/toolchain/webasm-darwin --config=web
 build:webasm --cpu=webasm --spawn_strategy=local --genrule_strategy=local --copt=-Oz --linkopt=-Oz --copt=-DMDB_USE_ROBUST=0
 build:webasm --define release=true
 build:webasm --compilation_mode=opt
+# Some of our options are only available in newer versions of clang.
+# TODO(jez) Remove this when we upgrade emscripten to the same version of our clang toolchain
+build:webasm --copt=-Wno-unknown-warning-option
 build:webasm --copt=-DNDEBUG --linkopt=-DNDEBUG # for some reason emscripten doesn't pass those when -O2\-Oz are specified
 build:webasm --copt=--llvm-lto --copt=3 --linkopt=--llvm-lto --linkopt=3
 # Specify a "sane" C++ toolchain for the host platform.

--- a/.bazelrc
+++ b/.bazelrc
@@ -52,6 +52,10 @@ build --copt=-Wno-macro-redefined
 # build --cxxopt=-Wno-deprecated-enum-enum-conversion
 # build --cxxopt=-Wno-ambiguous-reversed-operator
 
+# TODO(jez) Something between Clang 12 and Clang 15 seems to have introduced a
+# warning saying _never_ use unqualified `std` calls...
+build --cxxopt=-Wno-unqualified-std-cast-call --host_cxxopt=-Wno-unqualified-std-cast-call
+
 ##
 ## debug configuration
 ##

--- a/.bazelrc
+++ b/.bazelrc
@@ -35,6 +35,20 @@ build --copt=-fstack-protector
 
 build --copt=-Werror --copt=-Wimplicit-fallthrough --copt=-Wmissing-field-initializers
 
+# This is to break a circular dependency. The version of absl we're using
+# suffers from some compiler builtins that have been deprecated. Upstream absl
+# includes patches that avoid those warnings, but upstream absl also requires a
+# version of emscripten that is newer than what we currently build with.
+# Because emscsripten is powered by clang, then upgrading emscripten amounts to
+# upgrading clang and we have a cycle.
+#
+# Rather than upgrade clang AND emscripten at once, I'm choosing to silence
+# these warnings for the time being. This should not affect Sorbet's code,
+# because we don't actually use compiler builtins and I can't see that changing
+# in the near future.
+# TODO(jez) Remove this when we upgrade absl to a more recent version
+build --copt=-Wno-deprecated-builtins
+
 build --host_copt=-O1
 build --host_copt=-DFORCE_DEBUG
 build --host_cxxopt=-Wno-unused-variable --host_cxxopt=-Wno-overloaded-virtual --host_cxxopt=-Wno-unused-const-variable # ragel violates those and we want a silent build

--- a/.bazelrc
+++ b/.bazelrc
@@ -222,9 +222,9 @@ build:ubsan --define unsanitized=false
 build:ubsan --copt=-DHAS_SANITIZER
 
 # Bazel links C++ files with $CC, not $CXX, this breaks UBSan
-build:sanitize-linux --linkopt=external/llvm_toolchain_15_0_7/lib/clang/15.0.7/lib/linux/libclang_rt.asan_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain_15_0_7/lib/clang/15.0.7/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain_15_0_7/lib/clang/15.0.7/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_15_0_7/lib/clang/15.0.7/lib/x86_64-unknown-linux-gnu/libclang_rt.asan_cxx.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_15_0_7/lib/clang/15.0.7/lib/x86_64-unknown-linux-gnu/libclang_rt.ubsan_standalone_cxx.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_15_0_7/lib/clang/15.0.7/lib/x86_64-unknown-linux-gnu/libclang_rt.ubsan_standalone.a
 build:sanitize-linux --config=sanitize
 
 build:sanitize-mac --config=sanitize

--- a/README.md
+++ b/README.md
@@ -1041,7 +1041,7 @@ You are encouraged to play around with various clang-based tools which use the
 
     After successfully compiling Sorbet, point your editor to use the
     `clangd` executable located in
-    `bazel-sorbet/external/llvm_toolchain_12_0_0/bin/clangd`.
+    `bazel-sorbet/external/llvm_toolchain_15_0_7/bin/clangd`.
 
 -   [clang-format] -- Clang-based source code formatter
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,14 +36,14 @@ bazel_toolchain_dependencies()
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
-    name = "llvm_toolchain_12_0_0",
+    name = "llvm_toolchain_15_0_7",
     absolute_paths = True,
     llvm_mirror_prefixes = [
         "https://sorbet-deps.s3-us-west-2.amazonaws.com/",
         "https://artifactory-content.stripe.build/artifactory/github-archives/llvm/llvm-project/releases/download/llvmorg-",
         "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     ],
-    llvm_version = "12.0.0",
+    llvm_version = "15.0.7",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -339,9 +339,11 @@ template <> inline const ExpressionPtr &ExpressionPtr::cast<ExpressionPtr>(const
     return tree;
 }
 
-#define EXPRESSION(name)                                                                  \
-    class name;                                                                           \
-    template <> struct ExpressionToTag<name> { static constexpr Tag value = Tag::name; }; \
+#define EXPRESSION(name)                        \
+    class name;                                 \
+    template <> struct ExpressionToTag<name> {  \
+        static constexpr Tag value = Tag::name; \
+    };                                          \
     class __attribute__((aligned(8))) name final
 
 EXPRESSION(ClassDef) {

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -361,7 +361,7 @@ string BasicBlock::toString(const core::GlobalState &gs, const CFG &cfg) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "block[id={}, rubyRegionId={}]({})\n", this->id, this->rubyRegionId,
                    fmt::map_join(
-                       this->args, ", ", [&](const auto &arg) -> auto { return arg.toString(gs, cfg); }));
+                       this->args, ", ", [&](const auto &arg) -> auto{ return arg.toString(gs, cfg); }));
 
     if (this->outerLoops > 0) {
         fmt::format_to(std::back_inserter(buf), "outerLoops: {}\n", this->outerLoops);
@@ -378,7 +378,7 @@ string BasicBlock::toTextualString(const core::GlobalState &gs, const CFG &cfg) 
     fmt::format_to(std::back_inserter(buf), "bb{}[rubyRegionId={}, firstDead={}]({}):\n", this->id, this->rubyRegionId,
                    this->firstDeadInstructionIdx,
                    fmt::map_join(
-                       this->args, ", ", [&](const auto &arg) -> auto { return arg.toString(gs, cfg); }));
+                       this->args, ", ", [&](const auto &arg) -> auto{ return arg.toString(gs, cfg); }));
 
     if (this->outerLoops > 0) {
         fmt::format_to(std::back_inserter(buf), "    # outerLoops: {}\n", this->outerLoops);
@@ -410,7 +410,7 @@ string BasicBlock::showRaw(const core::GlobalState &gs, const CFG &cfg) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "block[id={}]({})\n", this->id,
                    fmt::map_join(
-                       this->args, ", ", [&](const auto &arg) -> auto { return arg.showRaw(gs, cfg); }));
+                       this->args, ", ", [&](const auto &arg) -> auto{ return arg.showRaw(gs, cfg); }));
 
     if (this->outerLoops > 0) {
         fmt::format_to(std::back_inserter(buf), "outerLoops: {}\n", this->outerLoops);

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -66,9 +66,11 @@ private:
     friend InstructionPtr;
 };
 
-#define INSN(name)                                                                  \
-    class name;                                                                     \
-    template <> struct InsnToTag<name> { static constexpr Tag value = Tag::name; }; \
+#define INSN(name)                              \
+    class name;                                 \
+    template <> struct InsnToTag<name> {        \
+        static constexpr Tag value = Tag::name; \
+    };                                          \
     class __attribute__((aligned(8))) name final
 
 INSN(Ident) : public Instruction {

--- a/common/counters/Counters.cc
+++ b/common/counters/Counters.cc
@@ -424,7 +424,7 @@ string getCounterStatistics() {
 
         fmt::format_to(std::back_inserter(buf), "{}",
                        fmt::map_join(
-                           sortedTimings, "", [](const auto &el) -> auto { return el.second; }));
+                           sortedTimings, "", [](const auto &el) -> auto{ return el.second; }));
     }
 
     {
@@ -440,7 +440,7 @@ string getCounterStatistics() {
 
         fmt::format_to(std::back_inserter(buf), "{}",
                        fmt::map_join(
-                           sortedOther, "", [](const auto &el) -> auto { return el.second; }));
+                           sortedOther, "", [](const auto &el) -> auto{ return el.second; }));
     }
     return to_string(buf);
 }

--- a/common/has_member.h
+++ b/common/has_member.h
@@ -23,9 +23,7 @@ template <class> struct sfinae_true : std::true_type {};
     template <class T>                                                                                 \
     static constexpr auto __has_##name(int)->sfinae_true<decltype(std::declval<T>().name(arg_types))>; \
     template <class> static constexpr auto __has_##name(long)->std::false_type;                        \
-    template <class T> static constexpr bool HAS_MEMBER_##name() {                                     \
-        return decltype(__has_##name<T>(0)){};                                                         \
-    }
+    template <class T> static constexpr bool HAS_MEMBER_##name() { return decltype(__has_##name<T>(0)){}; }
 
 /**
  * Given a method name, a default statement to run, and a list of argument types, do the following:
@@ -39,27 +37,25 @@ template <class> struct sfinae_true : std::true_type {};
  * CALL_MEMBER_toString<core::NameRef>::call(name, gs); // calls name.toString(gs)
  * CALL_MEMBER_toString<int>::call(10, gs); // returns ""
  */
-#define GENERATE_CALL_MEMBER(method_name, default_behavior, arg_types...)              \
-    GENERATE_HAS_MEMBER(method_name, arg_types)                                        \
-    template <typename T, bool has> class CALL_MEMBER_impl_##method_name {             \
-    public:                                                                            \
-        template <class... Args> static decltype(auto) call(T &self, Args &&...args) { \
-            Exception::raise("should never be called");                                \
-        };                                                                             \
-    };                                                                                 \
-    template <typename T> class CALL_MEMBER_impl_##method_name<T, true> {              \
-    public:                                                                            \
-        template <class... Args> static decltype(auto) call(T &self, Args &&...args) { \
-            return self.method_name(std::forward<Args>(args)...);                      \
-        };                                                                             \
-    };                                                                                 \
-    template <typename T> class CALL_MEMBER_impl_##method_name<T, false> {             \
-    public:                                                                            \
-        template <class... Args> static decltype(auto) call(T &self, Args &&...args) { \
-            default_behavior;                                                          \
-        };                                                                             \
-    };                                                                                 \
-    template <typename T>                                                              \
+#define GENERATE_CALL_MEMBER(method_name, default_behavior, arg_types...)                                   \
+    GENERATE_HAS_MEMBER(method_name, arg_types)                                                             \
+    template <typename T, bool has> class CALL_MEMBER_impl_##method_name {                                  \
+    public:                                                                                                 \
+        template <class... Args> static decltype(auto) call(T &self, Args &&...args) {                      \
+            Exception::raise("should never be called");                                                     \
+        };                                                                                                  \
+    };                                                                                                      \
+    template <typename T> class CALL_MEMBER_impl_##method_name<T, true> {                                   \
+    public:                                                                                                 \
+        template <class... Args> static decltype(auto) call(T &self, Args &&...args) {                      \
+            return self.method_name(std::forward<Args>(args)...);                                           \
+        };                                                                                                  \
+    };                                                                                                      \
+    template <typename T> class CALL_MEMBER_impl_##method_name<T, false> {                                  \
+    public:                                                                                                 \
+        template <class... Args> static decltype(auto) call(T &self, Args &&...args) { default_behavior; }; \
+    };                                                                                                      \
+    template <typename T>                                                                                   \
     class CALL_MEMBER_##method_name : public CALL_MEMBER_impl_##method_name<T, HAS_MEMBER_##method_name<T>()> {};
 
 } // namespace sorbet

--- a/common/typecase.h
+++ b/common/typecase.h
@@ -14,9 +14,15 @@ namespace sorbet {
 
 // Begin ecatmur's code
 template <typename T> struct remove_class {};
-template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...)> { using type = R(A...); };
-template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...) const> { using type = R(A...); };
-template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...) volatile> { using type = R(A...); };
+template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...)> {
+    using type = R(A...);
+};
+template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...) const> {
+    using type = R(A...);
+};
+template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...) volatile> {
+    using type = R(A...);
+};
 template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...) const volatile> {
     using type = R(A...);
 };
@@ -24,9 +30,15 @@ template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A.
 template <typename T> struct get_signature_impl {
     using type = typename remove_class<decltype(&std::remove_reference<T>::type::operator())>::type;
 };
-template <typename R, typename... A> struct get_signature_impl<R(A...)> { using type = R(A...); };
-template <typename R, typename... A> struct get_signature_impl<R (&)(A...)> { using type = R(A...); };
-template <typename R, typename... A> struct get_signature_impl<R (*)(A...)> { using type = R(A...); };
+template <typename R, typename... A> struct get_signature_impl<R(A...)> {
+    using type = R(A...);
+};
+template <typename R, typename... A> struct get_signature_impl<R (&)(A...)> {
+    using type = R(A...);
+};
+template <typename R, typename... A> struct get_signature_impl<R (*)(A...)> {
+    using type = R(A...);
+};
 template <typename T> using get_signature = typename get_signature_impl<T>::type;
 // End ecatmur's code
 

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -265,7 +265,7 @@ string TypeConstraint::toString(const core::GlobalState &gs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "bounds: [{}]\n",
                    fmt::map_join(
-                       collated.begin(), collated.end(), ", ", [&gs](auto entry) -> auto {
+                       collated.begin(), collated.end(), ", ", [&gs](auto entry) -> auto{
                            const auto &[sym, bounds] = entry;
                            const auto &[lowerBound, upperBound] = bounds;
                            auto lower = lowerBound != nullptr ? lowerBound.show(gs) : "_";
@@ -274,7 +274,7 @@ string TypeConstraint::toString(const core::GlobalState &gs) const {
                        }));
     fmt::format_to(std::back_inserter(buf), "solution: [{}]\n",
                    fmt::map_join(
-                       this->solution.begin(), this->solution.end(), ", ", [&gs](auto pair) -> auto {
+                       this->solution.begin(), this->solution.end(), ", ", [&gs](auto pair) -> auto{
                            return fmt::format("{}: {}", pair.first.show(gs), pair.second.show(gs));
                        }));
     return to_string(buf);

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -71,8 +71,12 @@ public:
 
     // A mapping from type to the type returned by `cast_type_nonnull`.
     template <typename T, bool isInlined> struct TypeToCastType {};
-    template <typename T> struct TypeToCastType<T, true> { using type = T; };
-    template <typename T> struct TypeToCastType<T, false> { using type = const T &; };
+    template <typename T> struct TypeToCastType<T, true> {
+        using type = T;
+    };
+    template <typename T> struct TypeToCastType<T, false> {
+        using type = const T &;
+    };
 
     // Required for typecase.
     template <class To> static bool isa(const TypePtr &what);

--- a/core/Types.h
+++ b/core/Types.h
@@ -356,16 +356,22 @@ template <> inline bool TypePtr::isa<TypePtr>(const TypePtr &what) {
 }
 
 // Required to support cast<TypePtr> specialization.
-template <> struct TypePtr::TypeToIsInlined<TypePtr> { static constexpr bool value = false; };
+template <> struct TypePtr::TypeToIsInlined<TypePtr> {
+    static constexpr bool value = false;
+};
 
 template <> inline TypePtr const &TypePtr::cast<TypePtr>(const TypePtr &what) {
     return what;
 }
 
-#define TYPE_IMPL(name, isInlined)                                                                             \
-    class name;                                                                                                \
-    template <> struct TypePtr::TypeToTag<name> { static constexpr TypePtr::Tag value = TypePtr::Tag::name; }; \
-    template <> struct TypePtr::TypeToIsInlined<name> { static constexpr bool value = isInlined; };            \
+#define TYPE_IMPL(name, isInlined)                                \
+    class name;                                                   \
+    template <> struct TypePtr::TypeToTag<name> {                 \
+        static constexpr TypePtr::Tag value = TypePtr::Tag::name; \
+    };                                                            \
+    template <> struct TypePtr::TypeToIsInlined<name> {           \
+        static constexpr bool value = isInlined;                  \
+    };                                                            \
     class __attribute__((aligned(8))) name
 
 #define TYPE(name) TYPE_IMPL(name, false)

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -462,7 +462,7 @@ string AppliedType::show(const GlobalState &gs, ShowOptions options) const {
             int arg_num = 0;
             fmt::format_to(std::back_inserter(buf), "{}",
                            fmt::map_join(
-                               targs_it, this->targs.end(), ", ", [&](auto targ) -> auto {
+                               targs_it, this->targs.end(), ", ", [&](auto targ) -> auto{
                                    return fmt::format("arg{}: {}", arg_num++, targ.show(gs, options));
                                }));
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -629,14 +629,12 @@ InlinedVector<TypeMemberRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, 
         for (auto originalTp : asIf.data(gs)->typeMembers()) {
             auto name = originalTp.data(gs)->name;
             SymbolRef align;
-            int i = 0;
             for (auto x : what.data(gs)->typeMembers()) {
                 if (x.data(gs)->name == name) {
                     align = x;
                     currentAlignment.emplace_back(x);
                     break;
                 }
-                i++;
             }
             if (!align.exists()) {
                 currentAlignment.emplace_back(Symbols::noTypeMember());

--- a/docs/build-llvm.md
+++ b/docs/build-llvm.md
@@ -1,0 +1,79 @@
+# Building an LLVM release
+
+Useful links:
+
+- <https://www.llvm.org/docs/ReleaseProcess.html>
+- <https://github.com/llvm/llvm-project/issues/53892>
+- <https://github.com/llvm/llvm-project/issues/64703>
+
+Commands I've run in the past:
+
+```bash
+pay ssh
+sudo apt-get install -y autoconf build-essential cmake parallel mc chrpath ninja
+
+# This builds LLVM with the GCC toolchain that's on the box
+# (It seems like it actually bootstraps it.)
+llvm/utils/release/test-release.sh \
+  -no-test-suite \
+  -no-compare-files \
+  -release 15.0.7 \
+  -final \
+  -triple x86_64-linux-gnu-ubuntu-20.04 \
+  -j 16 \
+  -use-ninja \
+  -lldb
+```
+
+The release tarball is at `final/*.tar.xz`.
+
+The build took over 2 hours to create on a devbox (I just know that the first
+attempt failed at the 2 hour mark--I didn't get the full runtime for the time it
+passed).
+
+It also ran the tests at the end (I thought that the `-no-test-suite` flag would
+have turned that off), which added another half hour to the runtime. The test
+results looked like this:
+
+```
+Testing Time: 1936.77s
+  Skipped          :    46
+  Unsupported      :  4791
+  Passed           : 99647
+  Expectedly Failed:   303
+  Timed Out        :    18
+  Failed           :    28
+FAILED: CMakeFiles/check-all
+```
+
+Having a 99.95% pass rate was good enough for me.
+
+## Tinkering with these releases
+
+The easiest way to trick bazel into using this tarball is to put the tarball in
+a folder, serve that folder with `python -m http.server`, and then update the
+`llvm_mirror_prefixes` variable in the `WORKSPACE` so that it hits the localhost
+mirror first.
+
+## Publishing these releases
+
+To make these archives available to Sorbet when building in Buildkite CI and in
+Stripe's CI environment, we store the archives in S3.
+
+I always use the AWS console for this. There are instructions for how to log in
+at <http://go/types/elastic-ci>. From there, you'll have to
+
+- Make a new folder with the LLVM version number
+- Upload any archives you built
+- Set the "Everyone (public access)"
+  (http://acs.amazonaws.com/groups/global/AllUsers) ACL to **Read**, so that
+  Buildkite can access it.
+  - To do this, you'll have to temporarily change the [Block Public Access
+    settings for this
+    account](https://us-west-2.console.aws.amazon.com/s3/settings?region=us-west-2&bucketType=general)
+    for the Sorbet S3 account.
+  - Be sure to flip this back to off when you're done.
+
+It may be useful to use an `aws s3 cp`
+invocation for this. If you do that, feel free to update this doc with what
+command you used.

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -158,10 +158,8 @@ MsgpackWriter::MsgpackWriter(int version)
     : version(assertValidVersion(version)), refAttrs(refAttrMap.at(version)), defAttrs(defAttrMap.at(version)) {}
 
 void writeSymbols(core::Context ctx, mpack_writer_t *writer, const vector<core::NameRef> &symbols) {
-    int i = -1;
     mpack_start_array(writer, symbols.size());
     for (auto sym : symbols) {
-        ++i;
         auto str = sym.shortName(ctx);
         packString(writer, str);
     }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -572,10 +572,8 @@ void LSPTypechecker::commitFileUpdates(LSPFileUpdates &updates, bool couldBeCanc
         indexedFinalGS.clear();
     }
 
-    int i = -1;
     ENFORCE(updates.updatedFileIndexes.size() == updates.updatedFiles.size());
     for (auto &ast : updates.updatedFileIndexes) {
-        i++;
         const int id = ast.file.id();
         if (id >= indexed.size()) {
             indexed.resize(id + 1);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -289,10 +289,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
 
     fmt::format_to(std::back_inserter(all_prints), "Print: [{}]",
                    fmt::map_join(
-                       print_options, ", ", [](const auto &pr) -> auto { return pr.option; }));
+                       print_options, ", ", [](const auto &pr) -> auto{ return pr.option; }));
     fmt::format_to(std::back_inserter(all_stop_after), "Stop After: [{}]",
                    fmt::map_join(
-                       stop_after_options, ", ", [](const auto &pr) -> auto { return pr.option; }));
+                       stop_after_options, ", ", [](const auto &pr) -> auto{ return pr.option; }));
 
     // Advanced options
     options.add_options("advanced")("dir", "Input directory", cxxopts::value<vector<string>>());

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1138,7 +1138,6 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const 
                                 core::FileRef file = job.file;
                                 try {
                                     core::Context ctx(gs, core::Symbols::root(), file);
-                                    auto file = job.file;
                                     typecheckOne(ctx, move(job), opts, intentionallyLeakASTs);
                                 } catch (SorbetException &) {
                                     Exception::failInFuzzer();

--- a/parser/parser/BUILD
+++ b/parser/parser/BUILD
@@ -104,6 +104,7 @@ cc_library(
     hdrs = glob(["include/**/*.hh"]),
     copts = [
         "-Wno-unused-const-variable",
+        "-Wno-unused-but-set-variable",
     ] + select({
         # What we really want here is to say "it's never ok to use -Os, because
         # that will take 2+ minutes to compile." We have to do this to override

--- a/test/cli/test_one.sh
+++ b/test/cli/test_one.sh
@@ -2,7 +2,7 @@
 script="$1"
 expect="$2"
 
-export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_12_0_0/bin/llvm-symbolizer
+export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_15_0_7/bin/llvm-symbolizer
 
 if ! diff "$expect" -u <("$script"); then
   cat <<EOF

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -13,7 +13,7 @@ def dropExtension(p):
     return p.partition(".")[0]
 
 _TEST_SCRIPT = """#!/usr/bin/env bash
-export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_12_0_0/bin/llvm-symbolizer
+export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_15_0_7/bin/llvm-symbolizer
 set -x
 exec {runner} --single_test="{test}"
 """

--- a/third_party/abseil_cpp/low_level_hash_array_parameter.patch
+++ b/third_party/abseil_cpp/low_level_hash_array_parameter.patch
@@ -1,0 +1,13 @@
+diff --git a/absl/hash/internal/low_level_hash.cc b/absl/hash/internal/low_level_hash.cc
+index 6f9cb9c7bff..d288f3ec94d 100644
+--- a/absl/hash/internal/low_level_hash.cc
++++ b/absl/hash/internal/low_level_hash.cc
+@@ -40,7 +40,7 @@ static uint64_t Mix(uint64_t v0, uint64_t v1) {
+ }
+ 
+ uint64_t LowLevelHash(const void* data, size_t len, uint64_t seed,
+-                      const uint64_t salt[]) {
++                      const uint64_t salt[5]) {
+   const uint8_t* ptr = static_cast<const uint8_t*>(data);
+   uint64_t starting_length = static_cast<uint64_t>(len);
+   uint64_t current_state = seed ^ salt[0];

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -162,6 +162,12 @@ def register_sorbet_dependencies():
         urls = _github_public_urls("abseil/abseil-cpp/archive/8910297baf87e1777c4fd30fb0693eecf9f2c134.zip"),
         sha256 = "c43b8cd8e306e7fe3f006d880181d60db59a3bae6b6bc725da86a28a6b0f9f30",
         strip_prefix = "abseil-cpp-8910297baf87e1777c4fd30fb0693eecf9f2c134",
+        patches = [
+            # https://github.com/abseil/abseil-cpp/commit/d2422b19e9ba41c952db1ed5514bb68114c2be15
+            # Abseil builds with `-Wall` which we can't override to silence this warning.
+            "@com_stripe_ruby_typer//third_party:abseil_cpp/low_level_hash_array_parameter.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
     http_archive(

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -181,9 +181,9 @@ def register_sorbet_dependencies():
     # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("sorbet/bazel-toolchain/archive/ec7f3bcee2a71daf07a6c8876b701d7622044744.zip"),
-        sha256 = "09b4fd4a586d952afe83dca68d1e333a0f0512ea861c12e27596f6f948587a5f",
-        strip_prefix = "bazel-toolchain-ec7f3bcee2a71daf07a6c8876b701d7622044744",
+        urls = _github_public_urls("sorbet/bazel-toolchain/archive/c2715fcb7ec7fc574eac501007b29277f316099f.zip"),
+        sha256 = "1fee34a3f4123b2ec60d2c81d4805e16e47c7f95b31259272274430a45d4f3da",
+        strip_prefix = "bazel-toolchain-c2715fcb7ec7fc574eac501007b29277f316099f",
     )
 
     http_archive(

--- a/third_party/lmdb.BUILD
+++ b/third_party/lmdb.BUILD
@@ -10,7 +10,10 @@ cc_library(
         "libraries/liblmdb/lmdb.h",
         "libraries/liblmdb/midl.h",
     ],
-    copts = ["-Wno-implicit-fallthrough"],
+    copts = [
+        "-Wno-implicit-fallthrough",
+        "-Wno-unused-but-set-variable",
+    ],
     includes = [
         "libraries/liblmdb/",
     ],

--- a/tools/clang.bzl
+++ b/tools/clang.bzl
@@ -30,6 +30,6 @@ _clang_tool = rule(
 def clang_tool(name):
     _clang_tool(
         name = name,
-        tool = "@llvm_toolchain_12_0_0//:bin/" + name,
+        tool = "@llvm_toolchain_15_0_7//:bin/" + name,
         visibility = ["//visibility:public"],
     )

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -28,7 +28,7 @@ echo "building $target"
 ./bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 # we want the bazel build command to run before this check so that bazel can download itself.
-export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_12_0_0/bin"
+export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_15_0_7/bin"
 if ! command -v llvm-symbolizer >/dev/null; then
   echo "fatal: command not found: llvm-symbolizer"
   exit 1

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -72,7 +72,7 @@ handle_TERM() {
 trap handle_INT SIGINT
 trap handle_TERM SIGTERM
 
-export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_12_0_0/bin"
+export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_15_0_7/bin"
 if ! command -v llvm-symbolizer >/dev/null; then
   echo "fatal: command not found: llvm-symbolizer"
   exit 1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- It's nice to be on more recent versions of our compiler.
  In particular, it looks like it might have fixed a bug which means that
  `ClassOrModule` is now 8 bytes smaller.

- This will get us closer to being able to use the upstream
  `bazel-contrib/toolchains_llvm` instead of our custom fork of
  `grailbio/bazel-toolchain`. In particular, there seems to be something about
  the way that the upstream invokes the linker such that our trick to get builds
  working on macOS Sonoma again (bf58b6293) does not work anymore.

  Our current hypothesis for how to work around that is to switch away from
  using `/usr/bin/ld` to link and instead to using the `lld.ld` from the LLVM
  toolchain, which we think will give us a better ability to statically link
  against `libc++` on macOS (despite the OS's best effort to make that not
  possible).

- Upgrading `toolchains_llvm` is important because starting in Bazel 7 the
  option `--incompatible_enable_cc_toolchain_resolution` will switch to
  being on by default, and Sorbet's fork of bazel-toolchain uses the old
  version. Also the upstream `bazel-contrib/toolchains_llvm` has better support
  for building on Apple Silicon.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests

I also plan to do some manual testing.