### PR TITLE
Log some more data to attempt to repro resolver crash

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2292,7 +2292,17 @@ class ResolveTypeMembersAndFieldsWalk {
             return;
         }
 
-        if (core::Types::equiv(ctx, priorField.data(ctx)->resultType, castType)) {
+        auto priorFieldResultType = priorField.data(ctx)->resultType;
+        if (priorFieldResultType == nullptr || castType == nullptr) [[unlikely]] {
+            const auto &file = ctx.file.data(ctx);
+            fatalLogger->error(
+                R"(msg="Bad core::Types::equiv in resolveField" path="{}" priorField="{}" resultTypeNull="{}" castTypeNull="{}")",
+                file.path(), priorField.show(ctx), priorFieldResultType == nullptr ? "true" : "false",
+                castType == nullptr ? "true" : "false");
+            fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
+        }
+
+        if (core::Types::equiv(ctx, priorFieldResultType, castType)) {
             // We already have a symbol for this field, and it matches what we already saw, so we can short
             // circuit.
             return;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1,4 +1,5 @@
 #include "core/errors/resolver.h"
+#include "absl/strings/escaping.h"
 #include "ast/Helpers.h"
 #include "ast/Trees.h"
 #include "ast/ast.h"
@@ -2289,30 +2290,31 @@ class ResolveTypeMembersAndFieldsWalk {
             // This was previously entered by namer and we are now resolving the type.
             priorField.data(ctx)->resultType = castType;
             return;
-        } else if (core::Types::equiv(ctx, priorField.data(ctx)->resultType, castType)) {
+        }
+
+        if (core::Types::equiv(ctx, priorField.data(ctx)->resultType, castType)) {
             // We already have a symbol for this field, and it matches what we already saw, so we can short
             // circuit.
             return;
-        } else {
-            // We do some normalization here to ensure that the file / line we report the error on doesn't
-            // depend on the order that we traverse files nor the order we traverse within a file.
-            auto priorLoc = priorField.data(ctx)->loc();
-            core::Loc reportOn;
-            core::Loc errorLine;
-            core::Loc thisLoc = core::Loc(job.file, uid->loc);
-            if (thisLoc.file() == priorLoc.file()) {
-                reportOn = thisLoc.beginPos() < priorLoc.beginPos() ? thisLoc : priorLoc;
-                errorLine = thisLoc.beginPos() < priorLoc.beginPos() ? priorLoc : thisLoc;
-            } else {
-                reportOn = thisLoc.file() < priorLoc.file() ? thisLoc : priorLoc;
-                errorLine = thisLoc.file() < priorLoc.file() ? priorLoc : thisLoc;
-            }
+        }
 
-            if (auto e = ctx.state.beginError(reportOn, core::errors::Resolver::DuplicateVariableDeclaration)) {
-                e.setHeader("Redeclaring variable `{}` with mismatching type", uid->name.show(ctx));
-                e.addErrorLine(errorLine, "Previous declaration is here:");
-            }
-            return;
+        // We do some normalization here to ensure that the file / line we report the error on doesn't
+        // depend on the order that we traverse files nor the order we traverse within a file.
+        auto priorLoc = priorField.data(ctx)->loc();
+        core::Loc reportOn;
+        core::Loc errorLine;
+        core::Loc thisLoc = core::Loc(job.file, uid->loc);
+        if (thisLoc.file() == priorLoc.file()) {
+            reportOn = thisLoc.beginPos() < priorLoc.beginPos() ? thisLoc : priorLoc;
+            errorLine = thisLoc.beginPos() < priorLoc.beginPos() ? priorLoc : thisLoc;
+        } else {
+            reportOn = thisLoc.file() < priorLoc.file() ? thisLoc : priorLoc;
+            errorLine = thisLoc.file() < priorLoc.file() ? priorLoc : thisLoc;
+        }
+
+        if (auto e = ctx.state.beginError(reportOn, core::errors::Resolver::DuplicateVariableDeclaration)) {
+            e.setHeader("Redeclaring variable `{}` with mismatching type", uid->name.show(ctx));
+            e.addErrorLine(errorLine, "Previous declaration is here:");
         }
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We've seen a handful of crashes coming from here but I haven't been able to
come up with an example where this fails. Most of the crashes that I see
happen during file hashing, which suggests to me that the crash is a pure
function of the input file, which is a good sign that if we can just get
the file contents we'll be able to make a minimal repro and then fix the
issue.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Testing in prod