### PR TITLE
LSP support for punned keyword arguments

### DIFF
--- a/main/lsp/LSPLoop.h
+++ b/main/lsp/LSPLoop.h
@@ -112,12 +112,14 @@ std::vector<core::ClassOrModuleRef> getSubclassesSlow(const core::GlobalState &g
                                                       bool includeSelf);
 
 std::unique_ptr<core::lsp::QueryResponse>
-skipLiteralIfMethodDef(std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses);
+skipLiteralIfMethodDef(const core::GlobalState &gs,
+                       std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses);
 
 // prop/const/attr setters are bogged down with a bunch of extra Ident and Literal query
 // responses, which don't make sense to use find all references on.
 std::unique_ptr<core::lsp::QueryResponse>
-getQueryResponseForFindAllReferences(std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses);
+getQueryResponseForFindAllReferences(const core::GlobalState &gs,
+                                     std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses);
 
 } // namespace sorbet::realmain::lsp
 #endif // RUBY_TYPER_LSPLOOP_H

--- a/main/lsp/LSPLoop.h
+++ b/main/lsp/LSPLoop.h
@@ -112,6 +112,10 @@ std::vector<core::ClassOrModuleRef> getSubclassesSlow(const core::GlobalState &g
                                                       bool includeSelf);
 
 std::unique_ptr<core::lsp::QueryResponse>
+skipLiteralIfPunnedKeywordArg(const core::GlobalState &gs,
+                              std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses);
+
+std::unique_ptr<core::lsp::QueryResponse>
 skipLiteralIfMethodDef(const core::GlobalState &gs,
                        std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses);
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -172,7 +172,7 @@ vector<core::ClassOrModuleRef> getSubclassesSlow(const core::GlobalState &gs, co
 }
 
 unique_ptr<core::lsp::QueryResponse>
-skipLiteralIfMethodDef(vector<unique_ptr<core::lsp::QueryResponse>> &queryResponses) {
+skipLiteralIfMethodDef(const core::GlobalState &gs, vector<unique_ptr<core::lsp::QueryResponse>> &queryResponses) {
     for (auto &r : queryResponses) {
         if (r->isMethodDef()) {
             return move(r);
@@ -185,12 +185,13 @@ skipLiteralIfMethodDef(vector<unique_ptr<core::lsp::QueryResponse>> &queryRespon
 }
 
 unique_ptr<core::lsp::QueryResponse>
-getQueryResponseForFindAllReferences(vector<unique_ptr<core::lsp::QueryResponse>> &queryResponses) {
+getQueryResponseForFindAllReferences(const core::GlobalState &gs,
+                                     vector<unique_ptr<core::lsp::QueryResponse>> &queryResponses) {
     // Find all references might show an Ident last if its a `prop`, and the Ident will be the
     // synthetic local variable name of the method argument.
     auto firstResp = queryResponses[0]->isIdent();
     if (firstResp == nullptr) {
-        return skipLiteralIfMethodDef(queryResponses);
+        return skipLiteralIfMethodDef(gs, queryResponses);
     }
 
     for (auto resp = queryResponses.begin() + 1; resp != queryResponses.end(); ++resp) {
@@ -210,11 +211,11 @@ getQueryResponseForFindAllReferences(vector<unique_ptr<core::lsp::QueryResponse>
         if ((*resp)->isMethodDef()) {
             return move(*resp);
         } else {
-            return skipLiteralIfMethodDef(queryResponses);
+            return skipLiteralIfMethodDef(gs, queryResponses);
         }
     }
 
-    return skipLiteralIfMethodDef(queryResponses);
+    return skipLiteralIfMethodDef(gs, queryResponses);
 }
 
 /**

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -67,7 +67,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
     if (!queryResponses.empty()) {
         const bool fileIsTyped =
             config.uri2FileRef(gs, params->textDocument->uri).data(gs).strictLevel >= core::StrictLevel::True;
-        auto resp = skipLiteralIfMethodDef(queryResponses);
+        auto resp = skipLiteralIfMethodDef(gs, queryResponses);
 
         // Only support go-to-definition on constants and fields in untyped files.
         if (auto c = resp->isConstant()) {

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -61,7 +61,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
         }
         const bool fileIsTyped = file.data(gs).strictLevel >= core::StrictLevel::True;
 
-        auto resp = getQueryResponseForFindAllReferences(queryResponses);
+        auto resp = getQueryResponseForFindAllReferences(gs, queryResponses);
 
         // If file is untyped, only supports find reference requests from constants and class definitions.
         if (auto constResp = resp->isConstant()) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -69,7 +69,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         return response;
     }
 
-    auto resp = move(queryResponses[0]);
+    auto resp = skipLiteralIfMethodDef(gs, queryResponses);
     auto options = core::ShowOptions();
     vector<core::Loc> documentationLocations;
     string typeString;

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -89,7 +89,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
         fileIsTyped = fref.data(gs).strictLevel >= core::StrictLevel::True;
     }
     if (!queryResponses.empty()) {
-        auto resp = getQueryResponseForFindAllReferences(queryResponses);
+        auto resp = getQueryResponseForFindAllReferences(gs, queryResponses);
 
         // If file is untyped, only supports find reference requests from constants and class definitions.
         if (auto constResp = resp->isConstant()) {

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -312,7 +312,7 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
         return response;
     }
 
-    auto resp = move(queryResponses[0]);
+    auto resp = skipLiteralIfMethodDef(gs, queryResponses);
     shared_ptr<AbstractRewriter> renamer;
     if (auto constResp = resp->isConstant()) {
         // Sanity check the text.

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -33,7 +33,7 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
         return response;
     }
 
-    auto resp = move(queryResponses[0]);
+    auto resp = skipLiteralIfMethodDef(gs, queryResponses);
 
     core::SymbolRef sym;
     if (auto c = resp->isConstant()) {

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/requests/type_definition.h"
 #include "common/typecase.h"
 #include "core/lsp/QueryResponse.h"
+#include "main/lsp/LSPLoop.h"
 #include "main/lsp/LSPQuery.h"
 #include "main/lsp/json_types.h"
 
@@ -103,7 +104,7 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
     if (!queryResponses.empty()) {
         const bool fileIsTyped =
             config.uri2FileRef(gs, params->textDocument->uri).data(gs).strictLevel >= core::StrictLevel::True;
-        auto resp = move(queryResponses[0]);
+        auto resp = skipLiteralIfMethodDef(gs, queryResponses);
 
         // Only support go-to-type-definition on constants and fields in untyped files.
         if (resp->isConstant() || resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {

--- a/test/testdata/lsp/punned_kwargs.rb
+++ b/test/testdata/lsp/punned_kwargs.rb
@@ -1,0 +1,17 @@
+# typed: true
+extend T::Sig
+
+class A; end
+#     ^ type-def: A
+
+sig { params(xyz: String).void }
+def takes_string(xyz:)
+end
+
+  xyz = A
+# ^^^ def: xyz
+takes_string(xyz:)
+#            ^^^^ error: Expected `String` but found `T.class_of(A)` for argument `xyz`
+#            ^^^ hover: T.class_of(A)
+#            ^^^ usage: xyz
+#            ^^^ type: A


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, we would show `Symbol(:xyz)` when hovering over punned keyword arguments.

That's less useful than showing information about the variable that the punned arg expands to.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.