### PR TITLE
Allow `RSpec.describe {...}` alongside `describe {...}`

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -268,6 +268,7 @@ NameDef names[] = {
     {"testEachHash", "test_each_hash"},
     {"constSet", "const_set"},
     {"collect"},
+    {"RSpec", "RSpec", true},
 
     {"dslOptional", "dsl_optional"},
     {"dslRequired", "dsl_required"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -269,6 +269,8 @@ NameDef names[] = {
     {"constSet", "const_set"},
     {"collect"},
     {"RSpec", "RSpec", true},
+    {"Core", "Core", true},
+    {"ExampleGroup", "ExampleGroup", true},
 
     {"dslOptional", "dsl_optional"},
     {"dslRequired", "dsl_required"},

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -437,8 +437,20 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
 
         // Avoid subclassing the containing context when it's a module, as that will produce an error in typed: false
         // files
-        if (isClass) {
-            ancestors.emplace_back(ast::MK::Self(arg.loc()));
+        if (send->recv.isSelfReference()) {
+            if (isClass) {
+                ancestors.emplace_back(ast::MK::Self(arg.loc()));
+            }
+        } else {
+            ENFORCE(isRSpec(send->recv));
+            auto exampleGroup = ast::MK::EmptyTree();
+            exampleGroup =
+                ast::MK::UnresolvedConstant(send->recv.loc(), move(exampleGroup), core::Names::Constants::RSpec());
+            exampleGroup =
+                ast::MK::UnresolvedConstant(send->recv.loc(), move(exampleGroup), core::Names::Constants::Core());
+            exampleGroup = ast::MK::UnresolvedConstant(send->recv.loc(), move(exampleGroup),
+                                                       core::Names::Constants::ExampleGroup());
+            ancestors.emplace_back(move(exampleGroup));
         }
 
         const bool bodyIsClass = true;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -336,6 +336,15 @@ bool isDestructuringInsSeq(core::GlobalState &gs, const ast::MethodDef::ARGS_sto
     });
 }
 
+bool isRSpec(const ast::ExpressionPtr &recv) {
+    auto *cnst = ast::cast_tree<ast::UnresolvedConstantLit>(recv);
+    if (cnst == nullptr) {
+        return false;
+    }
+
+    return cnst->cnst == core::Names::Constants::RSpec();
+}
+
 // this just walks the body of a `test_each` and tries to transform every statement
 ast::ExpressionPtr prepareTestEachBody(core::MutableContext ctx, core::NameRef eachName, ast::ExpressionPtr body,
                                        ast::MethodDef::ARGS_store &args, ast::InsSeq::STATS_store destructuringStmts,
@@ -369,7 +378,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
 
     auto *block = send->block();
 
-    if (!send->recv.isSelfReference()) {
+    if (!send->recv.isSelfReference() && !(send->fun == core::Names::describe() && isRSpec(send->recv))) {
         return nullptr;
     }
 

--- a/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
@@ -47,10 +47,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C T>.reveal_type(@x)
       end
 
-      begin
-        "does thing"
-        <runtime method definition of <it 'does thing'>>
-      end
+      "does thing"
+
+      <runtime method definition of <it 'does thing'>>
     end
   end
 end

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -84,8 +84,6 @@ describe 'extends T::Sig' do
   extend T::Sig
 
   sig { returns(Integer) }
-# ^^^ error: Method `sig` does not exist
-  #     ^^^^^^^ error: Method `returns` does not exist
   def example = 0
 
   it 'calls example' do

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -80,6 +80,20 @@ class MyTest
     end
 end
 
+describe 'extends T::Sig' do
+  extend T::Sig
+
+  sig { returns(Integer) }
+# ^^^ error: Method `sig` does not exist
+  #     ^^^^^^^ error: Method `returns` does not exist
+  def example = 0
+
+  it 'calls example' do
+    res = example
+    T.reveal_type(res) # error: `Integer`
+  end
+end
+
 def junk
 end
 

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -78,6 +78,23 @@ class MyTest
         end
       end
     end
+
+    class RSpec
+      def self.describe(thing, &blk); end
+    end
+    RSpec.describe "an explicit receiver" do
+      def some_method
+      end
+
+      def self.let(sym, &blk); end
+
+      let(:some_let) {}
+
+      it 'thing' do
+        some_method
+        some_let
+      end
+    end
 end
 
 describe 'extends T::Sig' do

--- a/test/testdata/rewriter/minitest.rb
+++ b/test/testdata/rewriter/minitest.rb
@@ -78,23 +78,6 @@ class MyTest
         end
       end
     end
-
-    class RSpec
-      def self.describe(thing, &blk); end
-    end
-    RSpec.describe "an explicit receiver" do
-      def some_method
-      end
-
-      def self.let(sym, &blk); end
-
-      let(:some_let) {}
-
-      it 'thing' do
-        some_method
-        some_let
-      end
-    end
 end
 
 describe 'extends T::Sig' do

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -145,12 +145,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         end
       end
 
+      <runtime method definition of inside_method>
+
       begin
-        <runtime method definition of inside_method>
-        begin
-          "works inside"
-          <runtime method definition of <it 'works inside'>>
-        end
+        "works inside"
+        <runtime method definition of <it 'works inside'>>
       end
     end
 
@@ -189,14 +188,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       begin
-        begin
-          <emptyTree>::<C Object>
-          <runtime method definition of <it 'Object'>>
-        end
-        begin
-          <emptyTree>::<C Object>
-          <runtime method definition of <it 'Object'>>
-        end
+        <emptyTree>::<C Object>
+        <runtime method definition of <it 'Object'>>
+      end
+
+      begin
+        <emptyTree>::<C Object>
+        <runtime method definition of <it 'Object'>>
       end
     end
 
@@ -217,13 +215,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>
       end
 
+      class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)
+      end
+
       begin
-        class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)
-        end
-        begin
-          "contains nested describes"
-          <runtime method definition of <it 'contains nested describes'>>
-        end
+        "contains nested describes"
+        <runtime method definition of <it 'contains nested describes'>>
       end
     end
   end
@@ -248,13 +245,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of example>
+
     begin
-      <self>.extend(<emptyTree>::<C T>::<C Sig>)
-      <runtime method definition of example>
-      begin
-        "calls example"
-        <runtime method definition of <it 'calls example'>>
-      end
+      "calls example"
+      <runtime method definition of <it 'calls example'>>
     end
   end
 

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -253,49 +253,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       "calls example"
       <runtime method definition of <it 'calls example'>>
     end
-
-    class <emptyTree>::<C RSpec><<C <todo sym>>> < (::<todo sym>)
-      def self.describe<<todo method>>(thing, &blk)
-        <emptyTree>
-      end
-
-      <runtime method definition of self.describe>
-    end
-
-    class <emptyTree>::<C <describe 'an explicit receiver'>><<C <todo sym>>> < (<self>)
-      def some_method<<todo method>>(&<blk>)
-        <emptyTree>
-      end
-
-      def self.let<<todo method>>(sym, &blk)
-        <emptyTree>
-      end
-
-      def some_let<<todo method>>(&<blk>)
-        <emptyTree>
-      end
-
-      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-        <self>.void()
-      end
-
-      def <it 'thing'><<todo method>>(&<blk>)
-        begin
-          <self>.some_method()
-          <self>.some_let()
-        end
-      end
-
-      begin
-        <runtime method definition of some_method>
-        <runtime method definition of self.let>
-        <runtime method definition of some_let>
-        begin
-          "thing"
-          <runtime method definition of <it 'thing'>>
-        end
-      end
-    end
   end
 
   <runtime method definition of junk>

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -228,6 +228,36 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
+  class <emptyTree>::<C <describe 'extends T::Sig'>><<C <todo sym>>> < (<self>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def example<<todo method>>(&<blk>)
+      0
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'calls example'><<todo method>>(&<blk>)
+      begin
+        res = <self>.example()
+        <emptyTree>::<C T>.reveal_type(res)
+      end
+    end
+
+    begin
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+      <runtime method definition of example>
+      begin
+        "calls example"
+        <runtime method definition of <it 'calls example'>>
+      end
+    end
+  end
+
   <runtime method definition of junk>
 
   module <emptyTree>::<C Mod><<C <todo sym>>> < ()

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -253,6 +253,49 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       "calls example"
       <runtime method definition of <it 'calls example'>>
     end
+
+    class <emptyTree>::<C RSpec><<C <todo sym>>> < (::<todo sym>)
+      def self.describe<<todo method>>(thing, &blk)
+        <emptyTree>
+      end
+
+      <runtime method definition of self.describe>
+    end
+
+    class <emptyTree>::<C <describe 'an explicit receiver'>><<C <todo sym>>> < (<self>)
+      def some_method<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      def self.let<<todo method>>(sym, &blk)
+        <emptyTree>
+      end
+
+      def some_let<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.void()
+      end
+
+      def <it 'thing'><<todo method>>(&<blk>)
+        begin
+          <self>.some_method()
+          <self>.some_let()
+        end
+      end
+
+      begin
+        <runtime method definition of some_method>
+        <runtime method definition of self.let>
+        <runtime method definition of some_let>
+        begin
+          "thing"
+          <runtime method definition of <it 'thing'>>
+        end
+      end
+    end
   end
 
   <runtime method definition of junk>

--- a/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
@@ -10,24 +10,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       begin
-        begin
-          "adds a method"
-          <runtime method definition of <it 'adds a method'>>
-        end
-        class <emptyTree>::<C <describe 'inner'>><<C <todo sym>>> < (<self>)
-          ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-            <self>.void()
-          end
+        "adds a method"
+        <runtime method definition of <it 'adds a method'>>
+      end
 
-          def <it 'inner test'><<todo method>>(&<blk>)
-            <emptyTree>
-          end
-
-          begin
-            "inner test"
-            <runtime method definition of <it 'inner test'>>
-          end
+      class <emptyTree>::<C <describe 'inner'>><<C <todo sym>>> < (<self>)
+        ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+          <self>.void()
         end
+
+        def <it 'inner test'><<todo method>>(&<blk>)
+          <emptyTree>
+        end
+
+        "inner test"
+
+        <runtime method definition of <it 'inner test'>>
       end
     end
   end
@@ -48,10 +46,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.test_method()
       end
 
-      begin
-        "adds a method"
-        <runtime method definition of <it 'adds a method'>>
-      end
+      "adds a method"
+
+      <runtime method definition of <it 'adds a method'>>
     end
   end
 end

--- a/test/testdata/rewriter/rspec.rb
+++ b/test/testdata/rewriter/rspec.rb
@@ -1,0 +1,27 @@
+# typed: true
+
+class RSpec
+  def self.describe(thing, &blk); end
+end
+
+class RSpec::Core::ExampleGroup
+  def self.include_context(context)
+  end
+end
+
+RSpec.describe('my group') do
+  extend T::Sig
+  include_context 'bar'
+
+  def some_method
+  end
+
+  def self.let(sym, &blk); end
+
+  let(:some_let) { 0 }
+
+  it 'thing' do
+    some_method
+    some_let
+  end
+end

--- a/test/testdata/rewriter/rspec.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec.rb.rewrite-tree.exp
@@ -1,0 +1,57 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C RSpec><<C <todo sym>>> < (::<todo sym>)
+    def self.describe<<todo method>>(thing, &blk)
+      <emptyTree>
+    end
+
+    <runtime method definition of self.describe>
+  end
+
+  class <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup><<C <todo sym>>> < (::<todo sym>)
+    def self.include_context<<todo method>>(context, &<blk>)
+      <emptyTree>
+    end
+
+    <runtime method definition of self.include_context>
+  end
+
+  class <emptyTree>::<C <describe 'my group'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+    def some_method<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    def self.let<<todo method>>(sym, &blk)
+      <emptyTree>
+    end
+
+    def some_let<<todo method>>(&<blk>)
+      0
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def <it 'thing'><<todo method>>(&<blk>)
+      begin
+        <self>.some_method()
+        <self>.some_let()
+      end
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <self>.include_context("bar")
+
+    <runtime method definition of some_method>
+
+    <runtime method definition of self.let>
+
+    <runtime method definition of some_let>
+
+    begin
+      "thing"
+      <runtime method definition of <it 'thing'>>
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #7994

The biggest difference between RSpec and Minitest is that `RSpec` codebases typically define their example groups using

```ruby
RSpec.describe(...) { ... }
```

instead of just

```ruby
describe(...) { ... }
```

The other thing is that these `describe` blocks have `RSpec::Core::ExampleGroup` as their superclass instead of `self`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.