### PR TITLE
Organize all --help options into meaningful sections

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1243,21 +1243,11 @@ void readOptions(Options &opts,
             }
         }
 
-        if (raw.count("error-white-list") > 0) {
-            logger->error("`{}` is deprecated; please use `{}` instead", "--error-white-list", "--isolate-error-code");
-            auto rawList = raw["error-white-list"].as<vector<int>>();
-            opts.isolateErrorCode.insert(rawList.begin(), rawList.end());
-        }
         if (raw.count("isolate-error-code") > 0) {
             auto rawList = raw["isolate-error-code"].as<vector<int>>();
             opts.isolateErrorCode.insert(rawList.begin(), rawList.end());
         }
 
-        if (raw.count("error-black-list") > 0) {
-            logger->error("`{}` is deprecated; please use `{}` instead", "--error-black-list", "--suppress-error-code");
-            auto rawList = raw["error-black-list"].as<vector<int>>();
-            opts.suppressErrorCode.insert(rawList.begin(), rawList.end());
-        }
         if (raw.count("suppress-error-code") > 0) {
             auto rawList = raw["suppress-error-code"].as<vector<int>>();
             opts.suppressErrorCode.insert(rawList.begin(), rawList.end());

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -205,7 +205,7 @@ struct Options {
 
     std::string metricsFile;
     std::string metricsRepo = "none";
-    std::string metricsPrefix = "ruby_typer.unknown.";
+    std::string metricsPrefix = "ruby_typer.unknown";
     std::string metricsBranch = "none";
     std::string metricsSha = "none";
     std::map<std::string, std::string> metricsExtraTags; // be super careful with cardinality here

--- a/test/cli/files-dirs/test.out
+++ b/test/cli/files-dirs/test.out
@@ -13,16 +13,43 @@
 ------------------------------------------------------------------------
 You must pass either `-e` or at least one folder or ruby file.
 
-Typechecker for Ruby
+Sorbet: A fast, powerful typechecker designed for Ruby
 Usage:
-  sorbet [OPTION...] <path 1> <path 2> ...
+  sorbet [options] [[--] <path>...]
 
-  -e string      Parse an inline ruby string (default: "")
-  -q, --quiet    Silence all non-critical errors
-  -v, --verbose  Verbosity level [0-3]
-  -h             Show short help
-      --help     Show long help
-      --version  Show version
+ INPUT options:
+  -e <string>                   Treat <string> as if it were the contents of a Ruby file passed on 
+                                the command line (default: "")
+      --e-rbi <string>          Like `-e`, but treat <string> as an RBI file (default: "")
+      --file <path>             Run over the contents of <path>
+                                (Equivalent to passing <path> as a positional argument)
+      --dir <path>              Run over all Ruby and RBI files in <path>, recursively
+                                (Equivalent to passing <path> as a positional argument)
+      --allowed-extension <ext>[,<ext>...]
+                                Use these extensions to determine which file types Sorbet should 
+                                discover inside directories. (default: .rb,.rbi)
+      --ignore <pattern>        Ignores input files that contain <pattern> in their paths (relative 
+                                to the input path passed to Sorbet).
+                                When <pattern> starts with `/` it matches against the prefix of 
+                                these relative paths; others match anywhere.
+                                Matches must be against whole path segments, so `foo` matches 
+                                `foo/bar.rb` and `bar/foo/baz.rb` but not `foo.rb` or 
+                                `foo2/bar.rb`.
+      --no-config               Do not load the content of the `sorbet/config` file.
+                                Otherwise, Sorbet reads the `sorbet/config` file and treats each 
+                                line as if it were passed on the command line, unless the line 
+                                starts with `#`.
+                                To load a <file> as if it were a config file, pass `@<file>` as a 
+                                positional arg
+      --typed {false,true,strict,strong,[auto]}
+                                Force all code to specified strictness level, disregarding all `# 
+                                typed:` sigils. For `auto`, uses the `# typed:` sigil in the file 
+                                or `false` for files without a sigil. (default: auto)
+      --typed-override <filepath.yaml>
+                                Read <filepath.yaml> to override the strictness of individual files.
+                                Contents must be a map of `<strictness>: ['path1.rb', ...]` pairs.
+                                Can be used to enable type checking for certain files temporarily 
+                                without having to add a comment to every file. (default: "")
 
 ------------------------------------------------------------------------
 {

--- a/test/cli/help/test.out
+++ b/test/cli/help/test.out
@@ -2,32 +2,86 @@
 
 You must pass either `-e` or at least one folder or ruby file.
 
-Typechecker for Ruby
+Sorbet: A fast, powerful typechecker designed for Ruby
 Usage:
-  sorbet [OPTION...] <path 1> <path 2> ...
+  sorbet [options] [[--] <path>...]
 
-  -e string      Parse an inline ruby string (default: "")
-  -q, --quiet    Silence all non-critical errors
-  -v, --verbose  Verbosity level [0-3]
-  -h             Show short help
-      --help     Show long help
-      --version  Show version
+ INPUT options:
+  -e <string>                   Treat <string> as if it were the contents of a Ruby file passed on 
+                                the command line (default: "")
+      --e-rbi <string>          Like `-e`, but treat <string> as an RBI file (default: "")
+      --file <path>             Run over the contents of <path>
+                                (Equivalent to passing <path> as a positional argument)
+      --dir <path>              Run over all Ruby and RBI files in <path>, recursively
+                                (Equivalent to passing <path> as a positional argument)
+      --allowed-extension <ext>[,<ext>...]
+                                Use these extensions to determine which file types Sorbet should 
+                                discover inside directories. (default: .rb,.rbi)
+      --ignore <pattern>        Ignores input files that contain <pattern> in their paths (relative 
+                                to the input path passed to Sorbet).
+                                When <pattern> starts with `/` it matches against the prefix of 
+                                these relative paths; others match anywhere.
+                                Matches must be against whole path segments, so `foo` matches 
+                                `foo/bar.rb` and `bar/foo/baz.rb` but not `foo.rb` or 
+                                `foo2/bar.rb`.
+      --no-config               Do not load the content of the `sorbet/config` file.
+                                Otherwise, Sorbet reads the `sorbet/config` file and treats each 
+                                line as if it were passed on the command line, unless the line 
+                                starts with `#`.
+                                To load a <file> as if it were a config file, pass `@<file>` as a 
+                                positional arg
+      --typed {false,true,strict,strong,[auto]}
+                                Force all code to specified strictness level, disregarding all `# 
+                                typed:` sigils. For `auto`, uses the `# typed:` sigil in the file 
+                                or `false` for files without a sigil. (default: auto)
+      --typed-override <filepath.yaml>
+                                Read <filepath.yaml> to override the strictness of individual files.
+                                Contents must be a map of `<strictness>: ['path1.rb', ...]` pairs.
+                                Can be used to enable type checking for certain files temporarily 
+                                without having to add a comment to every file. (default: "")
 
 
 ----- Abbreviated help output with empty config file: --------------------
 
 You must pass either `-e` or at least one folder or ruby file.
 
-Typechecker for Ruby
+Sorbet: A fast, powerful typechecker designed for Ruby
 Usage:
-  sorbet [OPTION...] <path 1> <path 2> ...
+  sorbet [options] [[--] <path>...]
 
-  -e string      Parse an inline ruby string (default: "")
-  -q, --quiet    Silence all non-critical errors
-  -v, --verbose  Verbosity level [0-3]
-  -h             Show short help
-      --help     Show long help
-      --version  Show version
+ INPUT options:
+  -e <string>                   Treat <string> as if it were the contents of a Ruby file passed on 
+                                the command line (default: "")
+      --e-rbi <string>          Like `-e`, but treat <string> as an RBI file (default: "")
+      --file <path>             Run over the contents of <path>
+                                (Equivalent to passing <path> as a positional argument)
+      --dir <path>              Run over all Ruby and RBI files in <path>, recursively
+                                (Equivalent to passing <path> as a positional argument)
+      --allowed-extension <ext>[,<ext>...]
+                                Use these extensions to determine which file types Sorbet should 
+                                discover inside directories. (default: .rb,.rbi)
+      --ignore <pattern>        Ignores input files that contain <pattern> in their paths (relative 
+                                to the input path passed to Sorbet).
+                                When <pattern> starts with `/` it matches against the prefix of 
+                                these relative paths; others match anywhere.
+                                Matches must be against whole path segments, so `foo` matches 
+                                `foo/bar.rb` and `bar/foo/baz.rb` but not `foo.rb` or 
+                                `foo2/bar.rb`.
+      --no-config               Do not load the content of the `sorbet/config` file.
+                                Otherwise, Sorbet reads the `sorbet/config` file and treats each 
+                                line as if it were passed on the command line, unless the line 
+                                starts with `#`.
+                                To load a <file> as if it were a config file, pass `@<file>` as a 
+                                positional arg
+      --typed {false,true,strict,strong,[auto]}
+                                Force all code to specified strictness level, disregarding all `# 
+                                typed:` sigils. For `auto`, uses the `# typed:` sigil in the file 
+                                or `false` for files without a sigil. (default: auto)
+      --typed-override <filepath.yaml>
+                                Read <filepath.yaml> to override the strictness of individual files.
+                                Contents must be a map of `<strictness>: ['path1.rb', ...]` pairs.
+                                Can be used to enable type checking for certain files temporarily 
+                                without having to add a comment to every file. (default: "")
 
 
 ----- Full help output: --------------------------------------------------

--- a/test/cli/help/test.out
+++ b/test/cli/help/test.out
@@ -86,6 +86,17 @@ Usage:
 
 ----- Full help output: --------------------------------------------------
 
- advanced options:
- dev options:
+ INPUT options:
+ OUTPUT options:
+ AUTOCORRECT options:
+ ERROR options:
+ METRIC options:
+ LSP options:
+ LSP FEATURE options:
+ PERFORMANCE options:
+ STRIPE PACKAGES MODE options:
+ STRIPE AUTOGEN options:
+ DEBUGGING options:
+ INTERNAL options:
+ OTHER options:
 --------------------------------------------------------------------------

--- a/test/cli/isolate-error-code/test.out
+++ b/test/cli/isolate-error-code/test.out
@@ -9,15 +9,3 @@ test/cli/isolate-error-code/isolate-error-code.rb:6: The method `foo` does not h
      6 | def foo
         ^
 Errors: 1
-`--error-white-list` is deprecated; please use `--isolate-error-code` instead
-test/cli/isolate-error-code/isolate-error-code.rb:6: The method `foo` does not have a `sig` https://srb.help/7017
-     6 | def foo
-         ^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `sig { returns(Integer) }`
-     6 | def foo
-         ^
-    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `extend T::Sig`
-     6 | def foo
-        ^
-Errors: 1

--- a/test/cli/isolate-error-code/test.sh
+++ b/test/cli/isolate-error-code/test.sh
@@ -1,6 +1,3 @@
 #!/bin/bash
 
 main/sorbet --silence-dev-message test/cli/isolate-error-code/isolate-error-code.rb --isolate-error-code=7017 2>&1
-
-# TODO(jvilk): Remove when we remove --error-white-list
-main/sorbet --silence-dev-message test/cli/isolate-error-code/isolate-error-code.rb --error-white-list=7017 2>&1

--- a/test/cli/metrics-file/test.out
+++ b/test/cli/metrics-file/test.out
@@ -11,11 +11,11 @@ No errors! Great job.
 No error metrics reported.
 ------------------------------
 No errors! Great job.
-   "name": "ruby_typer.unknown..types.input.modules.total",
+   "name": "ruby_typer.unknown.types.input.modules.total",
    "value": 1
-   "name": "ruby_typer.unknown..types.input.classes.total",
+   "name": "ruby_typer.unknown.types.input.classes.total",
    "value": 6
-   "name": "ruby_typer.unknown..types.input.singleton_classes.total",
+   "name": "ruby_typer.unknown.types.input.singleton_classes.total",
    "value": 4
-   "name": "ruby_typer.unknown..types.input.methods.total",
+   "name": "ruby_typer.unknown.types.input.methods.total",
    "value": 10

--- a/test/cli/metrics-file/test.sh
+++ b/test/cli/metrics-file/test.sh
@@ -27,7 +27,7 @@ echo ------------------------------
 # Compute metrics for classes, modules and methods
 
 main/sorbet --silence-dev-message --metrics-file=metrics5.json test/cli/metrics-file/files_for_metrics/ 2>&1
-grep -A1 "\"ruby_typer.unknown..types.input.modules.total\"" metrics5.json
-grep -A1 "\"ruby_typer.unknown..types.input.classes.total\"" metrics5.json
-grep -A1 "\"ruby_typer.unknown..types.input.singleton_classes.total\"" metrics5.json
-grep -A1 "\"ruby_typer.unknown..types.input.methods.total\"" metrics5.json
+grep -A1 "types.input.modules.total\"" metrics5.json
+grep -A1 "types.input.classes.total\"" metrics5.json
+grep -A1 "types.input.singleton_classes.total\"" metrics5.json
+grep -A1 "types.input.methods.total\"" metrics5.json

--- a/test/cli/suppress-error-code/test.out
+++ b/test/cli/suppress-error-code/test.out
@@ -34,16 +34,3 @@ test/cli/suppress-error-code/suppress-error-code.rb:4: `T.cast` is useless becau
      4 |T.cast(1, T.nilable(Integer))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1
-`--error-black-list` is deprecated; please use `--suppress-error-code` instead
-test/cli/suppress-error-code/suppress-error-code.rb:4: `T.cast` is useless because `Integer(1)` is already a subtype of `T.nilable(Integer)` https://srb.help/7015
-     4 |T.cast(1, T.nilable(Integer))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Got `Integer(1)` originating from:
-    test/cli/suppress-error-code/suppress-error-code.rb:4:
-     4 |T.cast(1, T.nilable(Integer))
-               ^
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/suppress-error-code/suppress-error-code.rb:4: Replace with `1`
-     4 |T.cast(1, T.nilable(Integer))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 1

--- a/test/cli/suppress-error-code/test.sh
+++ b/test/cli/suppress-error-code/test.sh
@@ -3,6 +3,3 @@
 main/sorbet --censor-for-snapshot-tests --silence-dev-message test/cli/suppress-error-code/suppress-error-code.rb 2>&1
 
 main/sorbet --censor-for-snapshot-tests --silence-dev-message test/cli/suppress-error-code/suppress-error-code.rb --suppress-error-code=7002 2>&1
-
-# TODO(jvilk): Remove these once we delete --error-black-list
-main/sorbet --censor-for-snapshot-tests --silence-dev-message test/cli/suppress-error-code/suppress-error-code.rb --error-black-list=7002 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Makes it substantially easier to read the options.

Two things I want to follow up with in a separate change:

- Autogenerate `--help` output into sorbet.org somewhere
- Write up something about how to deal with lots of errors when doing codemods (`--stop-after`, `--isolate-error-code`, etc.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

**Before**

```
Typechecker for Ruby
Usage:
  sorbet [OPTION...] <path 1> <path 2> ...

  -e string      Parse an inline ruby string (default: "")
  -q, --quiet    Silence all non-critical errors
  -v, --verbose  Verbosity level [0-3]
  -h             Show short help
      --help     Show long help
      --version  Show version

 advanced options:
      --e-rbi string            Parse an inline RBI string (default: "")
      --dir arg                 Input directory
      --file arg                Input file
      --allowed-extension arg   Allowed extension
      --web-trace-file file     Web trace file. For use with chrome 
                                about://tracing (default: "")
      --debug-log-file file     Path to debug log file (default: "")
      --reserve-class-table-capacity arg
                                Preallocate the specified number of entries 
                                in the class and modules table (default: 0)
      --reserve-method-table-capacity arg
                                Preallocate the specified number of entries 
                                in the method table (default: 0)
      --reserve-field-table-capacity arg
                                Preallocate the specified number of entries 
                                in the field table (default: 0)
      --reserve-type-argument-table-capacity arg
                                Preallocate the specified number of entries 
                                in the type argument table (default: 0)
      --reserve-type-member-table-capacity arg
                                Preallocate the specified number of entries 
                                in the type member table (default: 0)
      --reserve-utf8-name-table-capacity arg
                                Preallocate the specified number of entries 
                                in the UTF8 name table (default: 0)
      --reserve-constant-name-table-capacity arg
                                Preallocate the specified number of entries 
                                in the constant name table (default: 0)
      --reserve-unique-name-table-capacity arg
                                Preallocate the specified number of entries 
                                in the unique name table (default: 0)
      --stdout-hup-hack         Monitor STDERR for HUP and exit on hangup
      --remove-path-prefix prefix
                                Remove the provided path prefix from all 
                                printed paths. Defaults to the input 
                                directory passed to Sorbet, if any. 
                                (default: "")
  -a, --autocorrect             Auto-correct source files with suggested 
                                fixes
      --did-you-mean            Whether to include 'Did you mean' 
                                suggestions in autocorrects (default: true)
  -P, --progress                Draw progressbar
      --license                 Show license
      --color {always,never,[auto]}
                                Use color output (default: auto)
      --lsp                     Start in language-server-protocol mode
      --no-config               Do not load the content of the 
                                `sorbet/config` file
      --disable-watchman        When in language-server-protocol mode, 
                                disable file watching via Watchman
      --watchman-path arg       Path to watchman executable. Defaults to 
                                using `watchman` on your PATH. (default: 
                                watchman)
      --watchman-pause-state-name arg
                                Name of watchman state that halts 
                                processing for its duration (default: "")
      --enable-experimental-lsp-document-symbol
                                Enable experimental LSP feature: Document 
                                Symbol
      --enable-experimental-lsp-document-formatting-rubyfmt
                                Enable experimental LSP feature: Document 
                                Formatting with Rubyfmt
      --rubyfmt-path arg        Path to the rubyfmt executable used for 
                                document formatting. Defaults to using 
                                `rubyfmt` on your PATH. (default: rubyfmt)
      --enable-experimental-lsp-document-highlight
                                Enable experimental LSP feature: Document 
                                Highlight
      --enable-experimental-lsp-signature-help
                                Enable experimental LSP feature: Signature 
                                Help
      --enable-experimental-requires-ancestor
                                Enable experimental `requires_ancestor` 
                                annotation
      --enable-experimental-lsp-extract-to-variable
                                Enable experimental LSP feature: Extract To 
                                Variable
      --enable-all-experimental-lsp-features
                                Enable every experimental LSP feature. 
                                (WARNING: can be crashy; for developer use 
                                only. End users should prefer to use 
                                `--enable-all-beta-lsp-features`, instead.)
      --enable-all-beta-lsp-features
                                Enable (expected-to-be-non-crashy) 
                                early-access LSP features.
      --lsp-error-cap cap       Caps the maximum number of errors that LSP 
                                reports to the editor. Can prevent editor 
                                slowdown triggered by large error lists. A 
                                cap of 0 means 'no cap'. (default: 1000)
      --ignore string           Ignores input files that contain the given 
                                string in their paths (relative to the 
                                input path passed to Sorbet). Strings 
                                beginning with / match against the prefix 
                                of these relative paths; others are 
                                substring matches. Matches must be against 
                                whole folder and file names, so `foo` 
                                matches `/foo/bar.rb` and `/bar/foo/baz.rb` 
                                but not `/foo.rb` or `/foo2/bar.rb`.
      --lsp-directories-missing-from-client string
                                Directory prefixes that are not accessible 
                                editor-side. References to files in these 
                                directories will be sent as sorbet: URIs to 
                                clients that understand them.
      --no-error-count          Do not print the error count summary line
      --autogen-version arg     Autogen version to output
      --stripe-mode             Enable Stripe specific error enforcement
      --stripe-packages         Enable support for Stripe's internal Ruby 
                                package system
      --stripe-packages-hint-message arg
                                Optional hint message to add to packaging 
                                related errors (default: "")
      --autogen-constant-cache-file arg
                                Location of the cache file used to 
                                determine if it's safe to skip autogen. If 
                                this is not provided, autogen will always 
                                run. (default: "")
      --autogen-changed-files arg
                                List of files which have changed since the 
                                last autogen run. If a cache file is also 
                                provided, autogen may exit early if it 
                                determines that these files could not have 
                                affected the output of autogen.
      --error-url-base url-base
                                Error URL base string. If set, error URLs 
                                are generated by prefixing the error code 
                                with this string. (default: 
                                https://srb.help/)
      --experimental-ruby3-keyword-args
                                Enforce use of new (Ruby 3.0-style) keyword 
                                arguments
      --typed-super             Enable typechecking of `super` calls when 
                                possible (default: true)
      --check-out-of-order-constant-references
                                Enable out-of-order constant reference 
                                checks (error 5027)
      --track-untyped [={[nowhere],everywhere,everywhere-but-tests}(=everywhere)]
                                Track untyped usage statistics in the 
                                file-table output
      --suppress-payload-superclass-redefinition-for Fully::Qualified::ClassName
                                Explicitly suppress the superclass 
                                redefinition error for the specified class 
                                defined in Sorbet's payload. May be 
                                repeated.

 dev options:
      --extra-package-files-directory-prefix-underscore string
                                Extra parent directories which contain 
                                package files. These paths use an 
                                underscore package-munging convention, i.e. 
                                'Project_Foo'.This option must be used in 
                                conjunction with --stripe-packages
      --extra-package-files-directory-prefix-slash string
                                Extra parent directories which contain 
                                package files. These paths use an 
                                underscore package-munging convention, i.e. 
                                'project/foo'.This option must be used in 
                                conjunction with --stripe-packages
      --allow-relaxed-packager-checks-for string
                                Packages which are allowed to ignore the 
                                restrictions set by `visible_to` and 
                                `export` directives.This option must be 
                                used in conjunction with --stripe-packages
  -p, --print type              Print: [parse-tree, parse-tree-json, 
                                parse-tree-json-with-locs, 
                                parse-tree-whitequark, desugar-tree, 
                                desugar-tree-raw, rewrite-tree, 
                                rewrite-tree-raw, index-tree, 
                                index-tree-raw, name-tree, name-tree-raw, 
                                resolve-tree, resolve-tree-raw, 
                                flatten-tree, flatten-tree-raw, ast, 
                                ast-raw, cfg, cfg-raw, cfg-text, 
                                symbol-table, symbol-table-raw, 
                                symbol-table-json, symbol-table-proto, 
                                symbol-table-messagepack, 
                                symbol-table-full, symbol-table-full-raw, 
                                symbol-table-full-json, 
                                symbol-table-full-proto, 
                                symbol-table-full-messagepack, 
                                file-table-json, file-table-proto, 
                                file-table-messagepack, 
                                file-table-full-json, 
                                file-table-full-proto, 
                                file-table-full-messagepack, 
                                missing-constants, autogen, 
                                autogen-msgpack, autogen-subclasses, 
                                package-tree, minimized-rbi, 
                                payload-sources, untyped-blame]
      --trace-lexer             Emit the lexer's token stream in a debug 
                                format
      --trace-parser            Enable bison's parser trace functionality
      --autogen-subclasses-parent string
                                Parent classes for which generate a list of 
                                subclasses. This option must be used in 
                                conjunction with -p autogen-subclasses
      --autogen-subclasses-ignore string
                                Like --ignore, but it only affects `-p 
                                autogen-subclasses`.
      --autogen-behavior-allowed-in-rbi-files-paths string
                                RBI files defined in these paths can be 
                                considered by autogen as behavior-defining.
      --autogen-msgpack-skip-reference-metadata
                                Skip serializing extra metadata on 
                                references when printing msgpack in autogen
      --stop-after phase        Stop After: [init, parser, desugarer, 
                                rewriter, local-vars, namer, resolver, cfg, 
                                inferencer] (default: inferencer)
      --no-stdlib               Do not load included rbi files for stdlib
      --minimize-to-rbi <file.rbi>
                                [experimental] Output a minimal RBI 
                                containing the diff between Sorbet's view 
                                of a codebase and the definitions present 
                                in this file (default: "")
      --wait-for-dbg            Wait for debugger on start
      --stress-incremental-resolver
                                Force incremental updates to discover 
                                resolver & namer bugs
      --sleep-in-slow-path [=arg(=3)]
                                Add some sleeps to slow path to 
                                artificially slow it down
      --simulate-crash          Crash on start
      --silence-dev-message     Silence "You are running a development 
                                build" message
      --censor-for-snapshot-tests
                                When printing raw location information, 
                                don't show line numbers
      --isolate-error-code errorCode
                                Error code to include in reporting. Errors 
                                not mentioned will be silenced. This option 
                                can be passed multiple times.
      --single-package arg      Run in single-package mode (default: "")
      --package-rbi-generation  Enable rbi generation for stripe packages
      --package-rbi-dir arg     The location of generated package rbis 
                                (default: "")
      --package-skip-rbi-export-enforcement string
                                Constants defined in RBIs in these 
                                directories can be exported (otherwise, 
                                this behavior is disallowed).This option 
                                can only be used in conjunction with 
                                --stripe-packages
      --dump-package-info arg   Dump package info in JSON form to the given 
                                file. (default: "")
      --suppress-error-code errorCode
                                Error code to exclude from reporting. 
                                Errors mentioned will be silenced. This 
                                option can be passed multiple times.
      --error-white-list errorCode
                                (DEPRECATED) Alias for 
                                --isolate-error-code. Will be removed in a 
                                later release.
      --error-black-list errorCode
                                (DEPRECATED) Alias for 
                                --suppress-error-code. Will be removed in a 
                                later release.
      --no-error-sections       Do not print error sections.
      --typed {false,true,strict,strong,[auto]}
                                Force all code to specified strictness 
                                level (default: auto)
      --typed-override filepath.yaml
                                Yaml config that overrides strictness 
                                levels on files (default: "")
      --store-state file        Store state into file (default: "")
      --cache-dir dir           Use the specified folder to cache data 
                                (default: "")
      --max-cache-size-bytes dir
                                Must be a multiple of OS page size. Subject 
                                to restrictions on mdb_env_set_mapsize 
                                function in LMDB API docs. (default: 
                                4294967296)
      --suppress-non-critical   Exit 0 unless there was a critical error
      --max-threads int         Set number of threads (default: 12)
      --counter counter         Print internal counter
      --statsd-host host        StatsD sever hostname (default: "")
      --counters                Print all internal counters
      --suggest-typed           Suggest which typed: sigils to add or 
                                upgrade
      --suggest-unsafe [=<method>(=T.unsafe)]
                                In as many errors as possible, suggest 
                                autocorrects to wrap problem code with 
                                <method>. Omit the =<method> to default to 
                                wrapping with T.unsafe. This supersedes 
                                certain autocorrects, especially T.must.
      --statsd-prefix prefix    StatsD prefix (default: ruby_typer.unknown)
      --statsd-port port        StatsD server port (default: 8200)
      --metrics-file file       File to export metrics to (default: "")
      --metrics-prefix file     Prefix to use in metrics (default: 
                                ruby_typer.unknown.)
      --metrics-branch branch   Branch to report in metrics export 
                                (default: none)
      --metrics-sha sha1        Sha1 to report in metrics export (default: 
                                none)
      --metrics-repo repo       Repo to report in metrics export (default: 
                                none)
      --metrics-extra-tags key1=value1,key2=value2
                                Extra tags to report, comma separated 
                                (default: "")
      --force-hashing           Forces Sorbet to calculate file hashes when 
                                run from CLI. Useful for profiling 
                                purposes.

```

**After**

```
Sorbet: A fast, powerful typechecker designed for Ruby
Usage:
  sorbet [options] [[--] <path>...]

 INPUT options:
  -e <string>                   Treat <string> as if it were the contents of a Ruby file passed on 
                                the command line (default: "")
      --e-rbi <string>          Like `-e`, but treat <string> as an RBI file (default: "")
      --file <path>             Run over the contents of <path>
                                (Equivalent to passing <path> as a positional argument)
      --dir <path>              Run over all Ruby and RBI files in <path>, recursively
                                (Equivalent to passing <path> as a positional argument)
      --allowed-extension <ext>[,<ext>...]
                                Use these extensions to determine which file types Sorbet should 
                                discover inside directories. (default: .rb,.rbi)
      --ignore <pattern>        Ignores input files that contain <pattern> in their paths (relative 
                                to the input path passed to Sorbet).
                                When <pattern> starts with `/` it matches against the prefix of 
                                these relative paths; others match anywhere.
                                Matches must be against whole path segments, so `foo` matches 
                                `foo/bar.rb` and `bar/foo/baz.rb` but not `foo.rb` or 
                                `foo2/bar.rb`.
      --no-config               Do not load the content of the `sorbet/config` file.
                                Otherwise, Sorbet reads the `sorbet/config` file and treats each 
                                line as if it were passed on the command line, unless the line 
                                starts with `#`.
                                To load a <file> as if it were a config file, pass `@<file>` as a 
                                positional arg
      --typed {false,true,strict,strong,[auto]}
                                Force all code to specified strictness level, disregarding all `# 
                                typed:` sigils. For `auto`, uses the `# typed:` sigil in the file 
                                or `false` for files without a sigil. (default: auto)
      --typed-override <filepath.yaml>
                                Read <filepath.yaml> to override the strictness of individual files.
                                Contents must be a map of `<strictness>: ['path1.rb', ...]` pairs.
                                Can be used to enable type checking for certain files temporarily 
                                without having to add a comment to every file. (default: "")

 OUTPUT options:
  -q, --quiet                   Silence all non-critical errors
  -P, --progress                Draw progressbar
      --color {always,never,[auto]}
                                Use color output. For `auto`: use color if stderr is a tty 
                                (default: auto)
      --no-error-count          Do not print the `Errors: <N>` summary line
      --no-error-sections       Only print the first line of every error message (suppress any 
                                additional information below an error). Can provide substantial 
                                speedups when dealing with many errors
      --error-url-base <url-base>
                                Every error message includes a link created by prefixing that 
                                error's code with <url-base>. Can be used to maintain docs on 
                                Sorbet error codes which are more relevant to a specific project or 
                                company. (default: https://srb.help/)
      --remove-path-prefix <prefix>
                                Remove the provided <prefix> from all printed paths. Defaults to 
                                the input directory passed to Sorbet, if any. (default: "")

 AUTOCORRECT options:
  -a, --autocorrect             Auto-correct source files with suggested fixes.
                                Use the `--{isolate,suppress}-error-code` options to control which 
                                corrections to apply
      --suggest-unsafe [=<method>(=T.unsafe)]
                                Include 'unsafe' autocorrects, e.g. those which can be fixed by 
                                wrapping code in `T.unsafe` or using `T.untyped`. Provide a custom 
                                <method> to wrap with `<method>(...)` instead of `T.unsafe(...)`. 
                                This supersedes certain autocorrects, especially T.must.
      --did-you-mean            Whether to include 'Did you mean' suggestions in autocorrects. For 
                                large codemods, it's usually better to avoid spurious changes by 
                                setting this to false (default: true)
      --suggest-typed           Emit autocorrects to set the `# typed:` sigil in every file to the 
                                highest possible level where no errors would be reported in that 
                                file. Will downgrade the `# typed:` sigil for any files with 
                                errors.

 ERROR options:
      --typed-super             Enable typechecking of `super` calls when possible (default: true)
      --check-out-of-order-constant-references
                                Detect when a constant is referenced early in a file, but defined 
                                later in that file. Does not detect out-of-order references across 
                                file boundaries.
      --isolate-error-code <error-code>
                                Which error(s) to include in reporting. This option can be passed 
                                multiple times. All errors not mentioned will be silenced.
      --suppress-error-code <error-code>
                                Which error(s) to exclude from reporting. This option can be passed 
                                multiple times.
      --suppress-payload-superclass-redefinition-for Fully::Qualified::ClassName
                                Explicitly suppress the superclass redefinition error for the 
                                specified class defined in Sorbet's payload. May be repeated.
      --experimental-ruby3-keyword-args
                                Enforce use of new (Ruby 3.0-style) keyword arguments. (incomplete 
                                and experimental)
      --enable-experimental-requires-ancestor
                                Enable experimental `requires_ancestor` annotation
      --stripe-mode             Ensure that every class and module only defines 'behavior' in one 
                                file. Ensures that every class or module can be autoloaded by 
                                loading exactly one file.
      --stop-after <phase>      Stop after completing <phase>. Can be useful for debugging. Also 
                                useful when overwhelmed with errors, because errors from earlier 
                                phases (like resolver) can cause errors downstream (in inferencer).
                                Phases: [init, parser, desugarer, rewriter, local-vars, namer, 
                                resolver, cfg, inferencer] (default: inferencer)

 METRIC options:
      --counters                Print all internal counters
      --counter <counter>       Print internal counter for <counter> (repeatable)
      --track-untyped [={[nowhere],everywhere,everywhere-but-tests}(=everywhere)]
                                Include a per-file counter of untyped usages in the 
                                `--print=file-table-<format>` output. This is in addition to the 
                                codebase-wide `types.input.untyped.usages` counter.
      --metrics-file <file>     Report counters and some timers to <file>, in JSON format. 
                                (default: "")
      --metrics-prefix <string>
                                String to prefix all metrics with, e.g. `my_org.my_repo`. (default: 
                                ruby_typer.unknown)
      --metrics-branch <branch>
                                Branch to report in metrics export. (default: none)
      --metrics-sha <sha>       Set the `sha` field to <sha> in the `--metrics-file` output. 
                                (default: none)
      --metrics-repo <repo>     Set the `repo` field to <repo> in the `--metrics-file` output. 
                                (default: none)
      --statsd-host <host>      StatsD sever hostname (default: "")
      --statsd-prefix <prefix>  StatsD prefix (default: ruby_typer.unknown)
      --statsd-port <port>      StatsD server port (default: 8200)
      --metrics-extra-tags <key1>=<value1>,<key2>=<value2>
                                Extra tags to include in every statsd metric, comma separated. 
                                (default: "")

 LSP options:
      --lsp                     Start in language server protocol mode (LSP mode)
      --lsp-error-cap <cap>     Reports no more than <cap> diagnostics (e.g. errors and 
                                informations) to the language client, like VS Code. Can prevent 
                                slowdown triggered by large diagnostic lists. A <cap> of 0 means no 
                                limit. (default: 1000)
      --disable-watchman        When in LSP mode, disable file watching via Watchman
      --watchman-path <path>    Path to watchman executable. Will search on `PATH` if <path> 
                                contains no slashes. (default: watchman)
      --watchman-pause-state-name <state>
                                Name of watchman state that halts processing for its duration 
                                (default: "")
      --lsp-directories-missing-from-client <path>
                                Directory prefixes that only exist where the LSP server is running, 
                                not on the client. Useful when running Sorbet via an `ssh` 
                                connection to a remote server, where the remote server has 
                                generated files that do not exist on the client. References to 
                                files in these directories will be sent as `sorbet:` URIs to 
                                clients that understand them.

 LSP FEATURE options:
      --enable-experimental-lsp-document-formatting-rubyfmt
                                Enable experimental LSP feature: Document Formatting with Rubyfmt
      --rubyfmt-path <path>     Path to the rubyfmt executable used for document formatting. Will 
                                search on `PATH` if <path> contains no slashes. (default: rubyfmt)
      --enable-experimental-lsp-document-highlight
                                Enable experimental LSP feature: Document Highlight
      --enable-experimental-lsp-signature-help
                                Enable experimental LSP feature: Signature Help
      --enable-experimental-lsp-extract-to-variable
                                Enable experimental LSP feature: Extract To Variable
      --enable-all-experimental-lsp-features
                                Enable every experimental LSP feature. (WARNING: can be crashy; for 
                                developer use only. End users should prefer to use 
                                `--enable-all-beta-lsp-features`, instead.)
      --enable-all-beta-lsp-features
                                Enable (expected-to-be-non-crashy) early-access LSP features.

 PERFORMANCE options:
      --web-trace-file <file>   Generate a trace into <file> in the Trace Event Format (used by 
                                chrome://tracing) (default: "")
      --cache-dir <dir>         Use <dir> to cache certain data. Will create <dir> if it does not 
                                exist (default: "")
      --max-cache-size-bytes <bytes>
                                Must be a multiple of OS page size (usually 4096). Subject to 
                                restrictions on mdb_env_set_mapsize function in LMDB API docs. 
                                (default: 4294967296)
      --max-threads <n>         Set number of threads to use for fork/join worker pools. LSP will 
                                <n> threads plus some extra threads to manage the connection with 
                                the client, watchman, etc. (default: 12)
      --reserve-class-table-capacity <n>
                                Preallocate <n> slots in the class and modules table (default: 0)
      --reserve-method-table-capacity <n>
                                Preallocate <n> slots in the method table (default: 0)
      --reserve-field-table-capacity <n>
                                Preallocate <n> slots in the field table (default: 0)
      --reserve-type-argument-table-capacity <n>
                                Preallocate <n> slots in the type argument table (default: 0)
      --reserve-type-member-table-capacity <n>
                                Preallocate <n> slots in the type member table (default: 0)
      --reserve-utf8-name-table-capacity <n>
                                Preallocate <n> slots in the UTF8 name table (default: 0)
      --reserve-constant-name-table-capacity <n>
                                Preallocate <n> slots in the constant name table (default: 0)
      --reserve-unique-name-table-capacity <n>
                                Preallocate <n> slots in the unique name table (default: 0)

 STRIPE PACKAGES MODE options:
      --stripe-packages         Enable support for Stripe's internal Ruby package system
      --stripe-packages-hint-message arg
                                Optional hint message to add to packaging related errors (default: 
                                "")
      --extra-package-files-directory-prefix-underscore string
                                Extra parent directories which contain package files. These paths 
                                use an underscore package-munging convention, i.e. 'Project_Foo'
      --extra-package-files-directory-prefix-slash string
                                Extra parent directories which contain package files. These paths 
                                use a slash package-munging convention, i.e. 'project/foo'
      --allow-relaxed-packager-checks-for string
                                Packages which are allowed to ignore the restrictions set by 
                                `visible_to` and `export` directives
      --package-skip-rbi-export-enforcement string
                                Constants defined in RBIs in these directories (and no others) can 
                                be exported

 STRIPE AUTOGEN options:
      --autogen-version arg     Autogen version to output
      --autogen-constant-cache-file arg
                                Location of the cache file used to determine if it's safe to skip 
                                autogen. If this is not provided, autogen will always run. 
                                (default: "")
      --autogen-changed-files arg
                                List of files which have changed since the last autogen run. If a 
                                cache file is also provided, autogen may exit early if it 
                                determines that these files could not have affected the output of 
                                autogen.
      --autogen-subclasses-parent string
                                Parent classes for which generate a list of subclasses. This option 
                                must be used in conjunction with -p autogen-subclasses
      --autogen-subclasses-ignore string
                                Like --ignore, but it only affects `-p autogen-subclasses`.
      --autogen-behavior-allowed-in-rbi-files-paths string
                                RBI files defined in these paths can be considered by autogen as 
                                behavior-defining.
      --autogen-msgpack-skip-reference-metadata
                                Skip serializing extra metadata on references when printing msgpack 
                                in autogen

 DEBUGGING options:
  -v, --verbose                 Verbosity level [0-3]
      --debug-log-file <file>   Path to debug log file (default: "")
      --wait-for-dbg            Wait for debugger to attach after starting. Especially useful to 
                                attach to a Sorbet process launched by a language client
      --sleep-in-slow-path [=arg(=3)]
                                Add some sleeps to slow path to artificially slow it down
      --stress-incremental-resolver
                                Simulate updates which tend to expose namer and resolver bugs
      --simulate-crash          Raise an uncaught C++ exception on startup to simulate a crash
      --force-hashing           Force Sorbet to calculate file hashes, even from the CLI. Useful 
                                for profiling.
      --trace-lexer             Emit the lexer's token stream in a debug format
      --trace-parser            Enable bison's parser trace functionality
      --dump-package-info arg   Dump package info in JSON form to the given file. (default: "")
  -p, --print <format>          Print various internal data structures.
                                By default, the output is to stdout. To send the data to a file, use
                                --print=<format>:<file>
                                Most of these formats are unstable, for internal-use only.

                                Stable: [file-table-json, file-table-proto, file-table-messagepack, 
                                file-table-full-json, file-table-full-proto, 
                                file-table-full-messagepack, missing-constants, payload-sources, 
                                untyped-blame]

                                Unstable: [parse-tree, parse-tree-json, parse-tree-json-with-locs, 
                                parse-tree-whitequark, desugar-tree, desugar-tree-raw, 
                                rewrite-tree, rewrite-tree-raw, index-tree, index-tree-raw, 
                                name-tree, name-tree-raw, resolve-tree, resolve-tree-raw, 
                                flatten-tree, flatten-tree-raw, ast, ast-raw, cfg, cfg-raw, 
                                cfg-text, symbol-table, symbol-table-raw, symbol-table-json, 
                                symbol-table-proto, symbol-table-messagepack, symbol-table-full, 
                                symbol-table-full-raw, symbol-table-full-json, 
                                symbol-table-full-proto, symbol-table-full-messagepack, autogen, 
                                autogen-msgpack, autogen-subclasses, package-tree, minimized-rbi

 INTERNAL options:
      --suppress-non-critical   Exit 0 unless there was a critical error (i.e., an uncaught 
                                exception)
      --no-stdlib               Do not load Sorbet's payload which defines RBI files for the Ruby 
                                standard library
      --store-state file        Store state into file (default: "")
      --silence-dev-message     Silence "You are running a development build" message
      --censor-for-snapshot-tests
                                When printing raw location information, don't show line numbers

 OTHER options:
      --version                 Show Sorbet's version
      --license                 Show Sorbet's license, and licenses of its dependencies
      --stdout-hup-hack         Monitor STDERR for HUP and exit on hangup to work around OpenSSH 
                                bug
      --minimize-to-rbi <file.rbi>
                                [experimental] Output a minimal RBI containing the diff between 
                                Sorbet's view of a codebase and the definitions present in this 
                                file (default: "")
      --single-package arg      Run in single-package mode (default: "")
      --package-rbi-generation  Enable rbi generation for stripe packages
      --package-rbi-dir arg     The location of generated package rbis (default: "")
  -h, --help [=SECTION(=all)]   Show help. Can pass an optional SECTION to show help for only one 
                                section instead of the default of all sections
```