### PR TITLE
Force bison conflicts into errors, not warnings

### DIFF
--- a/parser/parser/BUILD
+++ b/parser/parser/BUILD
@@ -56,6 +56,8 @@ bison(
     bison_options = [
         "-Wno-empty-rule",
         "-Wno-precedence",
+        "-Werror=conflicts-rr",
+        "-Werror=conflicts-sr",
     ],
 )
 
@@ -65,6 +67,8 @@ bison(
     bison_options = [
         "-Wno-empty-rule",
         "-Wno-precedence",
+        "-Werror=conflicts-rr",
+        "-Werror=conflicts-sr",
         "--debug",
     ],
 )


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Otherwise, the only way to know whether you've introduced conflicts is
during development.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested this by manually introducing these conflicts:

```diff
diff --git a/parser/parser/cc/grammars/typedruby.ypp b/parser/parser/cc/grammars/typedruby.ypp
index 5bdb50e9e..f9d78c550 100644
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1849,6 +1849,12 @@ lbrace_cmd_block_start:
                       args->concat($2);
                       $$ = args;
                     }
+                | assocs opt_block_arg error
+                    {
+                      node_list *args = driver.alloc.node_list(driver.build.associate(self, nullptr, $1, nullptr));
+                      args->concat($2);
+                      $$ = args;
+                    }
                 | args tCOMMA assocs opt_block_arg
                     {
                       auto &args = $1;
```

#### master

Conflicts reported as warnings, build passes:

```
❯ bazel build //parser/parser:typedruby_release_bison
INFO: Invocation ID: 70a9df8e-b68f-4664-9dbc-064ff5608374
INFO: Analyzed target //parser/parser:typedruby_release_bison (1 packages loaded, 6 targets configured).
INFO: Found 1 target...
INFO: From Bison @//parser/parser:typedruby_release_bison:
bazel-out/darwin_arm64-fastbuild/bin/parser/parser/typedruby_release.ypp: warning: 2 shift/reduce conflicts [-Wconflicts-sr]
bazel-out/darwin_arm64-fastbuild/bin/parser/parser/typedruby_release.ypp: warning: 7 reduce/reduce conflicts [-Wconflicts-rr]
Target //parser/parser:typedruby_release_bison up-to-date:
  bazel-bin/parser/parser/typedruby_release_bison.cc
  bazel-bin/parser/parser/typedruby_release_bison.h
INFO: Elapsed time: 0.599s, Critical Path: 0.51s
INFO: 2 processes: 1 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
```

#### branch

Conflicts reported as errors, build fails:

```
❯ bazel build //parser/parser:typedruby_release_bison
INFO: Invocation ID: 8b46882a-2a92-4482-af10-a18890e3f274
INFO: Analyzed target //parser/parser:typedruby_release_bison (1 packages loaded, 6 targets configured).
INFO: Found 1 target...
ERROR: /Users/jez/stripe/sorbet/parser/parser/BUILD:53:6: Bison @//parser/parser:typedruby_release_bison failed: (Exit 1): bison failed: error executing command (from target //parser/parser:typedruby_release_bison) bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/bison_v3.3.2/bin/bison -Wall '--language=c++' '--output=bazel-out/darwin_arm64-fastbuild/bin/parser/parser/typedruby_release_bison.cc' '--report=all' ... (remaining 9 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
bazel-out/darwin_arm64-fastbuild/bin/parser/parser/typedruby_release.ypp: error: 2 shift/reduce conflicts [-Werror=conflicts-sr]
bazel-out/darwin_arm64-fastbuild/bin/parser/parser/typedruby_release.ypp: error: 7 reduce/reduce conflicts [-Werror=conflicts-rr]
Target //parser/parser:typedruby_release_bison failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.519s, Critical Path: 0.42s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
```