### PR TITLE
Fix the declLoc of `let`-defined methods

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -253,7 +253,7 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
                    ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
             auto argLiteral = ast::cast_tree_nonnull<ast::Literal>(send->getPosArg(0));
             if (argLiteral.isName()) {
-                auto declLoc = declLocForSendWithBlock(*send);
+                auto declLoc = send->loc.copyWithZeroLength().join(argLiteral.loc);
                 auto methodName = argLiteral.asName();
                 return ast::MK::SyntheticMethod0(send->loc, declLoc, methodName, std::move(send->block()->body));
             }
@@ -441,7 +441,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
             return nullptr;
         }
 
-        auto declLoc = declLocForSendWithBlock(*send);
+        auto declLoc = send->loc.copyWithZeroLength().join(argLiteral.loc);
         auto methodName = argLiteral.asName();
         return ast::MK::SyntheticMethod0(send->loc, declLoc, methodName, std::move(block->body));
     }

--- a/test/testdata/rewriter/minitest_let.rb
+++ b/test/testdata/rewriter/minitest_let.rb
@@ -12,7 +12,7 @@ class Minitest::Test < Minitest::Runnable; end
 class Minitest::Spec < Minitest::Test
   module DSL
     if T.unsafe(false)
-      def let(name, &block); end
+      def let(name, &block); end # error: does not have a `sig`
     end
   end
   extend DSL

--- a/test/testdata/rewriter/minitest_let.rb
+++ b/test/testdata/rewriter/minitest_let.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 
 require_relative '../../../gems/sorbet-runtime/lib/sorbet-runtime'
 
@@ -17,7 +17,7 @@ class Minitest::Spec < Minitest::Test
   end
   extend DSL
 
-  def self.test_each(iter, &blk)
+  def self.test_each(iter, &blk) # error: does not have a `sig`
     iter.each(&blk)
   end
 end
@@ -33,6 +33,7 @@ class MyTestHelper < Minitest::Spec
 
   describe 'test' do
     let(:untyped_helper) {
+  # ^^^^^^^^^^^^^^^^^^^ error: does not have a `sig`
       'hello'
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The old loc used to be a zero-length loc. This is better because you'll
be able to hover over the `let` and see the implicit arity. Also the
error diagnostic saying "this thing doesn't have a sig" will include the
name of the method in its location.


It looks like the `declLocForSendWithBlock` helper does not actually work as
intended, because according to my reading of Desugar, the Send loc and the Block
loc are always the same, and this is load bearing for some autocorrects that
pt fixed ages ago. I don't plan to attempt to fix that now.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.