### PR TITLE
Allow explicit nil to be serialized by enums

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -273,8 +273,11 @@ class T::Enum
 
   ### Private implementation ###
 
+  UNSET = T.let(Module.new.freeze, Module)
+  private_constant :UNSET
+
   sig {params(serialized_val: SerializedVal).void}
-  def initialize(serialized_val=nil)
+  def initialize(serialized_val=UNSET)
     raise 'T::Enum is abstract' if self.class == T::Enum
     if !self.class.started_initializing?
       raise "Must instantiate all enum values of #{self.class} inside 'enums do'."
@@ -300,7 +303,7 @@ class T::Enum
   sig {params(const_name: Symbol).void}
   def _bind_name(const_name)
     @const_name = const_name
-    @serialized_val = const_to_serialized_val(const_name) if @serialized_val.nil?
+    @serialized_val = const_to_serialized_val(const_name) if @serialized_val.equal?(UNSET)
     freeze
   end
 

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -19,6 +19,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
       SPADE = new('_spade_')
       DIAMOND = new('_diamond_')
       HEART = new('_heart_')
+      NONE = new(nil)
     end
   end
 
@@ -38,6 +39,7 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
         assert_equal('_spade_', CardSuitCustom::SPADE.serialize)
         assert_equal('_diamond_', CardSuitCustom::DIAMOND.serialize)
         assert_equal('_heart_', CardSuitCustom::HEART.serialize)
+        assert_equal(nil, CardSuitCustom::NONE.serialize)
       end
     end
   end
@@ -361,10 +363,11 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
           enums do
             new('foo')
             new
+            new(nil)
           end
         end
       end
-      assert_equal('Enum values must be assigned to constants: ["foo", nil]', ex.message)
+      assert_equal('Enum values must be assigned to constants: ["foo", T::Enum::UNSET, nil]', ex.message)
     end
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This commit uses an `UNSET` constant as the default `serialized_val` on `T::Enum`. This allows the runtime to understand the difference between an explicit `nil` and an unset default when serializing enum values. Sorbet already understands statically that a serialized value can be of type `NilClass`, but the runtime was serializing as a string representation based on the constant name instead.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #7702.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
