### PR TITLE
Silence __t_props_generated_(de)serialize redefined warnings

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -62,7 +62,9 @@ module T::Props
         source = lazily_defined_methods.fetch(name).call
 
         cls = decorated_class
-        cls.class_eval(source.to_s)
+        T::Configuration.without_ruby_warnings do
+          cls.class_eval(source.to_s)
+        end
         cls.send(:private, name)
       end
 


### PR DESCRIPTION
Reported on a Slack that the first `serialize` or `deserialize` calls on T::Struct generates warnings as these:
```rb
# using the example from https://sorbet.org/docs/tstruct
m = MonetaryAmount.new(amount: 1, currency: "USD")
m.serialize
# (eval at /Users/bdewater/.rbenv/versions/3.3.2/lib/ruby/gems/3.3.0/gems/sorbet-runtime-0.5.11406/lib/types/props/has_lazily_specialized_methods.rb:65):1: warning: method redefined; discarding old __t_props_generated_serialize
# /Users/bdewater/.rbenv/versions/3.3.2/lib/ruby/gems/3.3.0/gems/sorbet-runtime-0.5.11406/lib/types/props/has_lazily_specialized_methods.rb:91: warning: previous definition of __t_props_generated_serialize was here
```

When searching the repo I found https://github.com/sorbet/sorbet/pull/1266 and reused that solution.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
Manually tested in IRB by setting `$VERBOSE = true`, monkey patching the changed method from this PR (and getting a warning for that 😉), then using the same example as above and not getting a warning.
