### PR TITLE
Add annotations for IRB 1.13 extension APIs

### DIFF
--- a/rbi/stdlib/irb.rbi
+++ b/rbi/stdlib/irb.rbi
@@ -1682,3 +1682,37 @@ class IRB::WorkSpace
   # `IRB.conf[:__MAIN__]`
   def main; end
 end
+
+module IRB::Command
+  class << self
+    attr_reader :commands
+
+    def register(name, command_class); end
+  end
+end
+
+class IRB::Command::Base
+  class << self
+    def category(category = nil); end
+
+    def description(description = nil); end
+
+    def help_message(help_message = nil); end
+  end
+end
+
+module IRB::HelperMethod
+  class << self
+    attr_reader :helper_methods
+
+    def register(name, helper_class); end
+
+    def all_helper_methods_info; end
+  end
+end
+
+class IRB::HelperMethod::Base
+  class << self
+    def description(description = nil); end
+  end
+end


### PR DESCRIPTION
See title.

### Motivation
Make sure the examples given at https://github.com/ruby/irb/blob/master/EXTEND_IRB.md don't cause errors when used in an application. This can also be due to dependencies switching over to these APIs, in my case Console1984.

### Test plan
N/A
