### PR TITLE
Attempt to fix flaky `//website:update_cli_ref_test` test

### DIFF
--- a/website/scripts/generate_cli_ref.sh
+++ b/website/scripts/generate_cli_ref.sh
@@ -42,7 +42,8 @@ script -q /dev/null bash -c "stty cols 90 && \"$sorbet_orig\" --help" 2>&1 | \
   # I have no idea what's making this get into the output
   sed -e $'s/^\^D\x08\x08//' | \
   # It seems like when the output is to a tty, lines end with \r\n
-  sed -e $'s/\\\r$//' | \
+  # (... and sometimes more than one `\r` ??)
+  sed -e $'s/\\\r\\\r*$//' | \
   # Get rid of trailing spaces to make it look nice when reading the markdown
   sed -e 's/ *$//' | \
   # CI has different number of cores, so the `--max-threads` help output changes


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


A handful of recent master builds have had the `//website:update_cli_ref_test`
test fail:

- <https://buildkite.com/sorbet/sorbet/builds/32705>
- <https://buildkite.com/sorbet/sorbet/builds/32685>
- <https://buildkite.com/sorbet/sorbet/builds/32684>

It's always the same message:

    ==================== Test output for //website:update_cli_ref_test:
    297c297
    <                                 Extra parent directories which contain package files.
    ---
    >                                 Extra parent directories which contain package files.
    FAIL: files "website/docs/cli-ref.md.gen" and "website/docs/cli-ref.md" differ.
    @//website:docs/cli-ref.md is out of date. To update this file, run:

        bazel run //website:update_cli_ref

    ================================================================================

When I look at the raw log from Buildkite in Vim, which shows me control
characters, I see this output:

    ==================== Test output for //website:update_cli_ref_test:^M
    297c297^M
    <                                 Extra parent directories which contain package files. ^M^M
    ---^M
    >                                 Extra parent directories which contain package files.^M
    FAIL: files "website/docs/cli-ref.md.gen" and "website/docs/cli-ref.md" differ. ^M
    ^M
    @//website:docs/cli-ref.md is out of date. To update this file, run:^M
    ^M
        bazel run //website:update_cli_ref^M
    ^M
    ^M
    ================================================================================^M

So it looks like the lines differ because it's ending with `" \r\r\n"`
instead of just `" \r\n"`.

I have no clue why that might be the case, but we can at least try to
account for it in our post-processing commands.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test in prod, because the test is flaky.