### PR TITLE
Ignore magic method `<required-ancestor-lin>` during documentSymbols

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -44,6 +44,11 @@ bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym) {
     if (name.kind() == core::NameKind::UNIQUE && name.dataUnique(gs)->original == core::Names::blockTemp()) {
         return true;
     }
+
+    if (name == core::Names::requiredAncestorsLin()) {
+        return true;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
By design `requires_ancestor` keeps track of its usages by storing the loc of where it was defined. If requires_ancestor defined on Foo is used in thousands of files thorugh mixin of Foo then there would be thousands of `<required-ancestor-lin>` methods that point to the loc of Foo. This would mean documentSymbols will try to return all of those methods when `foo.rb` is opened which will crash the LSP.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In our case this looked something like:
```ruby
# foo.rb
module Foo
  requires_ancesetor { Object }
```

```ruby
# testcase.rb
class ActiveSupport::TestCase
  include Foo
end
```

With over 20k classes inheriting from `ActiveSupport::TestCase`.This meant seeing over 50k `<required-ancstor-lin` entries in [candidates](https://github.com/sorbet/sorbet/blob/5b4782ef14d493de57db52a314c5e1fb1a3018ec/main/lsp/requests/document_symbol.cc#L230).

One thing I couldn't understand was why `<required-ancestor-lin>` method isn't part of the method list if `Foo` was defined in the same file as its usages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
