### PR TITLE
Update llvm toolchain version in VSCode Clangd settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
   // Disable feature where Clangd auto-imports headers for missing references.
   // It inserts relative paths that we don't want.
   "clangd.arguments": ["--header-insertion=never"],
-  "clangd.path": "bazel-sorbet/external/llvm_toolchain_12_0_0/bin/clangd",
+  "clangd.path": "bazel-sorbet/external/llvm_toolchain_15_0_7/bin/clangd",
   "files.associations": {
     "*.rbi": "ruby",
     "*.rbupdated": "ruby",


### PR DESCRIPTION
### Motivation
#7886 updated to Clang 15, but the bin path in the VS Code settings file was never updated. This just bumps the version in the settings so it's easier to develop Sorbet in VS Code with the clangd extension.

### Test plan
I have tested this manually to make sure it works!
