### PR TITLE
Upgrade @platforms repo

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -6,9 +6,8 @@ load("//third_party/openssl:system_openssl_repository.bzl", "system_openssl_repo
 def register_sorbet_dependencies():
     http_archive(
         name = "platforms",
-        urls = _github_public_urls("bazelbuild/platforms/archive/d4c9d7f51a7c403814b60f66d20eeb425fbaaacb.zip"),
-        sha256 = "a5058ac93023092c406432ec650f30ec5a8c75d8b9d13c73150f60a9050a5663",
-        strip_prefix = "platforms-d4c9d7f51a7c403814b60f66d20eeb425fbaaacb",
+        urls = _github_public_urls("bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz"),
+        sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is required to switch to using emsdk's bazel toolchain, which is blocking
the clang 15 upgrade.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests