### PR TITLE
Trigger sorbet executable in the current shell

### DIFF
--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -106,7 +106,7 @@ typecheck() {
     fi
 
     # shellcheck disable=SC2086
-    "${sorbet}" "${args[@]}"
+    exec "${sorbet}" "${args[@]}"
   fi
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
TODO: Test on linux

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
`exec` runs the command in the current shell so we get the same PID which hopefully will resolve https://github.com/sorbet/sorbet/issues/8120

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
<img width="889" alt="360510781-229e3609-1f71-4714-8656-10bf2ad3a523" src="https://github.com/user-attachments/assets/84a89c7d-6f38-4756-bfee-990396e4b73f">


Manual testing shows PIDs being the same before and after execution. I built sorbet locally and pointed the Gemfile to local Sorbet and the`sorbet` variable to `bazel-bin/main/sorbet`. I didn't see any unwanted side effects of using `exec` in this script.

I also manually tested the new script on an editor with LSP mode and observed it was correctly killing the old processes upon restart 🎉 