### PR TITLE
Write trees to the cache even if GlobalState did not change

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2256,11 +2256,9 @@ ErrorBuilder GlobalState::beginError(Loc loc, ErrorClass what) const {
 }
 
 ErrorBuilder GlobalState::beginIndexerError(Loc loc, ErrorClass what) {
-    if (what.code < 4000) {
-        // As errors from the indexing phase control whether or not we should cache trees, we set this flag on the file
-        // even if the erorr would be suppressed, to ensure that the experience when the cache is enabled is consistent.
-        loc.file().data(*this).setHasIndexErrors(true);
-    }
+    // As errors from the indexing phase control whether or not we should cache trees, we set this flag on the file
+    // even if the erorr would be suppressed, to ensure that the experience when the cache is enabled is consistent.
+    loc.file().data(*this).setHasIndexErrors(true);
     return this->beginError(loc, what);
 }
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -28,30 +28,59 @@ namespace {
  * Returns 'true' if the given GlobalState was originally created from the current contents of
  * kvstore (e.g., kvstore has not since been modified).
  */
-bool kvstoreUnchangedSinceGsCreation(const core::GlobalState &gs, const unique_ptr<OwnedKeyValueStore> &kvstore) {
+bool kvstoreChangedSinceGsCreation(const core::GlobalState &gs, const unique_ptr<OwnedKeyValueStore> &kvstore) {
     const uint8_t *maybeGsBytes = kvstore->read(core::serialize::Serializer::GLOBAL_STATE_KEY).data;
-    const bool storedUidMatches =
-        maybeGsBytes && gs.kvstoreUuid == core::serialize::Serializer::loadGlobalStateUUID(gs, maybeGsBytes);
-    const bool noPreviouslyStoredUuid = !maybeGsBytes && gs.kvstoreUuid == 0;
-    return storedUidMatches || noPreviouslyStoredUuid;
+    if (maybeGsBytes) {
+        // If `GLOBAL_STATE_KEY` is in kvstore but it's not what `gs.kvstoreUuid` contains,
+        // this implies that some other process wrote a different GlobalState to the cache.
+        return gs.kvstoreUuid != core::serialize::Serializer::loadGlobalStateUUID(gs, maybeGsBytes);
+    } else {
+        // `GLOBAL_STATE_KEY` is not in kvstore, which implies the cache is empty.
+        // If kvstoreUuid != 0, that implies we tried to write GlobalState to the cache once before,
+        // and since we don't see `GLOBAL_STATE_KEY` in there now, someone else overwrote/dropped
+        // the cache.
+        return gs.kvstoreUuid != 0;
+    }
 }
 
 /**
- * Writes the GlobalState to kvstore, but only if it was modified. Returns 'true' if a write happens.
+ * Writes the GlobalState to kvstore, but only if it was modified. Returns 'true' if the cache
+ * now contains the contents of the current GlobalState (either because it already contained it, or
+ * it was just written).
  */
 bool retainGlobalState(core::GlobalState &gs, const unique_ptr<OwnedKeyValueStore> &kvstore) {
-    if (kvstore && gs.wasModified() && !gs.hadCriticalError()) {
-        // Verify that no other GlobalState was written to kvstore between when we read GlobalState and wrote it
-        // into the database.
-        if (kvstoreUnchangedSinceGsCreation(gs, kvstore)) {
-            // Generate a new UUID, since this GS has changed since it was read.
-            gs.kvstoreUuid = Random::uniformU4();
-            kvstore->write(core::serialize::Serializer::GLOBAL_STATE_KEY,
-                           core::serialize::Serializer::storePayloadAndNameTable(gs));
-            return true;
-        }
+    if (!kvstore) {
+        return false;
     }
-    return false;
+
+    if (gs.hadCriticalError()) {
+        // If an exception or InternalError happened, something has gone wrong, and we don't know
+        // what the contents of GlobalState might be. Don't write into the cache.
+        return false;
+    }
+
+    // Verify that no other GlobalState was written to kvstore between when we read GlobalState and wrote it
+    // into the database.
+    if (kvstoreChangedSinceGsCreation(gs, kvstore)) {
+        // Either
+        //   - `GLOBAL_STATE_KEY` is not in kvstore && `gs.kvstoreUuid != 0` (kvstore overwritten
+        //      with empty cache after we'd already written GlobalState to the cache once), or
+        //   - `GLOBAL_STATE_KEY` is in kvstore, BUT it's not what `gs.kvstoreUuid` contains
+        //      (some other process wrote a different GlobalState to the cache)
+        return false;
+    }
+
+    // Generate a new UUID, since this GS has changed since it was read.
+    //
+    // It would be valid to always generate a new UUID and write it to the cache, but as an
+    // optimization we can skip that when nothing has been modified.
+    if (gs.wasModified()) {
+        gs.kvstoreUuid = Random::uniformU4();
+        kvstore->write(core::serialize::Serializer::GLOBAL_STATE_KEY,
+                       core::serialize::Serializer::storePayloadAndNameTable(gs));
+    }
+
+    return true;
 }
 
 bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::Span<const ast::ParsedFile> parsedFiles,
@@ -131,12 +160,12 @@ unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, uniqu
     }
 
     auto ownedKvstore = make_unique<OwnedKeyValueStore>(move(kvstore));
-    if (kvstoreUnchangedSinceGsCreation(gs, ownedKvstore)) {
-        return ownedKvstore;
+    if (kvstoreChangedSinceGsCreation(gs, ownedKvstore)) {
+        // Some other process has written to kvstore; don't use.
+        return nullptr;
     }
 
-    // Some other process has written to kvstore; don't use.
-    return nullptr;
+    return ownedKvstore;
 }
 
 unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore> kvstore, const options::Options &opts,
@@ -146,8 +175,8 @@ unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore
         return kvstore;
     }
     auto ownedKvstore = make_unique<OwnedKeyValueStore>(move(kvstore));
-    auto wroteGlobalState = retainGlobalState(gs, ownedKvstore);
-    if (wroteGlobalState) {
+    auto cacheHasGlobalState = retainGlobalState(gs, ownedKvstore);
+    if (cacheHasGlobalState) {
         cacheTreesAndFiles(gs, workers, indexed, ownedKvstore);
         auto sizeBytes = ownedKvstore->cacheSize();
         kvstore = OwnedKeyValueStore::bestEffortCommit(gs.tracer(), move(ownedKvstore));

--- a/test/cli/stripe-packages-cache/test.out
+++ b/test/cli/stripe-packages-cache/test.out
@@ -3,11 +3,14 @@
             types.input.files.kvstore.miss :              4
            types.input.files.kvstore.write :              4
 ====second run (warm cache)====
+                             cache.aborted :              1
                          types.input.files :              4
              types.input.files.kvstore.hit :              1
 ====first after change (one cache miss)====
+                             cache.aborted :              1
                          types.input.files :              4
              types.input.files.kvstore.hit :              1
 ====second after change (warm cache)====
+                             cache.aborted :              1
                          types.input.files :              4
              types.input.files.kvstore.hit :              1

--- a/test/cli/stripe-packages-cache/test.out
+++ b/test/cli/stripe-packages-cache/test.out
@@ -3,14 +3,15 @@
             types.input.files.kvstore.miss :              4
            types.input.files.kvstore.write :              4
 ====second run (warm cache)====
-                             cache.aborted :              1
                          types.input.files :              4
-             types.input.files.kvstore.hit :              1
+             types.input.files.kvstore.hit :              4
+           types.input.files.kvstore.write :              0
 ====first after change (one cache miss)====
-                             cache.aborted :              1
                          types.input.files :              4
-             types.input.files.kvstore.hit :              1
+             types.input.files.kvstore.hit :              3
+            types.input.files.kvstore.miss :              1
+           types.input.files.kvstore.write :              1
 ====second after change (warm cache)====
-                             cache.aborted :              1
                          types.input.files :              4
-             types.input.files.kvstore.hit :              1
+             types.input.files.kvstore.hit :              4
+           types.input.files.kvstore.write :              0

--- a/test/cli/stripe-packages-cache/test.sh
+++ b/test/cli/stripe-packages-cache/test.sh
@@ -18,7 +18,7 @@ run_sorbet() {
     cat "$dir/stderr.txt"
     exit 1
   fi
-  grep 'types.input.files\(.kvstore.miss\|.kvstore.hit\|.kvstore.write\)\? :' "$dir/stderr.txt"
+  grep 'cache.abort\|types.input.files\(.kvstore.miss\|.kvstore.hit\|.kvstore.write\)\? :' "$dir/stderr.txt"
 }
 
 echo "====first run (cold cache)===="

--- a/test/cli/warm-cache-remove-file/test.out
+++ b/test/cli/warm-cache-remove-file/test.out
@@ -3,5 +3,6 @@
             types.input.files.kvstore.miss :             22
            types.input.files.kvstore.write :             22
 ====second run (only one file)====
+                             cache.aborted :              1
                          types.input.files :              2
              types.input.files.kvstore.hit :              1

--- a/test/cli/warm-cache-remove-file/test.out
+++ b/test/cli/warm-cache-remove-file/test.out
@@ -3,6 +3,6 @@
             types.input.files.kvstore.miss :             22
            types.input.files.kvstore.write :             22
 ====second run (only one file)====
-                             cache.aborted :              1
                          types.input.files :              2
-             types.input.files.kvstore.hit :              1
+             types.input.files.kvstore.hit :              2
+           types.input.files.kvstore.write :              0

--- a/test/cli/warm-cache-remove-file/test.sh
+++ b/test/cli/warm-cache-remove-file/test.sh
@@ -26,7 +26,7 @@ run_sorbet() {
     cat "$dir/stderr.txt"
     exit 1
   fi
-  grep 'types.input.files\(.kvstore.miss\|.kvstore.hit\|.kvstore.write\)\? :' "$dir/stderr.txt"
+  grep 'cache.abort\|types.input.files\(.kvstore.miss\|.kvstore.hit\|.kvstore.write\)\? :' "$dir/stderr.txt"
 }
 
 echo "====first run (all files)===="

--- a/test/cli/warm-cache/test.out
+++ b/test/cli/warm-cache/test.out
@@ -3,6 +3,7 @@
             types.input.files.kvstore.miss :              3
            types.input.files.kvstore.write :              3
 ====second run (warm cache)====
+                             cache.aborted :              1
                          types.input.files :              3
              types.input.files.kvstore.hit :              3
 ====first after change (one cache miss)====
@@ -11,13 +12,16 @@
             types.input.files.kvstore.miss :              1
            types.input.files.kvstore.write :              1
 ====second after change (warm cache)====
+                             cache.aborted :              1
                          types.input.files :              3
              types.input.files.kvstore.hit :              3
 ====first after comment change (one cache miss)====
+                             cache.aborted :              1
                          types.input.files :              3
              types.input.files.kvstore.hit :              2
             types.input.files.kvstore.miss :              1
 ====second after comment change (warm cache)====
+                             cache.aborted :              1
                          types.input.files :              3
              types.input.files.kvstore.hit :              2
             types.input.files.kvstore.miss :              1

--- a/test/cli/warm-cache/test.out
+++ b/test/cli/warm-cache/test.out
@@ -3,25 +3,24 @@
             types.input.files.kvstore.miss :              3
            types.input.files.kvstore.write :              3
 ====second run (warm cache)====
-                             cache.aborted :              1
                          types.input.files :              3
              types.input.files.kvstore.hit :              3
+           types.input.files.kvstore.write :              0
 ====first after change (one cache miss)====
                          types.input.files :              3
              types.input.files.kvstore.hit :              2
             types.input.files.kvstore.miss :              1
            types.input.files.kvstore.write :              1
 ====second after change (warm cache)====
-                             cache.aborted :              1
                          types.input.files :              3
              types.input.files.kvstore.hit :              3
+           types.input.files.kvstore.write :              0
 ====first after comment change (one cache miss)====
-                             cache.aborted :              1
                          types.input.files :              3
              types.input.files.kvstore.hit :              2
             types.input.files.kvstore.miss :              1
+           types.input.files.kvstore.write :              1
 ====second after comment change (warm cache)====
-                             cache.aborted :              1
                          types.input.files :              3
-             types.input.files.kvstore.hit :              2
-            types.input.files.kvstore.miss :              1
+             types.input.files.kvstore.hit :              3
+           types.input.files.kvstore.write :              0

--- a/test/cli/warm-cache/test.sh
+++ b/test/cli/warm-cache/test.sh
@@ -17,7 +17,7 @@ run_sorbet() {
     cat "$dir/stderr.txt"
     exit 1
   fi
-  grep 'types.input.files\(.kvstore.miss\|.kvstore.hit\|.kvstore.write\)\? :' "$dir/stderr.txt"
+  grep 'cache.abort\|types.input.files\(.kvstore.miss\|.kvstore.hit\|.kvstore.write\)\? :' "$dir/stderr.txt"
 }
 
 echo "====first run (cold cache)===="


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

I do not plan to merge this until the corresponding PR in Stripe's
codebase which re-enables `--cache-dir` has sat for a while
(at least a week or two, maybe more).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- First attempt: c9418bb
- (Semantically) reverted in: 6f56fa4

This change reimplements the spirit of the first attempt, but **only**
when `!gs.wasModified()`. In particular, we continue to not write trees
in all the other cases. For example, if `gs.hadCriticalError()` or if
`kvstoreChangedSinceGsCreation` we do not attempt to write the trees.

The problem with the first attempt was that we would **always** write
the trees into the cache, which might mention `NameRef`'s which are in
GlobalState. But if `retainGlobalState` had opted **not** to write
`GlobalState` into the cache, then those `NameRef`s would point to
nowhere.

I'm not sure of **all** the reasons why we were seeing
`retainGlobalState` opt to not cache `GlobalState`, but I don't think it
was just because `!gs.wasModified`. In particular, I know that it's
possible for the issue described in #8166 to have caused the cache to be
poisoned as a result of landing the first attempt (I know this because I
modified `test/cli/stripe-packages-cache` and was able to confirm the
cache crashes when a file has the `ForwardedRestArg` node).

I don't know if there are **other** internal errors that are common that
are causing this, but in any case, this PR leaves it like it was
originally, so that neither GlobalState nor trees are cached when
there was an internal error.

Similarly I don't know if it was the case that we have some flow which
routinely overwrites the cache file from another Sorbet process.
Technically someone could have invoked Sorbet twice at the same time
(e.g. in different terminal windows) but I would find it really
surprising if that were the root cause given how widespread the cache
poisoning was.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

~It's hard to write a test for this, because as far as I can tell, the cache only
gets poisoned in cases where there was a critical error.~ And while we could
write a test for the one critical error we're aware that Sorbet is susceptible
too right now (#8166), the moment we fix that bug, the regression test for this
feature would not be useful anymore.

**update**: The way that this was manifesting in practice was not that
we were getting critical errors, but that we were writing `FileRef's`
(via locs, via symbols) into the cache because we were writing to the
cache **after** namer had run. That change was reverted in #8237, with a
test for that case, which should then also cover the behavior changed
here.

As far as changes to existing tests:

The `types.input.files.kvstore.write : 0` lines are because that line is
written only if `cacheTreesAndFiles` is called, which it might not have
before, if `GlobalState` was not written.

In all other cases, the changes now match what the comments in the
output file say should be happening (e.g. the `... (warm cache)` lines
have no misses, and the `... (one cache miss)` lines are once again
accurate).
