### PR TITLE
Treat `type_alias` as a type alias only if called on `T`

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -629,12 +629,23 @@ public:
         return foundDefs->addTypeMember(move(found));
     }
 
+    bool sendRecvIsT(const ast::Send &s) {
+        bool result = false;
+
+        typecase(
+            s.recv, [&](const ast::UnresolvedConstantLit &c) { result = c.cnst == core::Names::Constants::T(); },
+            [&](const ast::ConstantLit &c) { result = c.symbol == core::Symbols::T(); },
+            [&](const ast::ExpressionPtr &_default) { result = false; });
+
+        return result;
+    }
+
     core::FoundDefinitionRef handleAssignment(core::Context ctx, const ast::Assign &asgn) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(asgn.rhs);
         auto foundRef = fillAssign(ctx, asgn);
         ENFORCE(foundRef.kind() == core::FoundDefinitionRef::Kind::StaticField);
         auto &staticField = foundRef.staticField(*foundDefs);
-        staticField.isTypeAlias = send.fun == core::Names::typeAlias();
+        staticField.isTypeAlias = sendRecvIsT(send) && send.fun == core::Names::typeAlias();
         return foundRef;
     }
 

--- a/test/testdata/namer/type_alias_not_on_T.rb
+++ b/test/testdata/namer/type_alias_not_on_T.rb
@@ -1,0 +1,20 @@
+# typed: true
+module A
+  module NotT
+    def self.type_alias(&blk); end
+  end
+
+  ValidTypeAlias = T.type_alias {Object}
+
+  NotActuallyATypeAlias = NotT.type_alias {Object}
+end
+
+module KnownLimitation
+  module T
+    def self.type_alias(&blk); end
+  end
+
+  # Known limitation: we can't distinguish between `::KnownLimitation::T` and `::T` in the namer,
+  # so this will have a false positive, being treated as a type alias when it shouldn't be.
+  StillATypeAlias = T.type_alias {Object}
+end

--- a/test/testdata/namer/type_alias_not_on_T.rb.symbol-table.exp
+++ b/test/testdata/namer/type_alias_not_on_T.rb.symbol-table.exp
@@ -1,0 +1,28 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/namer/type_alias_not_on_T.rb:2
+      argument <blk><block> @ Loc {file=test/testdata/namer/type_alias_not_on_T.rb start=??? end=???}
+  module ::A < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/namer/type_alias_not_on_T.rb:2
+    static-field ::A::NotActuallyATypeAlias -> <todo sym> @ test/testdata/namer/type_alias_not_on_T.rb:9
+    module ::A::NotT < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/namer/type_alias_not_on_T.rb:3
+    class ::A::<Class:NotT> < ::Module () @ test/testdata/namer/type_alias_not_on_T.rb:3
+      method ::A::<Class:NotT>#<static-init> (<blk>) @ test/testdata/namer/type_alias_not_on_T.rb:3
+        argument <blk><block> @ Loc {file=test/testdata/namer/type_alias_not_on_T.rb start=??? end=???}
+      method ::A::<Class:NotT>#type_alias (blk) @ test/testdata/namer/type_alias_not_on_T.rb:4
+        argument blk<block> @ Loc {file=test/testdata/namer/type_alias_not_on_T.rb start=4:26 end=4:29}
+    static-field-type-alias ::A::ValidTypeAlias -> Object @ test/testdata/namer/type_alias_not_on_T.rb:7
+  class ::<Class:A> < ::Module () @ test/testdata/namer/type_alias_not_on_T.rb:2
+    method ::<Class:A>#<static-init> (<blk>) @ test/testdata/namer/type_alias_not_on_T.rb:2
+      argument <blk><block> @ Loc {file=test/testdata/namer/type_alias_not_on_T.rb start=??? end=???}
+  module ::KnownLimitation < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/namer/type_alias_not_on_T.rb:12
+    static-field-type-alias ::KnownLimitation::StillATypeAlias -> Object @ test/testdata/namer/type_alias_not_on_T.rb:19
+    module ::KnownLimitation::T < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/namer/type_alias_not_on_T.rb:13
+    class ::KnownLimitation::<Class:T> < ::Module () @ test/testdata/namer/type_alias_not_on_T.rb:13
+      method ::KnownLimitation::<Class:T>#<static-init> (<blk>) @ test/testdata/namer/type_alias_not_on_T.rb:13
+        argument <blk><block> @ Loc {file=test/testdata/namer/type_alias_not_on_T.rb start=??? end=???}
+      method ::KnownLimitation::<Class:T>#type_alias (blk) @ test/testdata/namer/type_alias_not_on_T.rb:14
+        argument blk<block> @ Loc {file=test/testdata/namer/type_alias_not_on_T.rb start=14:26 end=14:29}
+  class ::<Class:KnownLimitation> < ::Module () @ test/testdata/namer/type_alias_not_on_T.rb:12
+    method ::<Class:KnownLimitation>#<static-init> (<blk>) @ test/testdata/namer/type_alias_not_on_T.rb:12
+      argument <blk><block> @ Loc {file=test/testdata/namer/type_alias_not_on_T.rb start=??? end=???}
+

--- a/test/testdata/resolver/type_alias_not_on_T.rb
+++ b/test/testdata/resolver/type_alias_not_on_T.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+module A
+  extend T::Sig
+
+  module NotT
+    def self.type_alias(&blk); end
+  end
+
+  NotATypeAlias = NotT.type_alias {Object}
+
+  sig {returns(NotATypeAlias)}
+  #            ^^^^^^^^^^^^^ error: Constant `A::NotATypeAlias` is not a class or type alias
+  def this_has_an_invalid_return_type; end
+end


### PR DESCRIPTION
### Motivation

Closes #6413

### Test plan

See included automated tests, which test this both in:

1. In the symbol table (looking for `static-field-type-alias` instead of `static-field`)
2. In the resolver (looking for an error when attempting to use the constant as a type).