### PR TITLE
Accept string or regexp for Regexp#initialize

### DIFF
--- a/rbi/core/regexp.rbi
+++ b/rbi/core/regexp.rbi
@@ -1080,11 +1080,11 @@ class Regexp < Object
         options: BasicObject,
         kcode: String,
     )
-    .returns(Object)
+    .void
   end
   sig do
     params(
-        arg0: Regexp,
+        arg0: T.any(Regexp, String),
     )
     .void
   end
@@ -1365,7 +1365,7 @@ class Regexp < Object
   def self.union(*pats); end
 
 
-  # [TimeoutError](https://docs.ruby-lang.org/en/3.2/Regexp/TimeoutError.html) 
+  # [TimeoutError](https://docs.ruby-lang.org/en/3.2/Regexp/TimeoutError.html)
   # is raised when the timeout set by calling
   # [::timeout=][https://docs.ruby-lang.org/en/3.2/Regexp.html#method-c-timeout-3D]
   # is reached during matching.


### PR DESCRIPTION
Started accepting both string or regexp for the case of a single argument in `Regexp#initialize`.

### Motivation

Because Sorbet matches on the call site arity, we end up selecting the wrong signatures for [this scenario](https://sorbet.run/#%23%20typed%3A%20true%0A%0At%20%3D%20T.let%28%22%22%2C%20T.any%28String%2C%20Regexp%29%29%0ARegexp.new%28t%29).

```ruby
a = T.let("", T.any(Regexp, String))
Regexp.new(a) # => Fails
```

### Test plan

Just an RBI change.