### PR TITLE
Add `T::Class`-aware overload for `grep` methods

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -749,6 +749,13 @@ module Enumerable
   # res                    #=> [0, 1, 2]
   # ```
   sig do
+    type_parameters(:Instance)
+      .params(
+          arg0: T::Class[T.type_parameter(:Instance)],
+      )
+      .returns(T::Array[T.all(Elem, T.type_parameter(:Instance))])
+  end
+  sig do
     params(
         arg0: BasicObject,
     )

--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -790,6 +790,13 @@ class Enumerator::Lazy < Enumerator
   # Also aliased as:
   # [`_enumerable_grep`](https://docs.ruby-lang.org/en/2.7.0/Enumerator/Lazy.html#method-i-_enumerable_grep)
   sig do
+    type_parameters(:Instance)
+      .params(
+          arg0: T::Class[T.type_parameter(:Instance)],
+      )
+      .returns(T::Enumerator::Lazy[T.all(Elem, T.type_parameter(:Instance))])
+  end
+  sig do
     params(
       arg0: BasicObject
     )

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -84,3 +84,7 @@ def example(xs)
   end
   T.reveal_type(res) # error: `T.untyped`
 end
+
+int_or_str_array = T::Array[T.any(Integer, String)].new
+int_array = int_or_str_array.grep(Integer)
+T.reveal_type(int_array) # error: `T::Array[Integer]`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

h/t Mark N on Slack for pointing out that this method exists.

If we ever get around to #7027, we could even expand this signature to
`T::Module`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.