### PR TITLE
Failing test: "Constants must have type annotations"

### DIFF
--- a/test/testdata/resolver/constant_type_at_least_once__1.rb
+++ b/test/testdata/resolver/constant_type_at_least_once__1.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+A = [true, false].sample

--- a/test/testdata/resolver/constant_type_at_least_once__2.rb
+++ b/test/testdata/resolver/constant_type_at_least_once__2.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+A = T.let([true, false].sample, T::Boolean)
+B = T.let([true, false].sample, T::Boolean)

--- a/test/testdata/resolver/constant_type_at_least_once__3.rb
+++ b/test/testdata/resolver/constant_type_at_least_once__3.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+B = [true, false].sample


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Whether we report an error or not for both "Constants must have type
annotations with `T.let`" should not depend on file order..

In this test, we see that the type annotation for `A` comes in the
second file (after the file where `A` is defined without an annotation),
while the type annotation for `B` comes first (before the file where `B`
is defined without an annotation).

There should not be this sort of order dependency.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.