### PR TITLE
Fix splat destructuring type information (retry#2)

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -433,11 +433,8 @@ ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlh
                 }
                 auto lhloc = lh.loc();
                 auto zlhloc = lhloc.copyWithZeroLength();
-                auto index = MK::Send3(lhloc, MK::Constant(lhloc, core::Symbols::Range()), core::Names::new_(), zlhloc,
-                                       MK::Int(lhloc, left), MK::Int(lhloc, -right), std::move(exclusive));
-                stats.emplace_back(MK::Assign(
-                    lhloc, std::move(lh),
-                    MK::Send1(loc, MK::Local(loc, tempExpanded), core::Names::slice(), zlhloc, std::move(index))));
+                auto ary = MK::Send0(loc, MK::Local(loc, tempExpanded), core::Names::toAry(), zlhloc);
+                stats.emplace_back(MK::Assign(lhloc, std::move(lh), std::move(ary)));
             }
             i = -right;
         } else {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -51,7 +51,6 @@ NameDef names[] = {
     {"tripleEq", "==="},
     {"orOp", "|"},
     {"backtick", "`"},
-    {"slice"},
     {"defined_p", "defined?"},
     {"undef"},
     {"each"},

--- a/test/testdata/desugar/multi_assign.rb
+++ b/test/testdata/desugar/multi_assign.rb
@@ -10,5 +10,7 @@ class Test
     a, b, *c, d, e = array
     a, * = array
     a.x, b = array
+    a, *b = *T.unsafe(array)
+    *a, b = *T.unsafe(array)
   end
 end

--- a/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
+++ b/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
@@ -36,13 +36,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <assignTemp>$8 = array
           <assignTemp>$9 = ::<Magic>.<expand-splat>(<assignTemp>$8, 1, 0)
           a = <assignTemp>$9.[](0)
-          b = <assignTemp>$9.slice(::Range.new(1, -1, false))
+          b = <assignTemp>$9.to_ary()
           <assignTemp>$8
         end
         begin
           <assignTemp>$10 = array
           <assignTemp>$11 = ::<Magic>.<expand-splat>(<assignTemp>$10, 0, 1)
-          a = <assignTemp>$11.slice(::Range.new(0, -1, true))
+          a = <assignTemp>$11.to_ary()
           b = <assignTemp>$11.[](-1)
           <assignTemp>$10
         end
@@ -51,7 +51,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <assignTemp>$13 = ::<Magic>.<expand-splat>(<assignTemp>$12, 2, 2)
           a = <assignTemp>$13.[](0)
           b = <assignTemp>$13.[](1)
-          c = <assignTemp>$13.slice(::Range.new(2, -2, true))
+          c = <assignTemp>$13.to_ary()
           d = <assignTemp>$13.[](-2)
           e = <assignTemp>$13.[](-1)
           <assignTemp>$12
@@ -68,6 +68,20 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           a.x=(<assignTemp>$17.[](0))
           b = <assignTemp>$17.[](1)
           <assignTemp>$16
+        end
+        begin
+          <assignTemp>$18 = ::<Magic>.<splat>(<emptyTree>::<C T>.unsafe(array))
+          <assignTemp>$19 = ::<Magic>.<expand-splat>(<assignTemp>$18, 1, 0)
+          a = <assignTemp>$19.[](0)
+          b = <assignTemp>$19.to_ary()
+          <assignTemp>$18
+        end
+        begin
+          <assignTemp>$20 = ::<Magic>.<splat>(<emptyTree>::<C T>.unsafe(array))
+          <assignTemp>$21 = ::<Magic>.<expand-splat>(<assignTemp>$20, 0, 1)
+          a = <assignTemp>$21.to_ary()
+          b = <assignTemp>$21.[](-1)
+          <assignTemp>$20
         end
       end
     end

--- a/test/testdata/desugar/multi_assign.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/multi_assign.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/multi_assign.rb start=2:1 end=14:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/desugar/multi_assign.rb start=2:1 end=16:4}
       argument <blk><block> @ Loc {file=test/testdata/desugar/multi_assign.rb start=??? end=???}
   static-field <C <U A>> @ Loc {file=test/testdata/desugar/multi_assign.rb start=2:1 end=2:2}
   static-field <C <U B>> @ Loc {file=test/testdata/desugar/multi_assign.rb start=2:4 end=2:5}
@@ -11,6 +11,6 @@ class <C <U <root>>> < <C <U Object>> ()
       argument <blk><block> @ Loc {file=test/testdata/desugar/multi_assign.rb start=??? end=???}
   class <S <C <U Test>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/desugar/multi_assign.rb start=4:1 end=4:11}
     type-member(+) <S <C <U Test>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Test>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Test) @ Loc {file=test/testdata/desugar/multi_assign.rb start=4:1 end=4:11}
-    method <S <C <U Test>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/multi_assign.rb start=4:1 end=14:4}
+    method <S <C <U Test>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/multi_assign.rb start=4:1 end=16:4}
       argument <blk><block> @ Loc {file=test/testdata/desugar/multi_assign.rb start=??? end=???}
 

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -187,7 +187,7 @@ rescue <emptyTree>::<C E> => x
   begin
     <assignTemp>$14 = ::<Magic>.<splat>(y)
     <assignTemp>$15 = ::<Magic>.<expand-splat>(<assignTemp>$14, 0, 0)
-    x = <assignTemp>$15.slice(::Range.new(0, -1, false))
+    x = <assignTemp>$15.to_ary()
     <assignTemp>$14
   end
 

--- a/test/testdata/resolver/multi_assign.rb
+++ b/test/testdata/resolver/multi_assign.rb
@@ -1,0 +1,54 @@
+# typed: true
+
+arr0 = []
+a, *b = arr0
+T.reveal_type(a) # error: Revealed type: `NilClass`
+T.reveal_type(b) # error: Revealed type: `T::Array[NilClass]`
+
+b = *arr0
+arr1 = [1, 2, 3]
+a, *b = arr1
+T.reveal_type(a) # error: Revealed type: `Integer(1)`
+T.reveal_type(b) # error: Revealed type: `T::Array[Integer]`
+
+arr2 = [1, :foo, "foo"]
+a, *b = arr2
+T.reveal_type(a) # error: Revealed type: `Integer(1)`
+T.reveal_type(b) # error: Revealed type: `T::Array[T.any(Integer, Symbol, String)]`
+
+arr3 = T.let([], T::Array[T.untyped])
+a, *b = arr3
+T.reveal_type(a) # error: Revealed type: `T.untyped`
+T.reveal_type(b) # error: Revealed type: `T::Array[T.untyped]`
+
+arr4 = T.unsafe([])
+a, *b = arr4
+T.reveal_type(a) # error: Revealed type: `T.untyped`
+T.reveal_type(b) # error: Revealed type: `T.untyped`
+
+arr5 = [1, 2, 3]
+a, *b, c = arr5
+T.reveal_type(a) # error: Revealed type: `Integer(1)`
+T.reveal_type(b) # error: Revealed type: `T::Array[Integer]`
+T.reveal_type(c) # error: Revealed type: `Integer(3)`
+
+arr6 = [1, 2, 3]
+a, b, *c = arr6
+T.reveal_type(a) # error: Revealed type: `Integer(1)`
+T.reveal_type(b) # error: Revealed type: `Integer(2)`
+T.reveal_type(c) # error: Revealed type: `T::Array[Integer]`
+
+arr7 = [1, 2, 3]
+a, *b = *arr7
+T.reveal_type(a) # error: Revealed type: `Integer(1)`
+T.reveal_type(b) # error: Revealed type: `T::Array[Integer]`
+
+arr8 = []
+a, *b = *T.unsafe(arr8)
+T.reveal_type(a) # error: Revealed type: `T.untyped`
+T.reveal_type(b) # error: Revealed type: `T.untyped`
+
+arr9 = T.let(nil, T.nilable(T::Array[Integer]))
+a, *b = arr9
+T.reveal_type(a) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type(b) # error: Revealed type: `T::Array[T.nilable(Integer)]`


### PR DESCRIPTION
### Motivation

Fixes https://github.com/sorbet/sorbet/issues/2020

Given this example of array destructuring:

```rb
arr = [1, 2, 3]
a, *b = arr
```

Currently, the desugar phase transforms the array destructuring using `slice`:

```rb
<assignTemp>$1 = arr
<assignTemp>$2 = ::<Magic>.<expand-splat>(<assignTemp>$1, 1, 0)
a = <assignTemp>$2.[](0)
b = <assignTemp>$2.slice(::Range.new(1, -1, false))
```

The undesirable side effect is that since `slice` [returns a nilable value](https://github.com/sorbet/sorbet/blob/ede4684fc7095e7fd30499bb80887d687d871fce/rbi/core/array.rbi#L2489), `b` becomes nilable:

```rb
T.reveal_type(b) # => T.nilable(T::Array[Integer])
```

The present change, uses `to_ary` instead which returns the non-nilable type of the array:

```rb
<assignTemp>$1 = arr
<assignTemp>$2 = ::<Magic>.<expand-splat>(<assignTemp>$1, 1, 0)
a = <assignTemp>$2.[](0)
b = <assignTemp>$2.to_ary()
```

While calling `to_ary` doesn't return the correct value, it returns the correct type. Which, in regard to type checking (i.e. not within a compiler), is all we're interested in:

```rb
T.reveal_type(b) # => T::Array[Integer]
```

### Test plan

See included automated tests.
