### PR TITLE
Revert "Make Sorbet faster to start in debug build (#8050)"

### DIFF
--- a/ast/verifier/Verifier.cc
+++ b/ast/verifier/Verifier.cc
@@ -36,7 +36,7 @@ public:
 };
 
 ExpressionPtr Verifier::run(core::Context ctx, ExpressionPtr node) {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return node;
     }
     VerifierWalker vw;

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -186,7 +186,7 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
 }
 
 void CFG::sanityCheck(core::Context ctx) {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
 

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -108,7 +108,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
 }
 
 void CFGBuilder::sanityCheck(core::Context ctx, CFG &cfg) {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
     for (auto &bb : cfg.basicBlocks) {

--- a/common/backtrace.cc
+++ b/common/backtrace.cc
@@ -58,7 +58,7 @@ void sorbet::Exception::printBacktrace() noexcept {
 void sorbet::Exception::printBacktrace() noexcept {}
 #endif // ifndef EMSCRIPTEN
 void sorbet::Exception::failInFuzzer() noexcept {
-    if constexpr (fuzz_mode) {
+    if (fuzz_mode) {
         __builtin_trap();
     }
 }

--- a/common/common.h
+++ b/common/common.h
@@ -60,9 +60,9 @@ constexpr bool skip_slow_enforce = false;
         }                                   \
     } while (false);
 
-#define DEBUG_ONLY(X)           \
-    if constexpr (debug_mode) { \
-        X;                      \
+#define DEBUG_ONLY(X) \
+    if (debug_mode) { \
+        X;            \
     }
 
 #define SLOW_DEBUG_ONLY(X)                                      \

--- a/common/counters/Counters.cc
+++ b/common/counters/Counters.cc
@@ -51,7 +51,7 @@ void CounterImpl::histogramAdd(const char *histogram, int key, unsigned long val
 }
 
 void CounterImpl::prodHistogramAdd(const char *histogram, int key, unsigned long value) {
-    if constexpr (fuzz_mode) {
+    if (fuzz_mode) {
         return;
     }
     this->histograms[histogram][key] += value;
@@ -65,7 +65,7 @@ void CounterImpl::categoryCounterAdd(const char *category, const char *counter, 
 }
 
 void CounterImpl::prodCategoryCounterAdd(const char *category, const char *counter, unsigned long value) {
-    if constexpr (fuzz_mode) {
+    if (fuzz_mode) {
         return;
     }
     this->countersByCategory[category][counter] += value;
@@ -79,21 +79,21 @@ void CounterImpl::counterAdd(const char *counter, unsigned long value) {
 }
 
 void CounterImpl::prodCounterAdd(const char *counter, unsigned long value) {
-    if constexpr (fuzz_mode) {
+    if (fuzz_mode) {
         return;
     }
     this->counters[counter] += value;
 }
 
 void CounterImpl::prodCounterSet(const char *counter, unsigned long value) {
-    if constexpr (fuzz_mode) {
+    if (fuzz_mode) {
         return;
     }
     this->counters[counter] = value;
 }
 
 void CounterImpl::timingAdd(CounterImpl::Timing timing) {
-    if constexpr (fuzz_mode) {
+    if (fuzz_mode) {
         return;
     }
     this->timings.emplace_back(move(timing));

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -105,7 +105,7 @@ FoundDefinitionRef FoundStaticFieldHash::owner() const {
 }
 
 void FoundStaticFieldHash::sanityCheck() const {
-    ENFORCE_NO_TIMER(nameHash.isDefined());
+    ENFORCE(nameHash.isDefined());
 }
 
 string FoundStaticFieldHash::toString() const {
@@ -122,7 +122,7 @@ FoundDefinitionRef FoundTypeMemberHash::owner() const {
 }
 
 void FoundTypeMemberHash::sanityCheck() const {
-    ENFORCE_NO_TIMER(nameHash.isDefined());
+    ENFORCE(nameHash.isDefined());
 }
 
 string FoundTypeMemberHash::toString() const {
@@ -140,7 +140,7 @@ FoundDefinitionRef FoundMethodHash::owner() const {
 }
 
 void FoundMethodHash::sanityCheck() const {
-    ENFORCE_NO_TIMER(nameHash.isDefined());
+    ENFORCE(nameHash.isDefined());
 }
 
 string FoundMethodHash::toString() const {
@@ -158,7 +158,7 @@ FoundDefinitionRef FoundFieldHash::owner() const {
 }
 
 void FoundFieldHash::sanityCheck() const {
-    ENFORCE_NO_TIMER(nameHash.isDefined());
+    ENFORCE(nameHash.isDefined());
 }
 
 string FoundFieldHash::toString() const {

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -20,8 +20,8 @@ public:
     WithoutUniqueNameHash(const WithoutUniqueNameHash &nm) noexcept = default;
     WithoutUniqueNameHash() noexcept : _hashValue(0){};
     inline bool operator==(const WithoutUniqueNameHash &rhs) const noexcept {
-        ENFORCE_NO_TIMER(isDefined());
-        ENFORCE_NO_TIMER(rhs.isDefined());
+        ENFORCE(isDefined());
+        ENFORCE(rhs.isDefined());
         return _hashValue == rhs._hashValue;
     }
 
@@ -52,8 +52,8 @@ public:
     FullNameHash(const FullNameHash &nm) noexcept = default;
     FullNameHash() noexcept : _hashValue(0){};
     inline bool operator==(const FullNameHash &rhs) const noexcept {
-        ENFORCE_NO_TIMER(isDefined());
-        ENFORCE_NO_TIMER(rhs.isDefined());
+        ENFORCE(isDefined());
+        ENFORCE(rhs.isDefined());
         return _hashValue == rhs._hashValue;
     }
 
@@ -299,19 +299,19 @@ struct LocalSymbolTableHashes {
     bool isInvalidParse() const {
         DEBUG_ONLY(
             if (hierarchyHash == HASH_STATE_INVALID_PARSE) {
-                ENFORCE_NO_TIMER(classModuleHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(typeMemberHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(fieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(staticFieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(classAliasHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(methodHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(classModuleHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(typeMemberHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(fieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(staticFieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(classAliasHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(methodHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
             } else {
-                ENFORCE_NO_TIMER(classModuleHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(typeMemberHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(fieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(staticFieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(classAliasHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE_NO_TIMER(methodHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(classModuleHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(typeMemberHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(fieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(staticFieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(classAliasHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE(methodHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
             });
         return hierarchyHash == HASH_STATE_INVALID_PARSE;
     }

--- a/core/FoundDefinitions.cc
+++ b/core/FoundDefinitions.cc
@@ -5,62 +5,62 @@ using namespace std;
 namespace sorbet::core {
 
 FoundClass &FoundDefinitionRef::klass(FoundDefinitions &foundDefs) {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Class);
-    ENFORCE_NO_TIMER(foundDefs._klasses.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
+    ENFORCE(foundDefs._klasses.size() > idx());
     return foundDefs._klasses[idx()];
 }
 const FoundClass &FoundDefinitionRef::klass(const FoundDefinitions &foundDefs) const {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Class);
-    ENFORCE_NO_TIMER(foundDefs._klasses.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
+    ENFORCE(foundDefs._klasses.size() > idx());
     return foundDefs._klasses[idx()];
 }
 
 FoundMethod &FoundDefinitionRef::method(FoundDefinitions &foundDefs) {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Method);
-    ENFORCE_NO_TIMER(foundDefs._methods.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
+    ENFORCE(foundDefs._methods.size() > idx());
     return foundDefs._methods[idx()];
 }
 const FoundMethod &FoundDefinitionRef::method(const FoundDefinitions &foundDefs) const {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Method);
-    ENFORCE_NO_TIMER(foundDefs._methods.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
+    ENFORCE(foundDefs._methods.size() > idx());
     return foundDefs._methods[idx()];
 }
 
 FoundStaticField &FoundDefinitionRef::staticField(FoundDefinitions &foundDefs) {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::StaticField);
-    ENFORCE_NO_TIMER(foundDefs._staticFields.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
+    ENFORCE(foundDefs._staticFields.size() > idx());
     return foundDefs._staticFields[idx()];
 }
 const FoundStaticField &FoundDefinitionRef::staticField(const FoundDefinitions &foundDefs) const {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::StaticField);
-    ENFORCE_NO_TIMER(foundDefs._staticFields.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
+    ENFORCE(foundDefs._staticFields.size() > idx());
     return foundDefs._staticFields[idx()];
 }
 
 FoundTypeMember &FoundDefinitionRef::typeMember(FoundDefinitions &foundDefs) {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::TypeMember);
-    ENFORCE_NO_TIMER(foundDefs._typeMembers.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
+    ENFORCE(foundDefs._typeMembers.size() > idx());
     return foundDefs._typeMembers[idx()];
 }
 const FoundTypeMember &FoundDefinitionRef::typeMember(const FoundDefinitions &foundDefs) const {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::TypeMember);
-    ENFORCE_NO_TIMER(foundDefs._typeMembers.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
+    ENFORCE(foundDefs._typeMembers.size() > idx());
     return foundDefs._typeMembers[idx()];
 }
 
 FoundField &FoundDefinitionRef::field(FoundDefinitions &foundDefs) {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Field);
-    ENFORCE_NO_TIMER(foundDefs._fields.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Field);
+    ENFORCE(foundDefs._fields.size() > idx());
     return foundDefs._fields[idx()];
 }
 const FoundField &FoundDefinitionRef::field(const FoundDefinitions &foundDefs) const {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Field);
-    ENFORCE_NO_TIMER(foundDefs._fields.size() > idx());
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Field);
+    ENFORCE(foundDefs._fields.size() > idx());
     return foundDefs._fields[idx()];
 }
 
 core::ClassOrModuleRef FoundDefinitionRef::symbol() const {
-    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Symbol);
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Symbol);
     return core::ClassOrModuleRef::fromRaw(_storage.id);
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -214,7 +214,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
         }
         data->mixins() = std::move(newMixins);
         data->flags.isLinearizationComputed = true;
-        if constexpr (debug_mode) {
+        if (debug_mode) {
             for (auto oldMixin : currentMixins) {
                 ENFORCE(ofClass.data(gs)->derivesFrom(gs, oldMixin), "{} no longer derives from {}",
                         ofClass.showFullName(gs), oldMixin.showFullName(gs));
@@ -318,162 +318,162 @@ void GlobalState::initEmpty() {
 
     ClassOrModuleRef klass;
     klass = synthesizeClass(core::Names::Constants::NoSymbol(), 0);
-    ENFORCE_NO_TIMER(klass == Symbols::noClassOrModule());
+    ENFORCE(klass == Symbols::noClassOrModule());
     MethodRef method = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noMethod());
-    ENFORCE_NO_TIMER(method == Symbols::noMethod());
+    ENFORCE(method == Symbols::noMethod());
     FieldRef field = enterFieldSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noFieldOrStaticField());
-    ENFORCE_NO_TIMER(field == Symbols::noField());
+    ENFORCE(field == Symbols::noField());
     TypeArgumentRef typeArgument =
         enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::NoTypeArgument(), Variance::CoVariant);
-    ENFORCE_NO_TIMER(typeArgument == Symbols::noTypeArgument());
+    ENFORCE(typeArgument == Symbols::noTypeArgument());
     TypeMemberRef typeMember =
         enterTypeMember(Loc::none(), Symbols::noClassOrModule(), Names::Constants::NoTypeMember(), Variance::CoVariant);
-    ENFORCE_NO_TIMER(typeMember == Symbols::noTypeMember());
+    ENFORCE(typeMember == Symbols::noTypeMember());
 
     klass = synthesizeClass(core::Names::Constants::Top(), 0);
-    ENFORCE_NO_TIMER(klass == Symbols::top());
+    ENFORCE(klass == Symbols::top());
     klass = synthesizeClass(core::Names::Constants::Bottom(), 0);
-    ENFORCE_NO_TIMER(klass == Symbols::bottom());
+    ENFORCE(klass == Symbols::bottom());
     klass = synthesizeClass(core::Names::Constants::Root(), 0);
-    ENFORCE_NO_TIMER(klass == Symbols::root());
+    ENFORCE(klass == Symbols::root());
 
     klass = core::Symbols::root().data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::rootSingleton());
+    ENFORCE(klass == Symbols::rootSingleton());
     klass = synthesizeClass(core::Names::Constants::Todo(), 0);
-    ENFORCE_NO_TIMER(klass == Symbols::todo());
+    ENFORCE(klass == Symbols::todo());
     klass = synthesizeClass(core::Names::Constants::Object(), Symbols::BasicObject().id());
-    ENFORCE_NO_TIMER(klass == Symbols::Object());
+    ENFORCE(klass == Symbols::Object());
     klass = synthesizeClass(core::Names::Constants::Integer());
-    ENFORCE_NO_TIMER(klass == Symbols::Integer());
+    ENFORCE(klass == Symbols::Integer());
     klass = synthesizeClass(core::Names::Constants::Float());
-    ENFORCE_NO_TIMER(klass == Symbols::Float());
+    ENFORCE(klass == Symbols::Float());
     klass = synthesizeClass(core::Names::Constants::String());
-    ENFORCE_NO_TIMER(klass == Symbols::String());
+    ENFORCE(klass == Symbols::String());
     klass = synthesizeClass(core::Names::Constants::Symbol());
-    ENFORCE_NO_TIMER(klass == Symbols::Symbol());
+    ENFORCE(klass == Symbols::Symbol());
     klass = synthesizeClass(core::Names::Constants::Array());
-    ENFORCE_NO_TIMER(klass == Symbols::Array());
+    ENFORCE(klass == Symbols::Array());
     klass = synthesizeClass(core::Names::Constants::Hash());
-    ENFORCE_NO_TIMER(klass == Symbols::Hash());
+    ENFORCE(klass == Symbols::Hash());
     klass = synthesizeClass(core::Names::Constants::TrueClass());
-    ENFORCE_NO_TIMER(klass == Symbols::TrueClass());
+    ENFORCE(klass == Symbols::TrueClass());
     klass = synthesizeClass(core::Names::Constants::FalseClass());
-    ENFORCE_NO_TIMER(klass == Symbols::FalseClass());
+    ENFORCE(klass == Symbols::FalseClass());
     klass = synthesizeClass(core::Names::Constants::NilClass());
-    ENFORCE_NO_TIMER(klass == Symbols::NilClass());
+    ENFORCE(klass == Symbols::NilClass());
     klass = synthesizeClass(core::Names::Constants::Untyped(), 0);
-    ENFORCE_NO_TIMER(klass == Symbols::untyped());
+    ENFORCE(klass == Symbols::untyped());
     klass = synthesizeClass(core::Names::Constants::T(), Symbols::todo().id(), true);
-    ENFORCE_NO_TIMER(klass == Symbols::T());
+    ENFORCE(klass == Symbols::T());
     klass = klass.data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::TSingleton());
+    ENFORCE(klass == Symbols::TSingleton());
     klass = synthesizeClass(core::Names::Constants::Class(), 0);
-    ENFORCE_NO_TIMER(klass == Symbols::Class());
+    ENFORCE(klass == Symbols::Class());
     klass = synthesizeClass(core::Names::Constants::BasicObject(), 0);
-    ENFORCE_NO_TIMER(klass == Symbols::BasicObject());
+    ENFORCE(klass == Symbols::BasicObject());
     method = enterMethod(*this, Symbols::BasicObject(), Names::initialize()).build();
-    ENFORCE_NO_TIMER(method == Symbols::BasicObject_initialize());
+    ENFORCE(method == Symbols::BasicObject_initialize());
     klass = synthesizeClass(core::Names::Constants::Kernel(), 0, true);
-    ENFORCE_NO_TIMER(klass == Symbols::Kernel());
+    ENFORCE(klass == Symbols::Kernel());
     klass = synthesizeClass(core::Names::Constants::Range());
-    ENFORCE_NO_TIMER(klass == Symbols::Range());
+    ENFORCE(klass == Symbols::Range());
     klass = synthesizeClass(core::Names::Constants::Regexp());
-    ENFORCE_NO_TIMER(klass == Symbols::Regexp());
+    ENFORCE(klass == Symbols::Regexp());
     klass = synthesizeClass(core::Names::Constants::Magic());
-    ENFORCE_NO_TIMER(klass == Symbols::Magic());
+    ENFORCE(klass == Symbols::Magic());
     klass = Symbols::Magic().data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::MagicSingleton());
+    ENFORCE(klass == Symbols::MagicSingleton());
     klass = synthesizeClass(core::Names::Constants::Module());
-    ENFORCE_NO_TIMER(klass == Symbols::Module());
+    ENFORCE(klass == Symbols::Module());
     klass = synthesizeClass(core::Names::Constants::Exception());
-    ENFORCE_NO_TIMER(klass == Symbols::Exception());
+    ENFORCE(klass == Symbols::Exception());
     klass = synthesizeClass(core::Names::Constants::StandardError());
-    ENFORCE_NO_TIMER(klass == Symbols::StandardError());
+    ENFORCE(klass == Symbols::StandardError());
     klass = synthesizeClass(core::Names::Constants::Complex());
-    ENFORCE_NO_TIMER(klass == Symbols::Complex());
+    ENFORCE(klass == Symbols::Complex());
     klass = synthesizeClass(core::Names::Constants::Rational());
-    ENFORCE_NO_TIMER(klass == Symbols::Rational());
+    ENFORCE(klass == Symbols::Rational());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Array());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Array());
+    ENFORCE(klass == Symbols::T_Array());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Hash());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Hash());
+    ENFORCE(klass == Symbols::T_Hash());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Proc());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Proc());
+    ENFORCE(klass == Symbols::T_Proc());
     klass = synthesizeClass(core::Names::Constants::Proc());
-    ENFORCE_NO_TIMER(klass == Symbols::Proc());
+    ENFORCE(klass == Symbols::Proc());
     klass = synthesizeClass(core::Names::Constants::Enumerable(), 0, true);
-    ENFORCE_NO_TIMER(klass == Symbols::Enumerable());
+    ENFORCE(klass == Symbols::Enumerable());
     klass = synthesizeClass(core::Names::Constants::Set());
-    ENFORCE_NO_TIMER(klass == Symbols::Set());
+    ENFORCE(klass == Symbols::Set());
     klass = synthesizeClass(core::Names::Constants::Struct());
-    ENFORCE_NO_TIMER(klass == Symbols::Struct());
+    ENFORCE(klass == Symbols::Struct());
     klass = synthesizeClass(core::Names::Constants::File());
-    ENFORCE_NO_TIMER(klass == Symbols::File());
+    ENFORCE(klass == Symbols::File());
     klass = synthesizeClass(core::Names::Constants::Sorbet());
-    ENFORCE_NO_TIMER(klass == Symbols::Sorbet());
+    ENFORCE(klass == Symbols::Sorbet());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet(), core::Names::Constants::Private());
-    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private());
+    ENFORCE(klass == Symbols::Sorbet_Private());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private(), core::Names::Constants::Static());
     klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
-    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static());
+    ENFORCE(klass == Symbols::Sorbet_Private_Static());
     klass = Symbols::Sorbet_Private_Static().data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_StaticSingleton());
+    ENFORCE(klass == Symbols::Sorbet_Private_StaticSingleton());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubModule());
     klass.data(*this)->setIsModule(true);
-    ENFORCE_NO_TIMER(klass == Symbols::StubModule());
+    ENFORCE(klass == Symbols::StubModule());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubMixin());
     klass.data(*this)->setIsModule(true);
-    ENFORCE_NO_TIMER(klass == Symbols::StubMixin());
+    ENFORCE(klass == Symbols::StubMixin());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::PlaceholderMixin());
     klass.data(*this)->setIsModule(true);
-    ENFORCE_NO_TIMER(klass == Symbols::PlaceholderMixin());
+    ENFORCE(klass == Symbols::PlaceholderMixin());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubSuperClass());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::StubSuperClass());
+    ENFORCE(klass == Symbols::StubSuperClass());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerable());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Enumerable());
+    ENFORCE(klass == Symbols::T_Enumerable());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Range());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Range());
+    ENFORCE(klass == Symbols::T_Range());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Set());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Set());
+    ENFORCE(klass == Symbols::T_Set());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Void());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::void_());
+    ENFORCE(klass == Symbols::void_());
     klass = synthesizeClass(core::Names::Constants::TypeAlias(), 0);
-    ENFORCE_NO_TIMER(klass == Symbols::typeAliasTemp());
+    ENFORCE(klass == Symbols::typeAliasTemp());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::Configuration());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Configuration());
+    ENFORCE(klass == Symbols::T_Configuration());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Generic());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Generic());
+    ENFORCE(klass == Symbols::T_Generic());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Tuple());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::Tuple());
+    ENFORCE(klass == Symbols::Tuple());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Shape());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::Shape());
+    ENFORCE(klass == Symbols::Shape());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Subclasses());
-    ENFORCE_NO_TIMER(klass == Symbols::Subclasses());
+    ENFORCE(klass == Symbols::Subclasses());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(),
                              core::Names::Constants::ImplicitModuleSuperclass());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
+    ENFORCE(klass == Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
     klass =
         enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ReturnTypeInference());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_ReturnTypeInference());
+    ENFORCE(klass == Symbols::Sorbet_Private_Static_ReturnTypeInference());
     typeArgument =
         enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::TodoTypeArgument(), Variance::CoVariant);
-    ENFORCE_NO_TIMER(typeArgument == Symbols::todoTypeArgument());
+    ENFORCE(typeArgument == Symbols::todoTypeArgument());
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
     method =
         enterMethod(*this, Symbols::Sorbet_Private_Static(), core::Names::guessedTypeTypeParameterHolder()).build();
-    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder());
+    ENFORCE(method == Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder());
     typeArgument = enterTypeArgument(
         Loc::none(), Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder(),
         freshNameUnique(core::UniqueNameKind::TypeVarName, core::Names::Constants::InferredReturnType(), 1),
         core::Variance::ContraVariant);
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
-    ENFORCE_NO_TIMER(
+    ENFORCE(
         typeArgument ==
         Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_contravariant());
     typeArgument = enterTypeArgument(
@@ -481,219 +481,218 @@ void GlobalState::initEmpty() {
         freshNameUnique(core::UniqueNameKind::TypeVarName, core::Names::Constants::InferredArgumentType(), 1),
         core::Variance::CoVariant);
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
-    ENFORCE_NO_TIMER(
-        typeArgument ==
-        Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_covariant());
+    ENFORCE(typeArgument ==
+            Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_covariant());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Sig());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Sig());
+    ENFORCE(klass == Symbols::T_Sig());
 
     // A magic non user-creatable class with methods to keep state between passes
     field = enterFieldSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::UndeclaredFieldStub());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_undeclaredFieldStub());
+    ENFORCE(field == Symbols::Magic_undeclaredFieldStub());
 
     // Sorbet::Private::Static#badAliasMethodStub(*arg0 : T.untyped) => T.untyped
     method = enterMethod(*this, Symbols::Sorbet_Private_Static(), core::Names::badAliasMethodStub())
                  .repeatedUntypedArg(Names::arg0())
                  .build();
-    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_badAliasMethodStub());
+    ENFORCE(method == Symbols::Sorbet_Private_Static_badAliasMethodStub());
 
     // T::Helpers
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Helpers());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Helpers());
+    ENFORCE(klass == Symbols::T_Helpers());
 
     // SigBuilder magic class
     klass = synthesizeClass(core::Names::Constants::DeclBuilderForProcs());
-    ENFORCE_NO_TIMER(klass == Symbols::DeclBuilderForProcs());
+    ENFORCE(klass == Symbols::DeclBuilderForProcs());
     klass = Symbols::DeclBuilderForProcs().data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::DeclBuilderForProcsSingleton());
+    ENFORCE(klass == Symbols::DeclBuilderForProcsSingleton());
 
     // Ruby 2.5 Hack
     klass = synthesizeClass(core::Names::Constants::Net(), 0, true);
-    ENFORCE_NO_TIMER(klass == Symbols::Net());
+    ENFORCE(klass == Symbols::Net());
     klass = enterClassSymbol(Loc::none(), Symbols::Net(), core::Names::Constants::IMAP());
     Symbols::Net_IMAP().data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::Net_IMAP());
+    ENFORCE(klass == Symbols::Net_IMAP());
     klass = enterClassSymbol(Loc::none(), Symbols::Net(), core::Names::Constants::Protocol());
-    ENFORCE_NO_TIMER(klass == Symbols::Net_Protocol());
+    ENFORCE(klass == Symbols::Net_Protocol());
     Symbols::Net_Protocol().data(*this)->setIsModule(false);
 
     klass = enterClassSymbol(Loc::none(), Symbols::T_Sig(), core::Names::Constants::WithoutRuntime());
     klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
-    ENFORCE_NO_TIMER(klass == Symbols::T_Sig_WithoutRuntime());
+    ENFORCE(klass == Symbols::T_Sig_WithoutRuntime());
 
     klass = synthesizeClass(core::Names::Constants::Enumerator());
-    ENFORCE_NO_TIMER(klass == Symbols::Enumerator());
+    ENFORCE(klass == Symbols::Enumerator());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerator());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Enumerator());
+    ENFORCE(klass == Symbols::T_Enumerator());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Enumerator(), core::Names::Constants::Lazy());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Enumerator_Lazy());
+    ENFORCE(klass == Symbols::T_Enumerator_Lazy());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Enumerator(), core::Names::Constants::Chain());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Enumerator_Chain());
+    ENFORCE(klass == Symbols::T_Enumerator_Chain());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Struct());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::T_Struct());
+    ENFORCE(klass == Symbols::T_Struct());
 
     klass = synthesizeClass(core::Names::Constants::Singleton(), 0, true);
-    ENFORCE_NO_TIMER(klass == Symbols::Singleton());
+    ENFORCE(klass == Symbols::Singleton());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enum());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::T_Enum());
+    ENFORCE(klass == Symbols::T_Enum());
 
     // T::Sig#sig
     method = enterMethod(*this, Symbols::T_Sig(), Names::sig()).defaultArg(Names::arg0()).build();
-    ENFORCE_NO_TIMER(method == Symbols::sig());
+    ENFORCE(method == Symbols::sig());
 
     // Enumerator::Lazy
     klass = enterClassSymbol(Loc::none(), Symbols::Enumerator(), core::Names::Constants::Lazy());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::Enumerator_Lazy());
+    ENFORCE(klass == Symbols::Enumerator_Lazy());
 
     // Enumerator::Chain
     klass = enterClassSymbol(Loc::none(), Symbols::Enumerator(), core::Names::Constants::Chain());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::Enumerator_Chain());
+    ENFORCE(klass == Symbols::Enumerator_Chain());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::Private());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Private());
+    ENFORCE(klass == Symbols::T_Private());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private(), Names::Constants::Types());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types());
+    ENFORCE(klass == Symbols::T_Private_Types());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private_Types(), Names::Constants::Void());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types_Void());
+    ENFORCE(klass == Symbols::T_Private_Types_Void());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private_Types_Void(), Names::Constants::VOID());
     klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
-    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types_Void_VOID());
+    ENFORCE(klass == Symbols::T_Private_Types_Void_VOID());
     klass = klass.data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types_Void_VOIDSingleton());
+    ENFORCE(klass == Symbols::T_Private_Types_Void_VOIDSingleton());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private(), Names::Constants::Methods());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Methods());
+    ENFORCE(klass == Symbols::T_Private_Methods());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private_Methods(), Names::Constants::DeclBuilder());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Methods_DeclBuilder());
+    ENFORCE(klass == Symbols::T_Private_Methods_DeclBuilder());
 
     method = enterMethod(*this, Symbols::T_Private_Methods_DeclBuilder(), Names::abstract()).build();
-    ENFORCE_NO_TIMER(method == Symbols::T_Private_Methods_DeclBuilder_abstract());
+    ENFORCE(method == Symbols::T_Private_Methods_DeclBuilder_abstract());
     method = enterMethod(*this, Symbols::T_Private_Methods_DeclBuilder(), Names::overridable()).build();
-    ENFORCE_NO_TIMER(method == Symbols::T_Private_Methods_DeclBuilder_overridable());
+    ENFORCE(method == Symbols::T_Private_Methods_DeclBuilder_overridable());
     method = enterMethod(*this, Symbols::T_Private_Methods_DeclBuilder(), Names::override_())
                  .defaultKeywordArg(Names::allowIncompatible())
                  .build();
-    ENFORCE_NO_TIMER(method == Symbols::T_Private_Methods_DeclBuilder_override());
+    ENFORCE(method == Symbols::T_Private_Methods_DeclBuilder_override());
 
     // T.class_of(T::Sig::WithoutRuntime)
     klass = Symbols::T_Sig_WithoutRuntime().data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::T_Sig_WithoutRuntimeSingleton());
+    ENFORCE(klass == Symbols::T_Sig_WithoutRuntimeSingleton());
 
     // T::Sig::WithoutRuntime.sig
     method =
         enterMethod(*this, Symbols::T_Sig_WithoutRuntimeSingleton(), Names::sig()).defaultArg(Names::arg0()).build();
-    ENFORCE_NO_TIMER(method == Symbols::sigWithoutRuntime());
+    ENFORCE(method == Symbols::sigWithoutRuntime());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::NonForcingConstants());
-    ENFORCE_NO_TIMER(klass == Symbols::T_NonForcingConstants());
+    ENFORCE(klass == Symbols::T_NonForcingConstants());
 
     method = enterMethod(*this, Symbols::Sorbet_Private_StaticSingleton(), Names::sig())
                  .arg(Names::arg0())
                  .defaultArg(Names::arg1())
                  .build();
-    ENFORCE_NO_TIMER(method == Symbols::SorbetPrivateStaticSingleton_sig());
+    ENFORCE(method == Symbols::SorbetPrivateStaticSingleton_sig());
 
     klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpecRegistry());
-    ENFORCE_NO_TIMER(klass == Symbols::PackageSpecRegistry());
+    ENFORCE(klass == Symbols::PackageSpecRegistry());
 
     // PackageSpec is a class that can be subclassed.
     klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpec());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::PackageSpec());
+    ENFORCE(klass == Symbols::PackageSpec());
 
     klass = klass.data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::PackageSpecSingleton());
+    ENFORCE(klass == Symbols::PackageSpecSingleton());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::import())
                  .typedArg(Names::arg0(), make_type<ClassType>(Symbols::PackageSpecSingleton()))
                  .build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_import());
+    ENFORCE(method == Symbols::PackageSpec_import());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::testImport())
                  .typedArg(Names::arg0(), make_type<ClassType>(Symbols::PackageSpecSingleton()))
                  .build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_test_import());
+    ENFORCE(method == Symbols::PackageSpec_test_import());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::export_()).arg(Names::arg0()).build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_export());
+    ENFORCE(method == Symbols::PackageSpec_export());
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::restrictToService()).arg(Names::arg0()).build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_restrict_to_service());
+    ENFORCE(method == Symbols::PackageSpec_restrict_to_service());
 
     klass = synthesizeClass(core::Names::Constants::Encoding());
-    ENFORCE_NO_TIMER(klass == Symbols::Encoding());
+    ENFORCE(klass == Symbols::Encoding());
 
     klass = synthesizeClass(core::Names::Constants::Thread());
-    ENFORCE_NO_TIMER(klass == Symbols::Thread());
+    ENFORCE(klass == Symbols::Thread());
 
     // Class#new
     method = enterMethod(*this, Symbols::Class(), Names::new_()).repeatedArg(Names::args()).build();
-    ENFORCE_NO_TIMER(method == Symbols::Class_new());
+    ENFORCE(method == Symbols::Class_new());
 
     method = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::TodoMethod());
     enterMethodArgumentSymbol(Loc::none(), method, Names::args());
-    ENFORCE_NO_TIMER(method == Symbols::todoMethod());
+    ENFORCE(method == Symbols::todoMethod());
 
     method = this->staticInitForClass(core::Symbols::root(), Loc::none());
-    ENFORCE_NO_TIMER(method == Symbols::rootStaticInit());
+    ENFORCE(method == Symbols::rootStaticInit());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::visibleTo()).arg(Names::arg0()).build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_visible_to());
+    ENFORCE(method == Symbols::PackageSpec_visible_to());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::exportAll()).build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_export_all());
+    ENFORCE(method == Symbols::PackageSpec_export_all());
 
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ResolvedSig());
     klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
-    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_ResolvedSig());
+    ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSig());
     klass = Symbols::Sorbet_Private_Static_ResolvedSig().data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_ResolvedSigSingleton());
+    ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSigSingleton());
 
     // Magic classes for special proc bindings
     klass = enterClassSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::BindToAttachedClass());
-    ENFORCE_NO_TIMER(klass == Symbols::MagicBindToAttachedClass());
+    ENFORCE(klass == Symbols::MagicBindToAttachedClass());
 
     klass = enterClassSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::BindToSelfType());
-    ENFORCE_NO_TIMER(klass == Symbols::MagicBindToSelfType());
+    ENFORCE(klass == Symbols::MagicBindToSelfType());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Types());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Types());
+    ENFORCE(klass == Symbols::T_Types());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T_Types(), core::Names::Constants::Base());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::T_Types_Base());
+    ENFORCE(klass == Symbols::T_Types_Base());
 
     klass = enterClassSymbol(Loc::none(), Symbols::root(), core::Names::Constants::Data());
     klass.data(*this)->setIsModule(false);
-    ENFORCE_NO_TIMER(klass == Symbols::Data());
+    ENFORCE(klass == Symbols::Data());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Class());
-    ENFORCE_NO_TIMER(klass == Symbols::T_Class());
+    ENFORCE(klass == Symbols::T_Class());
 
     method = enterMethod(*this, Symbols::T_Generic(), Names::squareBrackets()).repeatedTopArg(Names::args()).build();
-    ENFORCE_NO_TIMER(method == Symbols::T_Generic_squareBrackets());
+    ENFORCE(method == Symbols::T_Generic_squareBrackets());
 
     method = enterMethod(*this, Symbols::Kernel(), Names::lambda()).build();
-    ENFORCE_NO_TIMER(method == Symbols::Kernel_lambda());
+    ENFORCE(method == Symbols::Kernel_lambda());
 
     typeArgument = enterTypeArgument(Loc::none(), Symbols::Kernel_lambda(), Names::returnType(), Variance::CoVariant);
-    ENFORCE_NO_TIMER(typeArgument == Symbols::Kernel_lambda_returnType());
+    ENFORCE(typeArgument == Symbols::Kernel_lambda_returnType());
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
 
     method = enterMethod(*this, Symbols::Kernel(), Names::lambdaTLet()).typedArg(Names::type(), Types::top()).build();
-    ENFORCE_NO_TIMER(method == Symbols::Kernel_lambdaTLet());
+    ENFORCE(method == Symbols::Kernel_lambdaTLet());
 
     method = enterMethod(*this, Symbols::Kernel(), Names::proc()).build();
-    ENFORCE_NO_TIMER(method == Symbols::Kernel_proc());
+    ENFORCE(method == Symbols::Kernel_proc());
 
     typeArgument = enterTypeArgument(Loc::none(), Symbols::Kernel_proc(), Names::returnType(), Variance::CoVariant);
-    ENFORCE_NO_TIMER(typeArgument == Symbols::Kernel_proc_returnType());
+    ENFORCE(typeArgument == Symbols::Kernel_proc_returnType());
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
 
     // Root members
@@ -884,57 +883,57 @@ void GlobalState::initEmpty() {
     klass.data(*this)->setIsModule(true);
 
     klass = enterClassSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::UntypedSource());
-    ENFORCE_NO_TIMER(klass == Symbols::Magic_UntypedSource());
+    ENFORCE(klass == Symbols::Magic_UntypedSource());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::super());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_super());
+    ENFORCE(field == Symbols::Magic_UntypedSource_super());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::proc());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_proc());
+    ENFORCE(field == Symbols::Magic_UntypedSource_proc());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::buildArray());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_buildArray());
+    ENFORCE(field == Symbols::Magic_UntypedSource_buildArray());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::buildRange());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_buildRange());
+    ENFORCE(field == Symbols::Magic_UntypedSource_buildRange());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::buildHash());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_buildHash());
+    ENFORCE(field == Symbols::Magic_UntypedSource_buildHash());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::mergeHashValues());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_mergeHashValues());
+    ENFORCE(field == Symbols::Magic_UntypedSource_mergeHashValues());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::expandSplat());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_expandSplat());
+    ENFORCE(field == Symbols::Magic_UntypedSource_expandSplat());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::splat());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_splat());
+    ENFORCE(field == Symbols::Magic_UntypedSource_splat());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::tupleUnderlying());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_tupleUnderlying());
+    ENFORCE(field == Symbols::Magic_UntypedSource_tupleUnderlying());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeUnderlying());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_shapeUnderlying());
+    ENFORCE(field == Symbols::Magic_UntypedSource_shapeUnderlying());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::tupleLub());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_tupleLub());
+    ENFORCE(field == Symbols::Magic_UntypedSource_tupleLub());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeLub());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_shapeLub());
+    ENFORCE(field == Symbols::Magic_UntypedSource_shapeLub());
 
     field =
         enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeSquareBracketsEq());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_shapeSquareBracketsEq());
+    ENFORCE(field == Symbols::Magic_UntypedSource_shapeSquareBracketsEq());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::YieldLoadArg());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_YieldLoadArg());
+    ENFORCE(field == Symbols::Magic_UntypedSource_YieldLoadArg());
 
     field =
         enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::GetCurrentException());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_GetCurrentException());
+    ENFORCE(field == Symbols::Magic_UntypedSource_GetCurrentException());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::LoadYieldParams());
-    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_LoadYieldParams());
+    ENFORCE(field == Symbols::Magic_UntypedSource_LoadYieldParams());
 
     int reservedCount = 0;
 
@@ -949,7 +948,7 @@ void GlobalState::initEmpty() {
     }
 
     // This fills in all the way up to MAX_SYNTHETIC_CLASS_SYMBOLS
-    ENFORCE_NO_TIMER(classAndModules.size() < Symbols::Proc0().id());
+    ENFORCE(classAndModules.size() < Symbols::Proc0().id());
     while (classAndModules.size() < Symbols::Proc0().id()) {
         string name = absl::StrCat("<RESERVED_", reservedCount, ">");
         synthesizeClass(enterNameConstant(name));
@@ -959,27 +958,27 @@ void GlobalState::initEmpty() {
     for (int arity = 0; arity <= Symbols::MAX_PROC_ARITY; ++arity) {
         string name = absl::StrCat("Proc", arity);
         auto id = synthesizeClass(enterNameConstant(name), Symbols::Proc().id());
-        ENFORCE_NO_TIMER(id == Symbols::Proc(arity), "Proc creation failed for arity: {} got: {} expected: {}", arity,
-                         id.id(), Symbols::Proc(arity).id());
+        ENFORCE(id == Symbols::Proc(arity), "Proc creation failed for arity: {} got: {} expected: {}", arity, id.id(),
+                Symbols::Proc(arity).id());
         id.data(*this)->singletonClass(*this);
     }
 
-    ENFORCE_NO_TIMER(classAndModules.size() == Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS,
-                     "Too many synthetic class symbols? have: {} expected: {}", classAndModules.size(),
-                     Symbols::last_synthetic_class_sym().id() + 1);
+    ENFORCE(classAndModules.size() == Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS,
+            "Too many synthetic class symbols? have: {} expected: {}", classAndModules.size(),
+            Symbols::last_synthetic_class_sym().id() + 1);
 
-    ENFORCE_NO_TIMER(methods.size() == Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS,
-                     "Too many synthetic method symbols? have: {} expected: {}", methods.size(),
-                     Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS);
-    ENFORCE_NO_TIMER(fields.size() == Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS,
-                     "Too many synthetic field symbols? have: {} expected: {}", fields.size(),
-                     Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS);
-    ENFORCE_NO_TIMER(typeMembers.size() == Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS,
-                     "Too many synthetic typeMember symbols? have: {} expected: {}", typeMembers.size(),
-                     Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS);
-    ENFORCE_NO_TIMER(typeArguments.size() == Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS,
-                     "Too many synthetic typeArgument symbols? have: {} expected: {}", typeArguments.size(),
-                     Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS);
+    ENFORCE(methods.size() == Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS,
+            "Too many synthetic method symbols? have: {} expected: {}", methods.size(),
+            Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS);
+    ENFORCE(fields.size() == Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS,
+            "Too many synthetic field symbols? have: {} expected: {}", fields.size(),
+            Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS);
+    ENFORCE(typeMembers.size() == Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS,
+            "Too many synthetic typeMember symbols? have: {} expected: {}", typeMembers.size(),
+            Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS);
+    ENFORCE(typeArguments.size() == Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS,
+            "Too many synthetic typeArgument symbols? have: {} expected: {}", typeArguments.size(),
+            Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS);
 
     installIntrinsics();
     computeLinearization();
@@ -1062,8 +1061,7 @@ void GlobalState::preallocateTables(uint32_t classAndModulesSize, uint32_t metho
     typeArguments.reserve(typeArgumentsSizeScaled);
     typeMembers.reserve(typeMembersSizeScaled);
     expandNames(utf8NameSizeScaled, constantNameSizeScaled, uniqueNameSizeScaled);
-    sanityCheckTableSizes();
-    sanityCheckNames();
+    sanityCheck();
 
     trace(fmt::format("Preallocated symbol and name tables. classAndModules={} methods={} fields={} typeArguments={} "
                       "typeMembers={} utf8Names={} constantNames={} uniqueNames={}",
@@ -1084,15 +1082,16 @@ bool matchesArityHash(const GlobalState &gs, ArityHash arityHash, MethodRef meth
 } // namespace
 
 MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, ArityHash arityHash) const {
-    ENFORCE_NO_TIMER(owner.exists(), "looking up symbol from non-existing owner");
-    ENFORCE_NO_TIMER(name.exists(), "looking up symbol with non-existing name");
+    ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
+    ENFORCE(name.exists(), "looking up symbol with non-existing name");
     auto ownerScope = owner.dataAllowingNone(*this);
+    histogramInc("symbol_lookup_by_name", ownerScope->members().size());
 
     NameRef lookupName = name;
     uint32_t unique = 1;
     auto res = ownerScope->members().find(lookupName);
     while (res != ownerScope->members().end()) {
-        ENFORCE_NO_TIMER(res->second.exists());
+        ENFORCE(res->second.exists());
         auto resSym = res->second;
         if (resSym.isMethod()) {
             auto resMethod = resSym.asMethodRef();
@@ -1127,15 +1126,16 @@ MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRe
 // If no such symbol exists, then it will return defaultReturnValue.
 SymbolRef GlobalState::lookupSymbolWithKind(ClassOrModuleRef owner, NameRef name, SymbolRef::Kind kind,
                                             SymbolRef defaultReturnValue, bool ignoreKind) const {
-    ENFORCE_NO_TIMER(owner.exists(), "looking up symbol from non-existing owner");
-    ENFORCE_NO_TIMER(name.exists(), "looking up symbol with non-existing name");
+    ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
+    ENFORCE(name.exists(), "looking up symbol with non-existing name");
     auto ownerScope = owner.dataAllowingNone(*this);
+    histogramInc("symbol_lookup_by_name", ownerScope->members().size());
 
     NameRef lookupName = name;
     uint32_t unique = 1;
     auto res = ownerScope->members().find(lookupName);
     while (res != ownerScope->members().end()) {
-        ENFORCE_NO_TIMER(res->second.exists());
+        ENFORCE(res->second.exists());
         if (ignoreKind || res->second.kind() == kind) {
             return res->second;
         }
@@ -1153,9 +1153,9 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
     // This method works by knowing how to replicate the logic of renaming in order to find whatever
     // the previous name was: for `x$n` where `n` is larger than 2, it'll be `x$(n-1)`, for bare `x`,
     // it'll be whatever the largest `x$n` that exists is, if any; otherwise, there will be none.
-    ENFORCE_NO_TIMER(sym.exists(), "lookup up previous name of non-existing symbol");
+    ENFORCE(sym.exists(), "lookup up previous name of non-existing symbol");
     // The name un-mangling logic described here no longer applies to constant symbols, only methods.
-    ENFORCE_NO_TIMER(sym.isMethod());
+    ENFORCE(sym.isMethod());
     NameRef name = sym.name(*this);
     auto ownerScope = owner.dataAllowingNone(*this);
 
@@ -1163,7 +1163,7 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
         auto uniqueData = name.dataUnique(*this);
         if (uniqueData->uniqueNameKind == UniqueNameKind::MangleRenameOverload) {
             auto it = ownerScope->members().find(uniqueData->original);
-            ENFORCE_NO_TIMER(it != ownerScope->members().end());
+            ENFORCE(it != ownerScope->members().end());
             // return it->second;
             auto res = findRenamedSymbol(owner, it->second);
             if (res.exists() && res.isMethod()) {
@@ -1171,7 +1171,7 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
                 if (resData->flags.isOverloaded) {
                     auto overloadedName = lookupNameUnique(UniqueNameKind::MangleRenameOverload, resData->name, 1);
                     auto it = ownerScope->members().find(overloadedName);
-                    ENFORCE_NO_TIMER(it != ownerScope->members().end());
+                    ENFORCE(it != ownerScope->members().end());
                     res = it->second;
                 }
             }
@@ -1182,13 +1182,13 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
         if (uniqueData->num == 1) {
             return Symbols::noSymbol();
         } else {
-            ENFORCE_NO_TIMER(uniqueData->num > 1);
+            ENFORCE(uniqueData->num > 1);
             auto nm = lookupNameUnique(UniqueNameKind::MangleRename, uniqueData->original, uniqueData->num - 1);
             if (!nm.exists()) {
                 return Symbols::noSymbol();
             }
             auto res = ownerScope->members().find(nm);
-            ENFORCE_NO_TIMER(res != ownerScope->members().end());
+            ENFORCE(res != ownerScope->members().end());
             return res->second;
         }
     } else {
@@ -1196,7 +1196,7 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
         NameRef lookupName = lookupNameUnique(UniqueNameKind::MangleRename, name, unique);
         auto res = ownerScope->members().find(lookupName);
         while (res != ownerScope->members().end()) {
-            ENFORCE_NO_TIMER(res->second.exists());
+            ENFORCE(res->second.exists());
             unique++;
             lookupName = lookupNameUnique(UniqueNameKind::MangleRename, name, unique);
             if (!lookupName.exists()) {
@@ -1216,10 +1216,12 @@ ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, 
     ENFORCE_NO_TIMER(name.kind() != core::NameKind::UNIQUE ||
                      name.dataUnique(*this)->uniqueNameKind != core::UniqueNameKind::MangleRename);
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
+    histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
         ENFORCE_NO_TIMER(store.isClassOrModule(), "existing symbol is not a class or module");
+        counterInc("symbols.hit");
         return store.asClassOrModuleRef();
     }
 
@@ -1239,8 +1241,8 @@ ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, 
 
 TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance) {
     TypeParameter::Flags flags;
-    ENFORCE_NO_TIMER(owner.exists() || name == Names::Constants::NoTypeMember());
-    ENFORCE_NO_TIMER(name.exists());
+    ENFORCE(owner.exists() || name == Names::Constants::NoTypeMember());
+    ENFORCE(name.exists());
     if (variance == Variance::Invariant) {
         flags.isInvariant = true;
     } else if (variance == Variance::CoVariant) {
@@ -1253,15 +1255,17 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
     flags.isTypeMember = true;
 
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
+    histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE_NO_TIMER(store.isTypeMember() && store.asTypeMemberRef().data(*this)->flags.hasFlags(flags),
-                         "existing symbol has wrong flags");
+        ENFORCE(store.isTypeMember() && store.asTypeMemberRef().data(*this)->flags.hasFlags(flags),
+                "existing symbol has wrong flags");
+        counterInc("symbols.hit");
         return store.asTypeMemberRef();
     }
 
-    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE(!symbolTableFrozen);
     auto result = TypeMemberRef(*this, typeMembers.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on typeMembers invalidates `store`
     typeMembers.emplace_back();
@@ -1282,9 +1286,9 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
 }
 
 TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef name, Variance variance) {
-    ENFORCE_NO_TIMER(owner.exists() || name == Names::Constants::NoTypeArgument() ||
-                     name == Names::Constants::TodoTypeArgument());
-    ENFORCE_NO_TIMER(name.exists());
+    ENFORCE(owner.exists() || name == Names::Constants::NoTypeArgument() ||
+            name == Names::Constants::TodoTypeArgument());
+    ENFORCE(name.exists());
     TypeParameter::Flags flags;
     if (variance == Variance::Invariant) {
         flags.isInvariant = true;
@@ -1298,10 +1302,12 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     flags.isTypeArgument = true;
 
     auto ownerScope = owner.dataAllowingNone(*this);
+    histogramInc("symbol_enter_by_name", ownerScope->typeArguments().size());
 
     for (auto typeArg : ownerScope->typeArguments()) {
         if (typeArg.dataAllowingNone(*this)->name == name) {
-            ENFORCE_NO_TIMER(typeArg.dataAllowingNone(*this)->flags.hasFlags(flags), "existing symbol has wrong flags");
+            ENFORCE(typeArg.dataAllowingNone(*this)->flags.hasFlags(flags), "existing symbol has wrong flags");
+            counterInc("symbols.hit");
             if (!symbolTableFrozen) {
                 typeArg.data(*this)->addLoc(*this, loc);
             } else {
@@ -1313,7 +1319,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
         }
     }
 
-    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE(!symbolTableFrozen);
     auto result = TypeArgumentRef(*this, this->typeArguments.size());
     this->typeArguments.emplace_back();
 
@@ -1331,14 +1337,16 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
 
 MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
+    histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE_NO_TIMER(store.isMethod(), "existing symbol is not a method");
+        ENFORCE(store.isMethod(), "existing symbol is not a method");
+        counterInc("symbols.hit");
         return store.asMethodRef();
     }
 
-    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE(!symbolTableFrozen);
 
     auto result = MethodRef(*this, methods.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on methods invalidates `store`
@@ -1363,9 +1371,9 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
     auto res = enterMethodSymbol(loc, owner, name);
     bool newMethod = res != original;
     const auto &resArguments = res.data(*this)->arguments;
-    ENFORCE_NO_TIMER(newMethod || !resArguments.empty(), "must be at least the block arg");
+    ENFORCE(newMethod || !resArguments.empty(), "must be at least the block arg");
     auto resInitialArgSize = resArguments.size();
-    ENFORCE_NO_TIMER(original.data(*this)->arguments.size() == argsToKeep.size());
+    ENFORCE(original.data(*this)->arguments.size() == argsToKeep.size());
     const auto &originalArguments = original.data(*this)->arguments;
     int i = -1;
     for (auto &arg : originalArguments) {
@@ -1378,16 +1386,15 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
                 DEBUG_ONLY(if (!newMethod) {
                     auto f = [&](const auto &resArg) { return arg.name == resArg.name; };
                     auto it = absl::c_find_if(resArguments, move(f));
-                    ENFORCE_NO_TIMER(it == resArguments.end(),
-                                     "fast path should not remove arguments from existing overload");
+                    ENFORCE(it == resArguments.end(), "fast path should not remove arguments from existing overload");
                 });
                 continue;
             }
         }
         NameRef nm = arg.name;
         auto &newArg = enterMethodArgumentSymbol(loc, res, nm);
-        ENFORCE_NO_TIMER(newMethod || resArguments.size() == resInitialArgSize,
-                         "fast path should not add new arguments to existing overload");
+        ENFORCE(newMethod || resArguments.size() == resInitialArgSize,
+                "fast path should not add new arguments to existing overload");
         newArg = arg.deepCopy();
         newArg.loc = loc;
     }
@@ -1395,17 +1402,19 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
 }
 
 FieldRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
-    ENFORCE_NO_TIMER(name.exists());
+    ENFORCE(name.exists());
 
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
+    histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE_NO_TIMER(store.isField(*this), "existing symbol is not a field");
+        ENFORCE(store.isField(*this), "existing symbol is not a field");
+        counterInc("symbols.hit");
         return store.asFieldRef();
     }
 
-    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE(!symbolTableFrozen);
 
     auto result = FieldRef(*this, fields.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on fields invalidates `store`
@@ -1424,13 +1433,15 @@ FieldRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef 
 }
 
 FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
-    ENFORCE_NO_TIMER(name.exists());
+    ENFORCE(name.exists());
 
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
+    histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE_NO_TIMER(store.isStaticField(*this), "existing symbol is not a static field");
+        ENFORCE(store.isStaticField(*this), "existing symbol is not a static field");
+        counterInc("symbols.hit");
 
         // Ensures that locs get properly updated on the fast path
         auto fieldRef = store.asFieldRef();
@@ -1444,7 +1455,7 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
         return fieldRef;
     }
 
-    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE(!symbolTableFrozen);
 
     auto ret = FieldRef(*this, fields.size());
     store = ret; // DO NOT MOVE this assignment down. emplace_back on fields invalidates `store`
@@ -1463,8 +1474,8 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
 }
 
 ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name) {
-    ENFORCE_NO_TIMER(owner.exists(), "entering symbol in to non-existing owner");
-    ENFORCE_NO_TIMER(name.exists(), "entering symbol with non-existing name");
+    ENFORCE(owner.exists(), "entering symbol in to non-existing owner");
+    ENFORCE(name.exists(), "entering symbol with non-existing name");
     MethodData ownerScope = owner.data(*this);
 
     for (auto &arg : ownerScope->arguments) {
@@ -1474,7 +1485,7 @@ ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRe
     }
     auto &store = ownerScope->arguments.emplace_back();
 
-    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE(!symbolTableFrozen);
 
     store.name = name;
     store.loc = loc;
@@ -1492,6 +1503,7 @@ string_view GlobalState::enterString(string_view nm) {
         }
     });
     auto ret = strings.enterString(nm);
+    counterInc("strings");
     return ret;
 }
 
@@ -1507,7 +1519,10 @@ NameRef GlobalState::lookupNameUTF8(string_view nm) const {
         if (bucket.hash == hs) {
             auto name = NameRef::fromRaw(*this, bucket.rawId);
             if (name.kind() == NameKind::UTF8 && name.dataUtf8(*this)->utf8 == nm) {
+                counterInc("names.utf8.hit");
                 return name;
+            } else {
+                counterInc("names.hash_collision.utf8");
             }
         }
         bucketId = (bucketId + probeCount) & mask;
@@ -1529,15 +1544,18 @@ NameRef GlobalState::enterNameUTF8(string_view nm) {
         if (bucket.hash == hs) {
             auto name = NameRef::fromRaw(*this, bucket.rawId);
             if (name.kind() == NameKind::UTF8 && name.dataUtf8(*this)->utf8 == nm) {
+                counterInc("names.utf8.hit");
                 return name;
+            } else {
+                counterInc("names.hash_collision.utf8");
             }
         }
         bucketId = (bucketId + probeCount) & mask;
         probeCount++;
     }
-    ENFORCE_NO_TIMER(!nameTableFrozen);
+    ENFORCE(!nameTableFrozen);
 
-    ENFORCE_NO_TIMER(probeCount != hashTableSize, "Full table?");
+    ENFORCE(probeCount != hashTableSize, "Full table?");
 
     if (utf8Names.size() == utf8Names.capacity()) {
         expandNames(utf8Names.capacity() * 2, constantNames.capacity(), uniqueNames.capacity());
@@ -1565,8 +1583,8 @@ NameRef GlobalState::enterNameUTF8(string_view nm) {
 }
 
 NameRef GlobalState::enterNameConstant(NameRef original) {
-    ENFORCE_NO_TIMER(original.exists(), "making a constant name over non-existing name");
-    ENFORCE_NO_TIMER(original.isValidConstantName(*this), "making a constant name over wrong name kind");
+    ENFORCE(original.exists(), "making a constant name over non-existing name");
+    ENFORCE(original.isValidConstantName(*this), "making a constant name over wrong name kind");
 
     const auto hs = hashMixConstant(original.rawId());
     unsigned int hashTableSize = namesByHash.size();
@@ -1579,7 +1597,10 @@ NameRef GlobalState::enterNameConstant(NameRef original) {
         if (bucket.hash == hs) {
             auto name = NameRef::fromRaw(*this, bucket.rawId);
             if (name.kind() == NameKind::CONSTANT && name.dataCnst(*this)->original == original) {
+                counterInc("names.constant.hit");
                 return name;
+            } else {
+                counterInc("names.hash_collision.constant");
             }
         }
         bucketId = (bucketId + probeCount) & mask;
@@ -1588,7 +1609,7 @@ NameRef GlobalState::enterNameConstant(NameRef original) {
     if (probeCount == hashTableSize) {
         Exception::raise("Full table?");
     }
-    ENFORCE_NO_TIMER(!nameTableFrozen);
+    ENFORCE(!nameTableFrozen);
 
     if (constantNames.size() == constantNames.capacity()) {
         expandNames(utf8Names.capacity(), constantNames.capacity() * 2, uniqueNames.capacity());
@@ -1636,7 +1657,10 @@ NameRef GlobalState::lookupNameConstant(NameRef original) const {
         if (bucket.hash == hs) {
             auto name = NameRef::fromRaw(*this, bucket.rawId);
             if (name.kind() == NameKind::CONSTANT && name.dataCnst(*this)->original == original) {
+                counterInc("names.constant.hit");
                 return name;
+            } else {
+                counterInc("names.hash_collision.constant");
             }
         }
         bucketId = (bucketId + probeCount) & mask;
@@ -1656,8 +1680,8 @@ NameRef GlobalState::lookupNameConstant(string_view original) const {
 
 void GlobalState::moveNames(Bucket *from, Bucket *to, unsigned int szFrom, unsigned int szTo) {
     // printf("\nResizing name hash table from %u to %u\n", szFrom, szTo);
-    ENFORCE_NO_TIMER((szTo & (szTo - 1)) == 0, "name hash table size corruption");
-    ENFORCE_NO_TIMER((szFrom & (szFrom - 1)) == 0, "name hash table size corruption");
+    ENFORCE((szTo & (szTo - 1)) == 0, "name hash table size corruption");
+    ENFORCE((szFrom & (szFrom - 1)) == 0, "name hash table size corruption");
     unsigned int mask = szTo - 1;
     for (unsigned int orig = 0; orig < szFrom; orig++) {
         if (from[orig].rawId != 0u) {
@@ -1674,7 +1698,7 @@ void GlobalState::moveNames(Bucket *from, Bucket *to, unsigned int szFrom, unsig
 }
 
 void GlobalState::expandNames(uint32_t utf8NameSize, uint32_t constantNameSize, uint32_t uniqueNameSize) {
-    sanityCheckNames();
+    sanityCheck();
     utf8Names.reserve(utf8NameSize);
     constantNames.reserve(constantNameSize);
     uniqueNames.reserve(uniqueNameSize);
@@ -1689,7 +1713,7 @@ void GlobalState::expandNames(uint32_t utf8NameSize, uint32_t constantNameSize, 
 }
 
 NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef original, uint32_t num) const {
-    ENFORCE_NO_TIMER(num > 0, "num == 0, name overflow");
+    ENFORCE(num > 0, "num == 0, name overflow");
     const auto hs = hashMixUnique(uniqueNameKind, num, original.rawId());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
@@ -1702,7 +1726,10 @@ NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef ori
             auto name = NameRef::fromRaw(*this, bucket.rawId);
             if (name.kind() == NameKind::UNIQUE && name.dataUnique(*this)->uniqueNameKind == uniqueNameKind &&
                 name.dataUnique(*this)->num == num && name.dataUnique(*this)->original == original) {
+                counterInc("names.unique.hit");
                 return name;
+            } else {
+                counterInc("names.hash_collision.unique");
             }
         }
         bucketId = (bucketId + probeCount) & mask;
@@ -1712,7 +1739,7 @@ NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef ori
 }
 
 NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef original, uint32_t num) {
-    ENFORCE_NO_TIMER(num > 0, "num == 0, name overflow");
+    ENFORCE(num > 0, "num == 0, name overflow");
     const auto hs = hashMixUnique(uniqueNameKind, num, original.rawId());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
@@ -1725,7 +1752,10 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
             auto name = NameRef::fromRaw(*this, bucket.rawId);
             if (name.kind() == NameKind::UNIQUE && name.dataUnique(*this)->uniqueNameKind == uniqueNameKind &&
                 name.dataUnique(*this)->num == num && name.dataUnique(*this)->original == original) {
+                counterInc("names.unique.hit");
                 return name;
+            } else {
+                counterInc("names.hash_collision.unique");
             }
         }
         bucketId = (bucketId + probeCount) & mask;
@@ -1734,7 +1764,7 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
     if (probeCount == hashTableSize) {
         Exception::raise("Full table?");
     }
-    ENFORCE_NO_TIMER(!nameTableFrozen);
+    ENFORCE(!nameTableFrozen);
 
     if (uniqueNames.size() == uniqueNames.capacity()) {
         expandNames(utf8Names.capacity(), constantNames.capacity(), uniqueNames.capacity() * 2);
@@ -1762,7 +1792,7 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
 }
 
 FileRef GlobalState::enterFile(const shared_ptr<File> &file) {
-    ENFORCE_NO_TIMER(!fileTableFrozen);
+    ENFORCE(!fileTableFrozen);
 
     SLOW_DEBUG_ONLY(for (auto &f
                          : this->files) {
@@ -1785,10 +1815,10 @@ FileRef GlobalState::enterFile(string_view path, string_view source) {
 }
 
 FileRef GlobalState::enterNewFileAt(const shared_ptr<File> &file, FileRef id) {
-    ENFORCE_NO_TIMER(!fileTableFrozen);
-    ENFORCE_NO_TIMER(id.id() < this->files.size());
-    ENFORCE_NO_TIMER(this->files[id.id()]->sourceType == File::Type::NotYetRead);
-    ENFORCE_NO_TIMER(this->files[id.id()]->path() == file->path());
+    ENFORCE(!fileTableFrozen);
+    ENFORCE(id.id() < this->files.size());
+    ENFORCE(this->files[id.id()]->sourceType == File::Type::NotYetRead);
+    ENFORCE(this->files[id.id()]->path() == file->path());
 
     // was a tombstone before.
     this->files[id.id()] = file;
@@ -1816,9 +1846,9 @@ void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef origName, U
     auto ownerData = owner.data(*this);
     auto &ownerMembers = ownerData->members();
     auto fnd = ownerMembers.find(origName);
-    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
-    ENFORCE_NO_TIMER(fnd->second == what);
-    ENFORCE_NO_TIMER(what.data(*this)->name == origName);
+    ENFORCE(fnd != ownerMembers.end());
+    ENFORCE(fnd->second == what);
+    ENFORCE(what.data(*this)->name == origName);
     NameRef name;
     if (kind == UniqueNameKind::MangleRename) {
         name = nextMangledName(owner, origName);
@@ -1831,7 +1861,7 @@ void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef origName, U
         //
         // We know that there is no method with this name, because otherwise resolver would not have
         // called mangleRenameForOverload.
-        ENFORCE_NO_TIMER(kind == UniqueNameKind::MangleRenameOverload);
+        ENFORCE(kind == UniqueNameKind::MangleRenameOverload);
         name = freshNameUnique(UniqueNameKind::MangleRenameOverload, origName, 1);
     }
     // Both branches of the above `if` condition should ENFORCE this (either due to the loop post
@@ -1875,14 +1905,14 @@ void GlobalState::mangleRenameForOverload(MethodRef what, NameRef origName) {
 // similar to mangleRenameMethod, so it's nice to have the implementation in the same file). But in
 // spirit, this is a private Namer helper function.
 void GlobalState::deleteMethodSymbol(MethodRef what) {
-    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE(!symbolTableFrozen);
 
     const auto &whatData = what.data(*this);
     auto owner = whatData->owner;
     auto &ownerMembers = owner.data(*this)->members();
     auto fnd = ownerMembers.find(whatData->name);
-    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
-    ENFORCE_NO_TIMER(fnd->second == what);
+    ENFORCE(fnd != ownerMembers.end());
+    ENFORCE(fnd->second == what);
     ownerMembers.erase(fnd);
     for (const auto typeArgument : whatData->typeArguments()) {
         this->typeArguments[typeArgument.id()] = this->typeArguments[0].deepCopy(*this);
@@ -1895,21 +1925,21 @@ void GlobalState::deleteMethodSymbol(MethodRef what) {
 //
 // NOTE: This method does double duty, deleting both static-field and field symbols.
 void GlobalState::deleteFieldSymbol(FieldRef what) {
-    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE(!symbolTableFrozen);
 
     const auto &whatData = what.data(*this);
     auto owner = whatData->owner;
     auto &ownerMembers = owner.data(*this)->members();
     auto fnd = ownerMembers.find(whatData->name);
-    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
-    ENFORCE_NO_TIMER(fnd->second == what);
+    ENFORCE(fnd != ownerMembers.end());
+    ENFORCE(fnd->second == what);
     ownerMembers.erase(fnd);
     this->fields[what.id()] = this->fields[0].deepCopy(*this);
 }
 
 // Before using this method, double check the disclaimer on GlobalState::deleteMethodSymbol above.
 void GlobalState::deleteTypeMemberSymbol(TypeMemberRef what) {
-    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE(!symbolTableFrozen);
 
     const auto &whatData = what.data(*this);
     // Should always be a class or module for type members, but we use core::TypeParameter to model both
@@ -1918,13 +1948,13 @@ void GlobalState::deleteTypeMemberSymbol(TypeMemberRef what) {
 
     auto &ownerMembers = owner.data(*this)->members();
     auto fndMember = ownerMembers.find(whatData->name);
-    ENFORCE_NO_TIMER(fndMember != ownerMembers.end());
-    ENFORCE_NO_TIMER(fndMember->second == what);
+    ENFORCE(fndMember != ownerMembers.end());
+    ENFORCE(fndMember->second == what);
     ownerMembers.erase(fndMember);
 
     auto &ownerTypeMembers = owner.data(*this)->existingTypeMembers();
     auto fndTypeMember = absl::c_find(ownerTypeMembers, what);
-    ENFORCE_NO_TIMER(fndTypeMember != ownerTypeMembers.end());
+    ENFORCE(fndTypeMember != ownerTypeMembers.end());
     ownerTypeMembers.erase(fndTypeMember);
 
     this->typeMembers[what.id()] = this->typeMembers[0].deepCopy(*this);
@@ -1978,38 +2008,25 @@ string GlobalState::toStringWithOptions(bool showFull, bool showRaw) const {
     return Symbols::root().toStringWithOptions(*this, 0, showFull, showRaw);
 }
 
-void GlobalState::sanityCheckTableSizes() const {
-    if constexpr (!debug_mode) {
+void GlobalState::sanityCheck() const {
+    if (!debug_mode) {
         return;
     }
-    if constexpr (fuzz_mode) {
+    if (fuzz_mode) {
         // it's very slow to check this and it didn't find bugs
         return;
     }
 
-    Timer timeit(tracer(), "GlobalState::sanityCheckTableSizes");
-    ENFORCE_NO_TIMER(namesUsedTotal() > 0, "empty name table size");
-    ENFORCE_NO_TIMER(!strings.empty(), "empty string table size");
-    ENFORCE_NO_TIMER(!namesByHash.empty(), "empty name hash table size");
-    ENFORCE_NO_TIMER((namesByHash.size() & (namesByHash.size() - 1)) == 0,
-                     "name hash table size is not a power of two");
-    ENFORCE_NO_TIMER(nextPowerOfTwo(utf8Names.capacity() + constantNames.capacity() + uniqueNames.capacity()) * 2 ==
-                         namesByHash.capacity(),
-                     "name table and hash name table sizes out of sync names.capacity={} namesByHash.capacity={}",
-                     namesUsedTotal(), namesByHash.capacity());
-    ENFORCE_NO_TIMER(namesByHash.size() == namesByHash.capacity(), "hash name table not at full capacity");
-}
-
-void GlobalState::sanityCheckNames() const {
-    if constexpr (!debug_mode) {
-        return;
-    }
-    if constexpr (fuzz_mode) {
-        // it's very slow to check this and it didn't find bugs
-        return;
-    }
-
-    Timer timeit(tracer(), "GlobalState::sanityCheck (names)");
+    Timer timeit(tracer(), "GlobalState::sanityCheck");
+    ENFORCE(namesUsedTotal() > 0, "empty name table size");
+    ENFORCE(!strings.empty(), "empty string table size");
+    ENFORCE(!namesByHash.empty(), "empty name hash table size");
+    ENFORCE((namesByHash.size() & (namesByHash.size() - 1)) == 0, "name hash table size is not a power of two");
+    ENFORCE(nextPowerOfTwo(utf8Names.capacity() + constantNames.capacity() + uniqueNames.capacity()) * 2 ==
+                namesByHash.capacity(),
+            "name table and hash name table sizes out of sync names.capacity={} namesByHash.capacity={}",
+            namesUsedTotal(), namesByHash.capacity());
+    ENFORCE(namesByHash.size() == namesByHash.capacity(), "hash name table not at full capacity");
 
     for (uint32_t i = 0; i < utf8Names.size(); i++) {
         NameRef(*this, NameKind::UTF8, i).sanityCheck(*this);
@@ -2022,70 +2039,52 @@ void GlobalState::sanityCheckNames() const {
     for (uint32_t i = 0; i < uniqueNames.size(); i++) {
         NameRef(*this, NameKind::UNIQUE, i).sanityCheck(*this);
     }
-}
 
-void GlobalState::sanityCheck() const {
-    if constexpr (!debug_mode) {
-        return;
-    }
-    if constexpr (fuzz_mode) {
-        // it's very slow to check this and it didn't find bugs
-        return;
+    int i = -1;
+    for (auto &sym : classAndModules) {
+        i++;
+        if (i != 0) {
+            sym.sanityCheck(*this);
+        }
     }
 
-    Timer timeit(tracer(), "GlobalState::sanityCheck");
-
-    sanityCheckTableSizes();
-    sanityCheckNames();
-
-    {
-        Timer timeit(tracer(), "GlobalState::sanityCheck (symbols)");
-        int i = -1;
-        for (auto &sym : classAndModules) {
-            i++;
-            if (i != 0) {
-                sym.sanityCheck(*this);
-            }
+    i = -1;
+    for (auto &sym : methods) {
+        i++;
+        if (i != 0) {
+            sym.sanityCheck(*this);
         }
+    }
 
-        i = -1;
-        for (auto &sym : methods) {
-            i++;
-            if (i != 0) {
-                sym.sanityCheck(*this);
-            }
+    i = -1;
+    for (auto &sym : fields) {
+        i++;
+        if (i != 0) {
+            sym.sanityCheck(*this);
         }
+    }
 
-        i = -1;
-        for (auto &sym : fields) {
-            i++;
-            if (i != 0) {
-                sym.sanityCheck(*this);
-            }
+    i = -1;
+    for (auto &sym : typeArguments) {
+        i++;
+        if (i != 0) {
+            sym.sanityCheck(*this);
         }
+    }
 
-        i = -1;
-        for (auto &sym : typeArguments) {
-            i++;
-            if (i != 0) {
-                sym.sanityCheck(*this);
-            }
+    i = -1;
+    for (auto &sym : typeMembers) {
+        i++;
+        if (i != 0) {
+            sym.sanityCheck(*this);
         }
-
-        i = -1;
-        for (auto &sym : typeMembers) {
-            i++;
-            if (i != 0) {
-                sym.sanityCheck(*this);
-            }
+    }
+    for (auto &ent : namesByHash) {
+        if (ent.rawId == 0) {
+            continue;
         }
-        for (auto &ent : namesByHash) {
-            if (ent.rawId == 0) {
-                continue;
-            }
-            ENFORCE_NO_TIMER(ent.hash == hashNameRef(*this, NameRef::fromRaw(*this, ent.rawId)),
-                             "name hash table corruption");
-        }
+        ENFORCE_NO_TIMER(ent.hash == hashNameRef(*this, NameRef::fromRaw(*this, ent.rawId)),
+                         "name hash table corruption");
     }
 }
 
@@ -2262,7 +2261,7 @@ void GlobalState::mergeFileTable(const core::GlobalState &from) {
         if (fileIdx < this->filesUsed() && from.files[fileIdx].get() == this->files[fileIdx].get()) {
             continue;
         }
-        ENFORCE_NO_TIMER(fileIdx >= this->filesUsed() || this->files[fileIdx]->sourceType == File::Type::NotYetRead);
+        ENFORCE(fileIdx >= this->filesUsed() || this->files[fileIdx]->sourceType == File::Type::NotYetRead);
         this->enterNewFileAt(from.files[fileIdx], fileIdx);
     }
 }
@@ -2307,12 +2306,12 @@ void GlobalState::ignoreErrorClassForSuggestTyped(int code) {
 }
 
 void GlobalState::suppressErrorClass(int code) {
-    ENFORCE_NO_TIMER(onlyErrorClasses.empty());
+    ENFORCE(onlyErrorClasses.empty());
     suppressedErrorClasses.insert(code);
 }
 
 void GlobalState::onlyShowErrorClass(int code) {
-    ENFORCE_NO_TIMER(suppressedErrorClasses.empty());
+    ENFORCE(suppressedErrorClasses.empty());
     onlyErrorClasses.insert(code);
 }
 
@@ -2353,7 +2352,7 @@ bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
             }
         }
     }
-    ENFORCE_NO_TIMER(level <= StrictLevel::Strong);
+    ENFORCE(level <= StrictLevel::Strong);
 
     return level >= what.minLevel;
 }
@@ -2370,7 +2369,7 @@ void GlobalState::markAsPayload() {
     bool seenEmpty = false;
     for (auto &f : files) {
         if (!seenEmpty) {
-            ENFORCE_NO_TIMER(!f);
+            ENFORCE(!f);
             seenEmpty = true;
             continue;
         }
@@ -2379,8 +2378,8 @@ void GlobalState::markAsPayload() {
 }
 
 void GlobalState::replaceFile(FileRef whatFile, const shared_ptr<File> &withWhat) {
-    ENFORCE_NO_TIMER(whatFile.id() < filesUsed());
-    ENFORCE_NO_TIMER(whatFile.dataAllowingUnsafe(*this).path() == withWhat->path());
+    ENFORCE(whatFile.id() < filesUsed());
+    ENFORCE(whatFile.dataAllowingUnsafe(*this).path() == withWhat->path());
     files[whatFile.id()] = withWhat;
 }
 
@@ -2401,7 +2400,7 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &extraPackag
                                      const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
                                      const std::vector<std::string> &allowRelaxedPackagerChecksFor,
                                      std::string errorHint) {
-    ENFORCE_NO_TIMER(!packageDB_.frozen);
+    ENFORCE(!packageDB_.frozen);
 
     packageDB_.enabled_ = true;
     packageDB_.extraPackageFilesDirectoryUnderscorePrefixes_ = extraPackageFilesDirectoryUnderscorePrefixes;
@@ -2423,7 +2422,7 @@ packages::UnfreezePackages GlobalState::unfreezePackages() {
 }
 
 unique_ptr<GlobalState> GlobalState::markFileAsTombStone(unique_ptr<GlobalState> what, FileRef fref) {
-    ENFORCE_NO_TIMER(fref.id() < what->filesUsed());
+    ENFORCE(fref.id() < what->filesUsed());
     what->files[fref.id()]->sourceType = File::Type::TombStone;
     return what;
 }
@@ -2496,7 +2495,7 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
                 classAliasHash = mix(classAliasHash, symhash);
             }
         } else {
-            ENFORCE_NO_TIMER(field.flags.isField);
+            ENFORCE(field.flags.isField);
             auto &target = retypecheckableSymbolHashesMap[WithoutUniqueNameHash(*this, field.name)];
             target = mix(target, symhash);
         }
@@ -2568,8 +2567,7 @@ MethodRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {
 MethodRef GlobalState::lookupStaticInitForClass(ClassOrModuleRef klass, bool allowMissing) const {
     auto classData = klass.data(*this);
     auto ref = classData->lookupSingletonClass(*this).data(*this)->findMethod(*this, core::Names::staticInit());
-    ENFORCE_NO_TIMER(ref.exists() || allowMissing, "looking up non-existent <static-init> for {}",
-                     klass.toString(*this));
+    ENFORCE(ref.exists() || allowMissing, "looking up non-existent <static-init> for {}", klass.toString(*this));
     return ref;
 }
 
@@ -2591,7 +2589,7 @@ MethodRef GlobalState::staticInitForFile(Loc loc) {
 MethodRef GlobalState::lookupStaticInitForFile(FileRef file) const {
     auto nm = lookupNameUnique(core::UniqueNameKind::Namer, core::Names::staticInit(), file.id());
     auto ref = core::Symbols::rootSingleton().data(*this)->findMember(*this, nm);
-    ENFORCE_NO_TIMER(ref.exists(), "looking up non-existent <static-init> for {}", file.data(*this).path());
+    ENFORCE(ref.exists(), "looking up non-existent <static-init> for {}", file.data(*this).path());
     return ref.asMethodRef();
 }
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -194,8 +194,6 @@ public:
     unsigned int filesUsed() const;
     unsigned int symbolsUsedTotal() const;
 
-    void sanityCheckTableSizes() const;
-    void sanityCheckNames() const;
     void sanityCheck() const;
     void markAsPayload();
 

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -36,7 +36,7 @@ Loc Loc::join(Loc other) const {
     if (!other.exists()) {
         return *this;
     }
-    ENFORCE_NO_TIMER(this->file() == other.file(), "joining locations from different files");
+    ENFORCE(this->file() == other.file(), "joining locations from different files");
     return Loc(this->file(), min(this->beginPos(), other.beginPos()), max(this->endPos(), other.endPos()));
 }
 
@@ -46,7 +46,7 @@ Loc::Detail Loc::offset2Pos(const File &file, uint32_t off) {
     if (off > file.source().size()) {
         fatalLogger->error(R"(msg="Bad offset2Pos off" path="{}" off="{}"")", absl::CEscape(file.path()), off);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
-        ENFORCE_NO_TIMER(false);
+        ENFORCE(false);
     }
     auto it = absl::c_lower_bound(file.lineBreaks(), off);
     if (it == file.lineBreaks().begin()) {
@@ -128,7 +128,7 @@ void addLocLine(stringstream &buf, int line, const File &file, int tabs, int pos
     if (file.lineBreaks().size() <= line + 1) {
         fatalLogger->error(R"(msg="Bad addLocLine line" path="{}" line="{}"")", absl::CEscape(file.path()), line);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
-        ENFORCE_NO_TIMER(false);
+        ENFORCE(false);
     }
     auto endPos = file.lineBreaks()[line + 1];
     auto numToWrite = endPos - file.lineBreaks()[line] - 1;
@@ -140,13 +140,13 @@ void addLocLine(stringstream &buf, int line, const File &file, int tabs, int pos
         fatalLogger->error(R"(msg="Bad addLocLine offset" path="{}" line="{}" offset="{}")", absl::CEscape(file.path()),
                            line, offset);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
-        ENFORCE_NO_TIMER(false);
+        ENFORCE(false);
     }
     if (offset + numToWrite > file.source().size()) {
         fatalLogger->error(R"(msg="Bad addLocLine write size" path="{}" line="{}" offset="{}" numToWrite="{}")",
                            absl::CEscape(file.path()), line, offset, numToWrite);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
-        ENFORCE_NO_TIMER(false);
+        ENFORCE(false);
     }
     buf.write(file.source().data() + offset, numToWrite);
 }
@@ -371,7 +371,7 @@ Loc Loc::adjustLen(const GlobalState &gs, int32_t beginAdjust, int32_t len) cons
 pair<Loc, uint32_t> Loc::findStartOfLine(const GlobalState &gs) const {
     auto startDetail = this->position(gs).first;
     auto maybeLineStart = Loc::pos2Offset(this->file().data(gs), {startDetail.line, 1});
-    ENFORCE_NO_TIMER(maybeLineStart.has_value());
+    ENFORCE(maybeLineStart.has_value());
     auto lineStart = maybeLineStart.value();
     std::string_view lineView = this->file().data(gs).source().substr(lineStart);
 

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -73,9 +73,9 @@ public:
     }
 
     inline Loc(FileRef file, uint32_t begin, uint32_t end) : storage{{begin, end}, file} {
-        ENFORCE_NO_TIMER(begin <= INVALID_POS_LOC);
-        ENFORCE_NO_TIMER(end <= INVALID_POS_LOC);
-        ENFORCE_NO_TIMER(begin <= end);
+        ENFORCE(begin <= INVALID_POS_LOC);
+        ENFORCE(end <= INVALID_POS_LOC);
+        ENFORCE(begin <= end);
     }
 
     inline Loc(FileRef file, LocOffsets offsets) : Loc(file, offsets.beginPos(), offsets.endPos()){};

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -156,7 +156,7 @@ string_view NameRef::shortName(const GlobalState &gs) const {
 }
 
 void NameRef::sanityCheck(const GlobalState &gs) const {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
     switch (kind()) {
@@ -203,7 +203,7 @@ bool NameRef::isClassName(const GlobalState &gs) const {
                     return false;
             }
         case NameKind::CONSTANT:
-            ENFORCE_NO_TIMER(dataCnst(gs)->original.isValidConstantName(gs));
+            ENFORCE(dataCnst(gs)->original.isValidConstantName(gs));
             return true;
     }
 }
@@ -447,7 +447,7 @@ UTF8NameData::UTF8NameData(const UTF8Name &ref, const GlobalState &gs) : DebugOn
 NameDataDebugCheck::NameDataDebugCheck(const GlobalState &gs) : gs(gs), nameCountAtCreation(gs.namesUsedTotal()) {}
 
 void NameDataDebugCheck::check() const {
-    ENFORCE_NO_TIMER(nameCountAtCreation == gs.namesUsedTotal());
+    ENFORCE(nameCountAtCreation == gs.namesUsedTotal());
 }
 
 const UniqueName *UniqueNameData::operator->() const {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -811,7 +811,7 @@ vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findMemberFuzzyMatch(con
     // Don't run under the fuzzer, as otherwise fuzzy match dominates runtime.
     // N.B.: There are benefits to running this method under the fuzzer; we have found bugs in this method before
     // via fuzzing (e.g. https://github.com/sorbet/sorbet/issues/128).
-    if constexpr (fuzz_mode) {
+    if (fuzz_mode) {
         return res;
     }
 
@@ -2259,7 +2259,7 @@ int ClassOrModule::typeArity(const GlobalState &gs) const {
 }
 
 void ClassOrModule::sanityCheck(const GlobalState &gs) const {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
     ClassOrModuleRef current = this->ref(gs);
@@ -2276,7 +2276,7 @@ void ClassOrModule::sanityCheck(const GlobalState &gs) const {
 }
 
 void Method::sanityCheck(const GlobalState &gs) const {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
     MethodRef current = this->ref(gs);
@@ -2305,7 +2305,7 @@ void Method::sanityCheck(const GlobalState &gs) const {
 }
 
 void Field::sanityCheck(const GlobalState &gs) const {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
     FieldRef current = this->ref(gs);
@@ -2322,7 +2322,7 @@ void Field::sanityCheck(const GlobalState &gs) const {
 }
 
 void TypeParameter::sanityCheck(const GlobalState &gs) const {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
     SymbolRef current = this->ref(gs);

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -61,7 +61,7 @@ GENERATE_CALL_MEMBER(underlying,
 } // namespace
 
 void TypePtr::deleteTagged(Tag tag, void *ptr) noexcept {
-    ENFORCE_NO_TIMER(ptr != nullptr);
+    ENFORCE(ptr != nullptr);
 
 #define DELETE_TYPE(T) delete reinterpret_cast<T *>(ptr);
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -120,7 +120,7 @@ private:
         val |= static_cast<tagged_storage>(inlinedValue) << 16;
 
         // Asserts that tag isn't using the bit which we use to indicate that value is _not_ inlined.
-        ENFORCE_NO_TIMER((val & NOT_INLINED_MASK) == 0);
+        ENFORCE((val & NOT_INLINED_MASK) == 0);
 
         return val;
     }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -132,7 +132,7 @@ void Pickler::putU1(uint8_t u) {
 }
 
 uint8_t UnPickler::getU1() {
-    ENFORCE_NO_TIMER(zeroCounter == 0);
+    ENFORCE(zeroCounter == 0);
     auto res = data[pos++];
     return res;
 }
@@ -477,7 +477,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         case TypePtr::Tag::ShapeType: {
             auto &hash = cast_type_nonnull<ShapeType>(what);
             p.putU4(hash.keys.size());
-            ENFORCE_NO_TIMER(hash.keys.size() == hash.values.size());
+            ENFORCE(hash.keys.size() == hash.values.size());
             for (auto &el : hash.keys) {
                 pickle(p, el);
             }
@@ -753,8 +753,8 @@ ClassOrModule SerializerImpl::unpickleClassOrModule(UnPickler &p, const GlobalSt
         auto sym = SymbolRef::fromRaw(p.getU4());
         if (result.name != core::Names::Constants::Root() && result.name != core::Names::Constants::NoSymbol() &&
             result.name != core::Names::noMethod()) {
-            ENFORCE_NO_TIMER(name.exists());
-            ENFORCE_NO_TIMER(sym.exists());
+            ENFORCE(name.exists());
+            ENFORCE(sym.exists());
         }
         result.members()[name] = sym;
     }
@@ -951,19 +951,19 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
         Timer timeit(result.tracer(), "readNames");
 
         int namesSize = p.getU4();
-        ENFORCE_NO_TIMER(namesSize > 0);
+        ENFORCE(namesSize > 0);
         utf8Names.reserve(nextPowerOfTwo(namesSize));
         for (int i = 0; i < namesSize; i++) {
             utf8Names.emplace_back(unpickleUTF8Name(p, result));
         }
         namesSize = p.getU4();
-        ENFORCE_NO_TIMER(namesSize > 0);
+        ENFORCE(namesSize > 0);
         constantNames.reserve(nextPowerOfTwo(namesSize));
         for (int i = 0; i < namesSize; i++) {
             constantNames.emplace_back(unpickleConstantName(p, result));
         }
         namesSize = p.getU4();
-        ENFORCE_NO_TIMER(namesSize > 0);
+        ENFORCE(namesSize > 0);
         uniqueNames.reserve(nextPowerOfTwo(namesSize));
         for (int i = 0; i < namesSize; i++) {
             uniqueNames.emplace_back(unpickleUniqueName(p, result));
@@ -974,35 +974,35 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
         Timer timeit(result.tracer(), "readSymbols");
 
         int classAndModuleSize = p.getU4();
-        ENFORCE_NO_TIMER(classAndModuleSize > 0);
+        ENFORCE(classAndModuleSize > 0);
         classAndModules.reserve(nextPowerOfTwo(classAndModuleSize));
         for (int i = 0; i < classAndModuleSize; i++) {
             classAndModules.emplace_back(unpickleClassOrModule(p, &result));
         }
 
         int methodSize = p.getU4();
-        ENFORCE_NO_TIMER(methodSize > 0);
+        ENFORCE(methodSize > 0);
         methods.reserve(nextPowerOfTwo(methodSize));
         for (int i = 0; i < methodSize; i++) {
             methods.emplace_back(unpickleMethod(p, &result));
         }
 
         int fieldSize = p.getU4();
-        ENFORCE_NO_TIMER(fieldSize > 0);
+        ENFORCE(fieldSize > 0);
         fields.reserve(nextPowerOfTwo(fieldSize));
         for (int i = 0; i < fieldSize; i++) {
             fields.emplace_back(unpickleField(p, &result));
         }
 
         int typeArgumentSize = p.getU4();
-        ENFORCE_NO_TIMER(typeArgumentSize > 0);
+        ENFORCE(typeArgumentSize > 0);
         typeArguments.reserve(nextPowerOfTwo(typeArgumentSize));
         for (int i = 0; i < typeArgumentSize; i++) {
             typeArguments.emplace_back(unpickleTypeParameter(p, &result));
         }
 
         int typeMemberSize = p.getU4();
-        ENFORCE_NO_TIMER(typeMemberSize > 0);
+        ENFORCE(typeMemberSize > 0);
         typeMembers.reserve(nextPowerOfTwo(typeMemberSize));
         for (int i = 0; i < typeMemberSize; i++) {
             typeMembers.emplace_back(unpickleTypeParameter(p, &result));
@@ -1080,8 +1080,8 @@ std::vector<uint8_t> Serializer::storePayloadAndNameTable(const GlobalState &gs)
 }
 
 void Serializer::loadGlobalState(GlobalState &gs, const uint8_t *const data) {
-    ENFORCE_NO_TIMER(gs.files.empty() && gs.namesUsedTotal() == 0 && gs.symbolsUsedTotal() == 0,
-                     "Can't load into a non-empty state");
+    ENFORCE(gs.files.empty() && gs.namesUsedTotal() == 0 && gs.symbolsUsedTotal() == 0,
+            "Can't load into a non-empty state");
     UnPickler p(data, gs.tracer());
     SerializerImpl::unpickleGS(p, gs);
 }
@@ -1252,7 +1252,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
         case ast::Tag::Hash: {
             auto &h = ast::cast_tree_nonnull<ast::Hash>(what);
             pickle(p, h.loc);
-            ENFORCE_NO_TIMER(h.values.size() == h.keys.size());
+            ENFORCE(h.values.size() == h.keys.size());
             p.putU4(h.values.size());
             for (auto &v : h.values) {
                 pickle(p, v);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -216,7 +216,7 @@ void KnowledgeFact::min(core::Context ctx, const KnowledgeFact &other) {
 }
 
 void KnowledgeFact::sanityCheck() const {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
     for (auto &a : yesTypeTests) {
@@ -353,7 +353,7 @@ void TestedKnowledge::emitKnowledgeSizeMetric() const {
 }
 
 void TestedKnowledge::sanityCheck() const {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
     _truthy->sanityCheck();

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -260,7 +260,7 @@ uint32_t ErrorReporter::lastDiagnosticEpochForFile(core::FileRef file) {
 }
 
 void ErrorReporter::sanityCheck() const {
-    if constexpr (!debug_mode) {
+    if (!debug_mode) {
         return;
     }
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -614,6 +614,8 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
         return empty;
     }
 
+    gs.sanityCheck();
+
     if (files.size() < 3) {
         // Run singlethreaded if only using 2 files
         for (auto file : files) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3919,7 +3919,7 @@ private:
             },
 
             [&](ast::MethodDef &mdef) {
-                if constexpr (debug_mode) {
+                if (debug_mode) {
                     bool hasSig = !lastSigs.empty();
                     bool rewritten = mdef.flags.isRewriterSynthesized;
                     bool isRBI = ctx.file.data(ctx).isRBI();


### PR DESCRIPTION
This reverts commit 5101acfc7268f63cbab1ca714c19529bf432b665.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Somehow this caused CI to become flaky?


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```
bazel test --config=buildfarm-sanitized-linux --test_summary=terse --build_tests_only //test/lsp:multithreaded_protocol_test_corpus --runs_per_test=200
```

This failed with a 7% rate on my devbox with the changes in #8050, and didn't
fail at all without those changes.