### PR TITLE
Add definition for URI::RFC2396_PARSER

### DIFF
--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -143,6 +143,7 @@ module URI
   REL_PATH = T.let(T.unsafe(nil), Regexp)
   REL_URI = T.let(T.unsafe(nil), Regexp)
   REL_URI_REF = T.let(T.unsafe(nil), Regexp)
+  RFC2396_PARSER = T.let(T.unsafe(nil), URI::RFC2396_Parser)
   RFC3986_PARSER = T.let(T.unsafe(nil), URI::RFC3986_Parser)
   SCHEME = T.let(T.unsafe(nil), Regexp)
   TBLDECWWWCOMP_ = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])


### PR DESCRIPTION
### Motivation
URI added the ability to set [which parser it uses](https://github.com/ruby/uri/pull/107):

```
URI.parser = URI::RFC2396_PARSER
```

`URI::RFC2396_PARSER` is missing a type definition in `rbi/stdlib/uri.rbi`, which causes an error. This adds the missing type definition.

### Test plan
I didn't add tests for this change, it's a declaration and doesn't add any behavior.