### PR TITLE
Separate scopes to compare and insert for LCA

### DIFF
--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -314,6 +314,7 @@ class ExpressionPtrSearchWalk {
         if (LCAScopeStack.empty()) {
             for (auto *scope : enclosingScopeStack) {
                 const ast::ExpressionPtr *scopeToCompare = scope;
+                const ast::ExpressionPtr *scopeToInsertIn = scope;
                 if (ast::isa_tree<ast::If>(*scope)) {
                     auto &if_ = ast::cast_tree_nonnull<ast::If>(*scope);
                     if (if_.thenp.loc().exists() && if_.thenp.loc().contains(matchLoc)) {
@@ -322,6 +323,7 @@ class ExpressionPtrSearchWalk {
                         scopeToCompare = &if_.elsep;
                     } else if (if_.cond.loc().contains(matchLoc)) {
                         scopeToCompare = &if_.cond;
+                        scopeToInsertIn = LCAScopeStack.back().second;
                     } else {
                         ENFORCE(false);
                     }
@@ -349,16 +351,17 @@ class ExpressionPtrSearchWalk {
                         scopeToCompare = &while_.body;
                     } else if (while_.cond.loc().contains(matchLoc)) {
                         scopeToCompare = &while_.cond;
+                        scopeToInsertIn = LCAScopeStack.back().second;
                     } else {
                         ENFORCE(false);
                     }
                 }
-                LCAScopeStack.push_back(scopeToCompare);
+                LCAScopeStack.push_back(make_pair(scopeToCompare->loc(), scopeToInsertIn));
             }
         } else {
             for (size_t i = 0; i < LCAScopeStack.size(); i++) {
-                auto *scopeToCompare = LCAScopeStack[i];
-                if (!scopeToCompare->loc().contains(matchLoc)) {
+                auto scopeToCompare = LCAScopeStack[i].first;
+                if (!scopeToCompare.contains(matchLoc)) {
                     LCAScopeStack.erase(LCAScopeStack.begin() + i, LCAScopeStack.end());
                     break;
                 }
@@ -367,7 +370,7 @@ class ExpressionPtrSearchWalk {
     }
 
 public:
-    vector<const ast::ExpressionPtr *> LCAScopeStack;
+    vector<pair<core::LocOffsets, const ast::ExpressionPtr *>> LCAScopeStack;
     vector<core::LocOffsets> matches;
     ExpressionPtrSearchWalk(ast::ExpressionPtr *matchingNode, std::vector<core::LocOffsets> skippedLocs,
                             const std::shared_ptr<spdlog::logger> logger, const core::Loc selectionLoc)
@@ -473,17 +476,7 @@ MultipleOccurrenceResult VariableExtractor::getExtractMultipleOccurrenceEdits(co
         return {vector<unique_ptr<TextDocumentEdit>>(), 1};
     }
 
-    const ast::ExpressionPtr *scopeToInsertIn = nullptr;
-    for (auto scope = walk.LCAScopeStack.rbegin(); scope != walk.LCAScopeStack.rend(); ++scope) {
-        if (ast::isa_tree<ast::InsSeq>(**scope) || ast::isa_tree<ast::ClassDef>(**scope) ||
-            ast::isa_tree<ast::Block>(**scope) || ast::isa_tree<ast::MethodDef>(**scope) ||
-            ast::isa_tree<ast::If>(**scope) || ast::isa_tree<ast::Rescue>(**scope) ||
-            ast::isa_tree<ast::RescueCase>(**scope) || ast::isa_tree<ast::While>(**scope)) {
-            scopeToInsertIn = *scope;
-            break;
-        }
-    }
-    ENFORCE(scopeToInsertIn, "the LCA scope stack should always have a ClassDef or MethodDef");
+    const ast::ExpressionPtr *scopeToInsertIn = walk.LCAScopeStack.back().second;
 
     fast_sort(matches, [](auto a, auto b) { return a.beginPos() < b.beginPos(); });
     auto firstMatch = matches[0];

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -45,10 +45,9 @@ core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::
             whereToInsert = if_->thenp.loc();
         } else if (if_->elsep.loc().exists() && if_->elsep.loc().contains(target)) {
             whereToInsert = if_->elsep.loc();
-        } else if (if_->cond.loc().exists() && if_->cond.loc().contains(target)) {
-            ENFORCE(false, "shouldn't be inserting into the cond of an if");
         } else {
-            ENFORCE(false);
+            ENFORCE(!(if_->cond.loc().exists() && if_->cond.loc().contains(target)),
+                    "shouldn't be inserting into the cond of an if");
         }
     } else if (auto rescue = ast::cast_tree<ast::Rescue>(scope)) {
         if (rescue->body.loc().exists() && rescue->body.loc().contains(target)) {
@@ -65,8 +64,9 @@ core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::
     } else if (auto while_ = ast::cast_tree<ast::While>(scope)) {
         if (while_->body.loc().exists() && while_->body.loc().contains(target)) {
             whereToInsert = while_->body.loc();
-        } else if (while_->cond.loc().exists() && while_->cond.loc().contains(target)) {
-            ENFORCE(false, "shouldn't be inserting into the cond of a while");
+        } else {
+            ENFORCE(!(while_->cond.loc().exists() && while_->cond.loc().contains(target)),
+                    "shouldn't be inserting into the cond of a while");
         }
     } else {
         ENFORCE(false);

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -45,6 +45,8 @@ core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::
             whereToInsert = if_->thenp.loc();
         } else if (if_->elsep.loc().exists() && if_->elsep.loc().contains(target)) {
             whereToInsert = if_->elsep.loc();
+        } else if (if_->cond.loc().exists() && if_->cond.loc().contains(target)) {
+            ENFORCE(false, "shouldn't be inserting into the cond of an if");
         } else {
             ENFORCE(false);
         }
@@ -61,7 +63,11 @@ core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::
     } else if (auto rescueCase = ast::cast_tree<ast::RescueCase>(scope)) {
         whereToInsert = rescueCase->body.loc();
     } else if (auto while_ = ast::cast_tree<ast::While>(scope)) {
-        whereToInsert = while_->body.loc();
+        if (while_->body.loc().exists() && while_->body.loc().contains(target)) {
+            whereToInsert = while_->body.loc();
+        } else if (while_->cond.loc().exists() && while_->cond.loc().contains(target)) {
+            ENFORCE(false, "shouldn't be inserting into the cond of a while");
+        }
     } else {
         ENFORCE(false);
     }

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.A.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.B.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.C.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.D.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.E.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.E.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.F.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.F.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.G.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.G.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.H.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.H.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.I.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.I.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.J.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.J.rbedited
@@ -39,10 +39,10 @@ def same_cond_if(x)
 end
 
 def both_match_in_expr(x)
-  newVariable = 1
   if x + x
 #    ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    newVariable = 1
     newVariable + newVariable
 #   ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.J.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.J.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.K.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.K.rbedited
@@ -52,3 +52,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.L.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.L.rbedited
@@ -39,7 +39,6 @@ def same_cond_if(x)
 end
 
 def both_match_in_expr(x)
-  newVariable = 2
   if x + x
 #    ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #    ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
@@ -47,6 +46,7 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   else
+    newVariable = 2
     newVariable + newVariable
 #   ^ apply-code-action: [K] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.M.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.M.rbedited
@@ -46,8 +46,7 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   else
-    newVariable = 2
-    newVariable + newVariable
+    2 + 2
 #   ^ apply-code-action: [K] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
@@ -55,7 +54,8 @@ end
 
 def if_inside_if(x)
   if T.unsafe(3)
-    if x + x
+    newVariable = x
+    if newVariable + x
   #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
   #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
       1

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.N.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.N.rbedited
@@ -46,8 +46,7 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   else
-    newVariable = 2
-    newVariable + newVariable
+    2 + 2
 #   ^ apply-code-action: [K] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
@@ -55,7 +54,8 @@ end
 
 def if_inside_if(x)
   if T.unsafe(3)
-    if x + x
+    newVariable = x
+    if newVariable + newVariable
   #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
   #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
       1

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/if.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/if.rb
@@ -51,3 +51,15 @@ def both_match_in_expr(x)
 #   ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
   end
 end
+
+def if_inside_if(x)
+  if T.unsafe(3)
+    if x + x
+  #    ^ apply-code-action: [M] Extract Variable (this occurrence only)
+  #    ^ apply-code-action: [N] Extract Variable (all 2 occurrences)
+      1
+    else
+      2
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.A.rbedited
@@ -41,3 +41,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.C.rbedited
@@ -41,3 +41,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.D.rbedited
@@ -41,3 +41,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.E.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.E.rbedited
@@ -41,3 +41,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.F.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.F.rbedited
@@ -41,3 +41,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.G.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.G.rbedited
@@ -41,3 +41,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.H.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.H.rbedited
@@ -41,3 +41,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.I.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.I.rbedited
@@ -41,3 +41,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.J.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.J.rbedited
@@ -41,3 +41,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.J.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.J.rbedited
@@ -32,10 +32,10 @@ def while_3(x)
 end
 
 def while_4(x)
-  newVariable = 1
   while x + x
 #       ^ apply-code-action: [G] Extract Variable (this occurrence only)
 #       ^ apply-code-action: [H] Extract Variable (all 2 occurrences)
+    newVariable = 1
     newVariable + newVariable
 #       ^ apply-code-action: [I] Extract Variable (this occurrence only)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.K.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.K.rbedited
@@ -4,11 +4,10 @@
 
 def while_1(x)
   while T.unsafe(nil)
-    newVariable = x + 1
-    newVariable
+    x + 1
 #   ^^^^^ apply-code-action: [A] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [B] Extract Variable (all 2 occurrences)
-    newVariable
+    x + 1
   end
 end
 
@@ -44,7 +43,8 @@ end
 
 def while_5(x)
   while T.unsafe(1)
-    while x + x
+    newVariable = x
+    while newVariable + x
 #         ^ apply-code-action: [K] Extract Variable (this occurrence only)
 #         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
       1

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.L.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.L.rbedited
@@ -4,11 +4,10 @@
 
 def while_1(x)
   while T.unsafe(nil)
-    newVariable = x + 1
-    newVariable
+    x + 1
 #   ^^^^^ apply-code-action: [A] Extract Variable (this occurrence only)
 #   ^^^^^ apply-code-action: [B] Extract Variable (all 2 occurrences)
-    newVariable
+    x + 1
   end
 end
 
@@ -44,7 +43,8 @@ end
 
 def while_5(x)
   while T.unsafe(1)
-    while x + x
+    newVariable = x
+    while newVariable + newVariable
 #         ^ apply-code-action: [K] Extract Variable (this occurrence only)
 #         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
       1

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/while.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/while.rb
@@ -40,3 +40,13 @@ def while_4(x)
 #       ^ apply-code-action: [J] Extract Variable (all 2 occurrences)
   end
 end
+
+def while_5(x)
+  while T.unsafe(1)
+    while x + x
+#         ^ apply-code-action: [K] Extract Variable (this occurrence only)
+#         ^ apply-code-action: [L] Extract Variable (all 2 occurrences)
+      1
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

A better approach to #8104 that handles more cases.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Where we want to insert into, and where we want to compare for matches when trying to find the lowest common ancestors scope for multiple occurrences is not always the same. For example:

```ruby
def foo
  if 1 + 1
    2 + 2
  else
    3 + 3
  end
end
```

If we're trying to extract the `1`, when trying to find the lowest scope, we want to compare the other matches in the condition of the `if`, but if they're all there, we don't want to insert in the condition; we want to insert outside the `if`. Similarly, if we're trying to extract `2` or `3`, we want to compare in the `thenp` or `elsep`, but we don't want to insert in those (they're send nodes, which we can't insert into); we want to insert into the entire `if`, and then determine later which part of it we should insert into.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
