### PR TITLE
Add a sanity check for the TypePtr::Tag of the value in Literal

### DIFF
--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -107,10 +107,16 @@ void EmptyTree::_sanityCheck() {}
 
 void Literal::_sanityCheck() {
     ENFORCE(value != nullptr);
+
     auto tag = value.tag();
-    if (tag != core::TypePtr::Tag::IntegerLiteralType && tag != core::TypePtr::Tag::FloatLiteralType &&
-        tag != core::TypePtr::Tag::NamedLiteralType && tag != core::TypePtr::Tag::ClassType) {
-        ENFORCE(false, "unexpected TypePtr::Tag: {}", tag);
+    switch (tag) {
+        case core::TypePtr::Tag::IntegerLiteralType:
+        case core::TypePtr::Tag::FloatLiteralType:
+        case core::TypePtr::Tag::NamedLiteralType:
+        case core::TypePtr::Tag::ClassType:
+            break;
+        default:
+            ENFORCE(false, "unexpected TypePtr::Tag: {}", tag);
     }
 }
 

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -107,6 +107,11 @@ void EmptyTree::_sanityCheck() {}
 
 void Literal::_sanityCheck() {
     ENFORCE(value != nullptr);
+    auto tag = value.tag();
+    if (tag != core::TypePtr::Tag::IntegerLiteralType && tag != core::TypePtr::Tag::FloatLiteralType &&
+        tag != core::TypePtr::Tag::NamedLiteralType && tag != core::TypePtr::Tag::ClassType) {
+        ENFORCE(false, "unexpected TypePtr::Tag: {}", tag);
+    }
 }
 
 void Hash::_sanityCheck() {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#7893 add a structural equality function that assumes that these are the only possible tags for the value in a `Literal`. Adding a sanity check for that, so we can be more confident in that assumption.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Enforce doesn't fire in existing tests, as well as when running over stripe's codebase.