### PR TITLE
Add `-march=armv8.1a` for linux-aarch64 builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -134,6 +134,7 @@ build:release-linux-aarch64 --define mimalloc=true
 # however some AWS instances in our fleet still run Sandy Bridge (Skylake predecessor), as of 2018.
 build:release-linux           --copt=-march=sandybridge
 build:release-sanitized-linux --copt=-march=sandybridge
+build:release-linux-aarch64   --copt=-march=armv8.1a
 
 build:release-mac --config=release-common --platforms=@//tools/platforms:darwin_x86_64
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://github.com/sorbet/sorbet/issues/7932

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Built locally on a Graviton machine. Disassembly of binary had `ldadd*` family of instructions, introduced in v8.1a. typecheck succeeded.
