### PR TITLE
Correctly handle &&/|| in extract to variable

### DIFF
--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -399,6 +399,12 @@ public:
             return;
         }
 
+        if (std::find(matches.begin(), matches.end(), tree.loc()) != matches.end()) {
+            // We've already seen a node with the exact same loc before, so this is likely constructed by
+            // desugar. Skip it.
+            return;
+        }
+
         if (targetNode->structurallyEqual(ctx, tree, selectionLoc.file())) {
             matches.emplace_back(tree.loc());
             computeLCA(tree.loc());

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -399,7 +399,7 @@ public:
             return;
         }
 
-        if (std::find(matches.begin(), matches.end(), tree.loc()) != matches.end()) {
+        if (absl::c_find(matches, tree.loc()) != matches.end()) {
             // We've already seen a node with the exact same loc before, so this is likely constructed by
             // desugar. Skip it.
             return;

--- a/test/testdata/lsp/code_actions/extract_variable_single/insseq.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/insseq.A.rbedited
@@ -1,0 +1,20 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def and
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  newVariable = a
+  newVariable && b
+# ^ apply-code-action: [A] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [B] Extract Variable (this occurrence only)
+end
+
+def or
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  a || b
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end

--- a/test/testdata/lsp/code_actions/extract_variable_single/insseq.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/insseq.B.rbedited
@@ -1,0 +1,19 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def and
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  a && newVariable = b; newVariable
+# ^ apply-code-action: [A] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [B] Extract Variable (this occurrence only)
+end
+
+def or
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  a || b
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end

--- a/test/testdata/lsp/code_actions/extract_variable_single/insseq.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/insseq.C.rbedited
@@ -1,0 +1,20 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def and
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  a && b
+# ^ apply-code-action: [A] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [B] Extract Variable (this occurrence only)
+end
+
+def or
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  newVariable = a
+  newVariable || b
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end

--- a/test/testdata/lsp/code_actions/extract_variable_single/insseq.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/insseq.D.rbedited
@@ -1,0 +1,19 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def and
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  a && b
+# ^ apply-code-action: [A] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [B] Extract Variable (this occurrence only)
+end
+
+def or
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  a || newVariable = b; newVariable
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end

--- a/test/testdata/lsp/code_actions/extract_variable_single/insseq.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_single/insseq.rb
@@ -1,0 +1,19 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def and
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  a && b
+# ^ apply-code-action: [A] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [B] Extract Variable (this occurrence only)
+end
+
+def or
+  a = T.unsafe(1)
+  b = T.unsafe(1)
+  a || b
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible 
changes. -->

We desugar `a && b` to the following:
```
if a
  b
else
  a
end
```

The problem is that this has 2 instances of `a`, so we will incorrectly suggest the extract all occurrences action, which will then insert `newVariable` twice.

We can handle this by skipping any nodes that have the same loc as a node we've previously seen and stored as a match; if the locs are the same, one of them is likely a synthetic node we created in desugar.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Handle this case correctly and don't error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
