### PR TITLE
Specify sample return type based on args

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2266,7 +2266,10 @@ class Array < Object
         arg0: Integer,
         random: Random::Formatter,
     )
-    .returns(T.any(T.nilable(Elem), T::Array[Elem]))
+    .returns(T::Array[Elem])
+  end
+  sig do
+    returns(Elem)
   end
   def sample(arg0=T.unsafe(nil), random: T.unsafe(nil)); end
 


### PR DESCRIPTION
Right now, Sorbet has the return type of `[].sample` as either an array or an Elem, However the array is only possible if you pass an arg to sample

The types are still inaccurate for the `[].sample(random: Random.new)` case, but that is hopefully less common.

### Motivation

More accurate type information

### Test plan

ran `tools/scripts/update_testdata_exp.sh` and found no changes to apply.