### PR TITLE
Fix Extract to Variable crash when extracting entire file

### DIFF
--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -186,15 +186,17 @@ public:
     void preTransformExpressionPtr(core::Context ctx, const ast::ExpressionPtr &tree) {
         if (tree.loc() == targetLoc.offsets()) {
             // It's not valid to extract the following node types
-            if (!ast::isa_tree<ast::Break>(tree) && !ast::isa_tree<ast::Next>(tree) &&
-                !ast::isa_tree<ast::Return>(tree) && !ast::isa_tree<ast::Retry>(tree) &&
-                !ast::isa_tree<ast::RescueCase>(tree) && !ast::isa_tree<ast::InsSeq>(tree)) {
-                matchingNode = &tree;
-                ENFORCE(!enclosingClassStack.empty());
-                matchingNodeEnclosingClass = enclosingClassStack.back();
-                if (!enclosingMethodStack.empty()) {
-                    matchingNodeEnclosingMethod = enclosingMethodStack.back();
-                }
+            if (ast::isa_tree<ast::Break>(tree) || ast::isa_tree<ast::Next>(tree) || ast::isa_tree<ast::Return>(tree) ||
+                ast::isa_tree<ast::Retry>(tree) || ast::isa_tree<ast::RescueCase>(tree) ||
+                ast::isa_tree<ast::InsSeq>(tree)) {
+                return;
+            }
+
+            matchingNode = &tree;
+            ENFORCE(!enclosingClassStack.empty());
+            matchingNodeEnclosingClass = enclosingClassStack.back();
+            if (!enclosingMethodStack.empty()) {
+                matchingNodeEnclosingMethod = enclosingMethodStack.back();
             }
         }
     }

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -199,7 +199,7 @@ public:
             }
 
             matchingNode = &tree;
-            ENFORCE(!enclosingClassStack.empty());
+            ENFORCE(!enclosingClassStack.empty(), "Must at least have the <root> ClassDef");
             matchingNodeEnclosingClass = enclosingClassStack.back();
             if (!enclosingMethodStack.empty()) {
                 matchingNodeEnclosingMethod = enclosingMethodStack.back();

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -192,6 +192,12 @@ public:
                 return;
             }
 
+            if (auto classDef = ast::cast_tree<ast::ClassDef>(tree)) {
+                if (ast::isa_tree<ast::EmptyTree>(classDef->name)) {
+                    return;
+                }
+            }
+
             matchingNode = &tree;
             ENFORCE(!enclosingClassStack.empty());
             matchingNodeEnclosingClass = enclosingClassStack.back();

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -193,7 +193,7 @@ public:
             }
 
             if (auto classDef = ast::cast_tree<ast::ClassDef>(tree)) {
-                if (ast::isa_tree<ast::EmptyTree>(classDef->name)) {
+                if (classDef->symbol == core::Symbols::root()) {
                     return;
                 }
             }

--- a/test/testdata/lsp/code_actions/extract_variable_single/full_file.A.rbedited
+++ b/test/testdata/lsp/code_actions/extract_variable_single/full_file.A.rbedited
@@ -1,0 +1,6 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+  newVariable = 1
+  newVariable
+# ^ apply-code-action: [A] Extract Variable (this occurrence only)

--- a/test/testdata/lsp/code_actions/extract_variable_single/full_file.rb
+++ b/test/testdata/lsp/code_actions/extract_variable_single/full_file.rb
@@ -1,0 +1,5 @@
+# typed: true
+# selective-apply-code-action: refactor.extract
+# enable-experimental-lsp-extract-to-variable: true
+  1
+# ^ apply-code-action: [A] Extract Variable (this occurrence only)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

When the user selects the entire file, the matching node will be the synthetic root class, and so the `enclosingClassStack` will be empty, and `enclosingClassStack.back()` fails. But it doesn't make sense to extract that node, so we can just skip it (and so it'll be on `enclosingClassStack` later).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Crash less.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
