### PR TITLE
Only record a diagnostic for a duplicate argument error

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1784,7 +1784,7 @@ public:
         // Only report an error if this name doesn't start with an `_`, but still report it as being a duplicate of
         // another argument, for the purpose of mangling. The Ruby VM silences these errors.
         if (this_name.shortName(gs_)[0] != '_') {
-            error_without_recovery(ruby_parser::dclass::DuplicateArgument, this_loc, this_name.toString(gs_));
+            error(ruby_parser::dclass::DuplicateArgument, this_loc, this_name.toString(gs_));
         }
 
         return true;

--- a/test/testdata/namer/duplicate_field_error.rb
+++ b/test/testdata/namer/duplicate_field_error.rb
@@ -11,6 +11,7 @@ class A
                    # ^^ error: Malformed `sig`
                    # ^^^^^^ error: duplicate argument name x
     @x = T.let(x, T.nilable(String))
+       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Argument does not have asserted type
     @x = T.let(x, T.nilable(String))
        # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Argument does not have asserted type
   end


### PR DESCRIPTION
Instead of triggering error recovery from a duplicate argument error, only record a diagnostic. This ensures that we don't throw away any other definitions in the file when there's only a duplicate argument present.

### Motivation
This should help us avoid taking the slow path in a case where duplicate arguments are detected.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests should be sufficient
