### PR TITLE
Report more "unexpected bare value" errors

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -982,13 +982,12 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
             unwrappedElems.emplace_back(unwrapType(gs, loc, elem));
         }
         return make_type<TupleType>(move(unwrappedElems));
-    } else if (isa_type<NamedLiteralType>(tp) || isa_type<IntegerLiteralType>(tp) || isa_type<FloatLiteralType>(tp)) {
-        if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
-            e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
-        }
-        return Types::untypedUntracked();
     }
-    return tp;
+
+    if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
+        e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
+    }
+    return Types::untypedUntracked();
 }
 
 // This method is actually special: not only is it called from dispatchCall in calls.cc, it's

--- a/test/testdata/infer/generics/unwrap_type.rb
+++ b/test/testdata/infer/generics/unwrap_type.rb
@@ -1,0 +1,51 @@
+# typed: true
+
+class A
+  extend T::Sig
+  sig do
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U))
+      .void
+  end
+  def f1(x)
+    T.reveal_type(x) # error: `T.type_parameter(:U) (of A#f1)`
+
+    type = T::Array[x]
+    T.reveal_type(type) # error: `Runtime object representing type: T::Array[T.type_parameter(:U) (of A#f1)]`
+
+    type = T.class_of(x)
+    T.reveal_type(type) # error: `T.untyped`
+
+    type = T.any(x, x)
+    T.reveal_type(type) # error: `Runtime object representing type: T.type_parameter(:U) (of A#f1)`
+
+    type = T.all(x, x)
+    T.reveal_type(type) # error: `Runtime object representing type: T.type_parameter(:U) (of A#f1)`
+
+    type = T.nilable(x)
+    T.reveal_type(type) # error: `Runtime object representing type: T.nilable(T.type_parameter(:U) (of A#f1))`
+
+    type = T.proc.params(arg0: x).void
+    T.reveal_type(type) # error: `Runtime object representing type: T.proc.params(arg0: T.type_parameter(:U) (of A#f1)).void`
+
+    type = T.proc.returns(x)
+    T.reveal_type(type) # error: `Runtime object representing type: T.proc.returns(T.type_parameter(:U) (of A#f1))`
+  end
+
+  sig do
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U))
+      .void
+  end
+  def f2(x)
+    T.reveal_type(x) # error: `T.type_parameter(:U) (of A#f2)`
+    f = T.let(
+      -> (x) {
+        T.reveal_type(x) # error: `T.type_parameter(:U) (of A#f2)`
+      },
+      T.proc.params(arg0: x).void
+      #                   ^ error: Unsupported type syntax
+    )
+    T.reveal_type(f) # error: `T.proc.params(arg0: T.untyped).void`
+  end
+end

--- a/test/testdata/infer/generics/unwrap_type.rb
+++ b/test/testdata/infer/generics/unwrap_type.rb
@@ -58,4 +58,16 @@ class A
     )
     T.reveal_type(f) # error: `T.proc.params(arg0: T.untyped).void`
   end
+
+  sig do
+    type_parameters(:U)
+      .params(type: T::Types::Base)
+      .void
+  end
+  def f3(type)
+    T.nilable(type)
+    #         ^^^^ error: Unexpected bare `T::Types::Base` value found in type position
+    T.nilable(T.unsafe(type))
+  end
 end
+

--- a/test/testdata/infer/generics/unwrap_type.rb
+++ b/test/testdata/infer/generics/unwrap_type.rb
@@ -11,25 +11,34 @@ class A
     T.reveal_type(x) # error: `T.type_parameter(:U) (of A#f1)`
 
     type = T::Array[x]
-    T.reveal_type(type) # error: `Runtime object representing type: T::Array[T.type_parameter(:U) (of A#f1)]`
+    #               ^ error: Unexpected bare `T.type_parameter(:U) (of A#f1)` value found in type position
+    T.reveal_type(type) # error: `Runtime object representing type: T::Array[T.untyped]`
 
     type = T.class_of(x)
-    T.reveal_type(type) # error: `T.untyped`
+    #                 ^ error: Unexpected bare `T.type_parameter(:U) (of A#f1)` value found in type position
+    T.reveal_type(type) # error: `Runtime object representing type: T.untyped`
 
     type = T.any(x, x)
-    T.reveal_type(type) # error: `Runtime object representing type: T.type_parameter(:U) (of A#f1)`
+    #            ^ error: Unexpected bare `T.type_parameter(:U) (of A#f1)` value found in type position
+    #               ^ error: Unexpected bare `T.type_parameter(:U) (of A#f1)` value found in type position
+    T.reveal_type(type) # error: `Runtime object representing type: T.untyped`
 
     type = T.all(x, x)
-    T.reveal_type(type) # error: `Runtime object representing type: T.type_parameter(:U) (of A#f1)`
+    #            ^ error: Unexpected bare `T.type_parameter(:U) (of A#f1)` value found in type position
+    #               ^ error: Unexpected bare `T.type_parameter(:U) (of A#f1)` value found in type position
+    T.reveal_type(type) # error: `Runtime object representing type: T.untyped`
 
     type = T.nilable(x)
-    T.reveal_type(type) # error: `Runtime object representing type: T.nilable(T.type_parameter(:U) (of A#f1))`
+    #                ^ error: Unexpected bare `T.type_parameter(:U) (of A#f1)` value found in type position
+    T.reveal_type(type) # error: `Runtime object representing type: T.untyped`
 
     type = T.proc.params(arg0: x).void
-    T.reveal_type(type) # error: `Runtime object representing type: T.proc.params(arg0: T.type_parameter(:U) (of A#f1)).void`
+    #                          ^ error: Unexpected bare `T.type_parameter(:U) (of A#f1)` value found in type position
+    T.reveal_type(type) # error: `Runtime object representing type: T.proc.params(arg0: T.untyped).void`
 
     type = T.proc.returns(x)
-    T.reveal_type(type) # error: `Runtime object representing type: T.proc.returns(T.type_parameter(:U) (of A#f1))`
+    #                     ^ error: Unexpected bare `T.type_parameter(:U) (of A#f1)` value found in type position
+    T.reveal_type(type) # error: `Runtime object representing type: T.proc.returns(T.untyped)`
   end
 
   sig do
@@ -41,10 +50,11 @@ class A
     T.reveal_type(x) # error: `T.type_parameter(:U) (of A#f2)`
     f = T.let(
       -> (x) {
-        T.reveal_type(x) # error: `T.type_parameter(:U) (of A#f2)`
+        T.reveal_type(x) # error: `T.untyped`
       },
       T.proc.params(arg0: x).void
       #                   ^ error: Unsupported type syntax
+      #                   ^ error: Unexpected bare `T.type_parameter(:U) (of A#f2)` value found in type position
     )
     T.reveal_type(f) # error: `T.proc.params(arg0: T.untyped).void`
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

While helping a user attempt to write some code today, I noticed that they had
this in their code and it did the right thing statically but only worked at
runtime because generics are erased (`T::Array[x]`). Had they attempted to do
something similar with `T.class_of` or `T.any` or something else, it would not
have done the thing they hoped it would have.

Ideally an even better error message would include something like an autocorrect
like "Did you meant to explicitly annotate this value's type here?" and offer to
replace `x` in the test with `T.type_parameter(:U)`, or whatever the type of `x`
is. That isn't always going to be the right suggestion, but it will at least get
the user closer to understanding what the problem is.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.