### PR TITLE
Allow defining constants inside T::Enum

### DIFF
--- a/test/testdata/resolver/generic_enum.rb
+++ b/test/testdata/resolver/generic_enum.rb
@@ -2,7 +2,7 @@
 # disable-fast-path: true
 class MyEnum < T::Enum
   extend T::Generic
-  Value = type_template {{fixed: String}} # error: All constants defined on an `T::Enum` must be unique instances of the enum
+  Value = type_template {{fixed: String}} # error: All non-enum constants in a `T::Enum` must be defined after the `enums do` block
 
   enums do
     X = new # error: Type `Value` declared by parent `T.class_of(MyEnum)` must be re-declared

--- a/test/testdata/rewriter/enum_with_constants.rb
+++ b/test/testdata/rewriter/enum_with_constants.rb
@@ -1,0 +1,25 @@
+# typed: true
+
+class Suit < T::Enum
+  extend T::Sig
+
+  enums do
+    Spades = new
+    Hearts = new
+    Clubs = new
+    Diamonds = new
+  end
+
+  Reds = T.let([Hearts, Diamonds], T::Array[Suit])
+  Red = T.type_alias { T.any(Hearts, Diamonds) }
+
+  sig { returns(T.nilable(Red)) }
+  def to_red
+    case self
+    when Spades, Clubs
+      nil
+    else
+      self
+    end
+  end
+end

--- a/test/testdata/rewriter/t_enum_snapshot.rb
+++ b/test/testdata/rewriter/t_enum_snapshot.rb
@@ -25,13 +25,13 @@ class EnumsDoEnum < T::Enum
 end
 
 class BadConsts < T::Enum
-  Before = new # error: must be within the `enums do` block
-  StaticField1 = 1 # error: must be unique instances of the enum
+  Before = new # error: Definition of enum value `Before` must be within the `enums do` block for this `T::Enum`
+  StaticField1 = 1 # error: All non-enum constants in a `T::Enum` must be defined after the `enums do` block
   enums do
     Inside = new
-    StaticField2 = 2 # error: must be unique instances of the enum
+    StaticField2 = 2 # error: All non-enum constants in a `T::Enum` must be defined after the `enums do` block
   end
   After = new # error: must be within the `enums do` block
-  StaticField3 = 3 # error: must be unique instances of the enum
-  StaticField4 = T.let(1, Integer) # error: must be unique instances of the enum
+  StaticField3 = 3
+  StaticField4 = T.let(1, Integer)
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Historically we prevented people from defining constants inside T::Enum's
because the implementation of `T::Enum` uses `self.constants(false)` to discover
enum values which have been created and associate them with the constants
they've been assigned into:

<https://github.com/sorbet/sorbet/blob/a8aeb8f90918b798d4ddb140146cfc06f04dd67e/gems/sorbet-runtime/lib/types/enum.rb#L356>

When we open sourced `T::Enum`, we introduced the `enums do ... end` block.
Before that, the `self.constants(false)` code ran in an autoloader hook
(specific to Stripe's legacy autoloader) which ran after a file finished
loading. The nice thing about the `enums do ... end` block is that there is now
an obvious point at which no more enum definitions can be created, meaning that
there's no technical reason why we'd need to prevent constants from being
created after the `enums do ... end` block.

Defining non-enum constants are useful especially for doing things like defining
a common group of enums or defining type aliases of individual enum values.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.