### PR TITLE
Refactor requires_ancestor magic method

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1473,6 +1473,23 @@ ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRe
     return store;
 }
 
+ArgInfo &GlobalState::enterMethodArgumentSymbolWithDupes(Loc loc, MethodRef owner, NameRef name) {
+    ENFORCE_NO_TIMER(owner.exists(), "entering symbol in to non-existing owner");
+    ENFORCE_NO_TIMER(name.exists(), "entering symbol with non-existing name");
+    MethodData ownerScope = owner.data(*this);
+
+    auto &store = ownerScope->arguments.emplace_back();
+
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
+
+    store.name = name;
+    store.loc = loc;
+    DEBUG_ONLY(categoryCounterInc("symbols", "argument"););
+
+    wasModified_ = true;
+    return store;
+}
+
 string_view GlobalState::enterString(string_view nm) {
     DEBUG_ONLY(if (ensureCleanStrings) {
         if (nm != "<" && nm != "<<" && nm != "<=" && nm != "<=>" && nm != ">" && nm != ">>" && nm != ">=") {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -109,6 +109,7 @@ public:
     FieldRef enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     FieldRef enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     ArgInfo &enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name);
+    ArgInfo &enterMethodArgumentSymbolWithDupes(Loc loc, MethodRef owner, NameRef name);
 
     SymbolRef lookupSymbol(ClassOrModuleRef owner, NameRef name) const {
         return lookupSymbolWithKind(owner, name, SymbolRef::Kind::ClassOrModule, Symbols::noSymbol(),

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1969,7 +1969,7 @@ bool ClassOrModule::hasSingleSealedSubclass(const GlobalState &gs) const {
 }
 
 // Record a required ancestor for this class of module
-//
+// TODO: Edit
 // Each RequiredAncestor is stored into a magic method referenced by `prop` where:
 // * RequiredAncestor.symbol goes into the return type tuple
 // * RequiredAncestor.origin goes into the first argument type tuple
@@ -1982,37 +1982,31 @@ void ClassOrModule::recordRequiredAncestorInternal(GlobalState &gs, ClassOrModul
     if (!ancestors.exists()) {
         ancestors = gs.enterMethodSymbol(ancestor.loc, this->ref(gs), prop);
         ancestors.data(gs)->locs_.clear(); // Remove the original location
-
-        // Create the return type tuple to store RequiredAncestor.symbol
-        vector<TypePtr> tsymbols;
-        ancestors.data(gs)->resultType = make_type<TupleType>(move(tsymbols));
-
-        // Create the first argument typed as a tuple to store RequiredAncestor.origin
-        auto &arg = gs.enterMethodArgumentSymbol(core::Loc::none(), ancestors, core::Names::arg());
-        vector<TypePtr> torigins;
-        arg.type = make_type<TupleType>(move(torigins));
     }
 
     // Do not require the same ancestor twice
-    auto &elems = (cast_type<TupleType>(ancestors.data(gs)->resultType))->elems;
-    bool alreadyRecorded = absl::c_any_of(elems, [ancestor](auto elem) {
-        ENFORCE(isa_type<ClassType>(elem), "Something in requiredAncestors that's not a ClassType");
-        return cast_type_nonnull<ClassType>(elem).symbol == ancestor.symbol;
-    });
-    if (alreadyRecorded) {
-        return;
+    for (auto &arg : ancestors.data(gs)->arguments) {
+        auto type = arg.type;
+        ENFORCE(isa_type<TupleType>(type), "Something in requiredAncestors that's not a TupleType");
+        auto &tupleType = cast_type_nonnull<TupleType>(type);
+        ENFORCE(isa_type<ClassType>(tupleType.elems[0]), "TupleType for requiredAncestors doesn't contain ClassType");
+        auto classType = cast_type_nonnull<ClassType>(tupleType.elems[0]); // RequiredAncestor.symbol
+
+        if (classType.symbol == ancestor.symbol) {
+            // TODO: Aren't we losing information since origin could be different?
+            return;
+        }
     }
 
-    // Store the RequiredAncestor.symbol
+    // Store the RequiredAncestor.symbol and RequiredAncestor.origin
     auto tSymbol = core::make_type<ClassType>(ancestor.symbol);
-    (cast_type<TupleType>(ancestors.data(gs)->resultType))->elems.emplace_back(tSymbol);
-
-    // Store the RequiredAncestor.origin
     auto tOrigin = core::make_type<ClassType>(ancestor.origin);
-    (cast_type<TupleType>(ancestors.data(gs)->arguments[0].type))->elems.emplace_back(tOrigin);
+    vector<TypePtr> args = {tSymbol, tOrigin};
+    auto tupleType = core::make_type<TupleType>(std::move(args));
 
-    // Store the RequiredAncestor.loc
-    ancestors.data(gs)->locs_.emplace_back(ancestor.loc);
+    // Create a new argument from tupleType and append to ancestor arguments
+    auto &arg = gs.enterMethodArgumentSymbolWithDupes(ancestor.loc, ancestors, core::Names::arg());
+    arg.type = std::move(tupleType);
 }
 
 // Locally required ancestors by this class or module
@@ -2026,19 +2020,22 @@ vector<ClassOrModule::RequiredAncestor> ClassOrModule::readRequiredAncestorsInte
         return res;
     }
 
-    auto data = ancestors.data(gs);
-    auto tSymbols = cast_type<TupleType>(data->resultType);
-    auto tOrigins = cast_type<TupleType>(data->arguments[0].type);
-    auto index = 0;
-    for (auto elem : tSymbols->elems) {
-        ENFORCE(isa_type<ClassType>(elem), "Something in requiredAncestors that's not a ClassType");
-        ENFORCE(isa_type<ClassType>(tOrigins->elems[index]), "Bad origin in requiredAncestors");
-        ENFORCE(index < data->locs().size(), "Missing loc in requiredAncestors");
-        auto &origin = cast_type_nonnull<ClassType>(tOrigins->elems[index]).symbol;
-        auto &symbol = cast_type_nonnull<ClassType>(elem).symbol;
-        auto &loc = data->locs()[index];
-        res.emplace_back(origin, symbol, loc);
-        index++;
+    // iterate over ancestors.data(gs)->arguments
+    for (auto &arg : ancestors.data(gs)->arguments) {
+        ENFORCE(isa_type<TupleType>(arg.type), "Something in requiredAncestors that's not a TupleType");
+        auto &tupleType = cast_type_nonnull<TupleType>(arg.type);
+
+        auto symbol = tupleType.elems[0];
+        ENFORCE(isa_type<ClassType>(symbol),
+                "TupleType for requiredAncestors doesn't contain ClassType in first index");
+        auto tSymbol = cast_type_nonnull<ClassType>(symbol);
+
+        auto origin = tupleType.elems[1];
+        ENFORCE(isa_type<ClassType>(origin),
+                "TupleType for requiredAncestors doesn't contain ClassType in second index");
+        auto tOrigin = cast_type_nonnull<ClassType>(origin);
+
+        res.emplace_back(tOrigin.symbol, tSymbol.symbol, arg.loc);
     }
 
     return res;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -45,9 +45,9 @@ bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym) {
         return true;
     }
 
-    if (name == core::Names::requiredAncestorsLin()) {
-        return true;
-    }
+    // if (name == core::Names::requiredAncestorsLin()) {
+    //     return true;
+    // }
 
     return false;
 }


### PR DESCRIPTION
Before we were storing relevant information in both arguments and return type. This PR cleans it up a bit and only uses arguments.

Each argument to the magic <required-ancestor-lin> or <required-ancestor> methods is a tuple where first element is the ancestor being required and the second is the constant that required it. Each time a module which defines an ancestor is mixed in we create a new argument.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
