### PR TITLE
Add default value to SecureRandom.uuid_v7

### DIFF
--- a/rbi/core/random.rbi
+++ b/rbi/core/random.rbi
@@ -824,5 +824,5 @@ module SecureRandom
   sig do
     params(extra_timestamp_bits: T.nilable(Integer)).returns(String)
   end
-  def self.uuid_v7(extra_timestamp_bits:); end
+  def self.uuid_v7(extra_timestamp_bits: 0); end
 end


### PR DESCRIPTION
In https://github.com/sorbet/sorbet/pull/7960 we added a proper signature for `SecureRandom.uuid_v7` but it doesn't set the default value in the same way [as the SecureRandom gem](https://github.com/ruby/securerandom/blob/master/lib/random/formatter.rb#L247), so it's not quite correct 🤦🏼 


### Motivation
To make it possible to use `SecureRandom.uuid_v7` without triggering type warnings.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
