### PR TITLE
Always inherit from process.env right before launching server

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {
@@ -274,7 +274,11 @@
           "default": false
         },
         "sorbet.highlightUntyped": {
-          "enum": ["nowhere", "everywhere-but-tests", "everywhere"],
+          "enum": [
+            "nowhere",
+            "everywhere-but-tests",
+            "everywhere"
+          ],
           "description": "Shows warning for untyped values.",
           "default": "nowhere"
         },

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -298,7 +298,7 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
     this.context.log.debug(` > ${command} ${args.join(" ")}`);
     this.sorbetProcess = spawn(command, args, {
       cwd: workspace.rootPath,
-      env: activeConfig?.env ?? process.env,
+      env: { ...process.env, ...activeConfig?.env },
     });
     // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
     // So, we need to handle both events. ¯\_(ツ)_/¯

--- a/vscode_extension/src/sorbetLspConfig.ts
+++ b/vscode_extension/src/sorbetLspConfig.ts
@@ -94,14 +94,14 @@ export class SorbetLspConfig implements SorbetLspConfigData {
       this.name = name;
       this.description = description;
       this.cwd = cwd;
-      this.env = { ...process.env, ...env };
+      this.env = { ...env };
       this.command = command;
     } else {
       this.id = idOrData.id;
       this.name = idOrData.name;
       this.description = idOrData.description;
       this.cwd = idOrData.cwd;
-      this.env = { ...process.env, ...idOrData.env };
+      this.env = { ...idOrData.env };
       this.command = [...idOrData.command];
     }
   }


### PR DESCRIPTION
### Motivation

Before #7763, it's possible to setup VS Code's process env to help Sorbet starts its LSP. For example, Ruby LSP could handle Ruby activation and injects necessary env vars for Sorbet LSP to be started by the VS Code without additional configurations.

But that ability was lost after #7763 if:
- `activeConfig` is present
- Or, the Sorbet extension was activated a bit earlier then Ruby LSP. In that case, `SorbetLspConfig.env` would capture the same env and never captures the updated env even if the LSP failed to start.

And this PR addressed both cases.

### Test plan

All the existing tests should pass.
