### PR TITLE
Clarify unsupported literal error message

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -82,6 +82,7 @@ constexpr ErrorClass AbstractClassInstantiated{5073, StrictLevel::True};
 constexpr ErrorClass HasAttachedClassIncluded{5074, StrictLevel::False};
 constexpr ErrorClass TypeAliasToTypeMember{5075, StrictLevel::False};
 constexpr ErrorClass TNilableArity{5076, StrictLevel::False};
+constexpr ErrorClass UnsupportedLiteralType{5077, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1510,9 +1510,11 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
         } else {
             underlying = lit.value;
         }
-        if (auto e = ctx.beginError(lit.loc, core::errors::Resolver::InvalidMethodSignature)) {
+        if (auto e = ctx.beginError(lit.loc, core::errors::Resolver::UnsupportedLiteralType)) {
             e.setHeader("Unsupported literal in type syntax", lit.value.show(ctx));
             e.replaceWith("Replace with underlying type", ctx.locAt(lit.loc), "{}", underlying.show(ctx));
+            e.addErrorNote("Sorbet does not allow literal values in types. Consider defining a `{}` instead.",
+                           "T::Enum");
         }
         result.type = underlying;
     } else {

--- a/test/cli/autocorrect-strict/test.out
+++ b/test/cli/autocorrect-strict/test.out
@@ -1,10 +1,12 @@
-autocorrect-strict.rb:8: Unsupported literal in type syntax https://srb.help/5003
+autocorrect-strict.rb:8: Unsupported literal in type syntax https://srb.help/5077
      8 |  sig {returns(nil)}
                        ^^^
   Autocorrect: Done
     autocorrect-strict.rb:8: Replaced with `NilClass`
      8 |  sig {returns(nil)}
                        ^^^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
 autocorrect-strict.rb:13: Use `T::Array[...]`, not `Array[...]` to declare a typed `Array` https://srb.help/5026
     13 |  sig {returns(Array[Integer])}

--- a/test/cli/literal-type-syntax/test.out
+++ b/test/cli/literal-type-syntax/test.out
@@ -1,74 +1,92 @@
-literal-type-syntax.rb:3: Unsupported literal in type syntax https://srb.help/5003
+literal-type-syntax.rb:3: Unsupported literal in type syntax https://srb.help/5077
      3 |T.let(0, 0)
                  ^
   Autocorrect: Done
     literal-type-syntax.rb:3: Replaced with `Integer`
      3 |T.let(0, 0)
                  ^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
-literal-type-syntax.rb:4: Unsupported literal in type syntax https://srb.help/5003
+literal-type-syntax.rb:4: Unsupported literal in type syntax https://srb.help/5077
      4 |T.let(0.0, 0.0)
                    ^^^
   Autocorrect: Done
     literal-type-syntax.rb:4: Replaced with `Float`
      4 |T.let(0.0, 0.0)
                    ^^^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
-literal-type-syntax.rb:5: Unsupported literal in type syntax https://srb.help/5003
+literal-type-syntax.rb:5: Unsupported literal in type syntax https://srb.help/5077
      5 |T.let('', '')
                   ^^
   Autocorrect: Done
     literal-type-syntax.rb:5: Replaced with `String`
      5 |T.let('', '')
                   ^^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
-literal-type-syntax.rb:6: Unsupported literal in type syntax https://srb.help/5003
+literal-type-syntax.rb:6: Unsupported literal in type syntax https://srb.help/5077
      6 |T.let(:'', :'')
                    ^^^
   Autocorrect: Done
     literal-type-syntax.rb:6: Replaced with `Symbol`
      6 |T.let(:'', :'')
                    ^^^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
-literal-type-syntax.rb:7: Unsupported literal in type syntax https://srb.help/5003
+literal-type-syntax.rb:7: Unsupported literal in type syntax https://srb.help/5077
      7 |T.let(true, true)
                     ^^^^
   Autocorrect: Done
     literal-type-syntax.rb:7: Replaced with `TrueClass`
      7 |T.let(true, true)
                     ^^^^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
-literal-type-syntax.rb:8: Unsupported literal in type syntax https://srb.help/5003
+literal-type-syntax.rb:8: Unsupported literal in type syntax https://srb.help/5077
      8 |T.let(false, false)
                      ^^^^^
   Autocorrect: Done
     literal-type-syntax.rb:8: Replaced with `FalseClass`
      8 |T.let(false, false)
                      ^^^^^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
-literal-type-syntax.rb:9: Unsupported literal in type syntax https://srb.help/5003
+literal-type-syntax.rb:9: Unsupported literal in type syntax https://srb.help/5077
      9 |T.let(nil, nil)
                    ^^^
   Autocorrect: Done
     literal-type-syntax.rb:9: Replaced with `NilClass`
      9 |T.let(nil, nil)
                    ^^^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
-literal-type-syntax.rb:11: Unsupported literal in type syntax https://srb.help/5003
+literal-type-syntax.rb:11: Unsupported literal in type syntax https://srb.help/5077
     11 |T.let(true, T.any(true, false))
                           ^^^^
   Autocorrect: Done
     literal-type-syntax.rb:11: Replaced with `TrueClass`
     11 |T.let(true, T.any(true, false))
                           ^^^^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
-literal-type-syntax.rb:11: Unsupported literal in type syntax https://srb.help/5003
+literal-type-syntax.rb:11: Unsupported literal in type syntax https://srb.help/5077
     11 |T.let(true, T.any(true, false))
                                 ^^^^^
   Autocorrect: Done
     literal-type-syntax.rb:11: Replaced with `FalseClass`
     11 |T.let(true, T.any(true, false))
                                 ^^^^^
+  Note:
+    Sorbet does not allow literal values in types. Consider defining a `T::Enum` instead.
 
 literal-type-syntax.rb:11: Unexpected bare `TrueClass` value found in type position https://srb.help/7009
     11 |T.let(true, T.any(true, false))


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```
foo.rb:4: Unsupported literal in type syntax https://srb.help/5077
     4 |sig { params(x: T.any(1, 2)).void }
                              ^
  Autocorrect: Use -a to autocorrect
    foo.rb:4: Replace with Integer
     4 |sig { params(x: T.any(1, 2)).void }
                              ^
  Note:
    Sorbet does not allow literal values in types. Consider defining a T::Enum instead.
```