### PR TITLE
Experiment: measure using class_eval technique for call_validation

### DIFF
--- a/gems/sorbet-runtime/foo.rb
+++ b/gems/sorbet-runtime/foo.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative './lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module Typecheck
+    extend T::Sig
+
+    sig { params(x: Integer).void }
+    def self.integer_param(x)
+    end
+
+    def self.integer_param_module_eval(x)
+      raise
+    end
+
+    module_eval(<<~RUBY)
+      class << self
+        alias_method :"integer_param_module_eval (original)", :integer_param_module_eval
+        def integer_param_module_eval(arg0)
+          unless arg0.is_a?(Integer)
+            method_sig = T::Utils.signature_for_method(method(:integer_param))
+            T::Private::Methods::CallValidation.report_error(
+              method_sig,
+              method_sig.arg_types[0][1].error_message_for_obj(arg0),
+              'Parameter',
+              method_sig.arg_types[0][0],
+              Integer,
+              arg0,
+              caller_offset: 0
+            )
+          end
+
+          send(:"integer_param_module_eval (original)", arg0)
+
+          T::Private::Types::Void::VOID
+        end
+      end
+    RUBY
+
+    integer_param_module_eval(0)
+  end
+end

--- a/gems/sorbet-runtime/t_enum_serde.rb
+++ b/gems/sorbet-runtime/t_enum_serde.rb
@@ -1,0 +1,42 @@
+# typed: true
+require_relative './lib/sorbet-runtime'
+extend T::Sig
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+  end
+end
+
+class A < T::Struct
+  prop :enum_integer, T.any(MyEnum, Integer)
+  prop :enum_integer_float, T.any(MyEnum, Integer, Float)
+  prop :enum_integer_symbol, T.any(MyEnum, Integer, Symbol)
+  prop :enum_string, T.any(MyEnum, String)
+  prop :enum_symbol, T.any(MyEnum, Symbol)
+  prop :integer_enum, T.any(Integer, MyEnum)
+end
+
+a = A.new(
+  enum_integer:        MyEnum::X,
+  enum_integer_float:  MyEnum::X,
+  enum_integer_symbol: MyEnum::X,
+  enum_string:         MyEnum::X,
+  enum_symbol:         MyEnum::X,
+  integer_enum:        MyEnum::X,
+)
+pp(a.serialize)
+pp(A.from_hash(a.serialize))
+puts("----------------------------")
+
+a = A.new(
+  enum_integer:        123,
+  enum_integer_float:  123.0,
+  enum_integer_symbol: :x,
+  enum_string:         "x",
+  enum_symbol:         :x,
+  integer_enum:        123,
+)
+pp(a.serialize)
+pp(A.from_hash(a.serialize))


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```
❯ bex rake bench:typecheck
Vanilla Ruby method call: 11.896 ns
Vanilla Ruby is_a?: 13.669 ns
T.unsafe: 13.243 ns
T.must on non-nil: 17.201 ns
T::Types::Simple#valid?: 25.458 ns
T.nilable(Integer).valid?: 35.919 ns
T.any(Integer, Float, T::Boolean).valid?: 148.26 ns
T.let(..., Integer): 106.901 ns
sig {params(x: Integer).void}: 206.436 ns
sig {params(x: Integer).void} (module_eval): 71.835 ns
sig {params(x: Integer, blk: T.proc.void)} -- block literal: 1.724 μs
sig {params(x: Integer, blk: T.proc.void)} -- block pass: 511.367 ns
sig {params(x: Integer, blk: T.nilable(T.proc.void))} -- block literal: 393.357 ns
sig {params(x: Integer, blk: T.nilable(T.proc.void))} -- block pass: 118.449 ns
T.let(..., T.nilable(Integer)): 418.004 ns
sig {params(x: T.nilable(Integer)).void}: 160.092 ns
T.let(..., Example): 98.997 ns
sig {params(x: Example).void}: 152.437 ns
sig {params(x: Example).returns(T.anything)}: 150.728 ns
T.let(..., T.nilable(Example)): 431.428 ns
sig {params(x: T.nilable(Example)).void}: 209.537 ns
sig {params(x: T.nilable(Example)).returns(T.anything)}: 197.312 ns
sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs): 4.34 μs
sig {params(s: Symbol, x: Integer, y: Integer).void} (with kwargs, module_eval): 192.873 ns
direct call Object#class: 15.324 ns
.bind(example).call Object#class: 653.975 ns
.bind_call(example) Object#class: 126.173 ns
```
