### PR TITLE
refactor: New Literal::{is,as}Name helpers

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1335,13 +1335,16 @@ string Literal::nodeName() const {
 
 core::NameRef Literal::asString() const {
     ENFORCE(isString());
-    auto t = core::cast_type_nonnull<core::NamedLiteralType>(value);
-    core::NameRef res = t.asName();
-    return res;
+    return asName();
 }
 
 core::NameRef Literal::asSymbol() const {
     ENFORCE(isSymbol());
+    return asName();
+}
+
+core::NameRef Literal::asName() const {
+    ENFORCE(isName());
     auto t = core::cast_type_nonnull<core::NamedLiteralType>(value);
     core::NameRef res = t.asName();
     return res;
@@ -1361,6 +1364,10 @@ bool Literal::isString() const {
     return core::isa_type<core::NamedLiteralType>(value) &&
            core::cast_type_nonnull<core::NamedLiteralType>(value).literalKind ==
                core::NamedLiteralType::LiteralTypeKind::String;
+}
+
+bool Literal::isName() const {
+    return isString() || isSymbol();
 }
 
 bool Literal::isTrue(const core::GlobalState &gs) const {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1035,9 +1035,11 @@ public:
     std::string nodeName() const;
     bool isString() const;
     bool isSymbol() const;
+    bool isName() const;
     bool isNil(const core::GlobalState &gs) const;
     core::NameRef asString() const;
     core::NameRef asSymbol() const;
+    core::NameRef asName() const;
     bool isTrue(const core::GlobalState &gs) const;
     bool isFalse(const core::GlobalState &gs) const;
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -656,17 +656,10 @@ public:
         }
 
         auto isSymbol = lit->isSymbol();
-        core::NameRef nameRef;
-        if (!lit) {
+        if (!lit || !lit->isName()) {
             return;
         }
-        if (isSymbol) {
-            nameRef = lit->asSymbol();
-        } else if (lit->isString()) {
-            nameRef = lit->asString();
-        } else {
-            return;
-        }
+        auto nameRef = lit->asName();
 
         if (isSymbol && !hashKeySymbols.contains(nameRef)) {
             hashKeySymbols[nameRef] = key.loc();

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -42,17 +42,11 @@ private:
 
     core::NameRef unwrapLiteralToName(ExpressionPtr &arg) {
         auto *literal = cast_tree<Literal>(arg);
-        if (literal == nullptr) {
+        if (literal == nullptr || !literal->isName()) {
             return core::NameRef::noName();
         }
 
-        if (literal->isString()) {
-            return literal->asString();
-        } else if (literal->isSymbol()) {
-            return literal->asSymbol();
-        } else {
-            return core::NameRef::noName();
-        }
+        return literal->asName();
     }
 
 public:

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -514,24 +514,18 @@ public:
     }
 
     void addConstantModifier(core::Context ctx, core::NameRef modifierName, const ast::ExpressionPtr &arg) {
-        auto target = core::NameRef::noName();
-        if (auto sym = ast::cast_tree<ast::Literal>(arg)) {
-            if (sym->isSymbol()) {
-                target = sym->asSymbol();
-            } else if (sym->isString()) {
-                target = sym->asString();
-            }
+        auto sym = ast::cast_tree<ast::Literal>(arg);
+        if (sym == nullptr || !sym->isName()) {
+            return;
         }
 
-        if (target.exists()) {
-            foundDefs->addModifier(core::FoundModifier{
-                core::FoundModifier::Kind::ClassOrStaticField,
-                getOwner(),
-                arg.loc(),
-                /*name*/ modifierName,
-                target,
-            });
-        }
+        foundDefs->addModifier(core::FoundModifier{
+            core::FoundModifier::Kind::ClassOrStaticField,
+            getOwner(),
+            arg.loc(),
+            /*name*/ modifierName,
+            sym->asName(),
+        });
     }
 
     core::NameRef unwrapLiteralToMethodName(core::Context ctx, const ast::ExpressionPtr &expr) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1038,7 +1038,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
             }
             auto val = move(maybeVal.value());
             auto lit = ast::cast_tree<ast::Literal>(ktree);
-            if (lit && (lit->isSymbol() || lit->isString())) {
+            if (lit && lit->isName()) {
                 ENFORCE(core::isa_type<core::NamedLiteralType>(lit->value));
                 keys.emplace_back(lit->value);
                 values.emplace_back(val);

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -78,10 +78,10 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
 
     for (int i = 0; i < send->numPosArgs(); i++) {
         auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(i));
-        if (!sym || (!sym->isSymbol() && !sym->isString())) {
+        if (!sym || !sym->isName()) {
             return empty;
         }
-        core::NameRef name = sym->asSymbol();
+        core::NameRef name = sym->asName();
         auto symLoc = sym->loc;
         auto strname = name.shortName(ctx);
         if (!strname.empty() && strname.back() == '=') {

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -43,7 +43,7 @@ vector<ast::ExpressionPtr> runDefDelegator(core::MutableContext ctx, const ast::
     }
 
     auto *accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-    if (!accessor || !(accessor->isSymbol() || accessor->isString())) {
+    if (!accessor || !accessor->isName()) {
         return methodStubs;
     }
 
@@ -88,7 +88,7 @@ vector<ast::ExpressionPtr> runDefDelegators(core::MutableContext ctx, const ast:
     }
 
     auto *accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-    if (!accessor || !(accessor->isSymbol() || accessor->isString())) {
+    if (!accessor || !accessor->isName()) {
         return methodStubs;
     }
 

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -24,16 +24,11 @@ static bool isLiteralTrue(const core::GlobalState &gs, const ast::ExpressionPtr 
 
 static optional<core::NameRef> stringOrSymbolNameRef(const core::GlobalState &gs, const ast::ExpressionPtr &node) {
     auto lit = ast::cast_tree<ast::Literal>(node);
-    if (!lit) {
+    if (!lit || !lit->isName()) {
         return nullopt;
     }
-    if (lit->isSymbol()) {
-        return lit->asSymbol();
-    } else if (lit->isString()) {
-        return lit->asString();
-    } else {
-        return nullopt;
-    }
+
+    return lit->asName();
 }
 
 vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Send *send) {

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -142,12 +142,8 @@ ast::ExpressionPtr prepareBody(core::MutableContext ctx, bool isClass, ast::Expr
 string to_s(core::Context ctx, ast::ExpressionPtr &arg) {
     auto argLit = ast::cast_tree<ast::Literal>(arg);
     string argString;
-    if (argLit != nullptr) {
-        if (argLit->isString()) {
-            return argLit->asString().show(ctx);
-        } else if (argLit->isSymbol()) {
-            return argLit->asSymbol().show(ctx);
-        }
+    if (argLit != nullptr && argLit->isName()) {
+        return argLit->asName().show(ctx);
     }
     auto argConstant = ast::cast_tree<ast::UnresolvedConstantLit>(arg);
     if (argConstant != nullptr) {

--- a/test/testdata/rewriter/minitest_let.rb
+++ b/test/testdata/rewriter/minitest_let.rb
@@ -1,0 +1,109 @@
+# typed: true
+
+require_relative '../../../gems/sorbet-runtime/lib/sorbet-runtime'
+
+require 'minitest/autorun'
+require 'minitest/spec'
+
+# -- acts as a pseudo RBI file, while also being a no-op when run -----
+module Minitest; end
+class Minitest::Runnable; end
+class Minitest::Test < Minitest::Runnable; end
+class Minitest::Spec < Minitest::Test
+  module DSL
+    if T.unsafe(false)
+      def let(name, &block); end
+    end
+  end
+  extend DSL
+
+  def self.test_each(iter, &blk)
+    iter.each(&blk)
+  end
+end
+# ---------------------------------------------------------------------
+
+
+class MyTestHelper < Minitest::Spec
+  extend T::Sig
+
+  let(:defined_outside) {
+    puts('still works')
+  }
+
+  describe 'test' do
+    let(:untyped_helper) {
+      'hello'
+    }
+
+    sig { returns(String) }
+    let(:let_with_sig) {
+      'world'
+    }
+
+    sig { returns(Integer) }
+    let(:let_with_bad_sig) {
+      'not an int' # error: Expected `Integer` but found
+    }
+
+    it 'example' do
+      res = untyped_helper()
+      T.reveal_type(res) # error: `T.untyped`
+      puts(res)
+
+      res = let_with_sig()
+      T.reveal_type(res) # error: `String`
+      puts(res)
+
+      begin
+        res = let_with_bad_sig()
+        T.reveal_type(res) # error: `Integer`
+      rescue TypeError => ex
+        puts(ex.message)
+      end
+    end
+
+    it 'counter examples' do
+      # This will run ok but Sorbet rejects it, in case there are other `let` DSLs
+      # (Sorbet has always rejected it--the recent additions to support `let` are strictly additive)
+      begin
+        defined_outside() # error: Method `defined_outside` does not exist
+      rescue NameError => ex
+        puts(ex.message)
+      end
+    end
+
+    test_each(['once']) do |once|
+      it 'inside each' do
+        res = let_with_sig
+        T.reveal_type(res) # error: `String`
+        puts(once)
+      end
+    end
+  end
+
+  test_each(['foo', 'bar']) do |test_case|
+    describe("for #{test_case}") do
+      sig { returns(NilClass) } # error: Only valid `it`, `before`, `after`, and `describe` blocks can appear within `test_each`
+      let(:another_helper) { puts('another') }
+      it 'does the thing' do
+        begin
+          # This one is from the other describe block, not ours
+          let_with_sig # error: Method `let_with_sig` does not exist
+        rescue NameError => ex
+          puts(ex)
+        end
+
+        res = another_helper
+        T.reveal_type(res) # error: `NilClass`
+
+        begin
+          # `let`-defined methods which are defined outside describe are not supported (out of caution in rewriter)
+          defined_outside # error: Method `defined_outside` does not exist
+        rescue NameError => ex
+          puts(ex)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Many places that look at String or Symbol literals also want to look at the
other kind of literal. Also, the implementation shares some code (both backed by
`NamedLiteralType` types).

Factoring this out lets us delete some code.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests