### PR TITLE
Add Socket::MSG_EOF

### DIFF
--- a/rbi/stdlib/socket.rbi
+++ b/rbi/stdlib/socket.rbi
@@ -1820,6 +1820,8 @@ class Socket < BasicSocket
   MSG_DONTROUTE = ::T.let(nil, ::T.untyped)
   # This message should be non-blocking
   MSG_DONTWAIT = ::T.let(nil, ::T.untyped)
+  # [Data completes connection](https://ruby-doc.org/stdlib-3.0.0/libdoc/socket/rdoc/Socket.html#MSG_EOF)
+  MSG_EOF = ::T.let(nil, ::T.untyped) 
   # [`Data`](https://docs.ruby-lang.org/en/2.7.0/Data.html) completes record
   MSG_EOR = ::T.let(nil, ::T.untyped)
   # Fetch message from error queue


### PR DESCRIPTION
Add [Socket::MSG_EOF](https://ruby-doc.org/stdlib-3.0.0/libdoc/socket/rdoc/Socket.html#MSG_EOF) to rbis. 

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`MSG_EOF` is in the stdlib and has been for a while. I'm using it in my code and would be nice if sorbet didn't complain about it. 😄 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
