### PR TITLE
Fix signature for `String#match`

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -1652,17 +1652,17 @@ class String < Object
   sig do
     params(
         arg0: T.any(Regexp, String),
-        blk: T.untyped,
+        arg1: Integer,
     )
     .returns(T.nilable(MatchData))
   end
   sig do
-    params(
+    type_parameters(:P).params(
         arg0: T.any(Regexp, String),
         arg1: Integer,
-        blk: T.untyped,
+        blk: T.proc.params(arg0: MatchData).returns(T.type_parameter(:P)),
     )
-    .returns(T.nilable(MatchData))
+    .returns(T.nilable(T.type_parameter(:P)))
   end
   def match(arg0, arg1=T.unsafe(nil), &blk); end
 

--- a/test/testdata/rbi/string.rb
+++ b/test/testdata/rbi/string.rb
@@ -24,3 +24,20 @@ T.assert_type!(w, T::Array[String])
 "foo".encode("encoding", "other_encoding", fallback: {})
 "foo".encode("encoding", fallback: {})
 "foo".encode(fallback: {})
+
+# match
+m1 = "foo".match("f")
+m2 = "foo".match("f", 1)
+T.assert_type(m1, T.nilable(MatchData))
+T.assert_type(m2, T.nilable(MatchData))
+
+m3 = "foo".match("f") do |m|
+  T.assert_type(m, MatchData)
+  [m]
+end
+m4 = "foo".match("f", 1) do |m|
+  T.assert_type(m, MatchData)
+  [m]
+end
+T.assert_type(m3, T.nilable(T::Array[MatchData]))
+T.assert_type(m4, T.nilable(T::Array[MatchData]))

--- a/test/testdata/rbi/string.rb
+++ b/test/testdata/rbi/string.rb
@@ -28,16 +28,16 @@ T.assert_type!(w, T::Array[String])
 # match
 m1 = "foo".match("f")
 m2 = "foo".match("f", 1)
-T.assert_type(m1, T.nilable(MatchData))
-T.assert_type(m2, T.nilable(MatchData))
+T.assert_type!(m1, T.nilable(MatchData))
+T.assert_type!(m2, T.nilable(MatchData))
 
 m3 = "foo".match("f") do |m|
-  T.assert_type(m, MatchData)
+  T.assert_type!(m, MatchData)
   [m]
 end
-m4 = "foo".match("f", 1) do |m|
-  T.assert_type(m, MatchData)
+m4 = "foo".match("o", 1) do |m|
+  T.assert_type!(m, MatchData)
   [m]
 end
-T.assert_type(m3, T.nilable(T::Array[MatchData]))
-T.assert_type(m4, T.nilable(T::Array[MatchData]))
+T.assert_type!(m3, T.nilable(T::Array[MatchData]))
+T.assert_type!(m4, T.nilable(T::Array[MatchData]))


### PR DESCRIPTION
### Motivation
When given a block, `String#match` calls the block with the computed matchdata and returns the block’s return value.

https://ruby-doc.org/3.2.2/String.html#method-i-match

### Test plan
See included automated tests.