### PR TITLE
Desugar csend nodes specially when called from extract to variable

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1472,6 +1472,14 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what, 
                 }
             },
             [&](parser::CSend *csend) {
+                if (calledFromExtractToVariable) {
+                    auto newName = dctx.ctx.state.freshNameUnique(core::UniqueNameKind::DesugarCsend, csend->method, 1);
+                    auto sendNode = make_unique<parser::Send>(loc, std::move(csend->receiver), newName,
+                                                              csend->methodLoc, std::move(csend->args));
+                    auto send = node2TreeImpl(dctx, std::move(sendNode), calledFromExtractToVariable);
+                    result = std::move(send);
+                    return;
+                }
                 core::NameRef tempRecv = dctx.freshNameUnique(core::Names::assignTemp());
                 auto recvLoc = csend->receiver->loc;
                 // Assign some desugar-produced nodes with zero-length Locs so IDE ignores them when mapping text

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1473,6 +1473,12 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what, 
             },
             [&](parser::CSend *csend) {
                 if (calledFromExtractToVariable) {
+                    // Desugaring to a InsSeq + If causes problem for Extract to Variable; the fake If will be the where
+                    // the new variable is inserted, which is incorrect. Instead, desugar to a regular send, so that the
+                    // insertion happens in the correct place (what the csend is inside);
+
+                    // Replace the original method with a new special one that conveys that this is a CSend, so that
+                    // a&.foo is treated as different from a.foo when checking for structural equality.
                     auto newName = dctx.ctx.state.freshNameUnique(core::UniqueNameKind::DesugarCsend, csend->method, 1);
                     auto sendNode = make_unique<parser::Send>(loc, std::move(csend->receiver), newName,
                                                               csend->methodLoc, std::move(csend->args));

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1469,15 +1469,15 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::CSend *csend) {
                 if (dctx.calledFromExtractToVariable) {
-                    // Desugaring to a InsSeq + If causes problem for Extract to Variable; the fake If will be the where
+                    // Desugaring to a InsSeq + If causes a problem for Extract to Variable; the fake If will be where
                     // the new variable is inserted, which is incorrect. Instead, desugar to a regular send, so that the
                     // insertion happens in the correct place (what the csend is inside);
 
-                    // Replace the original method with a new special one that conveys that this is a CSend, so that
-                    // a&.foo is treated as different from a.foo when checking for structural equality.
-                    auto newName = dctx.ctx.state.freshNameUnique(core::UniqueNameKind::DesugarCsend, csend->method, 1);
-                    auto sendNode = make_unique<parser::Send>(loc, std::move(csend->receiver), newName,
-                                                              csend->methodLoc, std::move(csend->args));
+                    // Replace the original method name with a new special one that conveys that this is a CSend, so
+                    // that a&.foo is treated as different from a.foo when checking for structural equality.
+                    auto newFun = dctx.ctx.state.freshNameUnique(core::UniqueNameKind::DesugarCsend, csend->method, 1);
+                    auto sendNode = make_unique<parser::Send>(loc, std::move(csend->receiver), newFun, csend->methodLoc,
+                                                              std::move(csend->args));
                     auto send = node2TreeImpl(dctx, std::move(sendNode));
                     result = std::move(send);
                     return;

--- a/ast/desugar/Desugar.h
+++ b/ast/desugar/Desugar.h
@@ -8,7 +8,7 @@
 namespace sorbet::ast::desugar {
 
 ExpressionPtr node2Tree(core::MutableContext ctx, std::unique_ptr<parser::Node> what,
-                        bool calledFromExtractToVariable = false);
+                        bool preserveConcreteSyntax = false);
 } // namespace sorbet::ast::desugar
 
 #endif // SORBET_DESUGAR_H

--- a/ast/desugar/Desugar.h
+++ b/ast/desugar/Desugar.h
@@ -7,7 +7,8 @@
 
 namespace sorbet::ast::desugar {
 
-ExpressionPtr node2Tree(core::MutableContext ctx, std::unique_ptr<parser::Node> what);
+ExpressionPtr node2Tree(core::MutableContext ctx, std::unique_ptr<parser::Node> what,
+                        bool calledFromExtractToVariable = false);
 } // namespace sorbet::ast::desugar
 
 #endif // SORBET_DESUGAR_H

--- a/ast/desugar/Desugar.h
+++ b/ast/desugar/Desugar.h
@@ -7,6 +7,8 @@
 
 namespace sorbet::ast::desugar {
 
+// preserveConcreteSyntax is used to skip some of desugarings, to aid in implementation of the Extract to Variable code
+// action. It should not be used elsewhere.
 ExpressionPtr node2Tree(core::MutableContext ctx, std::unique_ptr<parser::Node> what,
                         bool preserveConcreteSyntax = false);
 } // namespace sorbet::ast::desugar

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -78,6 +78,9 @@ string NameRef::showRaw(const GlobalState &gs) const {
                 case UniqueNameKind::Packager:
                     kind = "G";
                     break;
+                case UniqueNameKind::DesugarCsend:
+                    kind = "&";
+                    break;
             }
             if (gs.censorForSnapshotTests && unique->uniqueNameKind == UniqueNameKind::Namer &&
                 unique->original == core::Names::staticInit()) {
@@ -103,6 +106,8 @@ string NameRef::toString(const GlobalState &gs) const {
                 return fmt::format("<Class:{}>", unique->original.show(gs));
             } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
                 return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
+            } else if (unique->uniqueNameKind == UniqueNameKind::DesugarCsend) {
+                return fmt::format("desugar_csend_{}${}", unique->original.show(gs), unique->num);
             }
             if (gs.censorForSnapshotTests && unique->uniqueNameKind == UniqueNameKind::Namer &&
                 unique->original == core::Names::staticInit()) {
@@ -201,6 +206,9 @@ bool NameRef::isClassName(const GlobalState &gs) const {
                 case UniqueNameKind::PositionalArg:
                 case UniqueNameKind::MangledKeywordArg:
                     return false;
+                case UniqueNameKind::DesugarCsend:
+                    ENFORCE(false, "UniqueNameKind::DesugarCsend should only be used in Extract to Variable");
+                    return false;
             }
         case NameKind::CONSTANT:
             ENFORCE_NO_TIMER(dataCnst(gs)->original.isValidConstantName(gs));
@@ -237,6 +245,9 @@ bool NameRef::isValidConstantName(const GlobalState &gs) const {
                 case UniqueNameKind::TypeVarName:
                 case UniqueNameKind::PositionalArg:
                 case UniqueNameKind::MangledKeywordArg:
+                    return false;
+                case UniqueNameKind::DesugarCsend:
+                    ENFORCE(false, "UniqueNameKind::DesugarCsend should only be used in Extract to Variable");
                     return false;
             }
         case NameKind::CONSTANT:

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -107,7 +107,7 @@ string NameRef::toString(const GlobalState &gs) const {
             } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
                 return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
             } else if (unique->uniqueNameKind == UniqueNameKind::DesugarCsend) {
-                return fmt::format("desugar_csend_{}${}", unique->original.show(gs), unique->num);
+                return fmt::format("<&{}>", unique->original.show(gs));
             }
             if (gs.censorForSnapshotTests && unique->uniqueNameKind == UniqueNameKind::Namer &&
                 unique->original == core::Names::staticInit()) {

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -207,7 +207,7 @@ bool NameRef::isClassName(const GlobalState &gs) const {
                 case UniqueNameKind::MangledKeywordArg:
                     return false;
                 case UniqueNameKind::DesugarCsend:
-                    ENFORCE(false, "UniqueNameKind::DesugarCsend should only be used in Extract to Variable");
+                    Exception::raise("UniqueNameKind::DesugarCsend should only be used in Extract to Variable");
                     return false;
             }
         case NameKind::CONSTANT:
@@ -247,7 +247,7 @@ bool NameRef::isValidConstantName(const GlobalState &gs) const {
                 case UniqueNameKind::MangledKeywordArg:
                     return false;
                 case UniqueNameKind::DesugarCsend:
-                    ENFORCE(false, "UniqueNameKind::DesugarCsend should only be used in Extract to Variable");
+                    Exception::raise("UniqueNameKind::DesugarCsend should only be used in Extract to Variable");
                     return false;
             }
         case NameKind::CONSTANT:

--- a/core/Names.h
+++ b/core/Names.h
@@ -34,6 +34,7 @@ enum class UniqueNameKind : uint8_t {
     TEnum,
     Struct,
     Packager,
+    DesugarCsend,
 };
 
 struct UniqueName final {

--- a/core/Names.h
+++ b/core/Names.h
@@ -34,7 +34,7 @@ enum class UniqueNameKind : uint8_t {
     TEnum,
     Struct,
     Packager,
-    DesugarCsend,
+    DesugarCsend, // Used for Extract to Variable; see the CSend case in desugar.cc for more details
 };
 
 struct UniqueName final {

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -68,7 +68,7 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
                     protoName.set_unique(com::stripe::rubytyper::Name::PACKAGER);
                     break;
                 case UniqueNameKind::DesugarCsend:
-                    ENFORCE(false, "UniqueNameKind::DesugarCsend should only be used in Extract to Variable");
+                    Exception::raise("UniqueNameKind::DesugarCsend should only be used in Extract to Variable");
             }
             break;
         case NameKind::CONSTANT:

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -67,6 +67,8 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
                 case UniqueNameKind::Packager:
                     protoName.set_unique(com::stripe::rubytyper::Name::PACKAGER);
                     break;
+                case UniqueNameKind::DesugarCsend:
+                    ENFORCE(false, "UniqueNameKind::DesugarCsend should only be used in Extract to Variable");
             }
             break;
         case NameKind::CONSTANT:

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -78,7 +78,6 @@ class LocSearchWalk {
     // the current top of the stack as the "deepest" class/method
     vector<ast::ExpressionPtr *> enclosingClassStack;
     vector<ast::ExpressionPtr *> enclosingMethodStack;
-    int inCsend = 0;
 
     void updateEnclosingScope(const ast::ExpressionPtr &node, core::LocOffsets nodeLoc) {
         if (!nodeLoc.exists() || !nodeLoc.contains(targetLoc.offsets())) {
@@ -160,18 +159,7 @@ public:
 
     void preTransformInsSeq(core::Context ctx, const ast::ExpressionPtr &tree) {
         auto &insSeq = ast::cast_tree_nonnull<ast::InsSeq>(tree);
-        if (isCsend(insSeq)) {
-            inCsend++;
-            return;
-        }
         updateEnclosingScope(tree, insSeq.loc);
-    }
-
-    void postTransformInsSeq(core::Context ctx, const ast::ExpressionPtr &tree) {
-        auto &insSeq = ast::cast_tree_nonnull<ast::InsSeq>(tree);
-        if (isCsend(insSeq)) {
-            inCsend--;
-        }
     }
 
     void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
@@ -219,11 +207,6 @@ public:
 
     void preTransformIf(core::Context ctx, const ast::ExpressionPtr &tree) {
         auto &if_ = ast::cast_tree_nonnull<ast::If>(tree);
-        if (auto thenp = ast::cast_tree<ast::Send>(if_.thenp)) {
-            if (thenp->fun == core::Names::nilForSafeNavigation()) {
-                return;
-            }
-        }
         updateEnclosingScope(tree, if_.thenp.loc());
         updateEnclosingScope(tree, if_.elsep.loc());
     }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -687,7 +687,7 @@ std::vector<std::unique_ptr<core::Error>> LSPTypechecker::retypecheck(vector<cor
 }
 
 ast::ExpressionPtr LSPTypechecker::getLocalVarTrees(core::FileRef fref) const {
-    auto afterDesugar = pipeline::desugarOne(config->opts, *gs, fref);
+    auto afterDesugar = pipeline::desugarOne(config->opts, *gs, fref, true);
     return local_vars::LocalVars::run(*gs, {move(afterDesugar), fref}).tree;
 }
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -687,7 +687,8 @@ std::vector<std::unique_ptr<core::Error>> LSPTypechecker::retypecheck(vector<cor
 }
 
 ast::ExpressionPtr LSPTypechecker::getLocalVarTrees(core::FileRef fref) const {
-    auto afterDesugar = pipeline::desugarOne(config->opts, *gs, fref, true);
+    auto preserveConcreteSyntax = true;
+    auto afterDesugar = pipeline::desugarOne(config->opts, *gs, fref, preserveConcreteSyntax);
     return local_vars::LocalVars::run(*gs, {move(afterDesugar), fref}).tree;
 }
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -18,7 +18,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
 
 // Primarily exposed for LSP—outside of LSP, you probably want `indexOne`.
 ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &gs, core::FileRef file,
-                              bool calledFromExtractToVariable);
+                              bool preserveConcreteSyntax);
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -17,7 +17,8 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                          ast::ExpressionPtr cachedTree = nullptr);
 
 // Primarily exposed for LSP—outside of LSP, you probably want `indexOne`.
-ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &gs, core::FileRef file);
+ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &gs, core::FileRef file,
+                              bool calledFromExtractToVariable);
 
 std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
 

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.A.rbedited
@@ -14,3 +14,10 @@ b = T.unsafe(1)
 
   1.times do b&.foo end
 # ^^^^^^^^^^^^^^^^^^^^^ apply-code-action: [C] Extract Variable (this occurrence only)
+  c = T.unsafe(1)
+  c.to_s
+  c&.foo
+  c&.to_s
+  c&.to_s
+# ^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+# ^^^^^^^ apply-code-action: [E] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.C.rbedited
@@ -14,3 +14,10 @@ b = T.unsafe(1)
   newVariable = 1.times do b&.foo end
   newVariable
 # ^^^^^^^^^^^^^^^^^^^^^ apply-code-action: [C] Extract Variable (this occurrence only)
+  c = T.unsafe(1)
+  c.to_s
+  c&.foo
+  c&.to_s
+  c&.to_s
+# ^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+# ^^^^^^^ apply-code-action: [E] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.D.rbedited
@@ -4,9 +4,8 @@
 
 a = T.let(1, T.nilable(Integer))
 
-newVariable = a
-puts(newVariable&.to_s)
-puts(newVariable&.to_s)
+puts(a&.to_s)
+puts(a&.to_s)
 #    ^ apply-code-action: [A] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [B] Extract Variable (all 2 occurrences)
 
@@ -18,6 +17,7 @@ b = T.unsafe(1)
   c.to_s
   c&.foo
   c&.to_s
-  c&.to_s
+  newVariable = c&.to_s
+  newVariable
 # ^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
 # ^^^^^^^ apply-code-action: [E] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.E.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.E.rbedited
@@ -4,9 +4,8 @@
 
 a = T.let(1, T.nilable(Integer))
 
-newVariable = a
-puts(newVariable&.to_s)
-puts(newVariable&.to_s)
+puts(a&.to_s)
+puts(a&.to_s)
 #    ^ apply-code-action: [A] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [B] Extract Variable (all 2 occurrences)
 
@@ -17,7 +16,8 @@ b = T.unsafe(1)
   c = T.unsafe(1)
   c.to_s
   c&.foo
-  c&.to_s
-  c&.to_s
+  newVariable = c&.to_s
+  newVariable
+  newVariable
 # ^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
 # ^^^^^^^ apply-code-action: [E] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/csend.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/csend.rb
@@ -13,3 +13,10 @@ b = T.unsafe(1)
 
   1.times do b&.foo end
 # ^^^^^^^^^^^^^^^^^^^^^ apply-code-action: [C] Extract Variable (this occurrence only)
+  c = T.unsafe(1)
+  c.to_s
+  c&.foo
+  c&.to_s
+  c&.to_s
+# ^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+# ^^^^^^^ apply-code-action: [E] Extract Variable (all 2 occurrences)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Review commit-by-commit.

`a&.foo` will desugar to `a.desugar_csend_foo`, where `desugar_csend_foo` is a special name kind to signify this actually represents a `CSend`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We desugar `a&.foo` to `begin; temp = a; if nil === temp then nil else temp.foo end end` currently. This causes problems for extract to variable, since we'll try to insert inside the fake `InsSeq`. I had a workaround in #8130, but that doesn't handle all cases.

Instead, we can just not do this when `desugar` is called from extract to variable. We can desugar it to regular send instead, but with a special name so that it's treated different from an actual send to that method.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
