### PR TITLE
Add flow-sensitive handling for `when *[some, tuple]`

### DIFF
--- a/core/Names.cc
+++ b/core/Names.cc
@@ -272,6 +272,7 @@ bool NameRef::isUpdateKnowledgeName() const {
         case Names::nil_p().rawId():
         case Names::present_p().rawId():
         case Names::tripleEq().rawId():
+        case Names::checkMatchArray().rawId():
             return true;
         default:
             return false;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -725,7 +725,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
                 }
 
                 typeTestType = core::Types::any(ctx, move(typeTestType), move(ty));
-            } else if (isSingleton(ctx, klassType)) {
+            } else if (isSingleton(ctx, klassType, /* includeSingletonClasses */ false)) {
                 typeTestType = core::Types::any(ctx, move(typeTestType), klassType);
             } else {
                 return;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -718,16 +718,18 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
             // This mimics the non-T::Class case in `updateKnowledgeKindOf`
             // We could extend this to `T::Class` types in the future, but let's start simple.
             auto klass = core::Types::getRepresentedClass(ctx, klassType);
-            if (!klass.exists()) {
+            if (klass.exists()) {
+                auto ty = klass.data(ctx)->externalType();
+                if (ty.isUntyped()) {
+                    return;
+                }
+
+                typeTestType = core::Types::any(ctx, move(typeTestType), move(ty));
+            } else if (isSingleton(ctx, klassType)) {
+                typeTestType = core::Types::any(ctx, move(typeTestType), klassType);
+            } else {
                 return;
             }
-
-            auto ty = klass.data(ctx)->externalType();
-            if (ty.isUntyped()) {
-                return;
-            }
-
-            typeTestType = core::Types::any(ctx, move(typeTestType), move(ty));
         }
 
         auto ref = send->args[0].variable;

--- a/test/testdata/infer/check_match_array.rb
+++ b/test/testdata/infer/check_match_array.rb
@@ -8,11 +8,21 @@ TYPES = T.let(
 def foo(x)
   case x
   when *[Integer, String]
-    T.reveal_type(x) # error: `T.untyped`
+    T.reveal_type(x) # error: `T.any(Integer, String)`
   end
 
   case x
   when *TYPES
-    T.reveal_type(x) # error: `T.untyped`
+    T.reveal_type(x) # error: `T.any(Integer, String)`
+  end
+
+  case x
+  when *[]
+    T.reveal_type(x) # error: This code is unreachable
+  end
+
+  case x
+  when *[Integer]
+    T.reveal_type(x) # error: `Integer`
   end
 end

--- a/test/testdata/infer/check_match_array.rb
+++ b/test/testdata/infer/check_match_array.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+TYPES = T.let(
+  [Integer, String],
+  [T.class_of(Integer), T.class_of(String)]
+)
+
+def foo(x)
+  case x
+  when *[Integer, String]
+    T.reveal_type(x) # error: `T.untyped`
+  end
+
+  case x
+  when *TYPES
+    T.reveal_type(x) # error: `T.untyped`
+  end
+end

--- a/test/testdata/infer/check_match_array.rb
+++ b/test/testdata/infer/check_match_array.rb
@@ -1,4 +1,5 @@
 # typed: true
+extend T::Sig
 
 TYPES = T.let(
   [Integer, String],
@@ -24,5 +25,43 @@ def foo(x)
   case x
   when *[Integer]
     T.reveal_type(x) # error: `Integer`
+  end
+end
+
+sig { params(int: Integer, int_or_str: T.any(Integer, String), sym: Symbol).void }
+def example(int, int_or_str, sym)
+  case int_or_str
+  when *[Integer]
+    T.reveal_type(int_or_str) # error: `Integer`
+  else
+    T.reveal_type(int_or_str) # error: `String`
+  end
+
+  case int_or_str
+  when *TYPES
+    T.reveal_type(int_or_str) # error: `T.any(Integer, String)`
+  else
+    T.absurd(int_or_str)
+    T.reveal_type(int_or_str) # error: This code is unreachable
+  end
+
+  x = case int_or_str
+  when *TYPES
+    T.reveal_type(int_or_str) # error: `T.any(Integer, String)`
+    'initialized'
+  end
+  T.reveal_type(x) # error: `String("initialized")`
+
+  case sym
+  when *TYPES
+    T.reveal_type(sym) # error: This code is unreachable
+  else
+    T.reveal_type(sym) # error: `Symbol`
+  end
+
+  untyped = T.unsafe(nil)
+  case untyped
+  when *[nil, true]
+    T.reveal_type(untyped) # error: `T.nilable(TrueClass)`
   end
 end

--- a/test/testdata/infer/check_match_array.rb
+++ b/test/testdata/infer/check_match_array.rb
@@ -65,3 +65,46 @@ def example(int, int_or_str, sym)
     T.reveal_type(untyped) # error: `T.nilable(TrueClass)`
   end
 end
+
+class Suit < T::Enum
+  enums do
+    Spades = new
+    Hearts = new
+    Clubs = new
+    Diamonds = new
+  end
+end
+
+RedSuits = T.let(
+  [Suit::Hearts, Suit::Diamonds].freeze,
+  [Suit::Hearts, Suit::Diamonds]
+)
+
+sig { params(suit: Suit).void }
+def enum_example(suit)
+  case suit
+  when *RedSuits
+    T.reveal_type(suit) # error: `T.any(Suit::Hearts, Suit::Diamonds)`
+  else
+    T.reveal_type(suit) # error: `T.any(Suit::Clubs, Suit::Spades)`
+  end
+
+  case suit
+  when *RedSuits
+    T.reveal_type(suit) # error: `T.any(Suit::Hearts, Suit::Diamonds)`
+  when *[Suit::Clubs, Suit::Spades]
+    nil
+  else
+    T.absurd(suit)
+    T.reveal_type(suit) # error: This code is unreachable
+  end
+
+  bool = case suit
+  when *RedSuits
+    T.reveal_type(suit) # error: `T.any(Suit::Hearts, Suit::Diamonds)`
+    true
+  when *[Suit::Clubs, Suit::Spades]
+    false
+  end
+  T.reveal_type(bool) # error: `T::Boolean`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The Ruby VM has special handling for splatting arrays when doing a `when`
statement:

```
❯ ruby --dump=insns -e 'case x; when *XS; end'
...
0013 splatarray                             false
0015 checkmatch                             6
0017 branchif                               22
...
```

Then in the `checkmatch` instruction, if the argument was a splatted array, it
loops over all the elements and calls `===` on them in turn, instead of calling
`===` on the array itself.

Sorbet already supports `===` for flow-sensitive type updates and exhaustiveness
checking, and we can extend that support for this special splatted array
construct. Sorbet already would desugar `case x; when *XS` to a call to
`<check-match-array>(x, XS)`. We just need to wire it up to flow-sensitivity.

I recommend reviewing by commit, they're mostly readable in isolation.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.