### PR TITLE
Fix crash when trying to extract the receiver of a safe navigation send

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1490,8 +1490,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                               core::Names::tripleEq(), zeroLengthRecvLoc, MK::Local(zeroLengthRecvLoc, tempRecv));
 
                 unique_ptr<parser::Node> sendNode =
-                    make_unique<parser::Send>(loc, make_unique<parser::LVar>(recvLoc, tempRecv), csend->method,
-                                              csend->methodLoc, std::move(csend->args));
+                    make_unique<parser::Send>(loc, make_unique<parser::LVar>(zeroLengthRecvLoc, tempRecv),
+                                              csend->method, csend->methodLoc, std::move(csend->args));
                 auto send = node2TreeImpl(dctx, std::move(sendNode));
 
                 ExpressionPtr nil =

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.A.rbedited
@@ -1,0 +1,11 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+#
+
+a = T.let(1, T.nilable(Integer))
+
+puts(a&.to_s)
+puts(newVariable = a; newVariable&.to_s)
+#    ^ apply-code-action: [A] Extract Variable (this occurrence only)
+#    ^ apply-code-action: [B] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.B.rbedited
@@ -1,0 +1,12 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+#
+
+a = T.let(1, T.nilable(Integer))
+
+newVariable = a
+puts(newVariable&.to_s)
+puts(newVariable&.to_s)
+#    ^ apply-code-action: [A] Extract Variable (this occurrence only)
+#    ^ apply-code-action: [B] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.rb
@@ -1,0 +1,11 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+#
+
+a = T.let(1, T.nilable(Integer))
+
+puts(a&.to_s)
+puts(a&.to_s)
+#    ^ apply-code-action: [A] Extract Variable (this occurrence only)
+#    ^ apply-code-action: [B] Extract Variable (all 2 occurrences)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
