### PR TITLE
Add missing :relative and :target_directory options to FileUtils#ln_s

### DIFF
--- a/rbi/stdlib/fileutils.rbi
+++ b/rbi/stdlib/fileutils.rbi
@@ -676,11 +676,13 @@ module FileUtils
       src: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
       dest: T.any(String, Pathname),
       force: T.nilable(T::Boolean),
+      relative: T::Boolean,
+      target_directory: T::Boolean,
       noop: T.nilable(T::Boolean),
       verbose: T.nilable(T::Boolean)
     ).void
   end
-  module_function def ln_s(src, dest, force: nil, noop: nil, verbose: nil); end
+  module_function def ln_s(src, dest, force: nil, relative: false, target_directory: true, noop: nil, verbose: nil); end
 
   # Alias for:
   # [`ln_s`](https://docs.ruby-lang.org/en/2.6.0/FileUtils.html#method-i-ln_s)
@@ -689,11 +691,13 @@ module FileUtils
       src: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
       dest: T.any(String, Pathname),
       force: T.nilable(T::Boolean),
+      relative: T::Boolean,
+      target_directory: T::Boolean,
       noop: T.nilable(T::Boolean),
       verbose: T.nilable(T::Boolean)
     ).void
   end
-  module_function def symlink(src, dest, force: nil, noop: nil, verbose: nil); end
+  module_function def symlink(src, dest, force: nil, relative: false, target_directory: true, noop: nil, verbose: nil); end
 
   # Same as
   #


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The RBI file for the `FileUtils#ln_s` method (and aliased `#symlink` method) is missing the `:relative` and `:target_directory` that can be found [in the docs here](https://ruby-doc.org/3.2.2/stdlibs/fileutils/FileUtils.html#method-c-ln_s).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.