### PR TITLE
Raise errors for anonymous rest args in block params

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -166,6 +166,7 @@ void checkBlockRestArg(DesugarContext dctx, const MethodDef::ARGS_store &args) {
         if (auto e = dctx.ctx.beginError(it->loc(), core::errors::Desugar::BlockAnonymousRestParam)) {
             e.setHeader("Anonymous rest parameter in block args");
             e.addErrorNote("Naming the rest parameter will ensure you can access it in the block");
+            e.replaceWith("Name the rest parameter", dctx.ctx.locAt(it->loc().copyEndWithZeroLength()), "_");
         }
     }
 }

--- a/core/errors/desugar.h
+++ b/core/errors/desugar.h
@@ -14,6 +14,7 @@ constexpr ErrorClass UndefUsage{3008, StrictLevel::Strict};
 constexpr ErrorClass UnsupportedRestArgsDestructure{3009, StrictLevel::True};
 constexpr ErrorClass CodeInRBI{3010, StrictLevel::False};
 constexpr ErrorClass DuplicatedHashKeys{3011, StrictLevel::False};
+constexpr ErrorClass BlockAnonymousRestParam{3012, StrictLevel::False};
 } // namespace sorbet::core::errors::Desugar
 
 #endif

--- a/test/testdata/desugar/forward_args.rb.autocorrects.exp
+++ b/test/testdata/desugar/forward_args.rb.autocorrects.exp
@@ -1,3 +1,4 @@
+# -- test/testdata/desugar/forward_args.rb --
 # typed: true
 
 class Foo
@@ -20,14 +21,14 @@ class Foo
   end
 
   def foo5(*)
-    [1,2,3].each do |*|
+    [1,2,3].each do |*_|
                    # ^ error: Anonymous rest parameter
       T.unsafe(self).p(*)
     end
   end
 
   def foo6(*args)
-    [1,2,3].each do |*|
+    [1,2,3].each do |*_|
                    # ^ error: Anonymous rest parameter
       T.unsafe(self).p(*)
     end
@@ -46,3 +47,4 @@ Foo.new.foo(1, 2)
 Foo.new.foo(k1: 1, k2: 2)
 Foo.new.foo do puts "foo" end
 Foo.new.foo(1, 2, k1: 1, k2: 2) do puts "foo" end
+# ------------------------------

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -25,6 +25,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
             <hashTemp>$2
           end], block)
     end
+
+    def foo5<<todo method>>(**, &<blk>)
+      [1, 2, 3].each() do |**|
+        ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
+      end
+    end
+
+    def foo6<<todo method>>(*args, &<blk>)
+      [1, 2, 3].each() do |**|
+        ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
+      end
+    end
+
+    def foo7<<todo method>>(**, &<blk>)
+      [1, 2, 3].each() do |*args|
+        ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
+      end
+    end
   end
 
   <emptyTree>::<C Foo>.new().foo()

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -332,6 +332,27 @@ sig {params(_a: String, _b: Integer).void} # ok
 def foo(_a, _b); end
 ```
 
+## 3012
+
+There was an anonymous rest argument defined in the block parameter list.
+
+```ruby
+[1,2,3].each do |*|
+  T.unsafe(self).p(*)
+end
+```
+
+The anonymous rest argument may only refer to method parameters, and uses of it
+will generate runtime syntax errors if it's used in the context of a block that
+defines it. This can be resolved by naming the rest argument parameter in the
+block:
+
+```ruby
+[1,2,3].each do |*args|
+  T.unsafe(self).p(*args)
+end
+```
+
 ## 3501
 
 Sorbet has special support for understanding Ruby's `attr_reader`,


### PR DESCRIPTION
It's not possible to use anonymous rest args with block params, as is defined to refer only to forwarded method arguments; any use of an anonymous rest argument defined by a block will result in a runtime `SyntaxError`. Instead, let's raise an error with a message indicating that the anonymous rest parameter must be named, during the desugar pass.

### Motivation

As #8204 points out, we currently don't raise any errors for programs that use anonymous rest args in block params. As they will raise a `SyntaxError` at runtime if the anonymous rest arg is named in the block body, we're choosing to raise an error at the block param definition site to avoid a potentially confusing runtime error.

Fixes #8204

### Test plan

See included automated tests.
