### PR TITLE
no-op: Remove unused `Types::all` call

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -112,7 +112,6 @@ DispatchResult AndType::dispatchCall(const GlobalState &gs, const DispatchArgs &
         rightRet = right.dispatchCall(gs, args.withThisRef(right));
     }
 
-    auto resultType = Types::all(gs, leftRet.returnType, rightRet.returnType);
     return DispatchResult::merge(gs, DispatchResult::Combinator::AND, std::move(leftRet), std::move(rightRet));
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was at some point moved into `DispatchResult::merge`. It looks like
at that time we forgot to delete this `Types::all` here.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a