### PR TITLE
Fix a crash with duplicate keyword arguments

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -854,16 +854,6 @@ private:
         // we know right now that pos >= arguments.size() because otherwise we would have hit the early return at the
         // beginning of this method
         auto &argInfo = ctx.state.enterMethodArgumentSymbol(ctx.locAt(parsedArg.loc), ctx.owner.asMethodRef(), name);
-        // if enterMethodArgumentSymbol did not emplace a new argument into the list, then it means it's reusing an
-        // existing one, which means we've seen a repeated kwarg (as it treats identically named kwargs as
-        // identical). We know that we need to match the arity of the function as written, so if we don't have as many
-        // arguments as we expect, clone the one we got back from enterMethodArgumentSymbol in the position we expect
-        if (methodData->arguments.size() == pos) {
-            auto argCopy = argInfo.deepCopy();
-            argCopy.name = ctx.state.freshNameUnique(core::UniqueNameKind::MangledKeywordArg, argInfo.name, pos + 1);
-            methodData->arguments.emplace_back(move(argCopy));
-            return;
-        }
         // at this point, we should have at least pos + 1 arguments, and arguments[pos] should be the thing we got back
         // from enterMethodArgumentSymbol
         ENFORCE(methodData->arguments.size() >= pos + 1);

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1782,7 +1782,7 @@ public:
         }
 
         // Only report an error if this name doesn't start with an `_`, but still report it as being a duplicate of
-        // another argument, for the purpose of mangling.
+        // another argument, for the purpose of mangling. The Ruby VM silences these errors.
         if (this_name.shortName(gs_)[0] != '_') {
             error_without_recovery(ruby_parser::dclass::DuplicateArgument, this_loc, this_name.toString(gs_));
         }

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1747,33 +1747,33 @@ public:
             ++pos;
 
             if (auto *arg = parser::cast_node<Arg>(this_arg.get())) {
-                checkDuplicateArg(arg->name, arg->loc, map);
+                hasDuplicateArg(arg->name, arg->loc, map);
             } else if (auto *optarg = parser::cast_node<Optarg>(this_arg.get())) {
-                checkDuplicateArg(optarg->name, optarg->loc, map);
+                hasDuplicateArg(optarg->name, optarg->loc, map);
             } else if (auto *restarg = parser::cast_node<Restarg>(this_arg.get())) {
-                checkDuplicateArg(restarg->name, restarg->loc, map);
+                hasDuplicateArg(restarg->name, restarg->loc, map);
             } else if (auto *blockarg = parser::cast_node<Blockarg>(this_arg.get())) {
-                checkDuplicateArg(blockarg->name, blockarg->loc, map);
+                hasDuplicateArg(blockarg->name, blockarg->loc, map);
             } else if (auto *kwarg = parser::cast_node<Kwarg>(this_arg.get())) {
-                if (checkDuplicateArg(kwarg->name, kwarg->loc, map)) {
+                if (hasDuplicateArg(kwarg->name, kwarg->loc, map)) {
                     kwarg->name = gs_.freshNameUnique(core::UniqueNameKind::MangledKeywordArg, kwarg->name, pos);
                 }
             } else if (auto *kwoptarg = parser::cast_node<Kwoptarg>(this_arg.get())) {
-                if (checkDuplicateArg(kwoptarg->name, kwoptarg->loc, map)) {
+                if (hasDuplicateArg(kwoptarg->name, kwoptarg->loc, map)) {
                     kwoptarg->name = gs_.freshNameUnique(core::UniqueNameKind::MangledKeywordArg, kwoptarg->name, pos);
                 }
             } else if (auto *kwrestarg = parser::cast_node<Kwrestarg>(this_arg.get())) {
-                checkDuplicateArg(kwrestarg->name, kwrestarg->loc, map);
+                hasDuplicateArg(kwrestarg->name, kwrestarg->loc, map);
             } else if (auto *shadowarg = parser::cast_node<Shadowarg>(this_arg.get())) {
-                checkDuplicateArg(shadowarg->name, shadowarg->loc, map);
+                hasDuplicateArg(shadowarg->name, shadowarg->loc, map);
             } else if (auto *mlhs = parser::cast_node<Mlhs>(this_arg.get())) {
                 checkDuplicateArgs(mlhs->exprs, map);
             }
         }
     }
 
-    bool checkDuplicateArg(core::NameRef this_name, core::LocOffsets this_loc,
-                           UnorderedMap<core::NameRef, core::LocOffsets> &map) {
+    bool hasDuplicateArg(core::NameRef this_name, core::LocOffsets this_loc,
+                         UnorderedMap<core::NameRef, core::LocOffsets> &map) {
         auto that_arg_loc_it = map.find(this_name);
 
         if (that_arg_loc_it == map.end()) {

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1742,7 +1742,10 @@ public:
     }
 
     void checkDuplicateArgs(sorbet::parser::NodeVec &args, UnorderedMap<core::NameRef, core::LocOffsets> &map) {
+        int pos = -1;
         for (auto &this_arg : args) {
+            ++pos;
+
             if (auto *arg = parser::cast_node<Arg>(this_arg.get())) {
                 checkDuplicateArg(arg->name, arg->loc, map);
             } else if (auto *optarg = parser::cast_node<Optarg>(this_arg.get())) {
@@ -1752,9 +1755,13 @@ public:
             } else if (auto *blockarg = parser::cast_node<Blockarg>(this_arg.get())) {
                 checkDuplicateArg(blockarg->name, blockarg->loc, map);
             } else if (auto *kwarg = parser::cast_node<Kwarg>(this_arg.get())) {
-                checkDuplicateArg(kwarg->name, kwarg->loc, map);
+                if (checkDuplicateArg(kwarg->name, kwarg->loc, map)) {
+                    kwarg->name = gs_.freshNameUnique(core::UniqueNameKind::MangledKeywordArg, kwarg->name, pos);
+                }
             } else if (auto *kwoptarg = parser::cast_node<Kwoptarg>(this_arg.get())) {
-                checkDuplicateArg(kwoptarg->name, kwoptarg->loc, map);
+                if (checkDuplicateArg(kwoptarg->name, kwoptarg->loc, map)) {
+                    kwoptarg->name = gs_.freshNameUnique(core::UniqueNameKind::MangledKeywordArg, kwoptarg->name, pos);
+                }
             } else if (auto *kwrestarg = parser::cast_node<Kwrestarg>(this_arg.get())) {
                 checkDuplicateArg(kwrestarg->name, kwrestarg->loc, map);
             } else if (auto *shadowarg = parser::cast_node<Shadowarg>(this_arg.get())) {
@@ -1765,18 +1772,22 @@ public:
         }
     }
 
-    void checkDuplicateArg(core::NameRef this_name, core::LocOffsets this_loc,
+    bool checkDuplicateArg(core::NameRef this_name, core::LocOffsets this_loc,
                            UnorderedMap<core::NameRef, core::LocOffsets> &map) {
         auto that_arg_loc_it = map.find(this_name);
 
         if (that_arg_loc_it == map.end()) {
             map[this_name] = this_loc;
-            return;
+            return false;
         }
 
-        if (argNameCollides(this_name)) {
+        // Only report an error if this name doesn't start with an `_`, but still report it as being a duplicate of
+        // another argument, for the purpose of mangling.
+        if (this_name.shortName(gs_)[0] != '_') {
             error_without_recovery(ruby_parser::dclass::DuplicateArgument, this_loc, this_name.toString(gs_));
         }
+
+        return true;
     }
 
     void checkDuplicatePatternVariable(std::string name, core::LocOffsets loc) {
@@ -1830,11 +1841,6 @@ public:
             }
         }
         return res;
-    }
-
-    bool argNameCollides(core::NameRef name) {
-        // Ignore everything beginning with underscore.
-        return (name.shortName(gs_)[0] != '_');
     }
 
     bool isLiteralNode(parser::Node &node) {

--- a/test/testdata/namer/duplicate_field_error.rb
+++ b/test/testdata/namer/duplicate_field_error.rb
@@ -1,0 +1,17 @@
+# typed: strict
+
+# Discovered in https://github.com/sorbet/sorbet/issues/7969
+
+class A
+  extend T::Sig
+  sig { params(x: Integer, x: String).void }
+                         # ^ error: Hash key `x` is duplicated
+                         # ^ error: Unknown argument name `x`
+  def initialize(x:, x: nil)
+                   # ^^ error: Malformed `sig`
+                   # ^^^^^^ error: duplicate argument name x
+    @x = T.let(x, T.nilable(String))
+    @x = T.let(x, T.nilable(String))
+       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Argument does not have asserted type
+  end
+end

--- a/test/testdata/parser/kwargs.rb
+++ b/test/testdata/parser/kwargs.rb
@@ -4,3 +4,11 @@ foo(x: 0)
 foo({x: 0})
 foo(**{x: 0})
 foo(**hash)
+
+def foo(x:, x:)
+          # ^^ error: duplicate argument name x
+end
+
+def foo(x:, x: 10)
+          # ^^^^^ error: duplicate argument name x
+end

--- a/test/testdata/parser/kwargs.rb.parse-tree.exp
+++ b/test/testdata/parser/kwargs.rb.parse-tree.exp
@@ -83,5 +83,36 @@ Begin {
         }
       ]
     }
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Kwarg {
+            name = <U x>
+          }
+          Kwarg {
+            name = <K <U x> $1>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U foo>
+      args = Args {
+        args = [
+          Kwarg {
+            name = <U x>
+          }
+          Kwoptarg {
+            name = <K <U x> $1>
+            default_ = Integer {
+              val = "10"
+            }
+          }
+        ]
+      }
+      body = NULL
+    }
   ]
 }


### PR DESCRIPTION
Instead of mangling duplicated keyword arguments in the namer, which introduces
the possibility that the argument hash will differ later on, eagerly mangle
duplicate keyword args in the parser. This gives us a more consistent tree for
the rest of the pipeline, avoiding the situation where the argument hashes can
get out of sync.

### Motivation
Fixes #8194
Fixes #7969


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
