### PR TITLE
Ignore representation of enums as classes in the document outline

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -36,6 +36,10 @@ bool hideSymbol(const core::GlobalState &gs, core::SymbolRef sym) {
     if (name == core::Names::beforeAngles()) {
         return true;
     }
+    // internal representation of enums as classes
+    if (sym.isClassOrModule() && sym.asClassOrModuleRef().data(gs)->name.isTEnumName(gs)) {
+        return true;
+    }
     // static-init for a file
     if (name.kind() == core::NameKind::UNIQUE && name.dataUnique(gs)->original == core::Names::staticInit()) {
         return true;

--- a/test/testdata/lsp/document_symbols_enum.rb
+++ b/test/testdata/lsp/document_symbols_enum.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+  end
+end

--- a/test/testdata/lsp/document_symbols_enum.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_enum.rb.document-symbols.exp
@@ -1,0 +1,138 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "requestMethod": "textDocument/documentSymbol",
+    "result": [
+        {
+            "name": "MyEnum",
+            "detail": "",
+            "kind": 5,
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 7,
+                    "character": 3
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 22
+                }
+            },
+            "children": [
+                {
+                    "name": "X",
+                    "detail": "",
+                    "kind": 14,
+                    "range": {
+                        "start": {
+                            "line": 4,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 4,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 4,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 4,
+                            "character": 5
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "Y",
+                    "detail": "",
+                    "kind": 14,
+                    "range": {
+                        "start": {
+                            "line": 5,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 5,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 5,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 5,
+                            "character": 5
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "serialize",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 2,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 7,
+                            "character": 3
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 2,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 22
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "self.sealed_subclasses",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 2,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 22
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 2,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 22
+                        }
+                    },
+                    "children": []
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
A small change that hides the internal representation of enums as classes from the document outline view.

**Before**
![Before](https://github.com/user-attachments/assets/61c68163-10e3-4069-8f9a-3effb2b45375)

**After**
![After](https://github.com/user-attachments/assets/873f7e41-4f4d-4a26-a01f-252154a15237)

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #7099.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. 
Please let me know if more sophisticated tests are necessary.
