### PR TITLE
sendTp -> returnTypeBeforeSolve

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1734,6 +1734,13 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
                                           args.enclosingMethodForSuper};
             auto original = wrapped.dispatchCall(gs, innerArgs);
             original.returnType = wrapped;
+            // We want this to behave as if MetaType::dispatchCall were an Intrinsic--in an
+            // intrinsic, all you have to do is set `returnType` and it will be used used for the
+            // `sendTp` too.
+            //
+            // This technically only matters if the method call site has a block and the
+            // `initialize` method we dispatch to has a `T.type_parameter` in its `.returns`, which
+            // can't happen but we handle it anyways for robustness.
             original.main.sendTp = wrapped;
             return original;
         }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2212,8 +2212,6 @@ public:
             }
             res.main = move(dispatched.main);
         }
-
-        res.main.sendTp = instanceTy;
     }
 } Class_new;
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1148,12 +1148,14 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 if (send.link) {
                     // This should eventually become ENFORCEs but currently they are wrong
                     if (!retainedResult->main.blockReturnType) {
+                        // TODO(jez) This only looks at the main component!
                         retainedResult->main.blockReturnType = core::Types::untyped(retainedResult->main.method);
                     }
                     if (!retainedResult->main.blockPreType) {
+                        // TODO(jez) This only looks at the main component!
                         retainedResult->main.blockPreType = core::Types::untyped(retainedResult->main.method);
                     }
-                    ENFORCE(retainedResult->main.sendTp);
+                    ENFORCE(retainedResult->main.returnTypeBeforeSolve);
                 }
 
                 // For `case x; when X ...`, desugar produces `X.===(x)`, but with
@@ -1284,7 +1286,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         }
                         type = core::Types::untypedUntracked();
                     } else {
-                        type = core::Types::instantiate(ctx, main.sendTp, *main.constr);
+                        type = core::Types::instantiate(ctx, main.returnTypeBeforeSolve, *main.constr);
                     }
                 } else {
                     type = i.link->result->returnType;

--- a/test/testdata/infer/meta_type_return_type_before_solve.rb
+++ b/test/testdata/infer/meta_type_return_type_before_solve.rb
@@ -16,7 +16,7 @@ T.reveal_type(xs) # error: `T::Array[Integer]`
 
 # Combination of "passed a block" and "initialize has type_parameters" means
 # that the SolveConstraint will attempt to solve and instantiate the return
-# type if we did not set sendTp directly to a type that does not have any
-# T.type_parameter in it.
+# type if we did not set returnTypeBeforeSolve directly to a type that does not
+# have any T.type_parameter in it.
 xs = T::Array[Integer].new("") {}
 T.reveal_type(xs) # error: `T::Array[Integer]`

--- a/test/testdata/infer/send_tp.rb
+++ b/test/testdata/infer/send_tp.rb
@@ -1,0 +1,22 @@
+# typed: true
+class Array
+  T::Sig::WithoutRuntime.sig {
+    type_parameters(:U)
+      .params(x: T.type_parameter(:U))
+      .returns(T.type_parameter(:U))
+    #  ^^^^^^^ error: The initialize method should always return void
+  }
+  def initialize(x) # error: redefined without matching
+    x
+  end
+end
+
+xs = T::Array[Integer].new("")
+T.reveal_type(xs) # error: `T::Array[Integer]`
+
+# Combination of "passed a block" and "initialize has type_parameters" means
+# that the SolveConstraint will attempt to solve and instantiate the return
+# type if we did not set sendTp directly to a type that does not have any
+# T.type_parameter in it.
+xs = T::Array[Integer].new("") {}
+T.reveal_type(xs) # error: `T::Array[Integer]`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Just found the old name a little weird.

In the process of trying to figure out what `sendTp` meant, I figured out a
better name for it, and figured I'd use that name and add some comments.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.