### PR TITLE
Desugar `let(:f) {...}` blocks in `describe` blocks

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -192,20 +192,20 @@ ast::ExpressionPtr getIteratee(ast::ExpressionPtr &exp) {
 
 ast::ExpressionPtr prepareTestEachBody(core::MutableContext ctx, core::NameRef eachName, ast::ExpressionPtr body,
                                        ast::MethodDef::ARGS_store &args, ast::InsSeq::STATS_store destructuringStmts,
-                                       ast::ExpressionPtr &iteratee);
+                                       ast::ExpressionPtr &iteratee, bool insideDescribe);
 
 // this applies to each statement contained within a `test_each`: if it's an `it`-block, then convert it appropriately,
 // otherwise flag an error about it
 ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName,
                                 ast::InsSeq::STATS_store &destructuringStmts, ast::ExpressionPtr stmt,
-                                ast::MethodDef::ARGS_store &args, ast::ExpressionPtr &iteratee) {
+                                ast::MethodDef::ARGS_store &args, ast::ExpressionPtr &iteratee, bool insideDescribe) {
     // this statement must be a send
     if (auto *send = ast::cast_tree<ast::Send>(stmt)) {
+        auto correctBlockArity = send->hasBlock() && send->block()->args.size() == 0;
         // the send must be a call to `it` with a single argument (the test name) and a block with no arguments
-        if ((send->fun == core::Names::it() && send->numPosArgs() == 1 && send->hasBlock() &&
-             send->block()->args.size() == 0) ||
+        if ((send->fun == core::Names::it() && send->numPosArgs() == 1 && correctBlockArity) ||
             ((send->fun == core::Names::before() || send->fun == core::Names::after()) && send->numPosArgs() == 0 &&
-             send->hasBlock() && send->block()->args.size() == 0)) {
+             correctBlockArity)) {
             core::NameRef name;
             if (send->fun == core::Names::before()) {
                 name = core::Names::beforeAngles();
@@ -245,11 +245,18 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
             auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, declLoc, move(name), move(each)));
             // add back any moved constants
             return constantMover.addConstantsToExpression(send->loc, move(method));
-        } else if (send->fun == core::Names::describe() && send->numPosArgs() == 1 && send->hasBlock() &&
-                   send->block()->args.size() == 0) {
-            // TODO(jez) Do we need special handling for these describe blocks, or are they handled already?
+        } else if (send->fun == core::Names::describe() && send->numPosArgs() == 1 && correctBlockArity) {
             return prepareTestEachBody(ctx, eachName, std::move(send->block()->body), args,
-                                       std::move(destructuringStmts), iteratee);
+                                       std::move(destructuringStmts), iteratee,
+                                       /* insideDescribe */ true);
+        } else if (insideDescribe && send->fun == core::Names::let() && send->numPosArgs() == 1 && correctBlockArity &&
+                   ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
+            auto argLiteral = ast::cast_tree_nonnull<ast::Literal>(send->getPosArg(0));
+            if (argLiteral.isName()) {
+                auto declLoc = declLocForSendWithBlock(*send);
+                auto methodName = argLiteral.asName();
+                return ast::MK::SyntheticMethod0(send->loc, declLoc, methodName, std::move(send->block()->body));
+            }
         }
     }
 
@@ -316,23 +323,24 @@ bool isDestructuringInsSeq(core::GlobalState &gs, const ast::MethodDef::ARGS_sto
 // this just walks the body of a `test_each` and tries to transform every statement
 ast::ExpressionPtr prepareTestEachBody(core::MutableContext ctx, core::NameRef eachName, ast::ExpressionPtr body,
                                        ast::MethodDef::ARGS_store &args, ast::InsSeq::STATS_store destructuringStmts,
-                                       ast::ExpressionPtr &iteratee) {
+                                       ast::ExpressionPtr &iteratee, bool insideDescribe) {
     if (auto *bodySeq = ast::cast_tree<ast::InsSeq>(body)) {
         if (isDestructuringInsSeq(ctx, args, bodySeq)) {
             ENFORCE(destructuringStmts.empty(), "Nested destructuring statements");
             destructuringStmts.reserve(bodySeq->stats.size());
             std::move(bodySeq->stats.begin(), bodySeq->stats.end(), std::back_inserter(destructuringStmts));
             return prepareTestEachBody(ctx, eachName, std::move(bodySeq->expr), args, std::move(destructuringStmts),
-                                       iteratee);
+                                       iteratee, insideDescribe);
         }
 
         for (auto &exp : bodySeq->stats) {
-            exp = runUnderEach(ctx, eachName, destructuringStmts, std::move(exp), args, iteratee);
+            exp = runUnderEach(ctx, eachName, destructuringStmts, std::move(exp), args, iteratee, insideDescribe);
         }
 
-        bodySeq->expr = runUnderEach(ctx, eachName, destructuringStmts, std::move(bodySeq->expr), args, iteratee);
+        bodySeq->expr =
+            runUnderEach(ctx, eachName, destructuringStmts, std::move(bodySeq->expr), args, iteratee, insideDescribe);
     } else {
-        body = runUnderEach(ctx, eachName, destructuringStmts, std::move(body), args, iteratee);
+        body = runUnderEach(ctx, eachName, destructuringStmts, std::move(body), args, iteratee, insideDescribe);
     }
 
     return body;
@@ -364,11 +372,11 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         // and then reconstruct the send but with a modified body
         return ast::MK::Send(
             send->loc, ast::MK::Self(send->recv.loc()), send->fun, send->funLoc, 1,
-            ast::MK::SendArgs(
-                move(send->getPosArg(0)),
-                ast::MK::Block(block->loc,
-                               prepareTestEachBody(ctx, send->fun, std::move(block->body), block->args, {}, iteratee),
-                               std::move(block->args))),
+            ast::MK::SendArgs(move(send->getPosArg(0)),
+                              ast::MK::Block(block->loc,
+                                             prepareTestEachBody(ctx, send->fun, std::move(block->body), block->args,
+                                                                 {}, iteratee, insideDescribe),
+                                             std::move(block->args))),
             send->flags);
     }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -247,6 +247,7 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
             return constantMover.addConstantsToExpression(send->loc, move(method));
         } else if (send->fun == core::Names::describe() && send->numPosArgs() == 1 && send->hasBlock() &&
                    send->block()->args.size() == 0) {
+            // TODO(jez) Do we need special handling for these describe blocks, or are they handled already?
             return prepareTestEachBody(ctx, eachName, std::move(send->block()->body), args,
                                        std::move(destructuringStmts), iteratee);
         }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -410,7 +410,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
 
         ast::ClassDef::RHS_store rhs;
         const bool bodyIsClass = true;
-        rhs.emplace_back(prepareBody(ctx, bodyIsClass, std::move(block->body), insideDescribe));
+        rhs.emplace_back(prepareBody(ctx, bodyIsClass, std::move(block->body), /* insideDescribe */ true));
         auto name = ast::MK::UnresolvedConstant(arg.loc(), ast::MK::EmptyTree(),
                                                 ctx.state.enterNameConstant("<describe '" + argString + "'>"));
         auto declLoc = declLocForSendWithBlock(*send);

--- a/test/testdata/rewriter/minitest_let.rb
+++ b/test/testdata/rewriter/minitest_let.rb
@@ -1,0 +1,68 @@
+# typed: true
+
+require_relative '../../../gems/sorbet-runtime/lib/sorbet-runtime'
+
+require 'minitest/autorun'
+require 'minitest/spec'
+
+# -- acts as a pseudo RBI file, while also being a no-op when run -----
+module Minitest; end
+class Minitest::Runnable; end
+class Minitest::Test < Minitest::Runnable; end
+class Minitest::Spec < Minitest::Test
+  module DSL
+    if T.unsafe(false)
+      def let(name, &block); end
+    end
+  end
+  extend DSL
+end
+# ---------------------------------------------------------------------
+
+
+class MyTestHelper < Minitest::Spec
+  extend T::Sig
+
+  let(:defined_outside) {
+    puts('still works')
+  }
+
+  describe 'test' do
+    let(:untyped_helper) {
+      'hello'
+    }
+
+    sig { returns(String) }
+    let(:let_with_sig) {
+      'world'
+    }
+
+    sig { returns(Integer) }
+    let(:let_with_bad_sig) {
+      'not an int' # error: Expected `Integer` but found
+    }
+
+    it 'example' do
+      res = untyped_helper()
+      T.reveal_type(res)
+      puts(res)
+
+      res = let_with_sig()
+      T.reveal_type(res)
+      puts(res)
+
+      begin
+        res = let_with_bad_sig()
+        T.reveal_type(res) # => `Integer`
+      rescue TypeError => ex
+        puts(ex.message)
+      end
+    end
+
+    it 'counter examples' do
+      # This will run ok but Sorbet rejects it, in case there are other `let` DSLs
+      # (Sorbet has always rejected it--the recent additions to support `let` are strictly additive)
+      defined_outside()
+    end
+  end
+end


### PR DESCRIPTION
Fixes #7944

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This should make it easier to work with minitest / rspec code that makes heavy
use of `let`-defined methods.

Generally at Stripe we discourage the use of these methods, but that doesn't
mean that we need to make Sorbet not support them. We can use other mechanisms
inside Stripe to discourage the use of these methods.

In fact, supporting `let`-defined methods in Sorbet makes it easy to discourage
the use of these methods, as test making heavy use of these methods can first be
upgraded to `# typed: true` or above, and then Sorbet can guide the codemod to
ensure that any `let`-defined test helper which is rewritten to not use `let`
has been safely migrated.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.