### PR TITLE
Update rbi to permit Data.define without arguments

### DIFF
--- a/rbi/core/data.rbi
+++ b/rbi/core/data.rbi
@@ -123,13 +123,12 @@ class Data < Object
   # ```
   sig do
     params(
-        arg0: T.any(Symbol, String),
-        arg1: T.any(Symbol, String),
+        args: T.any(Symbol, String),
         blk: T.untyped,
     )
     .returns(Data)
-  end
-  def self.define(arg0, *arg1, &blk); end
+  ens
+  def self.define(*args, &blk); end
 
   # Returns an array of member names of the data class:
   #

--- a/rbi/core/data.rbi
+++ b/rbi/core/data.rbi
@@ -127,7 +127,7 @@ class Data < Object
         blk: T.untyped,
     )
     .returns(Data)
-  ens
+  end
   def self.define(*args, &blk); end
 
   # Returns an array of member names of the data class:

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -66,7 +66,7 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
     }
 
     if (!ast::MK::isRootScope(recv->scope) || recv->cnst != core::Names::Constants::Data() ||
-        send->fun != core::Names::define() || !send->hasPosArgs()) {
+        send->fun != core::Names::define()) {
         return empty;
     }
 

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -66,7 +66,7 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
     }
 
     if (!ast::MK::isRootScope(recv->scope) || recv->cnst != core::Names::Constants::Data() ||
-        send->fun != core::Names::define()) {
+        send->fun != core::Names::define() || send->hasKwArgs() || send->hasKwSplat()) {
         return empty;
     }
 

--- a/test/testdata/rbi/data.rb
+++ b/test/testdata/rbi/data.rb
@@ -16,7 +16,7 @@ Point = Data.define(:x, :y)
 class ValidInitializers
   T.assert_type!(NotFound, T.class_of(NotFound))
   not_found = NotFound.new
-  T.assert_type!(notfound, NotFound)
+  T.assert_type!(not_found, NotFound)
 
   T.assert_type!(Point, T.class_of(Point))
 

--- a/test/testdata/rbi/data.rb
+++ b/test/testdata/rbi/data.rb
@@ -17,7 +17,7 @@ class ValidInitializers
   T.assert_type!(NotFound, T.class_of(NotFound))
   not_found = NotFound.new
   T.assert_type!(notfound, NotFound)
-  
+
   T.assert_type!(Point, T.class_of(Point))
 
   point = Point.new(1, 2)

--- a/test/testdata/rbi/data.rb
+++ b/test/testdata/rbi/data.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 class Define
-  Data.define # error: Not enough arguments provided for method `Data.define`. Expected: `1+`, got: `0`
+  Data.define
   Data.define(:x, :y)
   Data.define("x", "y")
 
@@ -10,9 +10,14 @@ class Define
   end
 end
 
+NotFound = Data.define
 Point = Data.define(:x, :y)
 
 class ValidInitializers
+  T.assert_type!(NotFound, T.class_of(NotFound))
+  not_found = NotFound.new
+  T.assert_type!(notfound, NotFound)
+  
   T.assert_type!(Point, T.class_of(Point))
 
   point = Point.new(1, 2)

--- a/test/testdata/rewriter/data.rb
+++ b/test/testdata/rewriter/data.rb
@@ -11,6 +11,10 @@ class NotData
     var = Data.define(:foo)
 end
 
+class NullData
+    N = Data.define
+end
+
 class RealData
     A = Data.define(:foo, :bar)
 end
@@ -61,13 +65,12 @@ class MixinData
 end
 
 class BadUsages
-  A = Data.define # error: Not enough arguments provided for method `Data.define`. Expected: `1+`, got: `0`
-  B = Data.define(giberish: 1)
-  #               ^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{giberish: Integer(1)}` for argument `arg0`
+  A = Data.define(giberish: 1)
+  #               ^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{giberish: Integer(1)}` for argument `args`
 
-  C = Data.define(:c)
-  c_data = C.new(1)
-  c_data.c = 6 # error: Setter method `c=` does not exist on `BadUsages::C`
+  B = Data.define(:b)
+  b_data = B.new(1)
+  b_data.b = 6 # error: Setter method `b=` does not exist on `BadUsages::B`
 end
 
 class Main
@@ -96,7 +99,9 @@ class FullyQualifiedDataUsages
   Foo = Data.define(:a)
   Bar = ::Data.define(:a)
   Baz = ::Foo::Data.new
+  Quux = Data.define
 
   Foo.new(1).a
   Bar.new(1).a
+  Quux.new()
 end


### PR DESCRIPTION
`Data.define()` can be called (with no args) to create a class. The documentation (copied to?) line 104 of this file has an example, `NotFound`.

I have never used rbi before so this PR may contain obvious errors or misunderstandings.

### Motivation
I tried to add Sorbet to a project and immediately ran into an incorrect error from `srb tc`: 

```
Not enough arguments provided for method `Data.define`. Expected: `1+`, got: `0`
```

### Test plan
I have attempted to update the appropriate test via GitHub, but I don't know how to run them.