### PR TITLE
Fix crash with empty file and `--cache-dir`

### DIFF
--- a/test/cli/warm-cache/test.out
+++ b/test/cli/warm-cache/test.out
@@ -1,0 +1,8 @@
+====first run (cold cache)====
+No errors! Great job.
+====second run (warm cache)====
+No errors! Great job.
+====first after change (one cache miss)====
+No errors! Great job.
+====second after change (warm cache)====
+No errors! Great job.

--- a/test/cli/warm-cache/test.out
+++ b/test/cli/warm-cache/test.out
@@ -10,5 +10,4 @@
             types.input.files.kvstore.miss :              1
 ====second after change (warm cache)====
                          types.input.files :              3
-             types.input.files.kvstore.hit :              2
-            types.input.files.kvstore.miss :              1
+             types.input.files.kvstore.hit :              3

--- a/test/cli/warm-cache/test.out
+++ b/test/cli/warm-cache/test.out
@@ -1,8 +1,14 @@
 ====first run (cold cache)====
-No errors! Great job.
+                         types.input.files :              3
+            types.input.files.kvstore.miss :              3
 ====second run (warm cache)====
-No errors! Great job.
+                         types.input.files :              3
+             types.input.files.kvstore.hit :              3
 ====first after change (one cache miss)====
-No errors! Great job.
+                         types.input.files :              3
+             types.input.files.kvstore.hit :              2
+            types.input.files.kvstore.miss :              1
 ====second after change (warm cache)====
-No errors! Great job.
+                         types.input.files :              3
+             types.input.files.kvstore.hit :              2
+            types.input.files.kvstore.miss :              1

--- a/test/cli/warm-cache/test.sh
+++ b/test/cli/warm-cache/test.sh
@@ -12,36 +12,22 @@ echo "class A; end" > "$dir/a.rb"
 echo "class B; end" > "$dir/b.rb"
 echo "class C; end" > "$dir/c.rb"
 
-echo "====first run (cold cache)===="
-# Explicitly trying to put stdout into a file and stderr to stdout.
-# Not trying to send stdout and stderr to the same place
-# shellcheck disable=SC2069
-main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir"/{a,b,c}.rb 2>&1 #"$dir/stderr.txt"
-# grep 'No errors! Great job.' "$dir/stderr.txt"
-# grep 'types.input' "$dir/stderr.txt"
+run_sorbet() {
+  if ! main/sorbet --silence-dev-message --counters --cache-dir "$dir/cache" "$dir"/{a,b,c}.rb 2> "$dir/stderr.txt"; then
+    cat "$dir/stderr.txt"
+    exit 1
+  fi
+  grep 'types.input.files\(.kvstore.miss\|.kvstore.hit\)\? :' "$dir/stderr.txt"
+}
 
+echo "====first run (cold cache)===="
+run_sorbet
 echo "====second run (warm cache)===="
-# Explicitly trying to put stdout into a file and stderr to stdout.
-# Not trying to send stdout and stderr to the same place
-# shellcheck disable=SC2069
-main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir"/{a,b,c}.rb 2>&1 #"$dir/stderr.txt"
-# grep 'No errors! Great job.' "$dir/stderr.txt"
-# grep 'types.input' "$dir/stderr.txt"
+run_sorbet
 
 echo '# comment' >> "$dir/a.rb"
 
 echo "====first after change (one cache miss)===="
-# Explicitly trying to put stdout into a file and stderr to stdout.
-# Not trying to send stdout and stderr to the same place
-# shellcheck disable=SC2069
-main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir"/{a,b,c}.rb 2>&1 #"$dir/stderr.txt"
-# grep 'No errors! Great job.' "$dir/stderr.txt"
-# grep 'types.input' "$dir/stderr.txt"
-
+run_sorbet
 echo "====second after change (warm cache)===="
-# Explicitly trying to put stdout into a file and stderr to stdout.
-# Not trying to send stdout and stderr to the same place
-# shellcheck disable=SC2069
-main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir"/{a,b,c}.rb 2>&1 #"$dir/stderr.txt"
-# grep 'No errors! Great job.' "$dir/stderr.txt"
-# grep 'types.input' "$dir/stderr.txt"
+run_sorbet

--- a/test/cli/warm-cache/test.sh
+++ b/test/cli/warm-cache/test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+dir=$(mktemp -d)
+cleanup() {
+    rm -r "$dir"
+}
+trap cleanup EXIT
+
+mkdir "$dir/cache"
+echo "class A; end" > "$dir/a.rb"
+echo "class B; end" > "$dir/b.rb"
+echo "class C; end" > "$dir/c.rb"
+
+echo "====first run (cold cache)===="
+# Explicitly trying to put stdout into a file and stderr to stdout.
+# Not trying to send stdout and stderr to the same place
+# shellcheck disable=SC2069
+main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir"/{a,b,c}.rb 2>&1 #"$dir/stderr.txt"
+# grep 'No errors! Great job.' "$dir/stderr.txt"
+# grep 'types.input' "$dir/stderr.txt"
+
+echo "====second run (warm cache)===="
+# Explicitly trying to put stdout into a file and stderr to stdout.
+# Not trying to send stdout and stderr to the same place
+# shellcheck disable=SC2069
+main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir"/{a,b,c}.rb 2>&1 #"$dir/stderr.txt"
+# grep 'No errors! Great job.' "$dir/stderr.txt"
+# grep 'types.input' "$dir/stderr.txt"
+
+echo '# comment' >> "$dir/a.rb"
+
+echo "====first after change (one cache miss)===="
+# Explicitly trying to put stdout into a file and stderr to stdout.
+# Not trying to send stdout and stderr to the same place
+# shellcheck disable=SC2069
+main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir"/{a,b,c}.rb 2>&1 #"$dir/stderr.txt"
+# grep 'No errors! Great job.' "$dir/stderr.txt"
+# grep 'types.input' "$dir/stderr.txt"
+
+echo "====second after change (warm cache)===="
+# Explicitly trying to put stdout into a file and stderr to stdout.
+# Not trying to send stdout and stderr to the same place
+# shellcheck disable=SC2069
+main/sorbet --silence-dev-message --cache-dir "$dir/cache" "$dir"/{a,b,c}.rb 2>&1 #"$dir/stderr.txt"
+# grep 'No errors! Great job.' "$dir/stderr.txt"
+# grep 'types.input' "$dir/stderr.txt"

--- a/test/cli/warm-cache/test.sh
+++ b/test/cli/warm-cache/test.sh
@@ -25,7 +25,7 @@ run_sorbet
 echo "====second run (warm cache)===="
 run_sorbet
 
-echo '# comment' >> "$dir/a.rb"
+echo 'class A2; end' >> "$dir/a.rb"
 
 echo "====first after change (one cache miss)===="
 run_sorbet


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is cursed.

My understanding:

- when we unpickle an AST from the cache, we do so in an empty global
  state (created with `GlobalState::initEmpty()`. That basically only
  has the names from `generate_names` and the symbols defined explicitly
  in `initEmpty`. it doesn't have anything in our payload.
- we do `NameRef::fromRawUnchecked` when we read a `uint32_t` to
  unpickle a NameRef which means we don't get the "this name ref is
  owned by the right GlobalState checking that our `NameRefDebugCheck`
  logic is supposed to do
- we DO run a sanity check that says "if you try to re-enter this name
  into the current GlobalState, you get back the same ID. since the
  `GlobalState` is basically empty, it doesn't have any custom names and
  that sanity check fails (the new ID is different)
- the only reason why this works in the real world is that unpickling an
  AST never creates NameRefs... and we skip the `NameSubstitution` step
  when merging index results for trees that were read out of the cache
  (!!)

The error that's happening is triggered by a call to `sanityCheck` in
unpickleNameRef. The only thing that `NameRef::sanityCheck` does is
reenter the name and check whether it's the same ID, and it seems like
for unpickled names this should never be the case.

Stepping back… I think this all stems from the fact that we apparently
never had a test for the warm `--disk-cache` path??

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.