### PR TITLE
Add bazel config for Blakey with ARM vector instructions

### DIFF
--- a/common/crypto_hashing/BUILD
+++ b/common/crypto_hashing/BUILD
@@ -7,8 +7,8 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = ["//common"] + select({
-        "//tools/config:linux_x86_64": ["@com_github_blake2_libb2"],
-        "//tools/config:darwin_x86_64": ["@com_github_blake2_libb2"],
-        "//conditions:default": ["@com_github_blake2_blake2"],
+        "@platforms//cpu:x86_64": ["@com_github_blake2_libb2"],
+        "@platforms//cpu:arm64": ["@com_github_blake2_blake2//:com_github_blake2_blake2_neon"],
+        "//conditions:default": ["@com_github_blake2_blake2//:com_github_blake2_blake2_ref"],
     }),
 )

--- a/third_party/blake2.BUILD
+++ b/third_party/blake2.BUILD
@@ -3,7 +3,7 @@
 # prod builds use libb2
 
 cc_library(
-    name = "com_github_blake2_blake2",
+    name = "com_github_blake2_blake2_ref",
     srcs = [
         "ref/blake2s-ref.c",
         "ref/blake2b-ref.c",
@@ -14,6 +14,23 @@ cc_library(
     ],
     includes = [
         "src",
+    ],
+    linkstatic = select({
+        "@com_stripe_ruby_typer//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "com_github_blake2_blake2_neon",
+    srcs = [
+        "neon/blake2s-neon.c",
+        "neon/blake2b-neon.c",
+    ],
+    hdrs = [
+        "neon/blake2.h",
+        "neon/blake2-impl.h",
     ],
     linkstatic = select({
         "@com_stripe_ruby_typer//tools/config:linkshared": 0,

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -200,8 +200,7 @@ def register_sorbet_dependencies():
         strip_prefix = "buildtools-5bcc31df55ec1de770cb52887f2e989e7068301f",
     )
 
-    # optimized version of blake2 hashing algorithm
-    # TODO(jez) Add something to use the neon implementation on Apple Silicon
+    # optimized version of blake2 hashing algorithm, using SSE vector extensions
     http_archive(
         name = "com_github_blake2_libb2",
         url = "https://github.com/BLAKE2/libb2/archive/fa83ddbe179912e9a7a57edf0333b33f6ff83056.zip",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A while back I noticed that there was a version of our blake2 library for
hashing that had an optimized implementation using arm64's neon vector
instructions. On arm64 and wasm we were falling back to the reference
implementation of the algorithms, which are plain C.

There isn't an optimized webassembly implementation, but there is an arm64
implementation that uses neon instructions, so I figured I may as well add some
Bazel config to expose that to our build.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested this change manually by cherry-picking it on top of #7916, which lets
us build macOS arm64 binaries natively, and it worked.

We also test on arm64 Linux in CI.