### PR TITLE
Treat EmptyTree as `nil` in `If`

### DIFF
--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -27,6 +27,7 @@ private:
     static void jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc);
     static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InstructionPtr inst);
     static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
+    static BasicBlock *walkEmptyTreeInIf(CFGContext cctx, core::LocOffsets loc, BasicBlock *current);
     static BasicBlock *walkBlockReturn(CFGContext cctx, core::LocOffsets loc, ast::ExpressionPtr &expr,
                                        BasicBlock *current);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -1034,7 +1034,14 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 ret = current;
             },
 
-            [&](const ast::EmptyTree &n) { ret = current; },
+            [&](const ast::EmptyTree &n) {
+                // TODO(jez) We might want to ENFORCE(false) here, and make all attempts to walk an
+                // empty tree be handled by the parent node where the `EmptyTree` is a child, so
+                // that there's more context to be able to handle the `EmptyTree` in context. For
+                // example, how the `ast::If` case handles `EmptyTree` so that the loc of the
+                // `EmptyTree` can be set to the loc of the whole `if` expression.
+                ret = current;
+            },
 
             [&](const ast::ClassDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
             [&](const ast::MethodDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },

--- a/test/cli/autocorrect_method_return/test.out
+++ b/test/cli/autocorrect_method_return/test.out
@@ -41,17 +41,19 @@ autocorrect_method_return.rb:22: Expected `String` but found `T.nilable(String)`
     22 |  return res
                  ^^^
 
-autocorrect_method_return.rb:30: Expected `String` but found `NilClass` for method result type https://srb.help/7005
-    30 |end
-        ^^^
+autocorrect_method_return.rb:27: Expected `String` but found `NilClass` for method result type https://srb.help/7005
+    27 |  if T.unsafe(nil)
+    28 |    return 'yep'
+    29 |  end
   Expected `String` for result type of method `implicit_return_via_else`:
     autocorrect_method_return.rb:26:
     26 |def implicit_return_via_else
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `NilClass` originating from:
-    autocorrect_method_return.rb:26: Possibly uninitialized (`NilClass`) in:
-    26 |def implicit_return_via_else
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    autocorrect_method_return.rb:27:
+    27 |  if T.unsafe(nil)
+    28 |    return 'yep'
+    29 |  end
 
 autocorrect_method_return.rb:34: Expected `String` but found `T.nilable(String)` for method result type https://srb.help/7005
     34 |  T.let("", T.nilable(String))
@@ -112,12 +114,13 @@ autocorrect_method_return.rb:55: Expected `String` but found `T.nilable(String)`
     51 |def implicit_return_without_keyword(x)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `T.nilable(String)` originating from:
+    autocorrect_method_return.rb:52:
+    52 |  if T.unsafe(nil)
+    53 |    ""
+    54 |  end
     autocorrect_method_return.rb:53:
     53 |    ""
             ^^
-    autocorrect_method_return.rb:51: Possibly uninitialized (`NilClass`) in:
-    51 |def implicit_return_without_keyword(x)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 8
 
 --------------------------------------------------------------------------
@@ -231,17 +234,26 @@ autocorrect_method_return.rb:22: Expected `String` but found `T.nilable(String)`
     22 |  return res
                  ^^^
 
-autocorrect_method_return.rb:30: Expected `String` but found `NilClass` for method result type https://srb.help/7005
-    30 |end
-        ^^^
+autocorrect_method_return.rb:27: Expected `String` but found `NilClass` for method result type https://srb.help/7005
+    27 |  if T.unsafe(nil)
+    28 |    return 'yep'
+    29 |  end
   Expected `String` for result type of method `implicit_return_via_else`:
     autocorrect_method_return.rb:26:
     26 |def implicit_return_via_else
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `NilClass` originating from:
-    autocorrect_method_return.rb:26: Possibly uninitialized (`NilClass`) in:
-    26 |def implicit_return_via_else
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    autocorrect_method_return.rb:27:
+    27 |  if T.unsafe(nil)
+    28 |    return 'yep'
+    29 |  end
+  Autocorrect: Done
+    autocorrect_method_return.rb:27: Replaced with `T.unsafe(if T.unsafe(nil)
+        return 'yep'
+      end)`
+    27 |  if T.unsafe(nil)
+    28 |    return 'yep'
+    29 |  end
 
 autocorrect_method_return.rb:34: Expected `String` but found `T.nilable(String)` for method result type https://srb.help/7005
     34 |  T.let("", T.nilable(String))
@@ -302,12 +314,13 @@ autocorrect_method_return.rb:55: Expected `String` but found `T.nilable(String)`
     51 |def implicit_return_without_keyword(x)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `T.nilable(String)` originating from:
+    autocorrect_method_return.rb:52:
+    52 |  if T.unsafe(nil)
+    53 |    ""
+    54 |  end
     autocorrect_method_return.rb:53:
     53 |    ""
             ^^
-    autocorrect_method_return.rb:51: Possibly uninitialized (`NilClass`) in:
-    51 |def implicit_return_without_keyword(x)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 8
 
 --------------------------------------------------------------------------
@@ -338,9 +351,9 @@ end
 
 sig {returns(String)}
 def implicit_return_via_else
-  if T.unsafe(nil)
+  T.unsafe(if T.unsafe(nil)
     return 'yep'
-  end
+  end)
 end
 
 sig {returns(String)}

--- a/test/cli/errors/test.out
+++ b/test/cli/errors/test.out
@@ -44,12 +44,12 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     test/cli/errors/errors.rb:29:
     .. |          nil
                   ^^^
+    test/cli/errors/errors.rb:30:
+    .. |        when 2
+    .. |          2
     test/cli/errors/errors.rb:31:
     .. |          2
                   ^
-    test/cli/errors/errors.rb:26: Possibly uninitialized (`NilClass`) in:
-    .. |  def main(foo)
-          ^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     test/cli/errors/errors.rb:33: Replace with `T.must(a)`
     .. |    bar(a)
@@ -101,12 +101,12 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     test/cli/errors/errors.rb:29:
     .. |          nil
                   ^^^
+    test/cli/errors/errors.rb:30:
+    .. |        when 2
+    .. |          2
     test/cli/errors/errors.rb:31:
     .. |          2
                   ^
-    test/cli/errors/errors.rb:26: Possibly uninitialized (`NilClass`) in:
-    .. |  def main(foo)
-          ^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     test/cli/errors/errors.rb:33: Replace with `T.must(a)`
     .. |    bar(a)
@@ -158,12 +158,12 @@ test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` 
     test/cli/errors/errors.rb:29:
     .. |          nil
                   ^^^
+    test/cli/errors/errors.rb:30:
+    .. |        when 2
+    .. |          2
     test/cli/errors/errors.rb:31:
     .. |          2
                   ^
-    test/cli/errors/errors.rb:26: Possibly uninitialized (`NilClass`) in:
-    .. |  def main(foo)
-          ^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     test/cli/errors/errors.rb:33: Replace with `T.must(a)`
     .. |    bar(a)

--- a/test/testdata/cfg/empty_tree.rb
+++ b/test/testdata/cfg/empty_tree.rb
@@ -6,7 +6,7 @@ aaaa =
     ''
   end
 
-T.reveal_type(aaaa) # error: T.any(Integer, String)
+T.reveal_type(aaaa) # error: T.nilable(String)
 
 bbbb = 0
 bbbb =
@@ -14,6 +14,6 @@ bbbb =
     ''
   elsif true
     ''
-  end # error: This code is unreachable
+  end
 
-T.reveal_type(bbbb) # error: `T.any(Integer, String)`
+T.reveal_type(bbbb) # error: `String("")`

--- a/test/testdata/cfg/empty_tree.rb
+++ b/test/testdata/cfg/empty_tree.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+aaaa = 0
+aaaa =
+  if rand(2) == 0
+    ''
+  end
+
+T.reveal_type(aaaa) # error: T.any(Integer, String)
+
+bbbb = 0
+bbbb =
+  if rand(2) == 0
+    ''
+  elsif true
+    ''
+  end # error: This code is unreachable
+
+T.reveal_type(bbbb) # error: `T.any(Integer, String)`

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -8,7 +8,7 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb9
+# - bb7
 # - bb10
 # - bb11
 # - bb12
@@ -32,9 +32,9 @@ bb4[firstDead=-1](<magic>$5: T.class_of(<Magic>)):
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: Integer(1)):
+bb5[firstDead=-1]():
     <ifTemp>$4: Integer(2) = 2
-    <ifTemp>$4 -> (Integer(2) ? bb6 : bb9)
+    <ifTemp>$4 -> (Integer(2) ? bb6 : bb7)
 
 # backedges
 # - bb5
@@ -44,7 +44,8 @@ bb6[firstDead=-1]():
 
 # backedges
 # - bb5
-bb9[firstDead=0](<returnMethodTemp>$2: Integer(1), <gotoDeadTemp>$10: NilClass):
+bb7[firstDead=0]():
+    <returnMethodTemp>$2 = nil
     <gotoDeadTemp>$10 -> (<nullptr> ? bb1 : bb12)
 
 # backedges
@@ -62,7 +63,7 @@ bb11[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
 
 # backedges
 # - bb6
-# - bb9
+# - bb7
 # - bb10
 # - bb11
 bb12[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):

--- a/test/testdata/cfg/retry.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry.rb.cfg-text.exp
@@ -30,10 +30,10 @@ bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 
 # backedges
 # - bb2
-bb4[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
-    <ifTemp>$5 -> (T::Boolean ? bb5 : bb7)
+    <ifTemp>$5 -> (T::Boolean ? bb5 : bb6)
 
 # backedges
 # - bb4
@@ -47,7 +47,13 @@ bb5[firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>
 
 # backedges
 # - bb4
+bb6[firstDead=-1](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+    <returnMethodTemp>$2: NilClass = nil
+    <unconditional> -> bb7
+
+# backedges
 # - bb5
+# - bb6
 bb7[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb9)

--- a/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
@@ -31,7 +31,7 @@ bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 
 # backedges
 # - bb2
-bb4[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
     <ifTemp>$5 -> (T::Boolean ? bb5 : bb6)
@@ -49,10 +49,10 @@ bb5[firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb6[firstDead=-1](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$17: Integer(6) = 6
     <ifTemp>$15: T::Boolean = try: Integer(0).<(<statTemp>$17: Integer(6))
-    <ifTemp>$15 -> (T::Boolean ? bb7 : bb10)
+    <ifTemp>$15 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb6
@@ -66,9 +66,15 @@ bb7[firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>
     <unconditional> -> bb10
 
 # backedges
-# - bb5
 # - bb6
+bb8[firstDead=-1](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+    <returnMethodTemp>$2: NilClass = nil
+    <unconditional> -> bb10
+
+# backedges
+# - bb5
 # - bb7
+# - bb8
 bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb12)

--- a/test/testdata/cfg/retry_nested.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg-text.exp
@@ -55,7 +55,7 @@ bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 
 # backedges
 # - bb5
-bb7[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$11: Integer(3) = 3
     <ifTemp>$9: T::Boolean = try: Integer(0).<(<statTemp>$11: Integer(3))
     <ifTemp>$9 -> (T::Boolean ? bb8 : bb9)
@@ -73,10 +73,10 @@ bb8[firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>
 
 # backedges
 # - bb7
-bb9[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb9[firstDead=-1](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$21: Integer(6) = 6
     <ifTemp>$19: T::Boolean = try: Integer(0).<(<statTemp>$21: Integer(6))
-    <ifTemp>$19 -> (T::Boolean ? bb10 : bb13)
+    <ifTemp>$19 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
 # - bb9
@@ -90,9 +90,15 @@ bb10[firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic
     <unconditional> -> bb13
 
 # backedges
-# - bb8
 # - bb9
+bb11[firstDead=-1](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+    <returnMethodTemp>$2: NilClass = nil
+    <unconditional> -> bb13
+
+# backedges
+# - bb8
 # - bb10
+# - bb11
 bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb6 : bb15)

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -89,7 +89,7 @@ bb11[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: StandardError,
 # - bb11
 bb13[firstDead=-1](is_successful: T::Boolean, ||$2: T.untyped):
     <ifTemp>$14: T.untyped = ||$2
-    <ifTemp>$14 -> (T.untyped ? bb19 : bb24)
+    <ifTemp>$14 -> (T.untyped ? bb19 : bb20)
 
 # backedges
 # - bb10
@@ -101,13 +101,13 @@ bb14[firstDead=-1](foo: T.untyped, err: StandardError, is_successful: FalseClass
 # - bb14
 bb15[firstDead=-1](foo: T.untyped, is_successful: FalseClass):
     <ifTemp>$14: T.untyped = foo
-    <ifTemp>$14 -> (T.untyped ? bb19 : bb24)
+    <ifTemp>$14 -> (T.untyped ? bb19 : bb20)
 
 # backedges
 # - bb14
 bb16[firstDead=0](err: StandardError, is_successful: FalseClass):
     <ifTemp>$14 = err
-    <ifTemp>$14 -> (<nullptr> ? bb19 : bb24)
+    <ifTemp>$14 -> (<nullptr> ? bb19 : bb20)
 
 # backedges
 # - bb13
@@ -115,7 +115,15 @@ bb16[firstDead=0](err: StandardError, is_successful: FalseClass):
 # - bb16
 bb19[firstDead=-1](is_successful: T::Boolean):
     <ifTemp>$19: T::Boolean = is_successful: T::Boolean.!()
-    <ifTemp>$19 -> (T::Boolean ? bb21 : bb24)
+    <ifTemp>$19 -> (T::Boolean ? bb21 : bb22)
+
+# backedges
+# - bb13
+# - bb15
+# - bb16
+bb20[firstDead=-1]():
+    <returnMethodTemp>$2: NilClass = nil
+    <unconditional> -> bb24
 
 # backedges
 # - bb19
@@ -124,11 +132,15 @@ bb21[firstDead=-1]():
     <unconditional> -> bb24
 
 # backedges
-# - bb13
-# - bb15
-# - bb16
 # - bb19
+bb22[firstDead=-1]():
+    <returnMethodTemp>$2: NilClass = nil
+    <unconditional> -> bb24
+
+# backedges
+# - bb20
 # - bb21
+# - bb22
 bb24[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1

--- a/test/testdata/infer/control_flow/complex_implications_2.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implications_2.rb.cfg-text.exp
@@ -30,7 +30,7 @@ bb4[firstDead=-1](foo: StandardError):
 # - bb4
 bb7[firstDead=-1](err: T.nilable(StandardError)):
     junk: T.nilable(StandardError) = err
-    err -> (T.nilable(StandardError) ? bb8 : bb10)
+    err -> (T.nilable(StandardError) ? bb8 : bb9)
 
 # backedges
 # - bb7
@@ -40,7 +40,13 @@ bb8[firstDead=-1]():
 
 # backedges
 # - bb7
+bb9[firstDead=-1]():
+    <returnMethodTemp>$2: NilClass = nil
+    <unconditional> -> bb10
+
+# backedges
 # - bb8
+# - bb9
 bb10[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -64,7 +64,13 @@ bb8[firstDead=-1](x: Concrete):
 bb10[firstDead=-1](x: T.any(Other, Concrete)):
     <cfgAlias>$30: T.class_of(Other) = alias <C Other>
     <ifTemp>$27: T::Boolean = x: T.any(Other, Concrete).is_a?(<cfgAlias>$30: T.class_of(Other))
-    <ifTemp>$27 -> (T::Boolean ? bb13 : bb12)
+    <ifTemp>$27 -> (T::Boolean ? bb11 : bb12)
+
+# backedges
+# - bb10
+bb11[firstDead=-1]():
+    <returnMethodTemp>$2: NilClass = nil
+    <unconditional> -> bb13
 
 # backedges
 # - bb10
@@ -77,7 +83,7 @@ bb12[firstDead=-1](x: Concrete):
     <unconditional> -> bb13
 
 # backedges
-# - bb10
+# - bb11
 # - bb12
 bb13[firstDead=1](<returnMethodTemp>$2: T.nilable(Concrete)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Concrete)
@@ -92,7 +98,7 @@ bb0[firstDead=-1]():
     x: T.any(Base, Other) = load_arg(x)
     <cfgAlias>$6: T.class_of(Base)[Base, T.untyped] = alias <C Base>
     <ifTemp>$3: T::Boolean = x: T.any(Base, Other).is_a?(<cfgAlias>$6: T.class_of(Base)[Base, T.untyped])
-    <ifTemp>$3 -> (T::Boolean ? bb2 : bb4)
+    <ifTemp>$3 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
 # - bb4
@@ -108,7 +114,13 @@ bb2[firstDead=-1](x: Base):
 
 # backedges
 # - bb0
+bb3[firstDead=-1]():
+    <returnMethodTemp>$2: NilClass = nil
+    <unconditional> -> bb4
+
+# backedges
 # - bb2
+# - bb3
 bb4[firstDead=1](<returnMethodTemp>$2: T.nilable(Base)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Base)
     <unconditional> -> bb1

--- a/test/testdata/infer/method_result_type_locs.rb
+++ b/test/testdata/infer/method_result_type_locs.rb
@@ -5,11 +5,9 @@ class Main
 
   sig {returns(String)}
   def implicit_return_via_else
-    if T.unsafe(nil)
-      return 'yep'
-    end
+    if T.unsafe(nil); return 'yep'; end
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `String` but found `NilClass` for method result type
   end
-# ^^^ error: Expected `String` but found `NilClass` for method result type
 
   sig {returns(String)}
   def implicit_return_non_empty_cont_block


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #7936

Normally this doesn't matter if the `if` or `case` expression has an empty
`else`, so long as the result of the `if`/`case` doesn't assign to a variable.

Even if it does assign to a variable, sometimes it still doesn't matter, so long
as the variable is either already possibly `nil` or untyped.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.