### PR TITLE
Add T::Class overload for grep with block

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -756,6 +756,14 @@ module Enumerable
       .returns(T::Array[T.all(Elem, T.type_parameter(:Instance))])
   end
   sig do
+    type_parameters(:Instance, :U)
+      .params(
+          arg0: T::Class[T.type_parameter(:Instance)],
+          blk: T.proc.params(arg0: T.type_parameter(:Instance)).returns(T.type_parameter(:U)),
+      )
+      .returns(T::Array[T.type_parameter(:U)])
+  end
+  sig do
     params(
         arg0: BasicObject,
     )

--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -797,6 +797,14 @@ class Enumerator::Lazy < Enumerator
       .returns(T::Enumerator::Lazy[T.all(Elem, T.type_parameter(:Instance))])
   end
   sig do
+    type_parameters(:Instance, :U)
+      .params(
+          arg0: T::Class[T.type_parameter(:Instance)],
+          blk: T.proc.params(arg0: T.type_parameter(:Instance)).returns(T.type_parameter(:U)),
+      )
+      .returns(T::Enumerator::Lazy[T.type_parameter(:U)])
+  end
+  sig do
     params(
       arg0: BasicObject
     )

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -88,3 +88,10 @@ end
 int_or_str_array = T::Array[T.any(Integer, String)].new
 int_array = int_or_str_array.grep(Integer)
 T.reveal_type(int_array) # error: `T::Array[Integer]`
+
+int_or_str_array = T::Array[T.any(Integer, String)].new
+bool_array = int_or_str_array.grep(Integer) do |x|
+  T.reveal_type(x) # error: `Integer`
+  x > 5
+end
+T.reveal_type(bool_array) # error: `T::Array[T::Boolean]`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The `T::Class`-aware overload for `grep` methods was added in 6951f1e. This PR enables the same overload for `grep` methods with a block. For example:

```rb
result = ["a", "b", 123, 456].grep(Integer) do |item|
  T.reveal_type(item) # => Integer
  item > 200
end
T.reveal_type(result) # => T::Array[T::Boolean]
```

<details>
  <summary>Examples covering existing overloads</summary>

```rb
result = ["foo", "bar", "car", "moo"].grep(/ar/) # => ["bar", "car"]
T.reveal_type(result) # => T::Array[String]

result = (1..10).grep(3..8) # => [3, 4, 5, 6, 7, 8]
T.reveal_type(result) # => T::Array[Integer]

result = ["a", "b", 0, 1].grep(Integer) # => [0, 1]
T.reveal_type(result) # => T::Array[Integer]

result = ["foo", "bar", "car", "moo"].grep(/ar/, &:upcase) # => ["BAR", "CAR"]
T.reveal_type(result) # => T::Array[String]
```

</details>


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Following on from #7903.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
