### PR TITLE
Remove unused case in ErrorQueueMessage::Kind

### DIFF
--- a/core/ErrorQueueMessage.h
+++ b/core/ErrorQueueMessage.h
@@ -8,7 +8,7 @@ namespace sorbet::core {
 class Error;
 
 struct ErrorQueueMessage {
-    enum class Kind { Error, Flush, QueryResponse };
+    enum class Kind { Error, QueryResponse };
     Kind kind;
     core::FileRef whatFile;
     // The text of the error. Is a `nullopt` if the error is silenced.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Per the tin

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
