### PR TITLE
Allow ancestors inside `describe` blocks

### DIFF
--- a/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
@@ -47,10 +47,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C T>.reveal_type(@x)
       end
 
-      begin
-        "does thing"
-        <runtime method definition of <it 'does thing'>>
-      end
+      "does thing"
+
+      <runtime method definition of <it 'does thing'>>
     end
   end
 end

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -84,8 +84,6 @@ describe 'extends T::Sig' do
   extend T::Sig
 
   sig { returns(Integer) }
-# ^^^ error: Method `sig` does not exist
-  #     ^^^^^^^ error: Method `returns` does not exist
   def example = 0
 
   it 'calls example' do

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -80,6 +80,20 @@ class MyTest
     end
 end
 
+describe 'extends T::Sig' do
+  extend T::Sig
+
+  sig { returns(Integer) }
+# ^^^ error: Method `sig` does not exist
+  #     ^^^^^^^ error: Method `returns` does not exist
+  def example = 0
+
+  it 'calls example' do
+    res = example
+    T.reveal_type(res) # error: `Integer`
+  end
+end
+
 def junk
 end
 

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -145,12 +145,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         end
       end
 
+      <runtime method definition of inside_method>
+
       begin
-        <runtime method definition of inside_method>
-        begin
-          "works inside"
-          <runtime method definition of <it 'works inside'>>
-        end
+        "works inside"
+        <runtime method definition of <it 'works inside'>>
       end
     end
 
@@ -189,14 +188,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       begin
-        begin
-          <emptyTree>::<C Object>
-          <runtime method definition of <it 'Object'>>
-        end
-        begin
-          <emptyTree>::<C Object>
-          <runtime method definition of <it 'Object'>>
-        end
+        <emptyTree>::<C Object>
+        <runtime method definition of <it 'Object'>>
+      end
+
+      begin
+        <emptyTree>::<C Object>
+        <runtime method definition of <it 'Object'>>
       end
     end
 
@@ -217,13 +215,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>
       end
 
+      class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)
+      end
+
       begin
-        class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)
-        end
-        begin
-          "contains nested describes"
-          <runtime method definition of <it 'contains nested describes'>>
-        end
+        "contains nested describes"
+        <runtime method definition of <it 'contains nested describes'>>
       end
     end
   end
@@ -248,13 +245,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of example>
+
     begin
-      <self>.extend(<emptyTree>::<C T>::<C Sig>)
-      <runtime method definition of example>
-      begin
-        "calls example"
-        <runtime method definition of <it 'calls example'>>
-      end
+      "calls example"
+      <runtime method definition of <it 'calls example'>>
     end
   end
 

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -228,6 +228,36 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
+  class <emptyTree>::<C <describe 'extends T::Sig'>><<C <todo sym>>> < (<self>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def example<<todo method>>(&<blk>)
+      0
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'calls example'><<todo method>>(&<blk>)
+      begin
+        res = <self>.example()
+        <emptyTree>::<C T>.reveal_type(res)
+      end
+    end
+
+    begin
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+      <runtime method definition of example>
+      begin
+        "calls example"
+        <runtime method definition of <it 'calls example'>>
+      end
+    end
+  end
+
   <runtime method definition of junk>
 
   module <emptyTree>::<C Mod><<C <todo sym>>> < ()

--- a/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
@@ -10,24 +10,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       begin
-        begin
-          "adds a method"
-          <runtime method definition of <it 'adds a method'>>
-        end
-        class <emptyTree>::<C <describe 'inner'>><<C <todo sym>>> < (<self>)
-          ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-            <self>.void()
-          end
+        "adds a method"
+        <runtime method definition of <it 'adds a method'>>
+      end
 
-          def <it 'inner test'><<todo method>>(&<blk>)
-            <emptyTree>
-          end
-
-          begin
-            "inner test"
-            <runtime method definition of <it 'inner test'>>
-          end
+      class <emptyTree>::<C <describe 'inner'>><<C <todo sym>>> < (<self>)
+        ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+          <self>.void()
         end
+
+        def <it 'inner test'><<todo method>>(&<blk>)
+          <emptyTree>
+        end
+
+        "inner test"
+
+        <runtime method definition of <it 'inner test'>>
       end
     end
   end
@@ -48,10 +46,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.test_method()
       end
 
-      begin
-        "adds a method"
-        <runtime method definition of <it 'adds a method'>>
-      end
+      "adds a method"
+
+      <runtime method definition of <it 'adds a method'>>
     end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Otherwise, people can't actually use `extend T::Sig` inside their `describe`
blocks, which makes it hard to get tests to `# typed: strict` unless they also
add `class Module; include T::Sig; end` somewhere in their codebase, which
shouldn't be a hard requirement.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests, which have before + after commits.

Note in particular that the test exp changes in the second test are only
whitespace changes and some deletions of `begin` / `end` keywords.