### PR TITLE
Change error message for redundant `T.must`

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -128,6 +128,7 @@ public:
     static TypePtr Float();
     static TypePtr Boolean();
     static TypePtr Object();
+    static TypePtr BasicObject();
     static TypePtr arrayOfUntyped(sorbet::core::SymbolRef blame);
     static TypePtr rangeOfUntyped(sorbet::core::SymbolRef blame);
     static TypePtr hashOfUntyped();

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -53,7 +53,7 @@ constexpr ErrorClass NonOverlappingEqual{7046, StrictLevel::True};
 constexpr ErrorClass UntypedValueInformation{7047, StrictLevel::True};
 constexpr ErrorClass UnknownSuperMethod{7048, StrictLevel::True};
 constexpr ErrorClass TypecheckOverloadBody{7049, StrictLevel::True};
-constexpr ErrorClass MustOnUntyped{7050, StrictLevel::Strict};
+constexpr ErrorClass RedundantMust{7050, StrictLevel::Strict};
 constexpr ErrorClass BranchOnVoid{7051, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1939,9 +1939,11 @@ public:
         }
         auto ret = Types::dropNil(gs, args.args[0]->type);
         if (ret == args.args[0]->type) {
-            auto code = args.args[0]->type.isUntyped() ? errors::Infer::MustOnUntyped : errors::Infer::InvalidCast;
+            auto isRedundant =
+                args.args[0]->type.isUntyped() || ret.isTop() || ret == Types::Object() || ret == Types::BasicObject();
+            auto code = isRedundant ? errors::Infer::RedundantMust : errors::Infer::InvalidCast;
             if (auto e = gs.beginError(args.argLoc(0), code)) {
-                if (code == errors::Infer::MustOnUntyped) {
+                if (code == errors::Infer::RedundantMust) {
                     e.setHeader("`{}` called on `{}`, which is redundant", methodName, args.args[0]->type.show(gs));
                 } else {
                     e.setHeader("`{}` called on `{}`, which is never `{}`", methodName, args.args[0]->type.show(gs),

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -144,6 +144,10 @@ TypePtr Types::Object() {
     return make_type<ClassType>(Symbols::Object());
 }
 
+TypePtr Types::BasicObject() {
+    return make_type<ClassType>(Symbols::BasicObject());
+}
+
 TypePtr Types::falsyTypes() {
     static auto res = OrType::make_shared(Types::nilClass(), Types::falseClass());
     return res;

--- a/test/testdata/infer/must_untyped.rb
+++ b/test/testdata/infer/must_untyped.rb
@@ -13,4 +13,4 @@ object = T.let(nil, Object)
 T.must(object) # error: `T.must` called on `Object`, which is redundant
 
 basic_object = T.let(nil, BasicObject)
-T.must(object) # error: `T.must` called on `BasicObject`, which is redundant
+T.must(basic_object) # error: `T.must` called on `BasicObject`, which is redundant

--- a/test/testdata/infer/must_untyped.rb
+++ b/test/testdata/infer/must_untyped.rb
@@ -5,3 +5,12 @@ T.must(T.unsafe(nil))
 
 T.must_because(T.unsafe(nil)) {'reason'}
 #              ^^^^^^^^^^^^^ error: `T.must_because` called on `T.untyped`, which is redundant
+
+anything = T.let(nil, T.anything)
+T.must(anything) # error: `T.must` called on `T.anything`, which is redundant
+
+object = T.let(nil, Object)
+T.must(object) # error: `T.must` called on `Object`, which is redundant
+
+basic_object = T.let(nil, BasicObject)
+T.must(object) # error: `T.must` called on `BasicObject`, which is redundant

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -4417,13 +4417,23 @@ to declare overloaded methods correctly.
 
 ## 7050
 
-Calling `T.must` with an untyped object is an indication that code that was
-considered typed (and `T.must` was ensuring that the value was not `nil`) is not
-typed anymore.
+Calling `T.must` when the argument is `T.untyped`, `T.anything`, `Object`, or
+`BasicObject` is redundant. This indicates that either:
 
-This was separated from [7015](#7015) to maintain this error in
-`# typed: strict` and above, but allow for [7015](#7015) to be enforced at lower
-strictness levels.
+- a previously-typed argument became untyped, indicating a regression in type
+  safety somewhere, or
+- the code does not benefit from `T.must`, because the type before and after the
+  call is the same.
+
+If raising an exception for `nil` values is the desired runtime behavior, do so
+explicitly:
+
+```ruby
+raise if x == nil
+```
+
+This was separated from [7015](#7015) allow it to be autocorrected independently
+from invalid usages of `T.let` and `T.cast`.
 
 ## 7051
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We could have implemented this by checking whether `NilClass` is a
subtype of the type, but this seems like it'll be faster and basically
as effective.

One case it won't handle is e.g. type members upper bounded by `Object`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.