### PR TITLE
Update type signature for Array#zip

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4097,26 +4097,31 @@ public:
         ENFORCE(!ap->targs.empty());
         unwrappedElems.emplace_back(ap->targs.front());
 
+        for (auto arg : args.args) {
+            auto argTyp = arg->type;
+            if (auto *ap = cast_type<AppliedType>(argTyp)) {
+                ENFORCE(ap->klass == Symbols::Enumerable() ||
+                        ap->klass.data(gs)->derivesFrom(gs, Symbols::Enumerable()));
+                ENFORCE(!ap->targs.empty());
+                unwrappedElems.emplace_back(Types::any(gs, ap->targs.front(), Types::nilClass()));
+            } else if (auto *tuple = cast_type<TupleType>(argTyp)) {
+                unwrappedElems.emplace_back(Types::any(gs, tuple->elementType(gs), Types::nilClass()));
+            } else {
+                // Arg type didn't match; we already reported an error for the arg type; just return untyped to
+                // recover.
+                res.returnType = Types::untypedUntracked();
+                return;
+            }
+        }
+
         if (args.block != nullptr) {
             res.returnType = Types::nilClass();
-        } else {
-            for (auto arg : args.args) {
-                auto argTyp = arg->type;
-                if (auto *ap = cast_type<AppliedType>(argTyp)) {
-                    ENFORCE(ap->klass == Symbols::Enumerable() ||
-                            ap->klass.data(gs)->derivesFrom(gs, Symbols::Enumerable()));
-                    ENFORCE(!ap->targs.empty());
-                    unwrappedElems.emplace_back(Types::any(gs, ap->targs.front(), Types::nilClass()));
-                } else if (auto *tuple = cast_type<TupleType>(argTyp)) {
-                    unwrappedElems.emplace_back(Types::any(gs, tuple->elementType(gs), Types::nilClass()));
-                } else {
-                    // Arg type didn't match; we already reported an error for the arg type; just return untyped to
-                    // recover.
-                    res.returnType = Types::untypedUntracked();
-                    return;
-                }
-            }
 
+            if (auto *blockAppliedType = cast_type<AppliedType>(res.main.blockPreType)) {
+                ENFORCE(blockAppliedType->targs.size() == 2);
+                blockAppliedType->targs[1] = make_type<TupleType>(move(unwrappedElems));
+            }
+        } else {
             res.returnType = Types::arrayOf(gs, make_type<TupleType>(move(unwrappedElems)));
         }
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4118,7 +4118,7 @@ public:
             res.returnType = Types::nilClass();
 
             if (auto *blockAppliedType = cast_type<AppliedType>(res.main.blockPreType)) {
-                ENFORCE(blockAppliedType->targs.size() == 2);
+                ENFORCE(blockAppliedType->targs.size() == 2, "calls.cc out of date w.r.t. array.rbi");
                 blockAppliedType->targs[1] = make_type<TupleType>(move(unwrappedElems));
             }
         } else {

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2799,7 +2799,7 @@ class Array < Object
   sig do
     type_parameters(:U).params(
         arg: T::Enumerable[T.type_parameter(:U)],
-        blk: T.proc.params(x: Elem, y: T.nilable(T.type_parameter(:U))).void
+        blk: T.proc.params(x: [Elem, T.nilable(T.type_parameter(:U))]).void
     ).void
   end
   def zip(*arg, &blk); end

--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2799,7 +2799,7 @@ class Array < Object
   sig do
     type_parameters(:U).params(
         arg: T::Enumerable[T.type_parameter(:U)],
-        blk: T.proc.params(x: [Elem, T.nilable(T.type_parameter(:U))]).void
+        blk: T.proc.params(x: T::Array[T.any(Elem, T.nilable(T.type_parameter(:U)))]).void
     ).void
   end
   def zip(*arg, &blk); end

--- a/test/testdata/intrinsics/zip.rb
+++ b/test/testdata/intrinsics/zip.rb
@@ -1,3 +1,9 @@
 # typed: true
 s = [1].zip([2], [3])
 T.reveal_type(s) # error: Revealed type: `T::Array[[Integer, T.nilable(Integer), T.nilable(Integer)]]`
+
+xs = T.let([1,2,3], T::Array[Integer])
+res = xs.zip(xs) do |zipped|
+  T.reveal_type(zipped) # error: Revealed type: `[Integer, T.nilable(Integer)] (2-tuple)`
+end
+T.reveal_type(res) # error: Revealed type: `NilClass`

--- a/test/testdata/intrinsics/zip.rb
+++ b/test/testdata/intrinsics/zip.rb
@@ -1,4 +1,5 @@
 # typed: true
+
 s = [1].zip([2], [3])
 T.reveal_type(s) # error: Revealed type: `T::Array[[Integer, T.nilable(Integer), T.nilable(Integer)]]`
 
@@ -7,3 +8,14 @@ res = xs.zip(xs) do |zipped|
   T.reveal_type(zipped) # error: Revealed type: `[Integer, T.nilable(Integer)] (2-tuple)`
 end
 T.reveal_type(res) # error: Revealed type: `NilClass`
+
+res = xs.zip(xs, xs) do |zipped|
+  T.reveal_type(zipped) # error: Revealed type: `[Integer, T.nilable(Integer), T.nilable(Integer)] (3-tuple)`
+end
+
+ys = T.let([""], T::Array[String])
+zs = T.let([false, true], T::Array[T::Boolean])
+res = xs.zip(ys, zs, xs) do |zipped|
+  T.reveal_type(zipped) # error: Revealed type: `[Integer, T.nilable(String), T.nilable(T::Boolean), T.nilable(Integer)] (4-tuple)`
+end
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The PR updates the block parameter type in the RBI and the return type in the intrinsic for the Array#zip to match the type in the docs
https://docs.ruby-lang.org/en/3.1/Array.html#method-i-zip

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://github.com/sorbet/sorbet/issues/8206

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
