### PR TITLE
wip: Skip dropping the rootPath in LSP

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -3,6 +3,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
+#include "absl/strings/strip.h"
 #include "common/FileOps.h"
 #include "main/lsp/LSPMessage.h"
 #include "main/lsp/LSPOutput.h"
@@ -136,10 +137,7 @@ void LSPConfiguration::setClientConfig(const shared_ptr<const LSPClientConfigura
 string LSPConfiguration::localName2Remote(string_view filePath) const {
     ENFORCE(absl::StartsWith(filePath, rootPath));
     assertHasClientConfig();
-    string_view relativeUri = filePath.substr(rootPath.length());
-    if (relativeUri.at(0) == '/') {
-        relativeUri = relativeUri.substr(1);
-    }
+    string_view relativeUri = absl::StripPrefix(filePath, "./");
 
     // Special case: Root uri is '' (happens in Monaco)
     if (clientConfig->rootUri.length() == 0) {


### PR DESCRIPTION
cc @sushain-stripe

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Given this:

    file.data(gs).path()  = "./puppet-config/bar.rb"
    rootPath              = "./puppet-config"
    clientConfig->rootUri = "file:///Users/jez/sandbox/editor"

You'll end up with

    "file:///Users/jez/sandbox/editor/puppet-config/bar.rb"

instead of

    "file:///Users/jez/sandbox/editor/bar.rb"

which is a file that doesn't actually exist.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Going to have to write some protocol tests for this, but I'd rather poke around
at it manually before getting there.