### PR TITLE
When an invalid loc is computed, log debug info and return no code actions instead of crashing

### DIFF
--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -9,9 +9,8 @@ namespace sorbet::realmain::lsp {
 
 void logDebugInfo(const std::shared_ptr<spdlog::logger> logger, const core::GlobalState &gs,
                   const core::Loc selectionLoc, const std::string message) {
-    logger->debug("ExtractToVariable: {}", message);
-    logger->debug("selectionLoc=\"{}\"", selectionLoc.showRaw(gs));
-    logger->debug("source=\"{}\"", absl::CEscape(selectionLoc.file().data(gs).source()));
+    logger->error("msg=\"ExtractToVariable: {}\" selectionLoc=\"{}\"", message, selectionLoc.showRaw(gs));
+    logger->error("source=\"{}\"", absl::CEscape(selectionLoc.file().data(gs).source()));
 }
 
 core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::LocOffsets target) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We should not crash when the user executes an extract action that triggers an edge case we don't handle.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Ran a sorbet release build with the `--debug-log-file=`, ran a known crashing extract action, saw that sorbet did not crash, and saw the relevant logs in the log file:
```
[2024-07-31 14:11:07.341] [consoleAndFile] [error] msg="ExtractToVariable: failed to determine whereToInsert in getExtractMultipleOccurrenceEdits" selectionLoc="Loc {file=./test.rb start=5:4 end=5:5}"
[2024-07-31 14:11:07.341] [consoleAndFile] [error] source="# typed: strict\n\na = T.unsafe([])\n\nif a && T.unsafe(1)\nend\n"
```