### PR TITLE
remove uses of `removePosArg` from the tree

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1076,12 +1076,6 @@ void Send::insertPosArg(uint16_t index, ExpressionPtr arg) {
     this->numPosArgs_++;
 }
 
-void Send::removePosArg(uint16_t index) {
-    ENFORCE(index < numPosArgs_);
-    this->args.erase(this->args.begin() + index);
-    this->numPosArgs_--;
-}
-
 void Send::setBlock(ExpressionPtr block) {
     if (hasBlock()) {
         this->args.pop_back();

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -840,9 +840,6 @@ public:
     // Insert the given positional argument at the given position, shifting existing arguments over.
     void insertPosArg(uint16_t index, ExpressionPtr arg);
 
-    // Removes the position argument at the given index.
-    void removePosArg(uint16_t index);
-
     // Reserve space for the given number of arguments.
     void reserveArguments(size_t posArgs, size_t kwArgs, bool hasSplat, bool hasBlock) {
         this->args.reserve(posArgs + (kwArgs * 2) + (hasSplat ? 1 : 0) + (hasBlock ? 1 : 0));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1058,10 +1058,9 @@ struct PackageSpecBodyWalk {
             // null indicates an invalid import.
             if (auto *target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
                 // Transform: `import Foo` -> `import <PackageSpecRegistry>::Foo`
-                auto importArg = move(send.getPosArg(0));
-                send.removePosArg(0);
-                ENFORCE(send.numPosArgs() == 0);
-                send.addPosArg(prependName(move(importArg)));
+                auto &posArg = send.getPosArg(0);
+                auto importArg = move(posArg);
+                posArg = prependName(move(importArg));
 
                 info.importedPackageNames.emplace_back(getPackageName(ctx, target), method2ImportType(send));
             }
@@ -1069,10 +1068,9 @@ struct PackageSpecBodyWalk {
 
         if (send.fun == core::Names::restrictToService() && send.numPosArgs() == 1) {
             // Transform: `restrict_to_service Foo` -> `restrict_to_service <PackageSpecRegistry>::Foo`
-            auto importArg = move(send.getPosArg(0));
-            send.removePosArg(0);
-            ENFORCE(send.numPosArgs() == 0);
-            send.addPosArg(prependName(move(importArg)));
+            auto &posArg = send.getPosArg(0);
+            auto importArg = move(posArg);
+            posArg = prependName(move(importArg));
         }
 
         if (send.fun == core::Names::exportAll() && send.numPosArgs() == 0) {
@@ -1103,10 +1101,9 @@ struct PackageSpecBodyWalk {
                 }
 
                 if (auto *recv = verifyConstant(ctx, send.fun, target->recv)) {
+                    auto &posArg = send.getPosArg(0);
                     auto importArg = move(target->recv);
-                    send.removePosArg(0);
-                    ENFORCE(send.numPosArgs() == 0);
-                    send.addPosArg(prependName(move(importArg)));
+                    posArg = prependName(move(importArg));
                     info.visibleTo_.emplace_back(getPackageName(ctx, recv), core::packages::VisibleToType::Wildcard);
                 } else {
                     if (auto e = ctx.beginError(target->loc, core::errors::Packager::InvalidConfiguration)) {
@@ -1116,10 +1113,9 @@ struct PackageSpecBodyWalk {
                     return;
                 }
             } else if (auto *target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
-                auto importArg = move(send.getPosArg(0));
-                send.removePosArg(0);
-                ENFORCE(send.numPosArgs() == 0);
-                send.addPosArg(prependName(move(importArg)));
+                auto &posArg = send.getPosArg(0);
+                auto importArg = move(posArg);
+                posArg = prependName(move(importArg));
 
                 info.visibleTo_.emplace_back(getPackageName(ctx, target), core::packages::VisibleToType::Normal);
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I have a long-term goal of making `Send` nodes functionally immutable with respect to the number of arguments they contain -- you are free to modify the arguments themselves, but not to add or remove arguments.  If you want to do that, you'll have to figure out how to copy the relevant `Send` node and use it instead.  (This could wind up being expensive, I suppose, but looking at the places we use the `*PosArg` family of arguments already on `Send`, I don't think any of them are hotspots -- with the possible exception of `MK::Helpers::Assign`.)

`removePosArg` gets in the way of that goal, and we can rewrite code to not use `removePosArg`, so let's do that.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
