### PR TITLE
Infer lambda return types

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -461,6 +461,10 @@ void GlobalState::initEmpty() {
         enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ReturnTypeInference());
     klass.data(*this)->setIsModule(false);
     ENFORCE(klass == Symbols::Sorbet_Private_Static_ReturnTypeInference());
+    typeArgument =
+        enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::TodoTypeArgument(), Variance::CoVariant);
+    ENFORCE(typeArgument == Symbols::todoTypeArgument());
+    typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
     method =
         enterMethod(*this, Symbols::Sorbet_Private_Static(), core::Names::guessedTypeTypeParameterHolder()).build();
     ENFORCE(method == Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder());
@@ -679,11 +683,6 @@ void GlobalState::initEmpty() {
 
     method = enterMethod(*this, Symbols::Kernel(), Names::lambdaTLet()).typedArg(Names::type(), Types::top()).build();
     ENFORCE(method == Symbols::Kernel_lambdaTLet());
-
-    typeArgument =
-        enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::TodoTypeArgument(), Variance::CoVariant);
-    ENFORCE(typeArgument == Symbols::todoTypeArgument());
-    typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
 
     // Root members
     Symbols::root().data(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -681,6 +681,10 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::Kernel(), Names::lambda()).build();
     ENFORCE(method == Symbols::Kernel_lambda());
 
+    typeArgument = enterTypeArgument(Loc::none(), Symbols::Kernel_lambda(), Names::returnType(), Variance::CoVariant);
+    ENFORCE(typeArgument == Symbols::Kernel_lambda_returnType());
+    typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
+
     method = enterMethod(*this, Symbols::Kernel(), Names::lambdaTLet()).typedArg(Names::type(), Types::top()).build();
     ENFORCE(method == Symbols::Kernel_lambdaTLet());
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -674,6 +674,9 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::T_Generic(), Names::squareBrackets()).repeatedTopArg(Names::args()).build();
     ENFORCE(method == Symbols::T_Generic_squareBrackets());
 
+    method = enterMethod(*this, Symbols::Kernel(), Names::lambda()).build();
+    ENFORCE(method == Symbols::Kernel_lambda());
+
     method = enterMethod(*this, Symbols::Kernel(), Names::lambdaTLet()).typedArg(Names::type(), Types::top()).build();
     ENFORCE(method == Symbols::Kernel_lambdaTLet());
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1101,6 +1101,10 @@ public:
         return MethodRef::fromRaw(20);
     }
 
+    static TypeArgumentRef Kernel_lambda_returnType() {
+        return TypeArgumentRef::fromRaw(4);
+    }
+
     static MethodRef Kernel_lambdaTLet() {
         return MethodRef::fromRaw(21);
     }

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -851,21 +851,21 @@ public:
         return TypeMemberRef::fromRaw(0);
     }
 
+    static TypeArgumentRef todoTypeArgument() {
+        return TypeArgumentRef::fromRaw(1);
+    }
+
     static MethodRef Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder() {
         return MethodRef::fromRaw(2);
     }
 
     static TypeArgumentRef
     Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_contravariant() {
-        return TypeArgumentRef::fromRaw(1);
+        return TypeArgumentRef::fromRaw(2);
     }
 
     static TypeArgumentRef
     Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_covariant() {
-        return TypeArgumentRef::fromRaw(2);
-    }
-
-    static TypeArgumentRef todoTypeArgument() {
         return TypeArgumentRef::fromRaw(3);
     }
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1097,8 +1097,12 @@ public:
         return MethodRef::fromRaw(19);
     }
 
-    static MethodRef Kernel_lambdaTLet() {
+    static MethodRef Kernel_lambda() {
         return MethodRef::fromRaw(20);
+    }
+
+    static MethodRef Kernel_lambdaTLet() {
+        return MethodRef::fromRaw(21);
     }
 
     static ClassOrModuleRef Magic_UntypedSource() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,7 +23,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 54;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 55;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 72;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -25,7 +25,7 @@ using namespace std;
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
 const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 55;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
-const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
+const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 5;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 72;
 
 namespace {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -357,6 +357,7 @@ NameDef names[] = {
 
     {"lambda"},
     {"lambdaTLet", "<lambda T.let>"},
+    {"returnType", "return_type"},
     {"nil_p", "nil?"},
     {"blank_p", "blank?"},
     {"present_p", "present?"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4221,8 +4221,16 @@ public:
         }
         auto untypedWithBlame = core::Types::untyped(Symbols::Magic_UntypedSource_proc());
         vector<core::TypePtr> targs(*numberOfPositionalBlockParams + 1, untypedWithBlame);
+        // TODO(jez) Should be able to suport Kernel#proc in the same way
+        auto isLambda = res.main.method == Symbols::Kernel_lambda();
+        if (isLambda) {
+            targs[0] = make_type<TypeVar>(Symbols::Kernel_lambda_returnType());
+        }
         auto procClass = core::Symbols::Proc(*numberOfPositionalBlockParams);
         res.returnType = make_type<core::AppliedType>(procClass, move(targs));
+        if (isLambda) {
+            handleBlockType(gs, res.main, res.returnType);
+        }
     }
 } Kernel_proc;
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1477,23 +1477,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 ENFORCE(i.link);
                 ENFORCE(i.link->result->main.blockReturnType != nullptr);
 
-                tp.type = core::Types::bottom();
-                tp.origins.emplace_back(ctx.locAt(bind.loc));
-
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(ctx, i.what);
-
-                if (i.link->result->main.method == core::Symbols::Kernel_lambda()) {
-                    if (auto *appType = core::cast_type<core::AppliedType>(i.link->result->returnType)) {
-                        if (auto procType = core::Types::getProcArity(*appType)) {
-                            auto blockReturnType = core::Types::dropLiteral(ctx, typeAndOrigin.type);
-                            appType->targs[0] = (appType->targs[0].isUntyped())
-                                                    ? blockReturnType
-                                                    : core::Types::any(ctx, appType->targs[0], blockReturnType);
-                            return;
-                        }
-                    }
-                }
-
                 auto expectedType = i.link->result->main.blockReturnType;
                 if (core::Types::isSubType(ctx, core::Types::void_(), expectedType)) {
                     expectedType = core::Types::top();
@@ -1528,6 +1512,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         core::TypeErrorDiagnostics::explainUntyped(ctx, e, what, typeAndOrigin, ownerLoc);
                     }
                 }
+
+                tp.type = core::Types::bottom();
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::Literal &i) {
                 tp.type = i.value;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1485,7 +1485,10 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 if (i.link->result->main.method == core::Symbols::Kernel_lambda()) {
                     if (auto *appType = core::cast_type<core::AppliedType>(i.link->result->returnType)) {
                         if (auto procType = core::Types::getProcArity(*appType)) {
-                            appType->targs[0] = core::Types::dropLiteral(ctx, typeAndOrigin.type);
+                            auto blockReturnType = core::Types::dropLiteral(ctx, typeAndOrigin.type);
+                            appType->targs[0] = (appType->targs[0].isUntyped())
+                                                    ? blockReturnType
+                                                    : core::Types::any(ctx, appType->targs[0], blockReturnType);
                             return;
                         }
                     }

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1887,7 +1887,8 @@ module Kernel
   # except the resulting [`Proc`](https://docs.ruby-lang.org/en/2.7.0/Proc.html)
   # objects check the number of parameters passed when called.
   sig do
-    params(
+    type_parameters(:return_type) # Used by Kernel#lambda intrinsic in calls.cc
+    .params(
         blk: T.untyped,
     )
     .returns(Proc)

--- a/test/testdata/infer/infer_lambda.rb
+++ b/test/testdata/infer/infer_lambda.rb
@@ -1,0 +1,40 @@
+# typed: true
+extend T::Sig
+
+sig { params(x: Integer).returns(String) }
+def returns_string(x); x.to_s; end
+
+sig { params(f: T.proc.returns(Integer)).void }
+def takes_void_proc(f); end
+
+f = -> () { 0 }
+T.reveal_type(f) # error: T.proc.returns(Integer)
+
+takes_void_proc(f)
+
+f = -> (x) { 0 }
+T.reveal_type(f) # error: T.proc.params(arg0: T.untyped).returns(Integer)
+
+f = -> (x) { x }
+T.reveal_type(f) # error: T.proc.params(arg0: T.untyped).returns(T.untyped)
+
+f = -> (x) { returns_string(x) }
+T.reveal_type(f) # error: T.proc.params(arg0: T.untyped).returns(String)
+
+f = -> (x) {
+  if x
+    return false
+  end
+
+  true
+}
+T.reveal_type(f) # error: `T.proc.params(arg0: T.untyped).returns(T::Boolean)`
+
+f = -> (x) {
+  if x
+    next false
+  end
+
+  true
+}
+T.reveal_type(f) # error: `T.proc.params(arg0: T.untyped).returns(T::Boolean)`

--- a/test/testdata/infer/infer_lambda.rb
+++ b/test/testdata/infer/infer_lambda.rb
@@ -38,3 +38,17 @@ f = -> (x) {
   true
 }
 T.reveal_type(f) # error: `T.proc.params(arg0: T.untyped).returns(T::Boolean)`
+
+f = -> () {
+  if T.unsafe(nil)
+    return T.unsafe(nil)
+  else
+    return 0
+  end
+}
+T.reveal_type(f) # error: `T.proc.returns(T.untyped)`
+
+f = -> () {
+  raise
+}
+T.reveal_type(f) # error: `T.proc.returns(T.noreturn)`

--- a/test/testdata/infer/lambda_block_return.rb
+++ b/test/testdata/infer/lambda_block_return.rb
@@ -18,11 +18,24 @@ def kernel_lambda
 end
 
 sig { returns(String) }
+def kernel_lambda_raises
+  f = Kernel.lambda {
+    raise
+  }
+  T.reveal_type(f) # error: `T.proc.returns(T.noreturn)`
+  f.call.to_s # error: This code is unreachable
+end
+
+sig { returns(String) }
 def plain_lambda
+  # This is wrong now because we don't treat `self.lambda` as a lambda, and
+  # thus choose the `return` keyword to be a method return, not a lambda
+  # return.
   f = lambda {
     return 0 # error: Expected `String` but found `Integer(0)` for method result type
   }
-  f.call.to_s
+  T.reveal_type(f) # error: `T.proc.returns(T.noreturn)`
+  f.call.to_s # error: This code is unreachable
 end
 
 sig { returns(String) }
@@ -31,7 +44,7 @@ def proc_to_lambda
     return 0 # error: Expected `String` but found `Integer(0)` for method result type
   }
   f = Kernel.lambda(&p)
-  f.call.to_s
+  f.call.to_s # error: This code is unreachable
 end
 
 sig { params(blk: T.proc.returns(NilClass)).void }

--- a/test/testdata/infer/lambda_block_return.rb
+++ b/test/testdata/infer/lambda_block_return.rb
@@ -46,9 +46,14 @@ def block_inside_lambda
       # At runtime, this returns from the lambda, but Sorbet treats it like it
       # returns from the enclosing block. This would be nice to fix, because
       # there is no workaround for this except manually raising and catching
-      # exceptions.
+      # exceptions. (Should be no error.)
       return 0 # error: Expected `NilClass` but found `Integer(0)` for block result type
     end
+
+    nil
   }
+
+  # Should be `T.proc.returns(T.nilable(Integer))`
+  T.reveal_type(f) # error: `T.proc.returns(NilClass)`
   f.call.to_s
 end

--- a/test/testdata/lsp/hover_untyped_lambda.rb
+++ b/test/testdata/lsp/hover_untyped_lambda.rb
@@ -6,4 +6,5 @@
 ->(arg0) do
   arg0.foo
   #    ^^^ error: Call to method `foo` on `T.untyped`
+# ^^^^^^^^ error: Value returned from block is `T.untyped`
 end

--- a/test/testdata/namer/yield.rb.cfg-text.exp
+++ b/test/testdata/namer/yield.rb.cfg-text.exp
@@ -133,20 +133,20 @@ bb2[rubyRegionId=1, firstDead=-1](<self>: Main, <block-pre-call-temp>$5: Sorbet:
 # backedges
 # - bb2(rubyRegionId=1)
 bb3[rubyRegionId=0, firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
-    l: T.proc.params(arg0: T.untyped).returns(T.untyped) = Solve<<block-pre-call-temp>$5, lambda>
+    l: T.proc.params(arg0: T.untyped).returns(Integer) = Solve<<block-pre-call-temp>$5, lambda>
     <self>: Main = <selfRestore>$6
     <cfgAlias>$15: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$17: Symbol(:yielder) = :yielder
-    <statTemp>$13: T.untyped = <cfgAlias>$15: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$17: Symbol(:yielder), l: T.proc.params(arg0: T.untyped).returns(T.untyped))
+    <statTemp>$13: T.untyped = <cfgAlias>$15: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$17: Symbol(:yielder), l: T.proc.params(arg0: T.untyped).returns(Integer))
     <cfgAlias>$21: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$23: Symbol(:blockpass) = :blockpass
-    <statTemp>$19: T.untyped = <cfgAlias>$21: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$23: Symbol(:blockpass), l: T.proc.params(arg0: T.untyped).returns(T.untyped))
+    <statTemp>$19: T.untyped = <cfgAlias>$21: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$23: Symbol(:blockpass), l: T.proc.params(arg0: T.untyped).returns(Integer))
     <cfgAlias>$27: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$29: Symbol(:mixed) = :mixed
-    <statTemp>$25: T.untyped = <cfgAlias>$27: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$29: Symbol(:mixed), l: T.proc.params(arg0: T.untyped).returns(T.untyped))
+    <statTemp>$25: T.untyped = <cfgAlias>$27: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$29: Symbol(:mixed), l: T.proc.params(arg0: T.untyped).returns(Integer))
     <cfgAlias>$32: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$34: Symbol(:blockyield) = :blockyield
-    <returnMethodTemp>$2: T.untyped = <cfgAlias>$32: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$34: Symbol(:blockyield), l: T.proc.params(arg0: T.untyped).returns(T.untyped))
+    <returnMethodTemp>$2: T.untyped = <cfgAlias>$32: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$34: Symbol(:blockyield), l: T.proc.params(arg0: T.untyped).returns(Integer))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 

--- a/test/testdata/namer/yield.rb.cfg-text.exp
+++ b/test/testdata/namer/yield.rb.cfg-text.exp
@@ -155,8 +155,8 @@ bb3[rubyRegionId=0, firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Stat
 bb5[rubyRegionId=1, firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     # outerLoops: 1
     <self>: Main = loadSelf(lambda)
-    <blk>$7: T.untyped = load_yield_params(lambda)
-    x$1: T.untyped = yield_load_arg(0, <blk>$7: T.untyped)
+    <blk>$7: [T.untyped] = load_yield_params(lambda)
+    x$1: T.untyped = yield_load_arg(0, <blk>$7: [T.untyped])
     <statTemp>$9: NilClass = <self>: Main.puts(x$1: T.untyped)
     <blockReturnTemp>$8: Integer(3) = 3
     <blockReturnTemp>$12: T.noreturn = blockreturn<lambda> <blockReturnTemp>$8: Integer(3)

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -52,8 +52,8 @@ T.reveal_type([1,2,3].to_h {|i| [i.to_s, i] }) # error: Revealed type: `T::Hash[
 p = T.let(->{ 1 }, T.proc.returns(Integer))
 T.reveal_type([1,2].detect) # error: Revealed type: `T::Enumerator[Integer]`
 T.reveal_type([1,2].detect {|x| false}) # error: Revealed type: `T.nilable(Integer)`
-T.reveal_type([1,2].detect(-> {}) {|x| false}) # error: Revealed type: `T.untyped`
-T.reveal_type([1,2].detect(-> {})) # error: Revealed type: `T::Enumerator[T.untyped]`
+T.reveal_type([1,2].detect(-> {}) {|x| false}) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type([1,2].detect(-> {})) # error: Revealed type: `T::Enumerator[T.nilable(Integer)]`
 T.reveal_type([1,2].detect(p) {|x| false}) # error: Revealed type: `Integer`
 T.reveal_type([1,2].detect(p)) # error: Revealed type: `T::Enumerator[Integer]`
 
@@ -61,8 +61,8 @@ T.reveal_type([1,2].detect(p)) # error: Revealed type: `T::Enumerator[Integer]`
 p = T.let(->{ 1 }, T.proc.returns(Integer))
 T.reveal_type([1,2].find) # error: Revealed type: `T::Enumerator[Integer]`
 T.reveal_type([1,2].find {|x| false}) # error: Revealed type: `T.nilable(Integer)`
-T.reveal_type([1,2].find(-> {}) {|x| false}) # error: Revealed type: `T.untyped`
-T.reveal_type([1,2].find(-> {})) # error: Revealed type: `T::Enumerator[T.untyped]`
+T.reveal_type([1,2].find(-> {}) {|x| false}) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type([1,2].find(-> {})) # error: Revealed type: `T::Enumerator[T.nilable(Integer)]`
 T.reveal_type([1,2].find(p) {|x| false}) # error: Revealed type: `Integer`
 T.reveal_type([1,2].find(p)) # error: Revealed type: `T::Enumerator[Integer]`
 


### PR DESCRIPTION
Alternative to #7741

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This doesn't rely on a large, hairy, tricky-to-get-right addition to
`guessOverload`, making it less brittle and faster at the expense of
maybe being less principled.

### Commit summary

The original implementation in this PR involved making `Kernel#lambda`-specific changes to `cfg::BlockReturn` in `processBinding` which worked but felt hacky.

I've since realized that it's possible to write that code directly into the `Kernel#lambda` intrinsic that we already have.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] TODO @jez write tests