### PR TITLE
Allow T.absurd to silence unreachable in middle of block

### DIFF
--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -360,7 +360,8 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     // this can also be result of evaluating an instruction, e.g. an always false hard_assert
                     bb->firstDeadInstructionIdx = i;
                 }
-            } else if (ctx.state.lspQuery.isEmpty() && current.isDead && !bind.value.isSynthetic()) {
+            } else if (ctx.state.lspQuery.isEmpty() && current.isDead && !bind.value.isSynthetic() &&
+                       !cfg::isa_instruction<cfg::TAbsurd>(bind.value)) {
                 if (auto e = ctx.beginError(bind.loc, core::errors::Infer::DeadBranchInferencer)) {
                     e.setHeader("This code is unreachable");
                     e.addErrorLine(madeBlockDead, "This expression always raises or can never be computed");

--- a/test/testdata/infer/exhaustiveness.rb
+++ b/test/testdata/infer/exhaustiveness.rb
@@ -265,3 +265,25 @@ sig{void}
 def rejects_absurd_on_integer_literal
   T.absurd(42) # error: `T.absurd` expects to be called on a variable
 end
+
+sig { params(x: T.noreturn).void }
+def allows_arg_noreturn(x)
+  T.absurd(x)
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+sig { params(x: T.noreturn, y: T.noreturn).void }
+def allows_args_noreturn(x, y)
+  T.absurd(x)
+  T.absurd(y)
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+sig { params(x: T.all(Integer, String)).void }
+def intersects_to_bottom(x)
+  T.absurd(x)
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end

--- a/test/testdata/infer/exhaustiveness.rb
+++ b/test/testdata/infer/exhaustiveness.rb
@@ -152,12 +152,7 @@ end
 
 def only_absurd
   temp1 = T.let(T.unsafe(nil), T.noreturn)
-  T.absurd(temp1) # error: This code is unreachable
-end
-
-sig {params(x: T.noreturn).returns(T.noreturn)}
-def cant_call_only_absurd(x)
-  T.absurd(x) # error: This code is unreachable
+  T.absurd(temp1)
 end
 
 sig { params(x: T.noreturn).void }

--- a/test/testdata/infer/exhaustiveness.rb
+++ b/test/testdata/infer/exhaustiveness.rb
@@ -160,6 +160,28 @@ def cant_call_only_absurd(x)
   T.absurd(x) # error: This code is unreachable
 end
 
+sig { params(x: T.noreturn).void }
+def allows_arg_noreturn(x)
+  T.absurd(x)
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+sig { params(x: T.noreturn, y: T.noreturn).void }
+def allows_args_noreturn(x, y)
+  T.absurd(x)
+  T.absurd(y)
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+sig { params(x: T.all(Integer, String)).void }
+def intersects_to_bottom(x)
+  T.absurd(x)
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
 # --- reasonable usage on global, class, instance, and local variables --------
 $some_global = T.let(true, T::Boolean)
 
@@ -264,26 +286,4 @@ end
 sig{void}
 def rejects_absurd_on_integer_literal
   T.absurd(42) # error: `T.absurd` expects to be called on a variable
-end
-
-sig { params(x: T.noreturn).void }
-def allows_arg_noreturn(x)
-  T.absurd(x)
-  puts(x)
-# ^^^^^^^ error: This code is unreachable
-end
-
-sig { params(x: T.noreturn, y: T.noreturn).void }
-def allows_args_noreturn(x, y)
-  T.absurd(x)
-  T.absurd(y)
-  puts(x)
-# ^^^^^^^ error: This code is unreachable
-end
-
-sig { params(x: T.all(Integer, String)).void }
-def intersects_to_bottom(x)
-  T.absurd(x)
-  puts(x)
-# ^^^^^^^ error: This code is unreachable
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, we only allowed allowed using `T.absurd` to silence unreachable
code errors if the block was dead from the get-go, i.e. if computing one of
the basic block arguments computed `T.noreturn`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.