### PR TITLE
Revert "Change optparse.rbi T::Class overload (#8146)"

### DIFF
--- a/rbi/stdlib/optparse.rbi
+++ b/rbi/stdlib/optparse.rbi
@@ -796,7 +796,6 @@ class OptionParser
   # for an explanation of parameters.
   sig do
     params(
-      short: String,
       type: T.any(T.class_of(TrueClass), T.class_of(FalseClass)),
       opts: T.untyped,
       block: T.nilable(T.proc.params(arg0: T::Boolean).void)
@@ -805,7 +804,6 @@ class OptionParser
   end
   sig do
     params(
-      short: String,
       type: T.any(T.class_of(Shellwords), T.class_of(Array)),
       opts: T.untyped,
       block: T.nilable(T.proc.params(arg0: T::Array[String]).void)
@@ -815,38 +813,6 @@ class OptionParser
   sig do
     type_parameters(:Type)
       .params(
-        short: String,
-        type: T::Class[T.type_parameter(:Type)],
-        opts: T.untyped,
-        block: T.nilable(T.proc.params(arg0: T.type_parameter(:Type)).void)
-      )
-      .returns(T.untyped)
-  end
-  sig do
-    params(
-      short: String,
-      long: String,
-      type: T.any(T.class_of(TrueClass), T.class_of(FalseClass)),
-      opts: T.untyped,
-      block: T.nilable(T.proc.params(arg0: T::Boolean).void)
-    )
-      .returns(T.untyped)
-  end
-  sig do
-    params(
-      short: String,
-      long: String,
-      type: T.any(T.class_of(Shellwords), T.class_of(Array)),
-      opts: T.untyped,
-      block: T.nilable(T.proc.params(arg0: T::Array[String]).void)
-    )
-      .returns(T.untyped)
-  end
-  sig do
-    type_parameters(:Type)
-      .params(
-        short: String,
-        long: String,
         type: T::Class[T.type_parameter(:Type)],
         opts: T.untyped,
         block: T.nilable(T.proc.params(arg0: T.type_parameter(:Type)).void)
@@ -854,7 +820,7 @@ class OptionParser
       .returns(T.untyped)
   end
   sig {params(opts: T.untyped, block: T.untyped).returns(T.untyped)}
-  def on(short=T.unsafe(nil), long=T.unsafe(nil), type=T.unsafe(nil), *opts, &block); end
+  def on(type=T.unsafe(nil), *opts, &block); end
 
   # Also aliased as:
   # [`def_head_option`](https://docs.ruby-lang.org/en/2.7.0/OptionParser.html#method-i-def_head_option)


### PR DESCRIPTION
This reverts commit 496b7bdb546c2385592f9f3d502f563c3852251e.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are a lot of errors on Stripe's codebase with Sorbet master around `optparse`-y things and this commit looks like it might be causing them.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
