### PR TITLE
Revert "Add cross compilation support for Darwin (#8162)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -137,17 +137,6 @@ build:release-sanitized-linux --copt=-march=sandybridge
 build:release-linux-aarch64   --copt=-march=armv8.1a
 
 build:release-mac --config=release-common --platforms=@//tools/platforms:darwin_x86_64
-build:release-mac-arm64 --config=release-common --config=shared-libs --platforms=@//tools/platforms:darwin_arm64
-
-# Cross-compile to x86 on an ARM64 machine
-build:release-mac-cross --config=release-mac
-build:release-mac-cross --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-x86_64-darwin
-build:release-mac-cross --copt=-stdlib=libc++ --linkopt=-lc++
-
-# Cross-compile to ARM64 on an x86 machine
-build:release-mac-arm64-cross --config=release-mac-arm64
-build:release-mac-arm64-cross --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-aarch64-darwin
-build:release-mac-arm64-cross --copt=-stdlib=libc++ --linkopt=-lc++
 
 build:release-debug-linux --config=release-linux
 build:release-debug-linux --config=release-debug-common

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -16,12 +16,8 @@ case "$platform" in
   linux-aarch64)
     CONFIG_OPTS="--config=release-${platform}"
     ;;
-  darwin-x86_64)
+  darwin-x86_64|darwin-arm64)
     CONFIG_OPTS="--config=release-mac"
-    command -v autoconf >/dev/null 2>&1 || brew install autoconf
-    ;;
-  darwin-arm64)
-    CONFIG_OPTS="--config=release-mac-arm64"
     command -v autoconf >/dev/null 2>&1 || brew install autoconf
     ;;
   *)
@@ -32,25 +28,10 @@ esac
 
 echo will run with $CONFIG_OPTS
 
-case "$platform" in
-  darwin-x86_64|darwin-arm64)
-    ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
-    cp bazel-bin/main/sorbet sorbet_x86_64
-
-    ./bazel build //main:sorbet --strip=always $CONFIG_OPTS --config=release-mac-arm64-cross
-    cp bazel-bin/main/sorbet sorbet_arm64
-
-    lipo -create -output sorbet_bin sorbet_x86_64 sorbet_arm64
-    rm -f sorbet_x86_64 sorbet_arm64
-    ;;
-  *)
-    ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
-    cp bazel-bin/main/sorbet sorbet_bin
-    ;;
-esac
+./bazel build //main:sorbet --strip=always $CONFIG_OPTS
 
 mkdir gems/sorbet-static/libexec/
-cp sorbet_bin gems/sorbet-static/libexec/sorbet
+cp bazel-bin/main/sorbet gems/sorbet-static/libexec/
 
 rbenv install --skip-existing
 
@@ -130,4 +111,4 @@ if [[ "$platform" == "linux-x86_64" ]]; then
 fi
 
 mkdir -p _out_/$platform
-cp sorbet_bin _out_/$platform/
+cp bazel-bin/main/sorbet _out_/$platform/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,12 +42,6 @@ llvm_toolchain(
         "https://github.com/sorbet/llvm-project/releases/download/llvmorg-{llvm_version}/{basename}",
     ],
     llvm_version = "15.0.7",
-    # The sysroots are needed for cross-compiling
-    sysroot = {
-        "": "",
-        "darwin-x86_64": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
-        "darwin-aarch64": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
-    },
 )
 
 load("@llvm_toolchain_15_0_7//:toolchains.bzl", "llvm_register_toolchains")

--- a/bazel
+++ b/bazel
@@ -32,7 +32,10 @@ case "$bazel_installer_platform" in
     bazel_installer_platform="linux-arm64"
     ;;
   darwin-x86_64) ;;
-  darwin-arm64) ;;
+  darwin-arm64)
+    # Pseudo Apple Silicon support by forcing x86_64 (Rosetta) for now
+    bazel_installer_platform="darwin-x86_64"
+    ;;
 esac
 
 expected_sha_file="$repo_root/.bazelversion_checksums/$bazel_installer_platform"

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -186,9 +186,9 @@ def register_sorbet_dependencies():
     # In 2ddd7d791 (#7912) we upgraded the toolchain. Our old toolchain patches are on the `sorbet-old-toolchain` branch
     http_archive(
         name = "toolchains_llvm",
-        url = "https://github.com/sorbet/bazel-toolchain/archive/5ed6d56dd7d2466bda56a6237c5ed70336b95ee5.tar.gz",
-        sha256 = "bdc706dbc33811ce4b2089d52564da106c2afbf3723cffbef301cc64e7615251",
-        strip_prefix = "bazel-toolchain-5ed6d56dd7d2466bda56a6237c5ed70336b95ee5",
+        url = "https://github.com/sorbet/bazel-toolchain/archive/8d9165fd3560f6ff50bc4794972f714f4ba2adaa.tar.gz",
+        sha256 = "238b5a777bbfac3d5ec35cbd45ae2b84ca4118aa8f902ab27894912352e94658",
+        strip_prefix = "bazel-toolchain-8d9165fd3560f6ff50bc4794972f714f4ba2adaa",
     )
 
     http_archive(

--- a/tools/platforms/BUILD
+++ b/tools/platforms/BUILD
@@ -9,14 +9,6 @@ platform(
 )
 
 platform(
-    name = "darwin_arm64",
-    constraint_values = [
-        "@platforms//os:osx",
-        "@platforms//cpu:arm64",
-    ],
-)
-
-platform(
     name = "linux_x86_64",
     constraint_values = [
         "@platforms//os:linux",


### PR DESCRIPTION
This reverts commit be27e0a819b6b42ccb7b9f17b2d149939b85bc1a.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Across multiple macOS laptops and multiple colleagues, I'm not able to run the
macOS Sorbet produced by this commit in any form (both from the gem and from the
binary release artifact).

Going to revert while we figure things out.

cc @vinistock @Morriar

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```bash
❯ curl -L https://github.com/sorbet/sorbet/releases/download/0.5.11568.20240918161953-be27e0a81/darwin-x86_64.sorbet_bin > sorbet_bin
❯ chmod +x ./sorbet_bin
❯ ./sorbet_bin
zsh: killed	./sorbet_bin
```