### PR TITLE
Release binary for Darwin ARM64 platform

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -137,21 +137,15 @@ build:release-linux           --copt=-march=sandybridge
 build:release-sanitized-linux --copt=-march=sandybridge
 build:release-linux-aarch64   --copt=-march=armv8.1a
 
-build:release-mac --config=release-common --config=static-libs --platforms=@//tools/platforms:darwin_x86_64
+build:release-mac --config=release-common --config=shared-libs
 
-build:release-mac-arm64 --config=release-common
-build:release-mac-arm64 --platforms=@//tools/platforms:darwin_arm64
-build:release-mac-arm64 --config=shared-libs
+build:cross-to-darwin-x86_64 --platforms=@//tools/platforms:darwin_x86_64
+build:cross-to-darwin-x86_64 --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-x86_64-darwin
+build:cross-to-darwin-x86_64 --copt=-stdlib=libc++ --linkopt=-lc++
 
-# Cross-compile to x86 on an ARM64 machine
-build:release-mac-cross --config=release-mac
-build:release-mac-cross --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-x86_64-darwin
-build:release-mac-cross --copt=-stdlib=libc++ --linkopt=-lc++
-
-# Cross-compile to ARM64 on an x86 machine
-build:release-mac-arm64-cross --config=release-mac-arm64
-build:release-mac-arm64-cross --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-aarch64-darwin
-build:release-mac-arm64-cross --copt=-stdlib=libc++ --linkopt=-lc++
+build:cross-to-darwin-arm64 --platforms=@//tools/platforms:darwin_arm64
+build:cross-to-darwin-arm64 --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-aarch64-darwin
+build:cross-to-darwin-arm64 --copt=-stdlib=libc++ --linkopt=-lc++
 
 build:release-debug-linux --config=release-linux
 build:release-debug-linux --config=release-debug-common

--- a/.bazelrc
+++ b/.bazelrc
@@ -91,7 +91,6 @@ build:dbg-linux --config=dbg --platforms=@//tools/platforms:linux_x86_64
 build:release-common --define release=true
 build:release-common --compilation_mode=opt
 build:release-common --config=backtracesymbols
-build:release-common --config=static-libs
 build:release-common --config=versioned
 
 build:release-debug-common --config=forcedebug
@@ -111,9 +110,11 @@ build:untyped-blame --copt=-DTRACK_UNTYPED_BLAME_MODE
 # harden: mark relocation sections read-only
 build:release-linux --linkopt=-Wl,-z,relro,-z,now
 build:release-linux --config=lto-linux --config=release-common
+build:release-linux --config=static-libs
 # Separate config for aarch64, so x86_64 can be differently optimized
 build:release-linux-aarch64 --linkopt=-Wl,-z,relro,-z,now
 build:release-linux-aarch64 --config=lto-linux --config=release-common
+build:release-linux-aarch64 --config=static-libs
 
 # It would be nice to move this back to release-common, but there is a build
 # failure when using clang 15 on macOS to build GNU make via rules_foreign_cc:
@@ -136,7 +137,7 @@ build:release-linux           --copt=-march=sandybridge
 build:release-sanitized-linux --copt=-march=sandybridge
 build:release-linux-aarch64   --copt=-march=armv8.1a
 
-build:release-mac --config=release-common --platforms=@//tools/platforms:darwin_x86_64
+build:release-mac --config=release-common --config=static-libs --platforms=@//tools/platforms:darwin_x86_64
 
 build:release-mac-arm64 --platforms=@//tools/platforms:darwin_arm64
 build:release-mac-arm64 --define release=true

--- a/.bazelrc
+++ b/.bazelrc
@@ -138,6 +138,23 @@ build:release-linux-aarch64   --copt=-march=armv8.1a
 
 build:release-mac --config=release-common --platforms=@//tools/platforms:darwin_x86_64
 
+build:release-mac-arm64 --platforms=@//tools/platforms:darwin_arm64
+build:release-mac-arm64 --define release=true
+build:release-mac-arm64 --compilation_mode=opt
+build:release-mac-arm64 --config=backtracesymbols
+build:release-mac-arm64 --config=shared-libs
+build:release-mac-arm64 --config=versioned
+
+# Cross-compile to x86 on an ARM64 machine
+build:release-mac-cross --config=release-mac
+build:release-mac-cross --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-x86_64-darwin
+build:release-mac-cross --copt=-stdlib=libc++ --linkopt=-lc++
+
+# Cross-compile to ARM64 on an x86 machine
+build:release-mac-arm64-cross --config=release-mac-arm64
+build:release-mac-arm64-cross --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-aarch64-darwin
+build:release-mac-arm64-cross --copt=-stdlib=libc++ --linkopt=-lc++
+
 build:release-debug-linux --config=release-linux
 build:release-debug-linux --config=release-debug-common
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -139,12 +139,9 @@ build:release-linux-aarch64   --copt=-march=armv8.1a
 
 build:release-mac --config=release-common --config=static-libs --platforms=@//tools/platforms:darwin_x86_64
 
+build:release-mac-arm64 --config=release-common
 build:release-mac-arm64 --platforms=@//tools/platforms:darwin_arm64
-build:release-mac-arm64 --define release=true
-build:release-mac-arm64 --compilation_mode=opt
-build:release-mac-arm64 --config=backtracesymbols
 build:release-mac-arm64 --config=shared-libs
-build:release-mac-arm64 --config=versioned
 
 # Cross-compile to x86 on an ARM64 machine
 build:release-mac-cross --config=release-mac

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -44,6 +44,8 @@ else
   ./bazel build //main:sorbet --strip=always "$CONFIG_OPTS" --config="cross-to-$cross_target"
   cp bazel-bin/main/sorbet "sorbet.$cross_target"
 
+  # TODO(jez) We might be able to replace this with `apple_universal_binary`?
+  # https://github.com/bazelbuild/rules_apple/blob/35a2fb854a47745deb035d3443008aa15a2c2b85/doc/rules-apple.md#apple_universal_binary
   lipo -create -output sorbet_bin sorbet.darwin-*
 fi
 

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -131,13 +131,13 @@ fi
 
 if [ "$kernel_name" = "darwin" ]; then
   mkdir -p _out_/darwin-universal
-  cp sorbet_bin _out_/darwin-universal/
+  mv sorbet_bin _out_/darwin-universal/sorbet
 
   for plat in {darwin-x86_64,darwin-arm64}; do
     mkdir -p "_out_/$plat"
-    cp "sorbet.$plat" "_out_/$plat/"
+    mv "sorbet.$plat" "_out_/$plat/sorbet"
   done
 else
   mkdir -p "_out_/$platform"
-  cp sorbet_bin "_out_/$platform/"
+  mv sorbet_bin "_out_/$platform/sorbet"
 fi

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -16,7 +16,7 @@ case "$platform" in
   linux-aarch64)
     CONFIG_OPTS="--config=release-${platform}"
     ;;
-  darwin-*)
+  darwin-x86_64|darwin-arm64)
     CONFIG_OPTS="--config=release-mac"
     command -v autoconf >/dev/null 2>&1 || brew install autoconf
     ;;
@@ -26,9 +26,9 @@ case "$platform" in
     ;;
 esac
 
-echo "will run with $CONFIG_OPTS"
+echo will run with $CONFIG_OPTS
 
-./bazel build //main:sorbet --strip=always "$CONFIG_OPTS"
+./bazel build //main:sorbet --strip=always $CONFIG_OPTS
 
 if [ "$kernel_name" != "darwin" ]; then
   cp bazel-bin/main/sorbet sorbet_bin

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -21,7 +21,7 @@ case "$platform" in
     command -v autoconf >/dev/null 2>&1 || brew install autoconf
     ;;
   darwin-arm64)
-    CONFIG_OPTS="--config=release-mac-arm64"
+    CONFIG_OPTS="--config=release-mac"
     command -v autoconf >/dev/null 2>&1 || brew install autoconf
     ;;
   *)
@@ -37,7 +37,8 @@ case "$platform" in
     ./bazel build //main:sorbet --strip=always $CONFIG_OPTS
     cp bazel-bin/main/sorbet sorbet_x86_64
 
-    ./bazel build //main:sorbet --strip=always $CONFIG_OPTS --config=release-mac-arm64-cross
+    # TODO: the cross-compile config needs to be changed if we change the MacOS runner architecture
+    ./bazel build //main:sorbet --strip=always --config=release-mac-arm64-cross
     cp bazel-bin/main/sorbet sorbet_arm64
 
     lipo -create -output sorbet_bin sorbet_x86_64 sorbet_arm64

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -16,11 +16,7 @@ case "$platform" in
   linux-aarch64)
     CONFIG_OPTS="--config=release-${platform}"
     ;;
-  darwin-x86_64)
-    CONFIG_OPTS="--config=release-mac"
-    command -v autoconf >/dev/null 2>&1 || brew install autoconf
-    ;;
-  darwin-arm64)
+  darwin-*)
     CONFIG_OPTS="--config=release-mac"
     command -v autoconf >/dev/null 2>&1 || brew install autoconf
     ;;

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,6 +42,12 @@ llvm_toolchain(
         "https://github.com/sorbet/llvm-project/releases/download/llvmorg-{llvm_version}/{basename}",
     ],
     llvm_version = "15.0.7",
+    # The sysroots are needed for cross-compiling
+    sysroot = {
+        "": "",
+        "darwin-x86_64": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+        "darwin-aarch64": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+    },
 )
 
 load("@llvm_toolchain_15_0_7//:toolchains.bzl", "llvm_register_toolchains")

--- a/bazel
+++ b/bazel
@@ -32,10 +32,7 @@ case "$bazel_installer_platform" in
     bazel_installer_platform="linux-arm64"
     ;;
   darwin-x86_64) ;;
-  darwin-arm64)
-    # Pseudo Apple Silicon support by forcing x86_64 (Rosetta) for now
-    bazel_installer_platform="darwin-x86_64"
-    ;;
+  darwin-arm64) ;;
 esac
 
 expected_sha_file="$repo_root/.bazelversion_checksums/$bazel_installer_platform"

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -186,9 +186,9 @@ def register_sorbet_dependencies():
     # In 2ddd7d791 (#7912) we upgraded the toolchain. Our old toolchain patches are on the `sorbet-old-toolchain` branch
     http_archive(
         name = "toolchains_llvm",
-        url = "https://github.com/sorbet/bazel-toolchain/archive/8d9165fd3560f6ff50bc4794972f714f4ba2adaa.tar.gz",
-        sha256 = "238b5a777bbfac3d5ec35cbd45ae2b84ca4118aa8f902ab27894912352e94658",
-        strip_prefix = "bazel-toolchain-8d9165fd3560f6ff50bc4794972f714f4ba2adaa",
+        url = "https://github.com/sorbet/bazel-toolchain/archive/5ed6d56dd7d2466bda56a6237c5ed70336b95ee5.tar.gz",
+        sha256 = "bdc706dbc33811ce4b2089d52564da106c2afbf3723cffbef301cc64e7615251",
+        strip_prefix = "bazel-toolchain-5ed6d56dd7d2466bda56a6237c5ed70336b95ee5",
     )
 
     http_archive(

--- a/tools/platforms/BUILD
+++ b/tools/platforms/BUILD
@@ -9,6 +9,14 @@ platform(
 )
 
 platform(
+    name = "darwin_arm64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+platform(
     name = "linux_x86_64",
     constraint_values = [
         "@platforms//os:linux",


### PR DESCRIPTION
Reroll of #8162 with 2 changes:

* Dropped the commit for reusing of `release-common`: it resulted in both `static-libs` and `shared-libs` being used and confused the linker
* [59a8605](https://github.com/sorbet/sorbet/pull/8183/commits/59a8605c9f1a47dd17a2738992135b9000d6f4a0): Fixed the options passed to bazel when cross compiling from x86_64 to arm64 to not pass both `release-mac` and `release-mac-arm64-cross`