### PR TITLE
Fix some formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,14 +480,14 @@ different version number, and also marked `default-arg-value`:
 This is due to the translation of defaults into the CFG: there is a synthetic conditional that chooses either to
 initialize the variable from the argument passed at the send, or to the default value when no value is present.
 
-Finding all references works differently in package specification (__package.rb) files. Consider the following:
+Finding all references works differently in package specification (`__package.rb`) files. Consider the following:
 
 ```ruby
 class Foo < PackageSpec
   import Bar
 ```
 
-Calling "find all references" on `Bar` in this file will return only references to `Bar` in the `Foo` package. LSP tests 
+Calling "find all references" on `Bar` in this file will return only references to `Bar` in the `Foo` package. LSP tests
 have access to `import` and `importusage` assertions that you can use to test this functionality.
 
 ```ruby
@@ -505,7 +505,7 @@ class Foo < PackageSpec
 
 With these annotations, the LSP test will check if "find all references" on `Bar` in `import Bar` statement returns the `Bar.new` usage.
 
-Note that an `import` assertion is dissimilar to a `def` assertion, in that it is in fact a subclass of a `usage` assertion. 
+Note that an `import` assertion is dissimilar to a `def` assertion, in that it is in fact a subclass of a `usage` assertion.
 In this case, the `def` corresponding to an `import` is the PackageSpec declaration of the imported package. Calling "find all references"
 on a PackageSpec declaration will return all imports of the package.
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was causing weird syntax highlighting for me in Vim (the
`__package.rb`) was getting treated as an unclosed bolded region.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a