### PR TITLE
insert in the right place for single line case bodies

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2198,21 +2198,34 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::Case *case_) {
                 if (dctx.preserveConcreteSyntax) {
+                    // Desugar to:
+                    //   Magic.caseWhen(condition, numPatterns, <pattern 1>, ..., <pattern N>, <body 1>, ..., <body M>)
+                    // Putting all the patterns at the start so that we can skip them when checking which body to insert
+                    // into.
                     Send::ARGS_store args;
                     args.emplace_back(node2TreeImpl(dctx, std::move(case_->condition)));
+
+                    Send::ARGS_store patterns;
+                    Send::ARGS_store bodies;
                     for (auto it = case_->whens.begin(); it != case_->whens.end(); ++it) {
                         auto when = parser::cast_node<parser::When>(it->get());
                         ENFORCE(when != nullptr, "case without a when?");
                         for (auto &cnode : when->patterns) {
-                            args.emplace_back(node2TreeImpl(dctx, std::move(cnode)));
+                            patterns.emplace_back(node2TreeImpl(dctx, std::move(cnode)));
                         }
-                        args.emplace_back(node2TreeImpl(dctx, std::move(when->body)));
+                        bodies.emplace_back(node2TreeImpl(dctx, std::move(when->body)));
                     }
-                    args.emplace_back(node2TreeImpl(dctx, std::move(case_->else_)));
+                    bodies.emplace_back(node2TreeImpl(dctx, std::move(case_->else_)));
+
+                    args.emplace_back(MK::Int(locZeroLen, patterns.size()));
+                    std::move(patterns.begin(), patterns.end(), std::back_inserter(args));
+                    std::move(bodies.begin(), bodies.end(), std::back_inserter(args));
+
                     result = MK::Send(loc, MK::Magic(locZeroLen), core::Names::caseWhen(), locZeroLen, args.size(),
                                       std::move(args));
                     return;
                 }
+
                 ExpressionPtr assign;
                 auto temp = core::NameRef::noName();
                 core::LocOffsets cloc;

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -20,9 +20,9 @@ optional<core::LocOffsets> detectCase(const ast::ExpressionPtr *whereToInsert, c
                                   ast::cast_tree_nonnull<ast::Literal>(send->getPosArg(1)).value)
                                   .value;
             for (int i = numPatterns + 2; i < send->numPosArgs(); i++) {
-                auto *body = &send->getPosArg(i);
-                if (body->loc().exists() && body->loc().contains(target)) {
-                    return body->loc();
+                const auto &body = send->getPosArg(i);
+                if (body.loc().exists() && body.loc().contains(target)) {
+                    return body.loc();
                 }
             }
         }
@@ -32,7 +32,7 @@ optional<core::LocOffsets> detectCase(const ast::ExpressionPtr *whereToInsert, c
 }
 
 core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::LocOffsets target) {
-    const ast::ExpressionPtr *whereToInsert = new ast::ExpressionPtr();
+    const ast::ExpressionPtr *whereToInsert = nullptr;
     if (auto insSeq = ast::cast_tree<ast::InsSeq>(scope)) {
         for (auto &stat : insSeq->stats) {
             if (stat.loc().contains(target)) {
@@ -91,7 +91,12 @@ core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::
     } else {
         ENFORCE(false);
     }
+
     ENFORCE(whereToInsert);
+    if (!whereToInsert) {
+        return core::LocOffsets::none();
+    }
+
     if (auto caseBodyLoc = detectCase(whereToInsert, target)) {
         return *caseBodyLoc;
     }

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -13,17 +13,35 @@ void logDebugInfo(const std::shared_ptr<spdlog::logger> logger, const core::Glob
     logger->error("source=\"{}\"", absl::CEscape(selectionLoc.file().data(gs).source()));
 }
 
+optional<core::LocOffsets> detectCase(const ast::ExpressionPtr *whereToInsert, const core::LocOffsets target) {
+    if (auto send = ast::cast_tree<ast::Send>(*whereToInsert)) {
+        if (send->fun == core::Names::caseWhen()) {
+            int numPatterns = core::cast_type_nonnull<core::IntegerLiteralType>(
+                                  ast::cast_tree_nonnull<ast::Literal>(send->getPosArg(1)).value)
+                                  .value;
+            for (int i = numPatterns + 2; i < send->numPosArgs(); i++) {
+                auto *body = &send->getPosArg(i);
+                if (body->loc().exists() && body->loc().contains(target)) {
+                    return body->loc();
+                }
+            }
+        }
+    }
+
+    return nullopt;
+}
+
 core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::LocOffsets target) {
-    core::LocOffsets whereToInsert = core::LocOffsets::none();
+    const ast::ExpressionPtr *whereToInsert = new ast::ExpressionPtr();
     if (auto insSeq = ast::cast_tree<ast::InsSeq>(scope)) {
         for (auto &stat : insSeq->stats) {
             if (stat.loc().contains(target)) {
-                whereToInsert = stat.loc();
+                whereToInsert = &stat;
                 break;
             }
         }
         if (insSeq->expr.loc().contains(target)) {
-            whereToInsert = insSeq->expr.loc();
+            whereToInsert = &insSeq->expr;
         }
     } else if (auto classDef = ast::cast_tree<ast::ClassDef>(scope)) {
         if (classDef->rhs.size() == 0) {
@@ -31,48 +49,53 @@ core::LocOffsets findWhereToInsert(const ast::ExpressionPtr &scope, const core::
         } else {
             for (auto &stat : classDef->rhs) {
                 if (stat.loc().contains(target)) {
-                    whereToInsert = stat.loc();
+                    whereToInsert = &stat;
                     break;
                 }
             }
         }
     } else if (auto block = ast::cast_tree<ast::Block>(scope)) {
-        whereToInsert = block->body.loc();
+        whereToInsert = &block->body;
     } else if (auto methodDef = ast::cast_tree<ast::MethodDef>(scope)) {
-        whereToInsert = methodDef->rhs.loc();
+        whereToInsert = &methodDef->rhs;
     } else if (auto if_ = ast::cast_tree<ast::If>(scope)) {
         if (if_->thenp.loc().exists() && if_->thenp.loc().contains(target)) {
-            whereToInsert = if_->thenp.loc();
+            whereToInsert = &if_->thenp;
         } else if (if_->elsep.loc().exists() && if_->elsep.loc().contains(target)) {
-            whereToInsert = if_->elsep.loc();
+            whereToInsert = &if_->elsep;
         } else {
             ENFORCE(!(if_->cond.loc().exists() && if_->cond.loc().contains(target)),
                     "shouldn't be inserting into the cond of an if");
+            ENFORCE(false, "none of the if sub-parts contain the target");
         }
     } else if (auto rescue = ast::cast_tree<ast::Rescue>(scope)) {
         if (rescue->body.loc().exists() && rescue->body.loc().contains(target)) {
-            whereToInsert = rescue->body.loc();
+            whereToInsert = &rescue->body;
         } else if (rescue->else_.loc().exists() && rescue->else_.loc().contains(target)) {
-            whereToInsert = rescue->else_.loc();
+            whereToInsert = &rescue->else_;
         } else if (rescue->ensure.loc().exists() && rescue->ensure.loc().contains(target)) {
-            whereToInsert = rescue->ensure.loc();
+            whereToInsert = &rescue->ensure;
         } else {
             ENFORCE(false)
         }
     } else if (auto rescueCase = ast::cast_tree<ast::RescueCase>(scope)) {
-        whereToInsert = rescueCase->body.loc();
+        whereToInsert = &rescueCase->body;
     } else if (auto while_ = ast::cast_tree<ast::While>(scope)) {
         if (while_->body.loc().exists() && while_->body.loc().contains(target)) {
-            whereToInsert = while_->body.loc();
+            whereToInsert = &while_->body;
         } else {
             ENFORCE(!(while_->cond.loc().exists() && while_->cond.loc().contains(target)),
                     "shouldn't be inserting into the cond of a while");
+            ENFORCE(false, "none of the while sub-parts contain the target");
         }
     } else {
         ENFORCE(false);
     }
-    ENFORCE(whereToInsert.exists());
-    return whereToInsert;
+    ENFORCE(whereToInsert);
+    if (auto caseBodyLoc = detectCase(whereToInsert, target)) {
+        return *caseBodyLoc;
+    }
+    return whereToInsert->loc();
 }
 
 // This tree walk takes a Loc and looks for nodes that have that Loc exactly

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/case.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/case.A.rbedited
@@ -9,10 +9,10 @@ end
 
 def test
   temp = T.unsafe(1)
-  newVariable = temp
   case temp
   when nil
   when A
+    newVariable = temp
     newVariable
 #   ^^^^ apply-code-action: [A] Extract Variable (this occurrence only)
 #   ^^^^ apply-code-action: [B] Extract Variable (all 3 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_multiple/case.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_multiple/case.C.rbedited
@@ -9,7 +9,6 @@ end
 
 def test
   temp = T.unsafe(1)
-  newVariable = A
   case temp
   when nil
   when A
@@ -17,6 +16,7 @@ def test
 #   ^^^^ apply-code-action: [A] Extract Variable (this occurrence only)
 #   ^^^^ apply-code-action: [B] Extract Variable (all 3 occurrences)
   when Integer
+    newVariable = A
     newVariable.new(temp)
 #   ^ apply-code-action: [C] Extract Variable (this occurrence only)
 #   ^ apply-code-action: [D] Extract Variable (all 2 occurrences)

--- a/test/testdata/lsp/code_actions/extract_variable_single/case.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/case.C.rbedited
@@ -23,9 +23,9 @@ def extract_from_when_pattern
 end
 
 def extract_from_when_body
-  newVariable = 2
   case T.unsafe(1)
   when Integer
+    newVariable = 2
     newVariable
 #   ^ apply-code-action: [C] Extract Variable (this occurrence only)
   else

--- a/test/testdata/lsp/code_actions/extract_variable_single/case.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/case.D.rbedited
@@ -33,11 +33,11 @@ def extract_from_when_body
 end
 
 def extract_from_else_body
-  newVariable = ""
   case T.unsafe(1)
   when Integer
     2
   else
+    newVariable = ""
     newVariable
 #   ^^ apply-code-action: [D] Extract Variable (this occurrence only)
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Because we desugared case to a send when `preserveConcreteSyntax` was `true`, we'd always insert outside of the case for single line bodies. To handle this correctly, we can do something similar to what we do for `if`: go through each body and see which one contains the target loc, and insert there. The one difference is that for `if` nodes, we'll always insert in either the `thenp` or the `elsep` case, while for `case`, we may not insert into any of the bodies (for example, if the target is in the condition or one of the patterns). In that case, we'll just fallback to the regular handling of statements and insert just before it.

Doing this requires a slight change in how we desugar `case` when `preserveConcreteSyntax` is `true`. Previously, we did something like: `Magic.caseWhen(condition, pattern 1 for body 1, pattern 2 for body 1, body 1, pattern 1 for body 2, body 2, ...)`. But since each body can have an arbitrary number of patterns, this means there was no way to know which args are the bodies. To handle this, we can instead insert all the patterns first, followed by the bodies, and then add the number of patterns to the args, so we can skip the patterns when looping through. This means something like this: `Magic.caseWhen(condition, number of patterns, pattern 1 for body 1, pattern 2 for body 1, pattern 1 for body 2, ...,  body 1, body 2, ...)`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Insert in the correct location for single line `case` bodies.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
