### PR TITLE
Use `--depth 1` to speed up publish.sh

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -39,7 +39,7 @@ if [ "$dryrun" = "" ]; then
   echo "--- releasing sorbet.run"
 
   rm -rf sorbet.run
-  git clone git@github.com:sorbet/sorbet.run.git --single-branch --branch master
+  git clone git@github.com:sorbet/sorbet.run.git --single-branch --branch master --depth 1
   mv _out_/webasm/sorbet-wasm.wasm sorbet.run/docs
   mv _out_/webasm/sorbet-wasm.js sorbet.run/docs
   pushd sorbet.run/docs


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Courtesy of @sushain-stripe: 5s vs 78s

    ❯ time git clone git@github.com:sorbet/sorbet.run.git --single-branch --branch master --depth 1
    Cloning into 'sorbet.run'...
    remote: Enumerating objects: 421, done.
    remote: Counting objects: 100% (421/421), done.
    remote: Compressing objects: 100% (301/301), done.
    remote: Total 421 (delta 107), reused 365 (delta 100), pack-reused 0
    Receiving objects: 100% (421/421), 29.91 MiB | 10.28 MiB/s, done.
    Resolving deltas: 100% (107/107), done.
    hub clone git@github.com:sorbet/sorbet.run.git --single-branch --branch maste  0.92s user 0.37s system 23% cpu 5.426 total

    ~
    ❯ time git clone git@github.com:sorbet/sorbet.run.git --single-branch --branch master ex
    Cloning into 'ex'...
    remote: Enumerating objects: 10690, done.
    remote: Counting objects: 100% (1289/1289), done.
    remote: Compressing objects: 100% (92/92), done.
    remote: Total 10690 (delta 1211), reused 1233 (delta 1169), pack-reused 9401
    Receiving objects: 100% (10690/10690), 1.33 GiB | 19.77 MiB/s, done.
    Resolving deltas: 100% (6744/6744), done.
    hub clone git@github.com:sorbet/sorbet.run.git --single-branch --branch maste  59.55s user 7.59s system 85% cpu 1:18.48 total


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Untested on branches, will have to wait until master.