### PR TITLE
Add OpenSSL::SSL::TLS1_2_VERSION constant to the OpenSSL RBI

### DIFF
--- a/rbi/stdlib/openssl.rbi
+++ b/rbi/stdlib/openssl.rbi
@@ -7545,6 +7545,7 @@ module OpenSSL::SSL
   # 1.1.0.
   OP_TLS_D5_BUG = ::T.let(nil, ::T.untyped)
   OP_TLS_ROLLBACK_BUG = ::T.let(nil, ::T.untyped)
+  TLS1_2_VERSION = ::T.let(nil, ::T.untyped)
   VERIFY_CLIENT_ONCE = ::T.let(nil, ::T.untyped)
   VERIFY_FAIL_IF_NO_PEER_CERT = ::T.let(nil, ::T.untyped)
   VERIFY_NONE = ::T.let(nil, ::T.untyped)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

```
$ irb                                                
irb(main):001:0> require 'openssl'
=> true
irb(main):002:0> OpenSSL::SSL::TLS1_2_VERSION
=> 771
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

User ask.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A