### PR TITLE
Fix method visivility

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -389,6 +389,11 @@ public:
                 }
                 if (!original.hasPosArgs()) {
                     ENFORCE(!methodVisiStack.empty());
+
+                    if (original.recv.tag() != ast::Tag::Local) {
+                        break;
+                    }
+
                     methodVisiStack.back() = optional<core::FoundModifier>{core::FoundModifier{
                         core::FoundModifier::Kind::Method,
                         getOwner(),

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -390,7 +390,7 @@ public:
                 if (!original.hasPosArgs()) {
                     ENFORCE(!methodVisiStack.empty());
 
-                    if (original.recv.tag() != ast::Tag::Local) {
+                    if (!original.recv.isSelfReference()) {
                         break;
                     }
 

--- a/test/testdata/namer/visibility.rb
+++ b/test/testdata/namer/visibility.rb
@@ -66,13 +66,10 @@ class Foo6
   def foo; end
 end
 
-class NilClass
-  def private; end
-end
-
 class Foo7
   bar = nil
   bar.private
+  #   ^^^^^^^ error: Method `private` does not exist on `NilClass`
 
   def foo; end
 end

--- a/test/testdata/namer/visibility.rb
+++ b/test/testdata/namer/visibility.rb
@@ -53,3 +53,15 @@ class Foo4
     private :foo
   end
 end
+
+class Foo5
+  T.unsafe(nil).private
+
+  def foo; end  # this does not end up being private
+end
+
+class Foo6
+  self.private
+
+  def foo; end
+end

--- a/test/testdata/namer/visibility.rb
+++ b/test/testdata/namer/visibility.rb
@@ -65,3 +65,14 @@ class Foo6
 
   def foo; end
 end
+
+class NilClass
+  def private; end
+end
+
+class Foo7
+  bar = nil
+  bar.private
+
+  def foo; end
+end

--- a/test/testdata/namer/visibility.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/visibility.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=67:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=78:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=3:8}
     method <C <U A>>#<U f1> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=4:3 end=4:9}
@@ -88,5 +88,15 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U Foo6>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=63:1 end=63:11}
     type-member(+) <S <C <U Foo6>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo6>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo6) @ Loc {file=test/testdata/namer/visibility.rb start=63:1 end=63:11}
     method <S <C <U Foo6>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=63:1 end=67:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U Foo7>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=73:1 end=73:11}
+    method <C <U Foo7>>#<U foo> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=77:3 end=77:10}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <S <C <U Foo7>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=73:1 end=73:11}
+    type-member(+) <S <C <U Foo7>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo7>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo7) @ Loc {file=test/testdata/namer/visibility.rb start=73:1 end=73:11}
+    method <S <C <U Foo7>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=73:1 end=78:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U NilClass>> < <C <U Object>> (<C <U NilClass>>) @ (Loc {file=test/testdata/namer/visibility.rb start=69:1 end=69:15}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/nil_class.rbi start=removed end=removed})
+    method <C <U NilClass>>#<U private> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=70:3 end=70:14}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
 

--- a/test/testdata/namer/visibility.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/visibility.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=55:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=67:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=3:8}
     method <C <U A>>#<U f1> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=4:3 end=4:9}
@@ -74,5 +74,19 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <S <C <U Foo4>> $1> $1>[<C <U <AttachedClass>>>] < <C <U Class>> () @ Loc {file=test/testdata/namer/visibility.rb start=50:3 end=50:8}
     type-member(+) <S <S <C <U Foo4>> $1> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U Foo4>> $1> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <S <C <U Foo4>> $1>   targs = [     <C <U <AttachedClass>>> = Foo4   ] }) @ Loc {file=test/testdata/namer/visibility.rb start=50:3 end=50:8}
     method <S <S <C <U Foo4>> $1> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=50:3 end=54:6}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U Foo5>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=57:1 end=57:11}
+    method <C <U Foo5>>#<U foo> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=60:3 end=60:10}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <S <C <U Foo5>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=57:1 end=57:11}
+    type-member(+) <S <C <U Foo5>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo5>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo5) @ Loc {file=test/testdata/namer/visibility.rb start=57:1 end=57:11}
+    method <S <C <U Foo5>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=57:1 end=61:4}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <C <U Foo6>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=63:1 end=63:11}
+    method <C <U Foo6>>#<U foo> : private (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=66:3 end=66:10}
+      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
+  class <S <C <U Foo6>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=63:1 end=63:11}
+    type-member(+) <S <C <U Foo6>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo6>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo6) @ Loc {file=test/testdata/namer/visibility.rb start=63:1 end=63:11}
+    method <S <C <U Foo6>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=63:1 end=67:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
 

--- a/test/testdata/namer/visibility.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/visibility.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=78:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=75:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=3:1 end=3:8}
     method <C <U A>>#<U f1> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=4:3 end=4:9}
@@ -89,14 +89,11 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U Foo6>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo6>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo6) @ Loc {file=test/testdata/namer/visibility.rb start=63:1 end=63:11}
     method <S <C <U Foo6>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=63:1 end=67:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
-  class <C <U Foo7>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=73:1 end=73:11}
-    method <C <U Foo7>>#<U foo> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=77:3 end=77:10}
+  class <C <U Foo7>> < <C <U Object>> () @ Loc {file=test/testdata/namer/visibility.rb start=69:1 end=69:11}
+    method <C <U Foo7>>#<U foo> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=74:3 end=74:10}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
-  class <S <C <U Foo7>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=73:1 end=73:11}
-    type-member(+) <S <C <U Foo7>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo7>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo7) @ Loc {file=test/testdata/namer/visibility.rb start=73:1 end=73:11}
-    method <S <C <U Foo7>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=73:1 end=78:4}
-      argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
-  class <C <U NilClass>> < <C <U Object>> (<C <U NilClass>>) @ (Loc {file=test/testdata/namer/visibility.rb start=69:1 end=69:15}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/nil_class.rbi start=removed end=removed})
-    method <C <U NilClass>>#<U private> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=70:3 end=70:14}
+  class <S <C <U Foo7>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/visibility.rb start=69:1 end=69:11}
+    type-member(+) <S <C <U Foo7>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Foo7>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Foo7) @ Loc {file=test/testdata/namer/visibility.rb start=69:1 end=69:11}
+    method <S <C <U Foo7>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/visibility.rb start=69:1 end=75:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/visibility.rb start=??? end=???}
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This PR fixes method visibility after calling visibility changing methods like `private`, `protected`, `public` on receivers other than local context itself.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, methods defined after a `private` call would incorrectly be marked as private, even if the receiver is not `self`.  
Also, it can be incorrect after calling methods that changes visibility like`public`, `protected`, and so on.

Like:
```ruby
# typed: true

class Foo
  T.unsafe(nil).private

  def foo; end
end

Foo.new.foo
```

In this example, the `foo` method should not be marked as private, as the `private` call is not on `self`. However, method `foo` is marked as private and calling Foo.new.foo can not pass type checks.
```sh
> bundle exec srb tc
a.rb:9: Non-private call to private method foo on Foo https://srb.help/7031
     9 |Foo.new.foo
                ^^^
    a.rb:6: Defined in Foo here
     6 |  def foo; end
          ^^^^^^^
Errors: 1
```

In practice, code like a example below could not pass type checks.

```ruby
class Model
  configure_something Settings.s3.private.bucket_name

  attr_accessor :my_variable
end

class Controller
  def action
    # ...
    model.my_variable = 1
    # ...
  end
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
