### PR TITLE
Don't restart the LSP for Gemfile changes by default

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -295,7 +295,6 @@
           },
           "default": [
             "**/sorbet/config",
-            "**/Gemfile",
             "**/Gemfile.lock"
           ]
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Restarting upon Gemfile changes can contribute to [multiple Sorbet processes](https://github.com/sorbet/sorbet/issues/8120) if it's followed by a `bundle install` in quick succession which modifies `Gemfile.lock`. Resulting in unnecessary CPU/memory overhead.

I also don't think watching `Gemfile` is necessary and `Gemfile.lock` will suffice.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
