### PR TITLE
Allow Struct with no args which works today on modern Ruby versions

### DIFF
--- a/rbi/core/struct.rbi
+++ b/rbi/core/struct.rbi
@@ -36,14 +36,14 @@ class Struct < Object
 
   sig do
     params(
-        arg0: T.any(Symbol, String),
+        arg0: T.nilable(T.any(Symbol, String)),
         arg1: T.any(Symbol, String),
         keyword_init: T::Boolean,
         blk: T.untyped,
     )
     .void
   end
-  def initialize(arg0, *arg1, keyword_init: false, &blk); end
+  def initialize(arg0 = nil, *arg1, keyword_init: false, &blk); end
 
   # Equality---Returns `true` if `other` has the same struct subclass and has
   # equal member values (according to Object#==).

--- a/test/testdata/resolver/type_syntax_rbi.rbi.autocorrects.exp
+++ b/test/testdata/resolver/type_syntax_rbi.rbi.autocorrects.exp
@@ -1,3 +1,4 @@
+# -- test/testdata/resolver/type_syntax_rbi.rbi --
 # typed: true
 
 sig {
@@ -14,3 +15,4 @@ sig {
     .void
 }
 def zero_args(x); end
+# ------------------------------

--- a/test/testdata/rewriter/struct.rb
+++ b/test/testdata/rewriter/struct.rb
@@ -76,14 +76,12 @@ class MixinStruct
 end
 
 class BadUsages
-  A = Struct.new # error: Not enough arguments provided for method `Struct#initialize`. Expected: `1+`, got: `0`
+  A = Struct.new
   B = Struct.new(giberish: 1)
-  #              ^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{giberish: Integer(1)}` for argument `arg0`
+  #              ^^^^^^^^^^^ error: Unrecognized keyword argument `giberish` passed for method `Struct#initialize`
   C = Struct.new(keyword_init: true)
-  #              ^^^^^^^^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{keyword_init: TrueClass}` for argument `arg0`
   local = true
   D = Struct.new(keyword_init: local)
-  #              ^^^^^^^^^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{keyword_init: TrueClass}` for argument `arg0`
   E = Struct.new(:a, keyword_init: local) # we run too early in to be able to support this
 end
 

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=138:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=136:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U AccidentallyStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=37:25}
     class <C <U AccidentallyStruct>>::<C <U <C <U A>> $1>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
@@ -42,11 +42,11 @@ class <C <U <root>>> < <C <U Object>> ()
     static-field <C <U BadUsages>>::<C <U A>> -> AppliedType {       klass = <C <U Struct>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/struct.rb start=79:3 end=79:4}
     static-field <C <U BadUsages>>::<C <U B>> -> AppliedType {       klass = <C <U Struct>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/struct.rb start=80:3 end=80:4}
     static-field <C <U BadUsages>>::<C <U C>> -> AppliedType {       klass = <C <U Struct>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/struct.rb start=82:3 end=82:4}
-    static-field <C <U BadUsages>>::<C <U D>> -> AppliedType {       klass = <C <U Struct>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/struct.rb start=85:3 end=85:4}
-    static-field <C <U BadUsages>>::<C <U E>> -> AppliedType {       klass = <C <U Struct>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/struct.rb start=87:3 end=87:4}
+    static-field <C <U BadUsages>>::<C <U D>> -> AppliedType {       klass = <C <U Struct>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/struct.rb start=84:3 end=84:4}
+    static-field <C <U BadUsages>>::<C <U E>> -> AppliedType {       klass = <C <U Struct>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/struct.rb start=85:3 end=85:4}
   class <S <C <U BadUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=78:1 end=78:16}
     type-member(+) <S <C <U BadUsages>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U BadUsages>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=BadUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=78:1 end=78:16}
-    method <S <C <U BadUsages>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=78:1 end=88:4}
+    method <S <C <U BadUsages>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=78:1 end=86:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   module <C <U Foo>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/struct.rb start=4:1 end=4:11}
     class <C <U Foo>>::<C <U Struct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=5:5 end=5:17}
@@ -57,67 +57,67 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U Foo>> $1> < <C <U Module>> () @ Loc {file=test/testdata/rewriter/struct.rb start=4:1 end=4:11}
     method <S <C <U Foo>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=4:1 end=7:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <C <U FullyQualifiedStructUsages>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=115:1 end=115:33}
-    class <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
-      type-member(=) <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>::<C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>::<C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
-      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>#<U a> (<blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=117:23 end=117:24}
+  class <C <U FullyQualifiedStructUsages>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=113:1 end=113:33}
+    class <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
+      type-member(=) <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>::<C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>::<C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
+      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>#<U a> (<blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=115:23 end=115:24}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>#<U a=> (a, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=117:23 end=117:24}
-        argument a<> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=117:23 end=117:24}
+      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>#<U a=> (a, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=115:23 end=115:24}
+        argument a<> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=115:23 end=115:24}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>#<U initialize> : private (a, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
-        argument a<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=117:23 end=117:24}
+      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>#<U initialize> : private (a, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
+        argument a<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=115:23 end=115:24}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-    class <C <U FullyQualifiedStructUsages>>::<C <U Bar>> < <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>> () @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
-      type-member(=) <C <U FullyQualifiedStructUsages>>::<C <U Bar>>::<C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<C <U Bar>>::<C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
-    class <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
-      type-member(+) <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
-      method <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
+    class <C <U FullyQualifiedStructUsages>>::<C <U Bar>> < <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>> () @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
+      type-member(=) <C <U FullyQualifiedStructUsages>>::<C <U Bar>>::<C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<C <U Bar>>::<C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
+    class <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
+      type-member(+) <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>>::<C <U <C <U Bar>> $1>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
+      method <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-    class <C <U FullyQualifiedStructUsages>>::<S <C <U Bar>> $1>[<C <U <AttachedClass>>>] < <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
-      type-member(+) <C <U FullyQualifiedStructUsages>>::<S <C <U Bar>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<S <C <U Bar>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>>::<C <U Bar>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
-      method <C <U FullyQualifiedStructUsages>>::<S <C <U Bar>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=117:3 end=117:25}
+    class <C <U FullyQualifiedStructUsages>>::<S <C <U Bar>> $1>[<C <U <AttachedClass>>>] < <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Bar>> $1>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
+      type-member(+) <C <U FullyQualifiedStructUsages>>::<S <C <U Bar>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<S <C <U Bar>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>>::<C <U Bar>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
+      method <C <U FullyQualifiedStructUsages>>::<S <C <U Bar>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=115:3 end=115:25}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-    static-field <C <U FullyQualifiedStructUsages>>::<C <U Baz>> -> Foo::Struct @ Loc {file=test/testdata/rewriter/struct.rb start=118:3 end=118:6}
-    class <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
-      type-member(=) <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>::<C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>::<C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
-      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>#<U a> (<blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=116:21 end=116:22}
+    static-field <C <U FullyQualifiedStructUsages>>::<C <U Baz>> -> Foo::Struct @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:6}
+    class <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
+      type-member(=) <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>::<C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>::<C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
+      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>#<U a> (<blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=114:21 end=114:22}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>#<U a=> (a, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=116:21 end=116:22}
-        argument a<> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=116:21 end=116:22}
+      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>#<U a=> (a, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=114:21 end=114:22}
+        argument a<> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=114:21 end=114:22}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>#<U initialize> : private (a, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
-        argument a<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=116:21 end=116:22}
+      method <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>#<U initialize> : private (a, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
+        argument a<optional> -> BasicObject @ Loc {file=test/testdata/rewriter/struct.rb start=114:21 end=114:22}
         argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-    class <C <U FullyQualifiedStructUsages>>::<C <U Foo>> < <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>> () @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
-      type-member(=) <C <U FullyQualifiedStructUsages>>::<C <U Foo>>::<C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<C <U Foo>>::<C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
-    class <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
-      type-member(+) <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
-      method <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
+    class <C <U FullyQualifiedStructUsages>>::<C <U Foo>> < <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>> () @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
+      type-member(=) <C <U FullyQualifiedStructUsages>>::<C <U Foo>>::<C <U Elem>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<C <U Foo>>::<C <U Elem>>, fixed=T.untyped) @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
+    class <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Struct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
+      type-member(+) <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>>::<C <U <C <U Foo>> $1>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
+      method <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-    class <C <U FullyQualifiedStructUsages>>::<S <C <U Foo>> $1>[<C <U <AttachedClass>>>] < <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
-      type-member(+) <C <U FullyQualifiedStructUsages>>::<S <C <U Foo>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<S <C <U Foo>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>>::<C <U Foo>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
-      method <C <U FullyQualifiedStructUsages>>::<S <C <U Foo>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=116:3 end=116:23}
+    class <C <U FullyQualifiedStructUsages>>::<S <C <U Foo>> $1>[<C <U <AttachedClass>>>] < <C <U FullyQualifiedStructUsages>>::<S <C <U <C <U Foo>> $1>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
+      type-member(+) <C <U FullyQualifiedStructUsages>>::<S <C <U Foo>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U FullyQualifiedStructUsages>>::<S <C <U Foo>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <C <U FullyQualifiedStructUsages>>::<C <U Foo>>   targs = [     <C <U Elem>> = T.untyped   ] }) @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
+      method <C <U FullyQualifiedStructUsages>>::<S <C <U Foo>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=114:3 end=114:23}
         argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <S <C <U FullyQualifiedStructUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=115:1 end=115:33}
-    type-member(+) <S <C <U FullyQualifiedStructUsages>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U FullyQualifiedStructUsages>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=FullyQualifiedStructUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=115:1 end=115:33}
-    method <S <C <U FullyQualifiedStructUsages>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=115:1 end=122:4}
+  class <S <C <U FullyQualifiedStructUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=113:1 end=113:33}
+    type-member(+) <S <C <U FullyQualifiedStructUsages>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U FullyQualifiedStructUsages>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=FullyQualifiedStructUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=113:1 end=113:33}
+    method <S <C <U FullyQualifiedStructUsages>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=113:1 end=120:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <C <U Immutable>> < <C <U T>>::<C <U ImmutableStruct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=124:37}
-    field <C <U Immutable>>#<U @b> -> String @ Loc {file=test/testdata/rewriter/struct.rb start=128:10 end=128:11}
-    method <C <U Immutable>>#<U b> (<blk>) -> String @ Loc {file=test/testdata/rewriter/struct.rb start=128:3 end=128:19}
+  class <C <U Immutable>> < <C <U T>>::<C <U ImmutableStruct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=122:1 end=122:37}
+    field <C <U Immutable>>#<U @b> -> String @ Loc {file=test/testdata/rewriter/struct.rb start=126:10 end=126:11}
+    method <C <U Immutable>>#<U b> (<blk>) -> String @ Loc {file=test/testdata/rewriter/struct.rb start=126:3 end=126:19}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-    method <C <U Immutable>>#<U initialize> : private (b, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=124:37}
-      argument b<keyword> -> String @ Loc {file=test/testdata/rewriter/struct.rb start=128:3 end=128:19}
+    method <C <U Immutable>>#<U initialize> : private (b, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=122:1 end=122:37}
+      argument b<keyword> -> String @ Loc {file=test/testdata/rewriter/struct.rb start=126:3 end=126:19}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <S <C <U Immutable>> $1>[<C <U <AttachedClass>>>] < <C <U T>>::<S <C <U ImmutableStruct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=124:37}
-    type-member(+) <S <C <U Immutable>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Immutable>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Immutable) @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=124:37}
-    method <S <C <U Immutable>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=129:4}
+  class <S <C <U Immutable>> $1>[<C <U <AttachedClass>>>] < <C <U T>>::<S <C <U ImmutableStruct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=122:1 end=122:37}
+    type-member(+) <S <C <U Immutable>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Immutable>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Immutable) @ Loc {file=test/testdata/rewriter/struct.rb start=122:1 end=122:37}
+    method <S <C <U Immutable>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=122:1 end=127:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <C <U ImmutableTest>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=131:1 end=131:20}
-  class <S <C <U ImmutableTest>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=131:1 end=131:20}
-    type-member(+) <S <C <U ImmutableTest>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U ImmutableTest>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=ImmutableTest) @ Loc {file=test/testdata/rewriter/struct.rb start=131:1 end=131:20}
-    method <S <C <U ImmutableTest>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=131:1 end=138:4}
+  class <C <U ImmutableTest>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=129:1 end=129:20}
+  class <S <C <U ImmutableTest>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=129:1 end=129:20}
+    type-member(+) <S <C <U ImmutableTest>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U ImmutableTest>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=ImmutableTest) @ Loc {file=test/testdata/rewriter/struct.rb start=129:1 end=129:20}
+    method <S <C <U ImmutableTest>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=129:1 end=136:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U InvalidMember>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=45:20}
     class <C <U InvalidMember>>::<C <U <C <U A>> $1>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=46:3 end=46:24}
@@ -144,12 +144,12 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U InvalidMember>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U InvalidMember>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=InvalidMember) @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=45:20}
     method <S <C <U InvalidMember>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=47:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <C <U Main>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=90:1 end=90:11}
-    method <C <U Main>>#<U main> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=91:5 end=91:13}
+  class <C <U Main>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=88:1 end=88:11}
+    method <C <U Main>>#<U main> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=89:5 end=89:13}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
-  class <S <C <U Main>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=90:1 end=90:11}
-    type-member(+) <S <C <U Main>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Main>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Main) @ Loc {file=test/testdata/rewriter/struct.rb start=90:1 end=90:11}
-    method <S <C <U Main>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=90:1 end=112:4}
+  class <S <C <U Main>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=88:1 end=88:11}
+    type-member(+) <S <C <U Main>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Main>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Main) @ Loc {file=test/testdata/rewriter/struct.rb start=88:1 end=88:11}
+    method <S <C <U Main>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=88:1 end=110:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U MixinStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=49:1 end=49:18}
     class <C <U MixinStruct>>::<C <U <C <U MyKeywordInitStruct>> $1>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=60:3 end=68:6}


### PR DESCRIPTION
    irb(main):001> Struct.new
    => #<Class:0x0000000122927958>

### Motivation

Allow creating `Struct.new` without arguments.

### Test plan

Please advise. I am not sure what is standard practice for testing RBI files.