### PR TITLE
Don't close cache file after caching `__package.rb` files

### DIFF
--- a/main/cache/cache-orig.cc
+++ b/main/cache/cache-orig.cc
@@ -13,9 +13,10 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
     return nullptr;
 }
 
-void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, WorkerPool &workers, const vector<ast::ParsedFile> &indexed) {
-    return;
+unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
+                                                        core::GlobalState &gs, WorkerPool &workers,
+                                                        const vector<ast::ParsedFile> &indexed) {
+    return kvstore;
 }
 
 } // namespace sorbet::realmain::cache

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -35,17 +35,18 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
     return nullptr;
 }
 
-void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, WorkerPool &workers, const vector<ast::ParsedFile> &indexed) {
+unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
+                                                        core::GlobalState &gs, WorkerPool &workers,
+                                                        const vector<ast::ParsedFile> &indexed) {
     if (kvstore == nullptr) {
-        return;
+        return kvstore;
     }
     auto ownedKvstore = make_unique<OwnedKeyValueStore>(move(kvstore));
     // TODO: Move these methods into this file.
     payload::retainGlobalState(gs, opts, ownedKvstore);
     pipeline::cacheTreesAndFiles(gs, workers, indexed, ownedKvstore);
     auto sizeBytes = ownedKvstore->cacheSize();
-    OwnedKeyValueStore::bestEffortCommit(gs.tracer(), move(ownedKvstore));
+    kvstore = OwnedKeyValueStore::bestEffortCommit(gs.tracer(), move(ownedKvstore));
     prodCounterInc("cache.committed");
 
     size_t usedPercent = round((sizeBytes * 100.0) / opts.maxCacheSizeBytes);
@@ -53,6 +54,8 @@ void maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const opti
     prodCounterSet("cache.used_percent", usedPercent);
     gs.tracer().debug("sorbet_version={} cache_used_bytes={} cache_used_percent={}", sorbet_full_version_string,
                       sizeBytes, usedPercent);
+
+    return kvstore;
 }
 
 } // namespace sorbet::realmain::cache

--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -32,9 +32,10 @@ std::unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, 
 
 // If kvstore is not null, caches global state and the given files to disk if they have changed. Can silently fail to
 // cache
-void maybeCacheGlobalStateAndFiles(std::unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
-                                   core::GlobalState &gs, WorkerPool &workers,
-                                   const std::vector<ast::ParsedFile> &indexed);
+std::unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(std::unique_ptr<KeyValueStore> kvstore,
+                                                             const options::Options &opts, core::GlobalState &gs,
+                                                             WorkerPool &workers,
+                                                             const std::vector<ast::ParsedFile> &indexed);
 } // namespace sorbet::realmain::cache
 
 #endif

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -732,8 +732,9 @@ int realmain(int argc, char *argv[]) {
 
                 // Cache these before any pipeline::package rewrites, so that the cache is still
                 // usable regardless of whether `--stripe-packages` was passed.
-                cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers,
-                                                     indexed);
+                // Want to keep the kvstore around so we can still write to it later.
+                kvstore = make_unique<OwnedKeyValueStore>(cache::maybeCacheGlobalStateAndFiles(
+                    OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers, indexed));
 
                 // First run: only the __package.rb files. This populates the packageDB
                 pipeline::setPackagerOptions(*gs, opts);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -733,8 +733,9 @@ int realmain(int argc, char *argv[]) {
                 // Cache these before any pipeline::package rewrites, so that the cache is still
                 // usable regardless of whether `--stripe-packages` was passed.
                 // Want to keep the kvstore around so we can still write to it later.
-                kvstore = make_unique<OwnedKeyValueStore>(cache::maybeCacheGlobalStateAndFiles(
-                    OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers, indexed));
+                kvstore = cache::ownIfUnchanged(
+                    *gs, cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs,
+                                                              *workers, indexed));
 
                 // First run: only the __package.rb files. This populates the packageDB
                 pipeline::setPackagerOptions(*gs, opts);

--- a/test/cli/stripe-packages-cache/test.out
+++ b/test/cli/stripe-packages-cache/test.out
@@ -1,0 +1,16 @@
+====first run (cold cache)====
+                         types.input.files :              4
+            types.input.files.kvstore.miss :              1
+           types.input.files.kvstore.write :              1
+====second run (warm cache)====
+                         types.input.files :              4
+             types.input.files.kvstore.hit :              1
+           types.input.files.kvstore.write :              0
+====first after change (one cache miss)====
+                         types.input.files :              4
+             types.input.files.kvstore.hit :              1
+           types.input.files.kvstore.write :              0
+====second after change (warm cache)====
+                         types.input.files :              4
+             types.input.files.kvstore.hit :              1
+           types.input.files.kvstore.write :              0

--- a/test/cli/stripe-packages-cache/test.out
+++ b/test/cli/stripe-packages-cache/test.out
@@ -1,16 +1,17 @@
 ====first run (cold cache)====
                          types.input.files :              4
-            types.input.files.kvstore.miss :              1
-           types.input.files.kvstore.write :              1
+            types.input.files.kvstore.miss :              4
+           types.input.files.kvstore.write :              4
 ====second run (warm cache)====
                          types.input.files :              4
-             types.input.files.kvstore.hit :              1
+             types.input.files.kvstore.hit :              4
            types.input.files.kvstore.write :              0
 ====first after change (one cache miss)====
                          types.input.files :              4
-             types.input.files.kvstore.hit :              1
-           types.input.files.kvstore.write :              0
+             types.input.files.kvstore.hit :              3
+            types.input.files.kvstore.miss :              1
+           types.input.files.kvstore.write :              1
 ====second after change (warm cache)====
                          types.input.files :              4
-             types.input.files.kvstore.hit :              1
+             types.input.files.kvstore.hit :              4
            types.input.files.kvstore.write :              0

--- a/test/cli/stripe-packages-cache/test.sh
+++ b/test/cli/stripe-packages-cache/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+dir=$(mktemp -d)
+cleanup() {
+    rm -r "$dir"
+}
+trap cleanup EXIT
+
+mkdir "$dir/cache"
+echo $'# typed: strict\nclass Root < PackageSpec; end' > "$dir/__package.rb"
+echo "class Root::A; end" > "$dir/a.rb"
+echo "class Root::B; end" > "$dir/b.rb"
+echo "class Root::C; end" > "$dir/c.rb"
+
+run_sorbet() {
+  if ! main/sorbet --silence-dev-message --stripe-packages --counters --cache-dir "$dir/cache" "$dir"/{__package,a,b,c}.rb 2> "$dir/stderr.txt"; then
+    cat "$dir/stderr.txt"
+    exit 1
+  fi
+  grep 'types.input.files\(.kvstore.miss\|.kvstore.hit\|.kvstore.write\)\? :' "$dir/stderr.txt"
+}
+
+echo "====first run (cold cache)===="
+run_sorbet
+echo "====second run (warm cache)===="
+run_sorbet
+
+echo '# comment' >> "$dir/a.rb"
+
+echo "====first after change (one cache miss)===="
+run_sorbet
+echo "====second after change (warm cache)===="
+run_sorbet


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We had silently disabled the cache in #7759 because I didn't notice that the
`kvstore` is getting moved into the call to `maybeCacheGlobalStateAndFiles` and
thus is `nullptr` the next time we try to use it for caching ASTs.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] Wrote a CLI test
- [ ] Tested on pay-server to see if it gets faster