### PR TITLE
Revert "Loc of single-element InsSeq should include parens (#7345)"

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -199,14 +199,6 @@ ExpressionPtr desugarBegin(DesugarContext dctx, core::LocOffsets loc, parser::No
         };
         auto &last = stmts.back();
 
-        if (stmts.size() == 1 && last != nullptr) {
-            // If we're about to make an InsSeq, but the stmts are empty, MK::InsSeq will return just expr.
-            // But we want to treat `(0)` as having a loc that spans the parens too, for autocorrects.
-            // We patch that here, because the loc on an ExpressionPtr is const (maybe we should fix
-            // that, and then solve this in MK::InsSeq?) but it's easier to solve this here.
-            last->loc = loc;
-        }
-
         auto expr = node2TreeImpl(dctx, std::move(last));
         return MK::InsSeq(loc, std::move(stats), std::move(expr));
     }
@@ -238,29 +230,13 @@ ExpressionPtr mergeStrings(DesugarContext dctx, core::LocOffsets loc,
     }
 }
 
-// In DString, the `#{...}` are all wrapped in parser::Begin nodes.
-// Normally, we have handling for parser::Begin nodes that treats the loc of such a node to include
-// the enclosing brackets. So e.g. the loc of `(x)` would be length 3.
-// But the parser also uses Begin nodes for `#{...}`, and for those we don't want the loc to include
-// the braces (think: we don't want a `T.must` to look like `"T.must(#{x})"`, we want it to look
-// like `"#{T.must(x)}"`, etc.)
-// So we have this skipSingletonBegin to skip over these nodes before desugaring them in DString
-unique_ptr<parser::Node> skipSingletonBegin(unique_ptr<parser::Node> node) {
-    auto begin = parser::cast_node<parser::Begin>(node.get());
-    if (begin == nullptr || begin->stmts.size() != 1) {
-        return node;
-    }
-
-    return move(begin->stmts[0]);
-}
-
 ExpressionPtr desugarDString(DesugarContext dctx, core::LocOffsets loc, parser::NodeVec nodes) {
     if (nodes.empty()) {
         return MK::String(loc, core::Names::empty());
     }
     auto it = nodes.begin();
     auto end = nodes.end();
-    ExpressionPtr first = node2TreeImpl(dctx, skipSingletonBegin(std::move(*it)));
+    ExpressionPtr first = node2TreeImpl(dctx, std::move(*it));
     InlinedVector<ExpressionPtr, 4> stringsAccumulated;
 
     Send::ARGS_store interpArgs;
@@ -277,7 +253,7 @@ ExpressionPtr desugarDString(DesugarContext dctx, core::LocOffsets loc, parser::
 
     for (; it != end; ++it) {
         auto &stat = *it;
-        ExpressionPtr narg = node2TreeImpl(dctx, skipSingletonBegin(std::move(stat)));
+        ExpressionPtr narg = node2TreeImpl(dctx, std::move(stat));
         if (allStringsSoFar && isStringLit(dctx, narg)) {
             stringsAccumulated.emplace_back(std::move(narg));
         } else if (isa_tree<EmptyTree>(narg)) {

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/kwarg_paren.A.rbedited
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/kwarg_paren.A.rbedited
@@ -7,8 +7,7 @@ class A
   end
 end
 
-A.example(A.new, x: (0))
+A.example(A.new, x: (0)
 
 A.example(A.new, x: begin
-       0
-  end)
+       0)

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/nullary.A.rbedited
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/nullary.A.rbedited
@@ -34,4 +34,4 @@ end
 
 (T.unsafe(A.new)).nullary
 
-A.nullary((A.new + A.new))
+A.nullary(A.new + A.new)

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.A.rbedited
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.A.rbedited
@@ -31,4 +31,4 @@ end
 
 (T.unsafe(A.new)).unary(0)
 
-A.unary((A.new + A.new), 0)
+A.unary(A.new + A.new, 0)

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.A.rbedited
@@ -18,7 +18,7 @@ foo(b&.foo) do
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
   d_ = (d&.foo)&.bar
-#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+#       ^^^^^^  apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   e_ = (e&.foo)&.bar
 #       ^ apply-code-action: [E] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.B.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.B.rbedited
@@ -18,7 +18,7 @@ foo(newVariable&.foo) do
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
   d_ = (d&.foo)&.bar
-#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+#       ^^^^^^  apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   e_ = (e&.foo)&.bar
 #       ^ apply-code-action: [E] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.C.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.C.rbedited
@@ -18,7 +18,7 @@ foo(b&.foo) do
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
   d_ = (d&.foo)&.bar
-#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+#       ^^^^^^  apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   e_ = (e&.foo)&.bar
 #       ^ apply-code-action: [E] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.D.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.D.rbedited
@@ -16,9 +16,9 @@ foo(b&.foo) do
   c&.foo
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
-  newVariable = (d&.foo)
-  d_ = newVariable&.bar
-#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+  newVariable = d&.foo
+  d_ = (newVariable)&.bar
+#       ^^^^^^  apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   e_ = (e&.foo)&.bar
 #       ^ apply-code-action: [E] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.E.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.E.rbedited
@@ -17,7 +17,7 @@ foo(b&.foo) do
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
   d_ = (d&.foo)&.bar
-#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+#       ^^^^^^  apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   newVariable = e
   e_ = (newVariable&.foo)&.bar

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.F.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.F.rbedited
@@ -17,7 +17,7 @@ foo(b&.foo) do
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
   d_ = (d&.foo)&.bar
-#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+#       ^^^^^^  apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   e_ = (e&.foo)&.bar
 #       ^ apply-code-action: [E] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.G.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.G.rbedited
@@ -17,7 +17,7 @@ foo(b&.foo) do
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
   d_ = (d&.foo)&.bar
-#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+#       ^^^^^^  apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   e_ = (e&.foo)&.bar
 #       ^ apply-code-action: [E] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_single/csend.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_single/csend.rb
@@ -17,7 +17,7 @@ foo(b&.foo) do
 # ^ apply-code-action: [C] Extract Variable (this occurrence only)
   d = T.unsafe(1)
   d_ = (d&.foo)&.bar
-#      ^^^^^^^^ apply-code-action: [D] Extract Variable (this occurrence only)
+#       ^^^^^^  apply-code-action: [D] Extract Variable (this occurrence only)
   e = T.unsafe(1)
   e_ = (e&.foo)&.bar
 #       ^ apply-code-action: [E] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/move_method/class_func.A.rbedited
+++ b/test/testdata/lsp/code_actions/move_method/class_func.A.rbedited
@@ -33,8 +33,8 @@ module A
       GreetingModule.greeting
 
       GreetingModule.greeting
-      print(GreetingModule.greeting)
-      print(GreetingModule.greeting)
+      print((GreetingModule).greeting)
+      print((GreetingModule).greeting)
       print((if T.unsafe(true); Foo; else Integer; end).greeting) # error: does not exist
     end
 

--- a/test/testdata/lsp/code_actions/move_method/no_resolve.A.rbedited
+++ b/test/testdata/lsp/code_actions/move_method/no_resolve.A.rbedited
@@ -36,7 +36,7 @@ module A
       GreetingModule.greeting
 
       GreetingModule.greeting
-      print(GreetingModule.greeting)
+      print((GreetingModule).greeting)
     end
 
     sig {params(m: T.class_of(Foo)).void}

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -92,7 +92,7 @@ module Helper11
   extend T::Helpers
 
   requires_ancestor (Kernel)
-  #                 ^^^^^^^^ error: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1`
+  #                  ^^^^^^  error: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1`
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
   #                         ^ error: `requires_ancestor` requires a block parameter, but no block was passed
 end
@@ -101,6 +101,6 @@ module Helper12
   extend T::Helpers
 
   requires_ancestor (Kernel) { Kernel }
-  #                 ^^^^^^^^ error: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1`
+  #                  ^^^^^^  error: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1`
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
 end

--- a/test/testdata/resolver/simple.rb
+++ b/test/testdata/resolver/simple.rb
@@ -26,3 +26,6 @@ class Outer2
   class Other < Inner1::Inner2
   end
 end
+
+(Does::Not::Exist)
+#^^^^ error: Unable to resolve constant `Does`

--- a/test/testdata/resolver/simple.rb.flatten-tree.exp
+++ b/test/testdata/resolver/simple.rb.flatten-tree.exp
@@ -5,7 +5,7 @@ begin
     <emptyTree>
 
     def self.<static-init><<static-init>$CENSORED>(<blk>)
-      <emptyTree>
+      Unresolved: Unresolved: Unresolved: <emptyTree>::<C Does>::<C Not>::<C Exist>
     end
   end
   class ::Outer1<<C Outer1>> < (::<todo sym>)

--- a/test/testdata/resolver/simple.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/simple.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/simple.rb start=2:1 end=28:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/simple.rb start=2:1 end=30:19}
       argument <blk><block> @ Loc {file=test/testdata/resolver/simple.rb start=??? end=???}
   class <C <U Outer1>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/simple.rb start=2:1 end=2:13}
   class <S <C <U Outer1>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/simple.rb start=2:1 end=2:13}


### PR DESCRIPTION
Partially reverts 2760eb82ff427c4ade9f80d1ea7151053a771e75, but keeps
the tests and avoids the conflicts on the now-deleted Sorbet Compiler
tests.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #8198. Need to figure out the best way forward.

For now, I'm just going to regress the code action doing the wrong thing, will figure out a better way forward but I want to get the cache turned back on.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] @jez tests