### PR TITLE
Make Proc generic in its return type

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -628,8 +628,8 @@ bool ClassOrModuleRef::isPackageSpecSymbol(const GlobalState &gs) const {
 
 bool ClassOrModuleRef::isBuiltinGenericForwarder() const {
     return *this == Symbols::T_Hash() || *this == Symbols::T_Array() || *this == Symbols::T_Set() ||
-           *this == Symbols::T_Range() || *this == Symbols::T_Class() || *this == Symbols::T_Module() ||
-           *this == Symbols::T_Enumerable() || *this == Symbols::T_Enumerator() ||
+           *this == Symbols::T_Proc() || *this == Symbols::T_Range() || *this == Symbols::T_Class() ||
+           *this == Symbols::T_Module() || *this == Symbols::T_Enumerable() || *this == Symbols::T_Enumerator() ||
            *this == Symbols::T_Enumerator_Lazy() || *this == Symbols::T_Enumerator_Chain();
 }
 
@@ -654,6 +654,8 @@ ClassOrModuleRef ClassOrModuleRef::maybeUnwrapBuiltinGenericForwarder() const {
         return Symbols::Class();
     } else if (*this == Symbols::T_Module()) {
         return Symbols::Module();
+    } else if (*this == Symbols::T_Proc()) {
+        return Symbols::Proc();
     } else {
         return *this;
     }
@@ -680,6 +682,8 @@ ClassOrModuleRef ClassOrModuleRef::forwarderForBuiltinGeneric() const {
         return Symbols::T_Class();
     } else if (*this == Symbols::Module()) {
         return Symbols::T_Module();
+    } else if (*this == Symbols::Proc()) {
+        return Symbols::T_Proc();
     } else {
         return Symbols::noClassOrModule();
     }
@@ -689,8 +693,9 @@ ClassOrModuleRef ClassOrModuleRef::forwarderForBuiltinGeneric() const {
 // !! The set of stdlib classes receiving this special behavior should NOT grow over time !!
 bool ClassOrModuleRef::isLegacyStdlibGeneric() const {
     return *this == Symbols::Hash() || *this == Symbols::Array() || *this == Symbols::Set() ||
-           *this == Symbols::Range() || *this == Symbols::Enumerable() || *this == Symbols::Enumerator() ||
-           *this == Symbols::Enumerator_Lazy() || *this == Symbols::Enumerator_Chain();
+           *this == Symbols::Range() || *this == Symbols::Proc() || *this == Symbols::Enumerable() ||
+           *this == Symbols::Enumerator() || *this == Symbols::Enumerator_Lazy() ||
+           *this == Symbols::Enumerator_Chain();
 }
 
 MethodRef ClassOrModuleRef::lookupStaticInit(const Context &ctx) const {

--- a/core/Types.h
+++ b/core/Types.h
@@ -133,8 +133,8 @@ public:
     static TypePtr rangeOfUntyped(sorbet::core::SymbolRef blame);
     static TypePtr hashOfUntyped();
     static TypePtr hashOfUntyped(sorbet::core::SymbolRef blame);
-    static TypePtr procClass();
-    static TypePtr nilableProcClass();
+    static TypePtr procOf(const TypePtr &returnType);
+    static TypePtr nilableProc();
     static TypePtr declBuilderForProcsSingletonClass();
     static TypePtr falsyTypes();
     static absl::Span<const ClassOrModuleRef> falsySymbols();
@@ -801,7 +801,7 @@ private:
      * constructor, so the friend declaration doesn't work), we provide the
      * `make_shared` helper here.
      */
-    friend TypePtr Types::nilableProcClass();
+    friend TypePtr Types::nilableProc();
     friend TypePtr Types::falsyTypes();
     friend TypePtr Types::Boolean();
     friend class NameSubstitution;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4653,6 +4653,7 @@ const vector<Intrinsic> intrinsics{
     {Symbols::T_Set(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},
     {Symbols::T_Class(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},
     {Symbols::T_Module(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},
+    {Symbols::T_Proc(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},
 
     {Symbols::Object(), Intrinsic::Kind::Instance, Names::class_(), &Object_class},
     {Symbols::Object(), Intrinsic::Kind::Instance, Names::singletonClass(), &Object_class},
@@ -4728,6 +4729,7 @@ const vector<Intrinsic> intrinsics{
     {Symbols::T_Range(), Intrinsic::Kind::Singleton, Names::tripleEq(), &GenericForwarder_tripleEq},
     {Symbols::T_Set(), Intrinsic::Kind::Singleton, Names::tripleEq(), &GenericForwarder_tripleEq},
     {Symbols::T_Class(), Intrinsic::Kind::Singleton, Names::tripleEq(), &GenericForwarder_tripleEq},
+    {Symbols::T_Proc(), Intrinsic::Kind::Singleton, Names::tripleEq(), &GenericForwarder_tripleEq},
 };
 
 UnorderedMap<NameRef, const vector<NameRef>> computeIntrinsicsDispatchMap() {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4350,7 +4350,7 @@ public:
 
         optional<int> numberOfPositionalBlockParams = args.block->fixedArity();
         if (!numberOfPositionalBlockParams || *numberOfPositionalBlockParams > core::Symbols::MAX_PROC_ARITY) {
-            res.returnType = core::Types::procClass();
+            res.returnType = Types::procOf(Types::untyped(Symbols::Magic_UntypedSource_proc()));
             return;
         }
         auto untypedWithBlame = core::Types::untyped(Symbols::Magic_UntypedSource_proc());
@@ -4376,7 +4376,7 @@ public:
         }
 
         auto procType = Types::unwrapType(gs, args.argLoc(0), args.args[0]->type);
-        if (!Types::isSubType(gs, procType, Types::nilableProcClass())) {
+        if (!Types::isSubType(gs, procType, Types::nilableProc())) {
             if (auto e = gs.beginError(args.argLoc(0), core::errors::Infer::CastTypeMismatch)) {
                 e.setHeader("Lambda type annotation must be either `{}` or a `{}` type (and possibly nilable)", "Proc",
                             "T.proc");

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -143,12 +143,13 @@ TypePtr Types::hashOfUntyped(sorbet::core::SymbolRef blame) {
     }
 }
 
-TypePtr Types::procClass() {
-    return make_type<ClassType>(Symbols::Proc());
+TypePtr Types::procOf(const TypePtr &returnType) {
+    vector<TypePtr> targs{move(returnType)};
+    return make_type<AppliedType>(Symbols::Proc(), move(targs));
 }
 
-TypePtr Types::nilableProcClass() {
-    static auto res = OrType::make_shared(nilClass(), procClass());
+TypePtr Types::nilableProc() {
+    static auto res = OrType::make_shared(nilClass(), procOf(Types::top()));
     return res;
 }
 

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -262,7 +262,7 @@ module Kernel
   sig do
     params(
         symbol: T.any(Symbol, String),
-        method: T.any(Proc, Method, UnboundMethod)
+        method: T.any(T::Proc[T.untyped], Method, UnboundMethod)
     )
     .returns(Symbol)
   end
@@ -1124,7 +1124,7 @@ module Kernel
     params(
         blk: T.proc.returns(BasicObject),
     )
-    .returns(Proc)
+    .returns(T::Proc[T.untyped])
   end
   def at_exit(&blk); end
 
@@ -1879,7 +1879,7 @@ module Kernel
     .params(
         blk: T.untyped,
     )
-    .returns(Proc)
+    .returns(T::Proc[T.untyped])
   end
   def proc(&blk); end
 
@@ -1892,7 +1892,7 @@ module Kernel
     .params(
         blk: T.untyped,
     )
-    .returns(Proc)
+    .returns(T::Proc[T.untyped])
   end
   def lambda(&blk); end
 
@@ -2845,14 +2845,14 @@ module Kernel
         signal: T.any(Integer, String, Symbol),
         command: BasicObject,
     )
-    .returns(T.any(String, Proc))
+    .returns(T.any(String, T::Proc[T.untyped]))
   end
   sig do
     params(
         signal: T.any(Integer, String, Symbol),
         blk: T.proc.params(arg0: Integer).returns(BasicObject),
     )
-    .returns(T.any(String, Proc))
+    .returns(T.any(String, T::Proc[T.untyped]))
   end
   def trap(signal, command=T.unsafe(nil), &blk); end
 

--- a/rbi/core/marshal.rbi
+++ b/rbi/core/marshal.rbi
@@ -208,7 +208,7 @@ module Marshal
   sig do
     params(
         arg0: T.any(String, IO),
-        arg1: Proc,
+        arg1: T::Proc[T.untyped],
     )
     .returns(Object)
   end

--- a/rbi/core/method.rbi
+++ b/rbi/core/method.rbi
@@ -34,7 +34,7 @@ class Method < Object
 
   # Returns a [`Proc`](https://docs.ruby-lang.org/en/2.7.0/Proc.html) object
   # corresponding to this method.
-  sig {returns(Proc)}
+  sig {returns(T::Proc[T.untyped])}
   def to_proc; end
 
   # Invokes the *meth* with the specified arguments, returning the method's

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -824,7 +824,7 @@ class Module < Object
   sig do
     params(
         arg0: T.any(Symbol, String),
-        arg1: T.any(Proc, Method, UnboundMethod)
+        arg1: T.any(T::Proc[T.untyped], Method, UnboundMethod)
     )
     .returns(Symbol)
   end

--- a/rbi/core/proc.rbi
+++ b/rbi/core/proc.rbi
@@ -814,4 +814,19 @@ class Proc < Object
   # See also
   # [`Proc#lambda?`](https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-i-lambda-3F).
   def yield(*_); end
+
+  sig do
+    type_parameters(:Return2)
+      .params(g: T::Proc[T.type_parameter(:Return2)])
+      .returns(T::Proc[T.type_parameter(:Return2)])
+  end
+  sig do
+     params(g: T.anything).returns(T::Proc[T.untyped])
+  end
+  def >>(g); end
+
+  sig do
+    params(g: T.anything).returns(T::Proc[Return])
+  end
+  def <<(g); end
 end

--- a/rbi/core/proc.rbi
+++ b/rbi/core/proc.rbi
@@ -347,6 +347,11 @@
 #
 # Numbered parameters were introduced in Ruby 2.7.
 class Proc < Object
+  # The return type of this proc. It accepts any and all arguments. To
+  # constraint the list of arguments that this proc can take, use a `T.proc`
+  # type.
+  Return = type_member(:out)
+
   # Creates a new [`Proc`](https://docs.ruby-lang.org/en/3.2/Proc.html)
   # object, bound to the current context.
   #

--- a/rbi/core/proc.rbi
+++ b/rbi/core/proc.rbi
@@ -366,8 +366,8 @@ class Proc < Object
   # ```ruby
   # Proc.new    #=> ArgumentError
   # ```
-  sig {params(blk: Proc).returns(T.attached_class)}
-  def self.new(&blk); end
+  sig {params(blk: T::Proc[T.untyped]).void}
+  def initialize(&blk); end
 
   # Invokes the block with `obj` as the proc's parameter like
   # [`Proc#call`](https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-i-call).
@@ -467,7 +467,7 @@ class Proc < Object
         arg0: T.untyped,
         blk: T.untyped,
     )
-    .returns(T.untyped)
+    .returns(Return)
   end
   def call(*arg0, &blk); end
 
@@ -509,7 +509,7 @@ class Proc < Object
     params(
         arg0: BasicObject,
     )
-    .returns(T.untyped)
+    .returns(Return)
   end
   def [](*arg0); end
 
@@ -554,7 +554,7 @@ class Proc < Object
     params(
         arity: Integer,
     )
-    .returns(Proc)
+    .returns(T::Proc[T.untyped])
   end
   def curry(arity=T.unsafe(nil)); end
 

--- a/rbi/core/signal.rbi
+++ b/rbi/core/signal.rbi
@@ -102,14 +102,14 @@ module Signal
         signal: T.any(Integer, String, Symbol),
         command: BasicObject,
     )
-    .returns(T.any(String, Proc))
+    .returns(T.any(String, T::Proc[T.untyped]))
   end
   sig do
     params(
         signal: T.any(Integer, String, Symbol),
         blk: T.proc.params(arg0: Integer).returns(BasicObject),
     )
-    .returns(T.any(String, Proc))
+    .returns(T.any(String, T::Proc[T.untyped]))
   end
   def self.trap(signal, command=T.unsafe(nil), &blk); end
 end

--- a/rbi/core/symbol.rbi
+++ b/rbi/core/symbol.rbi
@@ -255,7 +255,7 @@ class Symbol < Object
   # ```ruby
   # (1..3).collect(&:to_s)  #=> ["1", "2", "3"]
   # ```
-  sig {returns(Proc)}
+  sig {returns(T::Proc[T.untyped])}
   def to_proc(); end
 
   # Same as `sym.to_s.upcase.intern`.

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -356,6 +356,12 @@ module T::Module
   # Don't use case/when on T::Module--just use `when Module` instead.
   def self.===(arg0); end
 end
+module T::Proc
+  # Type syntax to specify the element type of a standard library Class
+  def self.[](type); end
+  # Don't use case/when on T::Proc--just use `when Class` instead.
+  def self.===(arg0); end
+end
 module T::Enumerable
   # Type syntax to specify the element type of a standard library Enumerable
   def self.[](type); end

--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -214,7 +214,7 @@
 # documentation (e.g. through `ri`) will contain more information. In some
 # cases, a brief description will follow.
 class Pathname < Object
-  SAME_PATHS = T.let(T.unsafe(nil), Proc)
+  SAME_PATHS = T.let(T.unsafe(nil), T::Proc[T.untyped])
   SEPARATOR_LIST = T.let(T.unsafe(nil), String)
   SEPARATOR_PAT = T.let(T.unsafe(nil), Regexp)
   TO_PATH = T.let(T.unsafe(nil), Symbol)

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3485,7 +3485,7 @@ private:
                 param.type = std::move(spec->type);
                 // Passing in a noOp collector even though this call is used for error reporting,
                 // because it's unlikely we'll add more details to a subtype check for T.nilable(Proc)
-                if (isBlkArg && !core::Types::isSubType(ctx, param.type, core::Types::nilableProcClass())) {
+                if (isBlkArg && !core::Types::isSubType(ctx, param.type, core::Types::nilableProc())) {
                     if (auto e = ctx.beginError(spec->nameLoc, core::errors::Resolver::InvalidMethodSignature)) {
                         e.setHeader("Block argument type must be either `{}` or a `{}` type (and possibly nilable)",
                                     "Proc", "T.proc");

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -11,10 +11,12 @@ namespace sorbet::rewriter {
 /// Generate method stub and sig for the delegator method
 void generateStub(vector<ast::ExpressionPtr> &methodStubs, const core::LocOffsets &loc,
                   const core::NameRef &methodName) {
-    // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
-    auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
-                                     ast::MK::Symbol(loc, core::Names::blkArg()),
-                                     ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
+    // sig {params(arg0: T.untyped, blk: T::Proc[T.untyped]).returns(T.untyped)}
+    auto sigArgs = ast::MK::SendArgs(
+        ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc), ast::MK::Symbol(loc, core::Names::blkArg()),
+        ast::MK::Nilable(loc, ast::MK::Send1(loc, ast::MK::Constant(loc, core::Symbols::T_Proc()),
+                                             core::Names::squareBrackets(), loc.copyWithZeroLength(),
+                                             ast::MK::Untyped(loc))));
 
     methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
 

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -100,10 +100,13 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         } else {
             methodName = lit->asSymbol();
         }
-        // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
-        auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
-                                         ast::MK::Symbol(loc, core::Names::blkArg()),
-                                         ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
+        // sig {params(arg0: T.untyped, blk: T::Proc[T.untyped]).returns(T.untyped)}
+        auto sigArgs =
+            ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
+                              ast::MK::Symbol(loc, core::Names::blkArg()),
+                              ast::MK::Nilable(loc, ast::MK::Send1(loc, ast::MK::Constant(loc, core::Symbols::T_Proc()),
+                                                                   core::Names::squareBrackets(),
+                                                                   loc.copyWithZeroLength(), ast::MK::Untyped(loc))));
 
         methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
 

--- a/test/testdata/infer/generics/t_proc.rb
+++ b/test/testdata/infer/generics/t_proc.rb
@@ -1,0 +1,28 @@
+# typed: strong
+extend T::Sig
+
+sig do
+  type_parameters(:Return)
+    .params(blk: T::Proc[T.type_parameter(:Return)])
+    .returns(T.type_parameter(:Return))
+end
+def example(&blk)
+  res = yield
+  T.reveal_type(res)
+  res
+end
+
+res = example do |x:|
+  0
+end
+T.reveal_type(res)
+
+res = T::Proc[Integer].new do |x:|
+  0
+end
+
+T.reveal_type(res)
+
+f = T.let(->() { 0 }, T.proc.returns(Integer))
+T.let(f, T::Proc[Integer])
+T.let(f, T::Proc[String])

--- a/test/testdata/infer/generics/t_proc.rb
+++ b/test/testdata/infer/generics/t_proc.rb
@@ -7,12 +7,13 @@ sig do
     .returns(T.type_parameter(:Return))
 end
 def example(&blk)
-  res = yield
+  res = yield(x: 0)
   T.reveal_type(res)
   res
 end
 
 res = example do |x:|
+  T.reveal_type(x)
   0
 end
 T.reveal_type(res)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This lets people write functions that accept "a proc with any arguments,"
including procs that take keyword and default arguments, and still at least
have proper type checking on the return type.

- [ ] @jez go / no-go decision on whether this is worth it
- [ ] @jez runtime support


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.