### PR TITLE
website: Add script to make new doc

### DIFF
--- a/tools/scripts/newdoc.sh
+++ b/tools/scripts/newdoc.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+if [ "${1:-}" = "" ] || [ "${1:-}" = "-h" ] || [ "${1:-}" = "" ]; then
+  >&2 echo "usage: $0 <slug>"
+  >&2 echo
+  >&2 echo "Initializes a post at website/docs/<slug>.md"
+  [ "${1:-}" = "" ]
+  exit
+fi
+
+slug="$1"
+newdoc="website/docs/$slug.md"
+sidebars_json="website/sidebars.json"
+
+cat > "$newdoc" <<EOF
+---
+id: $slug
+title: TODO
+# sidebar_label: TODO
+---
+
+EOF
+
+# shellcheck disable=SC1003
+sed -i.bak -e '/Type System/a\'$'\n''      "'"$slug"'",' "$sidebars_json"
+rm -f "$sidebars_json.bak"
+
+echo "Done:"
+echo "- $newdoc"
+echo "- $sidebars_json"
+
+if [ "${EDITOR:-}" != "" ]; then
+  editor_command=("$EDITOR")
+  if [[ "$EDITOR" =~ "vi" ]]; then
+    editor_command+=("-p")
+  fi
+  exec "${editor_command[@]}" "$newdoc" "$sidebars_json"
+fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think that it's important to have low activation energy to create new
docs or else people won't do it. This script creates you a file,
populates it with the right boilerplate, and edits the sidebars.json
file to mention your new doc. It will even open the files for you if
`$EDITOR` is set.

I was trying to figure out the best way to preview the site but I
couldn't figure out something good. For now I think people will want to
run the command to preview the site in another terminal.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.