### PR TITLE
Nilable parameter in Random.uuid_v7

### DIFF
--- a/rbi/core/random.rbi
+++ b/rbi/core/random.rbi
@@ -822,7 +822,7 @@ module SecureRandom
   # {Section 6.2}[https://www.ietf.org/archive/id/draft-ietf-uuidrev-rfc4122bis-07.html#monotonicity_counters]
   # of the specification.
   sig do
-    params(extra_timestamp_bits: Integer).returns(String)
+    params(extra_timestamp_bits: T.nilable(Integer)).returns(String)
   end
   def self.uuid_v7(extra_timestamp_bits:); end
 end


### PR DESCRIPTION
Per [this previous comment](https://github.com/sorbet/sorbet/pull/7951#discussion_r1630094844), fixing the type signature of `Random.uuid_v7` to take a `nilable` `Integer` for the `extra_timestamp_bits` parameter.