### PR TITLE
Move `--wait-for-dbg` into readOptions

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -687,6 +687,10 @@ void readOptions(Options &opts,
         if (raw["simulate-crash"].as<bool>()) {
             Exception::raise("simulated crash");
         }
+        opts.waitForDebugger = raw["wait-for-dbg"].as<bool>();
+        while (opts.waitForDebugger && !stopInDebugger()) {
+            // spin
+        }
 
         if (raw.count("allowed-extension") > 0) {
             auto exts = raw["allowed-extension"].as<vector<string>>();
@@ -918,7 +922,6 @@ void readOptions(Options &opts,
         if (raw.count("suggest-unsafe") > 0) {
             opts.suggestUnsafe = raw["suggest-unsafe"].as<string>();
         }
-        opts.waitForDebugger = raw["wait-for-dbg"].as<bool>();
         opts.traceLexer = raw["trace-lexer"].as<bool>();
         opts.traceParser = raw["trace-parser"].as<bool>();
         opts.stressIncrementalResolver = raw["stress-incremental-resolver"].as<bool>();

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -390,9 +390,6 @@ int realmain(int argc, char *argv[]) {
     vector<unique_ptr<sorbet::pipeline::semantic_extension::SemanticExtension>> extensions;
     options::Options opts;
     options::readOptions(opts, extensions, argc, argv, extensionProviders, logger);
-    while (opts.waitForDebugger && !stopInDebugger()) {
-        // spin
-    }
     if (opts.stdoutHUPHack) {
         startHUPMonitor();
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I wanted to be able to use `--wait-for-dbg` to debug some of the logic
that handles reading files recursively from the set of folders provided.
We read the files from disk as soon as we handle the `<files>` and
`--dir` argument in the `readOptions` function, whereas we handled the
`--wait-for-dbg` option after option parsing / reading files from disk
(in realmain).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I've been using this locally while debugging something else.