### PR TITLE
Narrow return type of `singleton_class`

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -655,7 +655,7 @@ module Kernel
   end
   def send(arg0, *arg1, &blk); end
 
-  sig {returns(T::Class[T.anything])}
+  sig {returns(T::Class[T.self_type])}
   def singleton_class(); end
 
   sig do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
I think this works: 
https://sorbet.run/#%23%20typed%3A%20true%0A%0AT.let%2842.singleton_class%2C%20T.class_of%28Integer%29%29%0AT.let%2842.singleton_class%2C%20T%3A%3AClass%5BInteger%5D%29%0AT.let%2842.singleton_class%2C%20T%3A%3AClass%5BString%5D%29

What I would really like is for the ~reverse operation, `attached_object`, to return something narrower than `BasicObject`, to avoid unnecessary type guards / casts.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests 🤞 
