### PR TITLE
[ruby] reinitialize native sched lock on `fork`

### DIFF
--- a/third_party/ruby/reinit_native_sched_lock.patch
+++ b/third_party/ruby/reinit_native_sched_lock.patch
@@ -1,0 +1,12 @@
+diff --git a/thread_pthread.c b/thread_pthread.c
+index 7918d0d3d9..a5568885e0 100644
+--- a/thread_pthread.c
++++ b/thread_pthread.c
+@@ -1530,6 +1530,7 @@ thread_sched_atfork(struct rb_thread_sched *sched)
+     }
+     vm->ractor.sched.running_cnt = 0;
+ 
++    rb_native_mutex_initialize(&vm->ractor.sched.lock);
+     // rb_native_cond_destroy(&vm->ractor.sched.cond);
+     rb_native_cond_initialize(&vm->ractor.sched.cond);
+     rb_native_cond_initialize(&vm->ractor.sched.barrier_complete_cond);

--- a/third_party/ruby_externals.bzl
+++ b/third_party/ruby_externals.bzl
@@ -76,6 +76,7 @@ def register_ruby_dependencies():
             "@com_stripe_ruby_typer//third_party/ruby:fix_grapheme_clusters_3_3_only.patch",
             "@com_stripe_ruby_typer//third_party/ruby:10151_no_hash_allocate_static_kwargs_3_3_only.patch",
             "@com_stripe_ruby_typer//third_party/ruby:10306_no_hash_allocate_static_kwargs_3_3_only.patch",
+            "@com_stripe_ruby_typer//third_party/ruby:reinit_native_sched_lock.patch",
         ],
     )
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This seems plausibly responsible for some hangs in our testing with Ruby 3.3.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
