### PR TITLE
Add special case for `Class < Module`

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -680,17 +680,19 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
 
     if (send->fun == core::Names::lessThan() || send->fun == core::Names::leq()) {
         const auto &recvType = send->recv.type;
+        if (!recvType.derivesFrom(ctx, core::Symbols::Module())) {
+            return;
+        }
+
         const auto &argType = send->args[0].type;
 
         if (core::isa_type<core::ClassType>(argType)) {
             auto argClass = core::cast_type_nonnull<core::ClassType>(argType);
-            if (!recvType.derivesFrom(ctx, core::Symbols::Module()) ||
-                !argClass.symbol.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
+            if (!argClass.symbol.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
                 return;
             }
         } else if (auto *argClass = core::cast_type<core::AppliedType>(argType)) {
-            if (!recvType.derivesFrom(ctx, core::Symbols::Module()) ||
-                !argClass->klass.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
+            if (!argClass->klass.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
                 return;
             }
         } else {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -679,7 +679,6 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
     }
 
     if (send->fun == core::Names::lessThan() || send->fun == core::Names::leq()) {
-        //
         auto argType = send->args[0].type;
         if (argType.isUntyped() ||
             (!core::isa_type<core::ClassType>(argType) && !core::isa_type<core::AppliedType>(argType))) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -679,6 +679,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
     }
 
     if (send->fun == core::Names::lessThan() || send->fun == core::Names::leq()) {
+        //
         auto argType = send->args[0].type;
         if (argType.isUntyped() ||
             (!core::isa_type<core::ClassType>(argType) && !core::isa_type<core::AppliedType>(argType))) {
@@ -695,10 +696,18 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
             return;
         }
 
+        // We only know the NoTypeTest for `<=`, not `<`, because `x < A` being false could mean
+        // that `x == A`, which would mean `x` still has type `T.class_of(A)`.
+        bool canAddNoTypeTest = send->fun == core::Names::leq();
+
         const auto &argSymData = argSym.data(ctx);
         if (argSymData->isModule()) {
             if (!recvType.isUntyped() && recvType.derivesFrom(ctx, core::Symbols::Class())) {
                 argType = core::Types::tClass(argSymData->externalType());
+
+                // Can't add noTypeTest for module types, because Ruby has multiple inheritance for modules
+                // Even if the current recv doesn't include argSym, that doesn't mean that a subclass couldn't.
+                canAddNoTypeTest = false;
             } else {
                 // Can't support this case until we have T::Module
                 return;
@@ -706,9 +715,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         }
 
         whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
-        if (send->fun == core::Names::leq()) {
-            // We only know the NoTypeTest for `<=`, not `<`, because `x < A` being false could mean
-            // that `x == A`, which would mean `x` still has type `T.class_of(A)`.
+        if (canAddNoTypeTest) {
             whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->recv.variable, argType);
         }
         whoKnows.sanityCheck();

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -680,7 +680,8 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
 
     if (send->fun == core::Names::lessThan() || send->fun == core::Names::leq()) {
         const auto &argType = send->args[0].type;
-        if (!core::isa_type<core::ClassType>(argType) && !core::isa_type<core::AppliedType>(argType)) {
+        if (argType.isUntyped() ||
+            (!core::isa_type<core::ClassType>(argType) && !core::isa_type<core::AppliedType>(argType))) {
             return;
         }
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -679,17 +679,17 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
     }
 
     if (send->fun == core::Names::lessThan() || send->fun == core::Names::leq()) {
-        const auto &recvKlass = send->recv.type;
+        const auto &recvType = send->recv.type;
         const auto &argType = send->args[0].type;
 
         if (core::isa_type<core::ClassType>(argType)) {
             auto argClass = core::cast_type_nonnull<core::ClassType>(argType);
-            if (!recvKlass.derivesFrom(ctx, core::Symbols::Module()) ||
+            if (!recvType.derivesFrom(ctx, core::Symbols::Module()) ||
                 !argClass.symbol.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
                 return;
             }
         } else if (auto *argClass = core::cast_type<core::AppliedType>(argType)) {
-            if (!recvKlass.derivesFrom(ctx, core::Symbols::Module()) ||
+            if (!recvType.derivesFrom(ctx, core::Symbols::Module()) ||
                 !argClass->klass.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
                 return;
             }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -697,7 +697,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
 
         const auto &argSymData = argSym.data(ctx);
         if (argSymData->isModule()) {
-            if (recvType.derivesFrom(ctx, core::Symbols::Class())) {
+            if (!recvType.isUntyped() && recvType.derivesFrom(ctx, core::Symbols::Class())) {
                 argType = core::Types::tClass(argSymData->externalType());
             } else {
                 // Can't support this case until we have T::Module

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -679,12 +679,16 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
     }
 
     if (send->fun == core::Names::lessThan() || send->fun == core::Names::leq()) {
+        const auto &argType = send->args[0].type;
+        if (!core::isa_type<core::ClassType>(argType) && !core::isa_type<core::AppliedType>(argType)) {
+            return;
+        }
+
         const auto &recvType = send->recv.type;
         if (!recvType.derivesFrom(ctx, core::Symbols::Module())) {
             return;
         }
 
-        const auto &argType = send->args[0].type;
         auto argSym = core::Types::getRepresentedClass(ctx, argType);
         if (!argSym.exists() || !argSym.data(ctx)->isClass()) {
             return;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -685,17 +685,8 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         }
 
         const auto &argType = send->args[0].type;
-
-        if (core::isa_type<core::ClassType>(argType)) {
-            auto argClass = core::cast_type_nonnull<core::ClassType>(argType);
-            if (!argClass.symbol.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
-                return;
-            }
-        } else if (auto *argClass = core::cast_type<core::AppliedType>(argType)) {
-            if (!argClass->klass.data(ctx)->derivesFrom(ctx, core::Symbols::Class())) {
-                return;
-            }
-        } else {
+        auto argSym = core::Types::getRepresentedClass(ctx, argType);
+        if (!argSym.exists() || !argSym.data(ctx)->isClass()) {
             return;
         }
 

--- a/test/testdata/infer/control_flow/module_less_than.rb
+++ b/test/testdata/infer/control_flow/module_less_than.rb
@@ -31,7 +31,7 @@ def valid?(obj)
     end
 
     if obj <= M
-      T.reveal_type(obj) # error: `T::Class[T.anything]`
+      T.reveal_type(obj) # error: `T::Class[M]`
     end
   end
 
@@ -64,11 +64,11 @@ end
 sig { params(klass: T.class_of(T::Enum)).void }
 def class_lt_module(klass)
   if klass < Exportable
-    T.reveal_type(klass) # error: `T.class_of(T::Enum)`
+    T.reveal_type(klass) # error: `T.class_of(T::Enum)[T.all(T::Enum, Exportable)]`
     value = klass.try_deserialize("foo")
     raise unless value
-    exported = value.export # error: Method `export` does not exist on `T::Enum`
-    T.reveal_type(exported) # error: `T.untyped`
+    exported = value.export
+    T.reveal_type(exported) # error: `Integer`
   end
 end
 
@@ -105,7 +105,7 @@ end
 sig { params(klass: T::Class[T.anything], mod: Module).void }
 def nothing_special_for_class_methods(klass, mod)
   if klass < HasClassMethods
-    T.reveal_type(klass) # error: `T::Class[T.anything]`
+    T.reveal_type(klass) # error: `T::Class[HasClassMethods]`
   end
 
   if mod < HasClassMethods

--- a/test/testdata/infer/control_flow/module_less_than.rb
+++ b/test/testdata/infer/control_flow/module_less_than.rb
@@ -112,3 +112,12 @@ def nothing_special_for_class_methods(klass, mod)
     T.reveal_type(mod) # error: `Module`
   end
 end
+
+sig { params(other: T.class_of(A)).void }
+def module_should_not_add_noTypeTest(other)
+  if other <= M
+    T.reveal_type(other) # error: `T.class_of(A)[T.all(A, M)]`
+  end
+
+  T.reveal_type(other) # error: `T.class_of(A)`
+end

--- a/test/testdata/infer/control_flow/module_less_than.rb
+++ b/test/testdata/infer/control_flow/module_less_than.rb
@@ -117,6 +117,7 @@ sig { params(other: T.class_of(A)).void }
 def module_should_not_add_noTypeTest(other)
   if other <= M
     T.reveal_type(other) # error: `T.class_of(A)[T.all(A, M)]`
+    return
   end
 
   T.reveal_type(other) # error: `T.class_of(A)`

--- a/test/testdata/infer/control_flow/module_less_than.rb
+++ b/test/testdata/infer/control_flow/module_less_than.rb
@@ -10,7 +10,105 @@ end
 sig {params(y: Object).void}
 def main(y)
   if y.is_a?(Module) && y < A
-    y.foo("bar") 
+    y.foo("bar")
   end
 end
 
+module M; end
+
+sig { params(obj: T.untyped).void }
+def valid?(obj)
+  T.reveal_type(obj) # error: `T.untyped`
+  if obj.is_a?(Class)
+    T.reveal_type(obj) # error: `T::Class[T.anything]`
+
+    if obj <= T.unsafe(Integer)
+      T.reveal_type(obj) # error: `T::Class[T.anything]`
+    end
+
+    if obj <= Integer
+      T.reveal_type(obj) # error: `T.class_of(Integer)`
+    end
+
+    if obj <= M
+      T.reveal_type(obj) # error: `T::Class[T.anything]`
+    end
+  end
+
+  T.reveal_type(obj) # error: `T.untyped`
+  if obj.is_a?(Module)
+    T.reveal_type(obj) # error: `Module`
+
+    if obj <= T.unsafe(Integer)
+      T.reveal_type(obj) # error: `Module`
+    end
+
+    if obj <= Integer
+      T.reveal_type(obj) # error: `T.class_of(Integer)`
+    end
+
+    if obj <= M
+      T.reveal_type(obj) # error: `Module`
+    end
+  end
+end
+
+module Exportable
+  extend T::Sig
+  sig { returns(Integer) }
+  def export
+    0
+  end
+end
+
+sig { params(klass: T.class_of(T::Enum)).void }
+def class_lt_module(klass)
+  if klass < Exportable
+    T.reveal_type(klass) # error: `T.class_of(T::Enum)`
+    value = klass.try_deserialize("foo")
+    raise unless value
+    exported = value.export # error: Method `export` does not exist on `T::Enum`
+    T.reveal_type(exported) # error: `T.untyped`
+  end
+end
+
+module FromHash
+  extend T::Sig, T::Generic
+  has_attached_class!
+  abstract!
+
+  sig { abstract.returns(T.attached_class) }
+  def from_hash
+  end
+end
+
+sig { params(klass: T.all(Module, FromHash[T.anything])).void }
+def module_lt_module(klass)
+  if klass < Exportable
+    T.reveal_type(klass) # error: `T.all(FromHash[T.anything], Module)`
+    value = klass.from_hash
+    T.reveal_type(value) # error: `T.anything`
+    raise unless value
+    exported = value.export # error: Method `export` does not exist on `T.anything`
+    T.reveal_type(exported) # error: `T.untyped`
+  end
+end
+
+module HasClassMethods
+  extend T::Helpers
+
+  module ClassMethods
+  end
+  mixes_in_class_methods(ClassMethods)
+end
+
+sig { params(klass: T::Class[T.anything], mod: Module).void }
+def nothing_special_for_class_methods(klass, mod)
+  if klass < HasClassMethods
+    T.reveal_type(klass) # error: `T::Class[T.anything]`
+  end
+
+  if mod < HasClassMethods
+    T.reveal_type(mod) # error: `Module`
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This still doesn't handle the `Module < Module` case, because there's no
type that Sorbet can write there that's accurate until `T::Module`
exists.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included tests