### PR TITLE
Ensure that aliased parent classes are handled correctly in subclass list generation

### DIFF
--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -54,7 +54,7 @@ optional<Subclasses::Map> Subclasses::listAllSubclasses(core::Context ctx, const
             continue;
         }
 
-        auto &mapEntry = out[ref.sym];
+        auto &mapEntry = out[ref.sym.dealias(ctx)];
         mapEntry.entries.insert(defn.data(pf).sym.asClassOrModuleRef());
         mapEntry.classKind = ref.parentKind;
     }

--- a/test/cli/autogen-subclasses/child_of_child.rb
+++ b/test/cli/autogen-subclasses/child_of_child.rb
@@ -3,5 +3,7 @@
 require_relative './child'
 
 module Bopus
-  class ChildOfChild < Child; end
+  ChildAlias = Child
+  class ChildOfChild1 < Child; end
+  class ChildOfChild2 < ChildAlias; end
 end

--- a/test/cli/autogen-subclasses/test.out
+++ b/test/cli/autogen-subclasses/test.out
@@ -2,7 +2,8 @@
 class Bopus::Parent
  class Bopus::Child child.rb
  class Bopus::ChildAgain child_again.rb
- class Bopus::ChildOfChild child_of_child.rb
+ class Bopus::ChildOfChild1 child_of_child.rb
+ class Bopus::ChildOfChild2 child_of_child.rb
 module MyMixin
  class MyClass a.rb
 module Opus::Mixin


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

cc @zanker-stripe 

Subclass list generation in autogen has a bug in it, where if you alias a parent class and use it at the subclass declaration site, we lose the reference and don't include it the corresponding subclass the list.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixing autogen.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase
