### PR TITLE
Add rbi definition for `Enumerator#+`

### DIFF
--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -154,6 +154,18 @@ class Enumerator < Object
   sig { params(initial: T.untyped, block: T.proc.params(arg: T.untyped).void).returns(T::Enumerator[T.untyped]) }
   def self.produce(initial = nil, &block); end
 
+  # Returns an enumerator object generated from this enumerator and a given 
+  # enumerable.
+  #
+  # ### Examples
+  #
+  # ```ruby
+  # e = (1..3).each + [4, 5]
+  # e.to_a #=> [1, 2, 3, 4, 5]
+  # ```
+  sig { params(enum: T::Enumerable[T.untyped]).returns(T::Enumerator::Chain[T.untyped]) }
+  def +(enum); end
+
   # Iterates over the block according to how this
   # [`Enumerator`](https://docs.ruby-lang.org/en/2.7.0/Enumerator.html) was
   # constructed. If no block and no arguments are given, returns self.

--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -163,7 +163,11 @@ class Enumerator < Object
   # e = (1..3).each + [4, 5]
   # e.to_a #=> [1, 2, 3, 4, 5]
   # ```
-  sig { params(enum: T::Enumerable[T.untyped]).returns(T::Enumerator::Chain[T.untyped]) }
+  sig do
+    type_parameters(:T).params(
+      enum: T::Enumerable[T.type_parameter(:T)]
+    ).returns(T::Enumerator::Chain[T.any(Elem, T.type_parameter(:T))])
+  end
   def +(enum); end
 
   # Iterates over the block according to how this


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

* Was added in Ruby 2.7.0
* https://ruby-doc.org/core-2.7.0/Enumerator.html#method-i-2B

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I am not familiar with this repo at all. If I need to update some tests somewhere please let me know!
