### PR TITLE
Fix signature for `Kernel#exec`

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -3018,8 +3018,15 @@ module Kernel
   # exec "echo", "*"    # echoes an asterisk
   # # never get here
   # ```
-  sig { params(args: String).returns(T.noreturn) }
-  def exec(*args); end
+  sig do
+    params(
+      env: T.any(String, [String, String], T::Hash[String, T.nilable(String)]),
+      argv0: T.any(String, [String, String]),
+      args: String,
+      options: T.untyped,
+    ).returns(T.noreturn)
+  end
+  def exec(env, argv0 = T.unsafe(nil), *args, **options); end
 
   # Executes *command...* in a subshell. *command...* is one of following forms.
   #


### PR DESCRIPTION
This copies the existing signature from `Kernel#system` which was added in https://github.com/sorbet/sorbet/commit/9a8a9d697c1f8cdcf77c51985fa6a7cb42ca95f3. `Kernel#exec` seems to use the same argument structure as `Kernel#system`.

### Motivation

Valid code such as:

```
exec({"ENV" => "1"}, "binary", "some", "args", out: :err)
```

was previously failing as the signature only accepted strings.

### Test plan

There's existing `system` tests that would be a copy-paste if we wanted to apply to `exec` too.
