### PR TITLE
Semantically revert "Hoist pipeline::name to after pipeline::package (#7817)"

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -749,10 +749,7 @@ int realmain(int argc, char *argv[]) {
                 // First run: only the __package.rb files. This populates the packageDB
                 pipeline::setPackagerOptions(*gs, opts);
                 pipeline::package(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers);
-                // Only need to compute hashes when running to compute a FileHash
-                auto foundHashes = nullptr;
-                auto canceled = pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers, foundHashes);
-                ENFORCE(!canceled, "There's no cancellation in batch mode");
+                // TODO(jez) Put the call to pipeline::name back here
             }
 
             auto nonPackageIndexed =
@@ -768,6 +765,14 @@ int realmain(int argc, char *argv[]) {
 
             // Second run: all the other files (the packageDB shouldn't change)
             pipeline::package(*gs, absl::Span<ast::ParsedFile>(nonPackageIndexed), opts, *workers);
+
+            {
+                // TODO(jez) Put this back after the call to `pipeline::package` in the stripePackages section
+                // Only need to compute hashes when running to compute a FileHash
+                auto foundHashes = nullptr;
+                auto canceled = pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers, foundHashes);
+                ENFORCE(!canceled, "There's no cancellation in batch mode");
+            }
 
             // Only need to compute hashes when running to compute a FileHash
             auto foundHashes = nullptr;

--- a/test/cli/warm-cache-remove-file/test.out
+++ b/test/cli/warm-cache-remove-file/test.out
@@ -3,3 +3,5 @@
             types.input.files.kvstore.miss :             22
            types.input.files.kvstore.write :             22
 ====second run (only one file)====
+                         types.input.files :              2
+             types.input.files.kvstore.hit :              1

--- a/test/cli/warm-cache-remove-file/test.out
+++ b/test/cli/warm-cache-remove-file/test.out
@@ -1,0 +1,5 @@
+====first run (all files)====
+                         types.input.files :             22
+            types.input.files.kvstore.miss :             22
+           types.input.files.kvstore.write :             22
+====second run (only one file)====

--- a/test/cli/warm-cache-remove-file/test.sh
+++ b/test/cli/warm-cache-remove-file/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+exec 2>&1
+
+dir=$(mktemp -d)
+cleanup() {
+    rm -r "$dir"
+}
+trap cleanup EXIT
+
+mkdir "$dir/cache"
+
+mkdir "$dir/a"
+echo "class A < PackageSpec; end # typed: strict" > "$dir/a/__package.rb"
+for i in {01..10}; do
+  echo "class A::A$i; end" > "$dir/a/a$i.rb"
+done
+mkdir "$dir/b"
+echo "class B < PackageSpec; end # typed: strict" > "$dir/b/__package.rb"
+for i in {01..10}; do
+  echo "class B::B$i; end" > "$dir/b/b$i.rb"
+done
+
+run_sorbet() {
+  if ! main/sorbet --silence-dev-message --counters --cache-dir "$dir/cache" --stripe-packages "$@" 2> "$dir/stderr.txt"; then
+    cat "$dir/stderr.txt"
+    exit 1
+  fi
+  grep 'types.input.files\(.kvstore.miss\|.kvstore.hit\|.kvstore.write\)\? :' "$dir/stderr.txt"
+}
+
+echo "====first run (all files)===="
+run_sorbet "$dir"/{a,b}/
+echo "====second run (only one file)===="
+run_sorbet "$dir"/b/__package.rb "$dir"/b/b10.rb


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In practice, this was never actually working because the problem which we fixed
in #8030 was preventing the cache from being written a second time (and we were
only ever caching `__package.rb` files).

When we fixed that, it exposed that it's not actually safe to call
`pipeline::name` before writing to the cache, because it will mean writing way
too much of `GlobalState` into the cache that shouldn't have been. The disk
cache is only ever meant to cache symbols from Sorbet's payload.

It's not clear to me why that is, and if that is, why it isn't implemented by
simply re-reading the payload out of Sorbet's binary every time. In any case, I
plan to continue looking at that further in an attempt to move `pipeline::name`
back to where it was—we need `pipeline::name` to be before indexing all files,
because in the future we want to make it so that we can decide not to index
files that we don't need. We're not at that point yet, so having a working disk
cache is more important.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The included test has an `ENFORCE` failure when it runs on `master`, and is
fixed in this change.
