### PR TITLE
Fix doc comments on hover for methods with params starting with 'end'

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -332,7 +332,7 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
                 // Start of sig block
                 && !(absl::StartsWith(line, "sig do") || absl::StartsWith(line, "sig(:final) do"))
                 // Invalid end keyword
-                && !absl::StartsWith(line, "end")) {
+                && !(absl::StartsWith(line, "end") && absl::EndsWith(line, "end"))) {
                 it++;
                 if (it != all_lines.rend()) {
                     line = absl::StripAsciiWhitespace(*it);
@@ -343,7 +343,7 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
             // 1) Reached the start of the file
             // 2) Found a `sig do`
             // 3) Found an invalid end keyword
-            if (it == all_lines.rend() || absl::StartsWith(line, "end")) {
+            if (it == all_lines.rend() || (absl::StartsWith(line, "end") && absl::EndsWith(line, "end"))) {
                 break;
             }
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -332,7 +332,7 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
                 // Start of sig block
                 && !(absl::StartsWith(line, "sig do") || absl::StartsWith(line, "sig(:final) do"))
                 // Invalid end keyword
-                && !(absl::StartsWith(line, "end") && absl::EndsWith(line, "end"))) {
+                && line != "end") {
                 it++;
                 if (it != all_lines.rend()) {
                     line = absl::StripAsciiWhitespace(*it);
@@ -343,7 +343,7 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
             // 1) Reached the start of the file
             // 2) Found a `sig do`
             // 3) Found an invalid end keyword
-            if (it == all_lines.rend() || (absl::StartsWith(line, "end") && absl::EndsWith(line, "end"))) {
+            if (it == all_lines.rend() || line == "end") {
                 break;
             }
 

--- a/test/testdata/lsp/hover_method.rb
+++ b/test/testdata/lsp/hover_method.rb
@@ -50,6 +50,17 @@ class Foo
   # ^ hover: sig { params(arg0: Integer).void }
   end
 
+  # Docs above a sig with an end in the params list on a new line
+  sig do 
+    params(
+      end_time: String
+    ).void
+  end
+  def quux(end_time)
+      # ^ hover: Docs above a sig with an end in the params list on a new line
+      # ^ hover: sig { params(end_time: String).void }
+  end
+
   sig {void}
   def no_args_and_void
   end
@@ -104,4 +115,8 @@ def main
   f.qux
   # ^^^ hover: Some docs for qux
   # ^^^ hover: sig { void }
+
+  f.quux('')
+  # ^^^^ hover: Docs above a sig with an end in the params list on a new line
+  # ^^^^ hover: sig { params(end_time: String).void }
 end


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This fixes a specific issue that occurs only when a valid line starts with an 'end' within the sig do/end block.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #6676 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
