### PR TITLE
Support native Darwin ARM64 builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -137,6 +137,12 @@ build:release-sanitized-linux --copt=-march=sandybridge
 build:release-linux-aarch64   --copt=-march=armv8.1a
 
 build:release-mac --config=release-common --platforms=@//tools/platforms:darwin_x86_64
+build:release-mac-arm64 --platforms=@//tools/platforms:darwin_arm64
+build:release-mac-arm64 --define release=true
+build:release-mac-arm64 --compilation_mode=opt
+build:release-mac-arm64 --config=backtracesymbols
+build:release-mac-arm64 --config=shared-libs
+build:release-mac-arm64 --config=versioned
 
 build:release-debug-linux --config=release-linux
 build:release-debug-linux --config=release-debug-common

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -16,8 +16,12 @@ case "$platform" in
   linux-aarch64)
     CONFIG_OPTS="--config=release-${platform}"
     ;;
-  darwin-x86_64|darwin-arm64)
+  darwin-x86_64)
     CONFIG_OPTS="--config=release-mac"
+    command -v autoconf >/dev/null 2>&1 || brew install autoconf
+    ;;
+  darwin-arm64)
+    CONFIG_OPTS="--config=release-mac-arm64"
     command -v autoconf >/dev/null 2>&1 || brew install autoconf
     ;;
   *)

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -33,6 +33,8 @@ case "$platform" in
     TARGET_PLATFORM=darwin-x86_64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
     mv bazel-bin/main/sorbet sorbet_x86_64
 
+    ./bazel clean --expunge
+
     TARGET_PLATFORM=darwin-arm64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
     mv bazel-bin/main/sorbet sorbet_arm64
 

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -28,7 +28,21 @@ esac
 
 echo will run with $CONFIG_OPTS
 
-./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+case "$platform" in
+  darwin-x86_64|darwin-arm64)
+    TARGET_PLATFORM=darwin-x86_64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+    mv bazel-bin/main/sorbet sorbet_x86_64
+
+    TARGET_PLATFORM=darwin-arm64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+    mv bazel-bin/main/sorbet sorbet_arm64
+
+    lipo -create -output bazel-bin/main/sorbet sorbet_x86_64 sorbet_arm64
+    rm sorbet_x86_64 sorbet_arm64
+    ;;
+  *)
+    ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+    ;;
+esac
 
 mkdir gems/sorbet-static/libexec/
 cp bazel-bin/main/sorbet gems/sorbet-static/libexec/

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -35,23 +35,24 @@ echo will run with $CONFIG_OPTS
 case "$platform" in
   darwin-x86_64|darwin-arm64)
     TARGET_PLATFORM=darwin-x86_64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
-    mv bazel-bin/main/sorbet sorbet_x86_64
+    cp bazel-bin/main/sorbet sorbet_x86_64
 
     ./bazel clean --expunge
 
     TARGET_PLATFORM=darwin-arm64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
-    mv bazel-bin/main/sorbet sorbet_arm64
+    cp bazel-bin/main/sorbet sorbet_arm64
 
-    lipo -create -output bazel-bin/main/sorbet sorbet_x86_64 sorbet_arm64
+    lipo -create -output sorbet_bin sorbet_x86_64 sorbet_arm64
     rm sorbet_x86_64 sorbet_arm64
     ;;
   *)
     ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+    cp bazel-bin/main/sorbet sorbet_bin
     ;;
 esac
 
 mkdir gems/sorbet-static/libexec/
-cp bazel-bin/main/sorbet gems/sorbet-static/libexec/
+cp sorbet_bin gems/sorbet-static/libexec/sorbet
 
 rbenv install --skip-existing
 

--- a/bazel
+++ b/bazel
@@ -166,4 +166,5 @@ mkdir -p "$BUILD_DIR"
 )
 rm -rf "$BUILD_DIR"
 
+"$bazel_exec_path" clean --expunge
 exec "$bazel_exec_path" "$@"

--- a/bazel
+++ b/bazel
@@ -34,18 +34,59 @@ export BAZEL_VERSION
 bazel_bin_loc="${bazel_bin_loc:-$HOME/.bazel_binaries}"
 bazel_exec_path="$bazel_bin_loc/$BAZEL_VERSION/bin/bazel-real"
 
+kernel_name="$(uname -s | tr 'A-Z' 'a-z')"
+processor_name="$(uname -m)"
+bazel_installer_platform="${kernel_name}-${processor_name}"
+
+if [ -f "$bazel_exec_path" ]; then
+  # If we already have a cached bazel binary, check if it's the right platform
+  bazel_type=$(file -b "$bazel_exec_path")
+
+  case "$bazel_type" in
+    *ELF*)
+      bazel_kernel="linux"
+      ;;
+    *Mach-O*)
+      bazel_kernel="darwin"
+      ;;
+    *)
+      bazel_kernel="unknown"
+      ;;
+  esac
+
+  case "$bazel_type" in
+    *x86-64* | *x86_64*)
+      bazel_proc="x86_64"
+      ;;
+    *arm64*)
+      bazel_proc="arm64"
+      ;;
+    *aarch64*)
+      bazel_proc="aarch64"
+      ;;
+    *)
+      bazel_proc="unknown"
+      ;;
+  esac
+
+  bazel_platform="${bazel_kernel}-${bazel_proc}"
+  echo >&2 "Found cached Bazel binary for ${bazel_platform}..."
+
+  if [[ $bazel_platform != $bazel_installer_platform ]]; then
+    echo >&2 "Bazel binary platform mismatch: expected $bazel_installer_platform, got $bazel_platform"
+    echo >&2 "Removing cached binary..."
+    rm -f "$bazel_exec_path"
+  fi
+fi
+
 if [ -f "$bazel_exec_path" ]; then
   exec "$bazel_exec_path" "$@"
 fi
 
 # ----- slow path -----
 
-echo >&2 "No cached Bazel v$BAZEL_VERSION found, installing..."
+echo >&2 "No cached Bazel v$BAZEL_VERSION found, installing for $bazel_installer_platform..."
 
-kernel_name="$(uname -s | tr 'A-Z' 'a-z')"
-processor_name="$(uname -m)"
-
-bazel_installer_platform="${kernel_name}-${processor_name}"
 case "$bazel_installer_platform" in
   linux-x86_64) ;;
   linux-aarch64)

--- a/bazel
+++ b/bazel
@@ -34,9 +34,13 @@ export BAZEL_VERSION
 bazel_bin_loc="${bazel_bin_loc:-$HOME/.bazel_binaries}"
 bazel_exec_path="$bazel_bin_loc/$BAZEL_VERSION/bin/bazel-real"
 
-kernel_name="$(uname -s | tr 'A-Z' 'a-z')"
-processor_name="$(uname -m)"
-bazel_installer_platform="${kernel_name}-${processor_name}"
+if [ "${TARGET_PLATFORM:-}" != "" ]; then
+  bazel_installer_platform="${TARGET_PLATFORM}"
+else
+  kernel_name="$(uname -s | tr 'A-Z' 'a-z')"
+  processor_name="$(uname -m)"
+  bazel_installer_platform="${kernel_name}-${processor_name}"
+fi
 
 if [ -f "$bazel_exec_path" ]; then
   # If we already have a cached bazel binary, check if it's the right platform

--- a/bazel
+++ b/bazel
@@ -52,10 +52,7 @@ case "$bazel_installer_platform" in
     bazel_installer_platform="linux-arm64"
     ;;
   darwin-x86_64) ;;
-  darwin-arm64)
-    # Pseudo Apple Silicon support by forcing x86_64 (Rosetta) for now
-    bazel_installer_platform="darwin-x86_64"
-    ;;
+  darwin-arm64) ;;
   *)
     echo >&2 "Building on $bazel_installer_platform is not implemented"
     exit 1

--- a/tools/platforms/BUILD
+++ b/tools/platforms/BUILD
@@ -9,6 +9,14 @@ platform(
 )
 
 platform(
+    name = "darwin_arm64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+platform(
     name = "linux_x86_64",
     constraint_values = [
         "@platforms//os:linux",


### PR DESCRIPTION
The original PR for this is #7922, but I'm re-opening it using Shopify's fork so that everyone can contribute to the PR.

This PR adds support for compiling Sorbet to ARM64 and for publishing the ARM64 binaries as a universal one, including both x86 and ARM64 support.

Please see the original PR for more context and discussions.