### PR TITLE
Implement `strict_dependencies "layered"`

### DIFF
--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -30,5 +30,6 @@ constexpr ErrorClass InvalidExport{3721, StrictLevel::False};
 constexpr ErrorClass ImportNotVisible{3723, StrictLevel::False};
 constexpr ErrorClass InvalidStrictDependencies{3724, StrictLevel::False};
 constexpr ErrorClass InvalidLayer{3725, StrictLevel::False};
+constexpr ErrorClass LayeringViolation{3726, StrictLevel::False};
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -31,5 +31,6 @@ constexpr ErrorClass ImportNotVisible{3723, StrictLevel::False};
 constexpr ErrorClass InvalidStrictDependencies{3724, StrictLevel::False};
 constexpr ErrorClass InvalidLayer{3725, StrictLevel::False};
 constexpr ErrorClass LayeringViolation{3726, StrictLevel::False};
+constexpr ErrorClass StrictDependenciesViolation{3727, StrictLevel::False};
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -217,6 +217,12 @@ const std::vector<core::NameRef> &PackageDB::layers() const {
     return layers_;
 }
 
+const int PackageDB::layerIndex(core::NameRef layer) const {
+    auto findResult = absl::c_find(layers_, layer);
+    ENFORCE(findResult != layers_.end());
+    return std::distance(layers_.begin(), findResult);
+}
+
 const bool PackageDB::enforceLayering() const {
     return !layers_.empty();
 }

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -67,6 +67,7 @@ public:
     // Ie. {'util', 'app'} means that code in `app` can call code in `util`, but code in `util` cannot call code in
     // `app`.
     const std::vector<core::NameRef> &layers() const;
+    const int layerIndex(core::NameRef layer) const;
     const bool enforceLayering() const;
 
     const std::string_view errorHint() const;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1571,12 +1571,11 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     if (pkgIndex < otherPkgIndex) {
         if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::LayeringViolation)) {
             e.setHeader("`{}` is at layer `{}`, so it can not import package `{}`, which is at layer `{}`",
-                        thisPkg.name.toString(ctx), pkgLayer.toString(ctx), otherPkg.name.toString(ctx),
-                        otherPkgLayer.toString(ctx));
+                        thisPkg.show(ctx), pkgLayer.show(ctx), otherPkg.show(ctx), otherPkgLayer.show(ctx));
             e.addErrorLine(core::Loc(thisPkg.loc.file(), thisPkg.layer.value().second), "`{}`'s `{}` declared here",
-                           thisPkg.name.toString(ctx), "layer");
+                           thisPkg.show(ctx), "layer");
             e.addErrorLine(core::Loc(otherPkg.loc.file(), otherPkg.layer.value().second), "`{}`'s `{}` declared here",
-                           otherPkg.name.toString(ctx), "layer");
+                           otherPkg.show(ctx), "layer");
         }
     }
 
@@ -1584,7 +1583,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
         if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::LayeringViolation)) {
             e.setHeader("All of this package's dependecies must be `{}` or higher", "layered");
             e.addErrorLine(core::Loc(otherPkg.loc.file(), otherPkg.strictDependenciesLevel.value().second),
-                           "`{}`'s `{}` level declared here", otherPkg.name.toString(ctx), "strict_dependencies");
+                           "`{}`'s `{}` level declared here", otherPkg.show(ctx), "strict_dependencies");
         }
     }
 }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1636,8 +1636,9 @@ void validatePackage(core::Context ctx) {
 
     auto &pkgInfo = PackageInfoImpl::from(absPkg);
     bool skipImportVisibilityCheck = packageDB.allowRelaxedPackagerChecksFor(pkgInfo.mangledName());
+    auto enforceLayering = ctx.state.packageDB().enforceLayering();
 
-    if (skipImportVisibilityCheck && !ctx.state.packageDB().enforceLayering()) {
+    if (skipImportVisibilityCheck && !enforceLayering) {
         return;
     }
 
@@ -1650,7 +1651,7 @@ void validatePackage(core::Context ctx) {
             continue;
         }
 
-        if (ctx.state.packageDB().enforceLayering()) {
+        if (enforceLayering) {
             validateLayering(ctx, i);
         }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1570,8 +1570,8 @@ void validateLayering(const core::Context &ctx, const Import &i) {
 
     if (pkgLayerIndex < otherPkgLayerIndex) {
         if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::LayeringViolation)) {
-            e.setHeader("`{}` is at layer `{}`, so it can not import package `{}`, which is at layer `{}`",
-                        thisPkg.show(ctx), pkgLayer.show(ctx), otherPkg.show(ctx), otherPkgLayer.show(ctx));
+            e.setHeader("Layering violation: cannot import `{}` (in layer `{}`) from `{}` (in layer `{}`)",
+                        otherPkg.show(ctx), otherPkgLayer.show(ctx), thisPkg.show(ctx), pkgLayer.show(ctx));
             e.addErrorLine(core::Loc(thisPkg.loc.file(), thisPkg.layer.value().second), "`{}`'s `{}` declared here",
                            thisPkg.show(ctx), "layer");
             e.addErrorLine(core::Loc(otherPkg.loc.file(), otherPkg.layer.value().second), "`{}`'s `{}` declared here",
@@ -1581,7 +1581,8 @@ void validateLayering(const core::Context &ctx, const Import &i) {
 
     if (otherPkg.strictDependenciesLevel.value().first == core::packages::StrictDependenciesLevel::False) {
         if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::StrictDependenciesViolation)) {
-            e.setHeader("All of `{}`'s `{}`s must be `{}` or higher", thisPkg.show(ctx), "import", "layered");
+            e.setHeader("Strict Dependencies violation: All of `{}`'s `{}`s must be `{}` or higher", thisPkg.show(ctx),
+                        "import", "layered");
             e.addErrorLine(core::Loc(otherPkg.loc.file(), otherPkg.strictDependenciesLevel.value().second),
                            "`{}`'s `{}` level declared here", otherPkg.show(ctx), "strict_dependencies");
         }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1547,10 +1547,11 @@ void validateLayering(const core::Context &ctx, const Import &i) {
         return;
     }
 
-    ENFORCE(ctx.state.packageDB().getPackageInfo(i.name.mangledName).exists())
-    ENFORCE(ctx.state.packageDB().getPackageForFile(ctx, ctx.file).exists())
-    auto &thisPkg = PackageInfoImpl::from(ctx.state.packageDB().getPackageForFile(ctx, ctx.file));
-    auto &otherPkg = PackageInfoImpl::from(ctx.state.packageDB().getPackageInfo(i.name.mangledName));
+    const auto &packageDB = ctx.state.packageDB();
+    ENFORCE(packageDB.getPackageInfo(i.name.mangledName).exists())
+    ENFORCE(packageDB.getPackageForFile(ctx, ctx.file).exists())
+    auto &thisPkg = PackageInfoImpl::from(packageDB.getPackageForFile(ctx, ctx.file));
+    auto &otherPkg = PackageInfoImpl::from(packageDB.getPackageInfo(i.name.mangledName));
 
     if (!thisPkg.strictDependenciesLevel.has_value() || !otherPkg.strictDependenciesLevel.has_value() ||
         !thisPkg.layer.has_value() || !otherPkg.layer.has_value()) {
@@ -1561,11 +1562,11 @@ void validateLayering(const core::Context &ctx, const Import &i) {
         return;
     }
 
-    auto possibleLayers = ctx.state.packageDB().layers();
+    auto possibleLayers = packageDB.layers();
     auto pkgLayer = thisPkg.layer.value().first;
     auto otherPkgLayer = otherPkg.layer.value().first;
-    auto pkgIndex = ctx.state.packageDB().layerIndex(pkgLayer);
-    auto otherPkgIndex = ctx.state.packageDB().layerIndex(otherPkgLayer);
+    auto pkgIndex = packageDB.layerIndex(pkgLayer);
+    auto otherPkgIndex = packageDB.layerIndex(otherPkgLayer);
 
     if (pkgIndex < otherPkgIndex) {
         if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::LayeringViolation)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1564,8 +1564,8 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     auto possibleLayers = ctx.state.packageDB().layers();
     auto pkgLayer = thisPkg.layer.value().first;
     auto otherPkgLayer = otherPkg.layer.value().first;
-    auto pkgIndex = std::distance(possibleLayers.begin(), absl::c_find(possibleLayers, pkgLayer));
-    auto otherPkgIndex = std::distance(possibleLayers.begin(), absl::c_find(possibleLayers, otherPkgLayer));
+    auto pkgIndex = ctx.state.packageDB().layerIndex(pkgLayer);
+    auto otherPkgIndex = ctx.state.packageDB().layerIndex(otherPkgLayer);
 
     if (pkgIndex < otherPkgIndex) {
         if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::LayeringViolation)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1581,7 +1581,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
 
     if (otherPkg.strictDependenciesLevel.value().first == core::packages::StrictDependenciesLevel::False) {
         if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::LayeringViolation)) {
-            e.setHeader("All of this package's dependecies must be `{}` or higher", "layered");
+            e.setHeader("All of `{}`'s `{}`s must be `{}` or higher", thisPkg.show(ctx), "import", "layered");
             e.addErrorLine(core::Loc(otherPkg.loc.file(), otherPkg.strictDependenciesLevel.value().second),
                            "`{}`'s `{}` level declared here", otherPkg.show(ctx), "strict_dependencies");
         }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1565,10 +1565,10 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     auto possibleLayers = packageDB.layers();
     auto pkgLayer = thisPkg.layer.value().first;
     auto otherPkgLayer = otherPkg.layer.value().first;
-    auto pkgIndex = packageDB.layerIndex(pkgLayer);
-    auto otherPkgIndex = packageDB.layerIndex(otherPkgLayer);
+    auto pkgLayerIndex = packageDB.layerIndex(pkgLayer);
+    auto otherPkgLayerIndex = packageDB.layerIndex(otherPkgLayer);
 
-    if (pkgIndex < otherPkgIndex) {
+    if (pkgLayerIndex < otherPkgLayerIndex) {
         if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::LayeringViolation)) {
             e.setHeader("`{}` is at layer `{}`, so it can not import package `{}`, which is at layer `{}`",
                         thisPkg.show(ctx), pkgLayer.show(ctx), otherPkg.show(ctx), otherPkgLayer.show(ctx));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -230,7 +230,7 @@ public:
     optional<pair<core::packages::StrictDependenciesLevel, core::LocOffsets>> strictDependenciesLevel = nullopt;
     optional<pair<core::NameRef, core::LocOffsets>> layer = nullopt;
 
-    // PackageInfoImpl is the only implementation of PackageInfoImpl
+    // PackageInfoImpl is the only implementation of PackageInfo
     const static PackageInfoImpl &from(const core::packages::PackageInfo &pkg) {
         ENFORCE(pkg.exists());
         return reinterpret_cast<const PackageInfoImpl &>(pkg); // TODO is there a more idiomatic way to do this?
@@ -1570,7 +1570,6 @@ void validateVisibility(const core::Context &ctx, const Import i) {
 
 } // namespace
 
-// Validate that the package file is marked `# typed: strict`.
 void validatePackage(core::Context ctx) {
     const auto &packageDB = ctx.state.packageDB();
     auto &absPkg = packageDB.getPackageForFile(ctx, ctx.file);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1580,7 +1580,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     }
 
     if (otherPkg.strictDependenciesLevel.value().first == core::packages::StrictDependenciesLevel::False) {
-        if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::LayeringViolation)) {
+        if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::StrictDependenciesViolation)) {
             e.setHeader("All of `{}`'s `{}`s must be `{}` or higher", thisPkg.show(ctx), "import", "layered");
             e.addErrorLine(core::Loc(otherPkg.loc.file(), otherPkg.strictDependenciesLevel.value().second),
                            "`{}`'s `{}` level declared here", otherPkg.show(ctx), "strict_dependencies");

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1554,6 +1554,13 @@ void validatePackage(core::Context ctx) {
         return;
     }
 
+    // Sanity check: __package.rb files _must_ be typed: strict
+    if (ctx.file.data(ctx).originalSigil < core::StrictLevel::Strict) {
+        if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::PackageFileMustBeStrict)) {
+            e.setHeader("Package files must be at least `{}`", "# typed: strict");
+        }
+    }
+
     auto &pkgInfo = PackageInfoImpl::from(absPkg);
     bool skipImportVisibilityCheck = packageDB.allowRelaxedPackagerChecksFor(pkgInfo.mangledName());
 
@@ -1588,13 +1595,6 @@ void validatePackage(core::Context ctx) {
                                    "visible_to", otherPkg.show(ctx));
                 }
             }
-        }
-    }
-
-    // Sanity check: __package.rb files _must_ be typed: strict
-    if (ctx.file.data(ctx).originalSigil < core::StrictLevel::Strict) {
-        if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::PackageFileMustBeStrict)) {
-            e.setHeader("Package files must be at least `{}`", "# typed: strict");
         }
     }
 }

--- a/test/testdata/packager/layered/__package.rb
+++ b/test/testdata/packager/layered/__package.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class Root < PackageSpec
+  strict_dependencies 'layered'
+  layer 'business'
+end

--- a/test/testdata/packager/layered/business1/__package.rb
+++ b/test/testdata/packager/layered/business1/__package.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class Business1 < PackageSpec
+  strict_dependencies 'layered'
+  layer 'business'
+
+  import Service1 # error: `Business1` is at layer `business`, so it can not import package `Service1`, which is at layer `service`
+  import Business2
+end

--- a/test/testdata/packager/layered/business1/__package.rb
+++ b/test/testdata/packager/layered/business1/__package.rb
@@ -5,6 +5,6 @@ class Business1 < PackageSpec
   strict_dependencies 'layered'
   layer 'business'
 
-  import Service1 # error: `Business1` is at layer `business`, so it can not import package `Service1`, which is at layer `service`
+  import Service1 # error: Layering violation: cannot import `Service1` (in layer `service`) from `Business1` (in layer `business`)
   import Business2
 end

--- a/test/testdata/packager/layered/business1/__package.rb
+++ b/test/testdata/packager/layered/business1/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class Business1 < PackageSpec
   strict_dependencies 'layered'

--- a/test/testdata/packager/layered/business2/__package.rb
+++ b/test/testdata/packager/layered/business2/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class Business2 < PackageSpec
   strict_dependencies 'layered'

--- a/test/testdata/packager/layered/business2/__package.rb
+++ b/test/testdata/packager/layered/business2/__package.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class Business2 < PackageSpec
+  strict_dependencies 'layered'
+  layer 'business'
+
+  import Utility1
+  test_import Service1
+end

--- a/test/testdata/packager/layered/service1/__package.rb
+++ b/test/testdata/packager/layered/service1/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class Service1 < PackageSpec
   strict_dependencies 'layered'

--- a/test/testdata/packager/layered/service1/__package.rb
+++ b/test/testdata/packager/layered/service1/__package.rb
@@ -6,5 +6,5 @@ class Service1 < PackageSpec
   layer 'service'
 
   import Business1
-  import Utility2 # error: All of `Service1`'s `import`s must be `layered` or higher
+  import Utility2 # error: Strict Dependencies violation: All of `Service1`'s `import`s must be `layered` or higher
 end

--- a/test/testdata/packager/layered/service1/__package.rb
+++ b/test/testdata/packager/layered/service1/__package.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class Service1 < PackageSpec
+  strict_dependencies 'layered'
+  layer 'service'
+
+  import Business1
+  import Utility2 # error: All of this package's dependecies must be `layered` or higher
+end

--- a/test/testdata/packager/layered/service1/__package.rb
+++ b/test/testdata/packager/layered/service1/__package.rb
@@ -8,5 +8,5 @@ class Service1 < PackageSpec
   layer 'service'
 
   import Business1
-  import Utility2 # error: All of this package's dependecies must be `layered` or higher
+  import Utility2 # error: All of `Service1`'s `import`s must be `layered` or higher
 end

--- a/test/testdata/packager/layered/utility1/__package.rb
+++ b/test/testdata/packager/layered/utility1/__package.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class Utility1 < PackageSpec
+  strict_dependencies 'layered'
+  layer 'utility'
+end

--- a/test/testdata/packager/layered/utility1/__package.rb
+++ b/test/testdata/packager/layered/utility1/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class Utility1 < PackageSpec
   strict_dependencies 'layered'

--- a/test/testdata/packager/layered/utility2/__package.rb
+++ b/test/testdata/packager/layered/utility2/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class Utility2 < PackageSpec
   strict_dependencies 'false'

--- a/test/testdata/packager/layered/utility2/__package.rb
+++ b/test/testdata/packager/layered/utility2/__package.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class Utility2 < PackageSpec
+  strict_dependencies 'false'
+  layer 'utility'
+
+  import Utility1
+  import Service1
+end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -976,14 +976,19 @@ If the flag is passed with no argument, then the default valid layers are
 > at Stripe, please see [go/modularity](http://go/modularity) and
 > [go/layers](http://go/layers) for more.
 
-If a package is at `strict_dependencies 'layered'` or stricter, there are two
-restrictions on what packages it may import:
+If a package is at `strict_dependencies 'layered'` or stricter, all packages it
+imports must be in the same or lower layer. For example, given
+`--packager-layers util,lib,app`, all imports for a package with layer `lib`
+must either also have layer `lib`, or have layer `util` (but not layer `app`).
 
-- all packages it imports must also be at `strict_dependencies 'layered'` (or
-  stricter)
-- all packages it imports must be in the same or lower layer. For example, given
-  `--packager-layers util,lib,app`, all imports for a package with layer `lib`
-  must either also have layer `lib`, or have layer `util` (but not layer `app`).
+## 3727
+
+> This error is specific to Stripe's custom `--stripe-packages` mode. If you are
+> at Stripe, please see [go/modularity](http://go/modularity) and
+> [go/strict-dependencies](http://go/strict-dependencies) for more.
+
+If a package is at `strict_dependencies 'layered'`, all packages it imports must
+also be at `strict_dependencies 'layered'`.
 
 ## 4001
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -974,7 +974,7 @@ If the flag is passed with no argument, then the default valid layers are
 If a package is at `strict_dependencies` level `layered` or stricter, there are
 2 restrictions on what packages it may import:
 
-- all packages it imports must also be at level `layered` (or stricter)
+- all packages it imports must also be at `strict_dependencies` level `layered` (or stricter)
 - all packages must be in the same or lower layer
 
 ## 4001

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -945,6 +945,8 @@ The 4 possible values are:
 All packages have a `layer`, which is used when checking for layering
 violations. See [3726](#3726).
 
+<!-- TODO(neil): Replace [3726](#3726) with a link to layering/strict_deps documentation when we write that. -->
+
 ```ruby
 class MyPackage < PackageSpec
   strict_dependencies 'false'
@@ -954,13 +956,16 @@ end
 
 You can choose the valid layers using the `--packager-layers` command line flag.
 For example, the following specifies that there are three valid layers: `util`,
-`lib` and `app`, ordered lowest to highest. This means that in `layered` (or
-stricter), packages in the `app` layer can import those in `util` or `lib`, but
-packages in the `util` layer cannot import those in `lib` or `app`.
+`lib` and `app`, ordered lowest to highest.
 
 ```bash
 srb tc --packager-layers util,lib,app
 ```
+
+Note that the order matters here. Passing the option as above means that in
+`layered` (or stricter), packages in the `app` layer can import those in `util`
+or `lib`, but packages in the `util` layer cannot import those in `lib` or
+`app`.
 
 If the flag is passed with no argument, then the default valid layers are
 `library` and `application`.
@@ -971,12 +976,14 @@ If the flag is passed with no argument, then the default valid layers are
 > at Stripe, please see [go/modularity](http://go/modularity) and
 > [go/layers](http://go/layers) for more.
 
-If a package is at `strict_dependencies` level `layered` or stricter, there are
-2 restrictions on what packages it may import:
+If a package is at `strict_dependencies 'layered'` or stricter, there are two
+restrictions on what packages it may import:
 
-- all packages it imports must also be at `strict_dependencies` level `layered`
-  (or stricter)
-- all packages must be in the same or lower layer
+- all packages it imports must also be at `strict_dependencies 'layered'` (or
+  stricter)
+- all packages it imports must be in the same or lower layer. For example, given
+  `--packager-layers util,lib,app`, all imports for a package with layer `lib`
+  must either also have layer `lib`, or have layer `util` (but not layer `app`).
 
 ## 4001
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -943,9 +943,7 @@ The 4 possible values are:
 > [go/layers](http://go/layers) for more.
 
 All packages have a `layer`, which is used when checking for layering
-violations.
-
-<!-- TODO(neil): explain this further once we implement these checks -->
+violations. See [3726](#3726).
 
 ```ruby
 class MyPackage < PackageSpec
@@ -956,9 +954,9 @@ end
 
 You can choose the valid layers using the `--packager-layers` command line flag.
 For example, the following specifies that there are three valid layers: `util`,
-`lib` and `app`, ordered lowest to highest.
-
-<!-- TODO(neil): explain what lowest to highest means once we implement these checks -->
+`lib` and `app`, ordered lowest to highest. This means that in `layered` (or
+stricter), packages in the `app` layer can import those in `util` or `lib`, but
+packages in the `util` layer cannot import those in `lib` or `app`.
 
 ```bash
 srb tc --packager-layers util,lib,app
@@ -966,6 +964,18 @@ srb tc --packager-layers util,lib,app
 
 If the flag is passed with no argument, then the default valid layers are
 `library` and `application`.
+
+## 3726
+
+> This error is specific to Stripe's custom `--stripe-packages` mode. If you are
+> at Stripe, please see [go/modularity](http://go/modularity) and
+> [go/layers](http://go/layers) for more.
+
+If a package is at `strict_dependencies` level `layered` or stricter, there are
+2 restrictions on what packages it may import:
+
+- all packages it imports must also be at level `layered` (or stricter)
+- all packages must be in the same or lower layer
 
 ## 4001
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -974,7 +974,8 @@ If the flag is passed with no argument, then the default valid layers are
 If a package is at `strict_dependencies` level `layered` or stricter, there are
 2 restrictions on what packages it may import:
 
-- all packages it imports must also be at `strict_dependencies` level `layered` (or stricter)
+- all packages it imports must also be at `strict_dependencies` level `layered`
+  (or stricter)
 - all packages must be in the same or lower layer
 
 ## 4001


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This implements the first level of `strict_dependencies`: `layered`. This check enforces it that every package with a `strict_dependencies` level that is `layered` or higher can only import packages that both:
- also `layered` or stricter
- part of a layer that is the same or lower

Review commit-by-commit. The pre-work commits will be easier to review with `?w=1`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Implement more of the packaging/layering system in sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
