### PR TITLE
Only check strict_dependencies and layer options when --packager-layers flag is passed

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -217,6 +217,10 @@ const std::vector<core::NameRef> &PackageDB::layers() const {
     return layers_;
 }
 
+const bool PackageDB::layeringChecksEnabled() const {
+    return !layers_.empty();
+}
+
 const std::vector<std::string> &PackageDB::extraPackageFilesDirectoryUnderscorePrefixes() const {
     return extraPackageFilesDirectoryUnderscorePrefixes_;
 }

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -217,7 +217,7 @@ const std::vector<core::NameRef> &PackageDB::layers() const {
     return layers_;
 }
 
-const bool PackageDB::layeringChecksEnabled() const {
+const bool PackageDB::enforceLayering() const {
     return !layers_.empty();
 }
 

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -67,7 +67,7 @@ public:
     // Ie. {'util', 'app'} means that code in `app` can call code in `util`, but code in `util` cannot call code in
     // `app`.
     const std::vector<core::NameRef> &layers() const;
-    const bool layeringChecksEnabled() const;
+    const bool enforceLayering() const;
 
     const std::string_view errorHint() const;
     bool allowRelaxedPackagerChecksFor(const MangledName mangledName) const;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -67,6 +67,7 @@ public:
     // Ie. {'util', 'app'} means that code in `app` can call code in `util`, but code in `util` cannot call code in
     // `app`.
     const std::vector<core::NameRef> &layers() const;
+    const bool layeringChecksEnabled() const;
 
     const std::string_view errorHint() const;
     bool allowRelaxedPackagerChecksFor(const MangledName mangledName) const;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -629,9 +629,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                  "Packages which are allowed to ignore the restrictions set by `visible_to` "
                                  "and `export` directives",
                                  cxxopts::value<vector<string>>(), "<name>");
-    options.add_options(section)("packager-layers", "Valid layer names for packages, ordered lowest to highest.",
-                                 cxxopts::value<vector<string>>()->implicit_value("library,application"),
-                                 "<layer-name>");
+    options.add_options(section)(
+        "packager-layers",
+        "Valid layer names for packages, ordered lowest to highest. Passing this flag also enables layering checks.",
+        cxxopts::value<vector<string>>()->implicit_value("library,application"), "<layer-name>");
     options.add_options(section)("package-skip-rbi-export-enforcement",
                                  "Constants defined in RBIs in these directories (and no others) can be exported",
                                  cxxopts::value<vector<string>>(), "<dir>");

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1126,8 +1126,11 @@ struct PackageSpecBodyWalk {
         if (send.fun == core::Names::strictDependencies()) {
             if (!ctx.state.packageDB().enforceLayering()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidStrictDependencies)) {
-                    e.setHeader("`{}` can only be declared when `{}` is passed", send.fun.show(ctx),
+                    e.setHeader("Found `{}` annotation, but `{}` was not passed", send.fun.show(ctx),
                                 "--packager-layers");
+                    e.addErrorNote("Use `{}` to define the valid layers, or `{}` to use the default layers "
+                                   "of `{}` and `{}`",
+                                   "--packager-layers=foo,bar", "--packager-layers", "library", "application");
                 }
                 return;
             }
@@ -1156,8 +1159,11 @@ struct PackageSpecBodyWalk {
         if (send.fun == core::Names::layer()) {
             if (!ctx.state.packageDB().enforceLayering()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidLayer)) {
-                    e.setHeader("`{}` can only be declared when `{}` is passed", send.fun.show(ctx),
+                    e.setHeader("Found `{}` annotation, but `{}` was not passed", send.fun.show(ctx),
                                 "--packager-layers");
+                    e.addErrorNote("Use `{}` to define the valid layers, or `{}` to use the default layers "
+                                   "of `{}` and `{}`",
+                                   "--packager-layers=foo,bar", "--packager-layers", "library", "application");
                 }
                 return;
             }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1124,7 +1124,7 @@ struct PackageSpecBodyWalk {
         }
 
         if (send.fun == core::Names::strictDependencies()) {
-            if (!ctx.state.packageDB().layeringChecksEnabled()) {
+            if (!ctx.state.packageDB().enforceLayering()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidStrictDependencies)) {
                     e.setHeader("`{}` can only be declared when `{}` is passed", send.fun.show(ctx),
                                 "--packager-layers");
@@ -1154,7 +1154,7 @@ struct PackageSpecBodyWalk {
         }
 
         if (send.fun == core::Names::layer()) {
-            if (!ctx.state.packageDB().layeringChecksEnabled()) {
+            if (!ctx.state.packageDB().enforceLayering()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidLayer)) {
                     e.setHeader("`{}` can only be declared when `{}` is passed", send.fun.show(ctx),
                                 "--packager-layers");

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1124,6 +1124,13 @@ struct PackageSpecBodyWalk {
         }
 
         if (send.fun == core::Names::strictDependencies()) {
+            if (!ctx.state.packageDB().layeringChecksEnabled()) {
+                if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidStrictDependencies)) {
+                    e.setHeader("`{}` can only be declared when `{}` is passed", send.fun.show(ctx),
+                                "--packager-layers");
+                }
+                return;
+            }
             if (info.strictDependenciesLevel.has_value()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidStrictDependencies)) {
                     e.setHeader("Repeated declaration of `{}`", send.fun.show(ctx));
@@ -1147,6 +1154,13 @@ struct PackageSpecBodyWalk {
         }
 
         if (send.fun == core::Names::layer()) {
+            if (!ctx.state.packageDB().layeringChecksEnabled()) {
+                if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidLayer)) {
+                    e.setHeader("`{}` can only be declared when `{}` is passed", send.fun.show(ctx),
+                                "--packager-layers");
+                }
+                return;
+            }
             if (info.layer.has_value()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidLayer)) {
                     e.setHeader("Repeated declaration of `{}`", send.fun.show(ctx));

--- a/test/cli/packager-layers/test.out
+++ b/test/cli/packager-layers/test.out
@@ -8,11 +8,15 @@ __package.rb:5: Argument to `layer` must be one of: `a`, `b`, or `c` https://srb
                 ^^^^^^
 Errors: 1
 --packager-layers can only be specified in --stripe-packages mode
-__package.rb:4: `strict_dependencies` can only be declared when `--packager-layers` is passed https://srb.help/3724
+__package.rb:4: Found `strict_dependencies` annotation, but `--packager-layers` was not passed https://srb.help/3724
      4 |  strict_dependencies 'false'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Use `--packager-layers=foo,bar` to define the valid layers, or `--packager-layers` to use the default layers of `library` and `application`
 
-__package.rb:5: `layer` can only be declared when `--packager-layers` is passed https://srb.help/3725
+__package.rb:5: Found `layer` annotation, but `--packager-layers` was not passed https://srb.help/3725
      5 |  layer 'fake'
           ^^^^^^^^^^^^
+  Note:
+    Use `--packager-layers=foo,bar` to define the valid layers, or `--packager-layers` to use the default layers of `library` and `application`
 Errors: 2

--- a/test/cli/packager-layers/test.out
+++ b/test/cli/packager-layers/test.out
@@ -8,3 +8,11 @@ __package.rb:5: Argument to `layer` must be one of: `a`, `b`, or `c` https://srb
                 ^^^^^^
 Errors: 1
 --packager-layers can only be specified in --stripe-packages mode
+__package.rb:4: `strict_dependencies` can only be declared when `--packager-layers` is passed https://srb.help/3724
+     4 |  strict_dependencies 'false'
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+__package.rb:5: `layer` can only be declared when `--packager-layers` is passed https://srb.help/3725
+     5 |  layer 'fake'
+          ^^^^^^^^^^^^
+Errors: 2

--- a/test/cli/packager-layers/test.sh
+++ b/test/cli/packager-layers/test.sh
@@ -1,8 +1,7 @@
 cd test/cli/packager-layers || exit 1
 
-# No --packager-layers flag with --stripe-packages
-../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1
-
+# --packager-layers flag with no argument with --stripe-packages
+../../../main/sorbet --silence-dev-message --stripe-packages --packager-layers . 2>&1
 
 # No --packager-layers flag with no --stripe-packages
 ../../../main/sorbet --silence-dev-message . 2>&1
@@ -12,3 +11,6 @@ cd test/cli/packager-layers || exit 1
 
 # --packager-layers flag with no --stripe-packages
 ../../../main/sorbet --silence-dev-message --packager-layers=a,b . 2>&1
+
+# No --packager-layers flag with --stripe-packages
+../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -580,7 +580,7 @@ TEST_CASE("LSPTest") {
             if (skipImportVisibility.has_value()) {
                 opts->allowRelaxedPackagerChecksFor.emplace_back(skipImportVisibility.value());
             }
-            std::vector<std::string> defaultLayers = {"library", "application"};
+            std::vector<std::string> defaultLayers = {};
             opts->packagerLayers =
                 StringPropertyAssertions::getValues("packager-layers", assertions).value_or(defaultLayers);
         }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -285,7 +285,7 @@ void setupPackager(unique_ptr<core::GlobalState> &gs, vector<shared_ptr<RangeAss
         allowRelaxedPackagerChecksFor.emplace_back(allowRelaxedPackager.value());
     }
 
-    std::vector<std::string> defaultLayers = {"library", "application"};
+    std::vector<std::string> defaultLayers = {};
     auto packagerLayers = StringPropertyAssertions::getValues("packager-layers", assertions).value_or(defaultLayers);
 
     {

--- a/test/testdata/packager/strict_dependencies/block/__package.rb
+++ b/test/testdata/packager/strict_dependencies/block/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# packager-layers: a
 
 class Block < PackageSpec
   strict_dependencies 'false' do end # error: Invalid expression in package: `Block` not allowed

--- a/test/testdata/packager/strict_dependencies/invalid_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/invalid_option/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# packager-layers: a
 
 class InvalidOption < PackageSpec
   strict_dependencies 'true' # error: Argument to `strict_dependencies` must be one of: `'false'`, `'layered'`, `'layered_dag'`, or `'dag'`

--- a/test/testdata/packager/strict_dependencies/keyword_arg/__package.rb
+++ b/test/testdata/packager/strict_dependencies/keyword_arg/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# packager-layers: a
 
 class KeywordArg < PackageSpec
   strict_dependencies(level: 'false') # error: Expected `String` but found `{level: String("false")}` for argument `arg0`

--- a/test/testdata/packager/strict_dependencies/missing/__package.rb
+++ b/test/testdata/packager/strict_dependencies/missing/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# packager-layers: a
 
 class Missing < PackageSpec
 end

--- a/test/testdata/packager/strict_dependencies/non_string_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/non_string_option/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# packager-layers: a
 
 class NonStringOption < PackageSpec
   strict_dependencies false # error: Argument to `strict_dependencies` must be one of: `'false'`, `'layered'`, `'layered_dag'`, or `'dag'`

--- a/test/testdata/packager/strict_dependencies/repeated/__package.rb
+++ b/test/testdata/packager/strict_dependencies/repeated/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# packager-layers: a
 
 class Repeated < PackageSpec
   strict_dependencies 'false'

--- a/test/testdata/packager/strict_dependencies/too_few_args/__package.rb
+++ b/test/testdata/packager/strict_dependencies/too_few_args/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# packager-layers: a
 
 class TooFewArgs < PackageSpec
   strict_dependencies # error: Not enough arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `0`

--- a/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
+++ b/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# packager-layers: a
 
 class TooManyArgs < PackageSpec
   strict_dependencies 'false', 'true' # error: Too many arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `2`

--- a/test/testdata/packager/strict_dependencies/valid_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/valid_option/__package.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
+# packager-layers: a
 
 class ValidOption < PackageSpec
   strict_dependencies 'false'

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -311,7 +311,7 @@ Usage:
                                 by `visible_to` and `export` directives
       --packager-layers [=<layer-name>(=library,application)]
                                 Valid layer names for packages, ordered lowest to
-                                highest.
+                                highest. Passing this flag also enables layering checks.
       --package-skip-rbi-export-enforcement <dir>
                                 Constants defined in RBIs in these directories (and no
                                 others) can be exported

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -309,9 +309,9 @@ Usage:
       --allow-relaxed-packager-checks-for <name>
                                 Packages which are allowed to ignore the restrictions set
                                 by `visible_to` and `export` directives
-      --packager-layers <layer-name>
+      --packager-layers [=<layer-name>(=library,application)]
                                 Valid layer names for packages, ordered lowest to
-                                highest. (default: library,application)
+                                highest.
       --package-skip-rbi-export-enforcement <dir>
                                 Constants defined in RBIs in these directories (and no
                                 others) can be exported

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -912,8 +912,8 @@ For example, the following specifies that there are three valid layers: `util`,
 srb tc --packager-layers util,lib,app
 ```
 
-If the flag is not passed, then the default valid layers are `library` and
-`application`.
+If the flag is passed with no argument, then the default valid layers are
+`library` and `application`.
 
 ## 4001
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This provides a way to enable the packaging system, without having to enable the layering checks too.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
