### PR TITLE
Correctly handle extracting to variable when all the occurrences are in the same "non-scope"

### DIFF
--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -473,7 +473,17 @@ MultipleOccurrenceResult VariableExtractor::getExtractMultipleOccurrenceEdits(co
         return {vector<unique_ptr<TextDocumentEdit>>(), 1};
     }
 
-    const ast::ExpressionPtr *scopeToInsertIn = walk.LCAScopeStack.back();
+    const ast::ExpressionPtr *scopeToInsertIn = nullptr;
+    for (auto scope = walk.LCAScopeStack.rbegin(); scope != walk.LCAScopeStack.rend(); ++scope) {
+        if (ast::isa_tree<ast::InsSeq>(**scope) || ast::isa_tree<ast::ClassDef>(**scope) ||
+            ast::isa_tree<ast::Block>(**scope) || ast::isa_tree<ast::MethodDef>(**scope) ||
+            ast::isa_tree<ast::If>(**scope) || ast::isa_tree<ast::Rescue>(**scope) ||
+            ast::isa_tree<ast::RescueCase>(**scope) || ast::isa_tree<ast::While>(**scope)) {
+            scopeToInsertIn = *scope;
+            break;
+        }
+    }
+    ENFORCE(scopeToInsertIn);
 
     fast_sort(matches, [](auto a, auto b) { return a.beginPos() < b.beginPos(); });
     auto firstMatch = matches[0];

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -483,7 +483,7 @@ MultipleOccurrenceResult VariableExtractor::getExtractMultipleOccurrenceEdits(co
             break;
         }
     }
-    ENFORCE(scopeToInsertIn);
+    ENFORCE(scopeToInsertIn, "the LCA scope stack should always have a ClassDef or MethodDef");
 
     fast_sort(matches, [](auto a, auto b) { return a.beginPos() < b.beginPos(); });
     auto firstMatch = matches[0];

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.A.rbedited
@@ -38,3 +38,17 @@ def same_cond_if(x)
     x + 2
   end
 end
+
+def both_match_in_expr(x)
+  if x + x
+#    ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#   ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  else
+    2 + 2
+#   ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.B.rbedited
@@ -38,3 +38,17 @@ def same_cond_if(x)
     x + 2
   end
 end
+
+def both_match_in_expr(x)
+  if x + x
+#    ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#   ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  else
+    2 + 2
+#   ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.C.rbedited
@@ -38,3 +38,17 @@ def same_cond_if(x)
     x + 2
   end
 end
+
+def both_match_in_expr(x)
+  if x + x
+#    ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#   ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  else
+    2 + 2
+#   ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.D.rbedited
@@ -38,3 +38,17 @@ def same_cond_if(x)
     x + 2
   end
 end
+
+def both_match_in_expr(x)
+  if x + x
+#    ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#   ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  else
+    2 + 2
+#   ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.E.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.E.rbedited
@@ -38,3 +38,17 @@ def same_cond_if(x)
     x + 2
   end
 end
+
+def both_match_in_expr(x)
+  if x + x
+#    ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#   ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  else
+    2 + 2
+#   ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.G.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.G.rbedited
@@ -27,12 +27,11 @@ def same_if_else(x)
 end
 
 def same_cond_if(x)
-  newVariable = x + 1
-  if newVariable
-    newVariable
+  if x + 1
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
-    newVariable
+    x + 1
   else
     x + 2
     x + 2
@@ -40,7 +39,8 @@ def same_cond_if(x)
 end
 
 def both_match_in_expr(x)
-  if x + x
+  newVariable = x
+  if newVariable + x
 #    ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
     1 + 1

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.H.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.H.rbedited
@@ -27,12 +27,11 @@ def same_if_else(x)
 end
 
 def same_cond_if(x)
-  newVariable = x + 1
-  if newVariable
-    newVariable
+  if x + 1
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
-    newVariable
+    x + 1
   else
     x + 2
     x + 2
@@ -40,7 +39,8 @@ def same_cond_if(x)
 end
 
 def both_match_in_expr(x)
-  if x + x
+  newVariable = x
+  if newVariable + newVariable
 #    ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
     1 + 1

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.I.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.I.rbedited
@@ -27,12 +27,11 @@ def same_if_else(x)
 end
 
 def same_cond_if(x)
-  newVariable = x + 1
-  if newVariable
-    newVariable
+  if x + 1
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
-    newVariable
+    x + 1
   else
     x + 2
     x + 2
@@ -43,7 +42,8 @@ def both_match_in_expr(x)
   if x + x
 #    ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
-    1 + 1
+    newVariable = 1
+    newVariable + 1
 #   ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   else

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.J.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.J.rbedited
@@ -27,12 +27,11 @@ def same_if_else(x)
 end
 
 def same_cond_if(x)
-  newVariable = x + 1
-  if newVariable
-    newVariable
+  if x + 1
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
-    newVariable
+    x + 1
   else
     x + 2
     x + 2
@@ -40,10 +39,11 @@ def same_cond_if(x)
 end
 
 def both_match_in_expr(x)
+  newVariable = 1
   if x + x
 #    ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
-    1 + 1
+    newVariable + newVariable
 #   ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   else

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.K.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.K.rbedited
@@ -27,12 +27,11 @@ def same_if_else(x)
 end
 
 def same_cond_if(x)
-  newVariable = x + 1
-  if newVariable
-    newVariable
+  if x + 1
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
-    newVariable
+    x + 1
   else
     x + 2
     x + 2
@@ -47,7 +46,8 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   else
-    2 + 2
+    newVariable = 2
+    newVariable + 2
 #   ^ apply-code-action: [K] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.L.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.L.rbedited
@@ -27,12 +27,11 @@ def same_if_else(x)
 end
 
 def same_cond_if(x)
-  newVariable = x + 1
-  if newVariable
-    newVariable
+  if x + 1
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
-    newVariable
+    x + 1
   else
     x + 2
     x + 2
@@ -40,6 +39,7 @@ def same_cond_if(x)
 end
 
 def both_match_in_expr(x)
+  newVariable = 2
   if x + x
 #    ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
@@ -47,7 +47,7 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   else
-    2 + 2
+    newVariable + newVariable
 #   ^ apply-code-action: [K] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.rb
@@ -37,3 +37,17 @@ def same_cond_if(x)
     x + 2
   end
 end
+
+def both_match_in_expr(x)
+  if x + x
+#    ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#   ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  else
+    2 + 2
+#   ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.A.rbedited
@@ -31,3 +31,13 @@ def while_3(x)
     x + 1
   end
 end
+
+def while_4(x)
+  while x + x
+#       ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#       ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.B.rbedited
@@ -31,3 +31,13 @@ def while_3(x)
     x + 1
   end
 end
+
+def while_4(x)
+  while x + x
+#       ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#       ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.C.rbedited
@@ -31,3 +31,13 @@ def while_3(x)
     x + 1
   end
 end
+
+def while_4(x)
+  while x + x
+#       ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#       ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.D.rbedited
@@ -31,3 +31,13 @@ def while_3(x)
     x + 1
   end
 end
+
+def while_4(x)
+  while x + x
+#       ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#       ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.F.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.F.rbedited
@@ -31,3 +31,13 @@ def while_3(x)
     newVariable
   end
 end
+
+def while_4(x)
+  while x + x
+#       ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#       ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.G.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.G.rbedited
@@ -24,8 +24,7 @@ end
 
 def while_3(x)
   while x + 1
-    newVariable = x + 1
-    newVariable
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
     x + 1
@@ -33,7 +32,8 @@ def while_3(x)
 end
 
 def while_4(x)
-  while x + x
+  newVariable = x
+  while newVariable + x
 #       ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
     1 + 1

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.H.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.H.rbedited
@@ -24,8 +24,7 @@ end
 
 def while_3(x)
   while x + 1
-    newVariable = x + 1
-    newVariable
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
     x + 1
@@ -33,7 +32,8 @@ def while_3(x)
 end
 
 def while_4(x)
-  while x + x
+  newVariable = x
+  while newVariable + newVariable
 #       ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
     1 + 1

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.I.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.I.rbedited
@@ -24,8 +24,7 @@ end
 
 def while_3(x)
   while x + 1
-    newVariable = x + 1
-    newVariable
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
     x + 1
@@ -36,7 +35,8 @@ def while_4(x)
   while x + x
 #       ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
-    1 + 1
+    newVariable = 1
+    1 + newVariable
 #       ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.J.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.J.rbedited
@@ -24,8 +24,7 @@ end
 
 def while_3(x)
   while x + 1
-    newVariable = x + 1
-    newVariable
+    x + 1
 #   ^^^^^ apply-code-action: [E] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [F] Extract Variable (all 3 occurrences)
     x + 1
@@ -33,10 +32,11 @@ def while_3(x)
 end
 
 def while_4(x)
+  newVariable = 1
   while x + x
 #       ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
-    1 + 1
+    newVariable + newVariable
 #       ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.rb
@@ -30,3 +30,13 @@ def while_3(x)
     x + 1
   end
 end
+
+def while_4(x)
+  while x + x
+#       ^ apply-code-action: [G] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    1 + 1
+#       ^ apply-code-action: [I] Extract Variable (this occurrence only)
+#       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

```
if x + x
  1 + 1
end
```

Given previous code, extracting both occurrences of `x` would previously fail.

That's because the code to compute the LCA would (correctly) determine that it's the condition of the `if`. But that's not a "scope" we can insert - it's just a single `Send` expression - so `findWhereToInsert` would raise.

The fix I have here is to walk further up the LCA stack until we hit a ancestor we can insert into.

This has the downside of not correctly handling extracting both occurrences of `1`; we'll now insert it outside rather than inside the `if`. This happens becomes if the body of the `if` is just a single line, the AST represents it by pointing to the send directly rather than an `InsSeq`. This is the wrong behavior and we should fix it later, but I don't think it's worth blocking this change on it; it's a fairly minor case, and previously we just failed on it.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Handle this case correctly and don't error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
