### PR TITLE
Add optional hash argument to transform_keys{!,}

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -1312,6 +1312,11 @@ class Hash < Object
   def to_s(); end
 
   # Returns a new hash with the results of running the block once for every key.
+  #
+  # An optional hash argument can be provided to map keys to new keys. Any key
+  # not given will be mapped using the provided block, or remain the same if no
+  # block is given.
+  #
   # This method does not change the values.
   #
   # ```ruby
@@ -1320,23 +1325,35 @@ class Hash < Object
   # h.transform_keys(&:to_s)        #=> { "a" => 1, "b" => 2, "c" => 3 }
   # h.transform_keys.with_index {|k, i| "#{k}.#{i}" }
   #                                 #=> { "a.0" => 1, "b.1" => 2, "c.2" => 3 }
+  # h.transform_keys({ a: "a", b: "b" }) #=> { "a" => 1, "b" => 2, c: 3 }
   # ```
   #
   # If no block is given, an enumerator is returned instead.
   sig do
     type_parameters(:A).params(
+      hash2: T.nilable(T::Hash[T.type_parameter(:A), V]),
       blk: T.proc.params(arg0: K).returns(T.type_parameter(:A))
     )
-                       .returns(T::Hash[T.type_parameter(:A), V])
+    .returns(T::Hash[T.type_parameter(:A), V])
+  end
+  sig do
+    type_parameters(:A).params(
+      hash2: T::Hash[T.type_parameter(:A), V],
+    )
+    .returns(T::Hash[T.type_parameter(:A), V])
   end
   sig do
     returns(T::Enumerator[K])
   end
-  def transform_keys(&blk); end
+  def transform_keys(hash2=nil, &blk); end
 
   # Invokes the given block once for each key in *hsh*, replacing it with the
   # new key returned by the block, and then returns *hsh*. This method does not
   # change the values.
+  #
+  # An optional hash argument can be provided to map keys to new keys. Any key
+  # not given will be mapped using the provided block, or remain the same if no
+  # block is given.
   #
   # ```ruby
   # h = { a: 1, b: 2, c: 3 }
@@ -1344,19 +1361,27 @@ class Hash < Object
   # h.transform_keys!(&:to_sym)      #=> { a: 1, b: 2, c: 3 }
   # h.transform_keys!.with_index {|k, i| "#{k}.#{i}" }
   #                                  #=> { "a.0" => 1, "b.1" => 2, "c.2" => 3 }
+  # h.transform_keys!({ a: "a", b: "b" }) #=> { "a" => 1, "b" => 2, c: 3 }
   # ```
   #
   # If no block is given, an enumerator is returned instead.
   sig do
     type_parameters(:A).params(
+      hash2: T.nilable(T::Hash[T.type_parameter(:A), V]),
       blk: T.proc.params(arg0: K).returns(T.type_parameter(:A))
     )
-                       .returns(T::Hash[T.type_parameter(:A), V])
+    .returns(T::Hash[T.type_parameter(:A), V])
+  end
+  sig do
+    type_parameters(:A).params(
+      hash2: T::Hash[T.type_parameter(:A), V],
+    )
+    .returns(T::Hash[T.type_parameter(:A), V])
   end
   sig do
     returns(T::Enumerator[K])
   end
-  def transform_keys!(&blk); end
+  def transform_keys!(hash2=nil, &blk); end
 
   # Returns a new hash with the results of running the block once for every
   # value. This method does not change the keys.

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -73,6 +73,12 @@ initial_hash.transform_keys!.with_index do |k, i|
   T.assert_type!(i, Integer)
 end
 
+transformed_keys_hash2 = initial_hash.dup.transform_keys({ a: :A, b: :B })
+T.assert_type!(transformed_keys_hash2, T::Hash[Symbol, Float])
+
+transformed_keys_bang_hash2 = initial_hash.dup.transform_keys!({ a: :A, b: :B })
+T.assert_type!(transformed_keys_bang_hash2, T::Hash[Symbol, Float])
+
 transformed_values_hash = initial_hash.transform_values(&:to_s)
 T.assert_type!(transformed_values_hash, T::Hash[Symbol, String])
 initial_hash.transform_values(&:size) # error: Method `size` does not exist on `Float`


### PR DESCRIPTION
This PR updates the signatures for `Hash#transform_keys` and `Hash#transform_keys!` to recognize the optional hash argument introduced in [Ruby 3.0](https://bugs.ruby-lang.org/issues/16274)

### Motivation
I wanted to use this functionality in my project, and was surprised that sorbet thought there was an error!

### Test plan
See included automated tests.
