### PR TITLE
Use `watch-project` when launching watchman

### DIFF
--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1306,6 +1306,16 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                         classTypes);
 
     /* Watchman JSON response objects */
+    auto WatchmanWatchProjectResponse =
+        makeObject("WatchmanWatchProjectResponse",
+                   {
+                       makeField("version", JSONString),
+                       makeField("watcher", JSONString),
+                       makeField("watch", JSONString),
+                       makeField("relative_path", "relativePath", makeOptional(JSONString)),
+                   },
+                   classTypes);
+
     auto WatchmanQueryResponse = makeObject("WatchmanQueryResponse",
                                             {
                                                 makeField("version", JSONString),

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -80,7 +80,7 @@ optional<WatchmanProcess::ReadResponse> WatchmanProcess::readResponse(FILE *file
 void WatchmanProcess::start() {
     auto mainPid = getpid();
     try {
-        string subscriptionName = fmt::format("ruby-typer-{}", getpid());
+        string subscriptionName = fmt::format("sorbet-{}", getpid());
 
         logger->debug("Starting monitoring path {} with watchman for files with extensions {}. Subscription id: {}",
                       workSpace, fmt::join(extensions, ","), subscriptionName);

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -114,6 +114,13 @@ void WatchmanProcess::start() {
         p.send(subscribeCommand.c_str(), subscribeCommand.size());
         logger->debug(subscribeCommand);
 
+        if (auto res = readResponse(file, fd, buffer)) {
+            if (!res->d.HasMember("subscribe")) {
+                // Something we don't understand yet.
+                logger->debug("Unknown Watchman response:\n{}", res->line);
+            }
+        }
+
         while (!isStopped()) {
             ReadResponse res;
             if (auto maybeRes = readResponse(file, fd, buffer)) {
@@ -146,7 +153,7 @@ void WatchmanProcess::start() {
                     auto stateLeave = sorbet::realmain::lsp::WatchmanStateLeave::fromJSONValue(d);
                     processStateLeave(move(stateLeave));
                 });
-            } else if (!d.HasMember("subscribe")) {
+            } else {
                 // Something we don't understand yet.
                 logger->debug("Unknown Watchman response:\n{}", line);
             }

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -98,16 +98,22 @@ void WatchmanProcess::start() {
         // Note 2: `empty_on_fresh_instance` prevents Watchman from sending entire contents of folder if this
         // subscription starts the daemon / causes the daemon to watch this folder for the first time.
         string subscribeCommand = fmt::format(
-            "[\"subscribe\", \"{}\", \"{}\", {{"
-            "\"expression\": [\"allof\", "
-            "[\"type\", \"f\"], "
-            "[\"anyof\", {}], "
-            // Exclude rsync tmpfiles
-            "[\"not\", [\"match\", \"**/.~tmp~/**\", \"wholename\", {{\"includedotfiles\": true}}]]"
-            "], "
-            "\"fields\": [\"name\"], "
-            "\"empty_on_fresh_instance\": true"
-            "}}]",
+            "["
+            /**/ "\"subscribe\", "
+            /**/ "\"{}\", "
+            /**/ "\"{}\", "
+            /**/ "{{"
+            /*    */ "\"expression\": ["
+            /*        */ "\"allof\", "
+            /*        */ "[\"type\", \"f\"], "
+            /*        */ "[\"anyof\", {}], "
+            /*        */ // Exclude rsync tmpfiles
+            /*        */ "[\"not\", [\"match\", \"**/.~tmp~/**\", \"wholename\", {{\"includedotfiles\": true}}]]"
+            /*    */ "], "
+            /*    */ "\"fields\": [\"name\"], "
+            /*    */ "\"empty_on_fresh_instance\": true"
+            /**/ "}}"
+            "]",
             workSpace, subscriptionName, fmt::map_join(extensions, ", ", [](const std::string &ext) -> string {
                 return fmt::format("[\"suffix\", \"{}\"]", ext);
             }));

--- a/main/lsp/watchman/WatchmanProcess.h
+++ b/main/lsp/watchman/WatchmanProcess.h
@@ -47,6 +47,8 @@ private:
 
     void enqueueNotification(std::unique_ptr<NotificationMessage> notification);
 
+    std::optional<std::string> readLine(FILE *file, int fd, std::string &buffer);
+
     void processQueryResponse(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>);
 
     void processStateEnter(std::unique_ptr<sorbet::realmain::lsp::WatchmanStateEnter>);

--- a/main/lsp/watchman/WatchmanProcess.h
+++ b/main/lsp/watchman/WatchmanProcess.h
@@ -6,6 +6,7 @@
 #include "common/common.h"
 #include "core/core.h"
 #include "main/lsp/MessageQueueState.h"
+#include "rapidjson/document.h"
 #include "spdlog/spdlog.h"
 
 namespace sorbet::realmain::lsp {
@@ -47,7 +48,13 @@ private:
 
     void enqueueNotification(std::unique_ptr<NotificationMessage> notification);
 
-    std::optional<std::string> readLine(FILE *file, int fd, std::string &buffer);
+    struct ReadResponse {
+        std::string line;
+        rapidjson::Document d;
+        ReadResponse() = default;
+        ReadResponse(std::string &&line, rapidjson::Document &&d) : line(std::move(line)), d(std::move(d)) {}
+    };
+    std::optional<ReadResponse> readResponse(FILE *file, int fd, std::string &buffer);
 
     void processQueryResponse(std::unique_ptr<sorbet::realmain::lsp::WatchmanQueryResponse>);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes #7982

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It looks like sometimes the `subscribe` command does not create a watch before
setting up subscriptions for the project. What can happen when you don't do this
is an error like this:

```json
{
  "version": "2024.06.10.00",
  "error": "watchman::RootResolveError: failed to resolve root: unable to resolve root /Users/jez/sandbox/editor: failed to resolve root: directory /Users/jez/sandbox/editor is not watched"
}
```

It's somewhat non-deterministic, depending on whether some _other_ project has
already set up a watch for the given folder in the past that the server
remembers.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We don't have automated tests for watchman in CI. I've been testing this
extensively by creating a sandbox project with a `sorbet/config` and a `Gemfile`
and a `.vscode/settings.json` that allows pointing Sorbet at the local binary
instead of a gem. There's a discussion of how to do that here

<https://github.com/sorbet/sorbet/blob/master/test/sandbox/vscode/README.md>

I've mostly been using the `--debug-log-file` flag, which lets me look at the
watchman input/output and make sure that it matches up with what I expect, and
then also triggering changes to files on disk and making sure that they have the
right effect.