### PR TITLE
Infer proc return types

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -688,6 +688,13 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::Kernel(), Names::lambdaTLet()).typedArg(Names::type(), Types::top()).build();
     ENFORCE(method == Symbols::Kernel_lambdaTLet());
 
+    method = enterMethod(*this, Symbols::Kernel(), Names::proc()).build();
+    ENFORCE(method == Symbols::Kernel_proc());
+
+    typeArgument = enterTypeArgument(Loc::none(), Symbols::Kernel_proc(), Names::returnType(), Variance::CoVariant);
+    ENFORCE(typeArgument == Symbols::Kernel_proc_returnType());
+    typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
+
     // Root members
     Symbols::root().data(*this)->members()[core::Names::Constants::NoSymbol()] = Symbols::noSymbol();
     Symbols::root().data(*this)->members()[core::Names::Constants::Top()] = Symbols::top();

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1109,6 +1109,14 @@ public:
         return MethodRef::fromRaw(21);
     }
 
+    static MethodRef Kernel_proc() {
+        return MethodRef::fromRaw(22);
+    }
+
+    static TypeArgumentRef Kernel_proc_returnType() {
+        return TypeArgumentRef::fromRaw(5);
+    }
+
     static ClassOrModuleRef Magic_UntypedSource() {
         return ClassOrModuleRef::fromRaw(99);
     }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,9 +23,9 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 55;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 56;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
-const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 5;
+const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 6;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 72;
 
 namespace {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2661,19 +2661,16 @@ private:
         }
 
         {
+            auto nonNilPassedInBlockType = Types::dropNil(gs, passedInBlockType);
+            auto passedInBlockReturnType = Types::getProcReturnType(gs, nonNilPassedInBlockType);
             auto it = &dispatched;
             while (it != nullptr) {
                 if (it->main.method.exists()) {
-                    const auto &methodArgs = it->main.method.data(gs)->arguments;
-                    ENFORCE(!methodArgs.empty());
-                    const auto &bspec = methodArgs.back();
-                    ENFORCE(bspec.flags.isBlock);
-
-                    auto bspecType = bspec.type;
-                    if (bspecType) {
+                    const auto &blockReturnType = it->main.blockReturnType;
+                    if (blockReturnType) {
                         // TODO(jez) How should this interact with highlight untyped?
                         // This subtype check is here to discover the correct generic bounds.
-                        Types::isSubTypeUnderConstraint(gs, *constr, passedInBlockType, bspecType,
+                        Types::isSubTypeUnderConstraint(gs, *constr, passedInBlockReturnType, blockReturnType,
                                                         UntypedMode::AlwaysCompatible, ErrorSection::Collector::NO_OP);
                     }
                 }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4223,16 +4223,12 @@ public:
         }
         auto untypedWithBlame = core::Types::untyped(Symbols::Magic_UntypedSource_proc());
         vector<core::TypePtr> targs(*numberOfPositionalBlockParams + 1, untypedWithBlame);
-        // TODO(jez) Should be able to suport Kernel#proc in the same way
         auto isLambda = res.main.method == Symbols::Kernel_lambda();
-        if (isLambda) {
-            targs[0] = make_type<TypeVar>(Symbols::Kernel_lambda_returnType());
-        }
+        targs[0] = isLambda ? make_type<TypeVar>(Symbols::Kernel_lambda_returnType())
+                            : make_type<TypeVar>(Symbols::Kernel_proc_returnType());
         auto procClass = core::Symbols::Proc(*numberOfPositionalBlockParams);
         res.returnType = make_type<core::AppliedType>(procClass, move(targs));
-        if (isLambda) {
-            handleBlockType(gs, res.main, res.returnType);
-        }
+        handleBlockType(gs, res.main, res.returnType);
     }
 } Kernel_proc;
 

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1875,7 +1875,8 @@ module Kernel
   # Equivalent to
   # [`Proc.new`](https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-c-new).
   sig do
-    params(
+    type_parameters(:return_type) # Used by Kernel#proc intrinsic in calls.cc
+    .params(
         blk: T.untyped,
     )
     .returns(Proc)

--- a/test/testdata/infer/call_with_block.rb
+++ b/test/testdata/infer/call_with_block.rb
@@ -73,4 +73,4 @@ res = generic_param(
   0,
   &T.unsafe(:even?)
 )
-T.reveal_type(res) # error: `T.untyped`
+T.reveal_type(res) # error: `Integer`

--- a/test/testdata/infer/call_with_block.rb
+++ b/test/testdata/infer/call_with_block.rb
@@ -35,7 +35,7 @@ end
 
 sig {params(a: Integer, blk: T.proc.returns(String)).void}
 def baz(a, &blk)
-  T.reveal_type(proc(&blk)) # error: Revealed type: `T.proc.returns(T.untyped)`
+  T.reveal_type(proc(&blk)) # error: Revealed type: `T.proc.returns(String)`
   foo(a, &blk)
   foo(a, &nil)
 end

--- a/test/testdata/infer/call_with_block.rb
+++ b/test/testdata/infer/call_with_block.rb
@@ -55,3 +55,22 @@ end
 
 a = [1, 2].map(&:to_s)
 T.reveal_type(a) # error: Revealed type: `T::Array[String]`
+
+sig do
+  type_parameters(:U)
+    .params(
+      input: T.type_parameter(:U),
+      blk: T.proc.params(x: T.type_parameter(:U)).void
+    )
+    .returns(T.type_parameter(:U))
+end
+def generic_param(input, &blk)
+  yield input
+  input
+end
+
+res = generic_param(
+  0,
+  &T.unsafe(:even?)
+)
+T.reveal_type(res) # error: `T.untyped`

--- a/test/testdata/infer/call_with_block_strict.rb
+++ b/test/testdata/infer/call_with_block_strict.rb
@@ -35,7 +35,7 @@ end
 
 sig {params(a: Integer, blk: T.proc.returns(String)).void}
 def baz(a, &blk)
-  T.reveal_type(proc(&blk)) # error: Revealed type: `T.proc.returns(T.untyped)`
+  T.reveal_type(proc(&blk)) # error: Revealed type: `T.proc.returns(String)`
   foo(a, &blk)
   foo(a, &nil)
 end

--- a/test/testdata/infer/infer_proc.rb
+++ b/test/testdata/infer/infer_proc.rb
@@ -1,0 +1,56 @@
+# typed: true
+extend T::Sig
+
+sig { params(x: Integer).returns(String) }
+def returns_string(x); x.to_s; end
+
+sig { params(f: T.proc.returns(Integer)).void }
+def takes_void_proc(f); end
+
+f = proc { 0 }
+T.reveal_type(f) # error: T.proc.returns(Integer)
+
+takes_void_proc(f)
+
+f = proc { |x| 0 }
+T.reveal_type(f) # error: T.proc.params(arg0: T.untyped).returns(Integer)
+
+f = proc { |x| x }
+T.reveal_type(f) # error: T.proc.params(arg0: T.untyped).returns(T.untyped)
+
+f = proc { |x| returns_string(x) }
+T.reveal_type(f) # error: T.proc.params(arg0: T.untyped).returns(String)
+
+def example
+  f = proc do |x|
+    if x
+      return false # returns from `example`, not from the proc
+    end
+
+    true
+  end
+  T.reveal_type(f) # error: `T.proc.params(arg0: T.untyped).returns(TrueClass)`
+end
+
+f = proc { |x|
+  if x
+    next false
+  end
+
+  true
+}
+T.reveal_type(f) # error: `T.proc.params(arg0: T.untyped).returns(T::Boolean)`
+
+f = proc {
+  if T.unsafe(nil)
+    next T.unsafe(nil)
+  else
+    next 0
+  end
+}
+T.reveal_type(f) # error: `T.proc.returns(T.untyped)`
+
+f = proc {
+  raise
+}
+T.reveal_type(f) # error: `T.proc.returns(T.noreturn)`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These are the same change as a2a3f1088 but for `Kernel#proc` instead of
`Kernel#lambda`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.