### PR TITLE
Fix typing for SystemCallError and its subclasses

### DIFF
--- a/rbi/core/errno.rbi
+++ b/rbi/core/errno.rbi
@@ -48,536 +48,1334 @@ end
 
 class Errno::E2BIG < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EACCES < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EADDRINUSE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EADDRNOTAVAIL < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EADV < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EAFNOSUPPORT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EAGAIN < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EWOULDBLOCK < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EALREADY < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EBADE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EBADF < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EBADFD < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EBADMSG < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EBADR < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EBADRQC < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EBADSLT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EBFONT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EBUSY < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ECANCELED < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ECHILD < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ECHRNG < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ECOMM < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 # Client sent TCP reset (RST) before server has accepted the connection
 # requested by client.
 class Errno::ECONNABORTED < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ECONNREFUSED < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 # Remote host reset the connection request.
 class Errno::ECONNRESET < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EDEADLK < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EDESTADDRREQ < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EDOM < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EDOTDOT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EDQUOT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EEXIST < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EFAULT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EFBIG < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EHOSTDOWN < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EHOSTUNREACH < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EHWPOISON < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EIDRM < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EILSEQ < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EINPROGRESS < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EINTR < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EINVAL < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EIO < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EISCONN < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EISDIR < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EISNAM < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EKEYEXPIRED < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EKEYREJECTED < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EKEYREVOKED < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EL2HLT < SystemCallError
   Errno = T.let(nil, Integer)
+
+ sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EL2NSYNC < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EL3HLT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EL3RST < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ELIBACC < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ELIBBAD < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ELIBEXEC < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ELIBMAX < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ELIBSCN < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ELNRNG < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ELOOP < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EMEDIUMTYPE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EMFILE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EMLINK < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EMSGSIZE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EMULTIHOP < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENAMETOOLONG < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENAVAIL < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENETDOWN < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENETRESET < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENETUNREACH < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENFILE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOANO < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOBUFS < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOCSI < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENODATA < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENODEV < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOENT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOEXEC < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOKEY < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOLCK < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOLINK < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOMEDIUM < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOMEM < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOMSG < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENONET < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOPKG < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOPROTOOPT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOSPC < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOSR < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOSTR < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOSYS < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOTBLK < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOTCONN < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOTDIR < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOTEMPTY < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOTNAM < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOTRECOVERABLE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOTSOCK < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOTTY < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENOTUNIQ < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ENXIO < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EOPNOTSUPP < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EOVERFLOW < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EOWNERDEAD < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EPERM < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EPFNOSUPPORT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EPIPE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 # Protocol error.
 class Errno::EPROTO < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EPROTONOSUPPORT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EPROTOTYPE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ERANGE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EREMCHG < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EREMOTE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EREMOTEIO < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ERESTART < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ERFKILL < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EROFS < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ESHUTDOWN < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ESOCKTNOSUPPORT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ESPIPE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ESRCH < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ESRMNT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ESTALE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ESTRPIPE < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ETIME < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ETIMEDOUT < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ETOOMANYREFS < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::ETXTBSY < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EUCLEAN < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EUNATCH < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EUSERS < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EXDEV < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::EXFULL < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end
 
 class Errno::NOERROR < SystemCallError
   Errno = T.let(nil, Integer)
+
+  sig { params(message: T.nilable(String), func: T.nilable(Object)).returns(T.attached_class) }
+  def self.new(message = nil, func = nil); end
+
+  sig { returns(Integer) }
+  def errno; end
 end

--- a/rbi/core/errors.rbi
+++ b/rbi/core/errors.rbi
@@ -542,14 +542,18 @@ class SystemCallError < StandardError
   # object. The error number is subsequently available via the
   # [`errno`](https://docs.ruby-lang.org/en/2.7.0/SystemCallError.html#method-i-errno)
   # method.
-  def self.new(*_); end
+  sig { params(arg0: T.any(String, T.nilable(Integer))).returns(SystemCallError) }
+  sig { params(arg0: String, errno: T.nilable(Integer), func: T.nilable(Object)).returns(SystemCallError) }
+  def self.new(arg0, errno = nil, func = nil); end
 
   # Return this SystemCallError's error number.
+  sig { returns(T.nilable(Integer)) }
   def errno; end
 
   # Return `true` if the receiver is a generic `SystemCallError`, or if the
   # error numbers `self` and *other* are the same.
-  def self.===(_); end
+  sig { params(other: BasicObject).returns(T::Boolean) }
+  def self.===(other); end
 end
 
 # Raised by `exit` to initiate the termination of the script.

--- a/test/testdata/rbi/exception.rb
+++ b/test/testdata/rbi/exception.rb
@@ -6,3 +6,19 @@ StandardError.new('msg')
 StandardError.new(:msg)
 ex = StandardError.new("bees")
 RuntimeError.new(ex)
+
+SystemCallError.new # error: Not enough arguments provided for method `SystemCallError.new`. Expected: `1`, got: `0`
+SystemCallError.new(1)
+SystemCallError.new(nil)
+SystemCallError.new("message")
+SystemCallError.new("message", 1)
+SystemCallError.new("message", nil)
+SystemCallError.new("message", "func") # error: Expected `T.nilable(Integer)` but found `String("func")` for argument `errno`
+SystemCallError.new("message", 1, "func")
+SystemCallError.new("message", nil, "func")
+Errno::ENOENT.new
+Errno::ENOENT.new(1) # error: Expected `T.nilable(String)` but found `Integer(1)` for argument `message`
+Errno::ENOENT.new("message")
+Errno::ENOENT.new("message", "func")
+T.reveal_type(SystemCallError.new(nil).errno) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type(Errno::ENOENT.new.errno) # error: Revealed type: `Integer`


### PR DESCRIPTION
`SystemCallError` is a bit of a mess. It has a custom object creator that varies in behaviour if it called on a subclass, even if that subclass doesn't define its own constructor.

Basically the way it works is:

* `SystemCallError.new` takes 1-3 args
* `(class < SystemCallError).new` takes 0-2 args
* `SystemCallError.new` will return a `SystemCallError` object
* `SystemCallError.new(1)` will return a `Errno::EPERM` object
* `SystemCallError.new(999)` will return a `SystemCallError` object (no child class found)
* `SystemCallError#errno` will return a nilable integer based on what was passed to the constructor
* `(class < SystemCallError)#errno` will return the value of `(class < SystemCallError)::Errno`. It is an error to create a subclass without defining the `Errno` constant. The constant must be an integer or nil.
  - Therefore the stdlib `Errno::E.*#errno` can never return nil as they all have `Errno` correctly defined to an integer. 

We can't really check all of that in Sorbet so I did the best I could.

### Motivation

Original motivation was seeing that `rescue SystemCallError` was untyped: https://sorbet.run/#%23%20typed%3A%20strong%0Aextend%20T%3A%3ASig%0A%0Asig%20%7Bvoid%7D%0Adef%20bar%0A%20%20begin%0A%20%20rescue%20SystemCallError%20%3D%3E%20e%0A%20%20end%0Aend%0A

And then I opened a can of worms I perhaps shouldn't have of trying to type the rest of `SystemCallError`.

### Test plan

See included automated tests.
