### PR TITLE
Instruct users how to give better VS Code extension bug reports

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -364,6 +364,19 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
         reason = RestartReason.FORCIBLY_TERMINATED;
       } else {
         reason = RestartReason.CRASH_LC_CLOSED;
+        this.context.log.error("");
+        this.context.log.error(
+          `The Sorbet LSP process crashed exit_code=${this.sorbetProcessExitCode}`,
+        );
+        this.context.log.error("The Node.js backtrace above is not useful.");
+        this.context.log.error(
+          "If there is a C++ backtrace above, that is useful.",
+        );
+        this.context.log.error(
+          "Otherwise, more useful output will be in the --debug-log-file to the Sorbet process",
+        );
+        this.context.log.error("(if provided as a command-line argument).");
+        this.context.log.error("");
       }
 
       this.status = ServerStatus.RESTARTING;


### PR DESCRIPTION
Output in the "Sorbet" window in the VS Code extension:

    Exception::raise(): simulated crash

    Backtrace:
    sorbet::realmain::realmain(int, char**) (in sorbet) + 828
    main (in sorbet) + 36
    start (in dyld) + 2840

    Sorbet raised uncaught exception type="sorbet::SorbetException" what="simulated crash"
    2024-09-25T21:08:33.538Z [debug] Process did not respond to SIGTERM. Sending a SIGKILL.
    Backtrace:
    0x0000000105a93c60 (in sorbet)
    0x0000000105a93be0 (in sorbet)
    0x00000001046b72b0 (in sorbet)
    0x0000000105605470 (in sorbet)
    0x00000001046b0ef8 (in sorbet)
    0x00000001046adb4c (in sorbet)
    start (in dyld) + 2840

    2024-09-25T21:08:33.596Z [error]
    2024-09-25T21:08:33.596Z [error] The Sorbet LSP process crashed exit_code=undefined
    2024-09-25T21:08:33.596Z [error] The Node.js backtrace above is not useful.
    2024-09-25T21:08:33.596Z [error] If there is a C++ backtrace above, that is useful.
    2024-09-25T21:08:33.596Z [error] Otherwise, more useful output will be in the --debug-log-file to the Sorbet process
    2024-09-25T21:08:33.596Z [error] (if provided as a command-line argument).
    2024-09-25T21:08:33.596Z [error]

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's ~never useful to get reports from users saying "Sorbet crashed" and then
having them point to a VS Code backtrace.

(The cases where the Node.js backtrace is useful is are so rare that it's worth
introducing another back-and-forth of clarification. We really want to push
people to try to find the C++ crash log when there was a crash.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.