### PR TITLE
Change optparse.rbi T::Class overload

### DIFF
--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -796,6 +796,7 @@ class OptionParser
   # for an explanation of parameters.
   sig do
     params(
+      short: String,
       type: T.any(T.class_of(TrueClass), T.class_of(FalseClass)),
       opts: T.untyped,
       block: T.nilable(T.proc.params(arg0: T::Boolean).void)
@@ -804,6 +805,7 @@ class OptionParser
   end
   sig do
     params(
+      short: String,
       type: T.any(T.class_of(Shellwords), T.class_of(Array)),
       opts: T.untyped,
       block: T.nilable(T.proc.params(arg0: T::Array[String]).void)
@@ -813,6 +815,38 @@ class OptionParser
   sig do
     type_parameters(:Type)
       .params(
+        short: String,
+        type: T::Class[T.type_parameter(:Type)],
+        opts: T.untyped,
+        block: T.nilable(T.proc.params(arg0: T.type_parameter(:Type)).void)
+      )
+      .returns(T.untyped)
+  end
+  sig do
+    params(
+      short: String,
+      long: String,
+      type: T.any(T.class_of(TrueClass), T.class_of(FalseClass)),
+      opts: T.untyped,
+      block: T.nilable(T.proc.params(arg0: T::Boolean).void)
+    )
+      .returns(T.untyped)
+  end
+  sig do
+    params(
+      short: String,
+      long: String,
+      type: T.any(T.class_of(Shellwords), T.class_of(Array)),
+      opts: T.untyped,
+      block: T.nilable(T.proc.params(arg0: T::Array[String]).void)
+    )
+      .returns(T.untyped)
+  end
+  sig do
+    type_parameters(:Type)
+      .params(
+        short: String,
+        long: String,
         type: T::Class[T.type_parameter(:Type)],
         opts: T.untyped,
         block: T.nilable(T.proc.params(arg0: T.type_parameter(:Type)).void)
@@ -820,7 +854,7 @@ class OptionParser
       .returns(T.untyped)
   end
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
-  def on(type=T.unsafe(nil), *opts, &block); end
+  def on(short=T.unsafe(nil), long=T.unsafe(nil), type=T.unsafe(nil), *opts, &block); end
 
   # Also aliased as:
   # [`def_head_option`](https://docs.ruby-lang.org/en/2.7.0/OptionParser.html#method-i-def_head_option)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm not sure why, but when I try to take advantage of this overload, it
doesn't work at runtime:

```ruby
# typed: true
require "optparse"
require "optparse/time"

OptionParser
  .new do |parser|
    parser.on(Time, "--time [TIME]") do |time|
      p(time)
    end
  end
  .parse!
```

```
❯ ruby foo.rb -t 9:30
foo.rb:7:in `block in <main>': argument type given twice: NilClass (ArgumentError)
        from foo.rb:6:in `new'
        from foo.rb:6:in `<main>'
```

(It's not clear from that error, but the error comes from inside the
optparse.rb gem, which does some filtering of the exception backtrace to
hide the optparse.rb frames.)

I'm not sure if that's because something changed and I'm not sure what,
or if it never worked and I didn't actually test the runtime when I
wrote the original change.

In any case, it seems like optparse expects the type argument to come
after any short or long option names. We can work around that with some
more overloads.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested that the runtime works with the `Time` argument swapped to the end:

```ruby
# typed: true
require "optparse"
require "optparse/time"

OptionParser
  .new do |parser|
    parser.on("--time [TIME]", Time) do |time|
      p(time)
    end
  end
  .parse!
```

```
❯ ruby foo.rb -t 9:30
2024-08-29 09:30:00 -0700
```