### PR TITLE
Enforce that package files have both `strict dependencies` and `layer` when `enforceLayering` is true

### DIFF
--- a/test/testdata/packager/layer/missing/__package.rb
+++ b/test/testdata/packager/layer/missing/__package.rb
@@ -3,6 +3,6 @@
 # enable-packager: true
 # packager-layers: a, b
 
-class Missing < PackageSpec
+class Missing < PackageSpec # error: This package does not declare a `layer`
   strict_dependencies 'false'
 end

--- a/test/testdata/packager/strict_dependencies/block/__package.rb
+++ b/test/testdata/packager/strict_dependencies/block/__package.rb
@@ -5,4 +5,5 @@
 
 class Block < PackageSpec
   strict_dependencies 'false' do end # error: Invalid expression in package: `Block` not allowed
+  layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/invalid_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/invalid_option/__package.rb
@@ -5,4 +5,5 @@
 
 class InvalidOption < PackageSpec
   strict_dependencies 'true' # error: Argument to `strict_dependencies` must be one of: `'false'`, `'layered'`, `'layered_dag'`, or `'dag'`
+  layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/keyword_arg/__package.rb
+++ b/test/testdata/packager/strict_dependencies/keyword_arg/__package.rb
@@ -5,4 +5,5 @@
 
 class KeywordArg < PackageSpec
   strict_dependencies(level: 'false') # error: Expected `String` but found `{level: String("false")}` for argument `arg0`
+  layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/missing/__package.rb
+++ b/test/testdata/packager/strict_dependencies/missing/__package.rb
@@ -3,5 +3,6 @@
 # enable-packager: true
 # packager-layers: a
 
-class Missing < PackageSpec
+class Missing < PackageSpec # error: This package does not declare a `strict_dependencies` level
+  layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/non_string_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/non_string_option/__package.rb
@@ -6,4 +6,5 @@
 class NonStringOption < PackageSpec
   strict_dependencies false # error: Argument to `strict_dependencies` must be one of: `'false'`, `'layered'`, `'layered_dag'`, or `'dag'`
 #                     ^^^^^ error: Expected `String` but found `FalseClass` for argument `arg0`
+  layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/repeated/__package.rb
+++ b/test/testdata/packager/strict_dependencies/repeated/__package.rb
@@ -6,4 +6,5 @@
 class Repeated < PackageSpec
   strict_dependencies 'false'
   strict_dependencies 'false' # error: Repeated declaration of `strict_dependencies`
+  layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/too_few_args/__package.rb
+++ b/test/testdata/packager/strict_dependencies/too_few_args/__package.rb
@@ -5,4 +5,5 @@
 
 class TooFewArgs < PackageSpec
   strict_dependencies # error: Not enough arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `0`
+  layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
+++ b/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
@@ -5,4 +5,5 @@
 
 class TooManyArgs < PackageSpec
   strict_dependencies 'false', 'true' # error: Too many arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `2`
+  layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/valid_option/__package.rb
+++ b/test/testdata/packager/strict_dependencies/valid_option/__package.rb
@@ -5,4 +5,5 @@
 
 class ValidOption < PackageSpec
   strict_dependencies 'false'
+  layer 'a'
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

So that code later in the pipeline doesn't need to enforce it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
