### PR TITLE
Change the hover output to not instantiate method generics

### DIFF
--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -20,12 +20,6 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
         resultType = core::Types::resultTypeAsSeenFrom(gs, resultType, inWhat.enclosingClass(gs), applied->klass,
                                                        applied->targs);
     }
-    if (receiver) {
-        resultType = core::Types::replaceSelfType(gs, resultType, receiver); // instantiate self types
-    }
-    if (constr) {
-        resultType = core::Types::instantiate(gs, resultType, *constr); // instantiate generic methods
-    }
     return resultType;
 }
 

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -6,7 +6,7 @@ using namespace std;
 namespace sorbet::core::source_generator {
 
 core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &type, core::SymbolRef inWhat,
-                            core::TypePtr receiver, const core::TypeConstraint *constr) {
+                            core::TypePtr receiver) {
     if (type == nullptr) {
         return core::Types::untypedUntracked();
     }
@@ -38,7 +38,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
     }
 
     if (!retType) {
-        retType = getResultType(gs, method.data(gs)->resultType, method, receiver, constraint);
+        retType = getResultType(gs, method.data(gs)->resultType, method, receiver);
     }
     string methodReturnType =
         (retType == core::Types::void_()) ? "void" : absl::StrCat("returns(", retType.show(gs, options), ")");
@@ -66,7 +66,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
         if (!argSym.isSyntheticBlockArgument()) {
             typeAndArgNames.emplace_back(
                 absl::StrCat(argSym.argumentName(gs), ": ",
-                             getResultType(gs, argSym.type, method, receiver, constraint).show(gs, options)));
+                             getResultType(gs, argSym.type, method, receiver).show(gs, options)));
         }
     }
 

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -182,11 +182,9 @@ string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method, c
 }
 
 string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
-                           const core::TypePtr &retType,
-                           const ShowOptions options) {
-    return fmt::format(
-        "{}\n{}", prettySigForMethod(gs, method.data(gs)->dealiasMethod(gs), receiver, retType, options),
-        prettyDefForMethod(gs, method, options));
+                           const core::TypePtr &retType, const ShowOptions options) {
+    return fmt::format("{}\n{}", prettySigForMethod(gs, method.data(gs)->dealiasMethod(gs), receiver, retType, options),
+                       prettyDefForMethod(gs, method, options));
 }
 
 } // namespace sorbet::core::source_generator

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -64,9 +64,8 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
     for (auto &argSym : method.data(gs)->arguments) {
         // Don't display synthetic arguments (like blk).
         if (!argSym.isSyntheticBlockArgument()) {
-            typeAndArgNames.emplace_back(
-                absl::StrCat(argSym.argumentName(gs), ": ",
-                             getResultType(gs, argSym.type, method, receiver).show(gs, options)));
+            typeAndArgNames.emplace_back(absl::StrCat(
+                argSym.argumentName(gs), ": ", getResultType(gs, argSym.type, method, receiver).show(gs, options)));
         }
     }
 

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -37,9 +37,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
         return "";
     }
 
-    if (!retType) {
-        retType = getResultType(gs, method.data(gs)->resultType, method, receiver);
-    }
+    auto retType = getResultType(gs, method.data(gs)->resultType, method, receiver);
     string methodReturnType =
         (retType == core::Types::void_()) ? "void" : absl::StrCat("returns(", retType.show(gs, options), ")");
     vector<string> typeAndArgNames;

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -29,7 +29,7 @@ constexpr int MAX_PRETTY_SIG_ARGS = 4;
 constexpr int MAX_PRETTY_WIDTH = 80;
 
 string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
-                          core::TypePtr retType, const core::TypeConstraint *constraint, const ShowOptions options) {
+                          core::TypePtr retType, const ShowOptions options) {
     ENFORCE(method.exists());
     ENFORCE(method.data(gs)->dealiasMethod(gs) == method);
     // handle this case anyways so that we don't crash in prod when this method is misused
@@ -182,10 +182,10 @@ string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method, c
 }
 
 string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
-                           const core::TypePtr &retType, const core::TypeConstraint *constraint,
+                           const core::TypePtr &retType,
                            const ShowOptions options) {
     return fmt::format(
-        "{}\n{}", prettySigForMethod(gs, method.data(gs)->dealiasMethod(gs), receiver, retType, constraint, options),
+        "{}\n{}", prettySigForMethod(gs, method.data(gs)->dealiasMethod(gs), receiver, retType, options),
         prettyDefForMethod(gs, method, options));
 }
 

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -29,7 +29,7 @@ constexpr int MAX_PRETTY_SIG_ARGS = 4;
 constexpr int MAX_PRETTY_WIDTH = 80;
 
 string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
-                          core::TypePtr retType, const ShowOptions options) {
+                          const ShowOptions options) {
     ENFORCE(method.exists());
     ENFORCE(method.data(gs)->dealiasMethod(gs) == method);
     // handle this case anyways so that we don't crash in prod when this method is misused
@@ -180,8 +180,8 @@ string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method, c
 }
 
 string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
-                           const core::TypePtr &retType, const ShowOptions options) {
-    return fmt::format("{}\n{}", prettySigForMethod(gs, method.data(gs)->dealiasMethod(gs), receiver, retType, options),
+                           const ShowOptions options) {
+    return fmt::format("{}\n{}", prettySigForMethod(gs, method.data(gs)->dealiasMethod(gs), receiver, options),
                        prettyDefForMethod(gs, method, options));
 }
 

--- a/core/source_generator/source_generator.h
+++ b/core/source_generator/source_generator.h
@@ -10,7 +10,7 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
                             core::TypePtr receiver);
 
 std::string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
-                                const core::TypePtr &retType, const core::TypeConstraint *constraint,
+                                const core::TypePtr &retType,
                                 const ShowOptions options);
 
 } // namespace sorbet::core::source_generator

--- a/core/source_generator/source_generator.h
+++ b/core/source_generator/source_generator.h
@@ -10,8 +10,7 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
                             core::TypePtr receiver);
 
 std::string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
-                                const core::TypePtr &retType,
-                                const ShowOptions options);
+                                const core::TypePtr &retType, const ShowOptions options);
 
 } // namespace sorbet::core::source_generator
 #endif // SORBET_CORE_SOURCE_GENERATOR_H

--- a/core/source_generator/source_generator.h
+++ b/core/source_generator/source_generator.h
@@ -7,7 +7,7 @@
 namespace sorbet::core::source_generator {
 
 core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &type, core::SymbolRef inWhat,
-                            core::TypePtr receiver, const core::TypeConstraint *constr);
+                            core::TypePtr receiver);
 
 std::string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
                                 const core::TypePtr &retType, const core::TypeConstraint *constraint,

--- a/core/source_generator/source_generator.h
+++ b/core/source_generator/source_generator.h
@@ -10,7 +10,7 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
                             core::TypePtr receiver);
 
 std::string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
-                                const core::TypePtr &retType, const ShowOptions options);
+                                const ShowOptions options);
 
 } // namespace sorbet::core::source_generator
 #endif // SORBET_CORE_SOURCE_GENERATOR_H

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -537,7 +537,7 @@ string SelfType::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string SelfType::show(const GlobalState &gs, ShowOptions options) const {
-    return "T.self_type()";
+    return "T.self_type";
 }
 
 string SelfType::showValue(const GlobalState &gs) const {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -992,9 +992,8 @@ private:
         if (sym.data(gs)->attachedClass(gs).exists()) {
             showOptions = showOptions.withForceSelfPrefix();
         }
-        auto resultType = abstractMethodRef.data(gs)->resultType;
         auto methodDefinition =
-            core::source_generator::prettyTypeForMethod(gs, abstractMethodRef, nullptr, resultType, showOptions);
+            core::source_generator::prettyTypeForMethod(gs, abstractMethodRef, nullptr, showOptions);
 
         vector<string> indentedLines;
         absl::c_transform(

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -993,8 +993,8 @@ private:
             showOptions = showOptions.withForceSelfPrefix();
         }
         auto resultType = abstractMethodRef.data(gs)->resultType;
-        auto methodDefinition = core::source_generator::prettyTypeForMethod(gs, abstractMethodRef, nullptr, resultType,
-                                                                            showOptions);
+        auto methodDefinition =
+            core::source_generator::prettyTypeForMethod(gs, abstractMethodRef, nullptr, resultType, showOptions);
 
         vector<string> indentedLines;
         absl::c_transform(

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -994,7 +994,7 @@ private:
         }
         auto resultType = abstractMethodRef.data(gs)->resultType;
         auto methodDefinition = core::source_generator::prettyTypeForMethod(gs, abstractMethodRef, nullptr, resultType,
-                                                                            nullptr, showOptions);
+                                                                            showOptions);
 
         vector<string> indentedLines;
         absl::c_transform(

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1288,6 +1288,10 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     } else {
                         type = core::Types::instantiate(ctx, main.returnTypeBeforeSolve, *main.constr);
                     }
+                    // Write back into the DispatchResult so that retained results affect LSP queries.
+                    // (Note that the SendResponse has already been pushed, with a shared_ptr to the
+                    // DispatchResult we're mutating here)
+                    i.link->result->returnType = type;
                 } else {
                     type = i.link->result->returnType;
                 }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1072,7 +1072,7 @@ unique_ptr<CompletionItem> CompletionTask::getCompletionItemForMethod(LSPTypeche
         documentation = findDocumentation(whatFile.data(gs).source(), what.data(gs)->loc().beginPos());
     }
 
-    auto prettyType = core::source_generator::prettyTypeForMethod(gs, maybeAlias, receiverType, nullptr, constraint,
+    auto prettyType = core::source_generator::prettyTypeForMethod(gs, maybeAlias, receiverType, nullptr,
                                                                   core::ShowOptions().withUseValidSyntax());
     item->documentation = formatRubyMarkup(markupKind, prettyType, documentation);
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -299,8 +299,7 @@ vector<core::NameRef> allSimilarLocalNames(const core::GlobalState &gs, const ve
 }
 
 string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatchResult, core::MethodRef maybeAlias,
-                     const core::TypePtr &receiverType, uint16_t totalArgs,
-                     core::Loc queryLoc) {
+                     const core::TypePtr &receiverType, uint16_t totalArgs, core::Loc queryLoc) {
     fmt::memory_buffer result;
     auto shortName = maybeAlias.data(gs)->name.shortName(gs);
     auto isSetter = maybeAlias.data(gs)->name.isSetter(gs);
@@ -353,8 +352,7 @@ string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatch
             fmt::format_to(std::back_inserter(argBuf), "{}: ", argSym.name.shortName(gs));
         }
         if (argSym.type) {
-            auto resultType =
-                core::source_generator::getResultType(gs, argSym.type, method, receiverType).show(gs);
+            auto resultType = core::source_generator::getResultType(gs, argSym.type, method, receiverType).show(gs);
             fmt::format_to(std::back_inserter(argBuf), "${{{}:{}}}", nextTabstop++, resultType);
         } else {
             fmt::format_to(std::back_inserter(argBuf), "${{{}}}", nextTabstop++);
@@ -379,8 +377,8 @@ string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatch
                 auto targs_it = appliedType->targs.begin();
                 targs_it++;
                 blkArgs = fmt::format(" |{}|", fmt::map_join(targs_it, appliedType->targs.end(), ", ", [&](auto targ) {
-                                          auto resultType = core::source_generator::getResultType(
-                                              gs, targ, method, receiverType);
+                                          auto resultType =
+                                              core::source_generator::getResultType(gs, targ, method, receiverType);
                                           return fmt::format("${{{}:{}}}", nextTabstop++, resultType.show(gs));
                                       }));
             }
@@ -1022,11 +1020,12 @@ unique_ptr<CompletionItem> CompletionTask::getCompletionItemForUntyped(const cor
     return item;
 }
 
-unique_ptr<CompletionItem>
-CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker, core::DispatchResult &dispatchResult,
-                                           core::MethodRef maybeAlias, const core::TypePtr &receiverType,
-                                           core::Loc queryLoc,
-                                           string_view prefix, size_t sortIdx, uint16_t totalArgs) const {
+unique_ptr<CompletionItem> CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
+                                                                      core::DispatchResult &dispatchResult,
+                                                                      core::MethodRef maybeAlias,
+                                                                      const core::TypePtr &receiverType,
+                                                                      core::Loc queryLoc, string_view prefix,
+                                                                      size_t sortIdx, uint16_t totalArgs) const {
     const auto &gs = typechecker.state();
     ENFORCE(maybeAlias.exists());
     auto clientConfig = config.getClientConfig();

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1072,7 +1072,7 @@ unique_ptr<CompletionItem> CompletionTask::getCompletionItemForMethod(LSPTypeche
         documentation = findDocumentation(whatFile.data(gs).source(), what.data(gs)->loc().beginPos());
     }
 
-    auto prettyType = core::source_generator::prettyTypeForMethod(gs, maybeAlias, receiverType, nullptr,
+    auto prettyType = core::source_generator::prettyTypeForMethod(gs, maybeAlias, receiverType,
                                                                   core::ShowOptions().withUseValidSyntax());
     item->documentation = formatRubyMarkup(markupKind, prettyType, documentation);
 

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -51,7 +51,6 @@ class CompletionTask final : public LSPRequestTask {
     std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
                                                                core::DispatchResult &dispatchResult,
                                                                core::MethodRef what, const core::TypePtr &receiverType,
-                                                               const core::TypeConstraint *constraint,
                                                                core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx, uint16_t totalArgs) const;
 

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -13,8 +13,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retType,
-                        const core::DispatchResult &dispatchResult,
-                        const core::ShowOptions options) {
+                        const core::DispatchResult &dispatchResult, const core::ShowOptions options) {
     string contents;
     auto start = &dispatchResult;
 
@@ -24,9 +23,8 @@ string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retTyp
             if (!contents.empty()) {
                 contents += "\n";
             }
-            contents = absl::StrCat(
-                move(contents), core::source_generator::prettyTypeForMethod(gs, component.method, component.receiver,
-                                                                            retType, options));
+            contents = absl::StrCat(move(contents), core::source_generator::prettyTypeForMethod(
+                                                        gs, component.method, component.receiver, retType, options));
         }
         start = start->secondary.get();
     }
@@ -121,8 +119,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
             }
         }
 
-        typeString =
-            core::source_generator::prettyTypeForMethod(gs, d->symbol, nullptr, d->retType.type, options);
+        typeString = core::source_generator::prettyTypeForMethod(gs, d->symbol, nullptr, d->retType.type, options);
     } else if (resp->isField()) {
         const auto &origins = resp->getTypeAndOrigins().origins;
         for (auto loc : origins) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -13,7 +13,7 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 
 string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retType,
-                        const core::DispatchResult &dispatchResult, const unique_ptr<core::TypeConstraint> &constraint,
+                        const core::DispatchResult &dispatchResult,
                         const core::ShowOptions options) {
     string contents;
     auto start = &dispatchResult;
@@ -26,7 +26,7 @@ string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retTyp
             }
             contents = absl::StrCat(
                 move(contents), core::source_generator::prettyTypeForMethod(gs, component.method, component.receiver,
-                                                                            retType, constraint.get(), options));
+                                                                            retType, options));
         }
         start = start->secondary.get();
     }
@@ -95,7 +95,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
                 // the result type.
                 typeString = retType.showWithMoreInfo(gs);
             } else {
-                typeString = methodInfoString(gs, retType, *s->dispatchResult, s->dispatchResult->main.constr, options);
+                typeString = methodInfoString(gs, retType, *s->dispatchResult, options);
             }
         }
     } else if (auto c = resp->isConstant()) {
@@ -122,7 +122,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         }
 
         typeString =
-            core::source_generator::prettyTypeForMethod(gs, d->symbol, nullptr, d->retType.type, nullptr, options);
+            core::source_generator::prettyTypeForMethod(gs, d->symbol, nullptr, d->retType.type, options);
     } else if (resp->isField()) {
         const auto &origins = resp->getTypeAndOrigins().origins;
         for (auto loc : origins) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -89,17 +89,13 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
             }
 
             auto retType = s->dispatchResult->returnType;
-            auto &constraint = s->dispatchResult->main.constr;
-            if (constraint) {
-                retType = core::Types::instantiate(gs, retType, *constraint);
-            }
             if (s->dispatchResult->main.method.exists() &&
                 s->dispatchResult->main.method.data(gs)->owner == core::Symbols::MagicSingleton()) {
                 // Most <Magic>.<foo> are not meant to be exposed to the user. Instead, just show
                 // the result type.
                 typeString = retType.showWithMoreInfo(gs);
             } else {
-                typeString = methodInfoString(gs, retType, *s->dispatchResult, constraint, options);
+                typeString = methodInfoString(gs, retType, *s->dispatchResult, s->dispatchResult->main.constr, options);
             }
         }
     } else if (auto c = resp->isConstant()) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -12,8 +12,8 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retType,
-                        const core::DispatchResult &dispatchResult, const core::ShowOptions options) {
+string methodInfoString(const core::GlobalState &gs, const core::DispatchResult &dispatchResult,
+                        const core::ShowOptions options) {
     string contents;
     auto start = &dispatchResult;
 
@@ -24,7 +24,7 @@ string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retTyp
                 contents += "\n";
             }
             contents = absl::StrCat(move(contents), core::source_generator::prettyTypeForMethod(
-                                                        gs, component.method, component.receiver, retType, options));
+                                                        gs, component.method, component.receiver, options));
         }
         start = start->secondary.get();
     }
@@ -86,14 +86,13 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
                 }
             }
 
-            auto retType = s->dispatchResult->returnType;
             if (s->dispatchResult->main.method.exists() &&
                 s->dispatchResult->main.method.data(gs)->owner == core::Symbols::MagicSingleton()) {
                 // Most <Magic>.<foo> are not meant to be exposed to the user. Instead, just show
                 // the result type.
-                typeString = retType.showWithMoreInfo(gs);
+                typeString = s->dispatchResult->returnType.showWithMoreInfo(gs);
             } else {
-                typeString = methodInfoString(gs, retType, *s->dispatchResult, options);
+                typeString = methodInfoString(gs, *s->dispatchResult, options);
             }
         }
     } else if (auto c = resp->isConstant()) {
@@ -119,7 +118,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
             }
         }
 
-        typeString = core::source_generator::prettyTypeForMethod(gs, d->symbol, nullptr, d->retType.type, options);
+        typeString = core::source_generator::prettyTypeForMethod(gs, d->symbol, nullptr, options);
     } else if (resp->isField()) {
         const auto &origins = resp->getTypeAndOrigins().origins;
         for (auto loc : origins) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -23,8 +23,9 @@ string methodInfoString(const core::GlobalState &gs, const core::DispatchResult 
             if (!contents.empty()) {
                 contents += "\n";
             }
-            contents = absl::StrCat(move(contents), core::source_generator::prettyTypeForMethod(
-                                                        gs, component.method, component.receiver, options));
+            contents = absl::StrCat(
+                move(contents), "# ", component.method.show(gs), ":\n",
+                core::source_generator::prettyTypeForMethod(gs, component.method, component.receiver, options));
         }
         start = start->secondary.get();
     }

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -29,6 +29,17 @@ string methodInfoString(const core::GlobalState &gs, const core::DispatchResult 
         start = start->secondary.get();
     }
 
+    // contents being empty implies that there were no components that existed, which means that
+    // there was an error. We don't show any hover results, so that the only thing that's shown on
+    // hover is any relevant diagnostics (e.g., we could show `result type: T.untyped` but for
+    // errors that would just be misleading--people might think the problem is _caused_ by untyped,
+    // but the untyped is an artifact of how we recover from errors).
+    if (!contents.empty()) {
+        // Reads from returnType on the overall DispatchResult, which will have aggregated all the
+        // components (e.g., unions and intersections)
+        contents = absl::StrCat(move(contents), "\n\n# result type:\n", dispatchResult.returnType.showWithMoreInfo(gs));
+    }
+
     return contents;
 }
 

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -39,8 +39,7 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::MethodRef method,
             methodDocumentation += ", ";
         }
         parameter->documentation =
-            core::source_generator::getResultType(gs, arg.type, method, resp.dispatchResult->main.receiver)
-                .show(gs);
+            core::source_generator::getResultType(gs, arg.type, method, resp.dispatchResult->main.receiver).show(gs);
         parameters.push_back(move(parameter));
         i += 1;
     }

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -39,8 +39,7 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::MethodRef method,
             methodDocumentation += ", ";
         }
         parameter->documentation =
-            core::source_generator::getResultType(gs, arg.type, method, resp.dispatchResult->main.receiver,
-                                                  resp.dispatchResult->main.constr.get())
+            core::source_generator::getResultType(gs, arg.type, method, resp.dispatchResult->main.receiver)
                 .show(gs);
         parameters.push_back(move(parameter));
         i += 1;

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -287,11 +287,17 @@ const UnorderedMap<
 
 // Ignore any comments that have these labels (e.g. `# typed: true`).
 const UnorderedSet<string> ignoredAssertionLabels = {
-    "typed",         "TODO",
-    "linearization", "commented-out-error",
-    "Note",          "See",
-    "packaged",      "rubyfmt-force-exit",
-    "compiled",      "exclude-from-file-update",
+    "typed",
+    "TODO",
+    "linearization",
+    "commented-out-error",
+    "Note",
+    "NOTE",
+    "See",
+    "packaged",
+    "rubyfmt-force-exit",
+    "compiled",
+    "exclude-from-file-update",
 };
 
 constexpr string_view NOTHING_LABEL = "(nothing)"sv;

--- a/test/testdata/lsp/genericMethods.rb
+++ b/test/testdata/lsp/genericMethods.rb
@@ -30,23 +30,28 @@ def main
   foo = Foo.new
   v1 = foo.id(1)
 # ^ hover: Integer
-         # ^ hover: sig { params(a: Integer).returns(Integer) }
-         # ^ usage: id
+  #        ^ hover: sig { params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
+  #        ^ usage: id
   v2 = foo.id("1")
 # ^ hover: String
-         # ^ hover: sig { params(a: String).returns(String) }
-         # ^ usage: id
+  #        ^ hover: sig { params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
+  #        ^ usage: id
   v3 = Foo.id(1)
 # ^ hover: Integer
-         # ^ hover: sig { params(a: Integer).returns(Integer) }
-         # ^ usage: staticid
+  #        ^ hover: sig { params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
+  #        ^ usage: staticid
   v4 = Foo.id("1")
 # ^ hover: String
-         # ^ hover: sig { params(a: String).returns(String) }
-         # ^ usage: staticid
+  #        ^ hover: sig { params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
+  #        ^ usage: staticid
 
   v5 = Foo.block_id do
-    #       ^ hover: sig { params(blk: T.proc.returns(String)).returns(String) }
+    #       ^ hover-line: 2 sig do
+    #       ^ hover-line: 3   params(
+    #       ^ hover-line: 4     blk: T.proc.returns(T.type_parameter(:U))
+    #       ^ hover-line: 5   )
+    #       ^ hover-line: 6   .returns(T.type_parameter(:U))
+    #       ^ hover-line: 7 end
     #       ^ usage: block_id
     "1"
   end

--- a/test/testdata/lsp/genericMethods.rb
+++ b/test/testdata/lsp/genericMethods.rb
@@ -15,6 +15,15 @@ class Foo
     a
   end
 
+  sig {
+    type_parameters(:U)
+      .params(blk: T.proc.returns(T.type_parameter(:U)))
+      .returns(T.type_parameter(:U))
+  }
+  def self.block_id(&blk)
+    #      ^ def: block_id
+    yield
+  end
 end
 
 def main
@@ -35,4 +44,10 @@ def main
 # ^ hover: String
          # ^ hover: sig { params(a: String).returns(String) }
          # ^ usage: staticid
+
+  v5 = Foo.block_id do
+    #       ^ hover: sig { params(blk: T.proc.returns(String)).returns(String) }
+    #       ^ usage: block_id
+    "1"
+  end
 end

--- a/test/testdata/lsp/genericMethods.rb
+++ b/test/testdata/lsp/genericMethods.rb
@@ -46,12 +46,12 @@ def main
   #        ^ usage: staticid
 
   v5 = Foo.block_id do
-    #       ^ hover-line: 2 sig do
-    #       ^ hover-line: 3   params(
-    #       ^ hover-line: 4     blk: T.proc.returns(T.type_parameter(:U))
-    #       ^ hover-line: 5   )
-    #       ^ hover-line: 6   .returns(T.type_parameter(:U))
-    #       ^ hover-line: 7 end
+    #       ^ hover-line: 3 sig do
+    #       ^ hover-line: 4   params(
+    #       ^ hover-line: 5     blk: T.proc.returns(T.type_parameter(:U))
+    #       ^ hover-line: 6   )
+    #       ^ hover-line: 7   .returns(T.type_parameter(:U))
+    #       ^ hover-line: 8 end
     #       ^ usage: block_id
     "1"
   end

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -148,6 +148,8 @@ def main
   foo = BigFoo.new
   #            ^^^ hover: sig { void }
   #            ^^^ hover: private def initialize; end
+  BigFoo.new.itself
+  #            ^ hover: sig { returns(T.self_type) }
   hoo = BigFoo::LittleFoo1.new
   #                        ^^^ hover: sig { returns(T.untyped) }
   raise "error message"

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -146,10 +146,10 @@ def main
       # ^^^^^^ hover: The docs for BigFoo
 
   foo = BigFoo.new
-  #            ^^^ hover: sig { returns(BigFoo) }
+  #            ^^^ hover: sig { void }
   #            ^^^ hover: private def initialize; end
   hoo = BigFoo::LittleFoo1.new
-                         # ^^^ hover: sig { returns(BigFoo::LittleFoo1) }
+  #                        ^^^ hover: sig { returns(T.untyped) }
   raise "error message"
   # ^ hover-line: 4     arg0: T.any(T::Class[T.anything], Exception, String)
 end

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -151,7 +151,12 @@ def main
   BigFoo.new.itself
   #            ^ hover: sig { returns(T.self_type) }
   hoo = BigFoo::LittleFoo1.new
-  #                        ^^^ hover: sig { returns(T.untyped) }
+  #                        ^^^ hover-line: 2 # BigFoo::LittleFoo1#initialize:
+  #                        ^^^ hover-line: 3 sig { returns(T.untyped) }
+  #                        ^^^ hover-line: 4 private def initialize; end
+  #                        ^^^ hover-line: 6 # result type:
+  #                        ^^^ hover-line: 7 BigFoo::LittleFoo1
+
   raise "error message"
   # ^ hover-line: 2 # Kernel#raise (overload.1):
   # ^ hover-line: 3 sig do

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -153,5 +153,14 @@ def main
   hoo = BigFoo::LittleFoo1.new
   #                        ^^^ hover: sig { returns(T.untyped) }
   raise "error message"
-  # ^ hover-line: 4     arg0: T.any(T::Class[T.anything], Exception, String)
+  # ^ hover-line: 2 # Kernel#raise (overload.1):
+  # ^ hover-line: 3 sig do
+  # ^ hover-line: 4   params(
+  # ^ hover-line: 5     arg0: T.any(T::Class[T.anything], Exception, String)
+  # ^ hover-line: 6   )
+  # ^ hover-line: 7   .returns(T.noreturn)
+  # ^ hover-line: 8 end
+  # ^ hover-line: 9 def raise (overload.1)(arg0=…); end
+  # ^ hover-line: 11 # result type:
+  # ^ hover-line: 12 T.noreturn
 end

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -12,10 +12,15 @@ def main
   dogs = T.let([], T::Array[Dog])
   # Check hover of breeds / map / : / breed
   breeds = dogs.map(&:breed)
-# ^ hover: T::Array[String]
-              # ^ hover:     blk: T.proc.params(arg0: Dog).returns(String)
-                   # ^ hover: sig { returns(String) }
-                    # ^ hover: sig { returns(String) }
+  # ^ hover: T::Array[String]
+  #             ^ hover-line: 2 sig do
+  #             ^ hover-line: 3   params(
+  #             ^ hover-line: 4     blk: T.proc.params(arg0: Dog).returns(T.type_parameter(:U))
+  #             ^ hover-line: 5   )
+  #             ^ hover-line: 6   .returns(T::Array[T.type_parameter(:U)])
+  #             ^ hover-line: 7 end
+  #                  ^ hover: sig { returns(String) }
+  #                   ^ hover: sig { returns(String) }
 
   # Safenav
   dog = Dog.new

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -13,12 +13,12 @@ def main
   # Check hover of breeds / map / : / breed
   breeds = dogs.map(&:breed)
   # ^ hover: T::Array[String]
-  #             ^ hover-line: 2 sig do
-  #             ^ hover-line: 3   params(
-  #             ^ hover-line: 4     blk: T.proc.params(arg0: Dog).returns(T.type_parameter(:U))
-  #             ^ hover-line: 5   )
-  #             ^ hover-line: 6   .returns(T::Array[T.type_parameter(:U)])
-  #             ^ hover-line: 7 end
+  #             ^ hover-line: 3 sig do
+  #             ^ hover-line: 4   params(
+  #             ^ hover-line: 5     blk: T.proc.params(arg0: Dog).returns(T.type_parameter(:U))
+  #             ^ hover-line: 6   )
+  #             ^ hover-line: 7   .returns(T::Array[T.type_parameter(:U)])
+  #             ^ hover-line: 8 end
   #                  ^ hover: sig { returns(String) }
   #                   ^ hover: sig { returns(String) }
 

--- a/test/testdata/lsp/hover_components.rb
+++ b/test/testdata/lsp/hover_components.rb
@@ -1,0 +1,73 @@
+# typed: true
+class Module; include T::Sig; end
+
+module A
+  sig {
+    params(blk: T.proc.returns(T.anything))
+      .returns(IFoo)
+  }
+  def foo(&blk)
+    Foo.new
+  end
+end
+
+module IFoo; end
+class Foo
+  include IFoo
+end
+
+module B
+  sig {
+    type_parameters(:U)
+      .params(blk: T.proc.returns(T.type_parameter(:U)))
+      .returns(T.type_parameter(:U))
+  }
+  def foo(&blk)
+    yield
+  end
+end
+
+# NOTE: At time of writing, this suffers from this bug:
+# https://github.com/sorbet/sorbet/issues/5409
+
+sig { params(x: T.any(A, B)).void }
+def example_any(x)
+  res = x.foo {
+    #      ^ hover-line: 2 # A#foo:
+    #      ^ hover-line: 3 sig { params(blk: T.proc.returns(T.anything)).returns(IFoo) }
+    #      ^ hover-line: 4 def foo(&blk); end
+    #      ^ hover-line: 5 # B#foo:
+    #      ^ hover-line: 6 sig do
+    #      ^ hover-line: 7   params(
+    #      ^ hover-line: 8     blk: T.proc.returns(T.type_parameter(:U))
+    #      ^ hover-line: 9   )
+    #      ^ hover-line: 10   .returns(T.type_parameter(:U))
+    #      ^ hover-line: 11 end
+    #      ^ hover-line: 12 def foo(&blk); end
+    #      ^ hover-line: 14 # result type:
+    #      ^ hover-line: 15 IFoo
+    ""
+  }
+  T.reveal_type(res) # error: `T.any(String, IFoo)`
+end
+
+sig { params(x: T.all(A, B)).void }
+def example_all(x)
+  res = x.foo {
+    #     ^ hover-line: 2 # A#foo:
+    #     ^ hover-line: 3 sig { params(blk: T.proc.returns(T.anything)).returns(IFoo) }
+    #     ^ hover-line: 4 def foo(&blk); end
+    #     ^ hover-line: 5 # B#foo:
+    #     ^ hover-line: 6 sig do
+    #     ^ hover-line: 7   params(
+    #     ^ hover-line: 8     blk: T.proc.returns(T.type_parameter(:U))
+    #     ^ hover-line: 9   )
+    #     ^ hover-line: 10   .returns(T.type_parameter(:U))
+    #     ^ hover-line: 11 end
+    #     ^ hover-line: 12 def foo(&blk); end
+    #     ^ hover-line: 14 # result type:
+    #     ^ hover-line: 15 IFoo
+    ""
+  }
+  T.reveal_type(res) # error: `T.any(String, IFoo)`
+end

--- a/test/testdata/lsp/hover_components.rb
+++ b/test/testdata/lsp/hover_components.rb
@@ -48,7 +48,8 @@ def example_any(x)
     #      ^ hover-line: 15 IFoo
     ""
   }
-  T.reveal_type(res) # error: `T.any(String, IFoo)`
+  # WRONG!
+  T.reveal_type(res) # error: `IFoo`
 end
 
 sig { params(x: T.all(A, B)).void }
@@ -69,5 +70,6 @@ def example_all(x)
     #     ^ hover-line: 15 IFoo
     ""
   }
-  T.reveal_type(res) # error: `T.any(String, IFoo)`
+  # WRONG!
+  T.reveal_type(res) # error: `IFoo`
 end

--- a/test/testdata/lsp/hover_constraint.rb
+++ b/test/testdata/lsp/hover_constraint.rb
@@ -1,0 +1,27 @@
+# typed: strict
+extend T::Sig
+
+sig { params(x: T.any(T::Array[Integer], T::Hash[String, Symbol])).void }
+def example(x)
+  x.map do |elem|
+    #^ hover-line: 2 # Array#map:
+    #^ hover-line: 3 sig do
+    #^ hover-line: 4   params(
+    #^ hover-line: 5     blk: T.proc.params(arg0: Integer).returns(T.type_parameter(:U))
+    #^ hover-line: 6   )
+    #^ hover-line: 7   .returns(T::Array[T.type_parameter(:U)])
+    #^ hover-line: 8 end
+    #^ hover-line: 9 def map(&blk); end
+    #^ hover-line: 10 # Enumerable#map:
+    #^ hover-line: 11 sig do
+    #^ hover-line: 12   params(
+    #^ hover-line: 13     blk: T.proc.params(arg0: [String, Symbol]).returns(T.type_parameter(:U))
+    #^ hover-line: 14   )
+    #^ hover-line: 15   .returns(T::Array[T.type_parameter(:U)])
+    #^ hover-line: 16 end
+    #^ hover-line: 17 def map(&blk); end
+    #^ hover-line: 19 # result type:
+    #^ hover-line: 20 T::Array[T.any(Integer, [String, Symbol])]
+    T.reveal_type(elem) # error: `T.any(Integer, [String, Symbol])`
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #8195
Fixes #4150

At first, I was about to fix the problem in #8195 by way of making Sorbet do the
"right" thing--the problem on master is that Sorbet uses a `TypeConstraint` to
`instantiate` a `TypePtr` but that `TypeConstraint` only makes sense for the
type in one of the components of the `DispatchResult`, not the `returnType` of
the whole `DispatchResult`.

But as I got further along, I started to think that showing the instantiated
types in the hover result is not actually that useful. It causes problems like
#4150 where the hover results are confusing, and also makes it hard to figure
out whether/how to change a call to a generic method (because you can't see
which parameters are concrete and which parameters are type vars that have
simply been instantiated for this call).

I went down a rabbit hole trying to solve all problems with `DispatchResults` in this PR but ran out of time on my timebox. I've opened issues for most of the problems I'm punting on.

### Commit summary

- **prework: Add a test** (e9d37568fe)

  This case was not covered (I noticed that one of my tests did not break 
  CI).

- **Don't instantiate the resultType** (2a16177e1d)


- **Stop replacing T.self_type and T.type_parameter** (bcff297f9a)


- **no-op: Remove now-unused constraint from getResultType** (471e5f51e5)


- **no-op: Formatting** (6e98ea2b38)


- **no-op: Also remove it from prettyTypeForMethod** (8543ce5247)


- **no-op: Formatting** (7631f378c8)


- **Always use the resultType from the MethodRef** (8df52eff4d)

  ... never uses the resultType from a DispatchResult. The one on the 
  DispatchResult might have certain generics instantiated (e.g., if the 
  call to the method was generic and the method does not take a block, 
  then it will have had its generics instantiated).

- **no-op: Remove now-unused retType from prettyTypeForMethod** (7417f492a4)


- **Update the tests that change** (8a6d0a5b17)


- **Add a test for T.self_type; tweak printing** (323296d7ef)


- **Add `# result type:` comment on hover for sends** (70f54a2a8a)


- **Show full method name in comment above each def** (8bfb1026d0)

  Makes it easier to see how union types are inferred.

- **Put SolveConstraint result into shared DispatchResult** (b78f4ff078)


- **Update the tests that change** (0f309aa8a9)


- **Add a test** (744b7d0b79)

  This test previously crashed because we would look for one of the type 
  parameters in the constraint for the wrong `DispatchComponent`.

  By not using the constraints in the hover results anymore, we sidestep 
  this problem entirely.

  Fixes #8195

- **Add some more tests** (99571fab5b)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] Update tests
- [x] Write new tests for uncovered things
- [x] Write tests for any issues you think this fixes
- [x] Figure out what to do about the case when `returnType` is not solved,
  because we're waiting to see the `SolveConstraint` node after handling the
  block.