### PR TITLE
Revert "Cache files before pipeline::package (#7759)"

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1264,7 +1264,7 @@ void printFileTable(unique_ptr<core::GlobalState> &gs, const options::Options &o
 #endif
 }
 
-bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::Span<const ast::ParsedFile> parsedFiles,
+bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, const vector<ast::ParsedFile> &parsedFiles,
                         const unique_ptr<OwnedKeyValueStore> &kvstore) {
     if (kvstore == nullptr) {
         return false;

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -71,7 +71,8 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
                                     const options::Options &opts);
 
 // Caches any uncached trees and files. Returns true if it modifies kvstore.
-bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::Span<const ast::ParsedFile> parsedFiles,
+bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers,
+                        const std::vector<ast::ParsedFile> &parsedFiles,
                         const std::unique_ptr<OwnedKeyValueStore> &kvstore);
 
 // Exported for tests only.

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -730,11 +730,6 @@ int realmain(int argc, char *argv[]) {
                     indexed = pipeline::index(*gs, inputPackageFiles, opts, *workers, kvstore);
                 }
 
-                // Cache these before any pipeline::package rewrites, so that the cache is still
-                // usable regardless of whether `--stripe-packages` was passed.
-                cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers,
-                                                     indexed);
-
                 // First run: only the __package.rb files. This populates the packageDB
                 pipeline::setPackagerOptions(*gs, opts);
                 pipeline::package(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers);
@@ -749,11 +744,6 @@ int realmain(int argc, char *argv[]) {
                     // Calculate file hashes alongside indexing when --store-state is specified for LSP mode
                     ? hashing::Hashing::indexAndComputeFileHashes(gs, opts, *logger, inputFilesSpan, *workers, kvstore)
                     : pipeline::index(*gs, inputFilesSpan, opts, *workers, kvstore);
-
-            // Cache these before any pipeline::package rewrites, so that the cache is still usable
-            // regardless of whether `--stripe-packages` was passed.
-            cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers,
-                                                 nonPackageIndexed);
 
             // Second run: all the other files (the packageDB shouldn't change)
             pipeline::package(*gs, absl::Span<ast::ParsedFile>(nonPackageIndexed), opts, *workers);
@@ -771,6 +761,7 @@ int realmain(int argc, char *argv[]) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
         }
+        cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers, indexed);
 
         if (gs->runningUnderAutogen) {
 #ifdef SORBET_REALMAIN_MIN


### PR DESCRIPTION
This reverts commit 26591f256ad453c901626adf08b74cd1ef043078.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.