### PR TITLE
Test accidentally using `module <<`

### DIFF
--- a/test/whitequark/test_sclass_module.rb
+++ b/test/whitequark/test_sclass_module.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+module << foo; nil; end
+#      ^^ error: unexpected token "<<"
+#                   ^^^ error: unexpected token "end"


### PR DESCRIPTION
### Motivation

This was a crasher in our work on Prism, which I think is worth documenting in a test case.

`module <<` isn't valid, but is something devs might write by accident instead of `class <<`

### Test plan

See included automated tests.
