### PR TITLE
Treat `void_` as another top type in subtyping

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -228,6 +228,10 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             categoryCounterInc("lub", "<top");
             return t1;
         }
+        if (mayBeSpecial1.symbol == Symbols::void_()) {
+            categoryCounterInc("lub", "<void");
+            return Types::top();
+        }
     }
 
     if (isa_type<ClassType>(t2)) {
@@ -243,6 +247,10 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         if (mayBeSpecial2.symbol == Symbols::top()) {
             categoryCounterInc("lub", "top>");
             return t2;
+        }
+        if (mayBeSpecial2.symbol == Symbols::void_()) {
+            categoryCounterInc("lub", "void>");
+            return Types::top();
         }
     }
 
@@ -668,7 +676,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
     if (isa_type<ClassType>(t1)) {
         auto mayBeSpecial1 = cast_type_nonnull<ClassType>(t1);
-        if (mayBeSpecial1.symbol == Symbols::top()) {
+        if (mayBeSpecial1.symbol == Symbols::top() || mayBeSpecial1.symbol == Symbols::void_()) {
             categoryCounterInc("glb", "<top");
             return t2;
         }
@@ -677,7 +685,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             // `glb(T.untyped,<any>)` will reduce to `T.untyped`.
             if (isa_type<ClassType>(t2)) {
                 auto mayBeSpecial2 = cast_type_nonnull<ClassType>(t2);
-                if (mayBeSpecial2.symbol == Symbols::top()) {
+                if (mayBeSpecial2.symbol == Symbols::top() || mayBeSpecial2.symbol == Symbols::void_()) {
                     categoryCounterInc("glb", "top>");
                     return t1;
                 }
@@ -693,7 +701,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
     if (isa_type<ClassType>(t2)) {
         auto mayBeSpecial2 = cast_type_nonnull<ClassType>(t2);
-        if (mayBeSpecial2.symbol == Symbols::top()) {
+        if (mayBeSpecial2.symbol == Symbols::top() || mayBeSpecial2.symbol == Symbols::void_()) {
             categoryCounterInc("glb", "top>");
             return t1;
         }
@@ -1109,10 +1117,11 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         if (mayBeSpecial1.symbol == Symbols::bottom()) {
             return true;
         }
-        if (mayBeSpecial1.symbol == Symbols::top()) {
+        if (mayBeSpecial1.symbol == Symbols::top() || mayBeSpecial1.symbol == Symbols::void_()) {
             if (isa_type<ClassType>(t2)) {
                 auto mayBeSpecial2 = cast_type_nonnull<ClassType>(t2);
-                return mayBeSpecial2.symbol == Symbols::top() || mayBeSpecial2.symbol == Symbols::untyped();
+                return mayBeSpecial2.symbol == Symbols::top() || mayBeSpecial2.symbol == Symbols::void_() ||
+                       mayBeSpecial2.symbol == Symbols::untyped();
             } else {
                 return false;
             }
@@ -1130,7 +1139,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         if (mayBeSpecial2.symbol == Symbols::bottom()) {
             return false; // (bot, bot) is handled above.
         }
-        if (mayBeSpecial2.symbol == Symbols::top()) {
+        if (mayBeSpecial2.symbol == Symbols::top() || mayBeSpecial2.symbol == Symbols::void_()) {
             return true;
         }
     }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -228,10 +228,6 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             categoryCounterInc("lub", "<top");
             return t1;
         }
-        if (mayBeSpecial1.symbol == Symbols::void_()) {
-            categoryCounterInc("lub", "<void");
-            return Types::top();
-        }
     }
 
     if (isa_type<ClassType>(t2)) {
@@ -247,10 +243,6 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         if (mayBeSpecial2.symbol == Symbols::top()) {
             categoryCounterInc("lub", "top>");
             return t2;
-        }
-        if (mayBeSpecial2.symbol == Symbols::void_()) {
-            categoryCounterInc("lub", "void>");
-            return Types::top();
         }
     }
 
@@ -676,7 +668,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
     if (isa_type<ClassType>(t1)) {
         auto mayBeSpecial1 = cast_type_nonnull<ClassType>(t1);
-        if (mayBeSpecial1.symbol == Symbols::top() || mayBeSpecial1.symbol == Symbols::void_()) {
+        if (mayBeSpecial1.symbol == Symbols::top()) {
             categoryCounterInc("glb", "<top");
             return t2;
         }
@@ -685,7 +677,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             // `glb(T.untyped,<any>)` will reduce to `T.untyped`.
             if (isa_type<ClassType>(t2)) {
                 auto mayBeSpecial2 = cast_type_nonnull<ClassType>(t2);
-                if (mayBeSpecial2.symbol == Symbols::top() || mayBeSpecial2.symbol == Symbols::void_()) {
+                if (mayBeSpecial2.symbol == Symbols::top()) {
                     categoryCounterInc("glb", "top>");
                     return t1;
                 }
@@ -701,7 +693,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
     if (isa_type<ClassType>(t2)) {
         auto mayBeSpecial2 = cast_type_nonnull<ClassType>(t2);
-        if (mayBeSpecial2.symbol == Symbols::top() || mayBeSpecial2.symbol == Symbols::void_()) {
+        if (mayBeSpecial2.symbol == Symbols::top()) {
             categoryCounterInc("glb", "top>");
             return t1;
         }
@@ -1117,7 +1109,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         if (mayBeSpecial1.symbol == Symbols::bottom()) {
             return true;
         }
-        if (mayBeSpecial1.symbol == Symbols::top() || mayBeSpecial1.symbol == Symbols::void_()) {
+        if (mayBeSpecial1.symbol == Symbols::top()) {
             if (isa_type<ClassType>(t2)) {
                 auto mayBeSpecial2 = cast_type_nonnull<ClassType>(t2);
                 return mayBeSpecial2.symbol == Symbols::top() || mayBeSpecial2.symbol == Symbols::void_() ||

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -431,17 +431,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
         // make sure the return types are compatible
 
         auto superReturn = superMethod.data(ctx)->resultType;
-        if (superReturn == core::Types::void_()) {
-            // Mimics how `.void` methods are handled in cfg::Return case of environment.cc
-            superReturn = core::Types::top();
-        }
-
         auto &methodReturn = method.data(ctx)->resultType;
-        // Don't have to do the void -> top trick, because if parent is top, the child method return
-        // type can be whatever. And if parent is not top, then neither void nor T.anything in the
-        // child return will be compatible with the parent, so we may as well keep it as `void` for
-        // the sake of showing an error message in the terms that the user wrote ("where did this
-        // T.anything come from? I wrote .void").
 
         core::ErrorSection::Collector errorDetailsCollector;
         if (!checkSubtype(ctx, *constr, methodReturn, method, superReturn, superMethod, core::Polarity::Positive,

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1407,9 +1407,6 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
 
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(ctx, i.what);
-                if (methodReturnType == core::Types::void_()) {
-                    methodReturnType = core::Types::top();
-                }
                 core::ErrorSection::Collector errorDetailsCollector;
                 if (!core::Types::isSubTypeUnderConstraint(ctx, constr, typeAndOrigin.type, methodReturnType,
                                                            core::UntypedMode::AlwaysCompatible,
@@ -1446,9 +1443,6 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
 
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(ctx, i.what);
                 auto expectedType = i.link->result->main.blockReturnType;
-                if (core::Types::isSubType(ctx, core::Types::void_(), expectedType)) {
-                    expectedType = core::Types::top();
-                }
                 bool isSubtype;
                 core::ErrorSection::Collector errorDetailsCollector;
                 if (i.link->result->main.constr) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1407,6 +1407,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
 
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(ctx, i.what);
+                if (methodReturnType == core::Types::void_()) {
+                    methodReturnType = core::Types::top();
+                }
                 core::ErrorSection::Collector errorDetailsCollector;
                 if (!core::Types::isSubTypeUnderConstraint(ctx, constr, typeAndOrigin.type, methodReturnType,
                                                            core::UntypedMode::AlwaysCompatible,
@@ -1443,6 +1446,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
 
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(ctx, i.what);
                 auto expectedType = i.link->result->main.blockReturnType;
+                if (core::Types::isSubType(ctx, core::Types::void_(), expectedType)) {
+                    expectedType = core::Types::top();
+                }
                 bool isSubtype;
                 core::ErrorSection::Collector errorDetailsCollector;
                 if (i.link->result->main.constr) {

--- a/test/testdata/infer/lub_between_self_params.rb
+++ b/test/testdata/infer/lub_between_self_params.rb
@@ -26,6 +26,6 @@ class Child < Parent
     self["foo"] || self["bar"]
 #        ^^^^^ error: Expected `Child::A` but found `String("foo")` for argument `k`
 #              ^^^^ error: Branching on `void` value
-#                  ^^^^^^^^^^^ error: This code is unreachable
+#                       ^^^^^ error: Expected `Child::A` but found `String("bar")` for argument `k`
   end
 end

--- a/test/testdata/infer/void_final.rb
+++ b/test/testdata/infer/void_final.rb
@@ -14,6 +14,6 @@ def main
     #^^^^^^ error: Branching on `void` value
     T.reveal_type(result) # error: Revealed type: `Sorbet::Private::Static::Void`
   else
-    T.reveal_type(result) # error: This code is unreachable
+    T.reveal_type(result) # error: `T.nilable(FalseClass)`
   end
 end

--- a/test/testdata/infer/void_proc.rb
+++ b/test/testdata/infer/void_proc.rb
@@ -9,3 +9,10 @@ end
 foo do
   3
 end
+
+sig {params(f: T.proc.void).void}
+def takes_void_proc(f)
+end
+
+f = T.let(-> () { 0 }, T.proc.returns(Integer))
+takes_void_proc(f)

--- a/test/testdata/lsp/fast_path/each.rb
+++ b/test/testdata/lsp/fast_path/each.rb
@@ -17,7 +17,7 @@ class A
     )
     .returns(T.untyped)
   end
-  def each(&blk) # error: Block parameter `blk` of type `T.proc.params(arg0: A::Elem).void` not compatible with type of abstract method `Enumerable#each`
+  def each(&blk)
     yield ''
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For all intents and purposes, `.void` is the same as `T.anything`. If it had been up to me, I would have made `.void` be `T.anything` from the release of Sorbet and not dealt with all the confusion that `.void` has caused. But it's what we have.

Normally, it's not possible to get a type of `Sorbet::Private::Static::Void` anywhere but the top level of a method (unless you write that type out by hand in your code, which I've never seen). Which means that we can get away with very few places where we do something like "if type is void, then make it top"

But that goes out the window for `T.proc` types, and thus, all types, where now you can have `Sorbet::Private::Static::Void` nested anywhere in the type (e.g. you could have an array of void procs). It should still be the case that you can use void procs and `returns(T.anything)` procs interchangeably.

This mostly doesn't bite people because

- There is a special case for `BlockReturn`, where we widen the expected type of **blocks** specifically when the declared return type is `void`
- Most lambda and proc types produce completely untyped proc values.

I'm working on some changes which will make Sorbet infer properly-typed lambdas (at least as far as the return values are concerned), after which the fact that Sorbet does not treat void and anything interchangeably for the purpose of proc type checking becomes quite apparent.

I had originally hoped to take the chance to *completely* eliminate all the places where we do `void -> anything` by pushing it into subtyping.cc, but there are a handful of places where people _really want to know_ whether they're dealing with `void` or `anything` for the purpose of error messages. You can see this in the git commit history—I started down that road and had to walk it back.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.