### PR TITLE
Fix crash in structurallyEqual

### DIFF
--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -275,7 +275,16 @@ bool structurallyEqual(const void *avoid, const Tag tag, const void *tree, const
         case Tag::ConstantLit: {
             auto *a = reinterpret_cast<const ConstantLit *>(tree);
             auto *b = reinterpret_cast<const ConstantLit *>(other);
-            return a->symbol == b->symbol && structurallyEqual(avoid, a->original, b->original);
+            if (a->symbol != b->symbol) {
+                return false;
+            }
+            if (a->original && b->original) {
+                return structurallyEqual(avoid, a->original, b->original);
+            } else if (!a->original && !b->original) {
+                return true;
+            } else {
+                return false;
+            }
         }
 
         case Tag::ZSuperArgs: {

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -281,6 +281,8 @@ bool structurallyEqual(const void *avoid, const Tag tag, const void *tree, const
             if (a->original && b->original) {
                 return structurallyEqual(avoid, a->original, b->original);
             } else if (!a->original && !b->original) {
+                // This occurs when the constant is created using MK::Constant instead of MK::UnresolvedConstant
+                // (original points to the UnresolvedConstantLit that created this ConstantLit)
                 return true;
             } else {
                 return false;

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.B.rbedited
@@ -10,3 +10,8 @@ puts(newVariable&.to_s)
 puts(newVariable&.to_s)
 #    ^ apply-code-action: [A] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [B] Extract Variable (all 2 occurrences)
+
+b = T.unsafe(1)
+
+  1.times do b&.foo end
+# ^^^^^^^^^^^^^^^^^^^^^ apply-code-action: [C] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.C.rbedited
@@ -6,11 +6,12 @@
 a = T.let(1, T.nilable(Integer))
 
 puts(a&.to_s)
-puts(newVariable = a; newVariable&.to_s)
+puts(a&.to_s)
 #    ^ apply-code-action: [A] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [B] Extract Variable (all 2 occurrences)
 
 b = T.unsafe(1)
 
-  1.times do b&.foo end
+  newVariable = 1.times do b&.foo end
+  newVariable
 # ^^^^^^^^^^^^^^^^^^^^^ apply-code-action: [C] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.rb
@@ -9,3 +9,8 @@ puts(a&.to_s)
 puts(a&.to_s)
 #    ^ apply-code-action: [A] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [B] Extract Variable (all 2 occurrences)
+
+b = T.unsafe(1)
+
+  1.times do b&.foo end
+# ^^^^^^^^^^^^^^^^^^^^^ apply-code-action: [C] Extract Variable (this occurrence only)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The `original` field in `ConstantLit` is `nullptr` for synthetic `ConstantLit`s.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Handle this case properly.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
