### PR TITLE
Hide Hash::Elem in detailed type errors

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1259,29 +1259,32 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             if (!doesMemberMatch) {
                 result = false;
                 if constexpr (shouldAddErrorDetails) {
-                    string variance;
-                    string joiningText;
-                    switch (idxTypeMember.data(gs)->variance()) {
-                        case Variance::CoVariant: {
-                            variance = "covariant";
-                            joiningText = "a subtype of";
-                            break;
+                    if (!(a2->klass == Symbols::Hash() &&
+                          idxTypeMember.data(gs)->name == core::Names::Constants::Elem())) {
+                        string variance;
+                        string joiningText;
+                        switch (idxTypeMember.data(gs)->variance()) {
+                            case Variance::CoVariant: {
+                                variance = "covariant";
+                                joiningText = "a subtype of";
+                                break;
+                            }
+                            case Variance::Invariant: {
+                                variance = "invariant";
+                                joiningText = "equivalent to";
+                                break;
+                            }
+                            case Variance::ContraVariant: {
+                                variance = "contravariant";
+                                joiningText = "a supertype of";
+                                break;
+                            }
                         }
-                        case Variance::Invariant: {
-                            variance = "invariant";
-                            joiningText = "equivalent to";
-                            break;
-                        }
-                        case Variance::ContraVariant: {
-                            variance = "contravariant";
-                            joiningText = "a supertype of";
-                            break;
-                        }
+                        auto message = ErrorColors::format("`{}` is not {} `{}` for {} type member `{}`", a1i.show(gs),
+                                                           joiningText, a2j.show(gs), variance, idxTypeMember.show(gs));
+                        subCollector.message = message;
+                        errorDetailsCollector.addErrorDetails(std::move(subCollector));
                     }
-                    auto message = ErrorColors::format("`{}` is not {} `{}` for {} type member `{}`", a1i.show(gs),
-                                                       joiningText, a2j.show(gs), variance, idxTypeMember.show(gs));
-                    subCollector.message = message;
-                    errorDetailsCollector.addErrorDetails(std::move(subCollector));
                 } else {
                     break;
                 }

--- a/test/cli/detailed-errors/hash.rb
+++ b/test/cli/detailed-errors/hash.rb
@@ -1,0 +1,11 @@
+# typed: strict
+extend T::Sig
+
+sig { params(string_hash: T.nilable(T::Hash[String, Integer])).void }
+def takes_string_hash(string_hash)
+end
+
+sig { params(symbol_hash: T.nilable(T::Hash[Symbol, Integer])).void }
+def takes_symbol_hash(symbol_hash)
+  takes_string_hash(symbol_hash)
+end

--- a/test/cli/detailed-errors/test.out
+++ b/test/cli/detailed-errors/test.out
@@ -224,8 +224,6 @@ hash.rb:10: Expected `T.nilable(T::Hash[String, Integer])` but found `T.nilable(
                               ^^^^^^^^^^^
   Detailed explanation:
     `Symbol` is not a subtype of `String` for covariant type member `Hash::K`
-    `[Symbol, Integer]` is not a subtype of `[String, Integer]` for covariant type member `Hash::Elem`
-      `Symbol` is not a subtype of `String` for index `0` of `2`-tuple
     `Hash` does not derive from `NilClass`
 
 tuples.rb:10: Expected `[Integer, String]` but found `[]` for argument `x` https://srb.help/7002

--- a/test/cli/detailed-errors/test.out
+++ b/test/cli/detailed-errors/test.out
@@ -211,6 +211,23 @@ shapes.rb:22: Expected `{a: Integer, b: String}` but found `{a: String(""), c: I
   Detailed explanation:
     `String("")` is not a subtype of `Integer` for key `Symbol(:a)`
 
+hash.rb:10: Expected `T.nilable(T::Hash[String, Integer])` but found `T.nilable(T::Hash[Symbol, Integer])` for argument `string_hash` https://srb.help/7002
+    10 |  takes_string_hash(symbol_hash)
+                            ^^^^^^^^^^^
+  Expected `T.nilable(T::Hash[String, Integer])` for argument `string_hash` of method `Object#takes_string_hash`:
+    hash.rb:4:
+     4 |sig { params(string_hash: T.nilable(T::Hash[String, Integer])).void }
+                     ^^^^^^^^^^^
+  Got `T.nilable(T::Hash[Symbol, Integer])` originating from:
+    hash.rb:9:
+     9 |def takes_symbol_hash(symbol_hash)
+                              ^^^^^^^^^^^
+  Detailed explanation:
+    `Symbol` is not a subtype of `String` for covariant type member `Hash::K`
+    `[Symbol, Integer]` is not a subtype of `[String, Integer]` for covariant type member `Hash::Elem`
+      `Symbol` is not a subtype of `String` for index `0` of `2`-tuple
+    `Hash` does not derive from `NilClass`
+
 tuples.rb:10: Expected `[Integer, String]` but found `[]` for argument `x` https://srb.help/7002
     10 |takes_tuple([])
                     ^^
@@ -275,4 +292,4 @@ tuples.rb:18: Expected `[Integer, String]` but found `[String("")]` for argument
     tuples.rb:18:
     18 |takes_tuple([''])
                     ^^^^
-Errors: 23
+Errors: 24


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Two types disagreeing for the type of `Hash::Elem` is always noise, because
Sorbet creates this type implicitly when constructing a hash. It behaves as if
it has the type `[Hash::K, Hash::V] (2-tuple)` for all hashes.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.