### PR TITLE
Show doc comments above multiline sigs with braces

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -291,27 +291,28 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
             //       .returns(Bar) }
             // ```
             it++;
+            line = absl::StripAsciiWhitespace(*it);
             while (
                 // SOF
                 it != all_lines.rend()
                 // Start of sig block
-                && !(absl::StartsWith(absl::StripAsciiWhitespace(*it), "sig {") ||
-                     absl::StartsWith(absl::StripAsciiWhitespace(*it), "sig(:final) {"))
+                && !(absl::StartsWith(line, "sig {") ||
+                     absl::StartsWith(line, "sig(:final) {"))
                 // Invalid closing brace
-                && !absl::StartsWith(absl::StripAsciiWhitespace(*it), "}")) {
+                && !absl::StartsWith(line, "}")) {
                 it++;
+                line = absl::StripAsciiWhitespace(*it);
             };
 
             // We have either
             // 1) Reached the start of the file
             // 2) Found a `sig {`
             // 3) Found an invalid closing brace
-            if (it == all_lines.rend() || absl::StartsWith(absl::StripAsciiWhitespace(*it), "}")) {
+            if (it == all_lines.rend() || absl::StartsWith(line, "}")) {
                 break;
             }
 
             // Reached a sig block.
-            line = absl::StripAsciiWhitespace(*it);
             ENFORCE(absl::StartsWith(line, "sig {") || absl::StartsWith(line, "sig(:final) {"));
         }
 
@@ -319,27 +320,28 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
         else if (absl::StartsWith(line, "end")) {
             // ASSUMPTION: We either hit the start of file, a `sig do`/`sig(:final) do` or an `end`
             it++;
+            line = absl::StripAsciiWhitespace(*it);
             while (
                 // SOF
                 it != all_lines.rend()
                 // Start of sig block
-                && !(absl::StartsWith(absl::StripAsciiWhitespace(*it), "sig do") ||
-                     absl::StartsWith(absl::StripAsciiWhitespace(*it), "sig(:final) do"))
+                && !(absl::StartsWith(line, "sig do") ||
+                     absl::StartsWith(line, "sig(:final) do"))
                 // Invalid end keyword
-                && !absl::StartsWith(absl::StripAsciiWhitespace(*it), "end")) {
+                && !absl::StartsWith(line, "end")) {
                 it++;
+                line = absl::StripAsciiWhitespace(*it);
             };
 
             // We have either
             // 1) Reached the start of the file
             // 2) Found a `sig do`
             // 3) Found an invalid end keyword
-            if (it == all_lines.rend() || absl::StartsWith(absl::StripAsciiWhitespace(*it), "end")) {
+            if (it == all_lines.rend() || absl::StartsWith(line, "end")) {
                 break;
             }
 
             // Reached a sig block.
-            line = absl::StripAsciiWhitespace(*it);
             ENFORCE(absl::StartsWith(line, "sig do") || absl::StartsWith(line, "sig(:final) do"));
 
             // Stop looking if this is a single-line block e.g `sig do; <block>; end`

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -296,8 +296,7 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
                 // SOF
                 it != all_lines.rend()
                 // Start of sig block
-                && !(absl::StartsWith(line, "sig {") ||
-                     absl::StartsWith(line, "sig(:final) {"))
+                && !(absl::StartsWith(line, "sig {") || absl::StartsWith(line, "sig(:final) {"))
                 // Invalid closing brace
                 && !absl::StartsWith(line, "}")) {
                 it++;
@@ -325,8 +324,7 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
                 // SOF
                 it != all_lines.rend()
                 // Start of sig block
-                && !(absl::StartsWith(line, "sig do") ||
-                     absl::StartsWith(line, "sig(:final) do"))
+                && !(absl::StartsWith(line, "sig do") || absl::StartsWith(line, "sig(:final) do"))
                 // Invalid end keyword
                 && !absl::StartsWith(line, "end")) {
                 it++;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -300,7 +300,9 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
                 // Invalid closing brace
                 && !absl::StartsWith(line, "}")) {
                 it++;
-                line = absl::StripAsciiWhitespace(*it);
+                if (it != all_lines.rend()) {
+                    line = absl::StripAsciiWhitespace(*it);
+                }
             };
 
             // We have either
@@ -328,7 +330,9 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
                 // Invalid end keyword
                 && !absl::StartsWith(line, "end")) {
                 it++;
-                line = absl::StripAsciiWhitespace(*it);
+                if (it != all_lines.rend()) {
+                    line = absl::StripAsciiWhitespace(*it);
+                }
             };
 
             // We have either

--- a/main/lsp/test/lsp_test.cc
+++ b/main/lsp/test/lsp_test.cc
@@ -56,6 +56,16 @@ const string file_string = "# typed: true\n"
                            "      1\n"
                            "    end\n"
                            "\n"
+                           "    # This is another method with documentation above its\n"
+                           "    # multi-line sig block using braces.\n"
+                           "    sig {\n"
+                           "      params(x: Integer)\n"
+                           "      .returns(Integer)\n"
+                           "    }\n"
+                           "    def multi_line_sig_brace_block\n"
+                           "      1\n"
+                           "    end\n"
+                           "\n"
                            "    # This is a method with documentation above its\n"
                            "    # multi-line sig(:final) block.\n"
                            "    sig(:final) do\n"
@@ -156,6 +166,11 @@ TEST_CASE("MultiLineSig") {
     int position = file.find("multi_line_sig_block");
     optional<string> b = findDocumentation(file, position);
     REQUIRE_EQ(*b, "This is a method with documentation above its\nmulti-line sig block.");
+}
+TEST_CASE("MultiLineSigBraces") {
+    int position = file.find("multi_line_sig_brace_block");
+    optional<string> b = findDocumentation(file, position);
+    REQUIRE_EQ(*b, "This is another method with documentation above its\nmulti-line sig block using braces.");
 }
 TEST_CASE("MultiLineSigFinal") {
     int position = file.find("multi_line_sig_final_block");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This adds support for showing documentation on hover for multi-line sigs that use braces. For example:

```ruby
# Show me!
sig {
  void
}
def example!; end
```

This implementation makes some particular assumptions, notably that the closing brace is on its own line.

```ruby
# This works!
sig { void
}
def foo; end

# This doesn't
sig {
void }
def foo; end
```

This is a fair enough assumption in the Stripe codebase, and I imagine it's probably good enough for most cases -- the preexisting code is already based on these sorts of assumptions for `do`/`end`, and handling all possible cases likely isn't worth the complexity, but happy to be told otherwise if folks feel differently!

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Closes #8127

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
