### PR TITLE
Annotate Fiber.[] and Fiber.[]=

### DIFF
--- a/rbi/core/fiber.rbi
+++ b/rbi/core/fiber.rbi
@@ -161,4 +161,8 @@ class Fiber < Object
   # [`Fiber.yield`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-c-yield)
   # expression evaluates to.
   def self.yield(*_); end
+
+  def self.[]=(key, value); end
+
+  def self.[](key); end
 end


### PR DESCRIPTION
Add method definitions to `rbi/core/fiber.rbi` for `Fiber.[]` and `Fiber.[]=` methods.

### Motivation

Right now, we're getting Sorbet errors when doing `Fiber[:a]` and `Fiber[:a] = 1`, but [these methods do exist](https://ruby-doc.org/3.3.1/Fiber.html#method-c-5B-5D)

### Test plan

I have not added tests for these, should I?
