### PR TITLE
Update signature of `Array#|` to accept broader inputs

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2812,10 +2812,11 @@ class Array < Object
   # See also
   # [`Array#union`](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-union).
   sig do
-    params(
-        arg0: T::Array[Elem],
+    type_parameters(:U)
+    .params(
+        arg0: T::Array[T.type_parameter(:U)],
     )
-    .returns(T::Array[Elem])
+    .returns(T::Array[T.any(Elem, T.type_parameter(:U))])
   end
   def |(arg0); end
 


### PR DESCRIPTION


The signature of `Array#|` should accept broader input and should also adjust the type of the returned array to accommodate the elements that are being joined into the array.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The following construct is [an error for Sorbet](https://sorbet.run/?arg=--enable-experimental-requires-ancestor#%23%20typed%3A%20true%0A%0Aa%20%3D%20%5B1%2C2%2C3%5D%0Ab%20%3D%20%5B%22a%22%2C%20%22b%22%5D%0A%0Ac%20%3D%20a%20%7C%20b%0A) even though it is valid Ruby code:
```ruby
# typed: true

a = [1, 2, 3]
b = ["a", "b"]

c = a | b
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests added
