### PR TITLE
Parse strict_dependencies in __package.rb

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -649,8 +649,9 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::exportAll()).build();
     ENFORCE_NO_TIMER(method == Symbols::PackageSpec_export_all());
 
-    method =
-        enterMethod(*this, Symbols::PackageSpecSingleton(), Names::strictDependencies()).arg(Names::arg0()).build();
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::strictDependencies())
+                 .typedArg(Names::arg0(), Types::String())
+                 .build();
     ENFORCE_NO_TIMER(method == Symbols::PackageSpec_strict_dependencies());
 
     // Magic classes for special proc bindings

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -649,6 +649,10 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::exportAll()).build();
     ENFORCE_NO_TIMER(method == Symbols::PackageSpec_export_all());
 
+    method =
+        enterMethod(*this, Symbols::PackageSpecSingleton(), Names::strictDependencies()).arg(Names::arg0()).build();
+    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_strict_dependencies());
+
     // Magic classes for special proc bindings
     klass = enterClassSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::BindToAttachedClass());
     ENFORCE_NO_TIMER(klass == Symbols::MagicBindToAttachedClass());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1061,6 +1061,10 @@ public:
         return MethodRef::fromRaw(18);
     }
 
+    static MethodRef PackageSpec_strict_dependencies() {
+        return MethodRef::fromRaw(19);
+    }
+
     static ClassOrModuleRef MagicBindToAttachedClass() {
         return ClassOrModuleRef::fromRaw(90);
     }
@@ -1086,11 +1090,11 @@ public:
     }
 
     static MethodRef T_Generic_squareBrackets() {
-        return MethodRef::fromRaw(19);
+        return MethodRef::fromRaw(20);
     }
 
     static MethodRef Kernel_lambda() {
-        return MethodRef::fromRaw(20);
+        return MethodRef::fromRaw(21);
     }
 
     static TypeArgumentRef Kernel_lambda_returnType() {
@@ -1098,11 +1102,11 @@ public:
     }
 
     static MethodRef Kernel_lambdaTLet() {
-        return MethodRef::fromRaw(21);
+        return MethodRef::fromRaw(22);
     }
 
     static MethodRef Kernel_proc() {
-        return MethodRef::fromRaw(22);
+        return MethodRef::fromRaw(23);
     }
 
     static TypeArgumentRef Kernel_proc_returnType() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,7 +23,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 56;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 57;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 6;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 71;

--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -28,5 +28,6 @@ constexpr ErrorClass UsedTestOnlyName{3720, StrictLevel::False};
 constexpr ErrorClass InvalidExport{3721, StrictLevel::False};
 // constexpr ErrorClass ExportingTypeAlias{3722, StrictLevel::False};
 constexpr ErrorClass ImportNotVisible{3723, StrictLevel::False};
+constexpr ErrorClass InvalidStrictDependencies{3724, StrictLevel::False};
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -27,6 +27,13 @@ enum class VisibleToType {
     Wildcard,
 };
 
+enum class StrictDependenciesLevel {
+    False,
+    Layered,
+    LayeredDag,
+    Dag,
+};
+
 struct VisibleTo {
     std::vector<core::NameRef> packageName;
     VisibleToType visibleToType;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -462,6 +462,11 @@ NameDef names[] = {
     {"visibleTo", "visible_to"},
     {"tests"},
     {"exportAll", "export_all!"},
+    {"strictDependencies", "strict_dependencies"},
+    {"false_", "false"},
+    {"layered"},
+    {"layeredDag", "layered_dag"},
+    {"dag"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageSpecRegistry", "<PackageSpecRegistry>", true},
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1260,11 +1260,11 @@ struct PackageSpecBodyWalk {
 
 private:
     optional<core::packages::StrictDependenciesLevel> parseStrictDependenciesOption(ast::ExpressionPtr &arg) {
-        auto value_ = ast::cast_tree<ast::Literal>(arg);
-        if (!value_ || !value_->isString()) {
+        auto *lit = ast::cast_tree<ast::Literal>(arg);
+        if (!lit || !lit->isString()) {
             return nullopt;
         }
-        auto value = value_->asString();
+        auto value = lit->asString();
 
         if (value == core::Names::false_()) {
             return core::packages::StrictDependenciesLevel::False;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1121,7 +1121,7 @@ struct PackageSpecBodyWalk {
                     info.strictDependenciesLevel = make_pair(parsedValue.value(), send.getPosArg(0).loc());
                 } else {
                     if (auto e = ctx.beginError(send.argsLoc(), core::errors::Packager::InvalidStrictDependencies)) {
-                        e.setHeader("Argument to `{}` must be one of: `{}`, `{}`, `{}` or `{}`", send.fun.show(ctx),
+                        e.setHeader("Argument to `{}` must be one of: `{}`, `{}`, `{}`, or `{}`", send.fun.show(ctx),
                                     "'false'", "'layered'", "'layered_dag'", "'dag'");
                     }
                 }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1366,7 +1366,7 @@ void rewritePackageSpec(const core::GlobalState &gs, ast::ParsedFile &package, P
     PackageSpecBodyWalk bodyWalk(info);
     core::Context ctx(gs, core::Symbols::root(), package.file);
     ast::TreeWalk::apply(ctx, bodyWalk, package.tree);
-    if (!info.strictDependenciesLevel) {
+    if (!info.strictDependenciesLevel.has_value()) {
         info.strictDependenciesLevel = core::packages::StrictDependenciesLevel::False;
     }
     bodyWalk.finalize(ctx);

--- a/test/testdata/packager/strict_dependencies/block/__package.rb
+++ b/test/testdata/packager/strict_dependencies/block/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Block < PackageSpec
+  strict_dependencies 'false' do end # error: Invalid expression in package: `Block` not allowed
+end

--- a/test/testdata/packager/strict_dependencies/invalid_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/invalid_option/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class InvalidOption < PackageSpec
+  strict_dependencies 'true' # error: Argument to `strict_dependencies` must be one of: `'false'`, `'layered'`, `'layered_dag'` or `'dag'`
+end

--- a/test/testdata/packager/strict_dependencies/invalid_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/invalid_option/__package.rb
@@ -3,5 +3,5 @@
 # enable-packager: true
 
 class InvalidOption < PackageSpec
-  strict_dependencies 'true' # error: Argument to `strict_dependencies` must be one of: `'false'`, `'layered'`, `'layered_dag'` or `'dag'`
+  strict_dependencies 'true' # error: Argument to `strict_dependencies` must be one of: `'false'`, `'layered'`, `'layered_dag'`, or `'dag'`
 end

--- a/test/testdata/packager/strict_dependencies/keyword_arg/__package.rb
+++ b/test/testdata/packager/strict_dependencies/keyword_arg/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class KeywordArg < PackageSpec
+  strict_dependencies(level: 'false') # error: Expected `String` but found `{level: String("false")}` for argument `arg0`
+end

--- a/test/testdata/packager/strict_dependencies/missing/__package.rb
+++ b/test/testdata/packager/strict_dependencies/missing/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Missing < PackageSpec
+end

--- a/test/testdata/packager/strict_dependencies/non_string_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/non_string_option/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class NonStringOption < PackageSpec
+  strict_dependencies false # error: Argument to `strict_dependencies` must be one of: `'false'`, `'layered'`, `'layered_dag'`, or `'dag'`
+#                     ^^^^^ error: Expected `String` but found `FalseClass` for argument `arg0`
+end

--- a/test/testdata/packager/strict_dependencies/repeated/__package.rb
+++ b/test/testdata/packager/strict_dependencies/repeated/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Repeated < PackageSpec
+  strict_dependencies 'false'
+  strict_dependencies 'false' # error: Repeated declaration of `strict_dependencies`
+end

--- a/test/testdata/packager/strict_dependencies/too_few_args/__package.rb
+++ b/test/testdata/packager/strict_dependencies/too_few_args/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class TooFewArgs < PackageSpec
+  strict_dependencies # error: Not enough arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `0`
+end

--- a/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
+++ b/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
@@ -3,5 +3,5 @@
 # enable-packager: true
 
 class TooManyArgs < PackageSpec
-  strict_dependencies 'true', 'false' # error: Too many arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `2`
+  strict_dependencies 'false', 'true' # error: Too many arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `2`
 end

--- a/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
+++ b/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class TooManyArgs < PackageSpec
+  strict_dependencies 'true', 'false' # error: Too many arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `2`
+end

--- a/test/testdata/packager/strict_dependencies/valid_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/valid_option/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class ValidOption < PackageSpec
+  strict_dependencies 'false'
+end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -862,6 +862,10 @@ you're sure that it should be okay to import this package, then you can add an
 additional `visible_to` directive in order to allow the import you're trying to
 add.
 
+## 3724
+
+> **TODO** This error code is not yet documented.
+
 ## 4001
 
 Sorbet parses the syntax of `include` and `extend` declarations, even in

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -864,7 +864,25 @@ add.
 
 ## 3724
 
-> **TODO** This error code is not yet documented.
+> This error is specific to Stripe's custom `--stripe-packages` mode. If you are
+> at Stripe, please see [go/modularity](http://go/modularity) and
+> [go/strict-dependencies](http://go/strict-dependencies) for more.
+
+All packages have a `strict_dependencies` level, which controls what
+restrictions are applied on imported packages.
+
+```ruby
+class MyPackage < PackageSpec
+  strict_dependencies 'false'
+end
+```
+
+The 4 possible values are:
+
+- `'false'`: No restrictions are placed on dependencies.
+- `'layered'`
+- `'layered_dag'`
+- `'dag'`
 
 ## 4001
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR parses, performs basic validation on, and stores the `strict_dependencies` option in `__package.rb` files. It does not actually validate whether the package is conforming to the strictness level being declared. That will be implemented in a future PR.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Implement more of the packaging system in Sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
