### PR TITLE
Special-case `return` inside `Kernel.lambda` and `-> ()`

### DIFF
--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -27,6 +27,8 @@ private:
     static void jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc);
     static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InstructionPtr inst);
     static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
+    static BasicBlock *walkBlockReturn(CFGContext cctx, core::LocOffsets loc, ast::ExpressionPtr &expr,
+                                       BasicBlock *current);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>
     walkDefault(CFGContext cctx, int argIndex, const core::ArgInfo &argInfo, LocalRef argLocal, core::LocOffsets argLoc,
                 ast::ExpressionPtr &def, BasicBlock *presentCont, BasicBlock *defaultCont);

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -43,6 +43,7 @@ public:
     LocalRef blockBreakTarget;
     int loops;
     bool isInsideRubyBlock;
+    bool isInsideLambda;
     bool breakIsJump;
     BasicBlock *nextScope;
     BasicBlock *breakScope;
@@ -66,8 +67,8 @@ private:
     CFGContext(core::Context ctx, CFG &inWhat, LocalRef target, int loops, BasicBlock *nextScope,
                BasicBlock *breakScope, BasicBlock *rescueScope, UnorderedMap<core::SymbolRef, LocalRef> &aliases,
                UnorderedMap<core::NameRef, LocalRef> &discoveredUndeclaredFields, uint32_t &temporaryCounter)
-        : ctx(ctx), inWhat(inWhat), target(target), loops(loops), isInsideRubyBlock(false), breakIsJump(false),
-          nextScope(nextScope), breakScope(breakScope), rescueScope(rescueScope), aliases(aliases),
+        : ctx(ctx), inWhat(inWhat), target(target), loops(loops), isInsideRubyBlock(false), isInsideLambda(false),
+          breakIsJump(false), nextScope(nextScope), breakScope(breakScope), rescueScope(rescueScope), aliases(aliases),
           discoveredUndeclaredFields(discoveredUndeclaredFields), temporaryCounter(temporaryCounter){};
 };
 } // namespace sorbet::cfg

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -669,7 +669,9 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                                            .withBlockBreakTarget(cctx.target)
                                            .withLoopScope(headerBlock, postBlock, true)
                                            .withSendAndBlockLink(link);
-                        newCctx.isInsideLambda = isKernelLambda(s);
+                        if (isKernelLambda(s)) {
+                            newCctx.isInsideLambda = true;
+                        }
                         blockLast = walk(newCctx, s.block()->body, argBlock);
                     }
                     if (blockLast != cctx.inWhat.deadBlock()) {

--- a/test/testdata/infer/lambda_block_return.rb
+++ b/test/testdata/infer/lambda_block_return.rb
@@ -33,3 +33,22 @@ def proc_to_lambda
   f = Kernel.lambda(&p)
   f.call.to_s
 end
+
+sig { params(blk: T.proc.returns(NilClass)).void }
+def takes_nil_block(&blk)
+  yield
+end
+
+sig { returns(String) }
+def block_inside_lambda
+  f = ->() {
+    takes_nil_block do
+      # At runtime, this returns from the lambda, but Sorbet treats it like it
+      # returns from the enclosing block. This would be nice to fix, because
+      # there is no workaround for this except manually raising and catching
+      # exceptions.
+      return 0 # error: Expected `NilClass` but found `Integer(0)` for block result type
+    end
+  }
+  f.call.to_s
+end

--- a/test/testdata/infer/lambda_block_return.rb
+++ b/test/testdata/infer/lambda_block_return.rb
@@ -1,0 +1,35 @@
+# typed: true
+extend T::Sig
+
+sig { returns(String) }
+def syntactic_lambda
+  f = ->() {
+    return 0
+  }
+  f.call.to_s
+end
+
+sig { returns(String) }
+def kernel_lambda
+  f = Kernel.lambda {
+    return 0
+  }
+  f.call.to_s
+end
+
+sig { returns(String) }
+def plain_lambda
+  f = lambda {
+    return 0 # error: Expected `String` but found `Integer(0)` for method result type
+  }
+  f.call.to_s
+end
+
+sig { returns(String) }
+def proc_to_lambda
+  p = proc {
+    return 0 # error: Expected `String` but found `Integer(0)` for method result type
+  }
+  f = Kernel.lambda(&p)
+  f.call.to_s
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #2651

We could expand this in the future to also handle plain
`lambda { return }` but that would be taking a leap of faith that
`lambda` is `Kernel#lambda`, which might not be the case if there are DSLs
that define methods with this name that do not have lambda's same
`return` semantics.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.