### PR TITLE
Don't show untyped warning when method is `<method-name-missing>`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -643,7 +643,7 @@ void handleBlockType(const GlobalState &gs, DispatchComponent &component, TypePt
 DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &args, core::ClassOrModuleRef symbol,
                                   const vector<TypePtr> &targs) {
     auto errLoc = args.errLoc();
-    if (symbol == core::Symbols::untyped()) {
+    if (symbol == core::Symbols::untyped() && args.name != core::Names::methodNameMissing()) {
         auto what = core::errors::Infer::errorClassForUntyped(gs, args.locs.file, args.thisType);
         if (auto e = gs.beginError(errLoc, what)) {
             e.setHeader("Call to method `{}` on `{}`", args.name.show(gs), "T.untyped");

--- a/test/testdata/infer/untyped.rb
+++ b/test/testdata/infer/untyped.rb
@@ -50,3 +50,9 @@ class Child < Parent
     nil
   end
 end
+
+sig { params(x: T.untyped).void }
+def method_name_missing(x)
+  x.
+# ^^ error: Call to method `<method-name-missing>` on `T.untyped`
+end # error: unexpected token "return"

--- a/test/testdata/infer/untyped.rb
+++ b/test/testdata/infer/untyped.rb
@@ -54,5 +54,4 @@ end
 sig { params(x: T.untyped).void }
 def method_name_missing(x)
   x.
-# ^^ error: Call to method `<method-name-missing>` on `T.untyped`
 end # error: unexpected token "return"

--- a/test/testdata/infer/untyped.rb
+++ b/test/testdata/infer/untyped.rb
@@ -54,4 +54,4 @@ end
 sig { params(x: T.untyped).void }
 def method_name_missing(x)
   x.
-end # error: unexpected token "return"
+end # error: unexpected token "end"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is not a real usage of `T.untyped`, it's just downstream of there being a
parse error in the program and using `T.untyped` to recover from that error.

This makes Sorbet highlight fewer things in the IDE, making untyped highlighting
less noisy and more signalful.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test shows before + after.