### PR TITLE
Don't hang if publishing fails

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -145,7 +145,7 @@ elif [ "$dryrun" = "" ]; then
     # It can take 4+ minutes for the marketplace to "verify" our extension
     # before it shows up as published according to `vsce show`.
     cat "$vsce_publish_output"
-    if grep -qF 'Version number cannot be the same'; then
+    if grep -qF 'Version number cannot be the same' "$vsce_publish_output"; then
       echo "... $extension_release_version is already published"
     else
       exit 1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


When `grep` isn't given a file to grep in, hangs without printing any
warnings. I think this is a pretty absurd default, and I even have a
blog post ranting about it:

→ <https://blog.jez.io/cli-tty/>

But this should fix the problem and make our publish.sh step not hang
indefinitely if the publish fails.

You can see an example of this hang happening in this build:

<https://buildkite.com/sorbet/sorbet/builds/31485#018fcad9-68c3-4c41-83b0-f3558eff2348/420-436>

Note the timestamps, it took ~2.5 hours before I realized that we had a
hanging build.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This will get tested on master, unless I'm able to go through our runbook to
update the personal access token faster than CI can reach the publish step.