### PR TITLE
Introduce a msgpack 'lite' mode that skips extra metadata in parsed files

### DIFF
--- a/main/autogen/data/BUILD
+++ b/main/autogen/data/BUILD
@@ -3,6 +3,7 @@ cc_library(
     srcs = [
         "definitions.cc",
         "msgpack.cc",
+        "msgpack_lite.cc",
     ],
     hdrs = [
         "definitions.h",

--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -171,12 +171,23 @@ vector<string> ParsedFile::listAllClasses(core::Context ctx) {
 
 // Convert this parsedfile to a msgpack representation
 string ParsedFile::toMsgpack(core::Context ctx, int version, const AutogenConfig &autogenCfg) {
-    MsgpackWriter write(version);
-    return write.pack(ctx, *this, autogenCfg);
+    if (autogenCfg.msgpackSkipReferenceMetadata) {
+        MsgpackWriterLite write(version);
+
+        return write.pack(ctx, *this, autogenCfg);
+    } else {
+        MsgpackWriter write(version);
+
+        return write.pack(ctx, *this, autogenCfg);
+    }
 }
 
-string ParsedFile::msgpackGlobalHeader(int version, size_t numFiles) {
-    return MsgpackWriter::msgpackGlobalHeader(version, numFiles);
+string ParsedFile::msgpackGlobalHeader(int version, size_t numFiles, const AutogenConfig &autogenCfg) {
+    if (autogenCfg.msgpackSkipReferenceMetadata) {
+        return MsgpackWriterLite::msgpackGlobalHeader(version, numFiles);
+    } else {
+        return MsgpackWriter::msgpackGlobalHeader(version, numFiles);
+    }
 }
 
 } // namespace sorbet::autogen

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -151,6 +151,7 @@ struct Reference {
 
 struct AutogenConfig {
     const std::vector<std::string> behaviorAllowedInRBIsPaths;
+    const bool msgpackSkipReferenceMetadata = false;
 };
 
 // A `ParsedFile` contains all the `Definition`s and `References` used in a particular file
@@ -174,7 +175,7 @@ struct ParsedFile {
 
     std::string toString(const core::GlobalState &gs, int version) const;
     std::string toMsgpack(core::Context ctx, int version, const AutogenConfig &autogenCfg);
-    static std::string msgpackGlobalHeader(int version, size_t numFiles);
+    static std::string msgpackGlobalHeader(int version, size_t numFiles, const AutogenConfig &autogenCfg);
 
     std::vector<core::NameRef> showFullName(const core::GlobalState &gs, DefinitionRef id) const;
     QualifiedName showQualifiedName(const core::GlobalState &gs, DefinitionRef id) const;

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -299,7 +299,7 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfi
     return ret;
 }
 
-string buildGlobalHeader(int version, size_t numFiles, const std::vector<std::string> &refAttrs,
+string buildGlobalHeader(int version, int serializedVersion, size_t numFiles, const std::vector<std::string> &refAttrs,
                          const std::vector<std::string> &defAttrs, const std::vector<std::string> &pfAttrs) {
     string header;
 
@@ -308,7 +308,7 @@ string buildGlobalHeader(int version, size_t numFiles, const std::vector<std::st
     size_t bodySize;
     mpack_writer_init_growable(&writer, &body, &bodySize);
 
-    mpack_write_u32(&writer, version);
+    mpack_write_u32(&writer, serializedVersion);
 
     mpack_start_array(&writer, pfAttrs.size());
     for (const auto &attr : pfAttrs) {
@@ -342,7 +342,7 @@ string MsgpackWriter::msgpackGlobalHeader(int version, size_t numFiles) {
     const vector<string> &refAttrs = refAttrMap.at(version);
     const vector<string> &defAttrs = defAttrMap.at(version);
 
-    return buildGlobalHeader(version, numFiles, refAttrs, defAttrs, pfAttrs);
+    return buildGlobalHeader(version, version, numFiles, refAttrs, defAttrs, pfAttrs);
 }
 
 const map<int, vector<string>> MsgpackWriter::parsedFileAttrMap{

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -9,10 +9,11 @@
 namespace sorbet::autogen {
 
 class MsgpackWriter {
-private:
+protected:
     int version;
     const std::vector<std::string> &refAttrs;
     const std::vector<std::string> &defAttrs;
+    const std::vector<std::string> &pfAttrs;
 
     std::vector<core::NameRef> symbols;
     UnorderedMap<core::NameRef, uint32_t> symbolIds;
@@ -28,9 +29,9 @@ private:
     void packReferenceRef(mpack_writer_t *writer, ReferenceRef ref);
     void packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref);
     void packRange(mpack_writer_t *writer, uint32_t begin, uint32_t end);
-    void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
-                        const AutogenConfig &autogenCfg);
-    void packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref);
+    virtual void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
+                                const AutogenConfig &autogenCfg);
+    virtual void packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref);
     static int assertValidVersion(int version) {
         if (version < AutogenVersion::MIN_VERSION || version > AutogenVersion::MAX_VERSION) {
             Exception::raise("msgpack version {} not in available range [{}, {}]", version, AutogenVersion::MIN_VERSION,
@@ -43,8 +44,46 @@ public:
     MsgpackWriter(int version);
 
     static std::string msgpackGlobalHeader(int version, size_t numFiles);
+    virtual std::string pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg);
+};
+
+// Lightweight version of writer that skips all reference metadata like expression ranges, inheritance information,
+// typing information, etc. Reduces size by ~37% for Stripe code.
+class MsgpackWriterLite : public MsgpackWriter {
+private:
+    int version;
+    const std::vector<std::string> &refAttrs;
+    const std::vector<std::string> &defAttrs;
+    const std::vector<std::string> &pfAttrs;
+
+    static const std::map<int, std::vector<std::string>> refAttrMap;
+    static const std::map<int, std::vector<std::string>> defAttrMap;
+    static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
+
+    static int assertValidVersion(int version) {
+        // Lite Msgpack writer is only supported after version 6.
+        if (version < 6 && version > AutogenVersion::MAX_VERSION) {
+            Exception::raise("msgpack version {} not in available range [6, {}]", version, 6,
+                             AutogenVersion::MAX_VERSION);
+        }
+        return version;
+    }
+
+    void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
+                        const AutogenConfig &autogenCfg);
+    void packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref);
+
+public:
+    MsgpackWriterLite(int version);
+
+    static std::string msgpackGlobalHeader(int version, size_t numFiles);
     std::string pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg);
 };
+
+void packString(mpack_writer_t *writer, std::string_view str);
+void writeSymbols(core::Context ctx, mpack_writer_t *writer, const std::vector<core::NameRef> &symbols);
+std::string buildGlobalHeader(int version, size_t numFiles, const std::vector<std::string> &refAttrs,
+                              const std::vector<std::string> &defAttrs, const std::vector<std::string> &pfAttrs);
 
 } // namespace sorbet::autogen
 

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -82,8 +82,9 @@ public:
 
 void packString(mpack_writer_t *writer, std::string_view str);
 void writeSymbols(core::Context ctx, mpack_writer_t *writer, const std::vector<core::NameRef> &symbols);
-std::string buildGlobalHeader(int version, size_t numFiles, const std::vector<std::string> &refAttrs,
-                              const std::vector<std::string> &defAttrs, const std::vector<std::string> &pfAttrs);
+std::string buildGlobalHeader(int version, int serializedVersion, size_t numFiles,
+                              const std::vector<std::string> &refAttrs, const std::vector<std::string> &defAttrs,
+                              const std::vector<std::string> &pfAttrs);
 
 } // namespace sorbet::autogen
 

--- a/main/autogen/data/msgpack_lite.cc
+++ b/main/autogen/data/msgpack_lite.cc
@@ -1,0 +1,170 @@
+// has to go first because it violates our poisons
+#include "mpack/mpack.h"
+
+#include "absl/strings/match.h"
+#include "core/GlobalState.h"
+#include "main/autogen/data/definitions.h"
+#include "main/autogen/data/msgpack.h"
+
+using namespace std;
+namespace sorbet::autogen {
+
+void MsgpackWriterLite::packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
+                                       const AutogenConfig &autogenCfg) {
+    mpack_start_array(writer, defAttrs[version].size());
+
+    // raw_full_name
+    auto raw_full_name = pf.showFullName(ctx, def.id);
+    packNames(writer, raw_full_name);
+
+    // defines_behavior
+    packBool(writer, def.defines_behavior);
+    const auto &filePath = ctx.file.data(ctx).path();
+    ENFORCE(!def.defines_behavior || !ctx.file.data(ctx).isRBI() ||
+                absl::c_any_of(autogenCfg.behaviorAllowedInRBIsPaths,
+                               [&](auto &allowedPath) { return absl::StartsWith(filePath, allowedPath); }),
+            "RBI files should never define behavior");
+
+    mpack_finish_array(writer);
+}
+
+void MsgpackWriterLite::packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref) {
+    mpack_start_array(writer, refAttrs[version].size());
+
+    // name
+    packNames(writer, ref.name.nameParts);
+
+    // resolved
+    if (ref.resolved.empty()) {
+        mpack_write_nil(writer);
+    } else if (absl::c_equal(ref.name.nameParts, ref.resolved.nameParts)) {
+        mpack_write_true(writer);
+    } else {
+        packNames(writer, ref.resolved.nameParts);
+    }
+
+    mpack_finish_array(writer);
+}
+
+MsgpackWriterLite::MsgpackWriterLite(int version)
+    : MsgpackWriter(version), version(assertValidVersion(version)), refAttrs(refAttrMap.at(version)),
+      defAttrs(defAttrMap.at(version)), pfAttrs(parsedFileAttrMap.at(version)) {}
+
+string MsgpackWriterLite::pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg) {
+    char *body;
+    size_t bodySize;
+    mpack_writer_t writer;
+    mpack_writer_init_growable(&writer, &body, &bodySize);
+
+    mpack_start_array(&writer, 3);
+
+    // path: 1
+    packString(&writer, ctx.state.getPrintablePath(pf.path));
+
+    size_t preDefsSize = mpack_writer_buffer_used(&writer);
+
+    // This is a little awkward.  We want to write the symbols used by
+    // defs and refs here, but the symbols hash isn't populated until after
+    // we've written the defs and refs.  So we're going to redirect
+    // everything into a temporary buffer, write the now-populated
+    // symbols, then write the temporary buffer as raw bytes.
+    char *temporary;
+    size_t temporarySize;
+    mpack_writer_t temporaryWriter;
+    mpack_writer_init_growable(&temporaryWriter, &temporary, &temporarySize);
+    {
+        mpack_start_array(&temporaryWriter, pf.defs.size());
+        for (auto &def : pf.defs) {
+            packDefinition(&temporaryWriter, ctx, pf, def, autogenCfg);
+        }
+        mpack_finish_array(&temporaryWriter);
+
+        mpack_start_array(&temporaryWriter, pf.refs.size());
+        for (auto &ref : pf.refs) {
+            packReference(&temporaryWriter, ctx, pf, ref);
+        }
+        mpack_finish_array(&temporaryWriter);
+    }
+
+    // symbols: 2
+    writeSymbols(ctx, &writer, symbols);
+
+    mpack_writer_destroy(&temporaryWriter);
+
+    // defs / refs: 3
+    mpack_write_object_bytes(&writer, temporary, temporarySize);
+    MPACK_FREE(temporary);
+
+    mpack_finish_array(&writer);
+
+    mpack_writer_destroy(&writer);
+
+    // write header
+    char *header;
+    size_t headerSize;
+    mpack_writer_init_growable(&writer, &header, &headerSize);
+
+    mpack_start_array(&writer, pfAttrs.size());
+
+    mpack_write_u32(&writer, pf.refs.size());
+    mpack_write_u32(&writer, pf.defs.size());
+    mpack_write_u32(&writer, symbols.size());
+
+    // v5 and up record the size of the parsed file's body to enable fast skipping
+    // of the entire data chunk, rather than reading and discarding
+    // individual msgpack fields.
+    size_t fieldsSize = bodySize - preDefsSize;
+    mpack_write_u64(&writer, fieldsSize);
+
+    mpack_write_object_bytes(&writer, body, bodySize);
+    MPACK_FREE(body);
+
+    mpack_writer_destroy(&writer);
+
+    auto ret = string(header, headerSize);
+    MPACK_FREE(header);
+
+    return ret;
+}
+
+// TODO (aadi-stripe, 6/20/2024): Ideally this static function does need to be repeated in the
+// MsgpackWriterLite class, consider refactoring by using templates.
+string MsgpackWriterLite::msgpackGlobalHeader(int version, size_t numFiles) {
+    const vector<string> &pfAttrs = parsedFileAttrMap.at(version);
+    const vector<string> &refAttrs = refAttrMap.at(version);
+    const vector<string> &defAttrs = defAttrMap.at(version);
+
+    return buildGlobalHeader(version, numFiles, refAttrs, defAttrs, pfAttrs);
+}
+
+const map<int, vector<string>> MsgpackWriterLite::parsedFileAttrMap{
+    {
+        6,
+        {
+            "ref_count",
+            "def_count",
+            "sym_count",
+            "body_size",
+        },
+    },
+};
+
+const map<int, vector<string>> MsgpackWriterLite::refAttrMap{
+    {6,
+     {
+         "name",
+         "resolved",
+     }},
+};
+
+const map<int, vector<string>> MsgpackWriterLite::defAttrMap{
+    {
+        6,
+        {
+            "raw_full_name",
+            "defines_behavior",
+        },
+    },
+};
+
+} // namespace sorbet::autogen

--- a/main/autogen/data/msgpack_lite.cc
+++ b/main/autogen/data/msgpack_lite.cc
@@ -134,7 +134,9 @@ string MsgpackWriterLite::msgpackGlobalHeader(int version, size_t numFiles) {
     const vector<string> &refAttrs = refAttrMap.at(version);
     const vector<string> &defAttrs = defAttrMap.at(version);
 
-    return buildGlobalHeader(version, numFiles, refAttrs, defAttrs, pfAttrs);
+    // set a high-bit (bit 8) on version to 1, to indicate "lite" msgpack mode.
+    int serializedVersion = version + 128;
+    return buildGlobalHeader(version, serializedVersion, numFiles, refAttrs, defAttrs, pfAttrs);
 }
 
 const map<int, vector<string>> MsgpackWriterLite::parsedFileAttrMap{

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -236,6 +236,9 @@ struct Options {
     std::vector<std::string> autogenSubclassesRelativeIgnorePatterns;
     // Allow RBI files to define behavior if they are in one of these paths.
     std::vector<std::string> autogenBehaviorAllowedInRBIFilesPaths;
+    // When set, msgpack serialization of references skips extra metadata like inheritance information and expression
+    // ranges.
+    bool autogenMsgpackSkipReferenceMetadata;
     AutogenConstCacheConfig autogenConstantCacheConfig;
 
     // List of directories not available editor-side. References to files in these directories should be sent via

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -282,7 +282,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
             Timer timeit(logger, "autogenDependencyDBPrint");
             if (opts.print.AutogenMsgPack.enabled) {
                 opts.print.AutogenMsgPack.print(
-                    autogen::ParsedFile::msgpackGlobalHeader(autogenVersion, merged.size()));
+                    autogen::ParsedFile::msgpackGlobalHeader(autogenVersion, merged.size(), autogenCfg));
             }
             for (auto &elem : merged) {
                 if (opts.print.Autogen.enabled) {
@@ -797,8 +797,9 @@ int realmain(int argc, char *argv[]) {
                 indexed = resolver::Resolver::runConstantResolution(*gs, move(indexed), *workers);
             }
 
-            autogen::AutogenConfig autogenCfg = {.behaviorAllowedInRBIsPaths =
-                                                     std::move(opts.autogenBehaviorAllowedInRBIFilesPaths)};
+            autogen::AutogenConfig autogenCfg = {
+                .behaviorAllowedInRBIsPaths = std::move(opts.autogenBehaviorAllowedInRBIFilesPaths),
+                .msgpackSkipReferenceMetadata = std::move(opts.autogenMsgpackSkipReferenceMetadata)};
 
             runAutogen(*gs, opts, autogenCfg, *workers, indexed, opts.autogenConstantCacheConfig.changedFiles);
 #endif


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Introduces a lightweight mode for msgpack serialization in autogen which skips extra reference metadata like scope, nesting, expression ranges, typing information, requires, etc. A few points

* The new mode is behind a flag called `--autogen-msgpack-skip-reference-metadata`. Open to a better name.
* The new logic is different enough from the full msgpack mode that I'm creating a derived class that has the new functionality, called `MsgpackWriterLite`. This duplicates some code, but still feels less clunky than sticking `if` statements all over the place in the original class. May create some maintenance overhead long term, but will be a lot easier and cleaner to read.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Facilitates a faster use-case (code preloading) for the msgpack printer mode at Stripe, where we only want to deserialize basic data like definition and reference names, and ignore everything else.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested new functionality on Stripe codebase both locally and in CI.