### PR TITLE
Fix signature for `Thread.pending_interrupt?`

### DIFF
--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -1140,7 +1140,7 @@ class Thread < Object
   # flag = false # stop thread
   # ```
   sig {params(error: T.class_of(Exception)).returns(T::Boolean)}
-  def self.pending_interrupt?(error); end
+  def self.pending_interrupt?(error = nil); end
 
   # Returns the status of the global "report on exception" condition.
   #


### PR DESCRIPTION
### Motivation

I fixed `Thread#pending_interrupt?` instance method but I failed to notice that there's _also_ a `Thread.pending_interrupt?` class method.

Fix the class method to match the instance method signature.

Fixes #8118

### Test plan

#8118
