### PR TITLE
Reapply all the good changes from #8050

### DIFF
--- a/ast/verifier/Verifier.cc
+++ b/ast/verifier/Verifier.cc
@@ -36,7 +36,7 @@ public:
 };
 
 ExpressionPtr Verifier::run(core::Context ctx, ExpressionPtr node) {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return node;
     }
     VerifierWalker vw;

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -186,7 +186,7 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
 }
 
 void CFG::sanityCheck(core::Context ctx) {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
 

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -108,7 +108,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
 }
 
 void CFGBuilder::sanityCheck(core::Context ctx, CFG &cfg) {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
     for (auto &bb : cfg.basicBlocks) {

--- a/common/backtrace.cc
+++ b/common/backtrace.cc
@@ -58,7 +58,7 @@ void sorbet::Exception::printBacktrace() noexcept {
 void sorbet::Exception::printBacktrace() noexcept {}
 #endif // ifndef EMSCRIPTEN
 void sorbet::Exception::failInFuzzer() noexcept {
-    if (fuzz_mode) {
+    if constexpr (fuzz_mode) {
         __builtin_trap();
     }
 }

--- a/common/common.h
+++ b/common/common.h
@@ -60,9 +60,9 @@ constexpr bool skip_slow_enforce = false;
         }                                   \
     } while (false);
 
-#define DEBUG_ONLY(X) \
-    if (debug_mode) { \
-        X;            \
+#define DEBUG_ONLY(X)           \
+    if constexpr (debug_mode) { \
+        X;                      \
     }
 
 #define SLOW_DEBUG_ONLY(X)                                      \

--- a/common/counters/Counters.cc
+++ b/common/counters/Counters.cc
@@ -51,7 +51,7 @@ void CounterImpl::histogramAdd(const char *histogram, int key, unsigned long val
 }
 
 void CounterImpl::prodHistogramAdd(const char *histogram, int key, unsigned long value) {
-    if (fuzz_mode) {
+    if constexpr (fuzz_mode) {
         return;
     }
     this->histograms[histogram][key] += value;
@@ -65,7 +65,7 @@ void CounterImpl::categoryCounterAdd(const char *category, const char *counter, 
 }
 
 void CounterImpl::prodCategoryCounterAdd(const char *category, const char *counter, unsigned long value) {
-    if (fuzz_mode) {
+    if constexpr (fuzz_mode) {
         return;
     }
     this->countersByCategory[category][counter] += value;
@@ -79,21 +79,21 @@ void CounterImpl::counterAdd(const char *counter, unsigned long value) {
 }
 
 void CounterImpl::prodCounterAdd(const char *counter, unsigned long value) {
-    if (fuzz_mode) {
+    if constexpr (fuzz_mode) {
         return;
     }
     this->counters[counter] += value;
 }
 
 void CounterImpl::prodCounterSet(const char *counter, unsigned long value) {
-    if (fuzz_mode) {
+    if constexpr (fuzz_mode) {
         return;
     }
     this->counters[counter] = value;
 }
 
 void CounterImpl::timingAdd(CounterImpl::Timing timing) {
-    if (fuzz_mode) {
+    if constexpr (fuzz_mode) {
         return;
     }
     this->timings.emplace_back(move(timing));

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -105,7 +105,7 @@ FoundDefinitionRef FoundStaticFieldHash::owner() const {
 }
 
 void FoundStaticFieldHash::sanityCheck() const {
-    ENFORCE(nameHash.isDefined());
+    ENFORCE_NO_TIMER(nameHash.isDefined());
 }
 
 string FoundStaticFieldHash::toString() const {
@@ -122,7 +122,7 @@ FoundDefinitionRef FoundTypeMemberHash::owner() const {
 }
 
 void FoundTypeMemberHash::sanityCheck() const {
-    ENFORCE(nameHash.isDefined());
+    ENFORCE_NO_TIMER(nameHash.isDefined());
 }
 
 string FoundTypeMemberHash::toString() const {
@@ -140,7 +140,7 @@ FoundDefinitionRef FoundMethodHash::owner() const {
 }
 
 void FoundMethodHash::sanityCheck() const {
-    ENFORCE(nameHash.isDefined());
+    ENFORCE_NO_TIMER(nameHash.isDefined());
 }
 
 string FoundMethodHash::toString() const {
@@ -158,7 +158,7 @@ FoundDefinitionRef FoundFieldHash::owner() const {
 }
 
 void FoundFieldHash::sanityCheck() const {
-    ENFORCE(nameHash.isDefined());
+    ENFORCE_NO_TIMER(nameHash.isDefined());
 }
 
 string FoundFieldHash::toString() const {

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -20,8 +20,8 @@ public:
     WithoutUniqueNameHash(const WithoutUniqueNameHash &nm) noexcept = default;
     WithoutUniqueNameHash() noexcept : _hashValue(0){};
     inline bool operator==(const WithoutUniqueNameHash &rhs) const noexcept {
-        ENFORCE(isDefined());
-        ENFORCE(rhs.isDefined());
+        ENFORCE_NO_TIMER(isDefined());
+        ENFORCE_NO_TIMER(rhs.isDefined());
         return _hashValue == rhs._hashValue;
     }
 
@@ -52,8 +52,8 @@ public:
     FullNameHash(const FullNameHash &nm) noexcept = default;
     FullNameHash() noexcept : _hashValue(0){};
     inline bool operator==(const FullNameHash &rhs) const noexcept {
-        ENFORCE(isDefined());
-        ENFORCE(rhs.isDefined());
+        ENFORCE_NO_TIMER(isDefined());
+        ENFORCE_NO_TIMER(rhs.isDefined());
         return _hashValue == rhs._hashValue;
     }
 
@@ -299,19 +299,19 @@ struct LocalSymbolTableHashes {
     bool isInvalidParse() const {
         DEBUG_ONLY(
             if (hierarchyHash == HASH_STATE_INVALID_PARSE) {
-                ENFORCE(classModuleHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(typeMemberHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(fieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(staticFieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(classAliasHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(methodHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(classModuleHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(typeMemberHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(fieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(staticFieldHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(classAliasHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(methodHash == core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
             } else {
-                ENFORCE(classModuleHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(typeMemberHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(fieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(staticFieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(classAliasHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
-                ENFORCE(methodHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(classModuleHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(typeMemberHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(fieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(staticFieldHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(classAliasHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
+                ENFORCE_NO_TIMER(methodHash != core::LocalSymbolTableHashes::HASH_STATE_INVALID_PARSE);
             });
         return hierarchyHash == HASH_STATE_INVALID_PARSE;
     }

--- a/core/FoundDefinitions.cc
+++ b/core/FoundDefinitions.cc
@@ -5,62 +5,62 @@ using namespace std;
 namespace sorbet::core {
 
 FoundClass &FoundDefinitionRef::klass(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
-    ENFORCE(foundDefs._klasses.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Class);
+    ENFORCE_NO_TIMER(foundDefs._klasses.size() > idx());
     return foundDefs._klasses[idx()];
 }
 const FoundClass &FoundDefinitionRef::klass(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
-    ENFORCE(foundDefs._klasses.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Class);
+    ENFORCE_NO_TIMER(foundDefs._klasses.size() > idx());
     return foundDefs._klasses[idx()];
 }
 
 FoundMethod &FoundDefinitionRef::method(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
-    ENFORCE(foundDefs._methods.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Method);
+    ENFORCE_NO_TIMER(foundDefs._methods.size() > idx());
     return foundDefs._methods[idx()];
 }
 const FoundMethod &FoundDefinitionRef::method(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
-    ENFORCE(foundDefs._methods.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Method);
+    ENFORCE_NO_TIMER(foundDefs._methods.size() > idx());
     return foundDefs._methods[idx()];
 }
 
 FoundStaticField &FoundDefinitionRef::staticField(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
-    ENFORCE(foundDefs._staticFields.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::StaticField);
+    ENFORCE_NO_TIMER(foundDefs._staticFields.size() > idx());
     return foundDefs._staticFields[idx()];
 }
 const FoundStaticField &FoundDefinitionRef::staticField(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
-    ENFORCE(foundDefs._staticFields.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::StaticField);
+    ENFORCE_NO_TIMER(foundDefs._staticFields.size() > idx());
     return foundDefs._staticFields[idx()];
 }
 
 FoundTypeMember &FoundDefinitionRef::typeMember(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
-    ENFORCE(foundDefs._typeMembers.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::TypeMember);
+    ENFORCE_NO_TIMER(foundDefs._typeMembers.size() > idx());
     return foundDefs._typeMembers[idx()];
 }
 const FoundTypeMember &FoundDefinitionRef::typeMember(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
-    ENFORCE(foundDefs._typeMembers.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::TypeMember);
+    ENFORCE_NO_TIMER(foundDefs._typeMembers.size() > idx());
     return foundDefs._typeMembers[idx()];
 }
 
 FoundField &FoundDefinitionRef::field(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Field);
-    ENFORCE(foundDefs._fields.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Field);
+    ENFORCE_NO_TIMER(foundDefs._fields.size() > idx());
     return foundDefs._fields[idx()];
 }
 const FoundField &FoundDefinitionRef::field(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Field);
-    ENFORCE(foundDefs._fields.size() > idx());
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Field);
+    ENFORCE_NO_TIMER(foundDefs._fields.size() > idx());
     return foundDefs._fields[idx()];
 }
 
 core::ClassOrModuleRef FoundDefinitionRef::symbol() const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Symbol);
+    ENFORCE_NO_TIMER(kind() == FoundDefinitionRef::Kind::Symbol);
     return core::ClassOrModuleRef::fromRaw(_storage.id);
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1999,6 +1999,31 @@ void GlobalState::sanityCheckTableSizes() const {
     ENFORCE_NO_TIMER(namesByHash.size() == namesByHash.capacity(), "hash name table not at full capacity");
 }
 
+void GlobalState::sanityCheckNames() const {
+    if constexpr (!debug_mode) {
+        return;
+    }
+
+    if constexpr (fuzz_mode) {
+        // it's very slow to check this and it didn't find bugs
+        return;
+    }
+
+    Timer timeit(tracer(), "GlobalState::sanityCheck (names)");
+
+    for (uint32_t i = 0; i < utf8Names.size(); i++) {
+        NameRef(*this, NameKind::UTF8, i).sanityCheck(*this);
+    }
+
+    for (uint32_t i = 0; i < constantNames.size(); i++) {
+        NameRef(*this, NameKind::CONSTANT, i).sanityCheck(*this);
+    }
+
+    for (uint32_t i = 0; i < uniqueNames.size(); i++) {
+        NameRef(*this, NameKind::UNIQUE, i).sanityCheck(*this);
+    }
+}
+
 void GlobalState::sanityCheck() const {
     if constexpr (!debug_mode) {
         return;
@@ -2011,21 +2036,7 @@ void GlobalState::sanityCheck() const {
     Timer timeit(tracer(), "GlobalState::sanityCheck");
 
     sanityCheckTableSizes();
-
-    {
-        Timer timeit(tracer(), "GlobalState::sanityCheck (names)");
-        for (uint32_t i = 0; i < utf8Names.size(); i++) {
-            NameRef(*this, NameKind::UTF8, i).sanityCheck(*this);
-        }
-
-        for (uint32_t i = 0; i < constantNames.size(); i++) {
-            NameRef(*this, NameKind::CONSTANT, i).sanityCheck(*this);
-        }
-
-        for (uint32_t i = 0; i < uniqueNames.size(); i++) {
-            NameRef(*this, NameKind::UNIQUE, i).sanityCheck(*this);
-        }
-    }
+    sanityCheckNames();
 
     {
         Timer timeit(tracer(), "GlobalState::sanityCheck (symbols)");

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2028,63 +2028,69 @@ void GlobalState::sanityCheck() const {
             namesUsedTotal(), namesByHash.capacity());
     ENFORCE(namesByHash.size() == namesByHash.capacity(), "hash name table not at full capacity");
 
-    for (uint32_t i = 0; i < utf8Names.size(); i++) {
-        NameRef(*this, NameKind::UTF8, i).sanityCheck(*this);
-    }
+    {
+        Timer timeit(tracer(), "GlobalState::sanityCheck (names)");
+        for (uint32_t i = 0; i < utf8Names.size(); i++) {
+            NameRef(*this, NameKind::UTF8, i).sanityCheck(*this);
+        }
 
-    for (uint32_t i = 0; i < constantNames.size(); i++) {
-        NameRef(*this, NameKind::CONSTANT, i).sanityCheck(*this);
-    }
+        for (uint32_t i = 0; i < constantNames.size(); i++) {
+            NameRef(*this, NameKind::CONSTANT, i).sanityCheck(*this);
+        }
 
-    for (uint32_t i = 0; i < uniqueNames.size(); i++) {
-        NameRef(*this, NameKind::UNIQUE, i).sanityCheck(*this);
-    }
-
-    int i = -1;
-    for (auto &sym : classAndModules) {
-        i++;
-        if (i != 0) {
-            sym.sanityCheck(*this);
+        for (uint32_t i = 0; i < uniqueNames.size(); i++) {
+            NameRef(*this, NameKind::UNIQUE, i).sanityCheck(*this);
         }
     }
 
-    i = -1;
-    for (auto &sym : methods) {
-        i++;
-        if (i != 0) {
-            sym.sanityCheck(*this);
+    {
+        Timer timeit(tracer(), "GlobalState::sanityCheck (symbols)");
+        int i = -1;
+        for (auto &sym : classAndModules) {
+            i++;
+            if (i != 0) {
+                sym.sanityCheck(*this);
+            }
         }
-    }
 
-    i = -1;
-    for (auto &sym : fields) {
-        i++;
-        if (i != 0) {
-            sym.sanityCheck(*this);
+        i = -1;
+        for (auto &sym : methods) {
+            i++;
+            if (i != 0) {
+                sym.sanityCheck(*this);
+            }
         }
-    }
 
-    i = -1;
-    for (auto &sym : typeArguments) {
-        i++;
-        if (i != 0) {
-            sym.sanityCheck(*this);
+        i = -1;
+        for (auto &sym : fields) {
+            i++;
+            if (i != 0) {
+                sym.sanityCheck(*this);
+            }
         }
-    }
 
-    i = -1;
-    for (auto &sym : typeMembers) {
-        i++;
-        if (i != 0) {
-            sym.sanityCheck(*this);
+        i = -1;
+        for (auto &sym : typeArguments) {
+            i++;
+            if (i != 0) {
+                sym.sanityCheck(*this);
+            }
         }
-    }
-    for (auto &ent : namesByHash) {
-        if (ent.rawId == 0) {
-            continue;
+
+        i = -1;
+        for (auto &sym : typeMembers) {
+            i++;
+            if (i != 0) {
+                sym.sanityCheck(*this);
+            }
         }
-        ENFORCE_NO_TIMER(ent.hash == hashNameRef(*this, NameRef::fromRaw(*this, ent.rawId)),
-                         "name hash table corruption");
+        for (auto &ent : namesByHash) {
+            if (ent.rawId == 0) {
+                continue;
+            }
+            ENFORCE_NO_TIMER(ent.hash == hashNameRef(*this, NameRef::fromRaw(*this, ent.rawId)),
+                             "name hash table corruption");
+        }
     }
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -189,7 +189,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
         InlinedVector<core::ClassOrModuleRef, 4> currentMixins = data->mixins();
         InlinedVector<core::ClassOrModuleRef, 4> newMixins;
         for (auto mixin : currentMixins) {
-            ENFORCE(mixin != core::Symbols::PlaceholderMixin(), "Resolver failed to replace all placeholders");
+            ENFORCE_NO_TIMER(mixin != core::Symbols::PlaceholderMixin(), "Resolver failed to replace all placeholders");
             if (mixin == data->superClass()) {
                 continue;
             }
@@ -297,7 +297,7 @@ GlobalState::GlobalState(shared_ptr<ErrorQueue> errorQueue, shared_ptr<lsp::Type
     int namesByHashSize = nextPowerOfTwo(
         2 * (PAYLOAD_MAX_UTF8_NAME_COUNT + PAYLOAD_MAX_CONSTANT_NAME_COUNT + PAYLOAD_MAX_UNIQUE_NAME_COUNT));
     namesByHash.resize(namesByHashSize);
-    ENFORCE((namesByHashSize & (namesByHashSize - 1)) == 0, "namesByHashSize is not a power of 2");
+    ENFORCE_NO_TIMER((namesByHashSize & (namesByHashSize - 1)) == 0, "namesByHashSize is not a power of 2");
 }
 
 unique_ptr<GlobalState> GlobalState::makeEmptyGlobalStateForHashing(spdlog::logger &logger) {
@@ -318,162 +318,162 @@ void GlobalState::initEmpty() {
 
     ClassOrModuleRef klass;
     klass = synthesizeClass(core::Names::Constants::NoSymbol(), 0);
-    ENFORCE(klass == Symbols::noClassOrModule());
+    ENFORCE_NO_TIMER(klass == Symbols::noClassOrModule());
     MethodRef method = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noMethod());
-    ENFORCE(method == Symbols::noMethod());
+    ENFORCE_NO_TIMER(method == Symbols::noMethod());
     FieldRef field = enterFieldSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noFieldOrStaticField());
-    ENFORCE(field == Symbols::noField());
+    ENFORCE_NO_TIMER(field == Symbols::noField());
     TypeArgumentRef typeArgument =
         enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::NoTypeArgument(), Variance::CoVariant);
-    ENFORCE(typeArgument == Symbols::noTypeArgument());
+    ENFORCE_NO_TIMER(typeArgument == Symbols::noTypeArgument());
     TypeMemberRef typeMember =
         enterTypeMember(Loc::none(), Symbols::noClassOrModule(), Names::Constants::NoTypeMember(), Variance::CoVariant);
-    ENFORCE(typeMember == Symbols::noTypeMember());
+    ENFORCE_NO_TIMER(typeMember == Symbols::noTypeMember());
 
     klass = synthesizeClass(core::Names::Constants::Top(), 0);
-    ENFORCE(klass == Symbols::top());
+    ENFORCE_NO_TIMER(klass == Symbols::top());
     klass = synthesizeClass(core::Names::Constants::Bottom(), 0);
-    ENFORCE(klass == Symbols::bottom());
+    ENFORCE_NO_TIMER(klass == Symbols::bottom());
     klass = synthesizeClass(core::Names::Constants::Root(), 0);
-    ENFORCE(klass == Symbols::root());
+    ENFORCE_NO_TIMER(klass == Symbols::root());
 
     klass = core::Symbols::root().data(*this)->singletonClass(*this);
-    ENFORCE(klass == Symbols::rootSingleton());
+    ENFORCE_NO_TIMER(klass == Symbols::rootSingleton());
     klass = synthesizeClass(core::Names::Constants::Todo(), 0);
-    ENFORCE(klass == Symbols::todo());
+    ENFORCE_NO_TIMER(klass == Symbols::todo());
     klass = synthesizeClass(core::Names::Constants::Object(), Symbols::BasicObject().id());
-    ENFORCE(klass == Symbols::Object());
+    ENFORCE_NO_TIMER(klass == Symbols::Object());
     klass = synthesizeClass(core::Names::Constants::Integer());
-    ENFORCE(klass == Symbols::Integer());
+    ENFORCE_NO_TIMER(klass == Symbols::Integer());
     klass = synthesizeClass(core::Names::Constants::Float());
-    ENFORCE(klass == Symbols::Float());
+    ENFORCE_NO_TIMER(klass == Symbols::Float());
     klass = synthesizeClass(core::Names::Constants::String());
-    ENFORCE(klass == Symbols::String());
+    ENFORCE_NO_TIMER(klass == Symbols::String());
     klass = synthesizeClass(core::Names::Constants::Symbol());
-    ENFORCE(klass == Symbols::Symbol());
+    ENFORCE_NO_TIMER(klass == Symbols::Symbol());
     klass = synthesizeClass(core::Names::Constants::Array());
-    ENFORCE(klass == Symbols::Array());
+    ENFORCE_NO_TIMER(klass == Symbols::Array());
     klass = synthesizeClass(core::Names::Constants::Hash());
-    ENFORCE(klass == Symbols::Hash());
+    ENFORCE_NO_TIMER(klass == Symbols::Hash());
     klass = synthesizeClass(core::Names::Constants::TrueClass());
-    ENFORCE(klass == Symbols::TrueClass());
+    ENFORCE_NO_TIMER(klass == Symbols::TrueClass());
     klass = synthesizeClass(core::Names::Constants::FalseClass());
-    ENFORCE(klass == Symbols::FalseClass());
+    ENFORCE_NO_TIMER(klass == Symbols::FalseClass());
     klass = synthesizeClass(core::Names::Constants::NilClass());
-    ENFORCE(klass == Symbols::NilClass());
+    ENFORCE_NO_TIMER(klass == Symbols::NilClass());
     klass = synthesizeClass(core::Names::Constants::Untyped(), 0);
-    ENFORCE(klass == Symbols::untyped());
+    ENFORCE_NO_TIMER(klass == Symbols::untyped());
     klass = synthesizeClass(core::Names::Constants::T(), Symbols::todo().id(), true);
-    ENFORCE(klass == Symbols::T());
+    ENFORCE_NO_TIMER(klass == Symbols::T());
     klass = klass.data(*this)->singletonClass(*this);
-    ENFORCE(klass == Symbols::TSingleton());
+    ENFORCE_NO_TIMER(klass == Symbols::TSingleton());
     klass = synthesizeClass(core::Names::Constants::Class(), 0);
-    ENFORCE(klass == Symbols::Class());
+    ENFORCE_NO_TIMER(klass == Symbols::Class());
     klass = synthesizeClass(core::Names::Constants::BasicObject(), 0);
-    ENFORCE(klass == Symbols::BasicObject());
+    ENFORCE_NO_TIMER(klass == Symbols::BasicObject());
     method = enterMethod(*this, Symbols::BasicObject(), Names::initialize()).build();
-    ENFORCE(method == Symbols::BasicObject_initialize());
+    ENFORCE_NO_TIMER(method == Symbols::BasicObject_initialize());
     klass = synthesizeClass(core::Names::Constants::Kernel(), 0, true);
-    ENFORCE(klass == Symbols::Kernel());
+    ENFORCE_NO_TIMER(klass == Symbols::Kernel());
     klass = synthesizeClass(core::Names::Constants::Range());
-    ENFORCE(klass == Symbols::Range());
+    ENFORCE_NO_TIMER(klass == Symbols::Range());
     klass = synthesizeClass(core::Names::Constants::Regexp());
-    ENFORCE(klass == Symbols::Regexp());
+    ENFORCE_NO_TIMER(klass == Symbols::Regexp());
     klass = synthesizeClass(core::Names::Constants::Magic());
-    ENFORCE(klass == Symbols::Magic());
+    ENFORCE_NO_TIMER(klass == Symbols::Magic());
     klass = Symbols::Magic().data(*this)->singletonClass(*this);
-    ENFORCE(klass == Symbols::MagicSingleton());
+    ENFORCE_NO_TIMER(klass == Symbols::MagicSingleton());
     klass = synthesizeClass(core::Names::Constants::Module());
-    ENFORCE(klass == Symbols::Module());
+    ENFORCE_NO_TIMER(klass == Symbols::Module());
     klass = synthesizeClass(core::Names::Constants::Exception());
-    ENFORCE(klass == Symbols::Exception());
+    ENFORCE_NO_TIMER(klass == Symbols::Exception());
     klass = synthesizeClass(core::Names::Constants::StandardError());
-    ENFORCE(klass == Symbols::StandardError());
+    ENFORCE_NO_TIMER(klass == Symbols::StandardError());
     klass = synthesizeClass(core::Names::Constants::Complex());
-    ENFORCE(klass == Symbols::Complex());
+    ENFORCE_NO_TIMER(klass == Symbols::Complex());
     klass = synthesizeClass(core::Names::Constants::Rational());
-    ENFORCE(klass == Symbols::Rational());
+    ENFORCE_NO_TIMER(klass == Symbols::Rational());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Array());
-    ENFORCE(klass == Symbols::T_Array());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Array());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Hash());
-    ENFORCE(klass == Symbols::T_Hash());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Hash());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Proc());
-    ENFORCE(klass == Symbols::T_Proc());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Proc());
     klass = synthesizeClass(core::Names::Constants::Proc());
-    ENFORCE(klass == Symbols::Proc());
+    ENFORCE_NO_TIMER(klass == Symbols::Proc());
     klass = synthesizeClass(core::Names::Constants::Enumerable(), 0, true);
-    ENFORCE(klass == Symbols::Enumerable());
+    ENFORCE_NO_TIMER(klass == Symbols::Enumerable());
     klass = synthesizeClass(core::Names::Constants::Set());
-    ENFORCE(klass == Symbols::Set());
+    ENFORCE_NO_TIMER(klass == Symbols::Set());
     klass = synthesizeClass(core::Names::Constants::Struct());
-    ENFORCE(klass == Symbols::Struct());
+    ENFORCE_NO_TIMER(klass == Symbols::Struct());
     klass = synthesizeClass(core::Names::Constants::File());
-    ENFORCE(klass == Symbols::File());
+    ENFORCE_NO_TIMER(klass == Symbols::File());
     klass = synthesizeClass(core::Names::Constants::Sorbet());
-    ENFORCE(klass == Symbols::Sorbet());
+    ENFORCE_NO_TIMER(klass == Symbols::Sorbet());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet(), core::Names::Constants::Private());
-    ENFORCE(klass == Symbols::Sorbet_Private());
+    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private(), core::Names::Constants::Static());
     klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
-    ENFORCE(klass == Symbols::Sorbet_Private_Static());
+    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static());
     klass = Symbols::Sorbet_Private_Static().data(*this)->singletonClass(*this);
-    ENFORCE(klass == Symbols::Sorbet_Private_StaticSingleton());
+    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_StaticSingleton());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubModule());
     klass.data(*this)->setIsModule(true);
-    ENFORCE(klass == Symbols::StubModule());
+    ENFORCE_NO_TIMER(klass == Symbols::StubModule());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubMixin());
     klass.data(*this)->setIsModule(true);
-    ENFORCE(klass == Symbols::StubMixin());
+    ENFORCE_NO_TIMER(klass == Symbols::StubMixin());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::PlaceholderMixin());
     klass.data(*this)->setIsModule(true);
-    ENFORCE(klass == Symbols::PlaceholderMixin());
+    ENFORCE_NO_TIMER(klass == Symbols::PlaceholderMixin());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubSuperClass());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::StubSuperClass());
+    ENFORCE_NO_TIMER(klass == Symbols::StubSuperClass());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerable());
-    ENFORCE(klass == Symbols::T_Enumerable());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Enumerable());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Range());
-    ENFORCE(klass == Symbols::T_Range());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Range());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Set());
-    ENFORCE(klass == Symbols::T_Set());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Set());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Void());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::void_());
+    ENFORCE_NO_TIMER(klass == Symbols::void_());
     klass = synthesizeClass(core::Names::Constants::TypeAlias(), 0);
-    ENFORCE(klass == Symbols::typeAliasTemp());
+    ENFORCE_NO_TIMER(klass == Symbols::typeAliasTemp());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::Configuration());
-    ENFORCE(klass == Symbols::T_Configuration());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Configuration());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Generic());
-    ENFORCE(klass == Symbols::T_Generic());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Generic());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Tuple());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::Tuple());
+    ENFORCE_NO_TIMER(klass == Symbols::Tuple());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Shape());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::Shape());
+    ENFORCE_NO_TIMER(klass == Symbols::Shape());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Subclasses());
-    ENFORCE(klass == Symbols::Subclasses());
+    ENFORCE_NO_TIMER(klass == Symbols::Subclasses());
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(),
                              core::Names::Constants::ImplicitModuleSuperclass());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
+    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
     klass =
         enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ReturnTypeInference());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::Sorbet_Private_Static_ReturnTypeInference());
+    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_ReturnTypeInference());
     typeArgument =
         enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::TodoTypeArgument(), Variance::CoVariant);
-    ENFORCE(typeArgument == Symbols::todoTypeArgument());
+    ENFORCE_NO_TIMER(typeArgument == Symbols::todoTypeArgument());
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
     method =
         enterMethod(*this, Symbols::Sorbet_Private_Static(), core::Names::guessedTypeTypeParameterHolder()).build();
-    ENFORCE(method == Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder());
+    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder());
     typeArgument = enterTypeArgument(
         Loc::none(), Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder(),
         freshNameUnique(core::UniqueNameKind::TypeVarName, core::Names::Constants::InferredReturnType(), 1),
         core::Variance::ContraVariant);
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
-    ENFORCE(
+    ENFORCE_NO_TIMER(
         typeArgument ==
         Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_contravariant());
     typeArgument = enterTypeArgument(
@@ -481,218 +481,219 @@ void GlobalState::initEmpty() {
         freshNameUnique(core::UniqueNameKind::TypeVarName, core::Names::Constants::InferredArgumentType(), 1),
         core::Variance::CoVariant);
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
-    ENFORCE(typeArgument ==
-            Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_covariant());
+    ENFORCE_NO_TIMER(
+        typeArgument ==
+        Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_covariant());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Sig());
-    ENFORCE(klass == Symbols::T_Sig());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Sig());
 
     // A magic non user-creatable class with methods to keep state between passes
     field = enterFieldSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::UndeclaredFieldStub());
-    ENFORCE(field == Symbols::Magic_undeclaredFieldStub());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_undeclaredFieldStub());
 
     // Sorbet::Private::Static#badAliasMethodStub(*arg0 : T.untyped) => T.untyped
     method = enterMethod(*this, Symbols::Sorbet_Private_Static(), core::Names::badAliasMethodStub())
                  .repeatedUntypedArg(Names::arg0())
                  .build();
-    ENFORCE(method == Symbols::Sorbet_Private_Static_badAliasMethodStub());
+    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_badAliasMethodStub());
 
     // T::Helpers
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Helpers());
-    ENFORCE(klass == Symbols::T_Helpers());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Helpers());
 
     // SigBuilder magic class
     klass = synthesizeClass(core::Names::Constants::DeclBuilderForProcs());
-    ENFORCE(klass == Symbols::DeclBuilderForProcs());
+    ENFORCE_NO_TIMER(klass == Symbols::DeclBuilderForProcs());
     klass = Symbols::DeclBuilderForProcs().data(*this)->singletonClass(*this);
-    ENFORCE(klass == Symbols::DeclBuilderForProcsSingleton());
+    ENFORCE_NO_TIMER(klass == Symbols::DeclBuilderForProcsSingleton());
 
     // Ruby 2.5 Hack
     klass = synthesizeClass(core::Names::Constants::Net(), 0, true);
-    ENFORCE(klass == Symbols::Net());
+    ENFORCE_NO_TIMER(klass == Symbols::Net());
     klass = enterClassSymbol(Loc::none(), Symbols::Net(), core::Names::Constants::IMAP());
     Symbols::Net_IMAP().data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::Net_IMAP());
+    ENFORCE_NO_TIMER(klass == Symbols::Net_IMAP());
     klass = enterClassSymbol(Loc::none(), Symbols::Net(), core::Names::Constants::Protocol());
-    ENFORCE(klass == Symbols::Net_Protocol());
+    ENFORCE_NO_TIMER(klass == Symbols::Net_Protocol());
     Symbols::Net_Protocol().data(*this)->setIsModule(false);
 
     klass = enterClassSymbol(Loc::none(), Symbols::T_Sig(), core::Names::Constants::WithoutRuntime());
     klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
-    ENFORCE(klass == Symbols::T_Sig_WithoutRuntime());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Sig_WithoutRuntime());
 
     klass = synthesizeClass(core::Names::Constants::Enumerator());
-    ENFORCE(klass == Symbols::Enumerator());
+    ENFORCE_NO_TIMER(klass == Symbols::Enumerator());
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerator());
-    ENFORCE(klass == Symbols::T_Enumerator());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Enumerator());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Enumerator(), core::Names::Constants::Lazy());
-    ENFORCE(klass == Symbols::T_Enumerator_Lazy());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Enumerator_Lazy());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Enumerator(), core::Names::Constants::Chain());
-    ENFORCE(klass == Symbols::T_Enumerator_Chain());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Enumerator_Chain());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Struct());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::T_Struct());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Struct());
 
     klass = synthesizeClass(core::Names::Constants::Singleton(), 0, true);
-    ENFORCE(klass == Symbols::Singleton());
+    ENFORCE_NO_TIMER(klass == Symbols::Singleton());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enum());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::T_Enum());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Enum());
 
     // T::Sig#sig
     method = enterMethod(*this, Symbols::T_Sig(), Names::sig()).defaultArg(Names::arg0()).build();
-    ENFORCE(method == Symbols::sig());
+    ENFORCE_NO_TIMER(method == Symbols::sig());
 
     // Enumerator::Lazy
     klass = enterClassSymbol(Loc::none(), Symbols::Enumerator(), core::Names::Constants::Lazy());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::Enumerator_Lazy());
+    ENFORCE_NO_TIMER(klass == Symbols::Enumerator_Lazy());
 
     // Enumerator::Chain
     klass = enterClassSymbol(Loc::none(), Symbols::Enumerator(), core::Names::Constants::Chain());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::Enumerator_Chain());
+    ENFORCE_NO_TIMER(klass == Symbols::Enumerator_Chain());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::Private());
-    ENFORCE(klass == Symbols::T_Private());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Private());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private(), Names::Constants::Types());
-    ENFORCE(klass == Symbols::T_Private_Types());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private_Types(), Names::Constants::Void());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::T_Private_Types_Void());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types_Void());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private_Types_Void(), Names::Constants::VOID());
     klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
-    ENFORCE(klass == Symbols::T_Private_Types_Void_VOID());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types_Void_VOID());
     klass = klass.data(*this)->singletonClass(*this);
-    ENFORCE(klass == Symbols::T_Private_Types_Void_VOIDSingleton());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types_Void_VOIDSingleton());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private(), Names::Constants::Methods());
-    ENFORCE(klass == Symbols::T_Private_Methods());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Methods());
     klass = enterClassSymbol(Loc::none(), Symbols::T_Private_Methods(), Names::Constants::DeclBuilder());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::T_Private_Methods_DeclBuilder());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Private_Methods_DeclBuilder());
 
     method = enterMethod(*this, Symbols::T_Private_Methods_DeclBuilder(), Names::abstract()).build();
-    ENFORCE(method == Symbols::T_Private_Methods_DeclBuilder_abstract());
+    ENFORCE_NO_TIMER(method == Symbols::T_Private_Methods_DeclBuilder_abstract());
     method = enterMethod(*this, Symbols::T_Private_Methods_DeclBuilder(), Names::overridable()).build();
-    ENFORCE(method == Symbols::T_Private_Methods_DeclBuilder_overridable());
+    ENFORCE_NO_TIMER(method == Symbols::T_Private_Methods_DeclBuilder_overridable());
     method = enterMethod(*this, Symbols::T_Private_Methods_DeclBuilder(), Names::override_())
                  .defaultKeywordArg(Names::allowIncompatible())
                  .build();
-    ENFORCE(method == Symbols::T_Private_Methods_DeclBuilder_override());
+    ENFORCE_NO_TIMER(method == Symbols::T_Private_Methods_DeclBuilder_override());
 
     // T.class_of(T::Sig::WithoutRuntime)
     klass = Symbols::T_Sig_WithoutRuntime().data(*this)->singletonClass(*this);
-    ENFORCE(klass == Symbols::T_Sig_WithoutRuntimeSingleton());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Sig_WithoutRuntimeSingleton());
 
     // T::Sig::WithoutRuntime.sig
     method =
         enterMethod(*this, Symbols::T_Sig_WithoutRuntimeSingleton(), Names::sig()).defaultArg(Names::arg0()).build();
-    ENFORCE(method == Symbols::sigWithoutRuntime());
+    ENFORCE_NO_TIMER(method == Symbols::sigWithoutRuntime());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::NonForcingConstants());
-    ENFORCE(klass == Symbols::T_NonForcingConstants());
+    ENFORCE_NO_TIMER(klass == Symbols::T_NonForcingConstants());
 
     method = enterMethod(*this, Symbols::Sorbet_Private_StaticSingleton(), Names::sig())
                  .arg(Names::arg0())
                  .defaultArg(Names::arg1())
                  .build();
-    ENFORCE(method == Symbols::SorbetPrivateStaticSingleton_sig());
+    ENFORCE_NO_TIMER(method == Symbols::SorbetPrivateStaticSingleton_sig());
 
     klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpecRegistry());
-    ENFORCE(klass == Symbols::PackageSpecRegistry());
+    ENFORCE_NO_TIMER(klass == Symbols::PackageSpecRegistry());
 
     // PackageSpec is a class that can be subclassed.
     klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpec());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::PackageSpec());
+    ENFORCE_NO_TIMER(klass == Symbols::PackageSpec());
 
     klass = klass.data(*this)->singletonClass(*this);
-    ENFORCE(klass == Symbols::PackageSpecSingleton());
+    ENFORCE_NO_TIMER(klass == Symbols::PackageSpecSingleton());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::import())
                  .typedArg(Names::arg0(), make_type<ClassType>(Symbols::PackageSpecSingleton()))
                  .build();
-    ENFORCE(method == Symbols::PackageSpec_import());
+    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_import());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::testImport())
                  .typedArg(Names::arg0(), make_type<ClassType>(Symbols::PackageSpecSingleton()))
                  .build();
-    ENFORCE(method == Symbols::PackageSpec_test_import());
+    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_test_import());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::export_()).arg(Names::arg0()).build();
-    ENFORCE(method == Symbols::PackageSpec_export());
+    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_export());
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::restrictToService()).arg(Names::arg0()).build();
-    ENFORCE(method == Symbols::PackageSpec_restrict_to_service());
+    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_restrict_to_service());
 
     klass = synthesizeClass(core::Names::Constants::Encoding());
-    ENFORCE(klass == Symbols::Encoding());
+    ENFORCE_NO_TIMER(klass == Symbols::Encoding());
 
     klass = synthesizeClass(core::Names::Constants::Thread());
-    ENFORCE(klass == Symbols::Thread());
+    ENFORCE_NO_TIMER(klass == Symbols::Thread());
 
     // Class#new
     method = enterMethod(*this, Symbols::Class(), Names::new_()).repeatedArg(Names::args()).build();
-    ENFORCE(method == Symbols::Class_new());
+    ENFORCE_NO_TIMER(method == Symbols::Class_new());
 
     method = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::TodoMethod());
     enterMethodArgumentSymbol(Loc::none(), method, Names::args());
-    ENFORCE(method == Symbols::todoMethod());
+    ENFORCE_NO_TIMER(method == Symbols::todoMethod());
 
     method = this->staticInitForClass(core::Symbols::root(), Loc::none());
-    ENFORCE(method == Symbols::rootStaticInit());
+    ENFORCE_NO_TIMER(method == Symbols::rootStaticInit());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::visibleTo()).arg(Names::arg0()).build();
-    ENFORCE(method == Symbols::PackageSpec_visible_to());
+    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_visible_to());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::exportAll()).build();
-    ENFORCE(method == Symbols::PackageSpec_export_all());
+    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_export_all());
 
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ResolvedSig());
     klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
-    ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSig());
+    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_ResolvedSig());
     klass = Symbols::Sorbet_Private_Static_ResolvedSig().data(*this)->singletonClass(*this);
-    ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSigSingleton());
+    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_ResolvedSigSingleton());
 
     // Magic classes for special proc bindings
     klass = enterClassSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::BindToAttachedClass());
-    ENFORCE(klass == Symbols::MagicBindToAttachedClass());
+    ENFORCE_NO_TIMER(klass == Symbols::MagicBindToAttachedClass());
 
     klass = enterClassSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::BindToSelfType());
-    ENFORCE(klass == Symbols::MagicBindToSelfType());
+    ENFORCE_NO_TIMER(klass == Symbols::MagicBindToSelfType());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Types());
-    ENFORCE(klass == Symbols::T_Types());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Types());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T_Types(), core::Names::Constants::Base());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::T_Types_Base());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Types_Base());
 
     klass = enterClassSymbol(Loc::none(), Symbols::root(), core::Names::Constants::Data());
     klass.data(*this)->setIsModule(false);
-    ENFORCE(klass == Symbols::Data());
+    ENFORCE_NO_TIMER(klass == Symbols::Data());
 
     klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Class());
-    ENFORCE(klass == Symbols::T_Class());
+    ENFORCE_NO_TIMER(klass == Symbols::T_Class());
 
     method = enterMethod(*this, Symbols::T_Generic(), Names::squareBrackets()).repeatedTopArg(Names::args()).build();
-    ENFORCE(method == Symbols::T_Generic_squareBrackets());
+    ENFORCE_NO_TIMER(method == Symbols::T_Generic_squareBrackets());
 
     method = enterMethod(*this, Symbols::Kernel(), Names::lambda()).build();
-    ENFORCE(method == Symbols::Kernel_lambda());
+    ENFORCE_NO_TIMER(method == Symbols::Kernel_lambda());
 
     typeArgument = enterTypeArgument(Loc::none(), Symbols::Kernel_lambda(), Names::returnType(), Variance::CoVariant);
-    ENFORCE(typeArgument == Symbols::Kernel_lambda_returnType());
+    ENFORCE_NO_TIMER(typeArgument == Symbols::Kernel_lambda_returnType());
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
 
     method = enterMethod(*this, Symbols::Kernel(), Names::lambdaTLet()).typedArg(Names::type(), Types::top()).build();
-    ENFORCE(method == Symbols::Kernel_lambdaTLet());
+    ENFORCE_NO_TIMER(method == Symbols::Kernel_lambdaTLet());
 
     method = enterMethod(*this, Symbols::Kernel(), Names::proc()).build();
-    ENFORCE(method == Symbols::Kernel_proc());
+    ENFORCE_NO_TIMER(method == Symbols::Kernel_proc());
 
     typeArgument = enterTypeArgument(Loc::none(), Symbols::Kernel_proc(), Names::returnType(), Variance::CoVariant);
-    ENFORCE(typeArgument == Symbols::Kernel_proc_returnType());
+    ENFORCE_NO_TIMER(typeArgument == Symbols::Kernel_proc_returnType());
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
 
     // Root members
@@ -883,57 +884,57 @@ void GlobalState::initEmpty() {
     klass.data(*this)->setIsModule(true);
 
     klass = enterClassSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::UntypedSource());
-    ENFORCE(klass == Symbols::Magic_UntypedSource());
+    ENFORCE_NO_TIMER(klass == Symbols::Magic_UntypedSource());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::super());
-    ENFORCE(field == Symbols::Magic_UntypedSource_super());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_super());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::proc());
-    ENFORCE(field == Symbols::Magic_UntypedSource_proc());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_proc());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::buildArray());
-    ENFORCE(field == Symbols::Magic_UntypedSource_buildArray());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_buildArray());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::buildRange());
-    ENFORCE(field == Symbols::Magic_UntypedSource_buildRange());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_buildRange());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::buildHash());
-    ENFORCE(field == Symbols::Magic_UntypedSource_buildHash());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_buildHash());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::mergeHashValues());
-    ENFORCE(field == Symbols::Magic_UntypedSource_mergeHashValues());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_mergeHashValues());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::expandSplat());
-    ENFORCE(field == Symbols::Magic_UntypedSource_expandSplat());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_expandSplat());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::splat());
-    ENFORCE(field == Symbols::Magic_UntypedSource_splat());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_splat());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::tupleUnderlying());
-    ENFORCE(field == Symbols::Magic_UntypedSource_tupleUnderlying());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_tupleUnderlying());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeUnderlying());
-    ENFORCE(field == Symbols::Magic_UntypedSource_shapeUnderlying());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_shapeUnderlying());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::tupleLub());
-    ENFORCE(field == Symbols::Magic_UntypedSource_tupleLub());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_tupleLub());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeLub());
-    ENFORCE(field == Symbols::Magic_UntypedSource_shapeLub());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_shapeLub());
 
     field =
         enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::shapeSquareBracketsEq());
-    ENFORCE(field == Symbols::Magic_UntypedSource_shapeSquareBracketsEq());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_shapeSquareBracketsEq());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::YieldLoadArg());
-    ENFORCE(field == Symbols::Magic_UntypedSource_YieldLoadArg());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_YieldLoadArg());
 
     field =
         enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::GetCurrentException());
-    ENFORCE(field == Symbols::Magic_UntypedSource_GetCurrentException());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_GetCurrentException());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::LoadYieldParams());
-    ENFORCE(field == Symbols::Magic_UntypedSource_LoadYieldParams());
+    ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_LoadYieldParams());
 
     int reservedCount = 0;
 
@@ -948,7 +949,7 @@ void GlobalState::initEmpty() {
     }
 
     // This fills in all the way up to MAX_SYNTHETIC_CLASS_SYMBOLS
-    ENFORCE(classAndModules.size() < Symbols::Proc0().id());
+    ENFORCE_NO_TIMER(classAndModules.size() < Symbols::Proc0().id());
     while (classAndModules.size() < Symbols::Proc0().id()) {
         string name = absl::StrCat("<RESERVED_", reservedCount, ">");
         synthesizeClass(enterNameConstant(name));
@@ -958,27 +959,27 @@ void GlobalState::initEmpty() {
     for (int arity = 0; arity <= Symbols::MAX_PROC_ARITY; ++arity) {
         string name = absl::StrCat("Proc", arity);
         auto id = synthesizeClass(enterNameConstant(name), Symbols::Proc().id());
-        ENFORCE(id == Symbols::Proc(arity), "Proc creation failed for arity: {} got: {} expected: {}", arity, id.id(),
-                Symbols::Proc(arity).id());
+        ENFORCE_NO_TIMER(id == Symbols::Proc(arity), "Proc creation failed for arity: {} got: {} expected: {}", arity,
+                         id.id(), Symbols::Proc(arity).id());
         id.data(*this)->singletonClass(*this);
     }
 
-    ENFORCE(classAndModules.size() == Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS,
-            "Too many synthetic class symbols? have: {} expected: {}", classAndModules.size(),
-            Symbols::last_synthetic_class_sym().id() + 1);
+    ENFORCE_NO_TIMER(classAndModules.size() == Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS,
+                     "Too many synthetic class symbols? have: {} expected: {}", classAndModules.size(),
+                     Symbols::last_synthetic_class_sym().id() + 1);
 
-    ENFORCE(methods.size() == Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS,
-            "Too many synthetic method symbols? have: {} expected: {}", methods.size(),
-            Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS);
-    ENFORCE(fields.size() == Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS,
-            "Too many synthetic field symbols? have: {} expected: {}", fields.size(),
-            Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS);
-    ENFORCE(typeMembers.size() == Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS,
-            "Too many synthetic typeMember symbols? have: {} expected: {}", typeMembers.size(),
-            Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS);
-    ENFORCE(typeArguments.size() == Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS,
-            "Too many synthetic typeArgument symbols? have: {} expected: {}", typeArguments.size(),
-            Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS);
+    ENFORCE_NO_TIMER(methods.size() == Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS,
+                     "Too many synthetic method symbols? have: {} expected: {}", methods.size(),
+                     Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS);
+    ENFORCE_NO_TIMER(fields.size() == Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS,
+                     "Too many synthetic field symbols? have: {} expected: {}", fields.size(),
+                     Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS);
+    ENFORCE_NO_TIMER(typeMembers.size() == Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS,
+                     "Too many synthetic typeMember symbols? have: {} expected: {}", typeMembers.size(),
+                     Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS);
+    ENFORCE_NO_TIMER(typeArguments.size() == Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS,
+                     "Too many synthetic typeArgument symbols? have: {} expected: {}", typeArguments.size(),
+                     Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS);
 
     installIntrinsics();
     computeLinearization();
@@ -1082,8 +1083,8 @@ bool matchesArityHash(const GlobalState &gs, ArityHash arityHash, MethodRef meth
 } // namespace
 
 MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, ArityHash arityHash) const {
-    ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
-    ENFORCE(name.exists(), "looking up symbol with non-existing name");
+    ENFORCE_NO_TIMER(owner.exists(), "looking up symbol from non-existing owner");
+    ENFORCE_NO_TIMER(name.exists(), "looking up symbol with non-existing name");
     auto ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_lookup_by_name", ownerScope->members().size());
 
@@ -1091,7 +1092,7 @@ MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRe
     uint32_t unique = 1;
     auto res = ownerScope->members().find(lookupName);
     while (res != ownerScope->members().end()) {
-        ENFORCE(res->second.exists());
+        ENFORCE_NO_TIMER(res->second.exists());
         auto resSym = res->second;
         if (resSym.isMethod()) {
             auto resMethod = resSym.asMethodRef();
@@ -1126,8 +1127,8 @@ MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRe
 // If no such symbol exists, then it will return defaultReturnValue.
 SymbolRef GlobalState::lookupSymbolWithKind(ClassOrModuleRef owner, NameRef name, SymbolRef::Kind kind,
                                             SymbolRef defaultReturnValue, bool ignoreKind) const {
-    ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
-    ENFORCE(name.exists(), "looking up symbol with non-existing name");
+    ENFORCE_NO_TIMER(owner.exists(), "looking up symbol from non-existing owner");
+    ENFORCE_NO_TIMER(name.exists(), "looking up symbol with non-existing name");
     auto ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_lookup_by_name", ownerScope->members().size());
 
@@ -1135,7 +1136,7 @@ SymbolRef GlobalState::lookupSymbolWithKind(ClassOrModuleRef owner, NameRef name
     uint32_t unique = 1;
     auto res = ownerScope->members().find(lookupName);
     while (res != ownerScope->members().end()) {
-        ENFORCE(res->second.exists());
+        ENFORCE_NO_TIMER(res->second.exists());
         if (ignoreKind || res->second.kind() == kind) {
             return res->second;
         }
@@ -1153,9 +1154,9 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
     // This method works by knowing how to replicate the logic of renaming in order to find whatever
     // the previous name was: for `x$n` where `n` is larger than 2, it'll be `x$(n-1)`, for bare `x`,
     // it'll be whatever the largest `x$n` that exists is, if any; otherwise, there will be none.
-    ENFORCE(sym.exists(), "lookup up previous name of non-existing symbol");
+    ENFORCE_NO_TIMER(sym.exists(), "lookup up previous name of non-existing symbol");
     // The name un-mangling logic described here no longer applies to constant symbols, only methods.
-    ENFORCE(sym.isMethod());
+    ENFORCE_NO_TIMER(sym.isMethod());
     NameRef name = sym.name(*this);
     auto ownerScope = owner.dataAllowingNone(*this);
 
@@ -1163,7 +1164,7 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
         auto uniqueData = name.dataUnique(*this);
         if (uniqueData->uniqueNameKind == UniqueNameKind::MangleRenameOverload) {
             auto it = ownerScope->members().find(uniqueData->original);
-            ENFORCE(it != ownerScope->members().end());
+            ENFORCE_NO_TIMER(it != ownerScope->members().end());
             // return it->second;
             auto res = findRenamedSymbol(owner, it->second);
             if (res.exists() && res.isMethod()) {
@@ -1171,7 +1172,7 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
                 if (resData->flags.isOverloaded) {
                     auto overloadedName = lookupNameUnique(UniqueNameKind::MangleRenameOverload, resData->name, 1);
                     auto it = ownerScope->members().find(overloadedName);
-                    ENFORCE(it != ownerScope->members().end());
+                    ENFORCE_NO_TIMER(it != ownerScope->members().end());
                     res = it->second;
                 }
             }
@@ -1182,13 +1183,13 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
         if (uniqueData->num == 1) {
             return Symbols::noSymbol();
         } else {
-            ENFORCE(uniqueData->num > 1);
+            ENFORCE_NO_TIMER(uniqueData->num > 1);
             auto nm = lookupNameUnique(UniqueNameKind::MangleRename, uniqueData->original, uniqueData->num - 1);
             if (!nm.exists()) {
                 return Symbols::noSymbol();
             }
             auto res = ownerScope->members().find(nm);
-            ENFORCE(res != ownerScope->members().end());
+            ENFORCE_NO_TIMER(res != ownerScope->members().end());
             return res->second;
         }
     } else {
@@ -1196,7 +1197,7 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
         NameRef lookupName = lookupNameUnique(UniqueNameKind::MangleRename, name, unique);
         auto res = ownerScope->members().find(lookupName);
         while (res != ownerScope->members().end()) {
-            ENFORCE(res->second.exists());
+            ENFORCE_NO_TIMER(res->second.exists());
             unique++;
             lookupName = lookupNameUnique(UniqueNameKind::MangleRename, name, unique);
             if (!lookupName.exists()) {
@@ -1241,8 +1242,8 @@ ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, 
 
 TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance) {
     TypeParameter::Flags flags;
-    ENFORCE(owner.exists() || name == Names::Constants::NoTypeMember());
-    ENFORCE(name.exists());
+    ENFORCE_NO_TIMER(owner.exists() || name == Names::Constants::NoTypeMember());
+    ENFORCE_NO_TIMER(name.exists());
     if (variance == Variance::Invariant) {
         flags.isInvariant = true;
     } else if (variance == Variance::CoVariant) {
@@ -1259,13 +1260,13 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE(store.isTypeMember() && store.asTypeMemberRef().data(*this)->flags.hasFlags(flags),
-                "existing symbol has wrong flags");
+        ENFORCE_NO_TIMER(store.isTypeMember() && store.asTypeMemberRef().data(*this)->flags.hasFlags(flags),
+                         "existing symbol has wrong flags");
         counterInc("symbols.hit");
         return store.asTypeMemberRef();
     }
 
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
     auto result = TypeMemberRef(*this, typeMembers.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on typeMembers invalidates `store`
     typeMembers.emplace_back();
@@ -1286,9 +1287,9 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
 }
 
 TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef name, Variance variance) {
-    ENFORCE(owner.exists() || name == Names::Constants::NoTypeArgument() ||
-            name == Names::Constants::TodoTypeArgument());
-    ENFORCE(name.exists());
+    ENFORCE_NO_TIMER(owner.exists() || name == Names::Constants::NoTypeArgument() ||
+                     name == Names::Constants::TodoTypeArgument());
+    ENFORCE_NO_TIMER(name.exists());
     TypeParameter::Flags flags;
     if (variance == Variance::Invariant) {
         flags.isInvariant = true;
@@ -1306,7 +1307,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
 
     for (auto typeArg : ownerScope->typeArguments()) {
         if (typeArg.dataAllowingNone(*this)->name == name) {
-            ENFORCE(typeArg.dataAllowingNone(*this)->flags.hasFlags(flags), "existing symbol has wrong flags");
+            ENFORCE_NO_TIMER(typeArg.dataAllowingNone(*this)->flags.hasFlags(flags), "existing symbol has wrong flags");
             counterInc("symbols.hit");
             if (!symbolTableFrozen) {
                 typeArg.data(*this)->addLoc(*this, loc);
@@ -1319,7 +1320,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
         }
     }
 
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
     auto result = TypeArgumentRef(*this, this->typeArguments.size());
     this->typeArguments.emplace_back();
 
@@ -1341,12 +1342,12 @@ MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRe
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE(store.isMethod(), "existing symbol is not a method");
+        ENFORCE_NO_TIMER(store.isMethod(), "existing symbol is not a method");
         counterInc("symbols.hit");
         return store.asMethodRef();
     }
 
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
 
     auto result = MethodRef(*this, methods.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on methods invalidates `store`
@@ -1371,9 +1372,9 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
     auto res = enterMethodSymbol(loc, owner, name);
     bool newMethod = res != original;
     const auto &resArguments = res.data(*this)->arguments;
-    ENFORCE(newMethod || !resArguments.empty(), "must be at least the block arg");
+    ENFORCE_NO_TIMER(newMethod || !resArguments.empty(), "must be at least the block arg");
     auto resInitialArgSize = resArguments.size();
-    ENFORCE(original.data(*this)->arguments.size() == argsToKeep.size());
+    ENFORCE_NO_TIMER(original.data(*this)->arguments.size() == argsToKeep.size());
     const auto &originalArguments = original.data(*this)->arguments;
     int i = -1;
     for (auto &arg : originalArguments) {
@@ -1386,15 +1387,16 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
                 DEBUG_ONLY(if (!newMethod) {
                     auto f = [&](const auto &resArg) { return arg.name == resArg.name; };
                     auto it = absl::c_find_if(resArguments, move(f));
-                    ENFORCE(it == resArguments.end(), "fast path should not remove arguments from existing overload");
+                    ENFORCE_NO_TIMER(it == resArguments.end(),
+                                     "fast path should not remove arguments from existing overload");
                 });
                 continue;
             }
         }
         NameRef nm = arg.name;
         auto &newArg = enterMethodArgumentSymbol(loc, res, nm);
-        ENFORCE(newMethod || resArguments.size() == resInitialArgSize,
-                "fast path should not add new arguments to existing overload");
+        ENFORCE_NO_TIMER(newMethod || resArguments.size() == resInitialArgSize,
+                         "fast path should not add new arguments to existing overload");
         newArg = arg.deepCopy();
         newArg.loc = loc;
     }
@@ -1402,19 +1404,19 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
 }
 
 FieldRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
-    ENFORCE(name.exists());
+    ENFORCE_NO_TIMER(name.exists());
 
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE(store.isField(*this), "existing symbol is not a field");
+        ENFORCE_NO_TIMER(store.isField(*this), "existing symbol is not a field");
         counterInc("symbols.hit");
         return store.asFieldRef();
     }
 
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
 
     auto result = FieldRef(*this, fields.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on fields invalidates `store`
@@ -1433,14 +1435,14 @@ FieldRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef 
 }
 
 FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
-    ENFORCE(name.exists());
+    ENFORCE_NO_TIMER(name.exists());
 
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE(store.isStaticField(*this), "existing symbol is not a static field");
+        ENFORCE_NO_TIMER(store.isStaticField(*this), "existing symbol is not a static field");
         counterInc("symbols.hit");
 
         // Ensures that locs get properly updated on the fast path
@@ -1455,7 +1457,7 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
         return fieldRef;
     }
 
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
 
     auto ret = FieldRef(*this, fields.size());
     store = ret; // DO NOT MOVE this assignment down. emplace_back on fields invalidates `store`
@@ -1474,8 +1476,8 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
 }
 
 ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name) {
-    ENFORCE(owner.exists(), "entering symbol in to non-existing owner");
-    ENFORCE(name.exists(), "entering symbol with non-existing name");
+    ENFORCE_NO_TIMER(owner.exists(), "entering symbol in to non-existing owner");
+    ENFORCE_NO_TIMER(name.exists(), "entering symbol with non-existing name");
     MethodData ownerScope = owner.data(*this);
 
     for (auto &arg : ownerScope->arguments) {
@@ -1485,7 +1487,7 @@ ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRe
     }
     auto &store = ownerScope->arguments.emplace_back();
 
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
 
     store.name = name;
     store.loc = loc;
@@ -1553,9 +1555,9 @@ NameRef GlobalState::enterNameUTF8(string_view nm) {
         bucketId = (bucketId + probeCount) & mask;
         probeCount++;
     }
-    ENFORCE(!nameTableFrozen);
+    ENFORCE_NO_TIMER(!nameTableFrozen);
 
-    ENFORCE(probeCount != hashTableSize, "Full table?");
+    ENFORCE_NO_TIMER(probeCount != hashTableSize, "Full table?");
 
     if (utf8Names.size() == utf8Names.capacity()) {
         expandNames(utf8Names.capacity() * 2, constantNames.capacity(), uniqueNames.capacity());
@@ -1583,8 +1585,8 @@ NameRef GlobalState::enterNameUTF8(string_view nm) {
 }
 
 NameRef GlobalState::enterNameConstant(NameRef original) {
-    ENFORCE(original.exists(), "making a constant name over non-existing name");
-    ENFORCE(original.isValidConstantName(*this), "making a constant name over wrong name kind");
+    ENFORCE_NO_TIMER(original.exists(), "making a constant name over non-existing name");
+    ENFORCE_NO_TIMER(original.isValidConstantName(*this), "making a constant name over wrong name kind");
 
     const auto hs = hashMixConstant(original.rawId());
     unsigned int hashTableSize = namesByHash.size();
@@ -1609,7 +1611,7 @@ NameRef GlobalState::enterNameConstant(NameRef original) {
     if (probeCount == hashTableSize) {
         Exception::raise("Full table?");
     }
-    ENFORCE(!nameTableFrozen);
+    ENFORCE_NO_TIMER(!nameTableFrozen);
 
     if (constantNames.size() == constantNames.capacity()) {
         expandNames(utf8Names.capacity(), constantNames.capacity() * 2, uniqueNames.capacity());
@@ -1680,8 +1682,8 @@ NameRef GlobalState::lookupNameConstant(string_view original) const {
 
 void GlobalState::moveNames(Bucket *from, Bucket *to, unsigned int szFrom, unsigned int szTo) {
     // printf("\nResizing name hash table from %u to %u\n", szFrom, szTo);
-    ENFORCE((szTo & (szTo - 1)) == 0, "name hash table size corruption");
-    ENFORCE((szFrom & (szFrom - 1)) == 0, "name hash table size corruption");
+    ENFORCE_NO_TIMER((szTo & (szTo - 1)) == 0, "name hash table size corruption");
+    ENFORCE_NO_TIMER((szFrom & (szFrom - 1)) == 0, "name hash table size corruption");
     unsigned int mask = szTo - 1;
     for (unsigned int orig = 0; orig < szFrom; orig++) {
         if (from[orig].rawId != 0u) {
@@ -1713,7 +1715,7 @@ void GlobalState::expandNames(uint32_t utf8NameSize, uint32_t constantNameSize, 
 }
 
 NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef original, uint32_t num) const {
-    ENFORCE(num > 0, "num == 0, name overflow");
+    ENFORCE_NO_TIMER(num > 0, "num == 0, name overflow");
     const auto hs = hashMixUnique(uniqueNameKind, num, original.rawId());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
@@ -1739,7 +1741,7 @@ NameRef GlobalState::lookupNameUnique(UniqueNameKind uniqueNameKind, NameRef ori
 }
 
 NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef original, uint32_t num) {
-    ENFORCE(num > 0, "num == 0, name overflow");
+    ENFORCE_NO_TIMER(num > 0, "num == 0, name overflow");
     const auto hs = hashMixUnique(uniqueNameKind, num, original.rawId());
     unsigned int hashTableSize = namesByHash.size();
     unsigned int mask = hashTableSize - 1;
@@ -1764,7 +1766,7 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
     if (probeCount == hashTableSize) {
         Exception::raise("Full table?");
     }
-    ENFORCE(!nameTableFrozen);
+    ENFORCE_NO_TIMER(!nameTableFrozen);
 
     if (uniqueNames.size() == uniqueNames.capacity()) {
         expandNames(utf8Names.capacity(), constantNames.capacity(), uniqueNames.capacity() * 2);
@@ -1792,7 +1794,7 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
 }
 
 FileRef GlobalState::enterFile(const shared_ptr<File> &file) {
-    ENFORCE(!fileTableFrozen);
+    ENFORCE_NO_TIMER(!fileTableFrozen);
 
     SLOW_DEBUG_ONLY(for (auto &f
                          : this->files) {
@@ -1815,10 +1817,10 @@ FileRef GlobalState::enterFile(string_view path, string_view source) {
 }
 
 FileRef GlobalState::enterNewFileAt(const shared_ptr<File> &file, FileRef id) {
-    ENFORCE(!fileTableFrozen);
-    ENFORCE(id.id() < this->files.size());
-    ENFORCE(this->files[id.id()]->sourceType == File::Type::NotYetRead);
-    ENFORCE(this->files[id.id()]->path() == file->path());
+    ENFORCE_NO_TIMER(!fileTableFrozen);
+    ENFORCE_NO_TIMER(id.id() < this->files.size());
+    ENFORCE_NO_TIMER(this->files[id.id()]->sourceType == File::Type::NotYetRead);
+    ENFORCE_NO_TIMER(this->files[id.id()]->path() == file->path());
 
     // was a tombstone before.
     this->files[id.id()] = file;
@@ -1846,9 +1848,9 @@ void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef origName, U
     auto ownerData = owner.data(*this);
     auto &ownerMembers = ownerData->members();
     auto fnd = ownerMembers.find(origName);
-    ENFORCE(fnd != ownerMembers.end());
-    ENFORCE(fnd->second == what);
-    ENFORCE(what.data(*this)->name == origName);
+    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
+    ENFORCE_NO_TIMER(fnd->second == what);
+    ENFORCE_NO_TIMER(what.data(*this)->name == origName);
     NameRef name;
     if (kind == UniqueNameKind::MangleRename) {
         name = nextMangledName(owner, origName);
@@ -1861,7 +1863,7 @@ void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef origName, U
         //
         // We know that there is no method with this name, because otherwise resolver would not have
         // called mangleRenameForOverload.
-        ENFORCE(kind == UniqueNameKind::MangleRenameOverload);
+        ENFORCE_NO_TIMER(kind == UniqueNameKind::MangleRenameOverload);
         name = freshNameUnique(UniqueNameKind::MangleRenameOverload, origName, 1);
     }
     // Both branches of the above `if` condition should ENFORCE this (either due to the loop post
@@ -1905,14 +1907,14 @@ void GlobalState::mangleRenameForOverload(MethodRef what, NameRef origName) {
 // similar to mangleRenameMethod, so it's nice to have the implementation in the same file). But in
 // spirit, this is a private Namer helper function.
 void GlobalState::deleteMethodSymbol(MethodRef what) {
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
 
     const auto &whatData = what.data(*this);
     auto owner = whatData->owner;
     auto &ownerMembers = owner.data(*this)->members();
     auto fnd = ownerMembers.find(whatData->name);
-    ENFORCE(fnd != ownerMembers.end());
-    ENFORCE(fnd->second == what);
+    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
+    ENFORCE_NO_TIMER(fnd->second == what);
     ownerMembers.erase(fnd);
     for (const auto typeArgument : whatData->typeArguments()) {
         this->typeArguments[typeArgument.id()] = this->typeArguments[0].deepCopy(*this);
@@ -1925,21 +1927,21 @@ void GlobalState::deleteMethodSymbol(MethodRef what) {
 //
 // NOTE: This method does double duty, deleting both static-field and field symbols.
 void GlobalState::deleteFieldSymbol(FieldRef what) {
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
 
     const auto &whatData = what.data(*this);
     auto owner = whatData->owner;
     auto &ownerMembers = owner.data(*this)->members();
     auto fnd = ownerMembers.find(whatData->name);
-    ENFORCE(fnd != ownerMembers.end());
-    ENFORCE(fnd->second == what);
+    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
+    ENFORCE_NO_TIMER(fnd->second == what);
     ownerMembers.erase(fnd);
     this->fields[what.id()] = this->fields[0].deepCopy(*this);
 }
 
 // Before using this method, double check the disclaimer on GlobalState::deleteMethodSymbol above.
 void GlobalState::deleteTypeMemberSymbol(TypeMemberRef what) {
-    ENFORCE(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
 
     const auto &whatData = what.data(*this);
     // Should always be a class or module for type members, but we use core::TypeParameter to model both
@@ -1948,13 +1950,13 @@ void GlobalState::deleteTypeMemberSymbol(TypeMemberRef what) {
 
     auto &ownerMembers = owner.data(*this)->members();
     auto fndMember = ownerMembers.find(whatData->name);
-    ENFORCE(fndMember != ownerMembers.end());
-    ENFORCE(fndMember->second == what);
+    ENFORCE_NO_TIMER(fndMember != ownerMembers.end());
+    ENFORCE_NO_TIMER(fndMember->second == what);
     ownerMembers.erase(fndMember);
 
     auto &ownerTypeMembers = owner.data(*this)->existingTypeMembers();
     auto fndTypeMember = absl::c_find(ownerTypeMembers, what);
-    ENFORCE(fndTypeMember != ownerTypeMembers.end());
+    ENFORCE_NO_TIMER(fndTypeMember != ownerTypeMembers.end());
     ownerTypeMembers.erase(fndTypeMember);
 
     this->typeMembers[what.id()] = this->typeMembers[0].deepCopy(*this);
@@ -2018,15 +2020,15 @@ void GlobalState::sanityCheck() const {
     }
 
     Timer timeit(tracer(), "GlobalState::sanityCheck");
-    ENFORCE(namesUsedTotal() > 0, "empty name table size");
-    ENFORCE(!strings.empty(), "empty string table size");
-    ENFORCE(!namesByHash.empty(), "empty name hash table size");
-    ENFORCE((namesByHash.size() & (namesByHash.size() - 1)) == 0, "name hash table size is not a power of two");
-    ENFORCE(nextPowerOfTwo(utf8Names.capacity() + constantNames.capacity() + uniqueNames.capacity()) * 2 ==
+    ENFORCE_NO_TIMER(namesUsedTotal() > 0, "empty name table size");
+    ENFORCE_NO_TIMER(!strings.empty(), "empty string table size");
+    ENFORCE_NO_TIMER(!namesByHash.empty(), "empty name hash table size");
+    ENFORCE_NO_TIMER((namesByHash.size() & (namesByHash.size() - 1)) == 0, "name hash table size is not a power of two");
+    ENFORCE_NO_TIMER(nextPowerOfTwo(utf8Names.capacity() + constantNames.capacity() + uniqueNames.capacity()) * 2 ==
                 namesByHash.capacity(),
             "name table and hash name table sizes out of sync names.capacity={} namesByHash.capacity={}",
             namesUsedTotal(), namesByHash.capacity());
-    ENFORCE(namesByHash.size() == namesByHash.capacity(), "hash name table not at full capacity");
+    ENFORCE_NO_TIMER(namesByHash.size() == namesByHash.capacity(), "hash name table not at full capacity");
 
     {
         Timer timeit(tracer(), "GlobalState::sanityCheck (names)");
@@ -2267,7 +2269,7 @@ void GlobalState::mergeFileTable(const core::GlobalState &from) {
         if (fileIdx < this->filesUsed() && from.files[fileIdx].get() == this->files[fileIdx].get()) {
             continue;
         }
-        ENFORCE(fileIdx >= this->filesUsed() || this->files[fileIdx]->sourceType == File::Type::NotYetRead);
+        ENFORCE_NO_TIMER(fileIdx >= this->filesUsed() || this->files[fileIdx]->sourceType == File::Type::NotYetRead);
         this->enterNewFileAt(from.files[fileIdx], fileIdx);
     }
 }
@@ -2312,12 +2314,12 @@ void GlobalState::ignoreErrorClassForSuggestTyped(int code) {
 }
 
 void GlobalState::suppressErrorClass(int code) {
-    ENFORCE(onlyErrorClasses.empty());
+    ENFORCE_NO_TIMER(onlyErrorClasses.empty());
     suppressedErrorClasses.insert(code);
 }
 
 void GlobalState::onlyShowErrorClass(int code) {
-    ENFORCE(suppressedErrorClasses.empty());
+    ENFORCE_NO_TIMER(suppressedErrorClasses.empty());
     onlyErrorClasses.insert(code);
 }
 
@@ -2358,7 +2360,7 @@ bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
             }
         }
     }
-    ENFORCE(level <= StrictLevel::Strong);
+    ENFORCE_NO_TIMER(level <= StrictLevel::Strong);
 
     return level >= what.minLevel;
 }
@@ -2375,7 +2377,7 @@ void GlobalState::markAsPayload() {
     bool seenEmpty = false;
     for (auto &f : files) {
         if (!seenEmpty) {
-            ENFORCE(!f);
+            ENFORCE_NO_TIMER(!f);
             seenEmpty = true;
             continue;
         }
@@ -2384,8 +2386,8 @@ void GlobalState::markAsPayload() {
 }
 
 void GlobalState::replaceFile(FileRef whatFile, const shared_ptr<File> &withWhat) {
-    ENFORCE(whatFile.id() < filesUsed());
-    ENFORCE(whatFile.dataAllowingUnsafe(*this).path() == withWhat->path());
+    ENFORCE_NO_TIMER(whatFile.id() < filesUsed());
+    ENFORCE_NO_TIMER(whatFile.dataAllowingUnsafe(*this).path() == withWhat->path());
     files[whatFile.id()] = withWhat;
 }
 
@@ -2406,7 +2408,7 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &extraPackag
                                      const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
                                      const std::vector<std::string> &allowRelaxedPackagerChecksFor,
                                      std::string errorHint) {
-    ENFORCE(!packageDB_.frozen);
+    ENFORCE_NO_TIMER(!packageDB_.frozen);
 
     packageDB_.enabled_ = true;
     packageDB_.extraPackageFilesDirectoryUnderscorePrefixes_ = extraPackageFilesDirectoryUnderscorePrefixes;
@@ -2428,7 +2430,7 @@ packages::UnfreezePackages GlobalState::unfreezePackages() {
 }
 
 unique_ptr<GlobalState> GlobalState::markFileAsTombStone(unique_ptr<GlobalState> what, FileRef fref) {
-    ENFORCE(fref.id() < what->filesUsed());
+    ENFORCE_NO_TIMER(fref.id() < what->filesUsed());
     what->files[fref.id()]->sourceType = File::Type::TombStone;
     return what;
 }
@@ -2501,7 +2503,7 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
                 classAliasHash = mix(classAliasHash, symhash);
             }
         } else {
-            ENFORCE(field.flags.isField);
+            ENFORCE_NO_TIMER(field.flags.isField);
             auto &target = retypecheckableSymbolHashesMap[WithoutUniqueNameHash(*this, field.name)];
             target = mix(target, symhash);
         }
@@ -2573,7 +2575,8 @@ MethodRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {
 MethodRef GlobalState::lookupStaticInitForClass(ClassOrModuleRef klass, bool allowMissing) const {
     auto classData = klass.data(*this);
     auto ref = classData->lookupSingletonClass(*this).data(*this)->findMethod(*this, core::Names::staticInit());
-    ENFORCE(ref.exists() || allowMissing, "looking up non-existent <static-init> for {}", klass.toString(*this));
+    ENFORCE_NO_TIMER(ref.exists() || allowMissing, "looking up non-existent <static-init> for {}",
+                     klass.toString(*this));
     return ref;
 }
 
@@ -2595,7 +2598,7 @@ MethodRef GlobalState::staticInitForFile(Loc loc) {
 MethodRef GlobalState::lookupStaticInitForFile(FileRef file) const {
     auto nm = lookupNameUnique(core::UniqueNameKind::Namer, core::Names::staticInit(), file.id());
     auto ref = core::Symbols::rootSingleton().data(*this)->findMember(*this, nm);
-    ENFORCE(ref.exists(), "looking up non-existent <static-init> for {}", file.data(*this).path());
+    ENFORCE_NO_TIMER(ref.exists(), "looking up non-existent <static-init> for {}", file.data(*this).path());
     return ref.asMethodRef();
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -214,7 +214,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
         }
         data->mixins() = std::move(newMixins);
         data->flags.isLinearizationComputed = true;
-        if (debug_mode) {
+        if constexpr (debug_mode) {
             for (auto oldMixin : currentMixins) {
                 ENFORCE(ofClass.data(gs)->derivesFrom(gs, oldMixin), "{} no longer derives from {}",
                         ofClass.showFullName(gs), oldMixin.showFullName(gs));
@@ -2011,10 +2011,10 @@ string GlobalState::toStringWithOptions(bool showFull, bool showRaw) const {
 }
 
 void GlobalState::sanityCheck() const {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
-    if (fuzz_mode) {
+    if constexpr (fuzz_mode) {
         // it's very slow to check this and it didn't find bugs
         return;
     }
@@ -2023,11 +2023,12 @@ void GlobalState::sanityCheck() const {
     ENFORCE_NO_TIMER(namesUsedTotal() > 0, "empty name table size");
     ENFORCE_NO_TIMER(!strings.empty(), "empty string table size");
     ENFORCE_NO_TIMER(!namesByHash.empty(), "empty name hash table size");
-    ENFORCE_NO_TIMER((namesByHash.size() & (namesByHash.size() - 1)) == 0, "name hash table size is not a power of two");
+    ENFORCE_NO_TIMER((namesByHash.size() & (namesByHash.size() - 1)) == 0,
+                     "name hash table size is not a power of two");
     ENFORCE_NO_TIMER(nextPowerOfTwo(utf8Names.capacity() + constantNames.capacity() + uniqueNames.capacity()) * 2 ==
-                namesByHash.capacity(),
-            "name table and hash name table sizes out of sync names.capacity={} namesByHash.capacity={}",
-            namesUsedTotal(), namesByHash.capacity());
+                         namesByHash.capacity(),
+                     "name table and hash name table sizes out of sync names.capacity={} namesByHash.capacity={}",
+                     namesUsedTotal(), namesByHash.capacity());
     ENFORCE_NO_TIMER(namesByHash.size() == namesByHash.capacity(), "hash name table not at full capacity");
 
     {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1977,7 +1977,7 @@ string GlobalState::toStringWithOptions(bool showFull, bool showRaw) const {
     return Symbols::root().toStringWithOptions(*this, 0, showFull, showRaw);
 }
 
-void GlobalState::sanityCheck() const {
+void GlobalState::sanityCheckTableSizes() const {
     if constexpr (!debug_mode) {
         return;
     }
@@ -1986,7 +1986,7 @@ void GlobalState::sanityCheck() const {
         return;
     }
 
-    Timer timeit(tracer(), "GlobalState::sanityCheck");
+    Timer timeit(tracer(), "GlobalState::sanityCheckTableSizes");
     ENFORCE_NO_TIMER(namesUsedTotal() > 0, "empty name table size");
     ENFORCE_NO_TIMER(!strings.empty(), "empty string table size");
     ENFORCE_NO_TIMER(!namesByHash.empty(), "empty name hash table size");
@@ -1997,6 +1997,20 @@ void GlobalState::sanityCheck() const {
                      "name table and hash name table sizes out of sync names.capacity={} namesByHash.capacity={}",
                      namesUsedTotal(), namesByHash.capacity());
     ENFORCE_NO_TIMER(namesByHash.size() == namesByHash.capacity(), "hash name table not at full capacity");
+}
+
+void GlobalState::sanityCheck() const {
+    if constexpr (!debug_mode) {
+        return;
+    }
+    if constexpr (fuzz_mode) {
+        // it's very slow to check this and it didn't find bugs
+        return;
+    }
+
+    Timer timeit(tracer(), "GlobalState::sanityCheck");
+
+    sanityCheckTableSizes();
 
     {
         Timer timeit(tracer(), "GlobalState::sanityCheck (names)");

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -195,6 +195,7 @@ public:
     unsigned int symbolsUsedTotal() const;
 
     void sanityCheckTableSizes() const;
+    void sanityCheckNames() const;
     void sanityCheck() const;
     void markAsPayload();
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -194,6 +194,7 @@ public:
     unsigned int filesUsed() const;
     unsigned int symbolsUsedTotal() const;
 
+    void sanityCheckTableSizes() const;
     void sanityCheck() const;
     void markAsPayload();
 

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -36,7 +36,7 @@ Loc Loc::join(Loc other) const {
     if (!other.exists()) {
         return *this;
     }
-    ENFORCE(this->file() == other.file(), "joining locations from different files");
+    ENFORCE_NO_TIMER(this->file() == other.file(), "joining locations from different files");
     return Loc(this->file(), min(this->beginPos(), other.beginPos()), max(this->endPos(), other.endPos()));
 }
 
@@ -46,7 +46,7 @@ Loc::Detail Loc::offset2Pos(const File &file, uint32_t off) {
     if (off > file.source().size()) {
         fatalLogger->error(R"(msg="Bad offset2Pos off" path="{}" off="{}"")", absl::CEscape(file.path()), off);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
-        ENFORCE(false);
+        ENFORCE_NO_TIMER(false);
     }
     auto it = absl::c_lower_bound(file.lineBreaks(), off);
     if (it == file.lineBreaks().begin()) {
@@ -128,7 +128,7 @@ void addLocLine(stringstream &buf, int line, const File &file, int tabs, int pos
     if (file.lineBreaks().size() <= line + 1) {
         fatalLogger->error(R"(msg="Bad addLocLine line" path="{}" line="{}"")", absl::CEscape(file.path()), line);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
-        ENFORCE(false);
+        ENFORCE_NO_TIMER(false);
     }
     auto endPos = file.lineBreaks()[line + 1];
     auto numToWrite = endPos - file.lineBreaks()[line] - 1;
@@ -140,13 +140,13 @@ void addLocLine(stringstream &buf, int line, const File &file, int tabs, int pos
         fatalLogger->error(R"(msg="Bad addLocLine offset" path="{}" line="{}" offset="{}")", absl::CEscape(file.path()),
                            line, offset);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
-        ENFORCE(false);
+        ENFORCE_NO_TIMER(false);
     }
     if (offset + numToWrite > file.source().size()) {
         fatalLogger->error(R"(msg="Bad addLocLine write size" path="{}" line="{}" offset="{}" numToWrite="{}")",
                            absl::CEscape(file.path()), line, offset, numToWrite);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
-        ENFORCE(false);
+        ENFORCE_NO_TIMER(false);
     }
     buf.write(file.source().data() + offset, numToWrite);
 }
@@ -371,7 +371,7 @@ Loc Loc::adjustLen(const GlobalState &gs, int32_t beginAdjust, int32_t len) cons
 pair<Loc, uint32_t> Loc::findStartOfLine(const GlobalState &gs) const {
     auto startDetail = this->position(gs).first;
     auto maybeLineStart = Loc::pos2Offset(this->file().data(gs), {startDetail.line, 1});
-    ENFORCE(maybeLineStart.has_value());
+    ENFORCE_NO_TIMER(maybeLineStart.has_value());
     auto lineStart = maybeLineStart.value();
     std::string_view lineView = this->file().data(gs).source().substr(lineStart);
 

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -73,9 +73,9 @@ public:
     }
 
     inline Loc(FileRef file, uint32_t begin, uint32_t end) : storage{{begin, end}, file} {
-        ENFORCE(begin <= INVALID_POS_LOC);
-        ENFORCE(end <= INVALID_POS_LOC);
-        ENFORCE(begin <= end);
+        ENFORCE_NO_TIMER(begin <= INVALID_POS_LOC);
+        ENFORCE_NO_TIMER(end <= INVALID_POS_LOC);
+        ENFORCE_NO_TIMER(begin <= end);
     }
 
     inline Loc(FileRef file, LocOffsets offsets) : Loc(file, offsets.beginPos(), offsets.endPos()){};

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -203,7 +203,7 @@ bool NameRef::isClassName(const GlobalState &gs) const {
                     return false;
             }
         case NameKind::CONSTANT:
-            ENFORCE(dataCnst(gs)->original.isValidConstantName(gs));
+            ENFORCE_NO_TIMER(dataCnst(gs)->original.isValidConstantName(gs));
             return true;
     }
 }
@@ -447,7 +447,7 @@ UTF8NameData::UTF8NameData(const UTF8Name &ref, const GlobalState &gs) : DebugOn
 NameDataDebugCheck::NameDataDebugCheck(const GlobalState &gs) : gs(gs), nameCountAtCreation(gs.namesUsedTotal()) {}
 
 void NameDataDebugCheck::check() const {
-    ENFORCE(nameCountAtCreation == gs.namesUsedTotal());
+    ENFORCE_NO_TIMER(nameCountAtCreation == gs.namesUsedTotal());
 }
 
 const UniqueName *UniqueNameData::operator->() const {

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -156,7 +156,7 @@ string_view NameRef::shortName(const GlobalState &gs) const {
 }
 
 void NameRef::sanityCheck(const GlobalState &gs) const {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
     switch (kind()) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -811,7 +811,7 @@ vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findMemberFuzzyMatch(con
     // Don't run under the fuzzer, as otherwise fuzzy match dominates runtime.
     // N.B.: There are benefits to running this method under the fuzzer; we have found bugs in this method before
     // via fuzzing (e.g. https://github.com/sorbet/sorbet/issues/128).
-    if (fuzz_mode) {
+    if constexpr (fuzz_mode) {
         return res;
     }
 
@@ -2259,7 +2259,7 @@ int ClassOrModule::typeArity(const GlobalState &gs) const {
 }
 
 void ClassOrModule::sanityCheck(const GlobalState &gs) const {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
     ClassOrModuleRef current = this->ref(gs);
@@ -2276,7 +2276,7 @@ void ClassOrModule::sanityCheck(const GlobalState &gs) const {
 }
 
 void Method::sanityCheck(const GlobalState &gs) const {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
     MethodRef current = this->ref(gs);
@@ -2305,7 +2305,7 @@ void Method::sanityCheck(const GlobalState &gs) const {
 }
 
 void Field::sanityCheck(const GlobalState &gs) const {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
     FieldRef current = this->ref(gs);
@@ -2322,7 +2322,7 @@ void Field::sanityCheck(const GlobalState &gs) const {
 }
 
 void TypeParameter::sanityCheck(const GlobalState &gs) const {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
     SymbolRef current = this->ref(gs);

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -61,7 +61,7 @@ GENERATE_CALL_MEMBER(underlying,
 } // namespace
 
 void TypePtr::deleteTagged(Tag tag, void *ptr) noexcept {
-    ENFORCE(ptr != nullptr);
+    ENFORCE_NO_TIMER(ptr != nullptr);
 
 #define DELETE_TYPE(T) delete reinterpret_cast<T *>(ptr);
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -120,7 +120,7 @@ private:
         val |= static_cast<tagged_storage>(inlinedValue) << 16;
 
         // Asserts that tag isn't using the bit which we use to indicate that value is _not_ inlined.
-        ENFORCE((val & NOT_INLINED_MASK) == 0);
+        ENFORCE_NO_TIMER((val & NOT_INLINED_MASK) == 0);
 
         return val;
     }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -132,7 +132,7 @@ void Pickler::putU1(uint8_t u) {
 }
 
 uint8_t UnPickler::getU1() {
-    ENFORCE(zeroCounter == 0);
+    ENFORCE_NO_TIMER(zeroCounter == 0);
     auto res = data[pos++];
     return res;
 }
@@ -477,7 +477,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         case TypePtr::Tag::ShapeType: {
             auto &hash = cast_type_nonnull<ShapeType>(what);
             p.putU4(hash.keys.size());
-            ENFORCE(hash.keys.size() == hash.values.size());
+            ENFORCE_NO_TIMER(hash.keys.size() == hash.values.size());
             for (auto &el : hash.keys) {
                 pickle(p, el);
             }
@@ -753,8 +753,8 @@ ClassOrModule SerializerImpl::unpickleClassOrModule(UnPickler &p, const GlobalSt
         auto sym = SymbolRef::fromRaw(p.getU4());
         if (result.name != core::Names::Constants::Root() && result.name != core::Names::Constants::NoSymbol() &&
             result.name != core::Names::noMethod()) {
-            ENFORCE(name.exists());
-            ENFORCE(sym.exists());
+            ENFORCE_NO_TIMER(name.exists());
+            ENFORCE_NO_TIMER(sym.exists());
         }
         result.members()[name] = sym;
     }
@@ -951,19 +951,19 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
         Timer timeit(result.tracer(), "readNames");
 
         int namesSize = p.getU4();
-        ENFORCE(namesSize > 0);
+        ENFORCE_NO_TIMER(namesSize > 0);
         utf8Names.reserve(nextPowerOfTwo(namesSize));
         for (int i = 0; i < namesSize; i++) {
             utf8Names.emplace_back(unpickleUTF8Name(p, result));
         }
         namesSize = p.getU4();
-        ENFORCE(namesSize > 0);
+        ENFORCE_NO_TIMER(namesSize > 0);
         constantNames.reserve(nextPowerOfTwo(namesSize));
         for (int i = 0; i < namesSize; i++) {
             constantNames.emplace_back(unpickleConstantName(p, result));
         }
         namesSize = p.getU4();
-        ENFORCE(namesSize > 0);
+        ENFORCE_NO_TIMER(namesSize > 0);
         uniqueNames.reserve(nextPowerOfTwo(namesSize));
         for (int i = 0; i < namesSize; i++) {
             uniqueNames.emplace_back(unpickleUniqueName(p, result));
@@ -974,35 +974,35 @@ void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
         Timer timeit(result.tracer(), "readSymbols");
 
         int classAndModuleSize = p.getU4();
-        ENFORCE(classAndModuleSize > 0);
+        ENFORCE_NO_TIMER(classAndModuleSize > 0);
         classAndModules.reserve(nextPowerOfTwo(classAndModuleSize));
         for (int i = 0; i < classAndModuleSize; i++) {
             classAndModules.emplace_back(unpickleClassOrModule(p, &result));
         }
 
         int methodSize = p.getU4();
-        ENFORCE(methodSize > 0);
+        ENFORCE_NO_TIMER(methodSize > 0);
         methods.reserve(nextPowerOfTwo(methodSize));
         for (int i = 0; i < methodSize; i++) {
             methods.emplace_back(unpickleMethod(p, &result));
         }
 
         int fieldSize = p.getU4();
-        ENFORCE(fieldSize > 0);
+        ENFORCE_NO_TIMER(fieldSize > 0);
         fields.reserve(nextPowerOfTwo(fieldSize));
         for (int i = 0; i < fieldSize; i++) {
             fields.emplace_back(unpickleField(p, &result));
         }
 
         int typeArgumentSize = p.getU4();
-        ENFORCE(typeArgumentSize > 0);
+        ENFORCE_NO_TIMER(typeArgumentSize > 0);
         typeArguments.reserve(nextPowerOfTwo(typeArgumentSize));
         for (int i = 0; i < typeArgumentSize; i++) {
             typeArguments.emplace_back(unpickleTypeParameter(p, &result));
         }
 
         int typeMemberSize = p.getU4();
-        ENFORCE(typeMemberSize > 0);
+        ENFORCE_NO_TIMER(typeMemberSize > 0);
         typeMembers.reserve(nextPowerOfTwo(typeMemberSize));
         for (int i = 0; i < typeMemberSize; i++) {
             typeMembers.emplace_back(unpickleTypeParameter(p, &result));
@@ -1080,8 +1080,8 @@ std::vector<uint8_t> Serializer::storePayloadAndNameTable(const GlobalState &gs)
 }
 
 void Serializer::loadGlobalState(GlobalState &gs, const uint8_t *const data) {
-    ENFORCE(gs.files.empty() && gs.namesUsedTotal() == 0 && gs.symbolsUsedTotal() == 0,
-            "Can't load into a non-empty state");
+    ENFORCE_NO_TIMER(gs.files.empty() && gs.namesUsedTotal() == 0 && gs.symbolsUsedTotal() == 0,
+                     "Can't load into a non-empty state");
     UnPickler p(data, gs.tracer());
     SerializerImpl::unpickleGS(p, gs);
 }
@@ -1252,7 +1252,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
         case ast::Tag::Hash: {
             auto &h = ast::cast_tree_nonnull<ast::Hash>(what);
             pickle(p, h.loc);
-            ENFORCE(h.values.size() == h.keys.size());
+            ENFORCE_NO_TIMER(h.values.size() == h.keys.size());
             p.putU4(h.values.size());
             for (auto &v : h.values) {
                 pickle(p, v);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -216,7 +216,7 @@ void KnowledgeFact::min(core::Context ctx, const KnowledgeFact &other) {
 }
 
 void KnowledgeFact::sanityCheck() const {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
     for (auto &a : yesTypeTests) {
@@ -353,7 +353,7 @@ void TestedKnowledge::emitKnowledgeSizeMetric() const {
 }
 
 void TestedKnowledge::sanityCheck() const {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
     _truthy->sanityCheck();

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -260,7 +260,7 @@ uint32_t ErrorReporter::lastDiagnosticEpochForFile(core::FileRef file) {
 }
 
 void ErrorReporter::sanityCheck() const {
-    if (!debug_mode) {
+    if constexpr (!debug_mode) {
         return;
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3919,7 +3919,7 @@ private:
             },
 
             [&](ast::MethodDef &mdef) {
-                if (debug_mode) {
+                if constexpr (debug_mode) {
                     bool hasSig = !lastSigs.empty();
                     bool rewritten = mdef.flags.isRewriterSynthesized;
                     bool isRBI = ctx.file.data(ctx).isRBI();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We discovered that the changes in #8050 were causing Sorbet's test suite to
become flaky, and reverted it in #8057.

Most of the changes in #8050 are completely benign and are still a nice speedup,
so I'm reapplying those changes here.

The only change that's not in this PR but is in #8050 is we can't remove the `gs.sanityCheck()` from `pipeline::index`:

https://github.com/sorbet/sorbet/pull/8050/files#diff-9649cbc5bd643f35c408d9a4e882a42b40637df8574fe71ca2e5df8bcfc1d2b6

It is quite concerning to have a load-bearing `gs.sanityCheck()` in Sorbet, and we should probably spend some time trying to figure out why that sanity check is load bearing.





### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I have been using this command to reproduce the failures:

```
bazel test --config=buildfarm-sanitized-linux --test_summary=terse --build_tests_only //test/lsp:multithreaded_protocol_test_corpus --runs_per_test=200
```

I tested that on `master` after #8057 landed, simply removing `gs.sanityCheck()` on its own was enough to cause the failures. I also was able to confirm that "doing all the ENFORCE -> ENFORCE_NO_TIMER changes" plus "removing `gs.sanityCheck()`" was also enough to cause flaky failures. So I don't think that this is a "straw that broke the camel's back" sort of failures—I think there is something unique to this `gs.sanityCheck()` call in `pipeline::index` making it so that it can't be deleted without making the tests flaky.