### PR TITLE
Update `Pathname#rmtree` signature

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -1181,9 +1181,15 @@ class Pathname < Object
   # Recursively deletes a directory, including all directories beneath it.
   #
   # See
-  # [`FileUtils.rm_r`](https://docs.ruby-lang.org/en/2.7.0/FileUtils.html#method-c-rm_r)
-  sig {returns(Integer)}
-  def rmtree(); end
+  # [`FileUtils.rm_rf`](https://docs.ruby-lang.org/en/2.7.0/FileUtils.html#method-c-rm_rf)
+  sig do
+    params(
+      noop: T.nilable(T::Boolean),
+      verbose: T.nilable(T::Boolean),
+      secure: T.nilable(T::Boolean)
+    ).void
+  end
+  def rmtree(noop: nil, verbose: nil, secure: nil); end
 
   # Predicate method for root directories. Returns `true` if the pathname
   # consists of consecutive slashes.


### PR DESCRIPTION
### Motivation
`Pathname#rmtree` accepts new keyword arguments since Ruby 3.2: https://github.com/ruby/ruby/commit/c83ec3aba72aeb50df3b3188b6a009e93f11494a

### Test plan
N/A