### PR TITLE
Add a signature for ObjectSpace.each_object

### DIFF
--- a/rbi/stdlib/objspace.rbi
+++ b/rbi/stdlib/objspace.rbi
@@ -115,6 +115,10 @@ module ObjectSpace
   # 2.2250738585072e-308
   # Total count: 7
   # ```
+  sig {returns(T::Enumerator[BasicObject])}
+  sig {params(blk: T.proc.params(obj: BasicObject).void).returns(Integer)}
+  sig {type_parameters(:Instance).params(mod: T::Class[T.type_parameter(:Instance)]).returns(T::Enumerator[T.type_parameter(:Instance)])}
+  sig {type_parameters(:Instance).params(mod: T::Class[T.type_parameter(:Instance)], blk: T.proc.params(obj: T.type_parameter(:Instance)).void).returns(Integer)}
   sig {params(mod: Module).returns(T::Enumerator[BasicObject])}
   sig {params(mod: Module, blk: T.proc.params(obj: BasicObject).void).returns(Integer)}
   def self.each_object(mod=BasicObject, &blk)

--- a/test/testdata/rbi/objspace.rb
+++ b/test/testdata/rbi/objspace.rb
@@ -1,4 +1,21 @@
 # typed: true
 
-ObjectSpace::WeakMap.new
-X = ObjectSpace::WeakMap.new
+class Parent; end
+module Mixin; end
+
+ObjectSpace.each_object do |obj|
+  T.reveal_type(obj) # error: `BasicObject`
+end
+ObjectSpace.each_object(Parent) do |obj|
+  T.reveal_type(obj) # error: `Parent`
+end
+ObjectSpace.each_object(Mixin) do |obj|
+  T.reveal_type(obj) # error: `BasicObject`
+end
+
+res = ObjectSpace.each_object
+T.reveal_type(res) # error: `T::Enumerator[BasicObject]`
+res = ObjectSpace.each_object(Parent)
+T.reveal_type(res) # error: `T::Enumerator[Parent]`
+res = ObjectSpace.each_object(Mixin)
+T.reveal_type(res) # error: `T::Enumerator[BasicObject]`


### PR DESCRIPTION
Relates to #7027, though does not actually fix the root cause.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This became unblocked by 2246d9e42b17677c6f94976ff9112b096131b319, which
allows generic methods to be considered by overload resolution.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.