### PR TITLE
Add cross compilation support for Darwin

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -137,12 +137,23 @@ build:release-sanitized-linux --copt=-march=sandybridge
 build:release-linux-aarch64   --copt=-march=armv8.1a
 
 build:release-mac --config=release-common --platforms=@//tools/platforms:darwin_x86_64
+
 build:release-mac-arm64 --platforms=@//tools/platforms:darwin_arm64
 build:release-mac-arm64 --define release=true
 build:release-mac-arm64 --compilation_mode=opt
 build:release-mac-arm64 --config=backtracesymbols
 build:release-mac-arm64 --config=shared-libs
 build:release-mac-arm64 --config=versioned
+
+# Cross-compile to x86 on an ARM64 machine
+build:release-mac-cross --config=release-mac
+build:release-mac-cross --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-x86_64-darwin
+build:release-mac-cross --copt=-stdlib=libc++ --linkopt=-lc++
+
+# Cross-compile to ARM64 on an x86 machine
+build:release-mac-arm64-cross --config=release-mac-arm64
+build:release-mac-arm64-cross --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-aarch64-darwin
+build:release-mac-arm64-cross --copt=-stdlib=libc++ --linkopt=-lc++
 
 build:release-debug-linux --config=release-linux
 build:release-debug-linux --config=release-debug-common

--- a/.bazelrc
+++ b/.bazelrc
@@ -137,6 +137,12 @@ build:release-sanitized-linux --copt=-march=sandybridge
 build:release-linux-aarch64   --copt=-march=armv8.1a
 
 build:release-mac --config=release-common --platforms=@//tools/platforms:darwin_x86_64
+build:release-mac-arm64 --platforms=@//tools/platforms:darwin_arm64
+build:release-mac-arm64 --define release=true
+build:release-mac-arm64 --compilation_mode=opt
+build:release-mac-arm64 --config=backtracesymbols
+build:release-mac-arm64 --config=shared-libs
+build:release-mac-arm64 --config=versioned
 
 build:release-debug-linux --config=release-linux
 build:release-debug-linux --config=release-debug-common

--- a/.bazelrc
+++ b/.bazelrc
@@ -137,13 +137,7 @@ build:release-sanitized-linux --copt=-march=sandybridge
 build:release-linux-aarch64   --copt=-march=armv8.1a
 
 build:release-mac --config=release-common --platforms=@//tools/platforms:darwin_x86_64
-
-build:release-mac-arm64 --platforms=@//tools/platforms:darwin_arm64
-build:release-mac-arm64 --define release=true
-build:release-mac-arm64 --compilation_mode=opt
-build:release-mac-arm64 --config=backtracesymbols
-build:release-mac-arm64 --config=shared-libs
-build:release-mac-arm64 --config=versioned
+build:release-mac-arm64 --config=release-common --config=shared-libs --platforms=@//tools/platforms:darwin_arm64
 
 # Cross-compile to x86 on an ARM64 machine
 build:release-mac-cross --config=release-mac

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -34,12 +34,10 @@ echo will run with $CONFIG_OPTS
 
 case "$platform" in
   darwin-x86_64|darwin-arm64)
-    TARGET_PLATFORM=darwin-x86_64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+    ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
     cp bazel-bin/main/sorbet sorbet_x86_64
 
-    ./bazel clean --expunge
-
-    TARGET_PLATFORM=darwin-arm64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+    ./bazel build //main:sorbet --strip=always $CONFIG_OPTS --config=release-mac-arm64-cross
     cp bazel-bin/main/sorbet sorbet_arm64
 
     lipo -create -output sorbet_bin sorbet_x86_64 sorbet_arm64

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -130,4 +130,4 @@ if [[ "$platform" == "linux-x86_64" ]]; then
 fi
 
 mkdir -p _out_/$platform
-cp bazel-bin/main/sorbet _out_/$platform/
+cp sorbet_bin _out_/$platform/

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -41,7 +41,7 @@ case "$platform" in
     cp bazel-bin/main/sorbet sorbet_arm64
 
     lipo -create -output sorbet_bin sorbet_x86_64 sorbet_arm64
-    rm sorbet_x86_64 sorbet_arm64
+    rm -f sorbet_x86_64 sorbet_arm64
     ;;
   *)
     ./bazel build //main:sorbet --strip=always $CONFIG_OPTS

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -16,8 +16,12 @@ case "$platform" in
   linux-aarch64)
     CONFIG_OPTS="--config=release-${platform}"
     ;;
-  darwin-x86_64|darwin-arm64)
+  darwin-x86_64)
     CONFIG_OPTS="--config=release-mac"
+    command -v autoconf >/dev/null 2>&1 || brew install autoconf
+    ;;
+  darwin-arm64)
+    CONFIG_OPTS="--config=release-mac-arm64"
     command -v autoconf >/dev/null 2>&1 || brew install autoconf
     ;;
   *)
@@ -28,10 +32,27 @@ esac
 
 echo will run with $CONFIG_OPTS
 
-./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+case "$platform" in
+  darwin-x86_64|darwin-arm64)
+    TARGET_PLATFORM=darwin-x86_64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+    cp bazel-bin/main/sorbet sorbet_x86_64
+
+    ./bazel clean --expunge
+
+    TARGET_PLATFORM=darwin-arm64 ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+    cp bazel-bin/main/sorbet sorbet_arm64
+
+    lipo -create -output sorbet_bin sorbet_x86_64 sorbet_arm64
+    rm sorbet_x86_64 sorbet_arm64
+    ;;
+  *)
+    ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
+    cp bazel-bin/main/sorbet sorbet_bin
+    ;;
+esac
 
 mkdir gems/sorbet-static/libexec/
-cp bazel-bin/main/sorbet gems/sorbet-static/libexec/
+cp sorbet_bin gems/sorbet-static/libexec/sorbet
 
 rbenv install --skip-existing
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,6 +42,12 @@ llvm_toolchain(
         "https://github.com/sorbet/llvm-project/releases/download/llvmorg-{llvm_version}/{basename}",
     ],
     llvm_version = "15.0.7",
+    # The sysroots are needed for cross-compiling
+    sysroot = {
+        "": "",
+        "darwin-x86_64": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+        "darwin-aarch64": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+    },
 )
 
 load("@llvm_toolchain_15_0_7//:toolchains.bzl", "llvm_register_toolchains")

--- a/bazel
+++ b/bazel
@@ -32,10 +32,7 @@ case "$bazel_installer_platform" in
     bazel_installer_platform="linux-arm64"
     ;;
   darwin-x86_64) ;;
-  darwin-arm64)
-    # Pseudo Apple Silicon support by forcing x86_64 (Rosetta) for now
-    bazel_installer_platform="darwin-x86_64"
-    ;;
+  darwin-arm64) ;;
 esac
 
 expected_sha_file="$repo_root/.bazelversion_checksums/$bazel_installer_platform"

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -186,9 +186,9 @@ def register_sorbet_dependencies():
     # In 2ddd7d791 (#7912) we upgraded the toolchain. Our old toolchain patches are on the `sorbet-old-toolchain` branch
     http_archive(
         name = "toolchains_llvm",
-        url = "https://github.com/sorbet/bazel-toolchain/archive/8d9165fd3560f6ff50bc4794972f714f4ba2adaa.tar.gz",
-        sha256 = "238b5a777bbfac3d5ec35cbd45ae2b84ca4118aa8f902ab27894912352e94658",
-        strip_prefix = "bazel-toolchain-8d9165fd3560f6ff50bc4794972f714f4ba2adaa",
+        url = "https://github.com/sorbet/bazel-toolchain/archive/5ed6d56dd7d2466bda56a6237c5ed70336b95ee5.tar.gz",
+        sha256 = "bdc706dbc33811ce4b2089d52564da106c2afbf3723cffbef301cc64e7615251",
+        strip_prefix = "bazel-toolchain-5ed6d56dd7d2466bda56a6237c5ed70336b95ee5",
     )
 
     http_archive(

--- a/tools/platforms/BUILD
+++ b/tools/platforms/BUILD
@@ -9,6 +9,14 @@ platform(
 )
 
 platform(
+    name = "darwin_arm64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+platform(
     name = "linux_x86_64",
     constraint_values = [
         "@platforms//os:linux",


### PR DESCRIPTION
CAN'T BE MERGED BEFORE https://github.com/sorbet/bazel-toolchain/pull/10

This PR is the second attempt of #8152

Instead of using the original approach of compiling a native ARM64 binary and an x86 binary through rosetta (which is this PR's first commit), this PR adds support for cross compiling `x86 -> arm64` and vice versa.

The major advantage of this approach is that we always use the Bazel installation native to the machine's architecture, instead of needing to remove and re-download so that we can swap between native vs rosetta version.

### Details

The implementation follows the steps outlined in `toolchains_llvm` [documentation](https://github.com/bazel-contrib/toolchains_llvm?tab=readme-ov-file#cross-compilation). Essentially, we need to define the `sysroot` for the different architectures that we want to cross compile to. It's a bit odd because on MacOS, the sysroot is always the MacOS SDK regardless of which target you're trying to compile to, but that's the only way `toolchains_llvm` will allow you to cross-compile.

Then we define configurations for cross compiling in both directions in `.bazelrc`. The buildkite release script will now use those configurations to produce both binaries.

### Test plan

We were able to manually test cross compilation from `arm64 -> x86`, which produces a working x86 binary. However, we don't have an x86 Darwin machine, so maybe we can test it on CI?