### PR TITLE
Fix typo in `procs.md`

### DIFF
--- a/website/docs/procs.md
+++ b/website/docs/procs.md
@@ -5,7 +5,7 @@ sidebar_label: Blocks, Procs, & Lambdas
 ---
 
 ```ruby
-T.proc.params(arg0: Arg0Type, arg1: Arg2Type, ...).returns(ReturnType)
+T.proc.params(arg0: Arg0Type, arg1: Arg1Type, ...).returns(ReturnType)
 ```
 
 This is the type of a `Proc` (such as a block passed to a method as a `&blk`


### PR DESCRIPTION
There's a typo in the documentation for procs, where `arg1` has type `Arg2Type`.

### Motivation
Just noticed the typo while reading the documentation.

### Test plan
No significant tests are required.