### PR TITLE
Test that duplicate argument names don't block the fast path

### DIFF
--- a/test/testdata/lsp/duplicate_kwarg.1.rbupdate
+++ b/test/testdata/lsp/duplicate_kwarg.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-fast-path: duplicate_kwarg.rb
+
+def foo(x:, x: nil)
+          # ^^^^^^ error: duplicate argument name x
+end
+
+def bar(x, y:, y: nil)
+             # ^^^^^^ error: duplicate argument name y
+end

--- a/test/testdata/lsp/duplicate_kwarg.rb
+++ b/test/testdata/lsp/duplicate_kwarg.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+def foo(x:, x: nil)
+          # ^^^^^^ error: duplicate argument name x
+end
+
+def bar(x, y:, y: nil)
+             # ^^^^^^ error: duplicate argument name y
+end

--- a/test/testdata/lsp/duplicate_kwarg.rb.desugar-tree.exp
+++ b/test/testdata/lsp/duplicate_kwarg.rb.desugar-tree.exp
@@ -1,0 +1,9 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def foo<<todo method>>(x:, x$1: = nil, &<blk>)
+    <emptyTree>
+  end
+
+  def bar<<todo method>>(x, y:, y$2: = nil, &<blk>)
+    <emptyTree>
+  end
+end

--- a/test/testdata/namer/fuzz_repeated_kwarg.rb.desugar-tree.exp
+++ b/test/testdata/namer/fuzz_repeated_kwarg.rb.desugar-tree.exp
@@ -1,0 +1,41 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def f1<<todo method>>(x, x, &<blk>)
+    <emptyTree>
+  end
+
+  def f2<<todo method>>(x, x = 0, &<blk>)
+    <emptyTree>
+  end
+
+  def f3<<todo method>>(x:, x$1:, &<blk>)
+    <emptyTree>
+  end
+
+  def f4<<todo method>>(x:, x$1: = nil, &<blk>)
+    <emptyTree>
+  end
+
+  def f5<<todo method>>(x, x$1:, &<blk>)
+    <emptyTree>
+  end
+
+  def f6<<todo method>>(x, x$1: = nil, &<blk>)
+    <emptyTree>
+  end
+
+  def f7<<todo method>>(x = 0, x$1: = nil, &<blk>)
+    <emptyTree>
+  end
+
+  def f8<<todo method>>(this, this$1:, &<blk>)
+    <emptyTree>
+  end
+
+  def f9<<todo method>>(x, y, z, x, &<blk>)
+    <emptyTree>
+  end
+
+  l1 = <self>.lambda() do |y, y|
+    <emptyTree>
+  end
+end


### PR DESCRIPTION
Add a test that asserts the claims of #8262: duplicate argument errors will no longer cause the slow path to be taken, as they no longer trigger an error path in the parser that discards earlier parts of the tree.

### Motivation
Follow up tests to #8262

### Test plan
See included automated tests.
