### PR TITLE
Always write the trees to the cache

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1314,7 +1314,7 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::
         }
     });
 
-    bool written = false;
+    size_t written = 0;
     {
         vector<pair<string, vector<uint8_t>>> threadResult;
         for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
@@ -1323,12 +1323,13 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::
             if (result.gotItem()) {
                 for (auto &a : threadResult) {
                     kvstore->write(move(a.first), move(a.second));
-                    written = true;
+                    written++;
                 }
             }
         }
     }
-    return written;
+    prodCounterAdd("types.input.files.kvstore.write", written);
+    return written != 0;
 }
 
 vector<ast::ParsedFile> autogenWriteCacheFile(const core::GlobalState &gs, const string &cachePath,

--- a/test/cli/warm-cache/test.out
+++ b/test/cli/warm-cache/test.out
@@ -5,6 +5,7 @@
 ====second run (warm cache)====
                          types.input.files :              3
              types.input.files.kvstore.hit :              3
+           types.input.files.kvstore.write :              0
 ====first after change (one cache miss)====
                          types.input.files :              3
              types.input.files.kvstore.hit :              2
@@ -13,11 +14,13 @@
 ====second after change (warm cache)====
                          types.input.files :              3
              types.input.files.kvstore.hit :              3
+           types.input.files.kvstore.write :              0
 ====first after comment change (one cache miss)====
                          types.input.files :              3
              types.input.files.kvstore.hit :              2
             types.input.files.kvstore.miss :              1
+           types.input.files.kvstore.write :              1
 ====second after comment change (warm cache)====
                          types.input.files :              3
-             types.input.files.kvstore.hit :              2
-            types.input.files.kvstore.miss :              1
+             types.input.files.kvstore.hit :              3
+           types.input.files.kvstore.write :              0

--- a/test/cli/warm-cache/test.out
+++ b/test/cli/warm-cache/test.out
@@ -1,6 +1,7 @@
 ====first run (cold cache)====
                          types.input.files :              3
             types.input.files.kvstore.miss :              3
+           types.input.files.kvstore.write :              3
 ====second run (warm cache)====
                          types.input.files :              3
              types.input.files.kvstore.hit :              3
@@ -8,6 +9,7 @@
                          types.input.files :              3
              types.input.files.kvstore.hit :              2
             types.input.files.kvstore.miss :              1
+           types.input.files.kvstore.write :              1
 ====second after change (warm cache)====
                          types.input.files :              3
              types.input.files.kvstore.hit :              3

--- a/test/cli/warm-cache/test.out
+++ b/test/cli/warm-cache/test.out
@@ -13,3 +13,11 @@
 ====second after change (warm cache)====
                          types.input.files :              3
              types.input.files.kvstore.hit :              3
+====first after comment change (one cache miss)====
+                         types.input.files :              3
+             types.input.files.kvstore.hit :              2
+            types.input.files.kvstore.miss :              1
+====second after comment change (warm cache)====
+                         types.input.files :              3
+             types.input.files.kvstore.hit :              2
+            types.input.files.kvstore.miss :              1

--- a/test/cli/warm-cache/test.sh
+++ b/test/cli/warm-cache/test.sh
@@ -31,3 +31,10 @@ echo "====first after change (one cache miss)===="
 run_sorbet
 echo "====second after change (warm cache)===="
 run_sorbet
+
+echo '# comment' >> "$dir/a.rb"
+
+echo "====first after comment change (one cache miss)===="
+run_sorbet
+echo "====second after comment change (warm cache)===="
+run_sorbet

--- a/test/cli/warm-cache/test.sh
+++ b/test/cli/warm-cache/test.sh
@@ -17,7 +17,7 @@ run_sorbet() {
     cat "$dir/stderr.txt"
     exit 1
   fi
-  grep 'types.input.files\(.kvstore.miss\|.kvstore.hit\)\? :' "$dir/stderr.txt"
+  grep 'types.input.files\(.kvstore.miss\|.kvstore.hit\|.kvstore.write\)\? :' "$dir/stderr.txt"
 }
 
 echo "====first run (cold cache)===="


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This fixes a bug where we were not writing newly parsed trees to the cache if
GlobalState didn't change. That could happen whenever a comment or whitespace
was added.

The `cacheTreesAndFiles` function already knows how to use the `.cached()` bit
on a file to know that if that tree was read out of the cache that we don't have
re-write it into the cache.




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.