### PR TITLE
Update sigs for Array#sample

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2263,10 +2263,16 @@ class Array < Object
   # ```
   sig do
     params(
+        random: Random::Formatter,
+    )
+    .returns(T.nilable(Elem))
+  end
+  sig do
+    params(
         arg0: Integer,
         random: Random::Formatter,
     )
-    .returns(T.any(T.nilable(Elem), T::Array[Elem]))
+    .returns(T::Array[Elem])
   end
   def sample(arg0=T.unsafe(nil), random: T.unsafe(nil)); end
 

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -79,3 +79,7 @@ x = [[3.4], [1, "a"]]
 T.reveal_type(x.transpose) # error: Revealed type: `T::Array[T::Array[T.untyped]]`
 x = [[3.4, "a"], [:a, 5]]
 T.reveal_type(x.transpose) # error: Revealed type: `[T::Array[T.any(Float, Symbol)], T::Array[T.any(Integer, String)]] (2-tuple)`
+
+# sampling
+T.assert_type([1, 2, 3].sample, T.nilable(Integer))
+T.assert_type([1, 2, 3].sample(2), T::Array[Integer])


### PR DESCRIPTION

Updating `Array#sample` to have multiple sigs for disambiguation so that if a size is passed or not it will represent the correct value of `T.nilable(Elem)` or `T::Array[Elem]` accordingly. 

```ruby
[1, 2, 3].sample      # T.nilable(Elem)
[1, 2, 3].sample(2)   # T::Array[Elem]
```

This puts the method inline with other Array methods like `Array#last` that does the same tactic.

### Motivation

At present the `Array#sample` method has a single signature returning `T.any(T.nilable(Elem), T::Array[Elem])` so the caller isn't able to get the correct typing for it. Using the 


### Test plan

Added some new tests to the array rbi test suite.