### PR TITLE
Add --rbi CLI flag to accept inline RBI input

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -295,6 +295,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                        stop_after_options, ", ", [](const auto &pr) -> auto{ return pr.option; }));
 
     // Advanced options
+    options.add_options("advanced")("e-rbi", "Parse an inline RBI string",
+                                    cxxopts::value<string>()->default_value(empty.inlineRBIInput), "string");
     options.add_options("advanced")("dir", "Input directory", cxxopts::value<vector<string>>());
     options.add_options("advanced")("file", "Input file", cxxopts::value<vector<string>>());
     options.add_options("advanced")("allowed-extension", "Allowed extension", cxxopts::value<vector<string>>());
@@ -792,6 +794,7 @@ void readOptions(Options &opts,
         opts.autocorrect = raw["autocorrect"].as<bool>();
         opts.didYouMean = raw["did-you-mean"].as<bool>();
         opts.inlineInput = raw["e"].as<string>();
+        opts.inlineRBIInput = raw["e-rbi"].as<string>();
         if (opts.autocorrect && opts.silenceErrors) {
             logger->error("You may not use autocorrect when silencing errors.");
             throw EarlyReturnWithCode(1);

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -263,6 +263,7 @@ struct Options {
     std::string inlineInput; // passed via -e
     std::string debugLogFile;
     std::string webTraceFile;
+    std::string inlineRBIInput; // passed via --e-rbi
 
     // Path to an RBI whose contents should be minimized by subtracting parts that Sorbet already
     // has a record of in its own GlobalState.

--- a/test/cli/e-rbi/test.out
+++ b/test/cli/e-rbi/test.out
@@ -1,0 +1,12 @@
+-e:1: Expected `Integer` but found `String("abc")` for argument `x` https://srb.help/7002
+     1 |Foo.foo("abc")
+                ^^^^^
+  Expected `Integer` for argument `x` of method `Foo.foo (overload.1)`:
+    --e-rbi.rbi:4:
+     4 |      sig { params(x: Integer).returns(Integer) }
+                           ^
+  Got `String("abc")` originating from:
+    -e:1:
+     1 |Foo.foo("abc")
+                ^^^^^
+Errors: 1

--- a/test/cli/e-rbi/test.sh
+++ b/test/cli/e-rbi/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+main/sorbet --silence-dev-message --censor-for-snapshot-tests \
+  --e-rbi $'
+    module Foo
+      sig { returns(T::Boolean) }
+      sig { params(x: Integer).returns(Integer) }
+      def self.foo(x); end;
+    end
+  ' \
+  -e $'Foo.foo("abc")' 2>&1


### PR DESCRIPTION
This PR adds an `--rbi` flag to the CLI which accepts inline RBI input, similar to how `-e` takes inline Ruby input. The implementation is almost identical to the `-e` argument, except for Sorbet treating the input as an RBI file.

### Motivation

This will be useful for quickly testing typechecking involving RBI code. In particular, it could be used by [sorbet.run](https://sorbet.run) to reproduce issues involving RBI specific functionality such as sig overloads.


### Test plan

See included automated tests.
