### PR TITLE
Fix publish.sh after webassembly changes

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -105,8 +105,7 @@ mv release/gems/* release
 rmdir release/gems
 rm release/website/website.tar.bz2
 rmdir release/website
-rm release/webasm/sorbet-wasm.*
-rmdir release/webasm
+rm -r release/webasm
 
 pushd release
 files=()


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It used to be the case that we would have a bunch of things in the
`release/webasm/` folder. Some of these would make their way into the sorbet.run
release, and the rest would have to be manually deleted so that everything that
remains is a gem archive (the code is written weirdly IMO, idk why it doesn't
just loop over all gems instead of looping over all file and assuming that ever
file is a gem).

Anyways, after the change to how we build Sorbet's webassembly, we only publish
the relevant files from the build-emscripten.sh step, and then `mv` those into
the sorbet.run folder, which means that there aren't any excess `sorbet-wasm.*`
files left around in the publish.sh step by the time this `rm` command runs.

There is still the `release/webasm/` folder itself, and we were trying to remove
everything in that folder anyways, so we can just recursively delete it and be
done with it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test on master.