### PR TITLE
Overhaul rootPath support

### DIFF
--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -57,8 +57,7 @@ public:
      * Returns 'true' if the file at the given path is ignored.
      * See sorbet::options for information on absolute and relative ignore patterns.
      */
-    static bool isFileIgnored(std::string_view basePath, std::string_view filePath,
-                              const std::vector<std::string> &absoluteIgnorePatterns,
+    static bool isFileIgnored(std::string_view filePath, const std::vector<std::string> &absoluteIgnorePatterns,
                               const std::vector<std::string> &relativeIgnorePatterns);
     static std::string_view getFileName(std::string_view path);
     static std::string_view getExtension(std::string_view path);

--- a/common/common.cc
+++ b/common/common.cc
@@ -247,9 +247,7 @@ bool sorbet::FileOps::isFolder(string_view path, string_view ignorePattern, cons
 }
 
 // Simple, naive implementation of regexp-free ignore rules.
-// TODO(jez) The basePath argument is unused here now.
-bool sorbet::FileOps::isFileIgnored(string_view basePath, string_view relative_path,
-                                    const vector<string> &absoluteIgnorePatterns,
+bool sorbet::FileOps::isFileIgnored(string_view relative_path, const vector<string> &absoluteIgnorePatterns,
                                     const vector<string> &relativeIgnorePatterns) {
     for (auto &p : absoluteIgnorePatterns) {
         if (relative_path.substr(0, p.length()) == p &&
@@ -306,8 +304,8 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
     ++pendingJobs;
     jobq->push(path, 1);
 
-    workers.multiplexJob("options.findFiles", [numWorkers, jobq, resultq, &pendingJobs, &basePath, &extensions,
-                                               &recursive, &absoluteIgnorePatterns, &relativeIgnorePatterns]() {
+    workers.multiplexJob("options.findFiles", [numWorkers, jobq, resultq, &pendingJobs, &extensions, &recursive,
+                                               &absoluteIgnorePatterns, &relativeIgnorePatterns]() {
         Job job;
         vector<string> output;
 
@@ -363,8 +361,7 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
                     }
 
                     auto fullPath = path == "." ? string(nameview) : fmt::format("{}/{}", path, nameview);
-                    if (sorbet::FileOps::isFileIgnored(basePath, fullPath, absoluteIgnorePatterns,
-                                                       relativeIgnorePatterns)) {
+                    if (sorbet::FileOps::isFileIgnored(fullPath, absoluteIgnorePatterns, relativeIgnorePatterns)) {
                         continue;
                     }
 

--- a/common/common.cc
+++ b/common/common.cc
@@ -247,12 +247,10 @@ bool sorbet::FileOps::isFolder(string_view path, string_view ignorePattern, cons
 }
 
 // Simple, naive implementation of regexp-free ignore rules.
-bool sorbet::FileOps::isFileIgnored(string_view basePath, string_view filePath,
+// TODO(jez) The basePath argument is unused here now.
+bool sorbet::FileOps::isFileIgnored(string_view basePath, string_view relative_path,
                                     const vector<string> &absoluteIgnorePatterns,
                                     const vector<string> &relativeIgnorePatterns) {
-    ENFORCE(filePath.substr(0, basePath.length()) == basePath);
-    // Note: relative_path always includes a leading /
-    string_view relative_path = filePath.substr(basePath.length());
     for (auto &p : absoluteIgnorePatterns) {
         if (relative_path.substr(0, p.length()) == p &&
             (isFile(relative_path, p, 0) || isFolder(relative_path, p, 0))) {
@@ -364,7 +362,7 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
                         }
                     }
 
-                    auto fullPath = fmt::format("{}/{}", path, nameview);
+                    auto fullPath = path == "." ? string(nameview) : fmt::format("{}/{}", path, nameview);
                     if (sorbet::FileOps::isFileIgnored(basePath, fullPath, absoluteIgnorePatterns,
                                                        relativeIgnorePatterns)) {
                         continue;

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -141,8 +141,7 @@ string LSPConfiguration::localName2Remote(string_view filePath) const {
     }
 
     // Use a sorbet: URI if the file is not present on the client AND the client supports sorbet: URIs
-    if (clientConfig->enableSorbetURIs &&
-        FileOps::isFileIgnored(rootPath, filePath, opts.lspDirsMissingFromClient, {})) {
+    if (clientConfig->enableSorbetURIs && FileOps::isFileIgnored(filePath, opts.lspDirsMissingFromClient, {})) {
         return absl::StrCat(sorbetScheme, filePath);
     }
     return absl::StrCat(clientConfig->rootUri, "/", filePath);
@@ -249,7 +248,7 @@ vector<string> LSPConfiguration::frefsToPaths(const core::GlobalState &gs, const
 }
 
 bool LSPConfiguration::isFileIgnored(string_view filePath) const {
-    return FileOps::isFileIgnored(rootPath, filePath, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
+    return FileOps::isFileIgnored(filePath, opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
 }
 
 bool LSPConfiguration::isSorbetUri(string_view uri) const {

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -18,21 +18,6 @@ constexpr string_view sorbetScheme = "sorbet:"sv;
 
 namespace {
 
-string getRootPath(const shared_ptr<LSPOutput> &output, const options::Options &opts,
-                   const shared_ptr<spdlog::logger> &logger) {
-    if (opts.rawInputDirNames.size() != 1) {
-        auto msg =
-            fmt::format("Sorbet's language server requires a single input directory. However, {} are configured: [{}]",
-                        opts.rawInputDirNames.size(), absl::StrJoin(opts.rawInputDirNames, ", "));
-        logger->error(msg);
-        auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
-        output->write(make_unique<LSPMessage>(
-            make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
-        throw EarlyReturnWithCode(1);
-    }
-    return opts.rawInputDirNames.at(0);
-}
-
 MarkupKind getPreferredMarkupKind(vector<MarkupKind> formats) {
     if (absl::c_find(formats, MarkupKind::Markdown) != formats.end()) {
         return MarkupKind::Markdown;
@@ -44,8 +29,7 @@ MarkupKind getPreferredMarkupKind(vector<MarkupKind> formats) {
 
 LSPConfiguration::LSPConfiguration(const options::Options &opts, const shared_ptr<LSPOutput> &output,
                                    const shared_ptr<spdlog::logger> &logger, bool disableFastPath)
-    : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger), disableFastPath(disableFastPath),
-      rootPath(getRootPath(output, opts, logger)) {}
+    : initialized(atomic<bool>(false)), opts(opts), output(output), logger(logger), disableFastPath(disableFastPath) {}
 
 void LSPConfiguration::assertHasClientConfig() const {
     if (!clientConfig) {

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -16,6 +16,7 @@ namespace {
 constexpr string_view sorbetScheme = "sorbet:"sv;
 } // namespace
 
+// TODO(jez) audit rawInputDirNames -> only needed for watchman at this point
 namespace {
 
 MarkupKind getPreferredMarkupKind(vector<MarkupKind> formats) {

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -94,8 +94,6 @@ public:
     const std::shared_ptr<spdlog::logger> logger;
     /** If true, all queries will hit the slow path. */
     const bool disableFastPath;
-    /** File system root of LSP client workspace. May be empty if it is the current working directory. */
-    const std::string rootPath;
 
     // The following properties are configured during initialization.
 

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -490,8 +490,7 @@ LSPPreprocessor::canonicalizeEdits(uint32_t v, unique_ptr<WatchmanQueryResponse>
     auto edit = make_unique<SorbetWorkspaceEditParams>();
     edit->epoch = v;
     for (auto &file : queryResponse->files) {
-        // Don't append rootPath if it is empty.
-        string localPath = !config->rootPath.empty() ? absl::StrCat(config->rootPath, "/", file) : file;
+        string localPath = file;
         // Editor contents supersede file system updates.
         if (!config->isFileIgnored(localPath) && !openFiles.contains(localPath)) {
             auto fileType = core::File::Type::Normal;

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -80,6 +80,11 @@ void WatchmanProcess::start() {
 
         string buffer;
 
+        // TODO(jez) I don't think we actually get to send multiple commands over stdin?
+        // We need to do something like send a watch-project command first, and follow up with one
+        // subscribe command for every path in rawInputDirNames, which needs 1 + N commands instead
+        // of only 1 like there is right now.
+
         // Note: Newer versions of Watchman (post 4.9.0) support ["suffix", ["suffix1", "suffix2", ...]], but Stripe
         // laptops have 4.9.0. Thus, we use [ "anyof", [ "suffix", "suffix1" ], [ "suffix", "suffix2" ], ... ].
         // Note 2: `empty_on_fresh_instance` prevents Watchman from sending entire contents of folder if this

--- a/main/lsp/watchman/WatchmanProcess.h
+++ b/main/lsp/watchman/WatchmanProcess.h
@@ -47,6 +47,8 @@ private:
 
     void enqueueNotification(std::unique_ptr<NotificationMessage> notification);
 
+    std::optional<std::string> readLine(FILE *file, int fd, std::string &buffer);
+
     void processQueryResponse(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>);
 
     void processStateEnter(std::unique_ptr<sorbet::realmain::lsp::WatchmanStateEnter>);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are a couple problems:

- Sorbet somewhat artificially only supports a single input directory in LSP
  mode. There's no good reason why that needs to be the case, and people
  frequently complain about it.
- Sorbet doesn't actually work in LSP mode if the `--dir` is not `.`. Certain
  things like errors will show up, but other things like go to definition will
  go to the wrong places, because those errors and jump to definition targets
  will be missing the `subdir/` prefix in their relative path.
- This lets us delete other code, like the various hacks we have to
  retroactively hide all the `./` prefixes that we forcibly prefix all paths
  with.

This fixes all of them.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I have been testing this manually as I've gone along, but it needs more testing.