### PR TITLE
Swap T::Props to use kwargs for rules

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -110,7 +110,7 @@ module T::Props
     #
     # @return [void]
     sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
-    def prop(name, cls, rules={})
+    def prop(name, cls, **rules)
       cls = T::Utils.coerce(cls) if !cls.is_a?(Module)
       decorator.prop_defined(name, cls, rules)
     end
@@ -132,16 +132,16 @@ module T::Props
     end
 
     # Shorthand helper to define a `prop` with `immutable => true`
-    sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
-    def const(name, cls_or_args, args={})
+    sig {params(name: Symbol, cls_or_args: T.untyped, args: T.untyped).void}
+    def const(name, cls_or_args, **args)
       if (cls_or_args.is_a?(Hash) && cls_or_args.key?(:immutable)) || args.key?(:immutable)
         Kernel.raise ArgumentError.new("Cannot pass 'immutable' argument when using 'const' keyword to define a prop")
       end
 
       if cls_or_args.is_a?(Hash)
-        self.prop(name, cls_or_args.merge(immutable: true))
+        self.prop(name, **cls_or_args.merge(immutable: true))
       else
-        self.prop(name, cls_or_args, args.merge(immutable: true))
+        self.prop(name, cls_or_args, **args.merge(immutable: true))
       end
     end
 

--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -39,7 +39,7 @@ class T::ImmutableStruct < T::InexactStruct
 
   # Matches the signature in Props, but raises since this is an immutable struct and only const is allowed
   sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
-  def self.prop(name, cls, rules={})
+  def self.prop(name, cls, **rules)
     return super if (cls.is_a?(Hash) && cls[:immutable]) || rules[:immutable]
 
     raise "Cannot use `prop` in #{self.name} because it is an immutable struct. Use `const` instead"

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -21,10 +21,10 @@ module T::Props
 end
 
 module T::Props::ClassMethods
-  sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
-  def const(name, cls_or_args, args={}); end
+  sig {params(name: Symbol, cls_or_args: T.untyped, args: T.untyped).void}
+  def const(name, cls_or_args, **args); end
   sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
-  def prop(name, cls, rules = nil); end
+  def prop(name, cls, **rules); end
   def decorator; end
   def decorator_class; end
   def plugin(mod); end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Move `rules` away from Ruby's default hash coalescing into kwargs, which allows us to type individual fields and provides more extensibility. Tested internally and it seems to be working fine with just these changes to Sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
