### PR TITLE
Reapply "no-op: Factor isSingleton to take the whole type"

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -481,7 +481,7 @@ namespace {
 // This is not the case for most other equality tests. e.g., x != 0 does not imply ¬ x : Integer.
 //
 // This powers (among other things) exhaustiveness checking for T::Enum.
-bool isSingleton(core::Context ctx, core::TypePtr ty, bool includeSingletonClasses) {
+bool isSingleton(core::Context ctx, const core::TypePtr &ty, bool includeSingletonClasses) {
     auto sym = core::Symbols::noClassOrModule();
     if (core::isa_type<core::ClassType>(ty)) {
         auto c = core::cast_type_nonnull<core::ClassType>(ty);

--- a/test/testdata/infer/when_final_singleton.rb
+++ b/test/testdata/infer/when_final_singleton.rb
@@ -6,14 +6,21 @@ class Unset
   final!
 end
 
+module UnsetModule
+  extend T::Helpers
+  final!
+end
+
 sig do
   type_parameters(:T)
-    .params(value: T.any(T.type_parameter(:T), Unset))
+    .params(value: T.any(T.type_parameter(:T), Unset, UnsetModule))
     .returns(T.type_parameter(:T))
 end
 def example(value)
   case value
   when Unset
+    raise RuntimeError.new
+  when UnsetModule
     raise RuntimeError.new
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

What was happening is that we were including two knowledge tests:

- if the condition is true, then `value` has type `Unset`
- if the condition is true, then `value` has type `T.class_of(Unset)`

So then Sorbet would say that `value` had type `T.all(Unset, 
T.class_of(Unset))` and then would collapse that to `T.noreturn`.

And because the `value` variable was live (used by a later block) it was 
tracked as a block argument to the `when` block. Then when attempting to 
compute it, Sorbet noticed that one of the block args was `T.noreturn` and
it reported an error that the whole block was unreachable.

The funny thing is that for the `module` case, this behavior was correct:
the block is unreachable because the `UnsetModule` type is uninhatibed.
Modules cannot be instantiated on their own, only via being mixed into a
class and then instantiating that class. But this module was final, so that
cannot happen. It's weird, in that we actually make Sorbet _worse_ at
detecting unreachable code, but the fact that it reached the right
conclusion in the `module` case was based on bad reasoning, so we're
arguably more correct here. We could potentially try to add logic back for
this case, but I don't really think it's worth it
(I would at least like to wait until someone shows me a program that would
benefit from such behavior).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.