### PR TITLE
Revert "no-op: Factor isSingleton to take the whole type"

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -481,20 +481,7 @@ namespace {
 // This is not the case for most other equality tests. e.g., x != 0 does not imply ¬ x : Integer.
 //
 // This powers (among other things) exhaustiveness checking for T::Enum.
-bool isSingleton(core::Context ctx, core::TypePtr ty) {
-    auto sym = core::Symbols::noClassOrModule();
-    if (core::isa_type<core::ClassType>(ty)) {
-        auto c = core::cast_type_nonnull<core::ClassType>(ty);
-        sym = c.symbol;
-    } else if (core::isa_type<core::AppliedType>(ty)) {
-        auto &a = core::cast_type_nonnull<core::AppliedType>(ty);
-        sym = a.klass;
-    }
-
-    if (!sym.exists()) {
-        return false;
-    }
-
+bool isSingleton(core::Context ctx, core::ClassOrModuleRef sym) {
     // Singletons that are built into the Ruby VM
     if (sym == core::Symbols::NilClass() || sym == core::Symbols::FalseClass() || sym == core::Symbols::TrueClass()) {
         return true;
@@ -636,14 +623,32 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         ENFORCE(recvType != nullptr);
         if (!argType.isUntyped()) {
             truthy.addYesTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
-            if (isSingleton(ctx, argType)) {
+
+            auto argSymbol = core::Symbols::noClassOrModule();
+            if (core::isa_type<core::ClassType>(argType)) {
+                auto c = core::cast_type_nonnull<core::ClassType>(argType);
+                argSymbol = c.symbol;
+            } else if (core::isa_type<core::AppliedType>(argType)) {
+                auto &a = core::cast_type_nonnull<core::AppliedType>(argType);
+                argSymbol = a.klass;
+            }
+            if (argSymbol.exists() && isSingleton(ctx, argSymbol)) {
                 falsy.addNoTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
             }
         }
 
         if (!recvType.isUntyped()) {
             truthy.addYesTypeTest(local, typeTestsWithVar, send->args[0].variable, recvType);
-            if (isSingleton(ctx, recvType)) {
+
+            core::ClassOrModuleRef recvSymbol = core::Symbols::noClassOrModule();
+            if (core::isa_type<core::ClassType>(recvType)) {
+                auto c = core::cast_type_nonnull<core::ClassType>(recvType);
+                recvSymbol = c.symbol;
+            } else if (core::isa_type<core::AppliedType>(recvType)) {
+                auto &a = core::cast_type_nonnull<core::AppliedType>(recvType);
+                recvSymbol = a.klass;
+            }
+            if (recvSymbol.exists() && isSingleton(ctx, recvSymbol)) {
                 falsy.addNoTypeTest(local, typeTestsWithVar, send->args[0].variable, recvType);
             }
         }
@@ -659,11 +664,14 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         updateKnowledgeKindOf(ctx, local, loc, klassType, ref, knowledgeFilter);
 
         // `when` against singleton
-        // check if s is a singleton. in this case we can learn that
-        // a failed comparison means that type test would also fail
-        if (isSingleton(ctx, klassType)) {
-            whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->args[0].variable, klassType);
-            whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->args[0].variable, klassType);
+        if (core::isa_type<core::ClassType>(klassType)) {
+            auto s = core::cast_type_nonnull<core::ClassType>(klassType);
+            // check if s is a singleton. in this case we can learn that
+            // a failed comparison means that type test would also fail
+            if (isSingleton(ctx, s.symbol)) {
+                whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->args[0].variable, klassType);
+                whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->args[0].variable, klassType);
+            }
         }
         whoKnows.sanityCheck();
         return;

--- a/test/testdata/infer/when_final_singleton.rb
+++ b/test/testdata/infer/when_final_singleton.rb
@@ -1,0 +1,21 @@
+# typed: true
+class Module; include T::Sig; end
+
+class Unset
+  extend T::Helpers
+  final!
+end
+
+sig do
+  type_parameters(:T)
+    .params(value: T.any(T.type_parameter(:T), Unset))
+    .returns(T.type_parameter(:T))
+end
+def example(value)
+  case value
+  when Unset
+    raise RuntimeError.new
+  end
+
+  value
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This reverts commit 1d7a312bde4c54d8f6960e33ebf5f860a381c551.

The last commit from #7990 was not as much of a no-op as I thought it was.

I spent a few moments looking into it and I mostly understand it but I'd rather
get this reverted to be sure it makes it in before the nightly publish tonight.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

The error message on master:

```
editor.rb:17: This code is unreachable https://srb.help/7006
    17 |    raise RuntimeError.new
            ^^^^^^^^^^^^^^^^^^^^^^
    editor.rb:16: This condition was always falsy (T::Boolean)
    16 |  when Unset
               ^^^^^
  Got T::Boolean originating from:
    editor.rb:16:
    16 |  when Unset
               ^^^^^
Errors: 1
```