### PR TITLE
callWithSplat: Overwrite the DispatchResult

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3139,10 +3139,7 @@ public:
             }
         }
 
-        for (auto &err : res.main.errors) {
-            dispatched.main.errors.emplace_back(std::move(err));
-        }
-        res = std::move(dispatched);
+        res = move(dispatched);
     }
 } Magic_checkAndAnd;
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2505,19 +2505,7 @@ public:
                                args.isPrivateOk,
                                args.suppressErrors,
                                args.enclosingMethodForSuper};
-        auto dispatched = receiver->type.dispatchCall(gs, innerArgs);
-        for (auto &err : dispatched.main.errors) {
-            res.main.errors.emplace_back(std::move(err));
-        }
-        dispatched.main.errors = move(res.main.errors);
-
-        // TODO(trevor) this should merge constraints from `res` and `dispatched` instead
-        if ((dispatched.main.constr == nullptr) || dispatched.main.constr->isEmpty()) {
-            dispatched.main.constr = move(res.main.constr);
-        }
-        res = move(dispatched);
-
-        return;
+        res = receiver->type.dispatchCall(gs, innerArgs);
     }
 } Magic_callWithSplat;
 


### PR DESCRIPTION
No need to be clever here: just overwrite it, and behave as if the dispatch
happened to something else.

This works because there's nothing that could have reported an error
earlier, before the call to the intrinsic kicked in: the method itself
takes untyped arguments, so there will never be anything important on
`res.main` worth saving.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Remove some code that's not needed.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.