### PR TITLE
Allow `# typed: __STDLIB_INTERNAL` to do what its designed for

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -207,7 +207,7 @@ constexpr string_view OVERLOADS_TEST_RB = "overloads_test.rb"sv;
 }
 
 bool File::permitOverloadDefinitions() const {
-    return this->isRBI() || FileOps::getFileName(this->path()) == OVERLOADS_TEST_RB;
+    return this->isRBI() || FileOps::getFileName(this->path()) == OVERLOADS_TEST_RB || this->isStdlib();
 }
 
 bool File::isPackage() const {

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -22,20 +22,18 @@ bool Inference::willRun(core::Context ctx, core::LocOffsets loc, core::MethodRef
     auto isMangleRenameOverload = name.kind() == core::NameKind::UNIQUE &&
                                   name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload;
     if (isMangleRenameOverload || methodData->flags.isOverloaded) {
-        if (!ctx.file.data(ctx).permitOverloadDefinitions()) {
-            if (auto e = ctx.beginError(loc, core::errors::Infer::TypecheckOverloadBody)) {
-                e.setHeader("Refusing to typecheck `{}` against an overloaded signature", method.show(ctx));
-                auto overloadMethod = method;
-                if (isMangleRenameOverload) {
-                    overloadMethod =
-                        methodData->owner.data(ctx)->findMember(ctx, name.dataUnique(ctx)->original).asMethodRef();
-                }
-                e.addErrorLine(overloadMethod.data(ctx)->loc(), "Given an overloaded signature here");
-                e.addErrorNote("Overloads are only supported in RBI files.\n"
-                               "    To silence this error, mark this file `{}`\n"
-                               "    Read the error doc for how to avoid using overloaded methods in the first place.",
-                               "# typed: false");
+        if (auto e = ctx.beginError(loc, core::errors::Infer::TypecheckOverloadBody)) {
+            e.setHeader("Refusing to typecheck `{}` against an overloaded signature", method.show(ctx));
+            auto overloadMethod = method;
+            if (isMangleRenameOverload) {
+                overloadMethod =
+                    methodData->owner.data(ctx)->findMember(ctx, name.dataUnique(ctx)->original).asMethodRef();
             }
+            e.addErrorLine(overloadMethod.data(ctx)->loc(), "Given an overloaded signature here");
+            e.addErrorNote("Overloads are only supported in RBI files.\n"
+                           "    To silence this error, mark this file `{}`\n"
+                           "    Read the error doc for how to avoid using overloaded methods in the first place.",
+                           "# typed: false");
         }
 
         return false;

--- a/test/testdata/infer/generics/overloads_test.rb
+++ b/test/testdata/infer/generics/overloads_test.rb
@@ -10,7 +10,7 @@ sig do
   params(x: String)
     .returns(T.nilable(String))
 end
-def example(x)
+def example(x) # error: against an overloaded signature
 end
 
 xs = T::Array[Integer].new
@@ -36,7 +36,7 @@ sig do
     )
     .void
 end
-def self.example2(type=T.unsafe(nil), *args, &blk)
+def self.example2(type=T.unsafe(nil), *args, &blk) # error: against an overloaded signature
 end
 
 example2(Integer, "--jobs=<n>") do |x|

--- a/test/testdata/infer/overload_stdlib_internal.rb
+++ b/test/testdata/infer/overload_stdlib_internal.rb
@@ -1,0 +1,14 @@
+# typed: __STDLIB_INTERNAL
+extend T::Sig
+
+sig { params(x: String).returns(String) }
+sig { params(x: Integer).returns(Integer) }
+def foo(x) # error: Refusing to typecheck `Object#foo` against an overloaded signature
+  raise
+end
+
+res = foo('')
+T.reveal_type(res) # error: `String`
+
+res = foo(0)
+T.reveal_type(res) # error: `Integer`

--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -33,7 +33,7 @@ class HasOverloads
     )
     .returns(Symbol)
   end
-  def overloaded(arg0, arg1=arg0, arg2=arg0);
+  def overloaded(arg0, arg1=arg0, arg2=arg0); # error: against an overloaded signature
     make_untyped
   end
 
@@ -51,7 +51,7 @@ class HasOverloads
     )
     .returns(Symbol)
   end
-  def invalid_overloaded(a:, b:);
+  def invalid_overloaded(a:, b:); # error: against an overloaded signature
     #                    ^^ error: Bad parameter ordering for `a`, expected `b` instead
     #                        ^^ error: Bad parameter ordering for `b`, expected `a` instead
     make_untyped
@@ -67,7 +67,7 @@ class OverloadAndGenerics
 
   sig {params(x: Elem).returns(Elem)}
   sig {params(x: String).returns(String)}
-  def overloaded(x); arg0; end
+  def overloaded(x); arg0; end # error: against an overloaded signature
 end
 
 class Foo
@@ -93,7 +93,7 @@ class PrivateOverloads
 
   sig {returns(NilClass)}
   sig {params(x: Integer).returns(Integer)}
-  private def foo(x=nil); end
+  private def foo(x=nil); end # error: against an overloaded signature
 end
 
 po1 = PrivateOverloads.new.foo # error: Non-private call to private method
@@ -111,25 +111,25 @@ class BlockOverloads
 
   sig { returns(A) }
   sig { params(blk: T.proc.void).returns(B) }
-  def simple(&blk); end
+  def simple(&blk); end # error: against an overloaded signature
 
   sig { params(blk: NilClass).returns(A) }
   sig { params(blk: T.proc.void).returns(B) }
-  def explicit_nilclass(&blk); end
+  def explicit_nilclass(&blk); end # error: against an overloaded signature
 
   sig { returns(A) }
   sig { params(blk: T.nilable(T.proc.void)).returns(B) }
-  def ambiguous_nilable_a(&blk); end
+  def ambiguous_nilable_a(&blk); end # error: against an overloaded signature
   sig { params(blk: T.nilable(T.proc.void)).returns(B) }
   sig { returns(A) }
-  def ambiguous_nilable_b(&blk); end
+  def ambiguous_nilable_b(&blk); end # error: against an overloaded signature
 
   sig { returns(A) }
   sig { params(blk: T.untyped).returns(B) }
-  def ambiguous_untyped_a(&blk); end
+  def ambiguous_untyped_a(&blk); end # error: against an overloaded signature
   sig { params(blk: T.untyped).returns(B) }
   sig { returns(A) }
-  def ambiguous_untyped_b(&blk); end
+  def ambiguous_untyped_b(&blk); end # error: against an overloaded signature
 
   sig { returns(A) }
   sig do
@@ -137,14 +137,14 @@ class BlockOverloads
       .params(blk: T.proc.returns(T.type_parameter(:U)))
       .returns(T.type_parameter(:U))
   end
-  def not_fully_defined(&blk); end
+  def not_fully_defined(&blk); end # error: against an overloaded signature
   sig do
     type_parameters(:U)
       .params(blk: T.proc.returns(T.type_parameter(:U)))
       .returns(T.type_parameter(:U))
   end
   sig { returns(A) }
-  def not_fully_defined_flipped(&blk); end
+  def not_fully_defined_flipped(&blk); end # error: against an overloaded signature
 
   def test
     x = simple

--- a/test/testdata/lsp/completion/overloads_test.A.rbedited
+++ b/test/testdata/lsp/completion/overloads_test.A.rbedited
@@ -6,7 +6,7 @@ class A
   extend T::Sig
   sig {params(x: I).void}
   sig {params(x: S).void}
-  def my_method(x); end
+  def my_method(x); end # error: against an overloaded signature
 end
 
 # Not possible to see in the test, but in VS Code though these items have the

--- a/test/testdata/lsp/completion/overloads_test.B.rbedited
+++ b/test/testdata/lsp/completion/overloads_test.B.rbedited
@@ -6,7 +6,7 @@ class A
   extend T::Sig
   sig {params(x: I).void}
   sig {params(x: S).void}
-  def my_method(x); end
+  def my_method(x); end # error: against an overloaded signature
 end
 
 # Not possible to see in the test, but in VS Code though these items have the

--- a/test/testdata/lsp/completion/overloads_test.rb
+++ b/test/testdata/lsp/completion/overloads_test.rb
@@ -6,7 +6,7 @@ class A
   extend T::Sig
   sig {params(x: I).void}
   sig {params(x: S).void}
-  def my_method(x); end
+  def my_method(x); end # error: against an overloaded signature
 end
 
 # Not possible to see in the test, but in VS Code though these items have the

--- a/test/testdata/lsp/fast_path/location_updates/overloads_test.1.rbupdate
+++ b/test/testdata/lsp/fast_path/location_updates/overloads_test.1.rbupdate
@@ -7,7 +7,7 @@ class A
   extend T::Sig
   sig {params(x: I).void}
   sig {params(x: S).void}
-  def my_method(x); end
+  def my_method(x); end # error: against an overloaded signature
 end
 
 

--- a/test/testdata/lsp/fast_path/location_updates/overloads_test.rb
+++ b/test/testdata/lsp/fast_path/location_updates/overloads_test.rb
@@ -43,7 +43,7 @@ class A
   extend T::Sig
   sig {params(x: I).void}
   sig {params(x: S).void}
-  def my_method(x); end
+  def my_method(x); end # error: against an overloaded signature
 end
 
 

--- a/test/testdata/lsp/fast_path/overloads_test.1.rbupdate
+++ b/test/testdata/lsp/fast_path/overloads_test.1.rbupdate
@@ -6,7 +6,7 @@ class A
 
   sig {params(x: Integer).void}
   sig {params(x: Integer, y: String).void}
-  def self.example1(x, y='')
+  def self.example1(x, y='') # error: against an overloaded signature
   end
 end
 

--- a/test/testdata/lsp/fast_path/overloads_test.rb
+++ b/test/testdata/lsp/fast_path/overloads_test.rb
@@ -5,7 +5,7 @@ class A
 
   sig {params(x: Integer).void}
   sig {params(x: Integer, y: String).void}
-  def self.example(x, y='')
+  def self.example(x, y='') # error: against an overloaded signature
   end
 end
 

--- a/test/testdata/lsp/rename/overloads_test.A.rbedited
+++ b/test/testdata/lsp/rename/overloads_test.A.rbedited
@@ -8,7 +8,7 @@ class A
   extend T::Sig
   sig {params(x: I).void}
   sig {params(target: S).void}
-  def my_method(target)
+  def my_method(target) # error: against an overloaded signature
     #           ^ apply-rename: [A] newName: target placeholderText: x
     puts(target)
   end

--- a/test/testdata/lsp/rename/overloads_test.rb
+++ b/test/testdata/lsp/rename/overloads_test.rb
@@ -8,7 +8,7 @@ class A
   extend T::Sig
   sig {params(x: I).void}
   sig {params(x: S).void}
-  def my_method(x)
+  def my_method(x) # error: against an overloaded signature
     #           ^ apply-rename: [A] newName: target placeholderText: x
     puts(x)
   end

--- a/test/testdata/resolver/overloads_test.rb
+++ b/test/testdata/resolver/overloads_test.rb
@@ -3,11 +3,11 @@ extend T::Sig
 
 sig {params(s: Integer).void}
 sig {params(s: String).void}
-def f(s); end
+def f(s); end # error: against an overloaded signature
 
 sig {params(s: Symbol).void}
 sig {params(s: Float).void}
-def f(s); end
+def f(s); end # error: against an overloaded signature
 
 f(0) # error: Expected `Symbol`
 f('') # error: Expected `Symbol`
@@ -19,19 +19,19 @@ class Wrap1
 
   sig {params(x: Integer).void}
   sig {params(x: Integer, blk: T.proc.returns(Integer)).void}
-  def one_kw(x:, &blk); end
+  def one_kw(x:, &blk); end # error: against an overloaded signature
 
   sig {params(x: Integer).void}
   sig {params(x: Integer, blk: T.proc.returns(Integer)).void}
-  def opt_kw(x: 0, &blk); end
+  def opt_kw(x: 0, &blk); end # error: against an overloaded signature
 
   sig {params(s: String, x: Integer).void}
   sig {params(s: String, x: Integer, blk: T.proc.returns(Integer)).void}
-  def opt_pos_opt_kw(s='', x: 0, &blk); end
+  def opt_pos_opt_kw(s='', x: 0, &blk); end # error: against an overloaded signature
 
   sig {params(x: Integer, y: String).void}
   sig {params(x: Integer, y: String, blk: T.proc.returns(Integer)).void}
-  def two_kw(x:, y:, &blk); end
+  def two_kw(x:, y:, &blk); end # error: against an overloaded signature
 
   sig {params(x: Integer, y: String).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
@@ -39,29 +39,31 @@ class Wrap1
   sig {params(x: Integer, y: String, blk: T.proc.returns(Integer)).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
 #                         ^ error: Unknown argument name
-  def arg_in_sig_but_not_method(x:, &blk); end
+  def arg_in_sig_but_not_method(x:, &blk); end # error: against an overloaded signature
 
   sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   sig {params(y: String, x: Integer).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
-  def keyword_ordering_matters(x:, y:); end # error-with-dupes: Bad parameter ordering
+  def keyword_ordering_matters(x:, y:); end # error: against an overloaded signature
+  #                            ^^ error: Bad parameter ordering
+  #                                ^^ error: Bad parameter ordering
 
   sig {params(x: T::Boolean).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
   sig {params(x: FalseClass, blk: T.proc.returns(Integer)).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
-  def arg_types_must_match(x:, &blk); end
+  def arg_types_must_match(x:, &blk); end # error: against an overloaded signature
 
   sig {params(x: Integer, blk: T.proc.returns(Integer)).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer, blk: T.proc.returns(String)).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
-  def only_one_block_per_pair(x:, &blk); end
+  def only_one_block_per_pair(x:, &blk); end # error: against an overloaded signature
 
   sig {params(x: Integer).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
-  def needs_one_block_per_pair(x:); end
+  def needs_one_block_per_pair(x:); end # error: against an overloaded signature
 
   # We currently require type equivalence for parameters in sigs for overloaded methods
   # with keyword arguments.  This is probably a little too strong, but fixing it would
@@ -76,7 +78,7 @@ class Wrap1
       .params(x: T.type_parameter(:U), y: Integer, blk: T.proc.returns(Integer)) # error: Overloaded functions cannot have keyword arguments
       .void
   end
-  def matching_positional_type_parameters_not_allowed(x, y:, &blk); end
+  def matching_positional_type_parameters_not_allowed(x, y:, &blk); end # error: against an overloaded signature
 
   sig do
     type_parameters(:U)
@@ -88,7 +90,7 @@ class Wrap1
       .params(x: T.type_parameter(:V), y: Integer, blk: T.proc.returns(Integer)) # error: Overloaded functions cannot have keyword arguments
       .void
   end
-  def mismatched_positional_type_parameters_not_allowed(x, y:, &blk); end
+  def mismatched_positional_type_parameters_not_allowed(x, y:, &blk); end # error: against an overloaded signature
 
   sig do
     type_parameters(:U)
@@ -100,7 +102,7 @@ class Wrap1
       .params(x: T.type_parameter(:U), blk: T.proc.returns(Integer)) # error: Overloaded functions cannot have keyword arguments
       .void
   end
-  def matching_kwarg_type_parameters_not_allowed(x:, &blk); end
+  def matching_kwarg_type_parameters_not_allowed(x:, &blk); end # error: against an overloaded signature
 
   sig do
     type_parameters(:U)
@@ -112,7 +114,7 @@ class Wrap1
       .params(x: T.type_parameter(:V), blk: T.proc.returns(Integer)) # error: Overloaded functions cannot have keyword arguments
       .void
   end
-  def mismatched_kwargs_type_parameters_not_allowed(x:, &blk); end
+  def mismatched_kwargs_type_parameters_not_allowed(x:, &blk); end # error: against an overloaded signature
 end
 
 Wrap1.new.opt_kw()
@@ -128,26 +130,26 @@ class Wrap2
 
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
-  def missing_kw1(x:, y: ''); end
+  def missing_kw1(x:, y: ''); end # error: against an overloaded signature
 
   sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
-  def missing_kw2(x:, y: ''); end
+  def missing_kw2(x:, y: ''); end # error: against an overloaded signature
 
   # Same pattern as the above, but 3 sigs will error where two will not.
   # TODO(froydnj): can we test what happens when the relevant error is suppressed?
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer, y: String, z: Float).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
-  def multiple_missing_kw(x:, y: '', z: 0.0); end
+  def multiple_missing_kw(x:, y: '', z: 0.0); end # error: against an overloaded signature
 
   sig {params(z: String, x: Integer).void} # error: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
-  def mismatched_positional_args1(z='', x:); end
+  def mismatched_positional_args1(z='', x:); end # error: against an overloaded signature
 
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
   sig {params(z: String, x: Integer).void} # error: Overloaded functions cannot have keyword arguments
-  def mismatched_positional_args2(z='', x:); end
+  def mismatched_positional_args2(z='', x:); end # error: against an overloaded signature
 end
 
 Wrap2.new.missing_kw1(x: 0, y: 'foo') # error: Unrecognized keyword argument
@@ -178,7 +180,7 @@ class WrapGeneric1
     params(x: Elem, y: Integer, blk: T.proc.returns(Integer))
       .void
   end
-  def matching_positional_type_members(x, y:, &blk); end
+  def matching_positional_type_members(x, y:, &blk); end # error: against an overloaded signature
 
   sig do
     params(x: Elem)
@@ -188,7 +190,7 @@ class WrapGeneric1
     params(x: Elem, blk: T.proc.returns(Integer))
       .void
   end
-  def matching_kwarg_type_members(x:, &blk); end
+  def matching_kwarg_type_members(x:, &blk); end # error: against an overloaded signature
 end
 
 class WrapGeneric2
@@ -205,7 +207,7 @@ class WrapGeneric2
     params(x: Elem, y: Integer, blk: T.proc.returns(Integer))
       .void
   end
-  def self.matching_positional_type_templates(x, y:, &blk); end
+  def self.matching_positional_type_templates(x, y:, &blk); end # error: against an overloaded signature
 
   sig do
     params(x: Elem)
@@ -215,7 +217,7 @@ class WrapGeneric2
     params(x: Elem, blk: T.proc.returns(Integer))
       .void
   end
-  def self.matching_kwarg_type_templates(x:, &blk); end
+  def self.matching_kwarg_type_templates(x:, &blk); end # error: against an overloaded signature
 end
 
 class WrapGeneric3
@@ -235,7 +237,7 @@ class WrapGeneric3
 #                   ^ error: Overloaded functions cannot have keyword arguments
       .void
   end
-  def mismatched_positional_type_members(x, y:, &blk); end
+  def mismatched_positional_type_members(x, y:, &blk); end # error: against an overloaded signature
 
   sig do
     params(x: Elem)
@@ -247,7 +249,7 @@ class WrapGeneric3
 #          ^ error: Overloaded functions cannot have keyword arguments
       .void
   end
-  def mismatched_kwarg_type_members(x:, &blk); end
+  def mismatched_kwarg_type_members(x:, &blk); end # error: against an overloaded signature
 end
 
 class WrapGeneric4
@@ -267,7 +269,7 @@ class WrapGeneric4
 #                   ^ error: Overloaded functions cannot have keyword arguments
       .void
   end
-  def self.mismatched_positional_type_templates(x, y:, &blk); end
+  def self.mismatched_positional_type_templates(x, y:, &blk); end # error: against an overloaded signature
 
   sig do
     params(x: Elem)
@@ -279,7 +281,7 @@ class WrapGeneric4
 #          ^ error: Overloaded functions cannot have keyword arguments
       .void
   end
-  def self.mismatched_kwarg_type_templates(x:, &blk); end
+  def self.mismatched_kwarg_type_templates(x:, &blk); end # error: against an overloaded signature
 end
 
 

--- a/test/testdata/resolver/redefined_and_overloaded/overloads_test.1.rbupdate
+++ b/test/testdata/resolver/redefined_and_overloaded/overloads_test.1.rbupdate
@@ -6,13 +6,14 @@ class A
 
   sig {params(x: Integer).void}
   sig {params(x: Integer, y: String).void}
-  def self.example(x, y='')
+  def self.example(x, y='') # error: against an overloaded signature
   end
 
   sig {params(x: Integer).void}
   sig {params(x: Integer, y: String).void}
   sig {params(x: Integer, y: String, z: Float).void}
   def self.example1(x, y='', z=0.0)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: against an overloaded signature
   end
 end
 

--- a/test/testdata/resolver/redefined_and_overloaded/overloads_test.rb
+++ b/test/testdata/resolver/redefined_and_overloaded/overloads_test.rb
@@ -5,13 +5,14 @@ class A
 
   sig {params(x: Integer).void}
   sig {params(x: Integer, y: String).void}
-  def self.example(x, y='')
+  def self.example(x, y='') # error: against an overloaded signature
   end
 
   sig {params(x: Integer).void}
   sig {params(x: Integer, y: String).void}
   sig {params(x: Integer, y: String, z: Float).void}
   def self.example(x, y='', z=0.0) # error: Method `A.example` redefined without matching argument count. Expected: `2`, got: `3`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: against an overloaded signature
   end
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The meaning of `# typed: __STDLIB_INTERNAL` is to permit overloaded
methods. Originally, that meant "in RBI files outside of those defined
in Sorbet's payload," thus the name `__STDLIB_INTERNAL`. But then in
7e4939fbdb3c86f477709a9e501b8d9dd5f1595d we relaxed the requirement that
overloads be defined in Sorbet's payload (allowing them in all RBI
files). I had tried to make it so that this strictness level would work
in non-RBI files to permit overloaded definitions but it seems like I
didn't test that.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.