### PR TITLE
Report arity errors for RBI and `typed: false` files

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -81,6 +81,7 @@ constexpr ErrorClass TypeMemberScopeMismatch{5072, StrictLevel::False};
 constexpr ErrorClass AbstractClassInstantiated{5073, StrictLevel::True};
 constexpr ErrorClass HasAttachedClassIncluded{5074, StrictLevel::False};
 constexpr ErrorClass TypeAliasToTypeMember{5075, StrictLevel::False};
+constexpr ErrorClass TNilableArity{5076, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -536,7 +536,7 @@ module Kernel
 
   sig do
     params(
-        arg0: T.any(Module),
+        arg0: Module,
     )
     .returns(T::Boolean)
   end

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -534,7 +534,7 @@ class Module < Object
   # ```
   sig do
     params(
-      const_name: T.any(Symbol)
+      const_name: Symbol
     )
     .returns(T.untyped)
   end

--- a/rbi/stdlib/big_math.rbi
+++ b/rbi/stdlib/big_math.rbi
@@ -40,7 +40,7 @@ module BigMath
   sig do
     params(
         x: T.any(Integer, BigDecimal, Float),
-        prec: T.any(Integer),
+        prec: Integer,
     )
     .returns(BigDecimal)
   end

--- a/rbi/stdlib/objspace.rbi
+++ b/rbi/stdlib/objspace.rbi
@@ -365,6 +365,6 @@ class ObjectSpace::WeakKeyMap < Object
   def inspect; end
   
   # Returns true if key is a key in self, otherwise false.
-  sig {params(key: T.any).returns(T::Boolean)}
+  sig {params(key: T.untyped).returns(T::Boolean)}
   def key?(key); end
 end

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -190,6 +190,26 @@ void addMultiStatementSigAutocorrect(core::Context ctx, core::ErrorBuilder &e, c
     e.replaceWith("Use a chained sig builder", ctx.locAt(insseq->loc), "{}", replacement);
 }
 
+void checkTypeFunArity(core::Context ctx, const ast::Send &send, size_t minArity, size_t maxArity) {
+    const auto &file = ctx.file.data(ctx);
+    if (!(file.isRBI() || file.strictLevel < core::StrictLevel::True)) {
+        // We want to rely on the infer error here, because it will be more descriptive.
+        // We do still need to report an error in `# typed: false` files and RBI files where
+        // inference will not run.
+        return;
+    }
+
+    if (send.numPosArgs() < minArity || send.numPosArgs() > maxArity) {
+        auto errLoc = send.numPosArgs() > 0 ? send.argsLoc() : send.loc;
+        if (auto e = ctx.beginError(errLoc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            auto howMany = minArity == maxArity ? "exactly" : "at least";
+            auto plural = minArity == 1 ? "" : "s";
+            e.setHeader("`{}` expects {} `{}` argument{}, but got `{}`", send.fun.show(ctx), howMany, minArity, plural,
+                        send.numPosArgs());
+        }
+    }
+}
+
 optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend, const ParsedSig *parent,
                                                TypeSyntaxArgs args) {
     ParsedSig sig;
@@ -287,9 +307,11 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
         // so we don't report multiple "method does not exist" errors arising from the same expression
         bool reportedInvalidMethod = false;
         switch (send->fun.rawId()) {
-            case core::Names::proc().rawId():
+            case core::Names::proc().rawId(): {
+                checkTypeFunArity(ctx, *send, 0, 0);
                 sig.seen.proc = true;
                 break;
+            }
             case core::Names::bind().rawId(): {
                 if (sig.seen.bind) {
                     if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
@@ -522,14 +544,18 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
 
                 break;
             }
-            case core::Names::void_().rawId():
+            case core::Names::void_().rawId(): {
+                checkTypeFunArity(ctx, *send, 0, 0);
                 sig.seen.void_ = true;
                 sig.returns = core::Types::void_();
                 sig.returnsLoc = ctx.locAt(send->loc);
                 break;
-            case core::Names::checked().rawId():
+            }
+            case core::Names::checked().rawId(): {
+                checkTypeFunArity(ctx, *send, 1, 1);
                 sig.seen.checked = true;
                 break;
+            }
             case core::Names::onFailure().rawId():
                 break;
             case core::Names::final_().rawId():
@@ -663,6 +689,7 @@ void maybeSuggestTClass(core::Context ctx, core::ErrorBuilder &e, core::LocOffse
 optional<core::ClassOrModuleRef> parseTClassOf(core::Context ctx, const ast::Send &send, const ParsedSig &sig,
                                                TypeSyntaxArgs args) {
     if (send.numPosArgs() != 1 || send.hasKwArgs()) {
+        checkTypeFunArity(ctx, send, 1, 1);
         unexpectedKwargs(ctx, send);
         return core::Symbols::untyped();
     }
@@ -722,16 +749,39 @@ optional<core::ClassOrModuleRef> parseTClassOf(core::Context ctx, const ast::Sen
     return singleton;
 }
 
+void checkTNilableArity(core::Context ctx, const ast::Send &send) {
+    const auto &file = ctx.file.data(ctx);
+    auto willReportInferError = !(file.isRBI() || file.strictLevel < core::StrictLevel::True);
+    auto canWrapWithTAny = send.numPosArgs() > 1 && !send.hasKwArgs() && send.argsLoc().exists();
+
+    if (willReportInferError && !canWrapWithTAny) {
+        // No use reporting a double error
+        return;
+    }
+
+    // Reports a double error when `willReportInferError && canWrapWithTAny`, so that we can attach
+    // an autocorrect even in files that have infer run on them.
+
+    auto errLoc = send.numPosArgs() > 0 ? send.argsLoc() : send.loc;
+    if (auto e = ctx.beginError(errLoc, core::errors::Resolver::TNilableArity)) {
+        e.setHeader("`{}` expects exactly `{}` arguments, but got `{}`", "T.nilable", 1, send.numPosArgs());
+        if (send.numPosArgs() > 1 && !send.hasKwArgs() && send.argsLoc().exists()) {
+            e.addErrorNote("Did you mean to use `{}` around the inner arguments?", "T.any");
+            auto replaceLoc = ctx.locAt(send.argsLoc());
+            e.replaceWith("Wrap args with T.any", replaceLoc, "T.any({})", replaceLoc.source(ctx).value());
+        }
+    }
+}
+
 optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const ast::Send &send, const ParsedSig &sig,
                                                       TypeSyntaxArgs args) {
     switch (send.fun.rawId()) {
         case core::Names::nilable().rawId(): {
             if (send.numPosArgs() != 1 || send.hasKwArgs()) {
+                checkTNilableArity(ctx, send);
                 unexpectedKwargs(ctx, send);
-                return TypeSyntax::ResultType{core::Types::untypedUntracked(),
-                                              core::Symbols::noClassOrModule()}; // error will be reported in infer.
+                return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
-
             auto maybeResult = getResultTypeAndBindWithSelfTypeParams(ctx, send.getPosArg(0), sig, args);
             if (!maybeResult.has_value()) {
                 return nullopt;
@@ -757,7 +807,8 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
             return TypeSyntax::ResultType{core::Types::any(ctx, result.type, core::Types::nilClass()), result.rebind};
         }
         case core::Names::all().rawId(): {
-            if (send.numPosArgs() == 0 || send.hasKwArgs()) {
+            if (send.numPosArgs() < 2 || send.hasKwArgs()) {
+                checkTypeFunArity(ctx, send, 2, SIZE_MAX);
                 unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
@@ -778,7 +829,8 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
             return TypeSyntax::ResultType{result, core::Symbols::noClassOrModule()};
         }
         case core::Names::any().rawId(): {
-            if (send.numPosArgs() == 0 || send.hasKwArgs()) {
+            if (send.numPosArgs() < 2 || send.hasKwArgs()) {
+                checkTypeFunArity(ctx, send, 2, SIZE_MAX);
                 unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
@@ -800,6 +852,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         }
         case core::Names::typeParameter().rawId(): {
             if (send.numPosArgs() != 1 || send.hasKwArgs()) {
+                checkTypeFunArity(ctx, send, 1, 1);
                 unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
@@ -827,6 +880,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::enum_().rawId():
         case core::Names::deprecatedEnum().rawId(): {
             if (send.numPosArgs() != 1 || send.hasKwArgs()) {
+                checkTypeFunArity(ctx, send, 1, 1);
                 unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
@@ -893,9 +947,20 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
                 return nullopt;
             }
         }
-        case core::Names::untyped().rawId():
+        case core::Names::untyped().rawId(): {
+            if (send.numPosArgs() != 0 || send.hasKwArgs()) {
+                checkTypeFunArity(ctx, send, 0, 0);
+                unexpectedKwargs(ctx, send);
+                return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
+            }
             return TypeSyntax::ResultType{core::Types::untyped(args.untypedBlame), core::Symbols::noClassOrModule()};
+        }
         case core::Names::selfType().rawId():
+            if (send.numPosArgs() != 0 || send.hasKwArgs()) {
+                checkTypeFunArity(ctx, send, 0, 0);
+                unexpectedKwargs(ctx, send);
+                return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
+            }
             if (args.allowSelfType) {
                 return TypeSyntax::ResultType{core::make_type<core::SelfType>(), core::Symbols::noClassOrModule()};
             }
@@ -911,6 +976,11 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
                                 "T.experimental_attached_class");
                     e.replaceWith("Replace with `T.attached_class`", ctx.locAt(send.loc), "T.attached_class");
                 }
+            }
+            if (send.numPosArgs() != 0 || send.hasKwArgs()) {
+                checkTypeFunArity(ctx, send, 0, 0);
+                unexpectedKwargs(ctx, send);
+                return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
 
             ENFORCE(ctx.owner.isClassOrModule());
@@ -955,10 +1025,22 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
                                               core::Symbols::noClassOrModule()};
             }
         }
-        case core::Names::noreturn().rawId():
+        case core::Names::noreturn().rawId(): {
+            if (send.numPosArgs() != 0 || send.hasKwArgs()) {
+                checkTypeFunArity(ctx, send, 0, 0);
+                unexpectedKwargs(ctx, send);
+                return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
+            }
             return TypeSyntax::ResultType{core::Types::bottom(), core::Symbols::noClassOrModule()};
-        case core::Names::anything().rawId():
+        }
+        case core::Names::anything().rawId(): {
+            if (send.numPosArgs() != 0 || send.hasKwArgs()) {
+                checkTypeFunArity(ctx, send, 0, 0);
+                unexpectedKwargs(ctx, send);
+                return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
+            }
             return TypeSyntax::ResultType{core::Types::top(), core::Symbols::noClassOrModule()};
+        }
 
         default:
             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -607,7 +607,7 @@ bool recurseOrType(core::Context ctx, core::TypePtr type, std::vector<std::strin
     }
 }
 
-void unexpectedKwargs(core::Context ctx, const ast::Send &send) {
+void checkUnexpectedKwargs(core::Context ctx, const ast::Send &send) {
     if (!send.hasKwArgs()) {
         return;
     }
@@ -690,7 +690,7 @@ optional<core::ClassOrModuleRef> parseTClassOf(core::Context ctx, const ast::Sen
                                                TypeSyntaxArgs args) {
     if (send.numPosArgs() != 1 || send.hasKwArgs()) {
         checkTypeFunArity(ctx, send, 1, 1);
-        unexpectedKwargs(ctx, send);
+        checkUnexpectedKwargs(ctx, send);
         return core::Symbols::untyped();
     }
 
@@ -779,7 +779,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::nilable().rawId(): {
             if (send.numPosArgs() != 1 || send.hasKwArgs()) {
                 checkTNilableArity(ctx, send);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             auto maybeResult = getResultTypeAndBindWithSelfTypeParams(ctx, send.getPosArg(0), sig, args);
@@ -809,7 +809,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::all().rawId(): {
             if (send.numPosArgs() < 2 || send.hasKwArgs()) {
                 checkTypeFunArity(ctx, send, 2, SIZE_MAX);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             auto maybeResult = getResultTypeWithSelfTypeParams(ctx, send.getPosArg(0), sig, args);
@@ -831,7 +831,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::any().rawId(): {
             if (send.numPosArgs() < 2 || send.hasKwArgs()) {
                 checkTypeFunArity(ctx, send, 2, SIZE_MAX);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             auto maybeResult = getResultTypeWithSelfTypeParams(ctx, send.getPosArg(0), sig, args);
@@ -853,7 +853,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::typeParameter().rawId(): {
             if (send.numPosArgs() != 1 || send.hasKwArgs()) {
                 checkTypeFunArity(ctx, send, 1, 1);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             auto arr = ast::cast_tree<ast::Literal>(send.getPosArg(0));
@@ -881,7 +881,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::deprecatedEnum().rawId(): {
             if (send.numPosArgs() != 1 || send.hasKwArgs()) {
                 checkTypeFunArity(ctx, send, 1, 1);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
 
@@ -950,7 +950,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::untyped().rawId(): {
             if (send.numPosArgs() != 0 || send.hasKwArgs()) {
                 checkTypeFunArity(ctx, send, 0, 0);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             return TypeSyntax::ResultType{core::Types::untyped(args.untypedBlame), core::Symbols::noClassOrModule()};
@@ -958,7 +958,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::selfType().rawId():
             if (send.numPosArgs() != 0 || send.hasKwArgs()) {
                 checkTypeFunArity(ctx, send, 0, 0);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             if (args.allowSelfType) {
@@ -979,7 +979,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
             }
             if (send.numPosArgs() != 0 || send.hasKwArgs()) {
                 checkTypeFunArity(ctx, send, 0, 0);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
 
@@ -1028,7 +1028,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::noreturn().rawId(): {
             if (send.numPosArgs() != 0 || send.hasKwArgs()) {
                 checkTypeFunArity(ctx, send, 0, 0);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             return TypeSyntax::ResultType{core::Types::bottom(), core::Symbols::noClassOrModule()};
@@ -1036,7 +1036,7 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
         case core::Names::anything().rawId(): {
             if (send.numPosArgs() != 0 || send.hasKwArgs()) {
                 checkTypeFunArity(ctx, send, 0, 0);
-                unexpectedKwargs(ctx, send);
+                checkUnexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             return TypeSyntax::ResultType{core::Types::top(), core::Symbols::noClassOrModule()};

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -765,7 +765,7 @@ void checkTNilableArity(core::Context ctx, const ast::Send &send) {
     auto errLoc = send.numPosArgs() > 0 ? send.argsLoc() : send.loc;
     if (auto e = ctx.beginError(errLoc, core::errors::Resolver::TNilableArity)) {
         e.setHeader("`{}` expects exactly `{}` arguments, but got `{}`", "T.nilable", 1, send.numPosArgs());
-        if (send.numPosArgs() > 1 && !send.hasKwArgs() && send.argsLoc().exists()) {
+        if (canWrapWithTAny) {
             e.addErrorNote("Did you mean to use `{}` around the inner arguments?", "T.any");
             auto replaceLoc = ctx.locAt(send.argsLoc());
             e.replaceWith("Wrap args with T.any", replaceLoc, "T.any({})", replaceLoc.source(ctx).value());

--- a/test/testdata/resolver/missing_type_combinator_args.rb
+++ b/test/testdata/resolver/missing_type_combinator_args.rb
@@ -2,6 +2,7 @@
 T.cast(nil, T.nilable) # error: Not enough arguments provided for method
 T.cast(nil, T.nilable(Integer, Integer))
 #                              ^^^^^^^  error: Too many arguments provided for method
+#                     ^^^^^^^^^^^^^^^^  error: `T.nilable` expects exactly `1` arguments, but got `2`
 T.cast(nil, T.any) # error: Not enough arguments provided for method
 T.cast(nil, T.all) # error: Not enough arguments provided for method
 T.must # error: Not enough arguments provided for method

--- a/test/testdata/resolver/type_syntax_rbi.rbi
+++ b/test/testdata/resolver/type_syntax_rbi.rbi
@@ -1,0 +1,16 @@
+# typed: true
+
+sig {
+  params(x: T.nilable(Integer, String))
+  #                   ^^^^^^^^^^^^^^^ error: `T.nilable` expects exactly `1` arguments, but got `2`
+    .void(42)
+  #       ^^ error: `void` expects exactly `0` arguments, but got `1`
+}
+def example(x); end
+
+sig {
+  params(x: T.any)
+  #         ^^^^^ error: `any` expects at least `2` arguments, but got `0`
+    .void
+}
+def zero_args(x); end

--- a/test/testdata/resolver/type_syntax_rbi.rbi.autocorrects.exp
+++ b/test/testdata/resolver/type_syntax_rbi.rbi.autocorrects.exp
@@ -1,0 +1,16 @@
+# typed: true
+
+sig {
+  params(x: T.nilable(T.any(Integer, String)))
+  #                   ^^^^^^^^^^^^^^^ error: `T.nilable` expects exactly `1` arguments, but got `2`
+    .void(42)
+  #       ^^ error: `void` expects exactly `0` arguments, but got `1`
+}
+def example(x); end
+
+sig {
+  params(x: T.any)
+  #         ^^^^^ error: `any` expects at least `2` arguments, but got `0`
+    .void
+}
+def zero_args(x); end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3137,6 +3137,15 @@ class PossiblyEmptyBox
 end
 ```
 
+## 5076
+
+`T.nilable` expects exactly one argument. A common typo is `T.nilable(X, Y)` to
+mean `T.nilable(T.any(X, Y))` (which would also be the same as `T.any(NilClass,
+X, Y)`).
+
+See [Nilable Types](nilable-types.md) and [Union Types](union-types.md) for more
+information.
+
 ## 6001
 
 Certain Ruby keywords like `break`, `next`, and `retry` can only be used inside

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3140,8 +3140,8 @@ end
 ## 5076
 
 `T.nilable` expects exactly one argument. A common typo is `T.nilable(X, Y)` to
-mean `T.nilable(T.any(X, Y))` (which would also be the same as `T.any(NilClass,
-X, Y)`).
+mean `T.nilable(T.any(X, Y))` (which would also be the same as
+`T.any(NilClass, X, Y)`).
 
 See [Nilable Types](nilable-types.md) and [Union Types](union-types.md) for more
 information.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #8054

We want the infer error if available, but we don't want no error if infer
won't run on these files.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.