### PR TITLE
Change the loc we use for mlhs pinning errors

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -460,7 +460,7 @@ ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlh
             } else {
                 ++before;
             }
-            auto val = MK::Send1(loc, MK::Local(loc, tempExpanded), core::Names::squareBrackets(),
+            auto val = MK::Send1(c->loc, MK::Local(loc, tempExpanded), core::Names::squareBrackets(),
                                  loc.copyWithZeroLength(), MK::Int(loc, i));
 
             if (auto *mlhs = parser::cast_node<parser::Mlhs>(c.get())) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -460,7 +460,7 @@ ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlh
             } else {
                 ++before;
             }
-            auto val = MK::Send1(c->loc, MK::Local(loc, tempExpanded), core::Names::squareBrackets(),
+            auto val = MK::Send1(c->loc, MK::Local(c->loc, tempExpanded), core::Names::squareBrackets(),
                                  loc.copyWithZeroLength(), MK::Int(loc, i));
 
             if (auto *mlhs = parser::cast_node<parser::Mlhs>(c.get())) {

--- a/test/cli/suggest_t_must/test.out
+++ b/test/cli/suggest_t_must/test.out
@@ -44,7 +44,7 @@ suggest_t_must.rb:25: Method `split` does not exist on `NilClass` component of `
   Got `T.nilable(String)` originating from:
     suggest_t_must.rb:24:
     24 |x, y = [1, T.let('', T.nilable(String))]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+           ^
   Autocorrect: Done
     suggest_t_must.rb:25: Replaced with `T.must(y)`
     25 |y.split

--- a/test/testdata/desugar/pin_mlhs.rb
+++ b/test/testdata/desugar/pin_mlhs.rb
@@ -11,6 +11,6 @@ def mlhs_example
   x, _ = tuple_str_int
   2.times do
     y, _ = tuple_int_str
-  # ^^^^^^^^^^^^^^^^^^^^ error: Changing the type of a variable is not permitted
+    #  ^ error: Changing the type of a variable is not permitted
   end
 end

--- a/test/testdata/desugar/pin_mlhs.rb
+++ b/test/testdata/desugar/pin_mlhs.rb
@@ -1,0 +1,16 @@
+# typed: true
+extend T::Sig
+
+sig { returns([Integer, String]) }
+def tuple_int_str = [0, '']
+
+sig { returns([String, Integer]) }
+def tuple_str_int = ['', 0]
+
+def mlhs_example
+  x, _ = tuple_str_int
+  2.times do
+    y, _ = tuple_int_str
+  # ^^^^^^^^^^^^^^^^^^^^ error: Changing the type of a variable is not permitted
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When there's a pinning error for a variable involved in a multiple assignment
statement, we currently show the error highlight as the entire multiple
assignment expression, which might span many lines, and which doesn't indicate
which of the variables in the assignment has a pinning error.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.