### PR TITLE
Handle extracting the receiver of CSend nodes correctly

### DIFF
--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -78,7 +78,7 @@ class LocSearchWalk {
     // the current top of the stack as the "deepest" class/method
     vector<ast::ExpressionPtr *> enclosingClassStack;
     vector<ast::ExpressionPtr *> enclosingMethodStack;
-    bool inCsend = false;
+    int inCsend = 0;
 
     void updateEnclosingScope(const ast::ExpressionPtr &node, core::LocOffsets nodeLoc) {
         if (!nodeLoc.exists() || !nodeLoc.contains(targetLoc.offsets())) {
@@ -161,7 +161,7 @@ public:
     void preTransformInsSeq(core::Context ctx, const ast::ExpressionPtr &tree) {
         auto &insSeq = ast::cast_tree_nonnull<ast::InsSeq>(tree);
         if (isCsend(insSeq)) {
-            inCsend = true;
+            inCsend++;
             return;
         }
         updateEnclosingScope(tree, insSeq.loc);
@@ -170,7 +170,7 @@ public:
     void postTransformInsSeq(core::Context ctx, const ast::ExpressionPtr &tree) {
         auto &insSeq = ast::cast_tree_nonnull<ast::InsSeq>(tree);
         if (isCsend(insSeq)) {
-            inCsend = false;
+            inCsend--;
         }
     }
 

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -218,10 +218,12 @@ public:
     }
 
     void preTransformIf(core::Context ctx, const ast::ExpressionPtr &tree) {
-        if (inCsend) {
-            return;
-        }
         auto &if_ = ast::cast_tree_nonnull<ast::If>(tree);
+        if (auto thenp = ast::cast_tree<ast::Send>(if_.thenp)) {
+            if (thenp->fun == core::Names::nilForSafeNavigation()) {
+                return;
+            }
+        }
         updateEnclosingScope(tree, if_.thenp.loc());
         updateEnclosingScope(tree, if_.elsep.loc());
     }

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -14,20 +14,15 @@ void logDebugInfo(const std::shared_ptr<spdlog::logger> logger, const core::Glob
 }
 
 core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::LocOffsets target) {
-    // The ENFORCE(!ast::isa_tree<ast::InsSeq>(...)) are there check that the enclosingScope returned
-    // by the TreeWalk doesn't contain a further InsSeq, because the preTransformInsSeq should have
-    // matched on that (if it contains the selectionLoc).
     core::LocOffsets whereToInsert = core::LocOffsets::none();
     if (auto insSeq = ast::cast_tree<ast::InsSeq>(scope)) {
         for (auto &stat : insSeq->stats) {
             if (stat.loc().contains(target)) {
-                ENFORCE(!ast::isa_tree<ast::InsSeq>(stat));
                 whereToInsert = stat.loc();
                 break;
             }
         }
         if (insSeq->expr.loc().contains(target)) {
-            ENFORCE(!ast::isa_tree<ast::InsSeq>(insSeq->expr));
             whereToInsert = insSeq->expr.loc();
         }
     } else if (auto classDef = ast::cast_tree<ast::ClassDef>(scope)) {
@@ -36,46 +31,36 @@ core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::
         } else {
             for (auto &stat : classDef->rhs) {
                 if (stat.loc().contains(target)) {
-                    ENFORCE(!ast::isa_tree<ast::InsSeq>(stat));
                     whereToInsert = stat.loc();
                     break;
                 }
             }
         }
     } else if (auto block = ast::cast_tree<ast::Block>(scope)) {
-        ENFORCE(!ast::isa_tree<ast::InsSeq>(block->body));
         whereToInsert = block->body.loc();
     } else if (auto methodDef = ast::cast_tree<ast::MethodDef>(scope)) {
-        ENFORCE(!ast::isa_tree<ast::InsSeq>(methodDef->rhs));
         whereToInsert = methodDef->rhs.loc();
     } else if (auto if_ = ast::cast_tree<ast::If>(scope)) {
         if (if_->thenp.loc().exists() && if_->thenp.loc().contains(target)) {
-            ENFORCE(!ast::isa_tree<ast::InsSeq>(if_->thenp));
             whereToInsert = if_->thenp.loc();
         } else if (if_->elsep.loc().exists() && if_->elsep.loc().contains(target)) {
-            ENFORCE(!ast::isa_tree<ast::InsSeq>(if_->elsep));
             whereToInsert = if_->elsep.loc();
         } else {
             ENFORCE(false);
         }
     } else if (auto rescue = ast::cast_tree<ast::Rescue>(scope)) {
         if (rescue->body.loc().exists() && rescue->body.loc().contains(target)) {
-            ENFORCE(!ast::isa_tree<ast::InsSeq>(rescue->body));
             whereToInsert = rescue->body.loc();
         } else if (rescue->else_.loc().exists() && rescue->else_.loc().contains(target)) {
-            ENFORCE(!ast::isa_tree<ast::InsSeq>(rescue->else_));
             whereToInsert = rescue->else_.loc();
         } else if (rescue->ensure.loc().exists() && rescue->ensure.loc().contains(target)) {
-            ENFORCE(!ast::isa_tree<ast::InsSeq>(rescue->ensure));
             whereToInsert = rescue->ensure.loc();
         } else {
             ENFORCE(false)
         }
     } else if (auto rescueCase = ast::cast_tree<ast::RescueCase>(scope)) {
-        ENFORCE(!ast::isa_tree<ast::InsSeq>(rescueCase->body));
         whereToInsert = rescueCase->body.loc();
     } else if (auto while_ = ast::cast_tree<ast::While>(scope)) {
-        ENFORCE(!ast::isa_tree<ast::InsSeq>(while_->body));
         whereToInsert = while_->body.loc();
     } else {
         ENFORCE(false);

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.A.rbedited
@@ -1,12 +1,12 @@
 # typed: true
 # selective-apply-code-action: refactor.extract
 # enable-experimental-lsp-extract-to-variable: true
-#
 
 a = T.let(1, T.nilable(Integer))
 
 puts(a&.to_s)
-puts(newVariable = a; newVariable&.to_s)
+newVariable = a
+puts(newVariable&.to_s)
 #    ^ apply-code-action: [A] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [B] Extract Variable (all 2 occurrences)
 

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.B.rbedited
@@ -1,7 +1,6 @@
 # typed: true
 # selective-apply-code-action: refactor.extract
 # enable-experimental-lsp-extract-to-variable: true
-#
 
 a = T.let(1, T.nilable(Integer))
 

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.C.rbedited
@@ -1,7 +1,6 @@
 # typed: true
 # selective-apply-code-action: refactor.extract
 # enable-experimental-lsp-extract-to-variable: true
-#
 
 a = T.let(1, T.nilable(Integer))
 

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.rb
@@ -1,7 +1,6 @@
 # typed: true
 # selective-apply-code-action: refactor.extract
 # enable-experimental-lsp-extract-to-variable: true
-#
 
 a = T.let(1, T.nilable(Integer))
 

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.A.rbedited
@@ -17,7 +17,15 @@ foo(b&.foo) do
   c&.foo
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
-  puts(d&.foo)
-#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+  d_ = (d&.foo)&.bar
+#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+  e = T.unsafe(1)
+  e_ = (e&.foo)&.bar
+#       ^ apply-code-action: [E] Extract Variable (this occurrence only)
+  T.unsafe(if T.unsafe(1) then 2 else 3 end)&.bar
+#                              ^ apply-code-action: [F] Extract Variable (this occurrence only)
+  f = T.unsafe(1)
+  d = T.unsafe(while T.unsafe(1); f_ = f&.foo end)&.bar
+#                                      ^ apply-code-action: [G] Extract Variable (this occurrence only)
 end
 

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.A.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def foo(x)
+end
+
+a = T.unsafe(1)
+newVariable = a
+a_ = newVariable&.to_s
+#    ^ apply-code-action: [A] Extract Variable (this occurrence only)
+
+b = T.unsafe(1)
+foo(b&.foo) do
+#   ^ apply-code-action: [B] Extract Variable (this occurrence only)
+  c = T.unsafe(1)
+  c&.foo
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+  d = T.unsafe(1)
+  puts(d&.foo)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end
+

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.B.rbedited
@@ -17,7 +17,15 @@ foo(newVariable&.foo) do
   c&.foo
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
-  puts(d&.foo)
-#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+  d_ = (d&.foo)&.bar
+#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+  e = T.unsafe(1)
+  e_ = (e&.foo)&.bar
+#       ^ apply-code-action: [E] Extract Variable (this occurrence only)
+  T.unsafe(if T.unsafe(1) then 2 else 3 end)&.bar
+#                              ^ apply-code-action: [F] Extract Variable (this occurrence only)
+  f = T.unsafe(1)
+  d = T.unsafe(while T.unsafe(1); f_ = f&.foo end)&.bar
+#                                      ^ apply-code-action: [G] Extract Variable (this occurrence only)
 end
 

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.B.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def foo(x)
+end
+
+a = T.unsafe(1)
+a_ = a&.to_s
+#    ^ apply-code-action: [A] Extract Variable (this occurrence only)
+
+b = T.unsafe(1)
+newVariable = b
+foo(newVariable&.foo) do
+#   ^ apply-code-action: [B] Extract Variable (this occurrence only)
+  c = T.unsafe(1)
+  c&.foo
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+  d = T.unsafe(1)
+  puts(d&.foo)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end
+

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.C.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def foo(x)
+end
+
+a = T.unsafe(1)
+a_ = a&.to_s
+#    ^ apply-code-action: [A] Extract Variable (this occurrence only)
+
+b = T.unsafe(1)
+foo(b&.foo) do
+#   ^ apply-code-action: [B] Extract Variable (this occurrence only)
+  c = T.unsafe(1)
+  newVariable = c
+  newVariable&.foo
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+  d = T.unsafe(1)
+  puts(d&.foo)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end
+

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.C.rbedited
@@ -17,7 +17,15 @@ foo(b&.foo) do
   newVariable&.foo
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
-  puts(d&.foo)
-#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+  d_ = (d&.foo)&.bar
+#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+  e = T.unsafe(1)
+  e_ = (e&.foo)&.bar
+#       ^ apply-code-action: [E] Extract Variable (this occurrence only)
+  T.unsafe(if T.unsafe(1) then 2 else 3 end)&.bar
+#                              ^ apply-code-action: [F] Extract Variable (this occurrence only)
+  f = T.unsafe(1)
+  d = T.unsafe(while T.unsafe(1); f_ = f&.foo end)&.bar
+#                                      ^ apply-code-action: [G] Extract Variable (this occurrence only)
 end
 

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.D.rbedited
@@ -1,0 +1,23 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def foo(x)
+end
+
+a = T.unsafe(1)
+a_ = a&.to_s
+#    ^ apply-code-action: [A] Extract Variable (this occurrence only)
+
+b = T.unsafe(1)
+foo(b&.foo) do
+#   ^ apply-code-action: [B] Extract Variable (this occurrence only)
+  c = T.unsafe(1)
+  c&.foo
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+  d = T.unsafe(1)
+  newVariable = d
+  puts(newVariable&.foo)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end
+

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.E.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.E.rbedited
@@ -16,11 +16,11 @@ foo(b&.foo) do
   c&.foo
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
-  newVariable = (d&.foo)
-  d_ = newVariable&.bar
+  d_ = (d&.foo)&.bar
 #      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
-  e_ = (e&.foo)&.bar
+  newVariable = e
+  e_ = (newVariable&.foo)&.bar
 #       ^ apply-code-action: [E] Extract Variable (this occurrence only)
   T.unsafe(if T.unsafe(1) then 2 else 3 end)&.bar
 #                              ^ apply-code-action: [F] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.F.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.F.rbedited
@@ -16,13 +16,12 @@ foo(b&.foo) do
   c&.foo
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
-  newVariable = (d&.foo)
-  d_ = newVariable&.bar
+  d_ = (d&.foo)&.bar
 #      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   e_ = (e&.foo)&.bar
 #       ^ apply-code-action: [E] Extract Variable (this occurrence only)
-  T.unsafe(if T.unsafe(1) then 2 else 3 end)&.bar
+  T.unsafe(if T.unsafe(1) then newVariable = 2; newVariable else 3 end)&.bar
 #                              ^ apply-code-action: [F] Extract Variable (this occurrence only)
   f = T.unsafe(1)
   d = T.unsafe(while T.unsafe(1); f_ = f&.foo end)&.bar

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.G.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.G.rbedited
@@ -16,8 +16,7 @@ foo(b&.foo) do
   c&.foo
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
-  newVariable = (d&.foo)
-  d_ = newVariable&.bar
+  d_ = (d&.foo)&.bar
 #      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   e_ = (e&.foo)&.bar
@@ -25,7 +24,7 @@ foo(b&.foo) do
   T.unsafe(if T.unsafe(1) then 2 else 3 end)&.bar
 #                              ^ apply-code-action: [F] Extract Variable (this occurrence only)
   f = T.unsafe(1)
-  d = T.unsafe(while T.unsafe(1); f_ = f&.foo end)&.bar
+  d = T.unsafe(while T.unsafe(1); newVariable = f; f_ = newVariable&.foo end)&.bar
 #                                      ^ apply-code-action: [G] Extract Variable (this occurrence only)
 end
 

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.rb
@@ -16,7 +16,15 @@ foo(b&.foo) do
   c&.foo
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
-  puts(d&.foo)
-#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+  d_ = (d&.foo)&.bar
+#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+  e = T.unsafe(1)
+  e_ = (e&.foo)&.bar
+#       ^ apply-code-action: [E] Extract Variable (this occurrence only)
+  T.unsafe(if T.unsafe(1) then 2 else 3 end)&.bar
+#                              ^ apply-code-action: [F] Extract Variable (this occurrence only)
+  f = T.unsafe(1)
+  d = T.unsafe(while T.unsafe(1); f_ = f&.foo end)&.bar
+#                                      ^ apply-code-action: [G] Extract Variable (this occurrence only)
 end
 

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.rb
@@ -1,0 +1,22 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+
+def foo(x)
+end
+
+a = T.unsafe(1)
+a_ = a&.to_s
+#    ^ apply-code-action: [A] Extract Variable (this occurrence only)
+
+b = T.unsafe(1)
+foo(b&.foo) do
+#   ^ apply-code-action: [B] Extract Variable (this occurrence only)
+  c = T.unsafe(1)
+  c&.foo
+# ^ apply-code-action: [C] Extract Variable (this occurrence only)
+  d = T.unsafe(1)
+  puts(d&.foo)
+#      ^ apply-code-action: [D] Extract Variable (this occurrence only)
+end
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

We can simply look for a `send` with `fun = core::Names::nilForSafeNavigation()` to check for a `csend` node; it's used nowhere else.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Extract the receiver of a `csend` to the correct place.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
