### PR TITLE
Desugar &&/|| nodes specially when called from extract to variable 

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1185,6 +1185,12 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             [&](parser::And *and_) {
                 auto lhs = node2TreeImpl(dctx, std::move(and_->left));
                 auto rhs = node2TreeImpl(dctx, std::move(and_->right));
+                if (dctx.preserveConcreteSyntax) {
+                    auto andAndLoc = core::LocOffsets{lhs.loc().endPos(), rhs.loc().beginPos()};
+                    result = MK::Send2(loc, MK::Magic(locZeroLen), core::Names::andAnd(), andAndLoc, std::move(lhs),
+                                       std::move(rhs));
+                    return;
+                }
                 if (isa_reference(lhs)) {
                     auto cond = MK::cpRef(lhs);
                     // Note that this case doesn't currently get the same "always truthy" dead code
@@ -1230,6 +1236,12 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             [&](parser::Or *or_) {
                 auto lhs = node2TreeImpl(dctx, std::move(or_->left));
                 auto rhs = node2TreeImpl(dctx, std::move(or_->right));
+                if (dctx.preserveConcreteSyntax) {
+                    auto andAndLoc = core::LocOffsets{lhs.loc().endPos(), rhs.loc().beginPos()};
+                    result = MK::Send2(loc, MK::Magic(locZeroLen), core::Names::orOr(), andAndLoc, std::move(lhs),
+                                       std::move(rhs));
+                    return;
+                }
                 if (isa_reference(lhs)) {
                     auto cond = MK::cpRef(lhs);
                     auto iff = MK::If(loc, std::move(cond), std::move(lhs), std::move(rhs));

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -385,6 +385,8 @@ public:
         if (absl::c_find(matches, tree.loc()) != matches.end()) {
             // We've already seen a node with the exact same loc before, so this is likely constructed by
             // desugar. Skip it.
+            // If this ENFORCE occurs, we should update desugar to not do this when preserveConcreteSyntax is true
+            ENFORCE(false, "found another node with a loc we've already seen");
             return;
         }
 

--- a/test/testdata/lsp/code_actions/extract_variable_single/insseq.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/insseq.B.rbedited
@@ -5,7 +5,8 @@
 def and
   a = T.unsafe(1)
   b = T.unsafe(1)
-  a && newVariable = b; newVariable
+  newVariable = b
+  a && newVariable
 # ^ apply-code-action: [A] Extract Variable (this occurrence only)
 #      ^ apply-code-action: [B] Extract Variable (this occurrence only)
 end

--- a/test/testdata/lsp/code_actions/extract_variable_single/insseq.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/insseq.D.rbedited
@@ -13,7 +13,8 @@ end
 def or
   a = T.unsafe(1)
   b = T.unsafe(1)
-  a || newVariable = b; newVariable
+  newVariable = b
+  a || newVariable
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
 #      ^ apply-code-action: [D] Extract Variable (this occurrence only)
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Similar to #8140.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We desugar `a && b` to `if a then b else a end` currently. This causes problems for extract to variable, since we'll try to insert inside the fake `If`.

Instead, we can just not do this when desugar is called from extract to variable. We can desugar it to `Magic.andAnd(a, b)`. This PR also does something similar for `||`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
