### PR TITLE
Remove rubyRegionId

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -31,17 +31,11 @@ int CFG::numLocalVariables() const {
     return this->localVariables.size();
 }
 
-BasicBlock *CFG::freshBlock(int outerLoops, BasicBlock *current) {
-    ENFORCE(current != nullptr);
-    return this->freshBlockWithRegion(outerLoops, current->rubyRegionId);
-}
-
-BasicBlock *CFG::freshBlockWithRegion(int outerLoops, int rubyRegionId) {
+BasicBlock *CFG::freshBlock(int outerLoops) {
     int id = this->maxBasicBlockId++;
     auto &r = this->basicBlocks.emplace_back(make_unique<BasicBlock>());
     r->id = id;
     r->outerLoops = outerLoops;
-    r->rubyRegionId = rubyRegionId;
     return r.get();
 }
 
@@ -69,8 +63,8 @@ LocalRef CFG::enterLocal(core::LocalVariable variable) {
 }
 
 CFG::CFG() {
-    freshBlockWithRegion(0, 0); // entry;
-    freshBlockWithRegion(0, 0); // dead code;
+    freshBlock(0); // entry;
+    freshBlock(0); // dead code;
     deadBlock()->bexit.elseb = deadBlock();
     deadBlock()->bexit.thenb = deadBlock();
     deadBlock()->bexit.cond.variable = LocalRef::unconditional();

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -253,8 +253,7 @@ string CFG::toTextualString(const core::GlobalState &gs) const {
         if (!basicBlock->backEdges.empty()) {
             fmt::format_to(std::back_inserter(buf), "# backedges\n");
             for (auto *backEdge : basicBlock->backEdges) {
-                fmt::format_to(std::back_inserter(buf), "# - bb{}(rubyRegionId={})\n", backEdge->id,
-                               backEdge->rubyRegionId);
+                fmt::format_to(std::back_inserter(buf), "# - bb{}\n", backEdge->id);
             }
         }
 
@@ -359,7 +358,7 @@ optional<BasicBlock::BlockExitCondInfo> BasicBlock::maybeGetUpdateKnowledgeRecei
 
 string BasicBlock::toString(const core::GlobalState &gs, const CFG &cfg) const {
     fmt::memory_buffer buf;
-    fmt::format_to(std::back_inserter(buf), "block[id={}, rubyRegionId={}]({})\n", this->id, this->rubyRegionId,
+    fmt::format_to(std::back_inserter(buf), "block[id={}]({})\n", this->id,
                    fmt::map_join(
                        this->args, ", ", [&](const auto &arg) -> auto{ return arg.toString(gs, cfg); }));
 
@@ -375,8 +374,7 @@ string BasicBlock::toString(const core::GlobalState &gs, const CFG &cfg) const {
 
 string BasicBlock::toTextualString(const core::GlobalState &gs, const CFG &cfg) const {
     fmt::memory_buffer buf;
-    fmt::format_to(std::back_inserter(buf), "bb{}[rubyRegionId={}, firstDead={}]({}):\n", this->id, this->rubyRegionId,
-                   this->firstDeadInstructionIdx,
+    fmt::format_to(std::back_inserter(buf), "bb{}[firstDead={}]({}):\n", this->id, this->firstDeadInstructionIdx,
                    fmt::map_join(
                        this->args, ", ", [&](const auto &arg) -> auto{ return arg.toString(gs, cfg); }));
 

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -63,14 +63,6 @@ public:
     };
     Flags flags;
     int outerLoops = 0;
-    // Tracks which Ruby block (do ... end) or Ruby exception-handling region
-    // (in begin ... rescue ... else ... ensure ... end, each `...` is its own
-    // region) this BasicBlock was generated from.  We call it a "region" to
-    // avoid confusion between BasicBlocks and Ruby blocks.
-    //
-    // Incremented every time builder_walk sees a new Ruby block while traversing a Ruby method.
-    // rubyRegionId == 0 means code at the top-level of this method (outside any Ruby block).
-    int rubyRegionId = 0;
     int firstDeadInstructionIdx = -1;
     std::vector<Binding> exprs;
     BlockExit bexit;
@@ -124,7 +116,6 @@ public:
      */
     core::MethodRef symbol;
     int maxBasicBlockId = 0;
-    int maxRubyRegionId = 0;
 
     /**
      * Get the number of unique local variables in the CFG. Used to size vectors that contain an entry per LocalRef.
@@ -192,8 +183,7 @@ public:
 
 private:
     CFG();
-    BasicBlock *freshBlock(int outerLoops, BasicBlock *current);
-    BasicBlock *freshBlockWithRegion(int outerLoops, int rubyRegionId);
+    BasicBlock *freshBlock(int outerLoops);
     void enterLocalInternal(core::LocalVariable variable, LocalRef &ref);
     std::vector<int> minLoops;
     std::vector<int> maxLoopWrite;

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -45,8 +45,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 // Remove condition from unconditional jumps
                 bb->bexit.cond = LocalRef::unconditional();
             }
-            if (thenb == elseb && thenb != cfg.deadBlock() && thenb != bb &&
-                bb->rubyRegionId == thenb->rubyRegionId) { // can be squashed together
+            if (thenb == elseb && thenb != cfg.deadBlock() && thenb != bb) { // can be squashed together
                 if (thenb->backEdges.size() == 1 && thenb->outerLoops == bb->outerLoops) {
                     bb->exprs.insert(bb->exprs.end(), make_move_iterator(thenb->exprs.begin()),
                                      make_move_iterator(thenb->exprs.end()));
@@ -79,8 +78,8 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                     continue;
                 }
             }
-            if (thenb != cfg.deadBlock() && bb->rubyRegionId == thenb->rubyRegionId && thenb->exprs.empty() &&
-                thenb->bexit.thenb == thenb->bexit.elseb && bb->bexit.thenb != thenb->bexit.thenb) {
+            if (thenb != cfg.deadBlock() && thenb->exprs.empty() && thenb->bexit.thenb == thenb->bexit.elseb &&
+                bb->bexit.thenb != thenb->bexit.thenb) {
                 // shortcut then
                 bb->bexit.thenb = thenb->bexit.thenb;
                 thenb->bexit.thenb->backEdges.emplace_back(bb);
@@ -90,8 +89,8 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 sanityCheck(ctx, cfg);
                 continue;
             }
-            if (elseb != cfg.deadBlock() && bb->rubyRegionId == thenb->rubyRegionId && elseb->exprs.empty() &&
-                elseb->bexit.thenb == elseb->bexit.elseb && bb->bexit.elseb != elseb->bexit.elseb) {
+            if (elseb != cfg.deadBlock() && elseb->exprs.empty() && elseb->bexit.thenb == elseb->bexit.elseb &&
+                bb->bexit.elseb != elseb->bexit.elseb) {
                 // shortcut else
                 sanityCheck(ctx, cfg);
                 bb->bexit.elseb = elseb->bexit.elseb;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -266,7 +266,7 @@ BasicBlock *CFGBuilder::walkBlockReturn(CFGContext cctx, core::LocOffsets loc, a
 }
 
 BasicBlock *CFGBuilder::joinBlocks(CFGContext cctx, BasicBlock *a, BasicBlock *b) {
-    auto *join = cctx.inWhat.freshBlock(cctx.loops, a);
+    auto *join = cctx.inWhat.freshBlock(cctx.loops);
     unconditionalJump(a, join, cctx.inWhat, core::LocOffsets::none());
     unconditionalJump(b, join, cctx.inWhat, core::LocOffsets::none());
     return join;
@@ -278,8 +278,8 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
                                                                     BasicBlock *presentCont, BasicBlock *defaultCont) {
     auto defLoc = def.loc();
 
-    auto *presentNext = cctx.inWhat.freshBlock(cctx.loops, presentCont);
-    auto *defaultNext = cctx.inWhat.freshBlock(cctx.loops, presentCont);
+    auto *presentNext = cctx.inWhat.freshBlock(cctx.loops);
+    auto *defaultNext = cctx.inWhat.freshBlock(cctx.loops);
 
     auto present = cctx.newTemporary(core::Names::argPresent());
     auto methodSymbol = cctx.inWhat.symbol;
@@ -321,17 +321,17 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
         typecase(
             what,
             [&](ast::While &a) {
-                auto headerBlock = cctx.inWhat.freshBlock(cctx.loops + 1, current);
+                auto headerBlock = cctx.inWhat.freshBlock(cctx.loops + 1);
                 // breakNotCalledBlock is only entered if break is not called in
                 // the loop body
-                auto breakNotCalledBlock = cctx.inWhat.freshBlock(cctx.loops, current);
-                auto continueBlock = cctx.inWhat.freshBlock(cctx.loops, current);
+                auto breakNotCalledBlock = cctx.inWhat.freshBlock(cctx.loops);
+                auto continueBlock = cctx.inWhat.freshBlock(cctx.loops);
                 unconditionalJump(current, headerBlock, cctx.inWhat, a.loc);
 
                 LocalRef condSym = cctx.newTemporary(core::Names::whileTemp());
                 auto headerEnd =
                     walk(cctx.withTarget(condSym).withLoopScope(headerBlock, continueBlock), a.cond, headerBlock);
-                auto bodyBlock = cctx.inWhat.freshBlock(cctx.loops + 1, current);
+                auto bodyBlock = cctx.inWhat.freshBlock(cctx.loops + 1);
                 conditionalJump(headerEnd, condSym, bodyBlock, breakNotCalledBlock, cctx.inWhat, a.cond.loc());
                 // finishHeader
                 LocalRef bodySym = cctx.newTemporary(core::Names::statTemp());
@@ -381,8 +381,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 LocalRef ifSym = cctx.newTemporary(core::Names::ifTemp());
                 ENFORCE(ifSym.exists(), "ifSym does not exist");
                 auto cont = walk(cctx.withTarget(ifSym), a.cond, current);
-                auto thenBlock = cctx.inWhat.freshBlock(cctx.loops, current);
-                auto elseBlock = cctx.inWhat.freshBlock(cctx.loops, current);
+                auto thenBlock = cctx.inWhat.freshBlock(cctx.loops);
+                auto elseBlock = cctx.inWhat.freshBlock(cctx.loops);
                 conditionalJump(cont, ifSym, thenBlock, elseBlock, cctx.inWhat, a.cond.loc());
 
                 auto thenEnd = walk(cctx, a.thenp, thenBlock);
@@ -393,7 +393,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     } else if (elseEnd == cctx.inWhat.deadBlock()) {
                         ret = thenEnd;
                     } else {
-                        ret = cctx.inWhat.freshBlock(cctx.loops, current);
+                        ret = cctx.inWhat.freshBlock(cctx.loops);
                         unconditionalJump(thenEnd, ret, cctx.inWhat, a.loc);
                         unconditionalJump(elseEnd, ret, cctx.inWhat, a.loc);
                     }
@@ -594,14 +594,13 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 }
 
                 if (auto *block = s.block()) {
-                    auto newRubyRegionId = ++cctx.inWhat.maxRubyRegionId;
                     auto &blockArgs = block->args;
                     vector<core::ParsedArg> blockArgFlags = ast::ArgParsing::parseArgs(blockArgs);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgFlags) {
                         argFlags.emplace_back(e.flags);
                     }
-                    auto link = make_shared<core::SendAndBlockLink>(s.fun, move(argFlags), newRubyRegionId);
+                    auto link = make_shared<core::SendAndBlockLink>(s.fun, move(argFlags));
                     auto send = make_insn<Send>(recv, s.recv.loc(), s.fun, s.funLoc, s.numPosArgs(), args,
                                                 std::move(argLocs), !!s.flags.isPrivateOk, link);
                     LocalRef sendTemp = cctx.newTemporary(core::Names::blockPreCallTemp());
@@ -611,13 +610,13 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     synthesizeExpr(current, restoreSelf, core::LocOffsets::none(),
                                    make_insn<Ident>(LocalRef::selfVariable()));
 
-                    auto headerBlock = cctx.inWhat.freshBlockWithRegion(cctx.loops + 1, newRubyRegionId);
+                    auto headerBlock = cctx.inWhat.freshBlock(cctx.loops + 1);
                     // solveConstraintBlock is only entered if break is not called
                     // in the block body.
-                    auto solveConstraintBlock = cctx.inWhat.freshBlock(cctx.loops, current);
-                    auto postBlock = cctx.inWhat.freshBlock(cctx.loops, current);
+                    auto solveConstraintBlock = cctx.inWhat.freshBlock(cctx.loops);
+                    auto postBlock = cctx.inWhat.freshBlock(cctx.loops);
                     auto bodyLoops = cctx.loops + 1;
-                    auto bodyBlock = cctx.inWhat.freshBlockWithRegion(bodyLoops, newRubyRegionId);
+                    auto bodyBlock = cctx.inWhat.freshBlock(bodyLoops);
 
                     bodyBlock->exprs.emplace_back(LocalRef::selfVariable(), s.loc,
                                                   make_insn<LoadSelf>(link, LocalRef::selfVariable()));
@@ -641,8 +640,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                             }
 
                             if (auto *opt = ast::cast_tree<ast::OptionalArg>(blockArgs[i])) {
-                                auto *presentBlock = cctx.inWhat.freshBlockWithRegion(bodyLoops, newRubyRegionId);
-                                auto *missingBlock = cctx.inWhat.freshBlockWithRegion(bodyLoops, newRubyRegionId);
+                                auto *presentBlock = cctx.inWhat.freshBlock(bodyLoops);
+                                auto *missingBlock = cctx.inWhat.freshBlock(bodyLoops);
 
                                 // add a test for YieldParamPresent
                                 auto present = cctx.newTemporary(core::Names::argPresent());
@@ -651,7 +650,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                                 conditionalJump(argBlock, present, presentBlock, missingBlock, cctx.inWhat, arg.loc);
 
                                 // make a new block for the present and missing blocks to join
-                                argBlock = cctx.inWhat.freshBlockWithRegion(bodyLoops, newRubyRegionId);
+                                argBlock = cctx.inWhat.freshBlock(bodyLoops);
 
                                 // compile the argument fetch in the present block
                                 presentBlock->exprs.emplace_back(argLoc, arg.loc,
@@ -822,13 +821,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             },
 
             [&](ast::Rescue &a) {
-                auto bodyRubyRegionId = ++cctx.inWhat.maxRubyRegionId;
-                auto handlersRubyRegionId = bodyRubyRegionId + CFG::HANDLERS_REGION_OFFSET;
-                auto ensureRubyRegionId = bodyRubyRegionId + CFG::ENSURE_REGION_OFFSET;
-                auto elseRubyRegionId = bodyRubyRegionId + CFG::ELSE_REGION_OFFSET;
-                cctx.inWhat.maxRubyRegionId = elseRubyRegionId;
-
-                auto rescueHeaderBlock = cctx.inWhat.freshBlock(cctx.loops, current);
+                auto rescueHeaderBlock = cctx.inWhat.freshBlock(cctx.loops);
                 unconditionalJump(current, rescueHeaderBlock, cctx.inWhat, a.loc);
                 cctx.rescueScope = rescueHeaderBlock;
 
@@ -840,8 +833,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 // Unanalyzable variable at the top of the body using
                 // `exceptionValue` and one at the end of the else using
                 // `rescueEndTemp` which can jump into the rescue handlers.
-                auto rescueHandlersBlock = cctx.inWhat.freshBlockWithRegion(cctx.loops, handlersRubyRegionId);
-                auto bodyBlock = cctx.inWhat.freshBlockWithRegion(cctx.loops, bodyRubyRegionId);
+                auto rescueHandlersBlock = cctx.inWhat.freshBlock(cctx.loops);
+                auto bodyBlock = cctx.inWhat.freshBlock(cctx.loops);
                 auto exceptionValue = cctx.newTemporary(core::Names::exceptionValue());
                 // In `rescue; ...; end`, we don't want the conditional jumps' variables nor the
                 // GetCurrentException calls to look like they blame to the whole `rescue; ...; end`
@@ -862,13 +855,13 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 bodyBlock = walk(cctx, a.body, bodyBlock);
 
                 // else is only executed if body didn't raise an exception
-                auto elseBody = cctx.inWhat.freshBlockWithRegion(cctx.loops, elseRubyRegionId);
+                auto elseBody = cctx.inWhat.freshBlock(cctx.loops);
                 synthesizeExpr(bodyBlock, exceptionValue, rescueKeywordLoc, make_insn<GetCurrentException>());
                 conditionalJump(bodyBlock, exceptionValue, rescueHandlersBlock, elseBody, cctx.inWhat,
                                 rescueKeywordLoc);
 
                 elseBody = walk(cctx, a.else_, elseBody);
-                auto ensureBody = cctx.inWhat.freshBlockWithRegion(cctx.loops, ensureRubyRegionId);
+                auto ensureBody = cctx.inWhat.freshBlock(cctx.loops);
                 unconditionalJump(elseBody, ensureBody, cctx.inWhat, a.loc);
 
                 auto magic = cctx.newTemporary(core::Names::magic());
@@ -876,7 +869,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
                 for (auto &expr : a.rescueCases) {
                     auto *rescueCase = ast::cast_tree<ast::RescueCase>(expr);
-                    auto caseBody = cctx.inWhat.freshBlockWithRegion(cctx.loops, handlersRubyRegionId);
+                    auto caseBody = cctx.inWhat.freshBlock(cctx.loops);
                     auto &exceptions = rescueCase->exceptions;
                     auto added = false;
                     auto *local = ast::cast_tree<ast::Local>(rescueCase->var);
@@ -931,7 +924,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                             make_insn<Send>(exceptionClass, loc, core::Names::tripleEq(), loc.copyWithZeroLength(),
                                             args.size(), args, std::move(argLocs), isPrivateOk));
 
-                        auto otherHandlerBlock = cctx.inWhat.freshBlockWithRegion(cctx.loops, handlersRubyRegionId);
+                        auto otherHandlerBlock = cctx.inWhat.freshBlock(cctx.loops);
                         conditionalJump(rescueHandlersBlock, isaCheck, caseBody, otherHandlerBlock, cctx.inWhat, loc);
                         rescueHandlersBlock = otherHandlerBlock;
                     }
@@ -952,7 +945,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
                 auto throwAway = cctx.newTemporary(core::Names::throwAwayTemp());
                 ensureBody = walk(cctx.withTarget(throwAway), a.ensure, ensureBody);
-                ret = cctx.inWhat.freshBlock(cctx.loops, current);
+                ret = cctx.inWhat.freshBlock(cctx.loops);
                 conditionalJump(ensureBody, gotoDeadTemp, cctx.inWhat.deadBlock(), ret, cctx.inWhat, a.loc);
             },
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -932,10 +932,9 @@ public:
     SendAndBlockLink(SendAndBlockLink &&) = default;
     std::vector<ArgInfo::ArgFlags> argFlags;
     core::NameRef fun;
-    int rubyRegionId;
     std::shared_ptr<DispatchResult> result;
 
-    SendAndBlockLink(NameRef fun, std::vector<ArgInfo::ArgFlags> &&argFlags, int rubyRegionId);
+    SendAndBlockLink(NameRef fun, std::vector<ArgInfo::ArgFlags> &&argFlags);
     std::optional<int> fixedArity() const;
     std::shared_ptr<SendAndBlockLink> duplicate();
 };

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2759,7 +2759,7 @@ public:
             Magic_callWithBlock::typeToProc(gs, *args.args[2], args.locs.file, args.locs.call, args.locs.args[2],
                                             args.locs.fun, args.originForUninitialized, args.suppressErrors);
         std::optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
-        auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity), -1);
+        auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity));
         res.main.constr = make_unique<TypeConstraint>();
 
         DispatchArgs innerArgs{fn,
@@ -2874,7 +2874,7 @@ public:
             Magic_callWithBlock::typeToProc(gs, *args.args[4], args.locs.file, args.locs.call, args.locs.args[4],
                                             args.locs.fun, args.originForUninitialized, args.suppressErrors);
         std::optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
-        auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity), -1);
+        auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity));
         res.main.constr = make_unique<TypeConstraint>();
 
         DispatchArgs innerArgs{fn,

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -783,8 +783,8 @@ TypePtr AndType::make_shared(const TypePtr &left, const TypePtr &right) {
     return res;
 }
 
-SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags, int rubyRegionId)
-    : argFlags(move(argFlags)), fun(fun), rubyRegionId(rubyRegionId) {}
+SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags)
+    : argFlags(move(argFlags)), fun(fun) {}
 
 shared_ptr<SendAndBlockLink> SendAndBlockLink::duplicate() {
     auto copy = *this;

--- a/test/cli/phases/test.out
+++ b/test/cli/phases/test.out
@@ -169,14 +169,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_0" [
         shape = cds;
         color = black;
-        label = "block[id=0, rubyRegionId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));\l<returnMethodTemp>$2: Integer(1) = 1\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
+        label = "block[id=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));\l<returnMethodTemp>$2: Integer(1) = 1\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
         shape = parallelogram;
         color = black;
-        label = "block[id=1, rubyRegionId=0]()\l<unconditional>\l"
+        label = "block[id=1]()\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
@@ -216,15 +216,15 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 --- cfg-text start ---
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Integer(1) = 1
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
@@ -277,11 +277,11 @@ class <C <U <root>>> < <C <U Object>> ()
 <   name = EmptyTree
 <   rhs = [
 <   symbol = <C <U <root>>>
-< # - bb0(rubyRegionId=0)
+< # - bb0
 < # backedges
 < ClassDef{
-< bb0[rubyRegionId=0, firstDead=3]():
-< bb1[rubyRegionId=0, firstDead=-1]():
+< bb0[firstDead=3]():
+< bb1[firstDead=-1]():
 < class <emptyTree><<C <root>>> < (::<todo sym>)
 < end
 < method ::<Class:<root>>#<static-init> {

--- a/test/testdata/cfg/array.rb.cfg-text.exp
+++ b/test/testdata/cfg/array.rb.cfg-text.exp
@@ -1,50 +1,50 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestArray#an_int {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: TestArray = cast(<self>: NilClass, TestArray);
     <returnMethodTemp>$2: Integer(0) = 0
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestArray#a_string {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: TestArray = cast(<self>: NilClass, TestArray);
     <returnMethodTemp>$2: String("str") = "str"
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String("str")
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestArray#test_arrays {
 
-bb0[rubyRegionId=0, firstDead=14]():
+bb0[firstDead=14]():
     <self>: TestArray = cast(<self>: NilClass, TestArray);
     <magic>$4: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$3: [] = <magic>$4: T.class_of(<Magic>).<build-array>()
@@ -62,15 +62,15 @@ bb0[rubyRegionId=0, firstDead=14]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:TestArray>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(TestArray) = cast(<self>: NilClass, T.class_of(TestArray));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(TestArray))
@@ -78,20 +78,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray)):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(TestArray) = <selfRestore>$8
     <cfgAlias>$16: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -100,8 +100,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray)):
+# - bb2
+bb5[firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestArray)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$12: T.class_of(Integer) = alias <C Integer>
@@ -110,15 +110,15 @@ bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(TestArray)):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(TestArray)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(TestArray)):
+# - bb6
+bb7[firstDead=6](<block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(TestArray)):
     <statTemp>$14: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$18, sig>
     <self>: T.class_of(TestArray) = <selfRestore>$19
     <cfgAlias>$28: T.class_of(T::Sig) = alias <C Sig>
@@ -128,8 +128,8 @@ bb7[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$18: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(TestArray)):
+# - bb6
+bb9[firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(TestArray)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$23: T.class_of(String) = alias <C String>

--- a/test/testdata/cfg/block_in_deadcode.rb.cfg-text.exp
+++ b/test/testdata/cfg/block_in_deadcode.rb.cfg-text.exp
@@ -1,35 +1,35 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Object.outer()
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb1[rubyRegionId=0, firstDead=-1](<self>):
+# - bb3
+# - bb5
+bb1[firstDead=-1](<self>):
     <statTemp>$9 = <self>
     <block-pre-call-temp>$10 = <statTemp>$9.inner()
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
+# - bb0
+bb2[firstDead=-1](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=3](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
+# - bb2
+bb3[firstDead=3](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, outer>
     <self>: Object = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=2](<self>: Object):
+# - bb2
+bb5[firstDead=2](<self>: Object):
     # outerLoops: 1
     <self>: Object = loadSelf(outer)
     <statTemp>$7: T.noreturn = return <returnTemp>$8: NilClass
@@ -39,15 +39,15 @@ bb5[rubyRegionId=1, firstDead=2](<self>: Object):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/blocks.rb.cfg-text.exp
+++ b/test/testdata/cfg/blocks.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::BlockTest#blockPass {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: BlockTest = cast(<self>: NilClass, BlockTest);
     <statTemp>$4: Integer(1) = 1
     <statTemp>$5: Integer(2) = 2
@@ -24,27 +24,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$7, foo>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=6](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
+# - bb2
+bb5[firstDead=6](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
     # outerLoops: 1
     <self>: BlockTest = loadSelf(foo)
     <blk>$9: T.untyped = load_yield_params(foo)
@@ -58,15 +58,15 @@ bb5[rubyRegionId=1, firstDead=6](<self>: BlockTest, <block-pre-call-temp>$7: Sor
 
 method ::<Class:BlockTest>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(BlockTest) = cast(<self>: NilClass, T.class_of(BlockTest));
     <returnMethodTemp>$2: Symbol(:blockPass) = :blockPass
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:blockPass)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/break.rb.cfg-text.exp
+++ b/test/testdata/cfg/break.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <arrayTemp>$5: Integer(1) = 1
     <arrayTemp>$6: Integer(2) = 2
@@ -11,34 +11,34 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
+# - bb0
+bb2[firstDead=-1](<self>: Object, <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
     target: T::Array[T.noreturn] = Solve<<block-pre-call-temp>$8, map>
     <unconditional> -> bb4
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb4[rubyRegionId=0, firstDead=3](target: T.any(T::Array[T.noreturn], Integer), <selfRestore>$9: Object):
+# - bb3
+# - bb5
+bb4[firstDead=3](target: T.any(T::Array[T.noreturn], Integer), <selfRestore>$9: Object):
     <cfgAlias>$19: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: T.any(T::Array[T.noreturn], Integer) = <cfgAlias>$19: T.class_of(T).reveal_type(target: T.any(T::Array[T.noreturn], Integer))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.any(T::Array[T.noreturn], Integer)
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <selfRestore>$9: Object):
+# - bb2
+bb5[firstDead=-1](<self>: Object, <selfRestore>$9: Object):
     # outerLoops: 1
     <self>: Object = loadSelf(map)
     <blk>$10: [Integer] = load_yield_params(map)
@@ -54,22 +54,22 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <selfRestore>$9: Object):
 
 method ::Object#bar {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: Object = cast(<self>: NilClass, Object);
     <returnMethodTemp>$2: String("foo bar") = "foo bar"
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String("foo bar")
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(<root>))
@@ -77,20 +77,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb20(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb20
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(<root>) = <selfRestore>$8
     <cfgAlias>$29: T.class_of(T::Sig) = alias <C Sig>
@@ -103,8 +103,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=13](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
+# - bb2
+bb5[firstDead=13](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$12: Symbol(:blk) = :blk
@@ -122,22 +122,22 @@ bb5[rubyRegionId=1, firstDead=13](<self>: T.class_of(<root>), <block-pre-call-te
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb11(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(<root>)):
+# - bb3
+# - bb11
+bb6[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(<root>)):
+# - bb6
+bb7[firstDead=-1](<block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(<root>)):
     a: String = Solve<<block-pre-call-temp>$40, bar>
     <unconditional> -> bb8
 
 # backedges
-# - bb7(rubyRegionId=0)
-# - bb10(rubyRegionId=2)
-bb8[rubyRegionId=0, firstDead=-1](a: T.any(String, Integer), <selfRestore>$41: T.class_of(<root>)):
+# - bb7
+# - bb10
+bb8[firstDead=-1](a: T.any(String, Integer), <selfRestore>$41: T.class_of(<root>)):
     <self>: T.class_of(<root>) = <selfRestore>$41
     <cfgAlias>$55: T.class_of(T) = alias <C T>
     <statTemp>$53: T.any(String, Integer) = <cfgAlias>$55: T.class_of(T).reveal_type(a: T.any(String, Integer))
@@ -146,8 +146,8 @@ bb8[rubyRegionId=0, firstDead=-1](a: T.any(String, Integer), <selfRestore>$41: T
     <unconditional> -> bb12
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(<root>)):
+# - bb6
+bb9[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf(bar)
     <blk>$42: [Integer] = load_yield_params(bar)
@@ -157,8 +157,8 @@ bb9[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-te
     <ifTemp>$45 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
-# - bb9(rubyRegionId=2)
-bb10[rubyRegionId=2, firstDead=-1](<selfRestore>$41: T.class_of(<root>)):
+# - bb9
+bb10[firstDead=-1](<selfRestore>$41: T.class_of(<root>)):
     # outerLoops: 1
     <returnTemp>$48: Integer(10) = 10
     <block-break-assign>$49: Integer(10) = <returnTemp>$48
@@ -168,37 +168,37 @@ bb10[rubyRegionId=2, firstDead=-1](<selfRestore>$41: T.class_of(<root>)):
     <unconditional> -> bb8
 
 # backedges
-# - bb9(rubyRegionId=2)
-bb11[rubyRegionId=2, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(<root>)):
+# - bb9
+bb11[firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(<root>)):
     # outerLoops: 1
     <blockReturnTemp>$43: String("test") = "test"
     <blockReturnTemp>$52: T.noreturn = blockreturn<bar> <blockReturnTemp>$43: String("test")
     <unconditional> -> bb6
 
 # backedges
-# - bb8(rubyRegionId=0)
-# - bb17(rubyRegionId=3)
-bb12[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$59: Sorbet::Private::Static::Void, <selfRestore>$60: T.class_of(<root>)):
+# - bb8
+# - bb17
+bb12[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$59: Sorbet::Private::Static::Void, <selfRestore>$60: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb15 : bb13)
 
 # backedges
-# - bb12(rubyRegionId=3)
-bb13[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$59: Sorbet::Private::Static::Void, <selfRestore>$60: T.class_of(<root>)):
+# - bb12
+bb13[firstDead=-1](<block-pre-call-temp>$59: Sorbet::Private::Static::Void, <selfRestore>$60: T.class_of(<root>)):
     b: String = Solve<<block-pre-call-temp>$59, bar>
     <unconditional> -> bb14
 
 # backedges
-# - bb13(rubyRegionId=0)
-# - bb16(rubyRegionId=3)
-bb14[rubyRegionId=0, firstDead=-1](b: T.nilable(String), <selfRestore>$60: T.class_of(<root>)):
+# - bb13
+# - bb16
+bb14[firstDead=-1](b: T.nilable(String), <selfRestore>$60: T.class_of(<root>)):
     <cfgAlias>$74: T.class_of(T) = alias <C T>
     <statTemp>$72: T.nilable(String) = <cfgAlias>$74: T.class_of(T).reveal_type(b: T.nilable(String))
     <unconditional> -> bb18
 
 # backedges
-# - bb12(rubyRegionId=3)
-bb15[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$59: Sorbet::Private::Static::Void, <selfRestore>$60: T.class_of(<root>)):
+# - bb12
+bb15[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$59: Sorbet::Private::Static::Void, <selfRestore>$60: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf(bar)
     <blk>$61: [Integer] = load_yield_params(bar)
@@ -208,8 +208,8 @@ bb15[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-t
     <ifTemp>$64 -> (T::Boolean ? bb16 : bb17)
 
 # backedges
-# - bb15(rubyRegionId=3)
-bb16[rubyRegionId=3, firstDead=-1](<selfRestore>$60: T.class_of(<root>)):
+# - bb15
+bb16[firstDead=-1](<selfRestore>$60: T.class_of(<root>)):
     # outerLoops: 1
     <block-break-assign>$68: NilClass = <returnTemp>$67
     <magic>$69: T.class_of(<Magic>) = alias <C <Magic>>
@@ -218,17 +218,17 @@ bb16[rubyRegionId=3, firstDead=-1](<selfRestore>$60: T.class_of(<root>)):
     <unconditional> -> bb14
 
 # backedges
-# - bb15(rubyRegionId=3)
-bb17[rubyRegionId=3, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$59: Sorbet::Private::Static::Void, <selfRestore>$60: T.class_of(<root>)):
+# - bb15
+bb17[firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$59: Sorbet::Private::Static::Void, <selfRestore>$60: T.class_of(<root>)):
     # outerLoops: 1
     <blockReturnTemp>$62: String("test") = "test"
     <blockReturnTemp>$71: T.noreturn = blockreturn<bar> <blockReturnTemp>$62: String("test")
     <unconditional> -> bb12
 
 # backedges
-# - bb14(rubyRegionId=0)
-# - bb21(rubyRegionId=0)
-bb18[rubyRegionId=0, firstDead=-1]():
+# - bb14
+# - bb21
+bb18[firstDead=-1]():
     # outerLoops: 1
     <statTemp>$79: Integer(1) = 1
     <statTemp>$78: String = <statTemp>$79: Integer(1).to_s()
@@ -237,23 +237,23 @@ bb18[rubyRegionId=0, firstDead=-1]():
     <whileTemp>$77 -> (T::Boolean ? bb21 : bb19)
 
 # backedges
-# - bb18(rubyRegionId=0)
-bb19[rubyRegionId=0, firstDead=-1]():
+# - bb18
+bb19[firstDead=-1]():
     c: NilClass = nil
     <unconditional> -> bb20
 
 # backedges
-# - bb19(rubyRegionId=0)
-# - bb22(rubyRegionId=0)
-bb20[rubyRegionId=0, firstDead=3](c: T.nilable(Symbol)):
+# - bb19
+# - bb22
+bb20[firstDead=3](c: T.nilable(Symbol)):
     <cfgAlias>$90: T.class_of(T) = alias <C T>
     <statTemp>$88: T.nilable(Symbol) = <cfgAlias>$90: T.class_of(T).reveal_type(c: T.nilable(Symbol))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb18(rubyRegionId=0)
-bb21[rubyRegionId=0, firstDead=-1]():
+# - bb18
+bb21[firstDead=-1]():
     # outerLoops: 1
     <statTemp>$84: Integer(1) = 1
     <statTemp>$83: String = <statTemp>$84: Integer(1).to_s()
@@ -262,8 +262,8 @@ bb21[rubyRegionId=0, firstDead=-1]():
     <ifTemp>$82 -> (T::Boolean ? bb22 : bb18)
 
 # backedges
-# - bb21(rubyRegionId=0)
-bb22[rubyRegionId=0, firstDead=-1]():
+# - bb21
+bb22[firstDead=-1]():
     # outerLoops: 1
     <returnTemp>$86: Symbol(:abc) = :abc
     <block-break-assign>$87: Symbol(:abc) = <returnTemp>$86

--- a/test/testdata/cfg/break_in_junk.rb.cfg-text.exp
+++ b/test/testdata/cfg/break_in_junk.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <returnTemp>$3: Integer(5) = 5
     <block-break-assign>$4: Integer(5) = <returnTemp>$3
@@ -9,8 +9,8 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
@@ -18,15 +18,15 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/break_in_while.rb.cfg-text.exp
+++ b/test/testdata/cfg/break_in_while.rb.cfg-text.exp
@@ -1,39 +1,39 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <unconditional> -> bb2
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<self>):
+# - bb4
+bb1[firstDead=-1](<self>):
     <statTemp>$9 = <self>
     <statTemp>$4 = <statTemp>$9.dead()
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     # outerLoops: 1
     <whileTemp>$3: TrueClass = true
     <whileTemp>$3 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb2
+bb3[firstDead=0]():
     <returnMethodTemp>$2 = nil
     <unconditional> -> bb4
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb5(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(2)):
+# - bb3
+# - bb5
+bb4[firstDead=1](<returnMethodTemp>$2: Integer(2)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(2)
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1]():
+# - bb2
+bb5[firstDead=-1]():
     # outerLoops: 1
     <returnTemp>$7: Integer(2) = 2
     <block-break-assign>$8: Integer(2) = <returnTemp>$7
@@ -44,7 +44,7 @@ bb5[rubyRegionId=0, firstDead=-1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$6: T.untyped = <self>: T.class_of(<root>).foo()
     <statTemp>$4: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$6: T.untyped)
@@ -52,8 +52,8 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
@@ -1,56 +1,56 @@
 method ::Object#a {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb4(rubyRegionId=1)
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+bb3[firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=2]():
+# - bb0
+bb4[firstDead=2]():
     <returnTemp>$5: Integer(1) = 1
     <statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](a: T.nilable(Integer), <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb7
+# - bb8
+bb6[firstDead=-1](a: T.nilable(Integer), <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: StandardError, <magic>$6: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$4: StandardError, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     a: Integer(2) = 2
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1]():
+# - bb3
+bb8[firstDead=-1]():
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=3](a: Integer(2)):
+# - bb6
+bb9[firstDead=3](a: Integer(2)):
     <statTemp>$14: Integer(3) = 3
     <returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$14: Integer(3))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
@@ -60,15 +60,15 @@ bb9[rubyRegionId=0, firstDead=3](a: Integer(2)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:a) = :a
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:a)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
@@ -8,7 +8,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb4
-# - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
@@ -29,27 +30,22 @@ bb4[firstDead=2]():
     <unconditional> -> bb1
 
 # backedges
-# - bb7
-# - bb8
-bb6[firstDead=-1](a: T.nilable(Integer), <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
-
-# backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$4: StandardError, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     a: Integer(2) = 2
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1]():
     <gotoDeadTemp>$11: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
 
 # backedges
-# - bb6
+# - bb7
+# - bb8
 bb9[firstDead=3](a: Integer(2)):
     <statTemp>$14: Integer(3) = 3
     <returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$14: Integer(3))

--- a/test/testdata/cfg/default_args_cases.rb.cfg-text.exp
+++ b/test/testdata/cfg/default_args_cases.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Test#test1 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Test = cast(<self>: NilClass, Test);
     a: Integer = load_arg(a)
     b: Integer = load_arg(b)
@@ -22,35 +22,35 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <argPresent>$3 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer):
+# - bb0
+bb2[firstDead=-1](a: Integer, b: Integer):
     c: Integer = load_arg(c)
     <argPresent>$6: T::Boolean = arg_present(d)
     <argPresent>$6 -> (T::Boolean ? bb4 : bb5)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer):
+# - bb0
+bb3[firstDead=-1](a: Integer, b: Integer):
     <statTemp>$4: Integer(10) = 10
     <castTemp>$5: Integer = cast(<statTemp>$4: Integer(10), Integer);
     c: Integer(10) = <statTemp>$4
     <unconditional> -> bb5
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer):
+# - bb2
+bb4[firstDead=-1](a: Integer, b: Integer, c: Integer):
     d: Integer = load_arg(d)
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer):
+# - bb2
+# - bb3
+bb5[firstDead=-1](a: Integer, b: Integer, c: Integer):
     x: Integer(20) = 20
     <statTemp>$7: Integer(20) = x
     <castTemp>$8: Integer = cast(<statTemp>$7: Integer(20), Integer);
@@ -58,31 +58,31 @@ bb5[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer):
     <unconditional> -> bb6
 
 # backedges
-# - bb4(rubyRegionId=0)
-# - bb5(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer)):
+# - bb4
+# - bb5
+bb6[firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer)):
     e: Integer = load_arg(e)
     <argPresent>$9: T::Boolean = arg_present(f)
     <argPresent>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb6(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer):
+# - bb6
+bb7[firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer):
     f: String = load_arg(f)
     <unconditional> -> bb9
 
 # backedges
-# - bb6(rubyRegionId=0)
-bb8[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer):
+# - bb6
+bb8[firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer):
     <statTemp>$10: String("foo") = "foo"
     <castTemp>$11: String = cast(<statTemp>$10: String("foo"), String);
     f: String("foo") = <statTemp>$10
     <unconditional> -> bb9
 
 # backedges
-# - bb7(rubyRegionId=0)
-# - bb8(rubyRegionId=0)
-bb9[rubyRegionId=0, firstDead=19](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer, f: String):
+# - bb7
+# - bb8
+bb9[firstDead=19](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer, f: String):
     blk: T.proc.void = load_arg(blk)
     <cfgAlias>$14: T.class_of(T) = alias <C T>
     <statTemp>$12: Integer = <cfgAlias>$14: T.class_of(T).reveal_type(a: Integer)
@@ -108,34 +108,34 @@ bb9[rubyRegionId=0, firstDead=19](a: Integer, b: Integer, c: Integer, d: Integer
 
 method ::Test#test2 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Test = cast(<self>: NilClass, Test);
     <argPresent>$3: T::Boolean = arg_present(x)
     <argPresent>$3 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     x: Integer = load_arg(x)
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb3[firstDead=-1]():
     <statTemp>$4: Integer(10) = 10
     <castTemp>$5: Integer = cast(<statTemp>$4: Integer(10), Integer);
     x: Integer(10) = <statTemp>$4
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=9](x: Integer):
+# - bb2
+# - bb3
+bb4[firstDead=9](x: Integer):
     rest: T::Array[Integer] = load_arg(rest)
     blk: T.proc.void = load_arg(blk)
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -151,34 +151,34 @@ bb4[rubyRegionId=0, firstDead=9](x: Integer):
 
 method ::Test#test3 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Test = cast(<self>: NilClass, Test);
     <argPresent>$3: T::Boolean = arg_present(x)
     <argPresent>$3 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     x: Integer = load_arg(x)
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb3[firstDead=-1]():
     <statTemp>$4: Integer(10) = 10
     <castTemp>$5: Integer = cast(<statTemp>$4: Integer(10), Integer);
     x: Integer(10) = <statTemp>$4
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=9](x: Integer):
+# - bb2
+# - bb3
+bb4[firstDead=9](x: Integer):
     rest: T::Hash[Symbol, Integer] = load_arg(rest)
     blk: T.proc.void = load_arg(blk)
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -194,7 +194,7 @@ bb4[rubyRegionId=0, firstDead=9](x: Integer):
 
 method ::<Class:Test>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Test) = cast(<self>: NilClass, T.class_of(Test));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Test))
@@ -202,20 +202,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb11(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb11
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test)):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(Test) = <selfRestore>$8
     <cfgAlias>$38: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -224,8 +224,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test)):
+# - bb2
+bb5[firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Test)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$12: Symbol(:a) = :a
@@ -250,15 +250,15 @@ bb5[rubyRegionId=1, firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(Test)):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(Test)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(Test)):
+# - bb6
+bb7[firstDead=-1](<block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(Test)):
     <statTemp>$36: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$40, sig>
     <self>: T.class_of(Test) = <selfRestore>$41
     <cfgAlias>$59: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -267,8 +267,8 @@ bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$40: Sorbet::Private::Sta
     <unconditional> -> bb10
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(Test)):
+# - bb6
+bb9[firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$40: Sorbet::Private::Static::Void, <selfRestore>$41: T.class_of(Test)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$45: Symbol(:x) = :x
@@ -285,15 +285,15 @@ bb9[rubyRegionId=2, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp
     <unconditional> -> bb6
 
 # backedges
-# - bb7(rubyRegionId=0)
-# - bb13(rubyRegionId=3)
-bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$61: Sorbet::Private::Static::Void, <selfRestore>$62: T.class_of(Test)):
+# - bb7
+# - bb13
+bb10[firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$61: Sorbet::Private::Static::Void, <selfRestore>$62: T.class_of(Test)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
-# - bb10(rubyRegionId=3)
-bb11[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$61: Sorbet::Private::Static::Void, <selfRestore>$62: T.class_of(Test)):
+# - bb10
+bb11[firstDead=6](<block-pre-call-temp>$61: Sorbet::Private::Static::Void, <selfRestore>$62: T.class_of(Test)):
     <statTemp>$57: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$61, sig>
     <self>: T.class_of(Test) = <selfRestore>$62
     <cfgAlias>$81: T.class_of(T::Sig) = alias <C Sig>
@@ -303,8 +303,8 @@ bb11[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$61: Sorbet::Private::Sta
     <unconditional> -> bb1
 
 # backedges
-# - bb10(rubyRegionId=3)
-bb13[rubyRegionId=3, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$61: Sorbet::Private::Static::Void, <selfRestore>$62: T.class_of(Test)):
+# - bb10
+bb13[firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$61: Sorbet::Private::Static::Void, <selfRestore>$62: T.class_of(Test)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$66: Symbol(:x) = :x

--- a/test/testdata/cfg/do_while.rb.cfg-text.exp
+++ b/test/testdata/cfg/do_while.rb.cfg-text.exp
@@ -1,25 +1,25 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <unconditional> -> bb2
 
 # backedges
-# - bb20(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb20
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <whileTemp>$4: TrueClass = true
     <whileTemp>$4 -> (TrueClass ? bb5 : bb8)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb2
+bb5[firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <statTemp>$8: Integer(2) = 2
     <statTemp>$6: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$8: Integer(2))
@@ -28,31 +28,31 @@ bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     <ifTemp>$9 -> (TrueClass ? bb6 : bb2)
 
 # backedges
-# - bb5(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb5
+bb6[firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <block-break-assign>$12: NilClass = <returnTemp>$11
     <unconditional> -> bb8
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb6(rubyRegionId=0)
-# - bb11(rubyRegionId=0)
-bb8[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb2
+# - bb6
+# - bb11
+bb8[firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <whileTemp>$14: TrueClass = true
     <whileTemp>$14 -> (TrueClass ? bb11 : bb10)
 
 # backedges
-# - bb8(rubyRegionId=0)
-# - bb12(rubyRegionId=0)
-bb10[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb8
+# - bb12
+bb10[firstDead=-1](<self>: T.class_of(<root>)):
     x: Integer(0) = 0
     <unconditional> -> bb14
 
 # backedges
-# - bb8(rubyRegionId=0)
-bb11[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb8
+bb11[firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <statTemp>$18: Integer(2) = 2
     <statTemp>$16: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$18: Integer(2))
@@ -60,29 +60,29 @@ bb11[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     <ifTemp>$19 -> (TrueClass ? bb12 : bb8)
 
 # backedges
-# - bb11(rubyRegionId=0)
-bb12[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb11
+bb12[firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <block-break-assign>$21: NilClass = <returnTemp>$20
     <unconditional> -> bb10
 
 # backedges
-# - bb10(rubyRegionId=0)
-# - bb17(rubyRegionId=0)
-bb14[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), x: Integer(0)):
+# - bb10
+# - bb17
+bb14[firstDead=-1](<self>: T.class_of(<root>), x: Integer(0)):
     # outerLoops: 1
     <whileTemp>$24: FalseClass = false
     <whileTemp>$24 -> (FalseClass ? bb17 : bb16)
 
 # backedges
-# - bb14(rubyRegionId=0)
-bb16[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), x: Integer(0)):
+# - bb14
+bb16[firstDead=-1](<self>: T.class_of(<root>), x: Integer(0)):
     y: Integer(0) = 0
     <unconditional> -> bb18
 
 # backedges
-# - bb14(rubyRegionId=0)
-bb17[rubyRegionId=0, firstDead=0](<self>: T.class_of(<root>), x: Integer(0)):
+# - bb14
+bb17[firstDead=0](<self>: T.class_of(<root>), x: Integer(0)):
     # outerLoops: 1
     <statTemp>$28 = 2
     <statTemp>$26 = <self>.puts(<statTemp>$28)
@@ -90,24 +90,24 @@ bb17[rubyRegionId=0, firstDead=0](<self>: T.class_of(<root>), x: Integer(0)):
     <unconditional> -> bb14
 
 # backedges
-# - bb16(rubyRegionId=0)
-# - bb21(rubyRegionId=0)
-bb18[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
+# - bb16
+# - bb21
+bb18[firstDead=-1](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
     # outerLoops: 1
     <statTemp>$32: TrueClass = true
     <whileTemp>$31: FalseClass = <statTemp>$32: TrueClass.!()
     <whileTemp>$31 -> (FalseClass ? bb21 : bb20)
 
 # backedges
-# - bb18(rubyRegionId=0)
-bb20[rubyRegionId=0, firstDead=2](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
+# - bb18
+bb20[firstDead=2](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
     <statTemp>$37: NilClass = <self>: T.class_of(<root>).puts(x: Integer(0), y: Integer(0))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb18(rubyRegionId=0)
-bb21[rubyRegionId=0, firstDead=0](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
+# - bb18
+bb21[firstDead=0](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
     # outerLoops: 1
     <statTemp>$36 = 2
     <statTemp>$34 = <self>.puts(<statTemp>$36)

--- a/test/testdata/cfg/examples.rb.cfg-text.exp
+++ b/test/testdata/cfg/examples.rb.cfg-text.exp
@@ -1,41 +1,41 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Examples#i_like_ifs {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2
+# - bb3
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=2]():
+# - bb0
+bb2[firstDead=2]():
     <returnTemp>$4: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb0
+bb3[firstDead=0]():
     <returnTemp>$5 = 2
     <returnMethodTemp>$2 = return <returnTemp>$5
     <unconditional> -> bb1
@@ -44,32 +44,32 @@ bb3[rubyRegionId=0, firstDead=0]():
 
 method ::Examples#i_like_exps {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     <returnMethodTemp>$2: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb0
+bb3[firstDead=0]():
     <returnMethodTemp>$2 = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(1)):
+# - bb2
+# - bb3
+bb4[firstDead=1](<returnMethodTemp>$2: Integer(1)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
@@ -77,27 +77,27 @@ bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(1)):
 
 method ::Examples#return_in_one_branch1 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb2
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=2]():
+# - bb0
+bb2[firstDead=2]():
     <returnTemp>$4: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb0
+bb3[firstDead=0]():
     <returnMethodTemp>$2 = 2
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
@@ -106,27 +106,27 @@ bb3[rubyRegionId=0, firstDead=0]():
 
 method ::Examples#return_in_one_branch2 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb2
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=2]():
+# - bb0
+bb2[firstDead=2]():
     <returnMethodTemp>$2: Integer(1) = 1
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb0
+bb3[firstDead=0]():
     <returnTemp>$4 = 2
     <returnMethodTemp>$2 = return <returnTemp>$4
     <unconditional> -> bb1
@@ -135,51 +135,51 @@ bb3[rubyRegionId=0, firstDead=0]():
 
 method ::Examples#variables {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$4: TrueClass = true
     <ifTemp>$4 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     a: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb0
+bb3[firstDead=0]():
     a = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1](a: Integer(1)):
+# - bb2
+# - bb3
+bb4[firstDead=-1](a: Integer(1)):
     <ifTemp>$6: FalseClass = false
     <ifTemp>$6 -> (FalseClass ? bb5 : bb6)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=0](a: Integer(1)):
+# - bb4
+bb5[firstDead=0](a: Integer(1)):
     b = 1
     <unconditional> -> bb7
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=-1](a: Integer(1)):
+# - bb4
+bb6[firstDead=-1](a: Integer(1)):
     b: Integer(2) = 2
     <unconditional> -> bb7
 
 # backedges
-# - bb5(rubyRegionId=0)
-# - bb6(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=2](a: Integer(1), b: Integer(2)):
+# - bb5
+# - bb6
+bb7[firstDead=2](a: Integer(1), b: Integer(2)):
     <returnMethodTemp>$2: Integer = a: Integer(1).+(b: Integer(2))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
@@ -188,62 +188,62 @@ bb7[rubyRegionId=0, firstDead=2](a: Integer(1), b: Integer(2)):
 
 method ::Examples#variables_and_loop {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     cond: T.untyped = load_arg(cond)
     <ifTemp>$4: TrueClass = true
     <ifTemp>$4 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](cond: T.untyped):
+# - bb0
+bb2[firstDead=-1](cond: T.untyped):
     a: Integer(1) = 1
     <unconditional> -> bb5
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0](cond: T.untyped):
+# - bb0
+bb3[firstDead=0](cond: T.untyped):
     a = 2
     <unconditional> -> bb5
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=0)
-# - bb10(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb2
+# - bb3
+# - bb9
+# - bb10
+bb5[firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     <whileTemp>$6: TrueClass = true
     <whileTemp>$6 -> (TrueClass ? bb8 : bb7)
 
 # backedges
-# - bb5(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=0](b: NilClass):
+# - bb5
+bb7[firstDead=0](b: NilClass):
     <returnMethodTemp>$2 = b
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb5(rubyRegionId=0)
-bb8[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb5
+bb8[firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     cond -> (T.untyped ? bb9 : bb10)
 
 # backedges
-# - bb8(rubyRegionId=0)
-bb9[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb8
+bb9[firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     b: T.untyped = 1
     <unconditional> -> bb5
 
 # backedges
-# - bb8(rubyRegionId=0)
-bb10[rubyRegionId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
+# - bb8
+bb10[firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
     # outerLoops: 1
     b: T.untyped = 2
     <unconditional> -> bb5
@@ -252,48 +252,48 @@ bb10[rubyRegionId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
 
 method ::Examples#variables_loop_if {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     cond: T.untyped = load_arg(cond)
     <unconditional> -> bb2
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb6(rubyRegionId=0)
-# - bb7(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb0
+# - bb6
+# - bb7
+bb2[firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     <whileTemp>$4: TrueClass = true
     <whileTemp>$4 -> (TrueClass ? bb5 : bb4)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=0](b: NilClass):
+# - bb2
+bb4[firstDead=0](b: NilClass):
     <returnMethodTemp>$2 = b
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb2
+bb5[firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     cond -> (T.untyped ? bb6 : bb7)
 
 # backedges
-# - bb5(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb5
+bb6[firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     b: T.untyped = 1
     <unconditional> -> bb2
 
 # backedges
-# - bb5(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
+# - bb5
+bb7[firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
     # outerLoops: 1
     b: T.untyped = 2
     <unconditional> -> bb2
@@ -302,33 +302,33 @@ bb7[rubyRegionId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
 
 method ::Examples#take_arguments {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     i: T.untyped = load_arg(i)
     <ifTemp>$3: FalseClass = false
     <ifTemp>$3 -> (FalseClass ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=0]():
+# - bb0
+bb2[firstDead=0]():
     <returnMethodTemp>$2 = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](i: T.untyped):
+# - bb0
+bb3[firstDead=-1](i: T.untyped):
     <returnMethodTemp>$2: T.untyped = i
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb2
+# - bb3
+bb4[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -336,14 +336,14 @@ bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::<Class:Examples>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Examples) = cast(<self>: NilClass, T.class_of(Examples));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/extra_bb_args.rb.cfg-text.exp
+++ b/test/testdata/cfg/extra_bb_args.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#main {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <cfgAlias>$6: T.class_of(T) = alias <C T>
     <cfgAlias>$8: T.class_of(String) = alias <C String>
@@ -12,21 +12,21 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <ifTemp>$11 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb2
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=2]():
+# - bb0
+bb2[firstDead=2]():
     <returnTemp>$13: String("missing name") = "missing name"
     <statTemp>$10: T.noreturn = return <returnTemp>$13: String("missing name")
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=3](name: String):
+# - bb0
+bb3[firstDead=3](name: String):
     <statTemp>$15: String("foo") = "foo"
     <returnMethodTemp>$2: T::Boolean = name: String.include?(<statTemp>$15: String("foo"))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Boolean
@@ -36,15 +36,15 @@ bb3[rubyRegionId=0, firstDead=3](name: String):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:main) = :main
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:main)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/floats.rb.cfg-text.exp
+++ b/test/testdata/cfg/floats.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#test_large_float {
 
-bb0[rubyRegionId=0, firstDead=15]():
+bb0[firstDead=15]():
     <self>: Object = cast(<self>: NilClass, Object);
     a: Float(3.141593) = 3.141593
     a: Float(0.000001) = 0.000001
@@ -19,23 +19,23 @@ bb0[rubyRegionId=0, firstDead=15]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:test_large_float) = :test_large_float
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:test_large_float)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/hash.rb.cfg-text.exp
+++ b/test/testdata/cfg/hash.rb.cfg-text.exp
@@ -1,35 +1,35 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestHash#something {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: TestHash = cast(<self>: NilClass, TestHash);
     <returnMethodTemp>$2: Integer(17) = 17
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(17)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestHash#test {
 
-bb0[rubyRegionId=0, firstDead=10]():
+bb0[firstDead=10]():
     <self>: TestHash = cast(<self>: NilClass, TestHash);
     <hashTemp>$3: T.untyped = <self>: TestHash.something()
     <hashTemp>$4: Symbol(:bar) = :bar
@@ -43,15 +43,15 @@ bb0[rubyRegionId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestHash#test_shaped {
 
-bb0[rubyRegionId=0, firstDead=12]():
+bb0[firstDead=12]():
     <self>: TestHash = cast(<self>: NilClass, TestHash);
     <hashTemp>$3: Integer(1) = 1
     <hashTemp>$4: Integer(2) = 2
@@ -67,22 +67,22 @@ bb0[rubyRegionId=0, firstDead=12]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:TestHash>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(TestHash) = cast(<self>: NilClass, T.class_of(TestHash));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/ivar_assign.rb.cfg-text.exp
+++ b/test/testdata/cfg/ivar_assign.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestIVar#initialize {
 
-bb0[rubyRegionId=0, firstDead=9]():
+bb0[firstDead=9]():
     @foo$3: Integer = alias @foo
     <self>: TestIVar = cast(<self>: NilClass, TestIVar);
     <cfgAlias>$5: T.class_of(Integer) = alias <C Integer>
@@ -27,15 +27,15 @@ bb0[rubyRegionId=0, firstDead=9]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestIVar#test {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     @foo$3: Integer = alias @foo
     <self>: TestIVar = cast(<self>: NilClass, TestIVar);
     @foo$3: Integer = nil
@@ -44,22 +44,22 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:TestIVar>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(TestIVar) = cast(<self>: NilClass, T.class_of(TestIVar));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/next.rb.cfg-text.exp
+++ b/test/testdata/cfg/next.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <arrayTemp>$4: Integer(1) = 1
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
@@ -10,30 +10,30 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<self>):
+# - bb3
+bb1[firstDead=-1](<self>):
     <statTemp>$15 = <self>
     <blockReturnTemp>$9 = <statTemp>$15.bad()
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=3](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
+# - bb2
+bb3[firstDead=3](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
     <returnMethodTemp>$2: T::Array[Integer] = Solve<<block-pre-call-temp>$6, map>
     <self>: Object = <selfRestore>$7
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Array[Integer]
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=6](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
+# - bb2
+bb5[firstDead=6](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
     # outerLoops: 1
     <self>: Object = loadSelf(map)
     <blk>$8: [Integer] = load_yield_params(map)
@@ -47,15 +47,15 @@ bb5[rubyRegionId=1, firstDead=6](<self>: Object, <block-pre-call-temp>$6: Sorbet
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/next_in_junk.rb.cfg-text.exp
+++ b/test/testdata/cfg/next_in_junk.rb.cfg-text.exp
@@ -1,12 +1,12 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
@@ -14,15 +14,15 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/next_in_while.rb.cfg-text.exp
+++ b/test/testdata/cfg/next_in_while.rb.cfg-text.exp
@@ -1,34 +1,34 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<self>):
+# - bb3
+bb1[firstDead=-1](<self>):
     <statTemp>$10 = <self>
     <statTemp>$4 = <statTemp>$10.bad()
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](<self>: Object):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: Object):
     # outerLoops: 1
     <whileTemp>$3: TrueClass = true
     <whileTemp>$3 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb2
+bb3[firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](<self>: Object):
+# - bb2
+bb5[firstDead=-1](<self>: Object):
     # outerLoops: 1
     <statTemp>$5: T.untyped = <self>: Object.good()
     <nextTemp>$8: T.untyped = <self>: Object.value()
@@ -38,15 +38,15 @@ bb5[rubyRegionId=0, firstDead=-1](<self>: Object):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/reassign_dead_block_bug.rb.cfg-text.exp
+++ b/test/testdata/cfg/reassign_dead_block_bug.rb.cfg-text.exp
@@ -1,35 +1,35 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$3: Integer(2) = 2
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <statTemp>$3: Integer(2).times()
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+# - bb5
+bb1[firstDead=-1]():
     x$1 = 10
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
+# - bb0
+bb2[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=3](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
+# - bb2
+bb3[firstDead=3](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     <returnMethodTemp>$2: Integer = Solve<<block-pre-call-temp>$4, times>
     <self>: T.class_of(<root>) = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(<root>)):
+# - bb2
+bb5[firstDead=4](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf(times)
     x$1: Integer(1) = 1

--- a/test/testdata/cfg/rescue.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue.rb.cfg-text.exp
@@ -1,65 +1,65 @@
 method ::Object#main {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: Object, <magic>$6: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<self>: Object, <exceptionValue>$3: NilClass):
+# - bb4
+bb5[firstDead=-1](<self>: Object, <exceptionValue>$3: NilClass):
     <returnMethodTemp>$2: T.untyped = <self>: Object.c()
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$15: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$15: T.nilable(TrueClass)):
     <cfgAlias>$8: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$8: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <throwAwayTemp>$16: T.untyped = <self>: Object.d()
     <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: Object, <exceptionValue>$3: StandardError, <magic>$6: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: Object, <exceptionValue>$3: StandardError, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: Object.b()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+# - bb3
+bb8[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
     <gotoDeadTemp>$15: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -67,63 +67,63 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::Object#a {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#b {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#c {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#d {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$10: T.untyped = <self>: T.class_of(<root>).foo()
     <statTemp>$8: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$10: T.untyped)
@@ -131,8 +131,8 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -1,80 +1,80 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#meth {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <returnMethodTemp>$2: Integer(0) = 0
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#foo {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <returnMethodTemp>$2: Integer(1) = 1
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#bar {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <returnMethodTemp>$2: Integer(2) = 2
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(2)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#baz {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <returnMethodTemp>$2: Integer(3) = 3
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#take_arg {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     x: T.untyped = load_arg(x)
     <returnMethodTemp>$2: T.untyped = x
@@ -82,15 +82,15 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#untyped_exceptions {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <cfgAlias>$4: T.class_of(Exception) = alias <C Exception>
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
@@ -99,15 +99,15 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#typed_exceptions {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <cfgAlias>$4: T.class_of(Exception) = alias <C Exception>
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
@@ -116,15 +116,15 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#tuple_exceptions {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <cfgAlias>$4: T.class_of(TypeError) = alias <C TypeError>
     <cfgAlias>$6: T.class_of(ArgumentError) = alias <C ArgumentError>
@@ -134,15 +134,15 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#initialize {
 
-bb0[rubyRegionId=0, firstDead=10]():
+bb0[firstDead=10]():
     @ex$3: T.nilable(StandardError) = alias @ex
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <cfgAlias>$6: T.class_of(T) = alias <C T>
@@ -156,86 +156,86 @@ bb0[rubyRegionId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#multiple_rescue {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb11(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb11
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb9(rubyRegionId=2)
-# - bb10(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb9
+# - bb10
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
     <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb11)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb8[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$13: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$14: T::Boolean = <cfgAlias>$13: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$14 -> (T::Boolean ? bb9 : bb10)
 
 # backedges
-# - bb8(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+# - bb8
+bb9[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$11: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb8(rubyRegionId=2)
-bb10[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb8
+bb10[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$16: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb11[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb11[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -243,49 +243,49 @@ bb11[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#multiple_rescue_classes {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb10(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb10
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.untyped = alias <C T.untyped>
     <isaCheckTemp>$9: T.untyped = <cfgAlias>$8: T.untyped.===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb9
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
     <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
-# - bb3(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+# - bb8
+bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     baz: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
@@ -293,21 +293,21 @@ bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.cl
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$11: T.untyped = alias <C T.untyped>
     <isaCheckTemp>$12: T.untyped = <cfgAlias>$11: T.untyped.===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$12 -> (T.untyped ? bb7 : bb9)
 
 # backedges
-# - bb8(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb8
+bb9[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb10[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -315,70 +315,70 @@ bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#multiple_rescue_classes_varuse {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb10(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb10
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(LoadError) = alias <C LoadError>
     <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(LoadError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
     <statTemp>$3: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1]():
+# - bb4
+bb5[firstDead=-1]():
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](baz: T.nilable(T.any(LoadError, SocketError)), <gotoDeadTemp>$14: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb9
+bb6[firstDead=-1](baz: T.nilable(T.any(LoadError, SocketError)), <gotoDeadTemp>$14: T.nilable(TrueClass)):
     <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
-# - bb3(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: T.any(LoadError, SocketError), <magic>$6: T.class_of(<Magic>)):
+# - bb3
+# - bb8
+bb7[firstDead=-1](<exceptionValue>$4: T.any(LoadError, SocketError), <magic>$6: T.class_of(<Magic>)):
     baz: T.any(LoadError, SocketError) = <exceptionValue>$4
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
+# - bb3
+bb8[firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$12: T.class_of(SocketError) = alias <C SocketError>
     <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(SocketError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb9)
 
 # backedges
-# - bb8(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=-1]():
+# - bb8
+bb9[firstDead=-1]():
     <gotoDeadTemp>$14: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb10[rubyRegionId=0, firstDead=3](baz: T.nilable(T.any(LoadError, SocketError))):
+# - bb6
+bb10[firstDead=3](baz: T.nilable(T.any(LoadError, SocketError))):
     <cfgAlias>$17: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: T.nilable(T.any(LoadError, SocketError)) = <cfgAlias>$17: T.class_of(T).reveal_type(baz: T.nilable(T.any(LoadError, SocketError)))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(T.any(LoadError, SocketError))
@@ -388,7 +388,7 @@ bb10[rubyRegionId=0, firstDead=3](baz: T.nilable(T.any(LoadError, SocketError)))
 
 method ::TestRescue#rescue_loop {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <cfgAlias>$6: T.class_of(T) = alias <C T>
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
@@ -401,28 +401,28 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb10(rubyRegionId=4)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+# - bb10
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb13(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$22: NilClass):
+# - bb0
+# - bb13
+bb2[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$22: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=1](<block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue):
+# - bb2
+bb3[firstDead=1](<block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue):
     <returnMethodTemp>$2: T.noreturn = Solve<<block-pre-call-temp>$11, loop>
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$22: NilClass):
+# - bb2
+bb5[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$22: NilClass):
     # outerLoops: 1
     <self>: TestRescue = loadSelf(loop)
     ex: NilClass = nil
@@ -431,39 +431,39 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardErro
     <exceptionValue>$15 -> (T.nilable(Exception) ? bb7 : bb8)
 
 # backedges
-# - bb5(rubyRegionId=1)
-# - bb8(rubyRegionId=2)
-bb7[rubyRegionId=3, firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: Exception, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
+# - bb5
+# - bb8
+bb7[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: Exception, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
     # outerLoops: 1
     <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$15: Exception)
     <isaCheckTemp>$21 -> (T::Boolean ? bb11 : bb12)
 
 # backedges
-# - bb5(rubyRegionId=1)
-bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
+# - bb5
+bb8[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$13: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$15: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$15 -> (T.nilable(Exception) ? bb7 : bb9)
 
 # backedges
-# - bb8(rubyRegionId=2)
-bb9[rubyRegionId=5, firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
+# - bb8
+bb9[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
     # outerLoops: 1
     <unconditional> -> bb10
 
 # backedges
-# - bb9(rubyRegionId=5)
-# - bb11(rubyRegionId=3)
-# - bb12(rubyRegionId=3)
-bb10[rubyRegionId=4, firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: T.nilable(TrueClass)):
+# - bb9
+# - bb11
+# - bb12
+bb10[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: T.nilable(TrueClass)):
     # outerLoops: 1
     <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
-# - bb7(rubyRegionId=3)
-bb11[rubyRegionId=3, firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: StandardError, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
+# - bb7
+bb11[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: StandardError, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
     # outerLoops: 1
     ex: StandardError = <exceptionValue>$15
     <exceptionValue>$15: NilClass = nil
@@ -471,15 +471,15 @@ bb11[rubyRegionId=3, firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-
     <unconditional> -> bb10
 
 # backedges
-# - bb7(rubyRegionId=3)
-bb12[rubyRegionId=3, firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped):
+# - bb7
+bb12[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped):
     # outerLoops: 1
     <gotoDeadTemp>$22: TrueClass = true
     <unconditional> -> bb10
 
 # backedges
-# - bb10(rubyRegionId=4)
-bb13[rubyRegionId=1, firstDead=1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
+# - bb10
+bb13[firstDead=1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$24: T.noreturn = blockreturn<loop> <blockReturnTemp>$13: T.untyped
     <unconditional> -> bb2
@@ -488,22 +488,22 @@ bb13[rubyRegionId=1, firstDead=1](<self>: TestRescue, ex: T.nilable(StandardErro
 
 method ::TestRescue#rescue_untyped_splat {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$10: T.untyped = <self>: TestRescue.untyped_exceptions()
     <exceptionClassTemp>$7: T.untyped = <cfgAlias>$9: T.class_of(<Magic>).<splat>(<statTemp>$10: T.untyped)
@@ -511,27 +511,27 @@ bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.un
     <isaCheckTemp>$12 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
     <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     e: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
@@ -540,14 +540,14 @@ bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.cl
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$16: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -555,22 +555,22 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#rescue_typed_splat {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$10: T::Array[T.class_of(Exception)] = <self>: TestRescue.typed_exceptions()
     <exceptionClassTemp>$7: T::Array[T.class_of(Exception)] = <cfgAlias>$9: T.class_of(<Magic>).<splat>(<statTemp>$10: T::Array[T.class_of(Exception)])
@@ -578,27 +578,27 @@ bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.un
     <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
     <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     e: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
@@ -607,14 +607,14 @@ bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.cl
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$16: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -622,22 +622,22 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#rescue_typed_splat {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$10: [T.class_of(TypeError), T.class_of(ArgumentError)] = <self>: TestRescue.tuple_exceptions()
     <exceptionClassTemp>$7: [T.class_of(TypeError), T.class_of(ArgumentError)] = <cfgAlias>$9: T.class_of(<Magic>).<splat>(<statTemp>$10: [T.class_of(TypeError), T.class_of(ArgumentError)])
@@ -645,27 +645,27 @@ bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.un
     <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
     <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     e: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
@@ -674,14 +674,14 @@ bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.cl
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$16: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -689,65 +689,65 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_rescue_ensure {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: NilClass):
+# - bb4
+bb5[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$14: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$14: T.nilable(TrueClass)):
     <cfgAlias>$7: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$7: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <throwAwayTemp>$15: T.untyped = <self>: TestRescue.bar()
     <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$9: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+# - bb3
+bb8[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
     <gotoDeadTemp>$14: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -755,60 +755,60 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_bug_rescue_empty_else {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$4: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$4: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<exceptionValue>$3: Exception, <magic>$4: T.class_of(<Magic>)):
     <cfgAlias>$7: T.class_of(LoadError) = alias <C LoadError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(LoadError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<magic>$4: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<magic>$4: T.class_of(<Magic>)):
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1]():
+# - bb4
+bb5[firstDead=-1]():
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$9: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<gotoDeadTemp>$9: T.nilable(TrueClass)):
     <gotoDeadTemp>$9 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: LoadError, <magic>$4: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$3: LoadError, <magic>$4: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: Sorbet::Private::Static::Void = <magic>$4: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1]():
+# - bb3
+bb8[firstDead=-1]():
     <gotoDeadTemp>$9: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1]():
+# - bb6
+bb9[firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -816,62 +816,62 @@ bb9[rubyRegionId=0, firstDead=1]():
 
 method ::TestRescue#parse_ruby_bug_12686 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
+# - bb4
+bb5[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
     <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$5: StandardError, <magic>$7: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$5: StandardError, <magic>$7: T.class_of(<Magic>)):
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
     <statTemp>$4: NilClass = nil
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
+# - bb3
+bb8[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
     <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
+# - bb6
+bb9[firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -880,62 +880,62 @@ bb9[rubyRegionId=0, firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
 
 method ::TestRescue#parse_rescue_mod {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -943,62 +943,62 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_resbody_list_var {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <exceptionClassTemp>$7: T.untyped = <self>: TestRescue.foo()
     <isaCheckTemp>$9: T.untyped = <exceptionClassTemp>$7: T.untyped.===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -1006,66 +1006,66 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_rescue_else_ensure {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: NilClass):
+# - bb4
+bb5[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: NilClass):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$15: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$15: T.nilable(TrueClass)):
     <cfgAlias>$8: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$8: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <throwAwayTemp>$16: T.untyped = <self>: TestRescue.bar()
     <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$6: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+# - bb3
+bb8[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
     <gotoDeadTemp>$15: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -1073,62 +1073,62 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_rescue {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -1136,62 +1136,62 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_resbody_var {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -1199,7 +1199,7 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_resbody_var_1 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     @ex$11: T.nilable(StandardError) = alias @ex
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
@@ -1207,41 +1207,41 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
     <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
     <rescueTemp>$2: StandardError = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
@@ -1250,14 +1250,14 @@ bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <exceptionValue>$3: Standa
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -1265,7 +1265,7 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_rescue_mod_op_assign {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <statTemp>$3: NilClass = foo
     <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
@@ -1273,55 +1273,55 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$4: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
+# - bb4
+bb5[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
     <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <exceptionValue>$5: StandardError, <magic>$7: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <exceptionValue>$5: StandardError, <magic>$7: T.class_of(<Magic>)):
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
+# - bb3
+bb8[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
+# - bb6
+bb9[firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: T.untyped)
     <returnMethodTemp>$2: T.untyped = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -1331,63 +1331,63 @@ bb9[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped
 
 method ::TestRescue#parse_ruby_bug_12402 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](foo: NilClass, <exceptionValue>$3: Exception, <magic>$7: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](foo: NilClass, <exceptionValue>$3: Exception, <magic>$7: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$5: T.untyped = <self>: TestRescue.bar()
     foo: T.noreturn = <self>: TestRescue.raise(<statTemp>$5: T.untyped)
     <exceptionValue>$3 = <get-current-exception>
     <exceptionValue>$3 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=0](foo: NilClass):
+# - bb4
+bb5[firstDead=0](foo: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](foo: NilClass, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](foo: NilClass, <gotoDeadTemp>$12: T.nilable(TrueClass)):
     <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: StandardError, <magic>$7: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$3: StandardError, <magic>$7: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     foo: NilClass = nil
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](foo: NilClass):
+# - bb3
+bb8[firstDead=-1](foo: NilClass):
     <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=2](foo: NilClass):
+# - bb6
+bb9[firstDead=2](foo: NilClass):
     <returnMethodTemp>$2: NilClass = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
@@ -1396,7 +1396,7 @@ bb9[rubyRegionId=0, firstDead=2](foo: NilClass):
 
 method ::TestRescue#parse_ruby_bug_12402_1 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <statTemp>$3: NilClass = foo
     <magic>$9: T.class_of(<Magic>) = alias <C <Magic>>
@@ -1404,56 +1404,56 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: Exception, <magic>$9: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: Exception, <magic>$9: T.class_of(<Magic>)):
     <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
     <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>)):
     <statTemp>$7: T.untyped = <self>: TestRescue.bar()
     <statTemp>$4: T.noreturn = <self>: TestRescue.raise(<statTemp>$7: T.untyped)
     <exceptionValue>$5 = <get-current-exception>
     <exceptionValue>$5 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
+# - bb4
+bb5[firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$14: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$14: T.nilable(TrueClass)):
     <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <exceptionValue>$5: StandardError, <magic>$9: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<statTemp>$3: NilClass, <exceptionValue>$5: StandardError, <magic>$9: T.class_of(<Magic>)):
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
     <statTemp>$4: NilClass = nil
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
+# - bb3
+bb8[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     <gotoDeadTemp>$14: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
+# - bb6
+bb9[firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: NilClass)
     <returnMethodTemp>$2: T.untyped = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -1463,7 +1463,7 @@ bb9[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass)
 
 method ::TestRescue#parse_ruby_bug_12402_2 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     []$3: T.untyped = <self>: TestRescue.foo()
     []$4: Integer(0) = 0
@@ -1473,56 +1473,56 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$13 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: Exception, <magic>$17: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: Exception, <magic>$17: T.class_of(<Magic>)):
     <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$13: Exception)
     <isaCheckTemp>$21 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>)):
     <statTemp>$15: T.untyped = <self>: TestRescue.bar()
     <statTemp>$12: T.noreturn = <self>: TestRescue.raise(<statTemp>$15: T.untyped)
     <exceptionValue>$13 = <get-current-exception>
     <exceptionValue>$13 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass):
+# - bb4
+bb5[firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$22: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$22: T.nilable(TrueClass)):
     <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <exceptionValue>$13: StandardError, <magic>$17: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <exceptionValue>$13: StandardError, <magic>$17: T.class_of(<Magic>)):
     <exceptionValue>$13: NilClass = nil
     <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)
     <statTemp>$12: NilClass = nil
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
+# - bb3
+bb8[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
     <gotoDeadTemp>$22: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
+# - bb6
+bb9[firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
     <statTemp>$8: T.untyped = <statTemp>$9: T.untyped.+(<statTemp>$12: NilClass)
     <returnMethodTemp>$2: T.untyped = []$3: T.untyped.[]=([]$4: Integer(0), <statTemp>$8: T.untyped)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -1532,7 +1532,7 @@ bb9[rubyRegionId=0, firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9
 
 method ::<Class:TestRescue>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(TestRescue) = cast(<self>: NilClass, T.class_of(TestRescue));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(TestRescue))
@@ -1540,20 +1540,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(TestRescue), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestRescue)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(TestRescue), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestRescue)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestRescue)):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestRescue)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(TestRescue) = <selfRestore>$8
     <cfgAlias>$24: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -1562,8 +1562,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(TestRescue), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestRescue)):
+# - bb2
+bb5[firstDead=9](<self>: T.class_of(TestRescue), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(TestRescue)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$13: T.class_of(T::Array) = alias <C Array>
@@ -1577,15 +1577,15 @@ bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(TestRescue), <block-pre-call
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(TestRescue), <block-pre-call-temp>$26: Sorbet::Private::Static::Void, <selfRestore>$27: T.class_of(TestRescue)):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(TestRescue), <block-pre-call-temp>$26: Sorbet::Private::Static::Void, <selfRestore>$27: T.class_of(TestRescue)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$26: Sorbet::Private::Static::Void, <selfRestore>$27: T.class_of(TestRescue)):
+# - bb6
+bb7[firstDead=6](<block-pre-call-temp>$26: Sorbet::Private::Static::Void, <selfRestore>$27: T.class_of(TestRescue)):
     <statTemp>$22: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$26, sig>
     <self>: T.class_of(TestRescue) = <selfRestore>$27
     <cfgAlias>$46: T.class_of(T::Sig) = alias <C Sig>
@@ -1595,8 +1595,8 @@ bb7[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$26: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=11](<self>: T.class_of(TestRescue), <block-pre-call-temp>$26: Sorbet::Private::Static::Void, <selfRestore>$27: T.class_of(TestRescue)):
+# - bb6
+bb9[firstDead=11](<self>: T.class_of(TestRescue), <block-pre-call-temp>$26: Sorbet::Private::Static::Void, <selfRestore>$27: T.class_of(TestRescue)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$33: T.class_of(T) = alias <C T>

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -172,6 +172,9 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb9
+# - bb10
 # - bb11
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -189,20 +192,12 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb9
-# - bb10
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
-    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb11)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: NilClass):
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb11)
 
 # backedges
 # - bb3
@@ -210,7 +205,7 @@ bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb11)
 
 # backedges
 # - bb3
@@ -225,16 +220,19 @@ bb9[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$11: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb11)
 
 # backedges
 # - bb8
 bb10[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$16: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (TrueClass ? bb1 : bb11)
 
 # backedges
 # - bb6
+# - bb7
+# - bb9
+# - bb10
 bb11[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -251,6 +249,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb9
 # - bb10
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -268,19 +268,12 @@ bb3[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb9
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
-    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb10)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: NilClass):
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb10)
 
 # backedges
 # - bb3
@@ -290,7 +283,7 @@ bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>))
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: Exception = baz
-    <unconditional> -> bb6
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb10)
 
 # backedges
 # - bb3
@@ -303,10 +296,12 @@ bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception
 # - bb8
 bb9[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$13: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb10)
 
 # backedges
 # - bb6
+# - bb7
+# - bb9
 bb10[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -323,6 +318,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb9
 # - bb10
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -340,19 +337,12 @@ bb3[firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>))
 bb4[firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
     <statTemp>$3: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1]():
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb9
-bb6[firstDead=-1](baz: T.nilable(T.any(LoadError, SocketError)), <gotoDeadTemp>$14: T.nilable(TrueClass)):
-    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb10)
+bb6[firstDead=-1](baz: NilClass, <gotoDeadTemp>$14: NilClass):
+    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb10)
 
 # backedges
 # - bb3
@@ -361,7 +351,7 @@ bb7[firstDead=-1](<exceptionValue>$4: T.any(LoadError, SocketError), <magic>$6: 
     baz: T.any(LoadError, SocketError) = <exceptionValue>$4
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <unconditional> -> bb6
+    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb10)
 
 # backedges
 # - bb3
@@ -374,10 +364,12 @@ bb8[firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>))
 # - bb8
 bb9[firstDead=-1]():
     <gotoDeadTemp>$14: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$14 -> (TrueClass ? bb1 : bb10)
 
 # backedges
 # - bb6
+# - bb7
+# - bb9
 bb10[firstDead=3](baz: T.nilable(T.any(LoadError, SocketError))):
     <cfgAlias>$17: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: T.nilable(T.any(LoadError, SocketError)) = <cfgAlias>$17: T.class_of(T).reveal_type(baz: T.nilable(T.any(LoadError, SocketError)))
@@ -403,6 +395,8 @@ bb0[firstDead=-1]():
 # backedges
 # - bb3
 # - bb10
+# - bb11
+# - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
 
@@ -445,21 +439,13 @@ bb8[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: So
     # outerLoops: 1
     <blockReturnTemp>$13: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$15: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$15 -> (T.nilable(Exception) ? bb7 : bb9)
+    <exceptionValue>$15 -> (T.nilable(Exception) ? bb7 : bb10)
 
 # backedges
 # - bb8
-bb9[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
+bb10[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
     # outerLoops: 1
-    <unconditional> -> bb10
-
-# backedges
-# - bb9
-# - bb11
-# - bb12
-bb10[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: T.nilable(TrueClass)):
-    # outerLoops: 1
-    <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb13)
+    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
@@ -468,17 +454,19 @@ bb11[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: S
     ex: StandardError = <exceptionValue>$15
     <exceptionValue>$15: NilClass = nil
     <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$15: NilClass)
-    <unconditional> -> bb10
+    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
 bb12[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped):
     # outerLoops: 1
     <gotoDeadTemp>$22: TrueClass = true
-    <unconditional> -> bb10
+    <gotoDeadTemp>$22 -> (TrueClass ? bb1 : bb13)
 
 # backedges
 # - bb10
+# - bb11
+# - bb12
 bb13[firstDead=1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$24: T.noreturn = blockreturn<loop> <blockReturnTemp>$13: T.untyped
@@ -496,6 +484,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -515,19 +505,12 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
-    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: NilClass):
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -537,16 +520,18 @@ bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>))
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <cfgAlias>$14: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: Exception = <cfgAlias>$14: T.class_of(T).reveal_type(e: Exception)
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$16: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -563,6 +548,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -582,19 +569,12 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
-    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: NilClass):
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -604,16 +584,18 @@ bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>))
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <cfgAlias>$14: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: Exception = <cfgAlias>$14: T.class_of(T).reveal_type(e: Exception)
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$16: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -630,6 +612,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -649,19 +633,12 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
-    <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: NilClass):
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -671,16 +648,18 @@ bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>))
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <cfgAlias>$14: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: Exception = <cfgAlias>$14: T.class_of(T).reveal_type(e: Exception)
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$16: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -714,15 +693,10 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$14: T.nilable(TrueClass)):
@@ -763,6 +737,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -779,35 +755,30 @@ bb3[firstDead=-1](<exceptionValue>$3: Exception, <magic>$4: T.class_of(<Magic>))
 # - bb0
 bb4[firstDead=-1](<magic>$4: T.class_of(<Magic>)):
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1]():
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<gotoDeadTemp>$9: T.nilable(TrueClass)):
-    <gotoDeadTemp>$9 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<gotoDeadTemp>$9: NilClass):
+    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: LoadError, <magic>$4: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: Sorbet::Private::Static::Void = <magic>$4: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <unconditional> -> bb6
+    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1]():
     <gotoDeadTemp>$9: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$9 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
@@ -824,6 +795,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -841,19 +814,12 @@ bb3[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$
 bb4[firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
-    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: NilClass):
+    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -861,16 +827,18 @@ bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$5: StandardError, <magic>
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
     <statTemp>$4: NilClass = nil
-    <unconditional> -> bb6
+    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
     <gotoDeadTemp>$12: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -888,6 +856,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -905,19 +875,12 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass):
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -925,16 +888,18 @@ bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -951,6 +916,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -968,19 +935,12 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass):
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -988,16 +948,18 @@ bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: Exception, <magic>$5: 
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -1081,6 +1043,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1098,19 +1062,12 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass):
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -1118,16 +1075,18 @@ bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -1144,6 +1103,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1161,19 +1122,12 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
-    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass):
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -1181,16 +1135,18 @@ bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -1208,6 +1164,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1225,19 +1183,12 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
-    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: NilClass):
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -1247,16 +1198,18 @@ bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     @ex$11: StandardError = <rescueTemp>$2
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <unconditional> -> bb6
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$13: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -1274,6 +1227,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1291,19 +1246,12 @@ bb3[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.un
 bb4[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$4: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
-    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: NilClass):
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -1311,16 +1259,18 @@ bb7[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <exceptionValue>$5
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
-    <unconditional> -> bb6
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     <gotoDeadTemp>$13: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: T.untyped)
     <returnMethodTemp>$2: T.untyped = foo
@@ -1339,6 +1289,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1357,19 +1309,12 @@ bb4[firstDead=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$5: T.untyped = <self>: TestRescue.bar()
     foo: T.noreturn = <self>: TestRescue.raise(<statTemp>$5: T.untyped)
     <exceptionValue>$3 = <get-current-exception>
-    <exceptionValue>$3 -> (<nullptr> ? bb3 : bb5)
+    <exceptionValue>$3 -> (<nullptr> ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=0](foo: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](foo: NilClass, <gotoDeadTemp>$12: T.nilable(TrueClass)):
-    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=0](foo: NilClass, <gotoDeadTemp>$12: NilClass):
+    <gotoDeadTemp>$12 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -1377,16 +1322,18 @@ bb7[firstDead=-1](<exceptionValue>$3: StandardError, <magic>$7: T.class_of(<Magi
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     foo: NilClass = nil
-    <unconditional> -> bb6
+    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](foo: NilClass):
     <gotoDeadTemp>$12: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=2](foo: NilClass):
     <returnMethodTemp>$2: NilClass = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
@@ -1405,6 +1352,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1423,19 +1372,12 @@ bb4[firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$9: T.class_
     <statTemp>$7: T.untyped = <self>: TestRescue.bar()
     <statTemp>$4: T.noreturn = <self>: TestRescue.raise(<statTemp>$7: T.untyped)
     <exceptionValue>$5 = <get-current-exception>
-    <exceptionValue>$5 -> (<nullptr> ? bb3 : bb5)
+    <exceptionValue>$5 -> (<nullptr> ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$14: T.nilable(TrueClass)):
-    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$14: NilClass):
+    <gotoDeadTemp>$14 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -1443,16 +1385,18 @@ bb7[firstDead=-1](<statTemp>$3: NilClass, <exceptionValue>$5: StandardError, <ma
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
     <statTemp>$4: NilClass = nil
-    <unconditional> -> bb6
+    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     <gotoDeadTemp>$14: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$14 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: NilClass)
     <returnMethodTemp>$2: T.untyped = foo
@@ -1474,6 +1418,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1492,19 +1438,12 @@ bb4[firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTem
     <statTemp>$15: T.untyped = <self>: TestRescue.bar()
     <statTemp>$12: T.noreturn = <self>: TestRescue.raise(<statTemp>$15: T.untyped)
     <exceptionValue>$13 = <get-current-exception>
-    <exceptionValue>$13 -> (<nullptr> ? bb3 : bb5)
+    <exceptionValue>$13 -> (<nullptr> ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$22: T.nilable(TrueClass)):
-    <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass, <gotoDeadTemp>$22: NilClass):
+    <gotoDeadTemp>$22 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -1512,16 +1451,18 @@ bb7[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <e
     <exceptionValue>$13: NilClass = nil
     <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)
     <statTemp>$12: NilClass = nil
-    <unconditional> -> bb6
+    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
     <gotoDeadTemp>$22: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$22 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
     <statTemp>$8: T.untyped = <statTemp>$9: T.untyped.+(<statTemp>$12: NilClass)
     <returnMethodTemp>$2: T.untyped = []$3: T.untyped.[]=([]$4: Integer(0), <statTemp>$8: T.untyped)

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -1,68 +1,68 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb9(rubyRegionId=3)
-# - bb12(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb9
+# - bb12
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: Integer(1) = 1
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: Integer(1)):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: Integer(1)):
     <ifTemp>$4: Integer(2) = 2
     <ifTemp>$4 -> (Integer(2) ? bb6 : bb9)
 
 # backedges
-# - bb5(rubyRegionId=4)
-bb6[rubyRegionId=4, firstDead=-1]():
+# - bb5
+bb6[firstDead=-1]():
     <returnMethodTemp>$2: Integer(3) = 3
     <unconditional> -> bb9
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb6(rubyRegionId=4)
-# - bb10(rubyRegionId=2)
-# - bb11(rubyRegionId=2)
-bb9[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$10: T.nilable(TrueClass)):
+# - bb5
+# - bb6
+# - bb10
+# - bb11
+bb9[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$10: T.nilable(TrueClass)):
     <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb12)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb10[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb10[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <unconditional> -> bb9
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb11[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
+# - bb3
+bb11[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
     <gotoDeadTemp>$10: TrueClass = true
     <unconditional> -> bb9
 
 # backedges
-# - bb9(rubyRegionId=3)
-bb12[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
+# - bb9
+bb12[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1
 
@@ -70,15 +70,15 @@ bb12[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -7,7 +7,10 @@ bb0[firstDead=-1]():
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
+# - bb6
 # - bb9
+# - bb10
+# - bb11
 # - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -37,31 +40,31 @@ bb5[firstDead=-1](<returnMethodTemp>$2: Integer(1)):
 # - bb5
 bb6[firstDead=-1]():
     <returnMethodTemp>$2: Integer(3) = 3
-    <unconditional> -> bb9
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb12)
 
 # backedges
 # - bb5
-# - bb6
-# - bb10
-# - bb11
-bb9[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$10: T.nilable(TrueClass)):
-    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb12)
+bb9[firstDead=0](<returnMethodTemp>$2: Integer(1), <gotoDeadTemp>$10: NilClass):
+    <gotoDeadTemp>$10 -> (<nullptr> ? bb1 : bb12)
 
 # backedges
 # - bb3
 bb10[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <unconditional> -> bb9
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb12)
 
 # backedges
 # - bb3
 bb11[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
     <gotoDeadTemp>$10: TrueClass = true
-    <unconditional> -> bb9
+    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb12)
 
 # backedges
+# - bb6
 # - bb9
+# - bb10
+# - bb11
 bb12[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1

--- a/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
@@ -8,6 +8,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -29,19 +31,12 @@ bb4[firstDead=3](<self>: Object, <magic>$8: T.class_of(<Magic>)):
     <statTemp>$5: MyException = <cfgAlias>$7: T.class_of(MyException).new()
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: MyException)
     <exceptionValue>$3 = <get-current-exception>
-    <exceptionValue>$3 -> (<nullptr> ? bb3 : bb5)
+    <exceptionValue>$3 -> (<nullptr> ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=0](<returnMethodTemp>$2: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass)):
-    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=0](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$15: NilClass):
+    <gotoDeadTemp>$15 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -49,16 +44,18 @@ bb7[firstDead=-1](<exceptionValue>$3: MyException, <magic>$8: T.class_of(<Magic>
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$9: Sorbet::Private::Static::Void = <magic>$8: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: Integer(3) = 3
-    <unconditional> -> bb6
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$15: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1

--- a/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
@@ -1,21 +1,21 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$8: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception, <magic>$8: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception, <magic>$8: T.class_of(<Magic>)):
     <cfgAlias>$13: T.class_of(MyException) = alias <C MyException>
     <statTemp>$11: MyException = <cfgAlias>$13: T.class_of(MyException).new()
     <exceptionClassTemp>$10: T.class_of(MyException) = <statTemp>$11: MyException.class()
@@ -23,8 +23,8 @@ bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValu
     <isaCheckTemp>$14 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=3](<self>: Object, <magic>$8: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=3](<self>: Object, <magic>$8: T.class_of(<Magic>)):
     <cfgAlias>$7: T.class_of(MyException) = alias <C MyException>
     <statTemp>$5: MyException = <cfgAlias>$7: T.class_of(MyException).new()
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: MyException)
@@ -32,34 +32,34 @@ bb4[rubyRegionId=1, firstDead=3](<self>: Object, <magic>$8: T.class_of(<Magic>))
     <exceptionValue>$3 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=0](<returnMethodTemp>$2: NilClass):
+# - bb4
+bb5[firstDead=0](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass)):
     <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: MyException, <magic>$8: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$3: MyException, <magic>$8: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$9: Sorbet::Private::Static::Void = <magic>$8: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: Integer(3) = 3
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$15: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1
 
@@ -67,7 +67,7 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$6: T.untyped = <self>: T.class_of(<root>).foo()
     <statTemp>$4: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$6: T.untyped)
@@ -75,22 +75,22 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:MyException>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(MyException) = cast(<self>: NilClass, T.class_of(MyException));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
@@ -8,8 +8,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb4
-# - bb6
 # - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
@@ -30,11 +30,6 @@ bb4[firstDead=2]():
     <unconditional> -> bb1
 
 # backedges
-# - bb8
-bb6[firstDead=-1](<self>: Object, <gotoDeadTemp>$12: TrueClass):
-    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
-
-# backedges
 # - bb3
 bb7[firstDead=4](<exceptionValue>$4: StandardError, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
@@ -47,10 +42,10 @@ bb7[firstDead=4](<exceptionValue>$4: StandardError, <magic>$6: T.class_of(<Magic
 # - bb3
 bb8[firstDead=-1](<self>: Object):
     <gotoDeadTemp>$12: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
 
 # backedges
-# - bb6
+# - bb8
 bb9[firstDead=0](<self>: Object):
     <returnMethodTemp>$2 = <self>.deadcode()
     <finalReturn> = return <returnMethodTemp>$2

--- a/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
@@ -1,42 +1,42 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb4(rubyRegionId=1)
-# - bb6(rubyRegionId=3)
-# - bb7(rubyRegionId=2)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+# - bb6
+# - bb7
+# - bb9
+bb1[firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+bb3[firstDead=-1](<self>: Object, <exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=2]():
+# - bb0
+bb4[firstDead=2]():
     <returnTemp>$5: Integer(1) = 1
     <statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <gotoDeadTemp>$12: TrueClass):
+# - bb8
+bb6[firstDead=-1](<self>: Object, <gotoDeadTemp>$12: TrueClass):
     <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=4](<exceptionValue>$4: StandardError, <magic>$6: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=4](<exceptionValue>$4: StandardError, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <returnTemp>$11: Integer(2) = 2
@@ -44,14 +44,14 @@ bb7[rubyRegionId=2, firstDead=4](<exceptionValue>$4: StandardError, <magic>$6: T
     <unconditional> -> bb1
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: Object):
+# - bb3
+bb8[firstDead=-1](<self>: Object):
     <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=0](<self>: Object):
+# - bb6
+bb9[firstDead=0](<self>: Object):
     <returnMethodTemp>$2 = <self>.deadcode()
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
@@ -60,15 +60,15 @@ bb9[rubyRegionId=0, firstDead=0](<self>: Object):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
@@ -1,48 +1,48 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(Exception) = alias <C Exception>
     <isaCheckTemp>$10: TrueClass = <cfgAlias>$9: T.class_of(Exception).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$10 -> (TrueClass ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=2](<self>: Object, <magic>$6: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=2](<self>: Object, <magic>$6: T.class_of(<Magic>)):
     <statTemp>$5: String("boop") = "boop"
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: String("boop"))
     <exceptionValue>$3 = <get-current-exception>
     <exceptionValue>$3 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=0](<returnMethodTemp>$2: NilClass):
+# - bb4
+bb5[firstDead=0](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: Integer(3), <gotoDeadTemp>$16: NilClass):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: Integer(3), <gotoDeadTemp>$16: NilClass):
     <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
     <rescueTemp>$2: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
@@ -53,14 +53,14 @@ bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$6: T.cl
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=0](<returnMethodTemp>$2: NilClass):
+# - bb3
+bb8[firstDead=0](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$16 = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1
 
@@ -68,7 +68,7 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$6: T.untyped = <self>: T.class_of(<root>).foo()
     <statTemp>$4: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$6: T.untyped)
@@ -76,37 +76,37 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::MyClass#foo= {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: MyClass = cast(<self>: NilClass, MyClass);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:MyClass>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(MyClass) = cast(<self>: NilClass, T.class_of(MyClass));
     <returnMethodTemp>$2: Symbol(:foo=) = :foo=
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo=)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
@@ -8,6 +8,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -26,19 +28,12 @@ bb4[firstDead=2](<self>: Object, <magic>$6: T.class_of(<Magic>)):
     <statTemp>$5: String("boop") = "boop"
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: String("boop"))
     <exceptionValue>$3 = <get-current-exception>
-    <exceptionValue>$3 -> (<nullptr> ? bb3 : bb5)
+    <exceptionValue>$3 -> (<nullptr> ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=0](<returnMethodTemp>$2: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: Integer(3), <gotoDeadTemp>$16: NilClass):
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=0](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$16: NilClass):
+    <gotoDeadTemp>$16 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -50,16 +45,18 @@ bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>))
     <statTemp>$12: MyClass = <cfgAlias>$14: T.class_of(MyClass).new()
     <statTemp>$11: Exception = <statTemp>$12: MyClass.foo=(<rescueTemp>$2: Exception)
     <returnMethodTemp>$2: Integer(3) = 3
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=0](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$16 = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$16 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1

--- a/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
@@ -8,7 +8,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb4
-# - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <exceptionValue>$3 = <get-current-exception>
@@ -29,26 +30,21 @@ bb4[firstDead=2]():
     <unconditional> -> bb1
 
 # backedges
-# - bb7
-# - bb8
-bb6[firstDead=-1](<gotoDeadTemp>$10: T.nilable(TrueClass)):
-    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
-
-# backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <unconditional> -> bb6
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1]():
     <gotoDeadTemp>$10: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
 
 # backedges
-# - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1

--- a/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
@@ -1,55 +1,55 @@
 method ::Object#a {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb4(rubyRegionId=1)
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <exceptionValue>$3 = <get-current-exception>
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb3[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=2]():
+# - bb0
+bb4[firstDead=2]():
     <returnTemp>$4: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$10: T.nilable(TrueClass)):
+# - bb7
+# - bb8
+bb6[firstDead=-1](<gotoDeadTemp>$10: T.nilable(TrueClass)):
     <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1]():
+# - bb3
+bb8[firstDead=-1]():
     <gotoDeadTemp>$10: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1]():
+# - bb6
+bb9[firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -57,15 +57,15 @@ bb9[rubyRegionId=0, firstDead=1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:a) = :a
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:a)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/retry.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry.rb.cfg-text.exp
@@ -8,6 +8,7 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb9
+# - bb11
 # - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -49,18 +50,12 @@ bb5[firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>
 # - bb5
 bb7[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb8)
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb9)
 
 # backedges
 # - bb7
-bb8[firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <unconditional> -> bb9
-
-# backedges
-# - bb8
-# - bb11
-bb9[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$24: T.nilable(TrueClass)):
-    <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb12)
+bb9[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$24: NilClass):
+    <gotoDeadTemp>$24 -> (NilClass ? bb1 : bb12)
 
 # backedges
 # - bb3
@@ -77,10 +72,11 @@ bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 # - bb3
 bb11[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$24: TrueClass = true
-    <unconditional> -> bb9
+    <gotoDeadTemp>$24 -> (TrueClass ? bb1 : bb12)
 
 # backedges
 # - bb9
+# - bb11
 bb12[firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1

--- a/test/testdata/cfg/retry.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry.rb.cfg-text.exp
@@ -1,42 +1,42 @@
 method ::Object#main {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
     <magic>$13: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
-# - bb9(rubyRegionId=3)
-# - bb12(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb9
+# - bb12
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb10(rubyRegionId=2)
-bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+# - bb0
+# - bb10
+bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb7(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$13: T.class_of(<Magic>)):
+# - bb2
+# - bb7
+bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$13: T.class_of(<Magic>)):
     <cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$17: T::Boolean = <cfgAlias>$16: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$17 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+# - bb2
+bb4[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
     <ifTemp>$5 -> (T::Boolean ? bb5 : bb7)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+# - bb4
+bb5[firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <statTemp>$9: Integer(0) = try
     <statTemp>$10: Integer(1) = 1
     try: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))
@@ -45,26 +45,26 @@ bb5[rubyRegionId=1, firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.
     <unconditional> -> bb7
 
 # backedges
-# - bb4(rubyRegionId=1)
-# - bb5(rubyRegionId=1)
-bb7[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+# - bb4
+# - bb5
+bb7[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb8)
 
 # backedges
-# - bb7(rubyRegionId=1)
-bb8[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb7
+bb8[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb9
 
 # backedges
-# - bb8(rubyRegionId=4)
-# - bb11(rubyRegionId=2)
-bb9[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$24: T.nilable(TrueClass)):
+# - bb8
+# - bb11
+bb9[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$24: T.nilable(TrueClass)):
     <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb12)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb10[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: StandardError, <magic>$13: T.class_of(<Magic>)):
+# - bb3
+bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: StandardError, <magic>$13: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$14: Sorbet::Private::Static::Void = <magic>$13: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <statTemp>$20: String("rescue") = "rescue"
@@ -74,14 +74,14 @@ bb10[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClas
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb11[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb3
+bb11[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$24: TrueClass = true
     <unconditional> -> bb9
 
 # backedges
-# - bb9(rubyRegionId=3)
-bb12[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
+# - bb9
+bb12[firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -89,15 +89,15 @@ bb12[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$4: T.untyped = <self>: T.class_of(<root>).main()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
@@ -8,6 +8,7 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb12
+# - bb16
 # - bb17
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -70,18 +71,12 @@ bb7[firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>
 # - bb7
 bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb11)
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb12)
 
 # backedges
 # - bb10
-bb11[firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <unconditional> -> bb12
-
-# backedges
-# - bb11
-# - bb16
-bb12[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$46: T.nilable(TrueClass)):
-    <gotoDeadTemp>$46 -> (T.nilable(TrueClass) ? bb1 : bb17)
+bb12[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$46: NilClass):
+    <gotoDeadTemp>$46 -> (NilClass ? bb1 : bb17)
 
 # backedges
 # - bb3
@@ -116,10 +111,11 @@ bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 # - bb14
 bb16[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$46: TrueClass = true
-    <unconditional> -> bb12
+    <gotoDeadTemp>$46 -> (TrueClass ? bb1 : bb17)
 
 # backedges
 # - bb12
+# - bb16
 bb17[firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1

--- a/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
@@ -1,43 +1,43 @@
 method ::Object#main {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
     <magic>$25: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
-# - bb12(rubyRegionId=3)
-# - bb17(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb12
+# - bb17
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb13(rubyRegionId=2)
-# - bb15(rubyRegionId=2)
-bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb0
+# - bb13
+# - bb15
+bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb10(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
+# - bb2
+# - bb10
+bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
     <cfgAlias>$28: T.class_of(A) = alias <C A>
     <isaCheckTemp>$29: T::Boolean = <cfgAlias>$28: T.class_of(A).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$29 -> (T::Boolean ? bb13 : bb14)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb2
+bb4[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
     <ifTemp>$5 -> (T::Boolean ? bb5 : bb6)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb4
+bb5[firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$9: Integer(0) = try
     <statTemp>$10: Integer(1) = 1
     try: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))
@@ -47,15 +47,15 @@ bb5[rubyRegionId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.
     <unconditional> -> bb10
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb6[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb4
+bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$17: Integer(6) = 6
     <ifTemp>$15: T::Boolean = try: Integer(0).<(<statTemp>$17: Integer(6))
     <ifTemp>$15 -> (T::Boolean ? bb7 : bb10)
 
 # backedges
-# - bb6(rubyRegionId=1)
-bb7[rubyRegionId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb6
+bb7[firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$19: Integer(0) = try
     <statTemp>$20: Integer(1) = 1
     try: Integer = <statTemp>$19: Integer(0).+(<statTemp>$20: Integer(1))
@@ -65,27 +65,27 @@ bb7[rubyRegionId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.
     <unconditional> -> bb10
 
 # backedges
-# - bb5(rubyRegionId=1)
-# - bb6(rubyRegionId=1)
-# - bb7(rubyRegionId=1)
-bb10[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb5
+# - bb6
+# - bb7
+bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb11)
 
 # backedges
-# - bb10(rubyRegionId=1)
-bb11[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb10
+bb11[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb12
 
 # backedges
-# - bb11(rubyRegionId=4)
-# - bb16(rubyRegionId=2)
-bb12[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$46: T.nilable(TrueClass)):
+# - bb11
+# - bb16
+bb12[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$46: T.nilable(TrueClass)):
     <gotoDeadTemp>$46 -> (T.nilable(TrueClass) ? bb1 : bb17)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb13[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: A, <magic>$25: T.class_of(<Magic>)):
+# - bb3
+bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: A, <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$26: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <statTemp>$32: String("rescue A ") = "rescue A "
@@ -95,15 +95,15 @@ bb13[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClas
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb14[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
+# - bb3
+bb14[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
     <cfgAlias>$38: T.class_of(B) = alias <C B>
     <isaCheckTemp>$39: T::Boolean = <cfgAlias>$38: T.class_of(B).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$39 -> (T::Boolean ? bb15 : bb16)
 
 # backedges
-# - bb14(rubyRegionId=2)
-bb15[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B, <magic>$25: T.class_of(<Magic>)):
+# - bb14
+bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B, <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$36: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <statTemp>$42: String("rescue B ") = "rescue B "
@@ -113,14 +113,14 @@ bb15[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClas
     <unconditional> -> bb2
 
 # backedges
-# - bb14(rubyRegionId=2)
-bb16[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb14
+bb16[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$46: TrueClass = true
     <unconditional> -> bb12
 
 # backedges
-# - bb12(rubyRegionId=3)
-bb17[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
+# - bb12
+bb17[firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -128,43 +128,43 @@ bb17[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$4: T.untyped = <self>: T.class_of(<root>).main()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/retry_nested.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg-text.exp
@@ -8,7 +8,9 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb15
+# - bb17
 # - bb20
+# - bb22
 # - bb23
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -93,18 +95,12 @@ bb10[firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic
 # - bb10
 bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$8 -> (T.nilable(Exception) ? bb6 : bb14)
+    <exceptionValue>$8 -> (T.nilable(Exception) ? bb6 : bb15)
 
 # backedges
 # - bb13
-bb14[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
-    <unconditional> -> bb15
-
-# backedges
-# - bb14
-# - bb17
-bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: T.nilable(TrueClass), <magic>$42: T.class_of(<Magic>)):
-    <gotoDeadTemp>$40 -> (T.nilable(TrueClass) ? bb1 : bb18)
+bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+    <gotoDeadTemp>$40 -> (NilClass ? bb1 : bb18)
 
 # backedges
 # - bb6
@@ -121,24 +117,19 @@ bb16[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 # - bb6
 bb17[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>)):
     <gotoDeadTemp>$40: TrueClass = true
-    <unconditional> -> bb15
+    <gotoDeadTemp>$40 -> (TrueClass ? bb1 : bb18)
 
 # backedges
 # - bb15
+# - bb17
 bb18[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb19)
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb20)
 
 # backedges
 # - bb18
-bb19[firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <unconditional> -> bb20
-
-# backedges
-# - bb19
-# - bb22
-bb20[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$53: T.nilable(TrueClass)):
-    <gotoDeadTemp>$53 -> (T.nilable(TrueClass) ? bb1 : bb23)
+bb20[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$53: NilClass):
+    <gotoDeadTemp>$53 -> (NilClass ? bb1 : bb23)
 
 # backedges
 # - bb3
@@ -155,10 +146,11 @@ bb21[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 # - bb3
 bb22[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$53: TrueClass = true
-    <unconditional> -> bb20
+    <gotoDeadTemp>$53 -> (TrueClass ? bb1 : bb23)
 
 # backedges
 # - bb20
+# - bb22
 bb23[firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1

--- a/test/testdata/cfg/retry_nested.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg-text.exp
@@ -1,66 +1,66 @@
 method ::Object#main {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
     <magic>$42: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
-# - bb15(rubyRegionId=7)
-# - bb20(rubyRegionId=3)
-# - bb23(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb15
+# - bb20
+# - bb23
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb21(rubyRegionId=2)
-bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb0
+# - bb21
+bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb18(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb2
+# - bb18
+bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <cfgAlias>$45: T.class_of(B) = alias <C B>
     <isaCheckTemp>$46: T::Boolean = <cfgAlias>$45: T.class_of(B).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$46 -> (T::Boolean ? bb21 : bb22)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb2
+bb4[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$7: String("top") = "top"
     <statTemp>$5: NilClass = <self>: Object.puts(<statTemp>$7: String("top"))
     <magic>$29: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb5
 
 # backedges
-# - bb4(rubyRegionId=1)
-# - bb16(rubyRegionId=6)
-bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb4
+# - bb16
+bb5[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb6 : bb7)
 
 # backedges
-# - bb5(rubyRegionId=1)
-# - bb13(rubyRegionId=5)
-bb6[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: Exception, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb5
+# - bb13
+bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: Exception, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <cfgAlias>$32: T.class_of(A) = alias <C A>
     <isaCheckTemp>$33: T::Boolean = <cfgAlias>$32: T.class_of(A).===(<exceptionValue>$8: Exception)
     <isaCheckTemp>$33 -> (T::Boolean ? bb16 : bb17)
 
 # backedges
-# - bb5(rubyRegionId=1)
-bb7[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb5
+bb7[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$11: Integer(3) = 3
     <ifTemp>$9: T::Boolean = try: Integer(0).<(<statTemp>$11: Integer(3))
     <ifTemp>$9 -> (T::Boolean ? bb8 : bb9)
 
 # backedges
-# - bb7(rubyRegionId=5)
-bb8[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb7
+bb8[firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$13: Integer(0) = try
     <statTemp>$14: Integer(1) = 1
     try: Integer = <statTemp>$13: Integer(0).+(<statTemp>$14: Integer(1))
@@ -70,15 +70,15 @@ bb8[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.
     <unconditional> -> bb13
 
 # backedges
-# - bb7(rubyRegionId=5)
-bb9[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb7
+bb9[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$21: Integer(6) = 6
     <ifTemp>$19: T::Boolean = try: Integer(0).<(<statTemp>$21: Integer(6))
     <ifTemp>$19 -> (T::Boolean ? bb10 : bb13)
 
 # backedges
-# - bb9(rubyRegionId=5)
-bb10[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb9
+bb10[firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$23: Integer(0) = try
     <statTemp>$24: Integer(1) = 1
     try: Integer = <statTemp>$23: Integer(0).+(<statTemp>$24: Integer(1))
@@ -88,27 +88,27 @@ bb10[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T
     <unconditional> -> bb13
 
 # backedges
-# - bb8(rubyRegionId=5)
-# - bb9(rubyRegionId=5)
-# - bb10(rubyRegionId=5)
-bb13[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb8
+# - bb9
+# - bb10
+bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb6 : bb14)
 
 # backedges
-# - bb13(rubyRegionId=5)
-bb14[rubyRegionId=8, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb13
+bb14[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <unconditional> -> bb15
 
 # backedges
-# - bb14(rubyRegionId=8)
-# - bb17(rubyRegionId=6)
-bb15[rubyRegionId=7, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: T.nilable(TrueClass), <magic>$42: T.class_of(<Magic>)):
+# - bb14
+# - bb17
+bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: T.nilable(TrueClass), <magic>$42: T.class_of(<Magic>)):
     <gotoDeadTemp>$40 -> (T.nilable(TrueClass) ? bb1 : bb18)
 
 # backedges
-# - bb6(rubyRegionId=6)
-bb16[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: A, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb6
+bb16[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: A, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$8: NilClass = nil
     <keepForCfgTemp>$30: Sorbet::Private::Static::Void = <magic>$29: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$8: NilClass)
     <statTemp>$36: String("rescue A") = "rescue A"
@@ -118,31 +118,31 @@ bb16[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClas
     <unconditional> -> bb5
 
 # backedges
-# - bb6(rubyRegionId=6)
-bb17[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>)):
+# - bb6
+bb17[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>)):
     <gotoDeadTemp>$40: TrueClass = true
     <unconditional> -> bb15
 
 # backedges
-# - bb15(rubyRegionId=7)
-bb18[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb15
+bb18[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb19)
 
 # backedges
-# - bb18(rubyRegionId=1)
-bb19[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb18
+bb19[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb20
 
 # backedges
-# - bb19(rubyRegionId=4)
-# - bb22(rubyRegionId=2)
-bb20[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$53: T.nilable(TrueClass)):
+# - bb19
+# - bb22
+bb20[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$53: T.nilable(TrueClass)):
     <gotoDeadTemp>$53 -> (T.nilable(TrueClass) ? bb1 : bb23)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb21[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb3
+bb21[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$43: Sorbet::Private::Static::Void = <magic>$42: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <statTemp>$49: String("rescue B ") = "rescue B "
@@ -152,14 +152,14 @@ bb21[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClas
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb22[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb3
+bb22[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$53: TrueClass = true
     <unconditional> -> bb20
 
 # backedges
-# - bb20(rubyRegionId=3)
-bb23[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
+# - bb20
+bb23[firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -167,43 +167,43 @@ bb23[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$4: T.untyped = <self>: T.class_of(<root>).main()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/side_effects.rb.cfg-text.exp
+++ b/test/testdata/cfg/side_effects.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Side#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Side = cast(<self>: NilClass, Side);
     cond: T.untyped = load_arg(cond)
     a: Integer(1) = 1
@@ -23,26 +23,26 @@ bb0[rubyRegionId=0, firstDead=-1]():
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
+# - bb0
+bb2[firstDead=-1](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
     a: TrueClass = true
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
+# - bb0
+bb3[firstDead=-1](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
     a: Integer(2) = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
+# - bb2
+# - bb3
+bb4[firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
     <returnMethodTemp>$2: T.untyped = <statTemp>$4: Integer(1).foo(<statTemp>$5: Integer(1), a: T.any(TrueClass, Integer))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -51,15 +51,15 @@ bb4[rubyRegionId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Int
 
 method ::<Class:Side>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Side) = cast(<self>: NilClass, T.class_of(Side));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/side_effects2.rb.cfg-text.exp
+++ b/test/testdata/cfg/side_effects2.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Side#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Side = cast(<self>: NilClass, Side);
     cond: T.untyped = load_arg(cond)
     a: Side = <self>
@@ -23,26 +23,26 @@ bb0[rubyRegionId=0, firstDead=-1]():
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](<statTemp>$4: Side, <statTemp>$5: Side):
+# - bb0
+bb2[firstDead=-1](<statTemp>$4: Side, <statTemp>$5: Side):
     a: TrueClass = true
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](<statTemp>$4: Side, <statTemp>$5: Side):
+# - bb0
+bb3[firstDead=-1](<statTemp>$4: Side, <statTemp>$5: Side):
     a: Integer(2) = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Side, <statTemp>$5: Side):
+# - bb2
+# - bb3
+bb4[firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Side, <statTemp>$5: Side):
     <returnMethodTemp>$2: T.untyped = <statTemp>$4: Side.bar(<statTemp>$5: Side, a: T.any(TrueClass, Integer), a: T.any(TrueClass, Integer))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -51,7 +51,7 @@ bb4[rubyRegionId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Sid
 
 method ::Side#bar {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     <self>: Side = cast(<self>: NilClass, Side);
     a: T.untyped = load_arg(a)
     b: T.untyped = load_arg(b)
@@ -61,22 +61,22 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Side>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Side) = cast(<self>: NilClass, T.class_of(Side));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -1,28 +1,28 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <magic>$14: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$14: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$14: T.class_of(<Magic>)):
     <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$21 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$14: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: T.class_of(<root>), <magic>$14: T.class_of(<Magic>)):
     <cfgAlias>$6: T.class_of(A) = alias <C A>
     <statTemp>$4: A = <cfgAlias>$6: T.class_of(A).new()
     <hashTemp>$8: Symbol(:z) = :z
@@ -37,15 +37,15 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$14: T.clas
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: NilClass):
+# - bb4
+bb5[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$24: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$24: T.nilable(TrueClass)):
     <cfgAlias>$16: T.class_of(T) = alias <C T>
     e: T.untyped = <cfgAlias>$16: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <statTemp>$27: String("done") = "done"
@@ -53,8 +53,8 @@ bb6[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>
     <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$3: StandardError, <magic>$14: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$3: StandardError, <magic>$14: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$14: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <statTemp>$23: String("whoops") = "whoops"
@@ -62,14 +62,14 @@ bb7[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$3
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+# - bb3
+bb8[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
     <gotoDeadTemp>$24: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -77,7 +77,7 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::A#f {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: A = cast(<self>: NilClass, A);
     x: T.untyped = load_arg(x)
     y: T.untyped = load_arg(y)
@@ -86,27 +86,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, map>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
+# - bb2
+bb5[firstDead=5](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
     # outerLoops: 1
     <self>: A = loadSelf(map)
     <blk>$6: T.untyped = load_yield_params(map)
@@ -119,7 +119,7 @@ bb5[rubyRegionId=1, firstDead=5](<self>: A, y: T.untyped, <block-pre-call-temp>$
 
 method ::A#g {
 
-bb0[rubyRegionId=0, firstDead=10]():
+bb0[firstDead=10]():
     <self>: A = cast(<self>: NilClass, A);
     x: T.untyped = load_arg(x)
     y: T.untyped = load_arg(y)
@@ -133,22 +133,22 @@ bb0[rubyRegionId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -34,15 +34,10 @@ bb4[firstDead=-1](<self>: T.class_of(<root>), <magic>$14: T.class_of(<Magic>)):
     <statTemp>$13: TrueClass = true
     <returnMethodTemp>$2: T.untyped = <statTemp>$4: A.f(<statTemp>$7: {z: Integer(3), w: String("string")}, <statTemp>$13: TrueClass)
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$24: T.nilable(TrueClass)):

--- a/test/testdata/cfg/uaf1.rb.cfg-text.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg-text.exp
@@ -24,6 +24,8 @@ bb0[firstDead=-1]():
 # backedges
 # - bb3
 # - bb10
+# - bb11
+# - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
 
@@ -65,21 +67,13 @@ bb8[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::V
     # outerLoops: 1
     <blockReturnTemp>$7: Integer(1) = 1
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$8 -> (T.nilable(Exception) ? bb7 : bb9)
+    <exceptionValue>$8 -> (T.nilable(Exception) ? bb7 : bb10)
 
 # backedges
 # - bb8
-bb9[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer(1), <gotoDeadTemp>$14: NilClass):
+bb10[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer(1), <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
-    <unconditional> -> bb10
-
-# backedges
-# - bb9
-# - bb11
-# - bb12
-bb10[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <gotoDeadTemp>$14: T.nilable(TrueClass)):
-    # outerLoops: 1
-    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb13)
+    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
@@ -88,17 +82,19 @@ bb11[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::
     <exceptionValue>$8: NilClass = nil
     <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$8: NilClass)
     <blockReturnTemp>$7: Integer(2) = 2
-    <unconditional> -> bb10
+    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
 bb12[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer)):
     # outerLoops: 1
     <gotoDeadTemp>$14: TrueClass = true
-    <unconditional> -> bb10
+    <gotoDeadTemp>$14 -> (TrueClass ? bb1 : bb13)
 
 # backedges
 # - bb10
+# - bb11
+# - bb12
 bb13[firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer, <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$16: T.noreturn = blockreturn<map> <blockReturnTemp>$7: Integer

--- a/test/testdata/cfg/uaf1.rb.cfg-text.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::A#initialize {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: A = cast(<self>: NilClass, A);
     <statTemp>$3: T.untyped = <self>: A.spec_list()
     <block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$3: T.untyped.map()
@@ -22,28 +22,28 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb10(rubyRegionId=4)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+# - bb10
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb13(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$14: NilClass):
+# - bb0
+# - bb13
+bb2[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$5, map>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$14: NilClass):
+# - bb2
+bb5[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
     <self>: A = loadSelf(map)
     <magic>$9: T.class_of(<Magic>) = alias <C <Magic>>
@@ -51,39 +51,39 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb7 : bb8)
 
 # backedges
-# - bb5(rubyRegionId=1)
-# - bb8(rubyRegionId=2)
-bb7[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <exceptionValue>$8: Exception, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
+# - bb5
+# - bb8
+bb7[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <exceptionValue>$8: Exception, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
     <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$8: Exception)
     <isaCheckTemp>$13 -> (T::Boolean ? bb11 : bb12)
 
 # backedges
-# - bb5(rubyRegionId=1)
-bb8[rubyRegionId=2, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
+# - bb5
+bb8[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$7: Integer(1) = 1
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb7 : bb9)
 
 # backedges
-# - bb8(rubyRegionId=2)
-bb9[rubyRegionId=5, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer(1), <gotoDeadTemp>$14: NilClass):
+# - bb8
+bb9[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer(1), <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
     <unconditional> -> bb10
 
 # backedges
-# - bb9(rubyRegionId=5)
-# - bb11(rubyRegionId=3)
-# - bb12(rubyRegionId=3)
-bb10[rubyRegionId=4, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <gotoDeadTemp>$14: T.nilable(TrueClass)):
+# - bb9
+# - bb11
+# - bb12
+bb10[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <gotoDeadTemp>$14: T.nilable(TrueClass)):
     # outerLoops: 1
     <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
-# - bb7(rubyRegionId=3)
-bb11[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <exceptionValue>$8: StandardError, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
+# - bb7
+bb11[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <exceptionValue>$8: StandardError, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
     <exceptionValue>$8: NilClass = nil
     <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$8: NilClass)
@@ -91,15 +91,15 @@ bb11[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::P
     <unconditional> -> bb10
 
 # backedges
-# - bb7(rubyRegionId=3)
-bb12[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer)):
+# - bb7
+bb12[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer)):
     # outerLoops: 1
     <gotoDeadTemp>$14: TrueClass = true
     <unconditional> -> bb10
 
 # backedges
-# - bb10(rubyRegionId=4)
-bb13[rubyRegionId=1, firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer, <gotoDeadTemp>$14: NilClass):
+# - bb10
+bb13[firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer, <gotoDeadTemp>$14: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$16: T.noreturn = blockreturn<map> <blockReturnTemp>$7: Integer
     <unconditional> -> bb2
@@ -108,15 +108,15 @@ bb13[rubyRegionId=1, firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <returnMethodTemp>$2: Symbol(:initialize) = :initialize
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:initialize)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
@@ -24,16 +24,11 @@ bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
 bb4[firstDead=-1](<self>: Object):
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
-
-# backedges
-# - bb4
-bb5[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
-    <unconditional> -> bb6
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb3
-# - bb5
+# - bb4
 bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$6: T.nilable(TrueClass)):
     <throwAwayTemp>$7: T.untyped = <self>: Object.b()
     <gotoDeadTemp>$6 -> (T.nilable(TrueClass) ? bb1 : bb7)

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
@@ -1,46 +1,46 @@
 method ::Object#main {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$6: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: Object):
+# - bb0
+bb4[firstDead=-1](<self>: Object):
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
+# - bb4
+bb5[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-# - bb5(rubyRegionId=4)
-bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$6: T.nilable(TrueClass)):
+# - bb3
+# - bb5
+bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$6: T.nilable(TrueClass)):
     <throwAwayTemp>$7: T.untyped = <self>: Object.b()
     <gotoDeadTemp>$6 -> (T.nilable(TrueClass) ? bb1 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb7[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6
+bb7[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -48,43 +48,43 @@ bb7[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::Object#a {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#b {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$6: T.untyped = <self>: T.class_of(<root>).main()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/desugar/for.rb.cfg-text.exp
+++ b/test/testdata/desugar/for.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Main) = alias <C Main>
     <returnMethodTemp>$2: T.untyped = <cfgAlias>$4: T.class_of(Main).main()
@@ -8,15 +8,15 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#each {
 
-bb0[rubyRegionId=0, firstDead=15]():
+bb0[firstDead=15]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     blk: T.untyped = load_arg(blk)
     <statTemp>$5: Integer(1) = 1
@@ -35,30 +35,30 @@ bb0[rubyRegionId=0, firstDead=15]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <returnMethodTemp>$2: Symbol(:each) = :each
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:each)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:E>#e= {
 
-bb0[rubyRegionId=0, firstDead=10]():
+bb0[firstDead=10]():
     @e$3: T.untyped = alias <C <undeclared-field-stub>> (@e)
     <self>: T.class_of(E) = cast(<self>: NilClass, T.class_of(E));
     e: T.untyped = load_arg(e)
@@ -72,15 +72,15 @@ bb0[rubyRegionId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:E>#e {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     @e$3: T.untyped = alias <C <undeclared-field-stub>> (@e)
     <self>: T.class_of(E) = cast(<self>: NilClass, T.class_of(E));
     <returnMethodTemp>$2: T.untyped = @e$3
@@ -88,29 +88,29 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:E>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(E) = cast(<self>: NilClass, T.class_of(E));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Main>#main {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     @a$104: T.untyped = alias <C <undeclared-field-stub>> (@a)
     @@b$114: T.untyped = alias <C <undeclared-field-stub>> (@@b)
     $c$124: T.untyped = alias <C <undeclared-field-stub>> ($c)
@@ -121,20 +121,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb23(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb23
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     <statTemp>$3: T.untyped = Solve<<block-pre-call-temp>$6, each>
     <self>: T.class_of(Main) = <selfRestore>$7
     <cfgAlias>$16: T.class_of(A) = alias <C A>
@@ -143,8 +143,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb2
+bb5[firstDead=6](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$8: T.untyped = load_yield_params(each)
@@ -155,15 +155,15 @@ bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Main), <block-pre-call-temp>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb6
+bb7[firstDead=-1](<block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     <statTemp>$14: T.untyped = Solve<<block-pre-call-temp>$17, each>
     <self>: T.class_of(Main) = <selfRestore>$18
     <cfgAlias>$41: T.class_of(A) = alias <C A>
@@ -172,8 +172,8 @@ bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$17: Sorbet::Private::Sta
     <unconditional> -> bb10
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=14](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb6
+bb9[firstDead=14](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$19: T.untyped = load_yield_params(each)
@@ -192,15 +192,15 @@ bb9[rubyRegionId=2, firstDead=14](<self>: T.class_of(Main), <block-pre-call-temp
     <unconditional> -> bb6
 
 # backedges
-# - bb7(rubyRegionId=0)
-# - bb13(rubyRegionId=3)
-bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb7
+# - bb13
+bb10[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
-# - bb10(rubyRegionId=3)
-bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb10
+bb11[firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     <statTemp>$39: T.untyped = Solve<<block-pre-call-temp>$42, each>
     <self>: T.class_of(Main) = <selfRestore>$43
     <cfgAlias>$56: T.class_of(A) = alias <C A>
@@ -209,8 +209,8 @@ bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::St
     <unconditional> -> bb14
 
 # backedges
-# - bb10(rubyRegionId=3)
-bb13[rubyRegionId=3, firstDead=9](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb10
+bb13[firstDead=9](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$44: T.untyped = load_yield_params(each)
@@ -224,15 +224,15 @@ bb13[rubyRegionId=3, firstDead=9](<self>: T.class_of(Main), <block-pre-call-temp
     <unconditional> -> bb10
 
 # backedges
-# - bb11(rubyRegionId=0)
-# - bb17(rubyRegionId=4)
-bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb11
+# - bb17
+bb14[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
-# - bb14(rubyRegionId=4)
-bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb14
+bb15[firstDead=-1](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     <statTemp>$54: T.untyped = Solve<<block-pre-call-temp>$57, each>
     <self>: T.class_of(Main) = <selfRestore>$58
     <statTemp>$88: String("main") = "main"
@@ -243,8 +243,8 @@ bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$57: Sorbet::Private::St
     <unconditional> -> bb18
 
 # backedges
-# - bb14(rubyRegionId=4)
-bb17[rubyRegionId=4, firstDead=18](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb14
+bb17[firstDead=18](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$59: T.untyped = load_yield_params(each)
@@ -267,15 +267,15 @@ bb17[rubyRegionId=4, firstDead=18](<self>: T.class_of(Main), <block-pre-call-tem
     <unconditional> -> bb14
 
 # backedges
-# - bb15(rubyRegionId=0)
-# - bb21(rubyRegionId=5)
-bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb15
+# - bb21
+bb18[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
-# - bb18(rubyRegionId=5)
-bb19[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb18
+bb19[firstDead=-1](<block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     <statTemp>$89: T.untyped = Solve<<block-pre-call-temp>$92, each>
     <self>: T.class_of(Main) = <selfRestore>$93
     <cfgAlias>$159: T.class_of(A) = alias <C A>
@@ -284,8 +284,8 @@ bb19[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$92: Sorbet::Private::St
     <unconditional> -> bb22
 
 # backedges
-# - bb18(rubyRegionId=5)
-bb21[rubyRegionId=5, firstDead=40](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
+# - bb18
+bb21[firstDead=40](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
     <cfgAlias>$99: T.class_of(<Magic>) = alias <C <Magic>>
@@ -330,22 +330,22 @@ bb21[rubyRegionId=5, firstDead=40](<self>: T.class_of(Main), <block-pre-call-tem
     <unconditional> -> bb18
 
 # backedges
-# - bb19(rubyRegionId=0)
-# - bb25(rubyRegionId=6)
-bb22[rubyRegionId=6, firstDead=-1](<self>: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped, <block-pre-call-temp>$160: Sorbet::Private::Static::Void, <selfRestore>$161: T.class_of(Main)):
+# - bb19
+# - bb25
+bb22[firstDead=-1](<self>: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped, <block-pre-call-temp>$160: Sorbet::Private::Static::Void, <selfRestore>$161: T.class_of(Main)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb25 : bb23)
 
 # backedges
-# - bb22(rubyRegionId=6)
-bb23[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$160: Sorbet::Private::Static::Void, <selfRestore>$161: T.class_of(Main)):
+# - bb22
+bb23[firstDead=2](<block-pre-call-temp>$160: Sorbet::Private::Static::Void, <selfRestore>$161: T.class_of(Main)):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$160, each>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb22(rubyRegionId=6)
-bb25[rubyRegionId=6, firstDead=44](<self>: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped, <block-pre-call-temp>$160: Sorbet::Private::Static::Void, <selfRestore>$161: T.class_of(Main)):
+# - bb22
+bb25[firstDead=44](<self>: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped, <block-pre-call-temp>$160: Sorbet::Private::Static::Void, <selfRestore>$161: T.class_of(Main)):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$162: T.untyped = load_yield_params(each)
@@ -397,15 +397,15 @@ bb25[rubyRegionId=6, firstDead=44](<self>: T.class_of(Main), @a$104: T.untyped, 
 
 method ::<Class:Main>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));
     <returnMethodTemp>$2: Symbol(:main) = :main
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:main)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/blocks2.rb.cfg-text.exp
+++ b/test/testdata/infer/blocks2.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#bar {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: Foo = cast(<self>: NilClass, Foo);
     <blk>: T.untyped = load_arg(<blk>)
     <statTemp>$4: Integer(1) = 1
@@ -23,42 +23,42 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#baz {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Foo = cast(<self>: NilClass, Foo);
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Foo.bar()
     <selfRestore>$5: Foo = <self>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, bar>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
+# - bb2
+bb5[firstDead=5](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
     # outerLoops: 1
     <self>: Foo = loadSelf(bar)
     <blk>$6: T.untyped = load_yield_params(bar)
@@ -71,14 +71,14 @@ bb5[rubyRegionId=1, firstDead=5](<self>: Foo, <block-pre-call-temp>$4: Sorbet::P
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -763,15 +763,10 @@ bb4[firstDead=-1](<self>: String, <magic>$11: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: String = <cfgAlias>$9: T.class_of(T).reveal_type(<self>: String)
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<self>: String, <returnMethodTemp>$2: String, <exceptionValue>$3: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$22: T.nilable(TrueClass)):
@@ -840,15 +835,10 @@ bb4[firstDead=-1](<self>: Float, <magic>$11: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: String = <cfgAlias>$9: T.class_of(T).reveal_type(<self>: String)
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<self>: String, <returnMethodTemp>$2: String, <exceptionValue>$3: NilClass):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$26: T.nilable(TrueClass)):
@@ -904,6 +894,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -927,19 +919,12 @@ bb4[firstDead=-1](<self>: String, <magic>$15: T.class_of(<Magic>)):
     <cfgAlias>$13: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: String = <cfgAlias>$13: T.class_of(T).reveal_type(<self>: String)
     <exceptionValue>$7: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$7 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$7 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](<returnMethodTemp>$2: String):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$23: T.nilable(TrueClass)):
-    <gotoDeadTemp>$23 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: String, <gotoDeadTemp>$23: NilClass):
+    <gotoDeadTemp>$23 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -948,16 +933,18 @@ bb7[firstDead=-1](<self>: String, <exceptionValue>$7: StandardError, <magic>$15:
     <keepForCfgTemp>$16: Sorbet::Private::Static::Void = <magic>$15: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$7: NilClass)
     <cfgAlias>$21: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: String = <cfgAlias>$21: T.class_of(T).reveal_type(<self>: String)
-    <unconditional> -> bb6
+    <gotoDeadTemp>$23 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.nilable(String)):
     <gotoDeadTemp>$23: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$23 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: String):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String
     <unconditional> -> bb1
@@ -975,6 +962,8 @@ bb0[firstDead=-1]():
 # backedges
 # - bb3
 # - bb10
+# - bb11
+# - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
 
@@ -1023,21 +1012,13 @@ bb8[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Sta
     <cfgAlias>$15: T.class_of(T) = alias <C T>
     <blockReturnTemp>$8: Integer = <cfgAlias>$15: T.class_of(T).reveal_type(<self>: Integer)
     <exceptionValue>$9: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$9 -> (T.nilable(Exception) ? bb7 : bb9)
+    <exceptionValue>$9 -> (T.nilable(Exception) ? bb7 : bb10)
 
 # backedges
 # - bb8
-bb9[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: Integer, <gotoDeadTemp>$25: NilClass):
+bb10[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: Integer, <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
-    <unconditional> -> bb10
-
-# backedges
-# - bb9
-# - bb11
-# - bb12
-bb10[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$25: T.nilable(TrueClass)):
-    # outerLoops: 1
-    <gotoDeadTemp>$25 -> (T.nilable(TrueClass) ? bb1 : bb13)
+    <gotoDeadTemp>$25 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
@@ -1047,17 +1028,19 @@ bb11[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::St
     <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$9: NilClass)
     <cfgAlias>$23: T.class_of(T) = alias <C T>
     <blockReturnTemp>$8: Integer = <cfgAlias>$23: T.class_of(T).reveal_type(<self>: Integer)
-    <unconditional> -> bb10
+    <gotoDeadTemp>$25 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
 bb12[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <castTemp>$13: T.nilable(Integer)):
     # outerLoops: 1
     <gotoDeadTemp>$25: TrueClass = true
-    <unconditional> -> bb10
+    <gotoDeadTemp>$25 -> (TrueClass ? bb1 : bb13)
 
 # backedges
 # - bb10
+# - bb11
+# - bb12
 bb13[firstDead=1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$27: T.noreturn = blockreturn<takes_block> <blockReturnTemp>$8: Integer

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(B) = alias <C B>
     <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(B).class_helper()
@@ -8,20 +8,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=5](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
+# - bb2
+bb3[firstDead=5](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$6, class_helper>
     <self>: T.class_of(<root>) = <selfRestore>$7
     <cfgAlias>$21: T.class_of(T) = alias <C T>
@@ -30,8 +30,8 @@ bb3[rubyRegionId=0, firstDead=5](<block-pre-call-temp>$6: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
+# - bb2
+bb5[firstDead=10](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf(class_helper)
     <cfgAlias>$11: T.class_of(B) = alias <C B>
@@ -49,49 +49,49 @@ bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(<root>), <block-pre-call-te
 
 method ::<Class:Base>#before_save {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Base) = cast(<self>: NilClass, T.class_of(Base));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Base>#before_create {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Base) = cast(<self>: NilClass, T.class_of(Base));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Base>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Base) = cast(<self>: NilClass, T.class_of(Base));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Concern#included {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     @block$3: T.untyped = alias <C <undeclared-field-stub>> (@block)
     <self>: Concern = cast(<self>: NilClass, Concern);
     block: T.untyped = load_arg(block)
@@ -101,30 +101,30 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Concern>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Concern) = cast(<self>: NilClass, T.class_of(Concern));
     <returnMethodTemp>$2: Symbol(:included) = :included
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:included)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Readable>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Readable) = cast(<self>: NilClass, T.class_of(Readable));
     <cfgAlias>$6: T.class_of(Concern) = alias <C Concern>
     <statTemp>$3: T.class_of(Readable) = <self>: T.class_of(Readable).extend(<cfgAlias>$6: T.class_of(Concern))
@@ -133,27 +133,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
     <statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
+# - bb2
+bb5[firstDead=4](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
     # outerLoops: 1
     <self>: T.class_of(Readable) = loadSelf(included)
     <statTemp>$13: Symbol(:do_this) = :do_this
@@ -165,7 +165,7 @@ bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(Readable), <block-pre-call-t
 
 method ::<Class:Writable>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Writable) = cast(<self>: NilClass, T.class_of(Writable));
     <cfgAlias>$6: T.class_of(Concern) = alias <C Concern>
     <statTemp>$3: T.class_of(Writable) = <self>: T.class_of(Writable).extend(<cfgAlias>$6: T.class_of(Concern))
@@ -174,27 +174,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
     <statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=15](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
+# - bb2
+bb5[firstDead=15](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
     # outerLoops: 1
     <self>: T.class_of(Writable) = loadSelf(included)
     <cfgAlias>$15: T.class_of(T) = alias <C T>
@@ -217,7 +217,7 @@ bb5[rubyRegionId=1, firstDead=15](<self>: T.class_of(Writable), <block-pre-call-
 
 method ::<Class:Shareable>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Shareable) = cast(<self>: NilClass, T.class_of(Shareable));
     <cfgAlias>$6: T.class_of(Concern) = alias <C Concern>
     <statTemp>$3: T.class_of(Shareable) = <self>: T.class_of(Shareable).extend(<cfgAlias>$6: T.class_of(Concern))
@@ -226,27 +226,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
     <statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
+# - bb2
+bb5[firstDead=10](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
     # outerLoops: 1
     <self>: T.class_of(Shareable) = loadSelf(included)
     <cfgAlias>$15: T.class_of(T) = alias <C T>
@@ -264,50 +264,50 @@ bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(Shareable), <block-pre-call
 
 method ::<Class:Post>#some_class_method {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Post) = cast(<self>: NilClass, T.class_of(Post));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Post#author {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Post = cast(<self>: NilClass, Post);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Post#should_run_callback? {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: Post = cast(<self>: NilClass, Post);
     <returnMethodTemp>$2: TrueClass = true
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: TrueClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Post#score {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: Post = cast(<self>: NilClass, Post);
     <cfgAlias>$4: T.class_of(Integer) = alias <C Integer>
     keep_for_ide$3: T.class_of(Integer) = <cfgAlias>$4
@@ -316,15 +316,15 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Post>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Post) = cast(<self>: NilClass, T.class_of(Post));
     <cfgAlias>$6: T.class_of(Readable) = alias <C Readable>
     <statTemp>$3: T.class_of(Post) = <self>: T.class_of(Post).include(<cfgAlias>$6: T.class_of(Readable))
@@ -339,28 +339,28 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=3](<statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
+# - bb2
+bb3[firstDead=3](<statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
     <hashTemp>$15: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$18, lambda>
     <statTemp>$11: T.untyped = <statTemp>$12: T.class_of(Post).before_create(<statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <hashTemp>$15: T.proc.returns(T.untyped))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=3](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
+# - bb2
+bb5[firstDead=3](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
     # outerLoops: 1
     <self>: T.class_of(Post) = loadSelf(lambda)
     <blockReturnTemp>$20: T.untyped = <self>: T.class_of(Post).should_run_callback?()
@@ -371,36 +371,36 @@ bb5[rubyRegionId=1, firstDead=3](<self>: T.class_of(Post), <statTemp>$12: T.clas
 
 method ::Article#author {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Article = cast(<self>: NilClass, Article);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Article#should_run_callback? {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: Article = cast(<self>: NilClass, Article);
     <returnMethodTemp>$2: TrueClass = true
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: TrueClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Article>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Article) = cast(<self>: NilClass, T.class_of(Article));
     <cfgAlias>$6: T.class_of(Writable) = alias <C Writable>
     <statTemp>$3: T.class_of(Article) = <self>: T.class_of(Article).include(<cfgAlias>$6: T.class_of(Writable))
@@ -415,28 +415,28 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=3](<statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
+# - bb2
+bb3[firstDead=3](<statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
     <hashTemp>$15: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$18, lambda>
     <statTemp>$11: T.untyped = <statTemp>$12: T.class_of(Article).before_create(<statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <hashTemp>$15: T.proc.returns(T.untyped))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
+# - bb2
+bb5[firstDead=8](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
     # outerLoops: 1
     <self>: T.class_of(Article) = loadSelf(lambda)
     <cfgAlias>$23: T.class_of(Article) = alias <C Article>
@@ -452,21 +452,21 @@ bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(Article), <statTemp>$12: T.c
 
 method ::A#instance_helper {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: A = cast(<self>: NilClass, A);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$6: T.class_of(Kernel) = alias <C Kernel>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$6: T.class_of(Kernel).lambda()
@@ -474,20 +474,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     f: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$7, lambda>
     <self>: T.class_of(A) = <selfRestore>$8
     <cfgAlias>$22: T.class_of(T) = alias <C T>
@@ -497,8 +497,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb2
+bb5[firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <self>: T.class_of(A) = loadSelf(lambda)
     <cfgAlias>$12: T.class_of(A) = alias <C A>
@@ -516,35 +516,35 @@ bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$7
 
 method ::<Class:B>#class_helper {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::B#instance_helper {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: B = cast(<self>: NilClass, B);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))
@@ -552,20 +552,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(B) = <selfRestore>$8
     <cfgAlias>$21: T.class_of(T::Sig) = alias <C Sig>
@@ -575,8 +575,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+# - bb2
+bb5[firstDead=8](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$12: Symbol(:blk) = :blk
@@ -592,50 +592,50 @@ bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(B), <block-pre-call-temp>$7:
 
 method ::N#helper_from_N {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: N = cast(<self>: NilClass, N);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:N>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(N) = cast(<self>: NilClass, T.class_of(N));
     <returnMethodTemp>$2: Symbol(:helper_from_N) = :helper_from_N
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:helper_from_N)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::M#helper_from_M {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: M = cast(<self>: NilClass, M);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::M#main {
 
-bb0[rubyRegionId=0, firstDead=13]():
+bb0[firstDead=13]():
     <self>: M = cast(<self>: NilClass, M);
     <cfgAlias>$6: T.class_of(T) = alias <C T>
     <cfgAlias>$8: T.class_of(M) = alias <C M>
@@ -652,15 +652,15 @@ bb0[rubyRegionId=0, firstDead=13]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:M>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: T.class_of(M) = cast(<self>: NilClass, T.class_of(M));
     <cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -669,15 +669,15 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::ThisSelf#main {
 
-bb0[rubyRegionId=0, firstDead=11]():
+bb0[firstDead=11]():
     <self>: ThisSelf = cast(<self>: NilClass, ThisSelf);
     <cfgAlias>$5: T.class_of(Kernel) = alias <C Kernel>
     keep_for_ide$4: T.class_of(Kernel) = <cfgAlias>$5
@@ -692,15 +692,15 @@ bb0[rubyRegionId=0, firstDead=11]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:ThisSelf>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: T.class_of(ThisSelf) = cast(<self>: NilClass, T.class_of(ThisSelf));
     <cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -709,29 +709,29 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Rescues>#takes_block {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Rescues) = cast(<self>: NilClass, T.class_of(Rescues));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Rescues#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
     <magic>$11: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
@@ -739,22 +739,22 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
     <cfgAlias>$17: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$18: T::Boolean = <cfgAlias>$17: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$18 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: String, <magic>$11: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: String, <magic>$11: T.class_of(<Magic>)):
     <cfgAlias>$6: T.class_of(String) = alias <C String>
     keep_for_ide$5: T.class_of(String) = <cfgAlias>$6
     keep_for_ide$5: T.untyped = <keep-alive> keep_for_ide$5
@@ -766,15 +766,15 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: String, <magic>$11: T.class_of(<Magic>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<self>: String, <returnMethodTemp>$2: String, <exceptionValue>$3: NilClass):
+# - bb4
+bb5[firstDead=-1](<self>: String, <returnMethodTemp>$2: String, <exceptionValue>$3: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$22: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$22: T.nilable(TrueClass)):
     <cfgAlias>$13: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$13: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <cfgAlias>$25: T.class_of(T) = alias <C T>
@@ -782,8 +782,8 @@ bb6[rubyRegionId=3, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilabl
     <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: String, <exceptionValue>$3: StandardError, <magic>$11: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: String, <exceptionValue>$3: StandardError, <magic>$11: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$15: Sorbet::Private::Static::Void = <magic>$11: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <cfgAlias>$20: T.class_of(T) = alias <C T>
@@ -791,14 +791,14 @@ bb7[rubyRegionId=2, firstDead=-1](<self>: String, <exceptionValue>$3: StandardEr
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
+# - bb3
+bb8[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
     <gotoDeadTemp>$22: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: String):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String
     <unconditional> -> bb1
 
@@ -806,7 +806,7 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
 
 method ::Rescues#bar {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
     <magic>$11: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
@@ -816,22 +816,22 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
     <cfgAlias>$17: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$18: T::Boolean = <cfgAlias>$17: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$18 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: Float, <magic>$11: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: Float, <magic>$11: T.class_of(<Magic>)):
     <cfgAlias>$6: T.class_of(String) = alias <C String>
     keep_for_ide$5: T.class_of(String) = <cfgAlias>$6
     keep_for_ide$5: T.untyped = <keep-alive> keep_for_ide$5
@@ -843,15 +843,15 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: Float, <magic>$11: T.class_of(<Magic>)
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<self>: String, <returnMethodTemp>$2: String, <exceptionValue>$3: NilClass):
+# - bb4
+bb5[firstDead=-1](<self>: String, <returnMethodTemp>$2: String, <exceptionValue>$3: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$26: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$26: T.nilable(TrueClass)):
     <cfgAlias>$13: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$13: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <cfgAlias>$30: T.class_of(Float) = alias <C Float>
@@ -864,8 +864,8 @@ bb6[rubyRegionId=3, firstDead=-1](<self>: T.any(Float, String, Integer), <return
     <gotoDeadTemp>$26 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <exceptionValue>$3: StandardError, <magic>$11: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: T.any(Float, String), <exceptionValue>$3: StandardError, <magic>$11: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$15: Sorbet::Private::Static::Void = <magic>$11: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <cfgAlias>$21: T.class_of(Integer) = alias <C Integer>
@@ -878,14 +878,14 @@ bb7[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <exceptionValue>
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
+# - bb3
+bb8[firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
     <gotoDeadTemp>$26: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.any(Integer, String)):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.any(Integer, String)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.any(Integer, String)
     <unconditional> -> bb1
 
@@ -893,7 +893,7 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.any(Integer, String)):
 
 method ::Rescues#baz {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
     <cfgAlias>$5: T.class_of(T) = alias <C T>
     <statTemp>$3: Rescues = <cfgAlias>$5: T.class_of(T).reveal_type(<self>: Rescues)
@@ -903,22 +903,22 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$7 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb9(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: Exception, <magic>$15: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: Exception, <magic>$15: T.class_of(<Magic>)):
     <cfgAlias>$18: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$19: T::Boolean = <cfgAlias>$18: T.class_of(StandardError).===(<exceptionValue>$7: Exception)
     <isaCheckTemp>$19 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: String, <magic>$15: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](<self>: String, <magic>$15: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(String) = alias <C String>
     keep_for_ide$9: T.class_of(String) = <cfgAlias>$10
     keep_for_ide$9: T.untyped = <keep-alive> keep_for_ide$9
@@ -930,20 +930,20 @@ bb4[rubyRegionId=1, firstDead=-1](<self>: String, <magic>$15: T.class_of(<Magic>
     <exceptionValue>$7 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: String):
+# - bb4
+bb5[firstDead=-1](<returnMethodTemp>$2: String):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$23: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$23: T.nilable(TrueClass)):
     <gotoDeadTemp>$23 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: String, <exceptionValue>$7: StandardError, <magic>$15: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](<self>: String, <exceptionValue>$7: StandardError, <magic>$15: T.class_of(<Magic>)):
     <exceptionValue>$7: NilClass = nil
     <keepForCfgTemp>$16: Sorbet::Private::Static::Void = <magic>$15: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$7: NilClass)
     <cfgAlias>$21: T.class_of(T) = alias <C T>
@@ -951,14 +951,14 @@ bb7[rubyRegionId=2, firstDead=-1](<self>: String, <exceptionValue>$7: StandardEr
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(String)):
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.nilable(String)):
     <gotoDeadTemp>$23: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: String):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String
     <unconditional> -> bb1
 
@@ -966,35 +966,35 @@ bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
 
 method ::<Class:Rescues>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Rescues) = cast(<self>: NilClass, T.class_of(Rescues));
     <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <self>: T.class_of(Rescues).takes_block()
     <selfRestore>$7: T.class_of(Rescues) = <self>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb10(rubyRegionId=4)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+# - bb10
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb13(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$25: NilClass):
+# - bb0
+# - bb13
+bb2[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues)):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues)):
     <statTemp>$4: T.untyped = Solve<<block-pre-call-temp>$6, takes_block>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$25: NilClass):
+# - bb2
+bb5[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
     <self>: T.class_of(Rescues) = loadSelf(takes_block)
     <magic>$17: T.class_of(<Magic>) = alias <C <Magic>>
@@ -1003,17 +1003,17 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-t
     <exceptionValue>$9 -> (T.nilable(Exception) ? bb7 : bb8)
 
 # backedges
-# - bb5(rubyRegionId=1)
-# - bb8(rubyRegionId=2)
-bb7[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: Exception, <castTemp>$13: T.nilable(Integer), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
+# - bb5
+# - bb8
+bb7[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: Exception, <castTemp>$13: T.nilable(Integer), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
     <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$9: Exception)
     <isaCheckTemp>$21 -> (T::Boolean ? bb11 : bb12)
 
 # backedges
-# - bb5(rubyRegionId=1)
-bb8[rubyRegionId=2, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
+# - bb5
+bb8[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
     <cfgAlias>$12: T.class_of(Integer) = alias <C Integer>
     keep_for_ide$11: T.class_of(Integer) = <cfgAlias>$12
@@ -1026,22 +1026,22 @@ bb8[rubyRegionId=2, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorb
     <exceptionValue>$9 -> (T.nilable(Exception) ? bb7 : bb9)
 
 # backedges
-# - bb8(rubyRegionId=2)
-bb9[rubyRegionId=5, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: Integer, <gotoDeadTemp>$25: NilClass):
+# - bb8
+bb9[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: Integer, <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
     <unconditional> -> bb10
 
 # backedges
-# - bb9(rubyRegionId=5)
-# - bb11(rubyRegionId=3)
-# - bb12(rubyRegionId=3)
-bb10[rubyRegionId=4, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$25: T.nilable(TrueClass)):
+# - bb9
+# - bb11
+# - bb12
+bb10[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$25: T.nilable(TrueClass)):
     # outerLoops: 1
     <gotoDeadTemp>$25 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
-# - bb7(rubyRegionId=3)
-bb11[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <exceptionValue>$9: StandardError, <castTemp>$13: T.nilable(Integer), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
+# - bb7
+bb11[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <exceptionValue>$9: StandardError, <castTemp>$13: T.nilable(Integer), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
     <exceptionValue>$9: NilClass = nil
     <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$9: NilClass)
@@ -1050,15 +1050,15 @@ bb11[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sor
     <unconditional> -> bb10
 
 # backedges
-# - bb7(rubyRegionId=3)
-bb12[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <castTemp>$13: T.nilable(Integer)):
+# - bb7
+bb12[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <castTemp>$13: T.nilable(Integer)):
     # outerLoops: 1
     <gotoDeadTemp>$25: TrueClass = true
     <unconditional> -> bb10
 
 # backedges
-# - bb10(rubyRegionId=4)
-bb13[rubyRegionId=1, firstDead=1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$25: NilClass):
+# - bb10
+bb13[firstDead=1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$25: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$27: T.noreturn = blockreturn<takes_block> <blockReturnTemp>$8: Integer
     <unconditional> -> bb2
@@ -1067,7 +1067,7 @@ bb13[rubyRegionId=1, firstDead=1](<self>: Integer, <block-pre-call-temp>$6: Sorb
 
 method ::UntypedBind#foo {
 
-bb0[rubyRegionId=0, firstDead=18]():
+bb0[firstDead=18]():
     <self>: UntypedBind = cast(<self>: NilClass, UntypedBind);
     <cfgAlias>$5: T.class_of(T) = alias <C T>
     <statTemp>$3: UntypedBind = <cfgAlias>$5: T.class_of(T).reveal_type(<self>: UntypedBind)
@@ -1089,23 +1089,23 @@ bb0[rubyRegionId=0, firstDead=18]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:UntypedBind>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(UntypedBind) = cast(<self>: NilClass, T.class_of(UntypedBind));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/casts.rb.cfg-text.exp
+++ b/test/testdata/infer/casts.rb.cfg-text.exp
@@ -1,34 +1,34 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestCasts#untyped {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: TestCasts = cast(<self>: NilClass, TestCasts);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestCasts#test_casts {
 
-bb0[rubyRegionId=0, firstDead=63]():
+bb0[firstDead=63]():
     <self>: TestCasts = cast(<self>: NilClass, TestCasts);
     <cfgAlias>$5: T.class_of(Integer) = alias <C Integer>
     keep_for_ide$4: T.class_of(Integer) = <cfgAlias>$5
@@ -95,22 +95,22 @@ bb0[rubyRegionId=0, firstDead=63]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:TestCasts>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(TestCasts) = cast(<self>: NilClass, T.class_of(TestCasts));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::ModuleMethods#instrumented_request {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ModuleMethods = cast(<self>: NilClass, ModuleMethods);
     final_attempt: T.untyped = load_arg(final_attempt)
     foo: T.untyped = load_arg(foo)
@@ -23,40 +23,40 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyRegionId=3)
-# - bb24(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb6
+# - bb24
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: Exception, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+# - bb4
+bb3[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: Exception, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0
+bb4[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyRegionId=1)
-bb5[rubyRegionId=4, firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
+# - bb4
+bb5[firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=4)
-# - bb7(rubyRegionId=2)
-# - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError), <gotoDeadTemp>$10: T.nilable(TrueClass)):
+# - bb5
+# - bb7
+# - bb8
+bb6[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError), <gotoDeadTemp>$10: T.nilable(TrueClass)):
     <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: StandardError, <magic>$5: T.class_of(<Magic>)):
+# - bb3
+bb7[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: StandardError, <magic>$5: T.class_of(<Magic>)):
     e: StandardError = <exceptionValue>$4
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
@@ -64,75 +64,75 @@ bb7[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exc
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=2)
-bb8[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
+# - bb3
+bb8[firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
     <gotoDeadTemp>$10: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyRegionId=3)
-bb9[rubyRegionId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError)):
+# - bb6
+bb9[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError)):
     is_successful: T::Boolean = err: T.nilable(StandardError).nil?()
     is_successful -> (T::Boolean ? bb10 : bb11)
 
 # backedges
-# - bb9(rubyRegionId=0)
-bb10[rubyRegionId=0, firstDead=-1](foo: T.untyped, err: NilClass, is_successful: TrueClass):
+# - bb9
+bb10[firstDead=-1](foo: T.untyped, err: NilClass, is_successful: TrueClass):
     ||$2: TrueClass = is_successful
     ||$2 -> (TrueClass ? bb13 : bb14)
 
 # backedges
-# - bb9(rubyRegionId=0)
-bb11[rubyRegionId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: StandardError, is_successful: FalseClass):
+# - bb9
+bb11[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: StandardError, is_successful: FalseClass):
     ||$2: T.untyped = final_attempt
     ||$2 -> (T.untyped ? bb13 : bb14)
 
 # backedges
-# - bb10(rubyRegionId=0)
-# - bb11(rubyRegionId=0)
-bb13[rubyRegionId=0, firstDead=-1](is_successful: T::Boolean, ||$2: T.untyped):
+# - bb10
+# - bb11
+bb13[firstDead=-1](is_successful: T::Boolean, ||$2: T.untyped):
     <ifTemp>$14: T.untyped = ||$2
     <ifTemp>$14 -> (T.untyped ? bb19 : bb24)
 
 # backedges
-# - bb10(rubyRegionId=0)
-# - bb11(rubyRegionId=0)
-bb14[rubyRegionId=0, firstDead=-1](foo: T.untyped, err: StandardError, is_successful: FalseClass):
+# - bb10
+# - bb11
+bb14[firstDead=-1](foo: T.untyped, err: StandardError, is_successful: FalseClass):
     err -> (StandardError ? bb15 : bb16)
 
 # backedges
-# - bb14(rubyRegionId=0)
-bb15[rubyRegionId=0, firstDead=-1](foo: T.untyped, is_successful: FalseClass):
+# - bb14
+bb15[firstDead=-1](foo: T.untyped, is_successful: FalseClass):
     <ifTemp>$14: T.untyped = foo
     <ifTemp>$14 -> (T.untyped ? bb19 : bb24)
 
 # backedges
-# - bb14(rubyRegionId=0)
-bb16[rubyRegionId=0, firstDead=0](err: StandardError, is_successful: FalseClass):
+# - bb14
+bb16[firstDead=0](err: StandardError, is_successful: FalseClass):
     <ifTemp>$14 = err
     <ifTemp>$14 -> (<nullptr> ? bb19 : bb24)
 
 # backedges
-# - bb13(rubyRegionId=0)
-# - bb15(rubyRegionId=0)
-# - bb16(rubyRegionId=0)
-bb19[rubyRegionId=0, firstDead=-1](is_successful: T::Boolean):
+# - bb13
+# - bb15
+# - bb16
+bb19[firstDead=-1](is_successful: T::Boolean):
     <ifTemp>$19: T::Boolean = is_successful: T::Boolean.!()
     <ifTemp>$19 -> (T::Boolean ? bb21 : bb24)
 
 # backedges
-# - bb19(rubyRegionId=0)
-bb21[rubyRegionId=0, firstDead=-1]():
+# - bb19
+bb21[firstDead=-1]():
     <returnMethodTemp>$2: Integer(1) = 1
     <unconditional> -> bb24
 
 # backedges
-# - bb13(rubyRegionId=0)
-# - bb15(rubyRegionId=0)
-# - bb16(rubyRegionId=0)
-# - bb19(rubyRegionId=0)
-# - bb21(rubyRegionId=0)
-bb24[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
+# - bb13
+# - bb15
+# - bb16
+# - bb19
+# - bb21
+bb24[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1
 
@@ -140,15 +140,15 @@ bb24[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
 
 method ::<Class:ModuleMethods>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(ModuleMethods) = cast(<self>: NilClass, T.class_of(ModuleMethods));
     <returnMethodTemp>$2: Symbol(:instrumented_request) = :instrumented_request
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:instrumented_request)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -24,6 +24,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 # - bb24
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -40,19 +42,12 @@ bb3[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: 
 # - bb0
 bb4[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb5)
+    <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError), <gotoDeadTemp>$10: T.nilable(TrueClass)):
-    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: NilClass, <gotoDeadTemp>$10: NilClass):
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
@@ -61,16 +56,18 @@ bb7[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: 
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     err: StandardError = e
-    <unconditional> -> bb6
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
     <gotoDeadTemp>$10: TrueClass = true
-    <unconditional> -> bb6
+    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
+# - bb7
+# - bb8
 bb9[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError)):
     is_successful: T::Boolean = err: T.nilable(StandardError).nil?()
     is_successful -> (T::Boolean ? bb10 : bb11)

--- a/test/testdata/infer/control_flow/complex_implications_2.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implications_2.rb.cfg-text.exp
@@ -1,47 +1,47 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     foo: T.untyped = load_arg(foo)
     foo -> (T.untyped ? bb2 : bb7)
 
 # backedges
-# - bb10(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb10
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](foo: T.untyped):
+# - bb0
+bb2[firstDead=-1](foo: T.untyped):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     bar: T.untyped = foo: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     bar -> (T.untyped ? bb4 : bb7)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1](foo: StandardError):
+# - bb2
+bb4[firstDead=-1](foo: StandardError):
     e: StandardError = foo
     err: StandardError = e
     <unconditional> -> bb7
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb2(rubyRegionId=0)
-# - bb4(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=-1](err: T.nilable(StandardError)):
+# - bb0
+# - bb2
+# - bb4
+bb7[firstDead=-1](err: T.nilable(StandardError)):
     junk: T.nilable(StandardError) = err
     err -> (T.nilable(StandardError) ? bb8 : bb10)
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb8[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb8[firstDead=-1]():
     <returnMethodTemp>$2: Integer(1) = 1
     <unconditional> -> bb10
 
 # backedges
-# - bb7(rubyRegionId=0)
-# - bb8(rubyRegionId=0)
-bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
+# - bb7
+# - bb8
+bb10[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1
 
@@ -49,15 +49,15 @@ bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/control_flow/normalize_params.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/normalize_params.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Test#normalize_params {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Test = cast(<self>: NilClass, Test);
     v: T.untyped = load_arg(v)
     <cfgAlias>$6: T.class_of(Hash)[T::Hash[T.untyped, T.untyped]] = alias <C Hash>
@@ -22,54 +22,54 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <ifTemp>$3 -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb11(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb11
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](<self>: Test, v: T::Hash[T.untyped, T.untyped]):
+# - bb0
+bb2[firstDead=-1](<self>: Test, v: T::Hash[T.untyped, T.untyped]):
     <statTemp>$9: T::Array[[T.untyped, T.untyped]] = v: T::Hash[T.untyped, T.untyped].to_a()
     <statTemp>$7: T.untyped = <self>: Test.normalize_params(<statTemp>$9: T::Array[[T.untyped, T.untyped]])
     <returnMethodTemp>$2: T.untyped = <statTemp>$7: T.untyped.sort()
     <unconditional> -> bb11
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](<self>: Test, v: T.untyped):
+# - bb0
+bb3[firstDead=-1](<self>: Test, v: T.untyped):
     <cfgAlias>$14: T.class_of(Array)[T::Array[T.untyped]] = alias <C Array>
     <ifTemp>$11: T.untyped = v: T.untyped.is_a?(<cfgAlias>$14: T.class_of(Array)[T::Array[T.untyped]])
     <ifTemp>$11 -> (T.untyped ? bb4 : bb5)
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1](<self>: Test, v: T::Array[T.untyped]):
+# - bb3
+bb4[firstDead=-1](<self>: Test, v: T::Array[T.untyped]):
     <block-pre-call-temp>$16: Sorbet::Private::Static::Void = v: T::Array[T.untyped].map()
     <selfRestore>$17: Test = <self>
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](v: T.untyped):
+# - bb3
+bb5[firstDead=-1](v: T.untyped):
     <returnMethodTemp>$2: T.untyped = v
     <unconditional> -> bb11
 
 # backedges
-# - bb4(rubyRegionId=0)
-# - bb9(rubyRegionId=1)
-bb6[rubyRegionId=1, firstDead=-1](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
+# - bb4
+# - bb9
+bb6[firstDead=-1](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=1)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
+# - bb6
+bb7[firstDead=-1](<block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
     <returnMethodTemp>$2: T::Array[T.untyped] = Solve<<block-pre-call-temp>$16, map>
     <unconditional> -> bb11
 
 # backedges
-# - bb6(rubyRegionId=1)
-bb9[rubyRegionId=1, firstDead=5](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
+# - bb6
+bb9[firstDead=5](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
     # outerLoops: 1
     <self>: Test = loadSelf(map)
     <blk>$18: [T.untyped] = load_yield_params(map)
@@ -79,10 +79,10 @@ bb9[rubyRegionId=1, firstDead=5](<self>: Test, <block-pre-call-temp>$16: Sorbet:
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb5(rubyRegionId=0)
-# - bb7(rubyRegionId=0)
-bb11[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb2
+# - bb5
+# - bb7
+bb11[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -90,15 +90,15 @@ bb11[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::<Class:Test>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Test) = cast(<self>: NilClass, T.class_of(Test));
     <returnMethodTemp>$2: Symbol(:normalize_params) = :normalize_params
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:normalize_params)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/control_flow/simple.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/simple.rb.cfg-text.exp
@@ -1,40 +1,40 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::ControlFlow#orZero0 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2
+# - bb3
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=1](a: Integer):
+# - bb0
+bb2[firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=2]():
+# - bb0
+bb3[firstDead=2]():
     <returnTemp>$5: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$5: Integer(0)
     <unconditional> -> bb1
@@ -43,27 +43,27 @@ bb3[rubyRegionId=0, firstDead=2]():
 
 method ::ControlFlow#orZero0a {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: Integer = load_arg(a)
     a -> (Integer ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2
+# - bb3
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=1](a: Integer):
+# - bb0
+bb2[firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb0
+bb3[firstDead=0]():
     <returnTemp>$5 = 0
     <returnMethodTemp>$2 = return <returnTemp>$5
     <unconditional> -> bb1
@@ -72,29 +72,29 @@ bb3[rubyRegionId=0, firstDead=0]():
 
 method ::ControlFlow#orZero0n {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     b: T::Boolean = a: T.nilable(Integer).!()
     b -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2
+# - bb3
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=2]():
+# - bb0
+bb2[firstDead=2]():
     <returnTemp>$6: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$6: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=1](a: Integer):
+# - bb0
+bb3[firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
@@ -102,7 +102,7 @@ bb3[rubyRegionId=0, firstDead=1](a: Integer):
 
 method ::ControlFlow#orZero1n {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     <cfgAlias>$7: T.class_of(Integer) = alias <C Integer>
@@ -111,22 +111,22 @@ bb0[rubyRegionId=0, firstDead=-1]():
     b -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2
+# - bb3
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=2]():
+# - bb0
+bb2[firstDead=2]():
     <returnTemp>$9: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$9: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=1](a: Integer):
+# - bb0
+bb3[firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
@@ -134,26 +134,26 @@ bb3[rubyRegionId=0, firstDead=1](a: Integer):
 
 method ::ControlFlow#orZero2 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb4 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb3[firstDead=-1]():
     a: Integer(0) = 0
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=2](a: Integer):
+# - bb0
+# - bb3
+bb4[firstDead=2](a: Integer):
     <returnMethodTemp>$2: Integer = a
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
@@ -162,44 +162,44 @@ bb4[rubyRegionId=0, firstDead=2](a: Integer):
 
 method ::ControlFlow#orZero3 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb5(rubyRegionId=0)
-# - bb6(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb5
+# - bb6
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     <statTemp>$5: Integer(1) = 1
     <statTemp>$6: Integer(2) = 2
     <ifTemp>$3: T::Boolean = <statTemp>$5: Integer(1).==(<statTemp>$6: Integer(2))
     <ifTemp>$3 -> (T::Boolean ? bb5 : bb6)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](a: NilClass):
+# - bb0
+bb3[firstDead=-1](a: NilClass):
     <ifTemp>$3: NilClass = a
     <ifTemp>$3 -> (NilClass ? bb5 : bb6)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=2]():
+# - bb2
+# - bb3
+bb5[firstDead=2]():
     <returnTemp>$7: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$7: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=2]():
+# - bb2
+# - bb3
+bb6[firstDead=2]():
     <returnTemp>$8: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$8: Integer(0)
     <unconditional> -> bb1
@@ -208,49 +208,49 @@ bb6[rubyRegionId=0, firstDead=2]():
 
 method ::ControlFlow#orZero3n {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb5(rubyRegionId=0)
-# - bb6(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb5
+# - bb6
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     <statTemp>$6: Integer(1) = 1
     <statTemp>$7: Integer(2) = 2
     <statTemp>$4: T::Boolean = <statTemp>$6: Integer(1).==(<statTemp>$7: Integer(2))
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](a: NilClass):
+# - bb0
+bb3[firstDead=-1](a: NilClass):
     <statTemp>$4: NilClass = a
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1](<statTemp>$4: T.nilable(T::Boolean)):
+# - bb2
+# - bb3
+bb4[firstDead=-1](<statTemp>$4: T.nilable(T::Boolean)):
     b: T::Boolean = <statTemp>$4: T.nilable(T::Boolean).!()
     b -> (T::Boolean ? bb5 : bb6)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=2]():
+# - bb4
+bb5[firstDead=2]():
     <returnTemp>$9: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$9: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=2]():
+# - bb4
+bb6[firstDead=2]():
     <returnTemp>$10: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$10: Integer(1)
     <unconditional> -> bb1
@@ -259,41 +259,41 @@ bb6[rubyRegionId=0, firstDead=2]():
 
 method ::ControlFlow#orZero4 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb5(rubyRegionId=0)
-# - bb6(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb5
+# - bb6
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](a: Integer):
+# - bb0
+bb2[firstDead=-1](a: Integer):
     <ifTemp>$3: Integer = a
     <ifTemp>$3 -> (Integer ? bb5 : bb6)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](a: NilClass):
+# - bb0
+bb3[firstDead=-1](a: NilClass):
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb5 : bb6)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=1](a: T.nilable(Integer)):
+# - bb2
+# - bb3
+bb5[firstDead=1](a: T.nilable(Integer)):
     <returnMethodTemp>$2: T.noreturn = return a: T.nilable(Integer)
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=0]():
+# - bb2
+# - bb3
+bb6[firstDead=0]():
     <returnTemp>$6 = 0
     <returnMethodTemp>$2 = return <returnTemp>$6
     <unconditional> -> bb1
@@ -302,41 +302,41 @@ bb6[rubyRegionId=0, firstDead=0]():
 
 method ::ControlFlow#orZero5 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb5(rubyRegionId=0)
-# - bb6(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb5
+# - bb6
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](a: Integer):
+# - bb0
+bb2[firstDead=-1](a: Integer):
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb5 : bb6)
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](a: NilClass):
+# - bb0
+bb3[firstDead=-1](a: NilClass):
     <ifTemp>$3: NilClass = a
     <ifTemp>$3 -> (NilClass ? bb5 : bb6)
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=1](a: Integer):
+# - bb2
+# - bb3
+bb5[firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=2]():
+# - bb2
+# - bb3
+bb6[firstDead=2]():
     <returnTemp>$6: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$6: Integer(0)
     <unconditional> -> bb1
@@ -345,7 +345,7 @@ bb6[rubyRegionId=0, firstDead=2]():
 
 method ::<Class:ControlFlow>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(ControlFlow) = cast(<self>: NilClass, T.class_of(ControlFlow));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(ControlFlow))
@@ -353,20 +353,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb35(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb35
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow)):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$8
     <cfgAlias>$25: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -375,8 +375,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow)):
+# - bb2
+bb5[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$12: Symbol(:a) = :a
@@ -391,15 +391,15 @@ bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-ca
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(ControlFlow)):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(ControlFlow)):
+# - bb6
+bb7[firstDead=-1](<block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(ControlFlow)):
     <statTemp>$23: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$27, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$28
     <cfgAlias>$40: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -408,8 +408,8 @@ bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$27: Sorbet::Private::Sta
     <unconditional> -> bb10
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(ControlFlow)):
+# - bb6
+bb9[firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$32: Symbol(:a) = :a
@@ -421,15 +421,15 @@ bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-cal
     <unconditional> -> bb6
 
 # backedges
-# - bb7(rubyRegionId=0)
-# - bb13(rubyRegionId=3)
-bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(ControlFlow)):
+# - bb7
+# - bb13
+bb10[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
-# - bb10(rubyRegionId=3)
-bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(ControlFlow)):
+# - bb10
+bb11[firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(ControlFlow)):
     <statTemp>$38: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$42, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$43
     <cfgAlias>$60: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -438,8 +438,8 @@ bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::St
     <unconditional> -> bb14
 
 # backedges
-# - bb10(rubyRegionId=3)
-bb13[rubyRegionId=3, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(ControlFlow)):
+# - bb10
+bb13[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$47: Symbol(:a) = :a
@@ -454,15 +454,15 @@ bb13[rubyRegionId=3, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-c
     <unconditional> -> bb10
 
 # backedges
-# - bb11(rubyRegionId=0)
-# - bb17(rubyRegionId=4)
-bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(ControlFlow)):
+# - bb11
+# - bb17
+bb14[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
-# - bb14(rubyRegionId=4)
-bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(ControlFlow)):
+# - bb14
+bb15[firstDead=-1](<block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(ControlFlow)):
     <statTemp>$58: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$62, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$63
     <cfgAlias>$80: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -471,8 +471,8 @@ bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$62: Sorbet::Private::St
     <unconditional> -> bb18
 
 # backedges
-# - bb14(rubyRegionId=4)
-bb17[rubyRegionId=4, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(ControlFlow)):
+# - bb14
+bb17[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$62: Sorbet::Private::Static::Void, <selfRestore>$63: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$67: Symbol(:a) = :a
@@ -487,15 +487,15 @@ bb17[rubyRegionId=4, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-c
     <unconditional> -> bb14
 
 # backedges
-# - bb15(rubyRegionId=0)
-# - bb21(rubyRegionId=5)
-bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$82: Sorbet::Private::Static::Void, <selfRestore>$83: T.class_of(ControlFlow)):
+# - bb15
+# - bb21
+bb18[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$82: Sorbet::Private::Static::Void, <selfRestore>$83: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
-# - bb18(rubyRegionId=5)
-bb19[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$82: Sorbet::Private::Static::Void, <selfRestore>$83: T.class_of(ControlFlow)):
+# - bb18
+bb19[firstDead=-1](<block-pre-call-temp>$82: Sorbet::Private::Static::Void, <selfRestore>$83: T.class_of(ControlFlow)):
     <statTemp>$78: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$82, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$83
     <cfgAlias>$100: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -504,8 +504,8 @@ bb19[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$82: Sorbet::Private::St
     <unconditional> -> bb22
 
 # backedges
-# - bb18(rubyRegionId=5)
-bb21[rubyRegionId=5, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$82: Sorbet::Private::Static::Void, <selfRestore>$83: T.class_of(ControlFlow)):
+# - bb18
+bb21[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$82: Sorbet::Private::Static::Void, <selfRestore>$83: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$87: Symbol(:a) = :a
@@ -520,15 +520,15 @@ bb21[rubyRegionId=5, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-c
     <unconditional> -> bb18
 
 # backedges
-# - bb19(rubyRegionId=0)
-# - bb25(rubyRegionId=6)
-bb22[rubyRegionId=6, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$102: Sorbet::Private::Static::Void, <selfRestore>$103: T.class_of(ControlFlow)):
+# - bb19
+# - bb25
+bb22[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$102: Sorbet::Private::Static::Void, <selfRestore>$103: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb25 : bb23)
 
 # backedges
-# - bb22(rubyRegionId=6)
-bb23[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$102: Sorbet::Private::Static::Void, <selfRestore>$103: T.class_of(ControlFlow)):
+# - bb22
+bb23[firstDead=-1](<block-pre-call-temp>$102: Sorbet::Private::Static::Void, <selfRestore>$103: T.class_of(ControlFlow)):
     <statTemp>$98: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$102, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$103
     <cfgAlias>$120: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -537,8 +537,8 @@ bb23[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$102: Sorbet::Private::S
     <unconditional> -> bb26
 
 # backedges
-# - bb22(rubyRegionId=6)
-bb25[rubyRegionId=6, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$102: Sorbet::Private::Static::Void, <selfRestore>$103: T.class_of(ControlFlow)):
+# - bb22
+bb25[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$102: Sorbet::Private::Static::Void, <selfRestore>$103: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$107: Symbol(:a) = :a
@@ -553,15 +553,15 @@ bb25[rubyRegionId=6, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-c
     <unconditional> -> bb22
 
 # backedges
-# - bb23(rubyRegionId=0)
-# - bb29(rubyRegionId=7)
-bb26[rubyRegionId=7, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$122: Sorbet::Private::Static::Void, <selfRestore>$123: T.class_of(ControlFlow)):
+# - bb23
+# - bb29
+bb26[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$122: Sorbet::Private::Static::Void, <selfRestore>$123: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb29 : bb27)
 
 # backedges
-# - bb26(rubyRegionId=7)
-bb27[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$122: Sorbet::Private::Static::Void, <selfRestore>$123: T.class_of(ControlFlow)):
+# - bb26
+bb27[firstDead=-1](<block-pre-call-temp>$122: Sorbet::Private::Static::Void, <selfRestore>$123: T.class_of(ControlFlow)):
     <statTemp>$118: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$122, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$123
     <cfgAlias>$140: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -570,8 +570,8 @@ bb27[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$122: Sorbet::Private::S
     <unconditional> -> bb30
 
 # backedges
-# - bb26(rubyRegionId=7)
-bb29[rubyRegionId=7, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$122: Sorbet::Private::Static::Void, <selfRestore>$123: T.class_of(ControlFlow)):
+# - bb26
+bb29[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$122: Sorbet::Private::Static::Void, <selfRestore>$123: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$127: Symbol(:a) = :a
@@ -586,15 +586,15 @@ bb29[rubyRegionId=7, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-c
     <unconditional> -> bb26
 
 # backedges
-# - bb27(rubyRegionId=0)
-# - bb33(rubyRegionId=8)
-bb30[rubyRegionId=8, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
+# - bb27
+# - bb33
+bb30[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb33 : bb31)
 
 # backedges
-# - bb30(rubyRegionId=8)
-bb31[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
+# - bb30
+bb31[firstDead=-1](<block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
     <statTemp>$138: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$142, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$143
     <cfgAlias>$160: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -603,8 +603,8 @@ bb31[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$142: Sorbet::Private::S
     <unconditional> -> bb34
 
 # backedges
-# - bb30(rubyRegionId=8)
-bb33[rubyRegionId=8, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
+# - bb30
+bb33[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$147: Symbol(:a) = :a
@@ -619,15 +619,15 @@ bb33[rubyRegionId=8, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-c
     <unconditional> -> bb30
 
 # backedges
-# - bb31(rubyRegionId=0)
-# - bb37(rubyRegionId=9)
-bb34[rubyRegionId=9, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$162: Sorbet::Private::Static::Void, <selfRestore>$163: T.class_of(ControlFlow)):
+# - bb31
+# - bb37
+bb34[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$162: Sorbet::Private::Static::Void, <selfRestore>$163: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb37 : bb35)
 
 # backedges
-# - bb34(rubyRegionId=9)
-bb35[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$162: Sorbet::Private::Static::Void, <selfRestore>$163: T.class_of(ControlFlow)):
+# - bb34
+bb35[firstDead=6](<block-pre-call-temp>$162: Sorbet::Private::Static::Void, <selfRestore>$163: T.class_of(ControlFlow)):
     <statTemp>$158: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$162, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$163
     <cfgAlias>$181: T.class_of(T::Sig) = alias <C Sig>
@@ -637,8 +637,8 @@ bb35[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$162: Sorbet::Private::St
     <unconditional> -> bb1
 
 # backedges
-# - bb34(rubyRegionId=9)
-bb37[rubyRegionId=9, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$162: Sorbet::Private::Static::Void, <selfRestore>$163: T.class_of(ControlFlow)):
+# - bb34
+bb37[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$162: Sorbet::Private::Static::Void, <selfRestore>$163: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$167: Symbol(:a) = :a

--- a/test/testdata/infer/fields.rb.cfg-text.exp
+++ b/test/testdata/infer/fields.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#initialize {
 
-bb0[rubyRegionId=0, firstDead=9]():
+bb0[firstDead=9]():
     @ivar$3: Integer = alias @ivar
     <self>: Foo = cast(<self>: NilClass, Foo);
     <cfgAlias>$5: T.class_of(Integer) = alias <C Integer>
@@ -27,15 +27,15 @@ bb0[rubyRegionId=0, firstDead=9]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#foo {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     @ivar$4: Integer = alias @ivar
     <self>: Foo = cast(<self>: NilClass, Foo);
     @ivar$4: Integer(2) = 2
@@ -45,22 +45,22 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/hashes.rb.cfg-text.exp
+++ b/test/testdata/infer/hashes.rb.cfg-text.exp
@@ -1,48 +1,48 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#bar {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Foo = cast(<self>: NilClass, Foo);
     cond: T.untyped = load_arg(cond)
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb4
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     s: {} = <magic>$5: T.class_of(<Magic>).<build-hash>()
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb3[firstDead=-1]():
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     s: {} = <magic>$6: T.class_of(<Magic>).<build-hash>()
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=2](s: {}):
+# - bb2
+# - bb3
+bb4[firstDead=2](s: {}):
     r: {} = s
     <returnMethodTemp>$2: T.noreturn = return r: {}
     <unconditional> -> bb1
@@ -51,15 +51,15 @@ bb4[rubyRegionId=0, firstDead=2](s: {}):
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <returnMethodTemp>$2: Symbol(:bar) = :bar
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:bar)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/huge_unions.rb.cfg-text.exp
+++ b/test/testdata/infer/huge_unions.rb.cfg-text.exp
@@ -1,384 +1,384 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C1>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C1) = cast(<self>: NilClass, T.class_of(C1));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C2>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C2) = cast(<self>: NilClass, T.class_of(C2));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C3>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C3) = cast(<self>: NilClass, T.class_of(C3));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C4>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C4) = cast(<self>: NilClass, T.class_of(C4));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C5>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C5) = cast(<self>: NilClass, T.class_of(C5));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C6>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C6) = cast(<self>: NilClass, T.class_of(C6));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C7>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C7) = cast(<self>: NilClass, T.class_of(C7));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C8>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C8) = cast(<self>: NilClass, T.class_of(C8));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C9>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C9) = cast(<self>: NilClass, T.class_of(C9));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C10>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C10) = cast(<self>: NilClass, T.class_of(C10));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C11>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C11) = cast(<self>: NilClass, T.class_of(C11));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C12>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C12) = cast(<self>: NilClass, T.class_of(C12));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C14>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C14) = cast(<self>: NilClass, T.class_of(C14));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C15>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C15) = cast(<self>: NilClass, T.class_of(C15));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C16>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C16) = cast(<self>: NilClass, T.class_of(C16));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C17>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C17) = cast(<self>: NilClass, T.class_of(C17));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C18>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C18) = cast(<self>: NilClass, T.class_of(C18));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C19>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C19) = cast(<self>: NilClass, T.class_of(C19));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C20>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(C20) = cast(<self>: NilClass, T.class_of(C20));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#send_beta_invitation {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     invite: T.untyped = load_arg(invite)
     <statTemp>$6: Integer(1) = 1
@@ -386,314 +386,314 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <ifTemp>$5 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb61(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb61
+bb1[firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     <cfgAlias>$8: T.class_of(C1) = alias <C C1>
     r: T.class_of(C1) = <cfgAlias>$8
     <unconditional> -> bb61
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb0
+bb3[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$10: Integer(2) = 2
     <ifTemp>$9: T::Boolean = <statTemp>$10: Integer(2).===(invite: T.untyped)
     <ifTemp>$9 -> (T::Boolean ? bb4 : bb5)
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb4[firstDead=-1]():
     <cfgAlias>$12: T.class_of(C2) = alias <C C2>
     r: T.class_of(C2) = <cfgAlias>$12
     <unconditional> -> bb61
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb3
+bb5[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$14: Integer(3) = 3
     <ifTemp>$13: T::Boolean = <statTemp>$14: Integer(3).===(invite: T.untyped)
     <ifTemp>$13 -> (T::Boolean ? bb6 : bb7)
 
 # backedges
-# - bb5(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=-1]():
+# - bb5
+bb6[firstDead=-1]():
     <cfgAlias>$16: T.class_of(C3) = alias <C C3>
     r: T.class_of(C3) = <cfgAlias>$16
     <unconditional> -> bb61
 
 # backedges
-# - bb5(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb5
+bb7[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$18: Integer(4) = 4
     <ifTemp>$17: T::Boolean = <statTemp>$18: Integer(4).===(invite: T.untyped)
     <ifTemp>$17 -> (T::Boolean ? bb8 : bb9)
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb8[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb8[firstDead=-1]():
     <cfgAlias>$20: T.class_of(C4) = alias <C C4>
     r: T.class_of(C4) = <cfgAlias>$20
     <unconditional> -> bb61
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb9[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb7
+bb9[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$22: Integer(5) = 5
     <ifTemp>$21: T::Boolean = <statTemp>$22: Integer(5).===(invite: T.untyped)
     <ifTemp>$21 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
-# - bb9(rubyRegionId=0)
-bb10[rubyRegionId=0, firstDead=-1]():
+# - bb9
+bb10[firstDead=-1]():
     <cfgAlias>$24: T.class_of(C5) = alias <C C5>
     r: T.class_of(C5) = <cfgAlias>$24
     <unconditional> -> bb61
 
 # backedges
-# - bb9(rubyRegionId=0)
-bb11[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb9
+bb11[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$26: Integer(6) = 6
     <ifTemp>$25: T::Boolean = <statTemp>$26: Integer(6).===(invite: T.untyped)
     <ifTemp>$25 -> (T::Boolean ? bb12 : bb13)
 
 # backedges
-# - bb11(rubyRegionId=0)
-bb12[rubyRegionId=0, firstDead=-1]():
+# - bb11
+bb12[firstDead=-1]():
     <cfgAlias>$28: T.class_of(C6) = alias <C C6>
     r: T.class_of(C6) = <cfgAlias>$28
     <unconditional> -> bb61
 
 # backedges
-# - bb11(rubyRegionId=0)
-bb13[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb11
+bb13[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$30: Integer(7) = 7
     <ifTemp>$29: T::Boolean = <statTemp>$30: Integer(7).===(invite: T.untyped)
     <ifTemp>$29 -> (T::Boolean ? bb14 : bb15)
 
 # backedges
-# - bb13(rubyRegionId=0)
-bb14[rubyRegionId=0, firstDead=-1]():
+# - bb13
+bb14[firstDead=-1]():
     <cfgAlias>$32: T.class_of(C7) = alias <C C7>
     r: T.class_of(C7) = <cfgAlias>$32
     <unconditional> -> bb61
 
 # backedges
-# - bb13(rubyRegionId=0)
-bb15[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb13
+bb15[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$34: Integer(8) = 8
     <ifTemp>$33: T::Boolean = <statTemp>$34: Integer(8).===(invite: T.untyped)
     <ifTemp>$33 -> (T::Boolean ? bb16 : bb17)
 
 # backedges
-# - bb15(rubyRegionId=0)
-bb16[rubyRegionId=0, firstDead=-1]():
+# - bb15
+bb16[firstDead=-1]():
     <cfgAlias>$36: T.class_of(C8) = alias <C C8>
     r: T.class_of(C8) = <cfgAlias>$36
     <unconditional> -> bb61
 
 # backedges
-# - bb15(rubyRegionId=0)
-bb17[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb15
+bb17[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$38: Integer(9) = 9
     <ifTemp>$37: T::Boolean = <statTemp>$38: Integer(9).===(invite: T.untyped)
     <ifTemp>$37 -> (T::Boolean ? bb18 : bb19)
 
 # backedges
-# - bb17(rubyRegionId=0)
-bb18[rubyRegionId=0, firstDead=-1]():
+# - bb17
+bb18[firstDead=-1]():
     <cfgAlias>$40: T.class_of(C9) = alias <C C9>
     r: T.class_of(C9) = <cfgAlias>$40
     <unconditional> -> bb61
 
 # backedges
-# - bb17(rubyRegionId=0)
-bb19[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb17
+bb19[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$42: Integer(10) = 10
     <ifTemp>$41: T::Boolean = <statTemp>$42: Integer(10).===(invite: T.untyped)
     <ifTemp>$41 -> (T::Boolean ? bb20 : bb21)
 
 # backedges
-# - bb19(rubyRegionId=0)
-bb20[rubyRegionId=0, firstDead=-1]():
+# - bb19
+bb20[firstDead=-1]():
     <cfgAlias>$44: T.class_of(C10) = alias <C C10>
     r: T.class_of(C10) = <cfgAlias>$44
     <unconditional> -> bb61
 
 # backedges
-# - bb19(rubyRegionId=0)
-bb21[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb19
+bb21[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$46: Integer(11) = 11
     <ifTemp>$45: T::Boolean = <statTemp>$46: Integer(11).===(invite: T.untyped)
     <ifTemp>$45 -> (T::Boolean ? bb22 : bb23)
 
 # backedges
-# - bb21(rubyRegionId=0)
-bb22[rubyRegionId=0, firstDead=-1]():
+# - bb21
+bb22[firstDead=-1]():
     <cfgAlias>$48: T.class_of(C11) = alias <C C11>
     r: T.class_of(C11) = <cfgAlias>$48
     <unconditional> -> bb61
 
 # backedges
-# - bb21(rubyRegionId=0)
-bb23[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb21
+bb23[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$50: Integer(12) = 12
     <ifTemp>$49: T::Boolean = <statTemp>$50: Integer(12).===(invite: T.untyped)
     <ifTemp>$49 -> (T::Boolean ? bb24 : bb25)
 
 # backedges
-# - bb23(rubyRegionId=0)
-bb24[rubyRegionId=0, firstDead=-1]():
+# - bb23
+bb24[firstDead=-1]():
     <cfgAlias>$52: T.class_of(C12) = alias <C C12>
     r: T.class_of(C12) = <cfgAlias>$52
     <unconditional> -> bb61
 
 # backedges
-# - bb23(rubyRegionId=0)
-bb25[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb23
+bb25[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$54: Integer(13) = 13
     <ifTemp>$53: T::Boolean = <statTemp>$54: Integer(13).===(invite: T.untyped)
     <ifTemp>$53 -> (T::Boolean ? bb26 : bb27)
 
 # backedges
-# - bb25(rubyRegionId=0)
-bb26[rubyRegionId=0, firstDead=-1]():
+# - bb25
+bb26[firstDead=-1]():
     <cfgAlias>$56: T.class_of(C13) = alias <C C13>
     r: T.class_of(C13) = <cfgAlias>$56
     <unconditional> -> bb61
 
 # backedges
-# - bb25(rubyRegionId=0)
-bb27[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb25
+bb27[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$58: Integer(14) = 14
     <ifTemp>$57: T::Boolean = <statTemp>$58: Integer(14).===(invite: T.untyped)
     <ifTemp>$57 -> (T::Boolean ? bb28 : bb29)
 
 # backedges
-# - bb27(rubyRegionId=0)
-bb28[rubyRegionId=0, firstDead=-1]():
+# - bb27
+bb28[firstDead=-1]():
     <cfgAlias>$60: T.class_of(C14) = alias <C C14>
     r: T.class_of(C14) = <cfgAlias>$60
     <unconditional> -> bb61
 
 # backedges
-# - bb27(rubyRegionId=0)
-bb29[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb27
+bb29[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$62: Integer(15) = 15
     <ifTemp>$61: T::Boolean = <statTemp>$62: Integer(15).===(invite: T.untyped)
     <ifTemp>$61 -> (T::Boolean ? bb30 : bb31)
 
 # backedges
-# - bb29(rubyRegionId=0)
-bb30[rubyRegionId=0, firstDead=-1]():
+# - bb29
+bb30[firstDead=-1]():
     <cfgAlias>$64: T.class_of(C15) = alias <C C15>
     r: T.class_of(C15) = <cfgAlias>$64
     <unconditional> -> bb61
 
 # backedges
-# - bb29(rubyRegionId=0)
-bb31[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb29
+bb31[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$66: Integer(16) = 16
     <ifTemp>$65: T::Boolean = <statTemp>$66: Integer(16).===(invite: T.untyped)
     <ifTemp>$65 -> (T::Boolean ? bb32 : bb33)
 
 # backedges
-# - bb31(rubyRegionId=0)
-bb32[rubyRegionId=0, firstDead=-1]():
+# - bb31
+bb32[firstDead=-1]():
     <cfgAlias>$68: T.class_of(C16) = alias <C C16>
     r: T.class_of(C16) = <cfgAlias>$68
     <unconditional> -> bb61
 
 # backedges
-# - bb31(rubyRegionId=0)
-bb33[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb31
+bb33[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$70: Integer(17) = 17
     <ifTemp>$69: T::Boolean = <statTemp>$70: Integer(17).===(invite: T.untyped)
     <ifTemp>$69 -> (T::Boolean ? bb34 : bb35)
 
 # backedges
-# - bb33(rubyRegionId=0)
-bb34[rubyRegionId=0, firstDead=-1]():
+# - bb33
+bb34[firstDead=-1]():
     <cfgAlias>$72: T.class_of(C17) = alias <C C17>
     r: T.class_of(C17) = <cfgAlias>$72
     <unconditional> -> bb61
 
 # backedges
-# - bb33(rubyRegionId=0)
-bb35[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb33
+bb35[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$74: Integer(18) = 18
     <ifTemp>$73: T::Boolean = <statTemp>$74: Integer(18).===(invite: T.untyped)
     <ifTemp>$73 -> (T::Boolean ? bb36 : bb37)
 
 # backedges
-# - bb35(rubyRegionId=0)
-bb36[rubyRegionId=0, firstDead=-1]():
+# - bb35
+bb36[firstDead=-1]():
     <cfgAlias>$76: T.class_of(C18) = alias <C C18>
     r: T.class_of(C18) = <cfgAlias>$76
     <unconditional> -> bb61
 
 # backedges
-# - bb35(rubyRegionId=0)
-bb37[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb35
+bb37[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$78: Integer(19) = 19
     <ifTemp>$77: T::Boolean = <statTemp>$78: Integer(19).===(invite: T.untyped)
     <ifTemp>$77 -> (T::Boolean ? bb38 : bb39)
 
 # backedges
-# - bb37(rubyRegionId=0)
-bb38[rubyRegionId=0, firstDead=-1]():
+# - bb37
+bb38[firstDead=-1]():
     <cfgAlias>$80: T.class_of(C19) = alias <C C19>
     r: T.class_of(C19) = <cfgAlias>$80
     <unconditional> -> bb61
 
 # backedges
-# - bb37(rubyRegionId=0)
-bb39[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb37
+bb39[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$82: Integer(20) = 20
     <ifTemp>$81: T::Boolean = <statTemp>$82: Integer(20).===(invite: T.untyped)
     <ifTemp>$81 -> (T::Boolean ? bb40 : bb41)
 
 # backedges
-# - bb39(rubyRegionId=0)
-bb40[rubyRegionId=0, firstDead=-1]():
+# - bb39
+bb40[firstDead=-1]():
     <cfgAlias>$84: T.class_of(C20) = alias <C C20>
     r: T.class_of(C20) = <cfgAlias>$84
     <unconditional> -> bb61
 
 # backedges
-# - bb39(rubyRegionId=0)
-bb41[rubyRegionId=0, firstDead=2](<self>: T.class_of(A)):
+# - bb39
+bb41[firstDead=2](<self>: T.class_of(A)):
     <statTemp>$86: String("Bla bla bla") = "Bla bla bla"
     <statTemp>$3: T.noreturn = <self>: T.class_of(A).raise(<statTemp>$86: String("Bla bla bla"))
     <unconditional> -> bb61
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb4(rubyRegionId=0)
-# - bb6(rubyRegionId=0)
-# - bb8(rubyRegionId=0)
-# - bb10(rubyRegionId=0)
-# - bb12(rubyRegionId=0)
-# - bb14(rubyRegionId=0)
-# - bb16(rubyRegionId=0)
-# - bb18(rubyRegionId=0)
-# - bb20(rubyRegionId=0)
-# - bb22(rubyRegionId=0)
-# - bb24(rubyRegionId=0)
-# - bb26(rubyRegionId=0)
-# - bb28(rubyRegionId=0)
-# - bb30(rubyRegionId=0)
-# - bb32(rubyRegionId=0)
-# - bb34(rubyRegionId=0)
-# - bb36(rubyRegionId=0)
-# - bb38(rubyRegionId=0)
-# - bb40(rubyRegionId=0)
-# - bb41(rubyRegionId=0)
-bb61[rubyRegionId=0, firstDead=2](r: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20))):
+# - bb2
+# - bb4
+# - bb6
+# - bb8
+# - bb10
+# - bb12
+# - bb14
+# - bb16
+# - bb18
+# - bb20
+# - bb22
+# - bb24
+# - bb26
+# - bb28
+# - bb30
+# - bb32
+# - bb34
+# - bb36
+# - bb38
+# - bb40
+# - bb41
+bb61[firstDead=2](r: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20))):
     s: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20)) = r
     <returnMethodTemp>$2: T.noreturn = return s: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20))
     <unconditional> -> bb1
@@ -702,15 +702,15 @@ bb61[rubyRegionId=0, firstDead=2](r: T.any(T.class_of(C1), T.class_of(C2), T.cla
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <returnMethodTemp>$2: Symbol(:send_beta_invitation) = :send_beta_invitation
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:send_beta_invitation)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/infer1.rb.cfg-text.exp
+++ b/test/testdata/infer/infer1.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#baz1 {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: Object = cast(<self>: NilClass, Object);
     a: String("foo") = "foo"
     b: T.nilable(Integer) = a: String("foo").getbyte(a: String("foo"))
@@ -9,15 +9,15 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#baz2 {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     <self>: Object = cast(<self>: NilClass, Object);
     a: String("foo") = "foo"
     <statTemp>$5: String("foo") = "foo"
@@ -27,15 +27,15 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#baz3 {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     <self>: Object = cast(<self>: NilClass, Object);
     <statTemp>$3: String("foo") = "foo"
     <statTemp>$4: String("foo") = "foo"
@@ -45,15 +45,15 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#baz4 {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     <self>: Object = cast(<self>: NilClass, Object);
     <statTemp>$3: T.untyped = <self>: Object.a()
     <statTemp>$5: String("foo") = "foo"
@@ -63,40 +63,40 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#baz5 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     cond: T.untyped = load_arg(cond)
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     b: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb3[firstDead=-1]():
     b: String("foo") = "foo"
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
+# - bb2
+# - bb3
+bb4[firstDead=5](b: T.any(Integer, String)):
     <statTemp>$5: T.any(Integer, String) = b
     <statTemp>$6: Integer(1) = 1
     b: T.untyped = <statTemp>$5: T.any(Integer, String).getbyte(<statTemp>$6: Integer(1))
@@ -108,32 +108,32 @@ bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
 
 method ::Object#baz6 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     cond: T.untyped = load_arg(cond)
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     b: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb3[firstDead=-1]():
     b: String("foo") = "foo"
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
+# - bb2
+# - bb3
+bb4[firstDead=5](b: T.any(Integer, String)):
     <statTemp>$5: String("foo") = "foo"
     <statTemp>$6: T.any(Integer, String) = b
     b: T.nilable(Integer) = <statTemp>$5: String("foo").getbyte(<statTemp>$6: T.any(Integer, String))
@@ -145,26 +145,26 @@ bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
 
 method ::Object#baz7 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     cond: T.untyped = load_arg(cond)
     cond -> (T.untyped ? bb2 : bb4)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb2[firstDead=-1]():
     b: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=5](b: T.nilable(Integer)):
+# - bb0
+# - bb2
+bb4[firstDead=5](b: T.nilable(Integer)):
     <statTemp>$5: String("foo") = "foo"
     <statTemp>$6: T.nilable(Integer) = b
     b: T.nilable(Integer) = <statTemp>$5: String("foo").getbyte(<statTemp>$6: T.nilable(Integer))
@@ -176,33 +176,33 @@ bb4[rubyRegionId=0, firstDead=5](b: T.nilable(Integer)):
 
 method ::Object#baz8 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+# - bb5
+bb2[firstDead=-1]():
     # outerLoops: 1
     <whileTemp>$3: TrueClass = true
     <whileTemp>$3 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb2
+bb3[firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1]():
+# - bb2
+bb5[firstDead=-1]():
     # outerLoops: 1
     b: Integer(1) = 1
     <unconditional> -> bb2
@@ -211,14 +211,14 @@ bb5[rubyRegionId=0, firstDead=-1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#f {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     x: T.any(Concrete, Other) = load_arg(x)
     <cfgAlias>$7: T.class_of(Concrete) = alias <C Concrete>
@@ -8,13 +8,13 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <ifTemp>$5 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb13(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb13
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](x: Concrete):
+# - bb0
+bb2[firstDead=-1](x: Concrete):
     <cfgAlias>$10: T.class_of(Concrete) = alias <C Concrete>
     keep_for_ide$9: T.class_of(Concrete) = <cfgAlias>$10
     keep_for_ide$9: T.untyped = <keep-alive> keep_for_ide$9
@@ -23,15 +23,15 @@ bb2[rubyRegionId=0, firstDead=-1](x: Concrete):
     <unconditional> -> bb7
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](x: Other):
+# - bb0
+bb3[firstDead=-1](x: Other):
     <cfgAlias>$14: T.class_of(Other) = alias <C Other>
     <ifTemp>$12: TrueClass = <cfgAlias>$14: T.class_of(Other).===(x: Other)
     <ifTemp>$12 -> (TrueClass ? bb4 : bb7)
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1](x: Other):
+# - bb3
+bb4[firstDead=-1](x: Other):
     <cfgAlias>$17: T.class_of(Other) = alias <C Other>
     keep_for_ide$16: T.class_of(Other) = <cfgAlias>$17
     keep_for_ide$16: T.untyped = <keep-alive> keep_for_ide$16
@@ -40,17 +40,17 @@ bb4[rubyRegionId=0, firstDead=-1](x: Other):
     <unconditional> -> bb7
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-# - bb4(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=-1](x: T.any(Concrete, Other)):
+# - bb2
+# - bb3
+# - bb4
+bb7[firstDead=-1](x: T.any(Concrete, Other)):
     <cfgAlias>$23: T.class_of(Concrete) = alias <C Concrete>
     <ifTemp>$20: T::Boolean = x: T.any(Concrete, Other).is_a?(<cfgAlias>$23: T.class_of(Concrete))
     <ifTemp>$20 -> (T::Boolean ? bb8 : bb10)
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb8[rubyRegionId=0, firstDead=-1](x: Concrete):
+# - bb7
+bb8[firstDead=-1](x: Concrete):
     <cfgAlias>$25: T.class_of(Concrete) = alias <C Concrete>
     keep_for_ide$24: T.class_of(Concrete) = <cfgAlias>$25
     keep_for_ide$24: T.untyped = <keep-alive> keep_for_ide$24
@@ -59,16 +59,16 @@ bb8[rubyRegionId=0, firstDead=-1](x: Concrete):
     <unconditional> -> bb10
 
 # backedges
-# - bb7(rubyRegionId=0)
-# - bb8(rubyRegionId=0)
-bb10[rubyRegionId=0, firstDead=-1](x: T.any(Other, Concrete)):
+# - bb7
+# - bb8
+bb10[firstDead=-1](x: T.any(Other, Concrete)):
     <cfgAlias>$30: T.class_of(Other) = alias <C Other>
     <ifTemp>$27: T::Boolean = x: T.any(Other, Concrete).is_a?(<cfgAlias>$30: T.class_of(Other))
     <ifTemp>$27 -> (T::Boolean ? bb13 : bb12)
 
 # backedges
-# - bb10(rubyRegionId=0)
-bb12[rubyRegionId=0, firstDead=-1](x: Concrete):
+# - bb10
+bb12[firstDead=-1](x: Concrete):
     <cfgAlias>$32: T.class_of(Concrete) = alias <C Concrete>
     keep_for_ide$31: T.class_of(Concrete) = <cfgAlias>$32
     keep_for_ide$31: T.untyped = <keep-alive> keep_for_ide$31
@@ -77,9 +77,9 @@ bb12[rubyRegionId=0, firstDead=-1](x: Concrete):
     <unconditional> -> bb13
 
 # backedges
-# - bb10(rubyRegionId=0)
-# - bb12(rubyRegionId=0)
-bb13[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Concrete)):
+# - bb10
+# - bb12
+bb13[firstDead=1](<returnMethodTemp>$2: T.nilable(Concrete)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Concrete)
     <unconditional> -> bb1
 
@@ -87,7 +87,7 @@ bb13[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Concrete)):
 
 method ::Object#f2 {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     x: T.any(Base, Other) = load_arg(x)
     <cfgAlias>$6: T.class_of(Base)[Base, T.untyped] = alias <C Base>
@@ -95,21 +95,21 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <ifTemp>$3 -> (T::Boolean ? bb2 : bb4)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb4
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](x: Base):
+# - bb0
+bb2[firstDead=-1](x: Base):
     <cfgAlias>$8: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: Base = <cfgAlias>$8: T.class_of(T).reveal_type(x: Base)
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Base)):
+# - bb0
+# - bb2
+bb4[firstDead=1](<returnMethodTemp>$2: T.nilable(Base)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Base)
     <unconditional> -> bb1
 
@@ -117,7 +117,7 @@ bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Base)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(<root>))
@@ -125,20 +125,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(<root>) = <selfRestore>$8
     <cfgAlias>$23: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -147,8 +147,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
+# - bb2
+bb5[firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$12: Symbol(:x) = :x
@@ -162,15 +162,15 @@ bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-tem
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(<root>)):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(<root>)):
+# - bb6
+bb7[firstDead=6](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(<root>)):
     <statTemp>$21: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$25, sig>
     <self>: T.class_of(<root>) = <selfRestore>$26
     <cfgAlias>$42: T.class_of(T::Sig) = alias <C Sig>
@@ -180,8 +180,8 @@ bb7[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$25: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(<root>)):
+# - bb6
+bb9[firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$30: Symbol(:x) = :x
@@ -198,7 +198,7 @@ bb9[rubyRegionId=2, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-tem
 
 method ::<Class:Base>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=7]():
+bb0[firstDead=7]():
     <C Klass>$10: Runtime object representing type: T.class_of(Base)::Klass = alias <C Klass>
     <self>: T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass] = cast(<self>: NilClass, T.class_of(Base)[T.attached_class (of Base), T.class_of(Base)::Klass]);
     <cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>
@@ -209,15 +209,15 @@ bb0[rubyRegionId=0, firstDead=7]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Concrete>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <C Klass>$10: Runtime object representing type: String = alias <C Klass>
     <self>: T.class_of(Concrete) = cast(<self>: NilClass, T.class_of(Concrete));
     <cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>
@@ -228,27 +228,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
     <C Klass>$10: T::Types::TypeTemplate = Solve<<block-pre-call-temp>$12, type_template>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
+# - bb2
+bb5[firstDead=6](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
     # outerLoops: 1
     <self>: T.class_of(Concrete) = loadSelf(type_template)
     <hashTemp>$15: Symbol(:fixed) = :fixed
@@ -262,14 +262,14 @@ bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Concrete), <block-pre-call-t
 
 method ::<Class:Other>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Other) = cast(<self>: NilClass, T.class_of(Other));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/loops.rb.cfg-text.exp
+++ b/test/testdata/infer/loops.rb.cfg-text.exp
@@ -1,46 +1,46 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::HasLoops#variable_only_inside_loop {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: HasLoops = cast(<self>: NilClass, HasLoops);
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1]():
+# - bb0
+# - bb5
+bb2[firstDead=-1]():
     # outerLoops: 1
     <whileTemp>$3: TrueClass = true
     <whileTemp>$3 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb2
+bb3[firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1]():
+# - bb2
+bb5[firstDead=-1]():
     # outerLoops: 1
     a: Integer(1) = 1
     <unconditional> -> bb2
@@ -49,34 +49,34 @@ bb5[rubyRegionId=0, firstDead=-1]():
 
 method ::HasLoops#incorrect_assignment {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: HasLoops = cast(<self>: NilClass, HasLoops);
     a: String("s") = "s"
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](a: String("s")):
+# - bb0
+# - bb5
+bb2[firstDead=-1](a: String("s")):
     # outerLoops: 1
     <whileTemp>$4: TrueClass = true
     <whileTemp>$4 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb2
+bb3[firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](a: String("s")):
+# - bb2
+bb5[firstDead=-1](a: String("s")):
     # outerLoops: 1
     a: T.untyped = 1
     <unconditional> -> bb2
@@ -85,34 +85,34 @@ bb5[rubyRegionId=0, firstDead=-1](a: String("s")):
 
 method ::HasLoops#correct_assignment {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: HasLoops = cast(<self>: NilClass, HasLoops);
     a: String("s") = "s"
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](a: String("s")):
+# - bb0
+# - bb5
+bb2[firstDead=-1](a: String("s")):
     # outerLoops: 1
     <whileTemp>$4: TrueClass = true
     <whileTemp>$4 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=0]():
+# - bb2
+bb3[firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](a: String("s")):
+# - bb2
+bb5[firstDead=-1](a: String("s")):
     # outerLoops: 1
     a: String("a") = "a"
     <unconditional> -> bb2
@@ -121,14 +121,14 @@ bb5[rubyRegionId=0, firstDead=-1](a: String("s")):
 
 method ::<Class:HasLoops>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(HasLoops) = cast(<self>: NilClass, T.class_of(HasLoops));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/meta_types.rb.cfg-text.exp
+++ b/test/testdata/infer/meta_types.rb.cfg-text.exp
@@ -1,34 +1,34 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestMetaType#_ {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: TestMetaType = cast(<self>: NilClass, TestMetaType);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestMetaType#testit {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: TestMetaType = cast(<self>: NilClass, TestMetaType);
     <cfgAlias>$7: T.class_of(T::Array) = alias <C Array>
     <cfgAlias>$9: T.class_of(T) = alias <C T>
@@ -39,13 +39,13 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <ifTemp>$15 -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
+# - bb0
+bb2[firstDead=-1](<self>: TestMetaType):
     <cfgAlias>$18: T.class_of(T::Array) = alias <C Array>
     <cfgAlias>$20: T.class_of(T) = alias <C T>
     <cfgAlias>$22: T.class_of(String) = alias <C String>
@@ -53,22 +53,22 @@ bb2[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb3[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
+# - bb0
+bb3[firstDead=-1](<self>: TestMetaType):
     <statTemp>$14: FalseClass = false
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyRegionId=0)
-# - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1](<self>: TestMetaType, <statTemp>$14: Object):
+# - bb2
+# - bb3
+bb4[firstDead=-1](<self>: TestMetaType, <statTemp>$14: Object):
     <statTemp>$12: NilClass = <self>: TestMetaType.puts(<statTemp>$14: Object)
     <ifTemp>$25: T.untyped = <self>: TestMetaType._()
     <ifTemp>$25 -> (T.untyped ? bb5 : bb6)
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
+# - bb4
+bb5[firstDead=-1](<self>: TestMetaType):
     <cfgAlias>$28: T.class_of(T::Array) = alias <C Array>
     <cfgAlias>$30: T.class_of(T) = alias <C T>
     <cfgAlias>$32: T.class_of(String) = alias <C String>
@@ -76,8 +76,8 @@ bb5[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
     <unconditional> -> bb7
 
 # backedges
-# - bb4(rubyRegionId=0)
-bb6[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
+# - bb4
+bb6[firstDead=-1](<self>: TestMetaType):
     <cfgAlias>$34: T.class_of(T::Array) = alias <C Array>
     <cfgAlias>$36: T.class_of(T) = alias <C T>
     <cfgAlias>$38: T.class_of(Float) = alias <C Float>
@@ -85,9 +85,9 @@ bb6[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
     <unconditional> -> bb7
 
 # backedges
-# - bb5(rubyRegionId=0)
-# - bb6(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=2](<self>: TestMetaType, <statTemp>$24: Object):
+# - bb5
+# - bb6
+bb7[firstDead=2](<self>: TestMetaType, <statTemp>$24: Object):
     <returnMethodTemp>$2: NilClass = <self>: TestMetaType.puts(<statTemp>$24: Object)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
@@ -96,14 +96,14 @@ bb7[rubyRegionId=0, firstDead=2](<self>: TestMetaType, <statTemp>$24: Object):
 
 method ::<Class:TestMetaType>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(TestMetaType) = cast(<self>: NilClass, T.class_of(TestMetaType));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/rebind.rb.cfg-text.exp
+++ b/test/testdata/infer/rebind.rb.cfg-text.exp
@@ -1,63 +1,63 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::C#only_on_C {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: C = cast(<self>: NilClass, C);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(C) = cast(<self>: NilClass, T.class_of(C));
     <returnMethodTemp>$2: Symbol(:only_on_C) = :only_on_C
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:only_on_C)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::B#only_on_B {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: B = cast(<self>: NilClass, B);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))
@@ -65,20 +65,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(B) = <selfRestore>$8
     <cfgAlias>$24: T.class_of(T::Sig) = alias <C Sig>
@@ -88,8 +88,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+# - bb2
+bb5[firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$12: Symbol(:blk) = :blk
@@ -107,21 +107,21 @@ bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$7
 
 method ::<Class:A>#mySig {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(A))
@@ -129,20 +129,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(A) = <selfRestore>$8
     <cfgAlias>$24: T.class_of(T::Sig) = alias <C Sig>
@@ -152,8 +152,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb2
+bb5[firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$12: Symbol(:blk) = :blk
@@ -171,48 +171,48 @@ bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$7
 
 method ::Use#only_on_Use {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Use = cast(<self>: NilClass, Use);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Use#shouldRemoveSelfTemp {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Use = cast(<self>: NilClass, Use);
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Use.only_on_Use()
     <selfRestore>$5: Use = <self>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, only_on_Use>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=3](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
+# - bb2
+bb5[firstDead=3](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
     # outerLoops: 1
     <self>: Use = loadSelf(only_on_Use)
     <blockReturnTemp>$6: Integer(1) = 1
@@ -223,7 +223,7 @@ bb5[rubyRegionId=1, firstDead=3](<self>: Use, <block-pre-call-temp>$4: Sorbet::P
 
 method ::Use#jumpBetweenClasses {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Use = cast(<self>: NilClass, Use);
     <cfgAlias>$4: T.class_of(A) = alias <C A>
     <block-pre-call-temp>$5: Sorbet::Private::Static::Void = <cfgAlias>$4: T.class_of(A).mySig()
@@ -231,27 +231,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb7(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
+# - bb0
+# - bb7
+bb2[firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
     <returnMethodTemp>$2: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, mySig>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Sorbet::Private::Static::Void
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
+# - bb2
+bb5[firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
     # outerLoops: 1
     <self>: B = loadSelf(mySig)
     <statTemp>$8: T.untyped = <self>: B.only_on_Use()
@@ -261,15 +261,15 @@ bb5[rubyRegionId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyRegionId=1)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: B):
+# - bb5
+# - bb9
+bb6[firstDead=-1](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: B):
     # outerLoops: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=1, firstDead=3](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: B):
+# - bb6
+bb7[firstDead=3](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: B):
     # outerLoops: 1
     <blockReturnTemp>$7: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$13, only_on_B>
     <self>: B = <selfRestore>$14
@@ -277,8 +277,8 @@ bb7[rubyRegionId=1, firstDead=3](<self>: B, <block-pre-call-temp>$5: Sorbet::Pri
     <unconditional> -> bb2
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=4](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: B):
+# - bb6
+bb9[firstDead=4](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: B):
     # outerLoops: 2
     <self>: C = loadSelf(only_on_B)
     <statTemp>$16: T.untyped = <self>: C.only_on_B()
@@ -290,7 +290,7 @@ bb9[rubyRegionId=2, firstDead=4](<self>: B, <block-pre-call-temp>$5: Sorbet::Pri
 
 method ::<Class:Use>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: T.class_of(Use) = cast(<self>: NilClass, T.class_of(Use));
     <cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -299,8 +299,8 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::Object#rnd {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Normal) = alias <C Normal>
     keep_for_ide$4: T.class_of(Normal) = <cfgAlias>$5
@@ -42,13 +42,13 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <ifTemp>$30 -> (T::Boolean ? bb2 : bb4)
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb2[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), a: T.all(Generic[String], B)):
+# - bb0
+bb2[firstDead=-1](<self>: T.class_of(<root>), a: T.all(Generic[String], B)):
     <cfgAlias>$36: T.class_of(T) = alias <C T>
     <cfgAlias>$39: T.class_of(Generic) = alias <C Generic>
     <cfgAlias>$41: T.class_of(String) = alias <C String>
@@ -61,9 +61,9 @@ bb2[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), a: T.all(Generic[S
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb2(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb0
+# - bb2
+bb4[firstDead=-1](<self>: T.class_of(<root>)):
     <cfgAlias>$49: T.class_of(Integer) = alias <C Integer>
     <cfgAlias>$51: T.class_of(Integer) = alias <C Integer>
     <magic>$52: T.class_of(<Magic>) = alias <C <Magic>>
@@ -80,32 +80,32 @@ bb4[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     <unconditional> -> bb5
 
 # backedges
-# - bb4(rubyRegionId=0)
-# - bb8(rubyRegionId=0)
-# - bb9(rubyRegionId=0)
-bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
+# - bb4
+# - bb8
+# - bb9
+bb5[firstDead=-1](<self>: T.class_of(<root>), s: A):
     # outerLoops: 1
     <whileTemp>$63: T.untyped = <self>: T.class_of(<root>).rnd()
     <whileTemp>$63 -> (T.untyped ? bb8 : bb7)
 
 # backedges
-# - bb5(rubyRegionId=0)
-bb7[rubyRegionId=0, firstDead=2](<self>: T.class_of(<root>), s: A):
+# - bb5
+bb7[firstDead=2](<self>: T.class_of(<root>), s: A):
     <statTemp>$71: NilClass = <self>: T.class_of(<root>).puts(s: A)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb5(rubyRegionId=0)
-bb8[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
+# - bb5
+bb8[firstDead=-1](<self>: T.class_of(<root>), s: A):
     # outerLoops: 1
     <cfgAlias>$69: T.class_of(B) = alias <C B>
     <ifTemp>$66: T::Boolean = s: A.is_a?(<cfgAlias>$69: T.class_of(B))
     <ifTemp>$66 -> (T::Boolean ? bb9 : bb5)
 
 # backedges
-# - bb8(rubyRegionId=0)
-bb9[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: T.all(A, B)):
+# - bb8
+bb9[firstDead=-1](<self>: T.class_of(<root>), s: T.all(A, B)):
     # outerLoops: 1
     <statTemp>$70: T.all(A, B) = s
     s: T.all(A, B) = <statTemp>$70: T.all(A, B).returns_self()
@@ -115,22 +115,22 @@ bb9[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: T.all(A, B)):
 
 method ::Parent#returns_self {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: Parent = cast(<self>: NilClass, Parent);
     <returnMethodTemp>$2: Parent = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Parent
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Parent>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Parent) = cast(<self>: NilClass, T.class_of(Parent));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Parent))
@@ -138,20 +138,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Parent), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Parent), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(Parent) = <selfRestore>$8
     <cfgAlias>$18: T.class_of(T::Sig) = alias <C Sig>
@@ -161,8 +161,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Parent), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent)):
+# - bb2
+bb5[firstDead=5](<self>: T.class_of(Parent), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Parent)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$13: T.class_of(T) = alias <C T>
@@ -175,21 +175,21 @@ bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Parent), <block-pre-call-tem
 
 method ::<Class:Normal>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Normal) = cast(<self>: NilClass, T.class_of(Normal));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Generic#bad {
 
-bb0[rubyRegionId=0, firstDead=7]():
+bb0[firstDead=7]():
     <self>: Generic[Generic::TM] = cast(<self>: NilClass, Generic[Generic::TM]);
     <cfgAlias>$5: T.class_of(Generic) = alias <C Generic>
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -200,15 +200,15 @@ bb0[rubyRegionId=0, firstDead=7]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Generic>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <C TM>$25: Runtime object representing type: Generic::TM = alias <C TM>
     <self>: T.class_of(Generic) = cast(<self>: NilClass, T.class_of(Generic));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -217,20 +217,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Generic), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Generic), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=7](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic)):
+# - bb2
+bb3[firstDead=7](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(Generic) = <selfRestore>$8
     <cfgAlias>$21: T.class_of(T::Generic) = alias <C Generic>
@@ -241,8 +241,8 @@ bb3[rubyRegionId=0, firstDead=7](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Generic), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic)):
+# - bb2
+bb5[firstDead=7](<self>: T.class_of(Generic), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Generic)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$13: T.class_of(Generic) = alias <C Generic>
@@ -257,36 +257,36 @@ bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Generic), <block-pre-call-te
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Array#returns_self {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T::Array[Array::Elem] = cast(<self>: NilClass, T::Array[Array::Elem]);
     <returnMethodTemp>$2: T::Array[Array::Elem] = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Array[Array::Elem]
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Array>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Array) = cast(<self>: NilClass, T.class_of(Array));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Array))
@@ -294,20 +294,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Array), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Array), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(Array) = <selfRestore>$8
     <cfgAlias>$18: T.class_of(T::Sig) = alias <C Sig>
@@ -317,8 +317,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Array), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array)):
+# - bb2
+bb5[firstDead=5](<self>: T.class_of(Array), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Array)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$13: T.class_of(T) = alias <C T>
@@ -331,36 +331,36 @@ bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Array), <block-pre-call-temp
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::B#returns_self {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: B = cast(<self>: NilClass, B);
     <returnMethodTemp>$2: B = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: B
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(B))
@@ -368,20 +368,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(B) = <selfRestore>$8
     <cfgAlias>$18: T.class_of(T::Sig) = alias <C Sig>
@@ -391,8 +391,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
+# - bb2
+bb5[firstDead=5](<self>: T.class_of(B), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(B)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$13: T.class_of(T) = alias <C T>

--- a/test/testdata/infer/sigil.rb.cfg-text.exp
+++ b/test/testdata/infer/sigil.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#foo {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: Object = cast(<self>: NilClass, Object);
     <statTemp>$3: String("3") = "3"
     <statTemp>$4: Integer(3) = 3
@@ -9,23 +9,23 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/singleton_methods.rb.cfg-text.exp
+++ b/test/testdata/infer/singleton_methods.rb.cfg-text.exp
@@ -1,50 +1,50 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#bar {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <returnMethodTemp>$2: Integer(1) = 1
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <returnMethodTemp>$2: Symbol(:bar) = :bar
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:bar)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Bar#baz {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: Bar = cast(<self>: NilClass, Bar);
     <cfgAlias>$4: T.class_of(Foo) = alias <C Foo>
     <returnMethodTemp>$2: T.untyped = <cfgAlias>$4: T.class_of(Foo).bar()
@@ -52,23 +52,23 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Bar>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Bar) = cast(<self>: NilClass, T.class_of(Bar));
     <returnMethodTemp>$2: Symbol(:baz) = :baz
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:baz)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/singleton_of_singleton.rb.cfg-text.exp
+++ b/test/testdata/infer/singleton_of_singleton.rb.cfg-text.exp
@@ -1,58 +1,58 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#foo {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <returnMethodTemp>$2: Symbol(:bar) = :bar
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:bar)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#bar {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <returnMethodTemp>$2: T.class_of(A) = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.class_of(A)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <returnMethodTemp>$2: Symbol(:foo) = :foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:foo)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/transitive.rb.cfg-text.exp
+++ b/test/testdata/infer/transitive.rb.cfg-text.exp
@@ -1,34 +1,34 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::A#foo {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: A = cast(<self>: NilClass, A);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(A))
@@ -36,20 +36,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(A) = <selfRestore>$8
     <cfgAlias>$17: T.class_of(T::Sig) = alias <C Sig>
@@ -59,8 +59,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb2
+bb5[firstDead=4](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$12: T.class_of(Integer) = alias <C Integer>
@@ -72,22 +72,22 @@ bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(A), <block-pre-call-temp>$7:
 
 method ::Bar#baz {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: Bar = cast(<self>: NilClass, Bar);
     <returnMethodTemp>$2: Integer = <self>: Bar.foo()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Bar>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Bar) = cast(<self>: NilClass, T.class_of(Bar));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Bar))
@@ -95,20 +95,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Bar), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Bar), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(Bar) = <selfRestore>$8
     <cfgAlias>$21: T.class_of(T::Sig) = alias <C Sig>
@@ -118,8 +118,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Bar), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar)):
+# - bb2
+bb5[firstDead=7](<self>: T.class_of(Bar), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Bar)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$12: Symbol(:arg) = :arg

--- a/test/testdata/infer/zsuper.rb.cfg-text.exp
+++ b/test/testdata/infer/zsuper.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#baz {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: Foo = cast(<self>: NilClass, Foo);
     a: T.untyped = load_arg(a)
     <returnMethodTemp>$2: NilClass = <self>: Foo.puts(a: T.untyped)
@@ -22,30 +22,30 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <returnMethodTemp>$2: Symbol(:baz) = :baz
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:baz)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Bar#baz {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Bar = cast(<self>: NilClass, Bar);
     b: T.untyped = load_arg(b)
     <block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Bar.<super>(b: T.untyped)
@@ -53,27 +53,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$5, <super>>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
+# - bb2
+bb5[firstDead=5](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
     # outerLoops: 1
     <self>: Bar = loadSelf(<super>)
     <blk>$7: T.untyped = load_yield_params(<super>)
@@ -86,15 +86,15 @@ bb5[rubyRegionId=1, firstDead=5](<self>: Bar, <block-pre-call-temp>$5: Sorbet::P
 
 method ::<Class:Bar>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Bar) = cast(<self>: NilClass, T.class_of(Bar));
     <returnMethodTemp>$2: Symbol(:baz) = :baz
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:baz)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/namer/module_function.rb.cfg-text.exp
+++ b/test/testdata/namer/module_function.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Funcs#f {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: Funcs = cast(<self>: NilClass, Funcs);
     x: Integer = load_arg(x)
     <returnMethodTemp>$2: Integer = x
@@ -22,29 +22,29 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Funcs>#f {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Funcs) = cast(<self>: NilClass, T.class_of(Funcs));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Funcs#g {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: Funcs = cast(<self>: NilClass, Funcs);
     s: Symbol = load_arg(s)
     <returnMethodTemp>$2: Symbol = s
@@ -52,15 +52,15 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Funcs>#g {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: T.class_of(Funcs) = cast(<self>: NilClass, T.class_of(Funcs));
     s: Symbol = load_arg(s)
     <returnMethodTemp>$2: Symbol = s
@@ -68,15 +68,15 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Funcs#h {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: Funcs = cast(<self>: NilClass, Funcs);
     s: String = load_arg(s)
     <returnMethodTemp>$2: String = s
@@ -84,15 +84,15 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Funcs>#h {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: T.class_of(Funcs) = cast(<self>: NilClass, T.class_of(Funcs));
     s: String = load_arg(s)
     <returnMethodTemp>$2: String = s
@@ -100,15 +100,15 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Funcs>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(Funcs) = cast(<self>: NilClass, T.class_of(Funcs));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(Funcs))
@@ -116,20 +116,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb19(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb19
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs)):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$8
     <cfgAlias>$20: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -138,8 +138,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs)):
+# - bb2
+bb5[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$12: Symbol(:x) = :x
@@ -151,15 +151,15 @@ bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(Funcs)):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(Funcs)):
+# - bb6
+bb7[firstDead=-1](<block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(Funcs)):
     <statTemp>$18: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$22, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$23
     <cfgAlias>$35: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -168,8 +168,8 @@ bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$22: Sorbet::Private::Sta
     <unconditional> -> bb10
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(Funcs)):
+# - bb6
+bb9[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$27: Symbol(:s) = :s
@@ -181,15 +181,15 @@ bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp
     <unconditional> -> bb6
 
 # backedges
-# - bb7(rubyRegionId=0)
-# - bb13(rubyRegionId=3)
-bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$37: Sorbet::Private::Static::Void, <selfRestore>$38: T.class_of(Funcs)):
+# - bb7
+# - bb13
+bb10[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$37: Sorbet::Private::Static::Void, <selfRestore>$38: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
-# - bb10(rubyRegionId=3)
-bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$37: Sorbet::Private::Static::Void, <selfRestore>$38: T.class_of(Funcs)):
+# - bb10
+bb11[firstDead=-1](<block-pre-call-temp>$37: Sorbet::Private::Static::Void, <selfRestore>$38: T.class_of(Funcs)):
     <statTemp>$33: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$37, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$38
     <cfgAlias>$50: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -198,8 +198,8 @@ bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$37: Sorbet::Private::St
     <unconditional> -> bb14
 
 # backedges
-# - bb10(rubyRegionId=3)
-bb13[rubyRegionId=3, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$37: Sorbet::Private::Static::Void, <selfRestore>$38: T.class_of(Funcs)):
+# - bb10
+bb13[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$37: Sorbet::Private::Static::Void, <selfRestore>$38: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$42: Symbol(:s) = :s
@@ -211,15 +211,15 @@ bb13[rubyRegionId=3, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-tem
     <unconditional> -> bb10
 
 # backedges
-# - bb11(rubyRegionId=0)
-# - bb17(rubyRegionId=4)
-bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(Funcs)):
+# - bb11
+# - bb17
+bb14[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
-# - bb14(rubyRegionId=4)
-bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(Funcs)):
+# - bb14
+bb15[firstDead=-1](<block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(Funcs)):
     <statTemp>$48: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$52, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$53
     <cfgAlias>$65: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -228,8 +228,8 @@ bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$52: Sorbet::Private::St
     <unconditional> -> bb18
 
 # backedges
-# - bb14(rubyRegionId=4)
-bb17[rubyRegionId=4, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(Funcs)):
+# - bb14
+bb17[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$52: Sorbet::Private::Static::Void, <selfRestore>$53: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$57: Symbol(:s) = :s
@@ -241,15 +241,15 @@ bb17[rubyRegionId=4, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-tem
     <unconditional> -> bb14
 
 # backedges
-# - bb15(rubyRegionId=0)
-# - bb21(rubyRegionId=5)
-bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$67: Sorbet::Private::Static::Void, <selfRestore>$68: T.class_of(Funcs)):
+# - bb15
+# - bb21
+bb18[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$67: Sorbet::Private::Static::Void, <selfRestore>$68: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
-# - bb18(rubyRegionId=5)
-bb19[rubyRegionId=0, firstDead=12](<block-pre-call-temp>$67: Sorbet::Private::Static::Void, <selfRestore>$68: T.class_of(Funcs)):
+# - bb18
+bb19[firstDead=12](<block-pre-call-temp>$67: Sorbet::Private::Static::Void, <selfRestore>$68: T.class_of(Funcs)):
     <statTemp>$63: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$67, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$68
     <cfgAlias>$81: T.class_of(T::Sig) = alias <C Sig>
@@ -265,8 +265,8 @@ bb19[rubyRegionId=0, firstDead=12](<block-pre-call-temp>$67: Sorbet::Private::St
     <unconditional> -> bb1
 
 # backedges
-# - bb18(rubyRegionId=5)
-bb21[rubyRegionId=5, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$67: Sorbet::Private::Static::Void, <selfRestore>$68: T.class_of(Funcs)):
+# - bb18
+bb21[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$67: Sorbet::Private::Static::Void, <selfRestore>$68: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$72: Symbol(:s) = :s
@@ -281,7 +281,7 @@ bb21[rubyRegionId=5, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-tem
 
 method ::C#test_calls {
 
-bb0[rubyRegionId=0, firstDead=19]():
+bb0[firstDead=19]():
     <self>: C = cast(<self>: NilClass, C);
     <statTemp>$5: Integer(0) = 0
     <statTemp>$3: Integer = <self>: C.f(<statTemp>$5: Integer(0))
@@ -304,15 +304,15 @@ bb0[rubyRegionId=0, firstDead=19]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: T.class_of(C) = cast(<self>: NilClass, T.class_of(C));
     <cfgAlias>$6: T.class_of(Funcs) = alias <C Funcs>
     <statTemp>$3: T.class_of(C) = <self>: T.class_of(C).include(<cfgAlias>$6: T.class_of(Funcs))
@@ -320,8 +320,8 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/namer/redefines_object.rb.cfg-text.exp
+++ b/test/testdata/namer/redefines_object.rb.cfg-text.exp
@@ -1,34 +1,34 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Object>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Object) = cast(<self>: NilClass, T.class_of(Object));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Trigger#trigger {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     @__fake_logger$3: T.untyped = alias <C <undeclared-field-stub>> (@__fake_logger)
     <self>: Trigger = cast(<self>: NilClass, Trigger);
     <returnMethodTemp>$2: T.untyped = @__fake_logger$3
@@ -36,51 +36,51 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Trigger>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=3]():
+bb0[firstDead=3]():
     <self>: T.class_of(Trigger) = cast(<self>: NilClass, T.class_of(Trigger));
     <returnMethodTemp>$2: Symbol(:trigger) = :trigger
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:trigger)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Bar>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Bar) = cast(<self>: NilClass, T.class_of(Bar));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/namer/yield.rb.cfg-text.exp
+++ b/test/testdata/namer/yield.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=5]():
+bb0[firstDead=5]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Main) = alias <C Main>
     <statTemp>$3: Main = <cfgAlias>$5: T.class_of(Main).new()
@@ -9,15 +9,15 @@ bb0[rubyRegionId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Main#yielder {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     <self>: Main = cast(<self>: NilClass, Main);
     <blk>: T.untyped = load_arg(<blk>)
     <statTemp>$5: Integer(1) = 1
@@ -27,15 +27,15 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Main#blockpass {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     <self>: Main = cast(<self>: NilClass, Main);
     blk: T.untyped = load_arg(blk)
     <statTemp>$5: Integer(1) = 1
@@ -45,15 +45,15 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Main#mixed {
 
-bb0[rubyRegionId=0, firstDead=6]():
+bb0[firstDead=6]():
     <self>: Main = cast(<self>: NilClass, Main);
     blk: T.untyped = load_arg(blk)
     <statTemp>$5: Integer(1) = 1
@@ -63,15 +63,15 @@ bb0[rubyRegionId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Main#blockyield {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Main = cast(<self>: NilClass, Main);
     <blk>: T.untyped = load_arg(<blk>)
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Main.yielder()
@@ -79,27 +79,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, yielder>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=5](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
+# - bb2
+bb5[firstDead=5](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
     # outerLoops: 1
     <self>: Main = loadSelf(yielder)
     <blk>$6: T.untyped = load_yield_params(yielder)
@@ -112,27 +112,27 @@ bb5[rubyRegionId=1, firstDead=5](<self>: Main, <blk>: T.untyped, <block-pre-call
 
 method ::Main#main {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: Main = cast(<self>: NilClass, Main);
     <block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Main.lambda()
     <selfRestore>$6: Main = <self>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
+# - bb2
+bb3[firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     l: T.proc.params(arg0: T.untyped).returns(Integer) = Solve<<block-pre-call-temp>$5, lambda>
     <self>: Main = <selfRestore>$6
     <cfgAlias>$15: T.class_of(<Magic>) = alias <C <Magic>>
@@ -151,8 +151,8 @@ bb3[rubyRegionId=0, firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
+# - bb2
+bb5[firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     # outerLoops: 1
     <self>: Main = loadSelf(lambda)
     <blk>$7: [T.untyped] = load_yield_params(lambda)
@@ -166,14 +166,14 @@ bb5[rubyRegionId=1, firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::
 
 method ::<Class:Main>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#make {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$5: T.class_of(Class)[T::Class[T.anything]] = alias <C Class>
     <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Class)[T::Class[T.anything]].new()
@@ -22,20 +22,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
     _cls: T::Class[T.untyped] = Solve<<block-pre-call-temp>$6, new>
     <self>: T.class_of(A) = <selfRestore>$7
     <cfgAlias>$18: T.class_of(Class)[T::Class[T.anything]] = alias <C Class>
@@ -45,8 +45,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
+# - bb2
+bb5[firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
     # outerLoops: 1
     <self>: T.class_of(A) = loadSelf(new)
     <cfgAlias>$12: T.class_of(T::Class) = alias <C Class>
@@ -59,23 +59,23 @@ bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$6:
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=3](<block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
+# - bb6
+bb7[firstDead=3](<block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
     _cls: T.class_of(A) = Solve<<block-pre-call-temp>$21, new>
     <returnMethodTemp>$2: T.class_of(A) = _cls
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.class_of(A)
     <unconditional> -> bb1
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
+# - bb6
+bb9[firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
     # outerLoops: 1
     <self>: T.class_of(A) = loadSelf(new)
     <cfgAlias>$27: T.class_of(T) = alias <C T>
@@ -91,7 +91,7 @@ bb9[rubyRegionId=2, firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$21
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(Sorbet::Private::Static).sig(<self>: T.class_of(A))
@@ -99,20 +99,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb2
+bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$7, sig>
     <self>: T.class_of(A) = <selfRestore>$8
     <cfgAlias>$15: T.class_of(T::Sig) = alias <C Sig>
@@ -122,8 +122,8 @@ bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=3](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
+# - bb2
+bb5[firstDead=3](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <blockReturnTemp>$9: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.void()

--- a/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::MyEnum#serialize {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: MyEnum = cast(<self>: NilClass, MyEnum);
     <cfgAlias>$4: T.class_of(Kernel) = alias <C Kernel>
     <statTemp>$5: String("Sorbet rewriter pass partially unimplemented") = "Sorbet rewriter pass partially unimplemented"
@@ -23,15 +23,15 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:MyEnum>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <C X>$30: MyEnum::X = alias <C X>
     <C Y>$38: MyEnum::Y = alias <C Y>
     <C Z>$47: MyEnum::Z = alias <C Z>
@@ -43,20 +43,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$8, sig>
     <self>: T.class_of(MyEnum) = <selfRestore>$9
     <cfgAlias>$18: T.class_of(T::Helpers) = alias <C Helpers>
@@ -68,8 +68,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(MyEnum), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
+# - bb2
+bb5[firstDead=4](<self>: T.class_of(MyEnum), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$13: T.class_of(String) = alias <C String>
@@ -78,15 +78,15 @@ bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(MyEnum), <block-pre-call-tem
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=4](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(MyEnum)):
+# - bb6
+bb7[firstDead=4](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(MyEnum)):
     <statTemp>$23: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$25, enums>
     <self>: T.class_of(MyEnum) = <selfRestore>$26
     <statTemp>$54: T.class_of(MyEnum) = <self>: T.class_of(MyEnum).public()
@@ -94,8 +94,8 @@ bb7[rubyRegionId=0, firstDead=4](<block-pre-call-temp>$25: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=22](<self>: T.class_of(MyEnum), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
+# - bb6
+bb9[firstDead=22](<self>: T.class_of(MyEnum), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(MyEnum), <C X>$30: MyEnum::X, <C Y>$38: MyEnum::Y, <C Z>$47: MyEnum::Z):
     # outerLoops: 1
     <self>: T.class_of(MyEnum) = loadSelf(enums)
     <cfgAlias>$32: T.class_of(MyEnum::X) = alias <C X$1>
@@ -125,49 +125,49 @@ bb9[rubyRegionId=2, firstDead=22](<self>: T.class_of(MyEnum), <block-pre-call-te
 
 method ::MyEnum::<Class:X>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(MyEnum::X) = cast(<self>: NilClass, T.class_of(MyEnum::X));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::MyEnum::<Class:Y>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(MyEnum::Y) = cast(<self>: NilClass, T.class_of(MyEnum::Y));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::MyEnum::<Class:Z>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(MyEnum::Z) = cast(<self>: NilClass, T.class_of(MyEnum::Z));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:NotAnEnum>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <C X>$8: T.untyped = alias <C X>
     <C Y>$13: NotAnEnum = alias <C Y>
     <self>: T.class_of(NotAnEnum) = cast(<self>: NilClass, T.class_of(NotAnEnum));
@@ -176,27 +176,27 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb3
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$8: T.untyped, <C Y>$13: NotAnEnum):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$8: T.untyped, <C Y>$13: NotAnEnum):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum)):
+# - bb2
+bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum)):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, enums>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$8: T.untyped, <C Y>$13: NotAnEnum):
+# - bb2
+bb5[firstDead=10](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$8: T.untyped, <C Y>$13: NotAnEnum):
     # outerLoops: 1
     <self>: T.class_of(NotAnEnum) = loadSelf(enums)
     <cfgAlias>$10: T.class_of(<Magic>) = alias <C <Magic>>
@@ -214,21 +214,21 @@ bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(NotAnEnum), <block-pre-call
 
 method ::EnumsDoEnum#something_outside {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: EnumsDoEnum = cast(<self>: NilClass, EnumsDoEnum);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::EnumsDoEnum#serialize {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: EnumsDoEnum = cast(<self>: NilClass, EnumsDoEnum);
     <cfgAlias>$4: T.class_of(Kernel) = alias <C Kernel>
     <statTemp>$5: String("Sorbet rewriter pass partially unimplemented") = "Sorbet rewriter pass partially unimplemented"
@@ -237,15 +237,15 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:EnumsDoEnum>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <C X>$30: EnumsDoEnum::X = alias <C X>
     <C Y>$38: EnumsDoEnum::Y = alias <C Y>
     <C Z>$47: EnumsDoEnum::Z = alias <C Z>
@@ -257,20 +257,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$8, sig>
     <self>: T.class_of(EnumsDoEnum) = <selfRestore>$9
     <cfgAlias>$18: T.class_of(T::Helpers) = alias <C Helpers>
@@ -282,8 +282,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
+# - bb2
+bb5[firstDead=4](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$13: T.class_of(String) = alias <C String>
@@ -292,15 +292,15 @@ bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(EnumsDoEnum), <block-pre-cal
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=4](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(EnumsDoEnum)):
+# - bb6
+bb7[firstDead=4](<block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(EnumsDoEnum)):
     <statTemp>$23: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$25, enums>
     <self>: T.class_of(EnumsDoEnum) = <selfRestore>$26
     <statTemp>$55: T.class_of(EnumsDoEnum) = <self>: T.class_of(EnumsDoEnum).public()
@@ -308,8 +308,8 @@ bb7[rubyRegionId=0, firstDead=4](<block-pre-call-temp>$25: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=22](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
+# - bb6
+bb9[firstDead=22](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$25: Sorbet::Private::Static::Void, <selfRestore>$26: T.class_of(EnumsDoEnum), <C X>$30: EnumsDoEnum::X, <C Y>$38: EnumsDoEnum::Y, <C Z>$47: EnumsDoEnum::Z):
     # outerLoops: 1
     <self>: T.class_of(EnumsDoEnum) = loadSelf(enums)
     <cfgAlias>$32: T.class_of(EnumsDoEnum::X) = alias <C X$1>
@@ -339,49 +339,49 @@ bb9[rubyRegionId=2, firstDead=22](<self>: T.class_of(EnumsDoEnum), <block-pre-ca
 
 method ::EnumsDoEnum::<Class:X>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(EnumsDoEnum::X) = cast(<self>: NilClass, T.class_of(EnumsDoEnum::X));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::EnumsDoEnum::<Class:Y>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(EnumsDoEnum::Y) = cast(<self>: NilClass, T.class_of(EnumsDoEnum::Y));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::EnumsDoEnum::<Class:Z>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(EnumsDoEnum::Z) = cast(<self>: NilClass, T.class_of(EnumsDoEnum::Z));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::BadConsts#serialize {
 
-bb0[rubyRegionId=0, firstDead=4]():
+bb0[firstDead=4]():
     <self>: BadConsts = cast(<self>: NilClass, BadConsts);
     <cfgAlias>$4: T.class_of(Kernel) = alias <C Kernel>
     <statTemp>$5: String("Sorbet rewriter pass partially unimplemented") = "Sorbet rewriter pass partially unimplemented"
@@ -390,15 +390,15 @@ bb0[rubyRegionId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:BadConsts>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=-1]():
+bb0[firstDead=-1]():
     <C Before>$24: BadConsts::Before = alias <C Before>
     <C StaticField1>$31: Integer = alias <C StaticField1>
     <C Inside>$39: BadConsts::Inside = alias <C Inside>
@@ -414,20 +414,20 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb7(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb7
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-# - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(BadConsts), <C Before>$24: BadConsts::Before, <C StaticField1>$31: Integer, <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
+# - bb0
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(BadConsts), <C Before>$24: BadConsts::Before, <C StaticField1>$31: Integer, <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(BadConsts), <C Before>$24: BadConsts::Before, <C StaticField1>$31: Integer, <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
+# - bb2
+bb3[firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(BadConsts), <C Before>$24: BadConsts::Before, <C StaticField1>$31: Integer, <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$8, sig>
     <self>: T.class_of(BadConsts) = <selfRestore>$9
     <cfgAlias>$18: T.class_of(T::Helpers) = alias <C Helpers>
@@ -446,8 +446,8 @@ bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Stat
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(BadConsts), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(BadConsts), <C Before>$24: BadConsts::Before, <C StaticField1>$31: Integer, <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
+# - bb2
+bb5[firstDead=4](<self>: T.class_of(BadConsts), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(BadConsts), <C Before>$24: BadConsts::Before, <C StaticField1>$31: Integer, <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$13: T.class_of(String) = alias <C String>
@@ -456,15 +456,15 @@ bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(BadConsts), <block-pre-call-
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyRegionId=0)
-# - bb9(rubyRegionId=2)
-bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$34: Sorbet::Private::Static::Void, <selfRestore>$35: T.class_of(BadConsts), <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$34: Sorbet::Private::Static::Void, <selfRestore>$35: T.class_of(BadConsts), <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb7[rubyRegionId=0, firstDead=16](<block-pre-call-temp>$34: Sorbet::Private::Static::Void, <selfRestore>$35: T.class_of(BadConsts), <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
+# - bb6
+bb7[firstDead=16](<block-pre-call-temp>$34: Sorbet::Private::Static::Void, <selfRestore>$35: T.class_of(BadConsts), <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
     <statTemp>$32: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$34, enums>
     <self>: T.class_of(BadConsts) = <selfRestore>$35
     <cfgAlias>$51: T.class_of(BadConsts::After) = alias <C After$1>
@@ -484,8 +484,8 @@ bb7[rubyRegionId=0, firstDead=16](<block-pre-call-temp>$34: Sorbet::Private::Sta
     <unconditional> -> bb1
 
 # backedges
-# - bb6(rubyRegionId=2)
-bb9[rubyRegionId=2, firstDead=10](<self>: T.class_of(BadConsts), <block-pre-call-temp>$34: Sorbet::Private::Static::Void, <selfRestore>$35: T.class_of(BadConsts), <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
+# - bb6
+bb9[firstDead=10](<self>: T.class_of(BadConsts), <block-pre-call-temp>$34: Sorbet::Private::Static::Void, <selfRestore>$35: T.class_of(BadConsts), <C Inside>$39: BadConsts::Inside, <C StaticField2>$46: Integer, <C After>$49: BadConsts::After, <C StaticField3>$56: Integer, <C StaticField4>$58: Integer):
     # outerLoops: 1
     <self>: T.class_of(BadConsts) = loadSelf(enums)
     <cfgAlias>$41: T.class_of(BadConsts::Inside) = alias <C Inside$1>
@@ -503,42 +503,42 @@ bb9[rubyRegionId=2, firstDead=10](<self>: T.class_of(BadConsts), <block-pre-call
 
 method ::BadConsts::<Class:Before>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(BadConsts::Before) = cast(<self>: NilClass, T.class_of(BadConsts::Before));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::BadConsts::<Class:Inside>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(BadConsts::Inside) = cast(<self>: NilClass, T.class_of(BadConsts::Inside));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::BadConsts::<Class:After>#<static-init> {
 
-bb0[rubyRegionId=0, firstDead=2]():
+bb0[firstDead=2]():
     <self>: T.class_of(BadConsts::After) = cast(<self>: NilClass, T.class_of(BadConsts::After));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyRegionId=0)
-bb1[rubyRegionId=0, firstDead=-1]():
+# - bb0
+bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was added in service of the Sorbet Compiler, which is now deleted (#7849).

It had the unfortunate consequence of bloating the CFG in a way that only
mattered for compiling code, not for type checking code.

We should be able to put it back to what it was and save a little memory (and
have less code to read and wonder about its meaning).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Only exp files change