### PR TITLE
Make find-references work for foreign prop accessors

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -509,9 +509,9 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
 
         core::LocOffsets methodLoc;
         if (ret.foreignKwLit != nullptr) {
-          methodLoc = ret.foreignKwLit.loc();
+            methodLoc = ret.foreignKwLit.loc();
         } else {
-          methodLoc = loc;
+            methodLoc = loc;
         }
 
         auto fkMethodDef = ast::MK::SyntheticMethod1(loc, methodLoc, fkMethod, std::move(arg),

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -110,6 +110,7 @@ struct PropInfo {
     ast::ExpressionPtr default_;
     core::NameRef computedByMethodName;
     core::LocOffsets computedByMethodNameLoc;
+    ast::ExpressionPtr foreignKwLit;
     ast::ExpressionPtr foreign;
     ast::ExpressionPtr enum_;
     ast::ExpressionPtr ifunset;
@@ -312,6 +313,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
         auto [fk, foreignTree] = ASTUtil::extractHashValue(ctx, *rules, core::Names::foreign());
         if (foreignTree != nullptr) {
             ret.foreign = move(foreignTree);
+            ret.foreignKwLit = move(fk);
             if (auto body = ASTUtil::thunkBody(ctx, ret.foreign)) {
                 ret.foreign = std::move(body);
             } else {
@@ -504,7 +506,8 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
         auto arg = ast::MK::KeywordArgWithDefault(nameLoc, core::Names::allowDirectMutation(), ast::MK::Nil(loc));
         ast::MethodDef::Flags fkFlags;
         fkFlags.discardDef = true;
-        auto fkMethodDef = ast::MK::SyntheticMethod1(loc, loc, fkMethod, std::move(arg),
+        auto foreignKwLoc = ret.foreignKwLit.loc();
+        auto fkMethodDef = ast::MK::SyntheticMethod1(loc, foreignKwLoc, fkMethod, std::move(arg),
                                                      ast::MK::RaiseTypedUnimplemented(loc), fkFlags);
         nodes.emplace_back(std::move(fkMethodDef));
 

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -506,8 +506,15 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
         auto arg = ast::MK::KeywordArgWithDefault(nameLoc, core::Names::allowDirectMutation(), ast::MK::Nil(loc));
         ast::MethodDef::Flags fkFlags;
         fkFlags.discardDef = true;
-        auto foreignKwLoc = ret.foreignKwLit.loc();
-        auto fkMethodDef = ast::MK::SyntheticMethod1(loc, foreignKwLoc, fkMethod, std::move(arg),
+
+        core::LocOffsets methodLoc;
+        if (ret.foreignKwLit != nullptr) {
+          methodLoc = ret.foreignKwLit.loc();
+        } else {
+          methodLoc = loc;
+        }
+
+        auto fkMethodDef = ast::MK::SyntheticMethod1(loc, methodLoc, fkMethod, std::move(arg),
                                                      ast::MK::RaiseTypedUnimplemented(loc), fkFlags);
         nodes.emplace_back(std::move(fkMethodDef));
 

--- a/test/testdata/lsp/prop_references.rb
+++ b/test/testdata/lsp/prop_references.rb
@@ -7,6 +7,10 @@ class A < T::InexactStruct
 
   prop :some_prop, String
   #     ^^^^^^^^^ def: A#some_prop
+
+  prop :foreign_b, T.nilable(String), foreign: -> { B }
+  #     ^^^^^^^^^ def: A#foreign_b
+  #                                   ^^^^^^^ def: A#foreign_b_
 end
 
 a = A.new(some_const: '', some_prop: '')
@@ -16,6 +20,8 @@ a.some_prop=('')
 # ^^^^^^^^^^ usage: A#some_prop
 a.some_prop
 # ^^^^^^^^^ usage: A#some_prop
+a.foreign_b_
+# ^^^^^^^^^^ usage: A#foreign_b_
 
 class B < T::Struct
   const :some_const, String

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -32,7 +32,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>>#<U foreign=> (foreign, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
       argument foreign<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_> (allow_direct_mutation, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+    method <C <U AdvancedODM>>#<U foreign_> (allow_direct_mutation, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:28 end=52:35}
       argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_!> (allow_direct_mutation, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
@@ -43,7 +43,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>>#<U foreign_invalid=> (foreign_invalid, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
       argument foreign_invalid<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_invalid_> (allow_direct_mutation, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+    method <C <U AdvancedODM>>#<U foreign_invalid_> (allow_direct_mutation, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:36 end=55:43}
       argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_invalid_!> (allow_direct_mutation, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
@@ -54,7 +54,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>>#<U foreign_lazy=> (foreign_lazy, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
       argument foreign_lazy<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_lazy_> (allow_direct_mutation, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+    method <C <U AdvancedODM>>#<U foreign_lazy_> (allow_direct_mutation, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:33 end=53:40}
       argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_lazy_!> (allow_direct_mutation, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
@@ -65,7 +65,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>>#<U foreign_proc=> (foreign_proc, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
       argument foreign_proc<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_proc_> (allow_direct_mutation, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+    method <C <U AdvancedODM>>#<U foreign_proc_> (allow_direct_mutation, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:33 end=54:40}
       argument allow_direct_mutation<optional, keyword> -> T.nilable(T::Boolean) @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_proc_!> (allow_direct_mutation, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Per the in -- find all references does not currently work for `foo_` type accessors for `foreign` props. This PR fixes the problem by moving the definition loc of the foreign prop to the `foreign:` keyword itself so it doesn't collide with the "regular" getter.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
[See example](https://sorbet.run/#%23%20typed%3A%20strict%0A%0Aclass%20A%20%3C%20T%3A%3AStruct%0A%20%20prop%20%3Ab%2C%20T.nilable%28String%29%2C%20foreign%3A%20-%3E%20%7B%20B%20%7D%0Aend%0A%0Aclass%20B%20%3C%20T%3A%3AStruct%0Aend%0A%0Aa%20%3D%20A.new%0Aa.b%0Aa.b%20%3D%20%22hello%22%0Aa.b_)

```
class A < T::Struct
  prop :b, T.nilable(String), foreign: -> { B }
  ^^^ # Find references reports a.b, a.b = "hello", but not a.b_ below.
end

class B < T::Struct
end

a = A.new
a.b
a.b = "hello"
a.b_
```

Find-references on props reports callsites of the corresponding rewritten getters and setters, but does not include foreign getters. This is seemingly because the definition loc of the prop itself is already overloaded by the getter/setter, and we cannot reuse the same loc for the foreign prop getter.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Also tested on Stripe codebase.
