### PR TITLE
Fix signature for `MatchData#offset`

### DIFF
--- a/rbi/core/match_data.rbi
+++ b/rbi/core/match_data.rbi
@@ -289,7 +289,7 @@ class MatchData < Object
   # ```
   sig do
     params(
-        n: Integer,
+        n: T.any(Integer, Symbol, String),
     )
     .returns(T::Array[Integer])
   end


### PR DESCRIPTION
### Motivation

Fixes the signature to allow string and symbol keys. These specify regex capture group names.

See the documentation just a couple lines up to for an example with a symbol is valid.

### Test plan

N/A. See Ruby documentation.