### PR TITLE
Tweak TypeVar::_approximate to consult other bound

### DIFF
--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -54,6 +54,11 @@ TypePtr TypeVar::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
                 if (bound.isFullyDefined()) {
                     return bound;
                 }
+            } else if (tc.hasLowerBound(sym)) {
+                auto bound = tc.findLowerBound(sym);
+                if (bound.isFullyDefined()) {
+                    return bound;
+                }
             }
             break;
         }
@@ -62,6 +67,11 @@ TypePtr TypeVar::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
                 auto bound = tc.findLowerBound(sym);
                 // TODO(jez) Need to check for isBottom?
                 // if (bound.isFullyDefined() && !bound.isBottom()) {
+                if (bound.isFullyDefined()) {
+                    return bound;
+                }
+            } else if (tc.hasUpperBound(sym)) {
+                auto bound = tc.findUpperBound(sym);
                 if (bound.isFullyDefined()) {
                     return bound;
                 }

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -56,7 +56,7 @@ TypePtr TypeVar::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
                 }
             } else if (tc.hasLowerBound(sym)) {
                 auto bound = tc.findLowerBound(sym);
-                if (bound.isFullyDefined()) {
+                if (bound.isFullyDefined() && !bound.isBottom()) {
                     return bound;
                 }
             }
@@ -65,8 +65,6 @@ TypePtr TypeVar::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
         case core::Polarity::Negative: {
             if (tc.hasLowerBound(sym)) {
                 auto bound = tc.findLowerBound(sym);
-                // TODO(jez) Need to check for isBottom?
-                // if (bound.isFullyDefined() && !bound.isBottom()) {
                 if (bound.isFullyDefined()) {
                     return bound;
                 }

--- a/test/testdata/infer/generics/type_var_positive_polarity_lower_bound.rb
+++ b/test/testdata/infer/generics/type_var_positive_polarity_lower_bound.rb
@@ -1,0 +1,75 @@
+# typed: true
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(
+      x: T.type_parameter(:U),
+      blk: T.proc.returns(T.type_parameter(:U))
+    )
+      .returns(T.type_parameter(:U))
+end
+def example(x, &blk)
+  if [true, false].sample
+    return x
+  else
+    return blk.call
+  end
+end
+
+f = T.let(->() { 0 }, T.proc.returns(Integer))
+res = example('', &f)
+T.reveal_type(res) # error: `T.any(String, Integer)`
+
+
+# --- more complicated example ---
+
+sig do
+  type_parameters(:U)
+    .params(
+      exn_class: T.class_of(StandardError)[T.all(StandardError, T.type_parameter(:U))],
+      blk: T.proc.params(
+        raiser: T.proc.params(exn: T.all(StandardError, T.type_parameter(:U))).void
+      ).void
+    )
+      .void
+end
+def complicated(exn_class, &blk)
+  raiser = T.let(
+    -> (exn) do
+      T.reveal_type(exn) # error: `T.all(StandardError, T.type_parameter(:U) (of Object#complicated))`
+      raise exn
+    end,
+    T.proc.params(exn: T.all(StandardError, T.type_parameter(:U))).void
+  )
+
+  bad_raiser = T.let(
+    -> (x) do
+      raise x
+      #     ^ error: Expected `T.any(T::Class[T.anything], Exception, String)` but found `T.type_parameter(:U) (of Object#complicated)` for argument `arg0`
+    end,
+    T.proc.params(x: T.type_parameter(:U)).void
+  )
+
+  begin
+    yield raiser
+  rescue exn_class => exn
+    T.reveal_type(exn_class) # error: `T.class_of(StandardError)[T.all(StandardError, T.type_parameter(:U) (of Object#complicated))]`
+  end
+
+  # This is fine by variance rules. The user will be limited to passing in
+  # values for `x` that are instances of `exn_class`, but that's an artificial
+  # limitation--this function accepts more values than required (because
+  # `T.type_parameter(:U) <: T.anything`).
+  technically_good_raiser = T.let(
+    -> (x) { raise },
+    T.proc.params(x: T.anything).void
+  )
+  yield technically_good_raiser
+end
+
+complicated(TypeError) do |raiser|
+  T.reveal_type(raiser) # error: `T.proc.params(arg0: StandardError).void`
+  raiser.call(TypeError.new)
+  raiser.call(ArgumentError.new)
+end

--- a/test/testdata/infer/generics/type_var_positive_polarity_lower_bound.rb
+++ b/test/testdata/infer/generics/type_var_positive_polarity_lower_bound.rb
@@ -18,7 +18,7 @@ def example(x, &blk)
 end
 
 f = T.let(->() { 0 }, T.proc.returns(Integer))
-res = example('', &f)
+res = example('', &f) # error: Expected `T.proc.returns(String)` but found `T.proc.returns(Integer)` for block argument
 T.reveal_type(res) # error: `T.any(String, Integer)`
 
 
@@ -69,7 +69,7 @@ def complicated(exn_class, &blk)
 end
 
 complicated(TypeError) do |raiser|
-  T.reveal_type(raiser) # error: `T.proc.params(arg0: StandardError).void`
+  T.reveal_type(raiser) # error: `T.proc.params(arg0: TypeError).void`
   raiser.call(TypeError.new)
-  raiser.call(ArgumentError.new)
+  raiser.call(ArgumentError.new) # error: Expected `TypeError` but found `ArgumentError` for argument `arg0`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Before the changes in #6076 (dc0319bc98055a4a9f3676b1c48f721a8f8823c1),
the behavior of this function was "look at one bound, if there isn't a
bound for that, then use the other bound, and if there are no bounds,
use `<top>`."

After the changes in #6076, we started to **only** consult one of the
bounds, depending on polarity.

We can improve the heuristic if we attempt to smush those two heuristics
together: always consult both bounds, but choose which bound to consult
**first** based on the polarity of the type variable.

As dmitry wrote:

    // TODO: in many languages this method is a huge adhoc heuristic
    // let's see if we can keep it small

Maybe adding complexity here isn't great, but ¯\\\_(ツ)\_/¯

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The test included here motivates the user who was trying to type their code. In this case, they wanted to be able to write a function which, as long as you only raise exceptions through the `raiser` function that gets yielded to a block, the framework will handle catching those exceptions and wrapping them up into a `Result` type, while other exceptions will not be caught.