### PR TITLE
Add an error for duplicate props

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -18,5 +18,6 @@ constexpr ErrorClass NilableUntyped{3512, StrictLevel::False};
 // moved to namer:
 // constexpr ErrorClass HasAttachedClassInClass{3513, StrictLevel::False};
 constexpr ErrorClass ContravariantHasAttachedClass{3514, StrictLevel::False};
+constexpr ErrorClass DuplicateProp{3515, StrictLevel::True};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -604,6 +604,17 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
             continue;
         }
 
+        if (wantTypedInitialize(syntacticSuperClass)) {
+            auto it = absl::c_find_if(props, [&propInfo](auto &existing) { return existing.name == propInfo->name; });
+            if (it != props.end()) {
+                if (auto e = ctx.beginIndexerError(propInfo->loc, core::errors::Rewriter::DuplicateProp)) {
+                    e.setHeader("{} is defined multiple times", propInfo->isImmutable ? "const" : "prop");
+                    e.addErrorLine(ctx.locAt(it->loc), "Previous definition is here");
+                }
+                continue;
+            }
+        }
+
         auto processed = processProp(ctx, propInfo.value(), propContext);
         ENFORCE(!processed.empty(), "if parseProp completed successfully, processProp must complete too");
 

--- a/test/testdata/rewriter/prop_duplicated.rb
+++ b/test/testdata/rewriter/prop_duplicated.rb
@@ -3,29 +3,14 @@
 class A < T::Struct
 
   const :name, String
-#        ^^^^         error: Argument does not have asserted type `Float`
   prop :name, Integer
-# ^^^^^^^^^^^^^^^^^^^ error: Expected `Integer`
-# ^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`
-# ^^^^^^^^^^^^^^^^^^^ error: Unknown argument
-# ^^^^^^^^^^^^^^^^^^^ error: duplicate argument name
-#       ^^^^          error: Argument does not have asserted type `Float`
-#       ^^^^          error: Expected `Float`
+# ^^^^^^^^^^^^^^^^^^^ error: prop is defined multiple times
 
   prop :age, Integer
-# ^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found
-#       ^^^          error: Argument does not have asserted type `Float`
-#       ^^^          error: Expected `Float`
   const :name, Float
-# ^^^^^^^^^^^^^^^^^^ error: Malformed `sig`
-# ^^^^^^^^^^^^^^^^^^ error: Unknown argument
-# ^^^^^^^^^^^^^^^^^^ error: duplicate argument name
-#        ^^^^        error: Argument does not have asserted type `Float`
+# ^^^^^^^^^^^^^^^^^^ error: const is defined multiple times
 
   const :age, Float
-# ^^^^^^^^^^^^^^^^^ error: Malformed `sig`
-# ^^^^^^^^^^^^^^^^^ error: Unknown argument
-# ^^^^^^^^^^^^^^^^^ error: duplicate argument name
-#        ^^^        error: Argument does not have asserted type `Float`
+# ^^^^^^^^^^^^^^^^^ error: const is defined multiple times
 
 end

--- a/test/testdata/rewriter/prop_duplicated.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_duplicated.rb.rewrite-tree.exp
@@ -1,16 +1,13 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (<emptyTree>::<C T>::<C Struct>)
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:name, <emptyTree>::<C String>, :name, <emptyTree>::<C Integer>, :age, <emptyTree>::<C Integer>, :name, <emptyTree>::<C Float>, :age, <emptyTree>::<C Float>).void()
+      <self>.params(:name, <emptyTree>::<C String>, :age, <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<todo method>>(name:, name:, age:, name:, age:, &<blk>)
+    def initialize<<todo method>>(name:, age:, &<blk>)
       begin
-        @name = <cast:let>(name, <todo sym>, <emptyTree>::<C Float>)
-        @name = <cast:let>(name, <todo sym>, <emptyTree>::<C Float>)
-        @age = <cast:let>(age, <todo sym>, <emptyTree>::<C Float>)
-        @name = <cast:let>(name, <todo sym>, <emptyTree>::<C Float>)
-        @age = <cast:let>(age, <todo sym>, <emptyTree>::<C Float>)
+        @name = <cast:let>(name, <todo sym>, <emptyTree>::<C String>)
+        @age = <cast:let>(age, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end
@@ -21,22 +18,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def name<<todo method>>(&<blk>)
       @name
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.returns(<emptyTree>::<C Integer>)
-    end
-
-    def name<<todo method>>(&<blk>)
-      @name
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
-    end
-
-    def name=<<todo method>>(arg0, &<blk>)
-      @name = arg0
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -55,33 +36,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @age = arg0
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.returns(<emptyTree>::<C Float>)
-    end
-
-    def name<<todo method>>(&<blk>)
-      @name
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.returns(<emptyTree>::<C Float>)
-    end
-
-    def age<<todo method>>(&<blk>)
-      @age
-    end
-
     <runtime method definition of initialize>
 
     <self>.const(:name, <emptyTree>::<C String>, :without_accessors, true)
 
     <runtime method definition of name>
 
-    <self>.prop(:name, <emptyTree>::<C Integer>, :without_accessors, true)
-
-    <runtime method definition of name>
-
-    <runtime method definition of name=>
+    <self>.prop(:name, <emptyTree>::<C Integer>)
 
     <self>.prop(:age, <emptyTree>::<C Integer>, :without_accessors, true)
 
@@ -89,12 +50,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of age=>
 
-    <self>.const(:name, <emptyTree>::<C Float>, :without_accessors, true)
+    <self>.const(:name, <emptyTree>::<C Float>)
 
-    <runtime method definition of name>
-
-    <self>.const(:age, <emptyTree>::<C Float>, :without_accessors, true)
-
-    <runtime method definition of age>
+    <self>.const(:age, <emptyTree>::<C Float>)
   end
 end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -564,6 +564,37 @@ This error code is from an old Sorbet version. It's equivalent to error 4023:
 The `has_attached_class!` annotation cannot be given a contravariant `:in`
 annotation because `T.attached_class` is only allowed in output positions.
 
+## 3515
+
+This error indicates that a `prop` or `const` has already been defined with the
+name provided. For example:
+
+```ruby
+class Info < T::Struct
+  const :name, String
+  const :age, Integer
+  prop :age, Float
+end
+```
+
+In this case, the `:age` prop has been defined twice on lines 3 and 4, and this
+error will be raised on the occurrenct on line 4.
+
+While these errors exist, the first occurrence of the conflicting name will be
+used when computing a typed initializer for static typechecking purposes. For
+the example above, the initializer would look as though it was defined with the
+following signature:
+
+```ruby
+class Info < T::struct
+  ...
+  sig {params(name: String, age: Integer).void}
+  def initialize(name:, age:)
+    ...
+  end
+end
+```
+
 ## 3702
 
 > This error is specific to Stripe's custom `--stripe-packages` mode. If you are


### PR DESCRIPTION
Raise an error in the prop rewriter when two props share the same name. This gives a much more readable error for the case where this happens, and prevents an explosion of errors from later stages in the pipeline.

### Motivation
Better user experience for errors with props.

### Test plan
See included automated tests.
