### PR TITLE
Check `layered_dag` and `dag`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2356,6 +2356,10 @@ const packages::PackageDB &GlobalState::packageDB() const {
     return packageDB_;
 }
 
+packages::PackageDB &GlobalState::packageDB() {
+    return packageDB_;
+}
+
 void GlobalState::setPackagerOptions(const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                                      const std::vector<std::string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                      const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -162,6 +162,7 @@ public:
     FileRef findFileByPath(std::string_view path) const;
 
     const packages::PackageDB &packageDB() const;
+    packages::PackageDB &packageDB();
     void setPackagerOptions(const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                             const std::vector<std::string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
                             const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -203,6 +203,15 @@ const PackageInfo &PackageDB::getPackageInfo(MangledName mangledName) const {
     return *it->second;
 }
 
+PackageInfo &PackageDB::getPackageInfo(MangledName mangledName) {
+    auto it = packages_.find(mangledName);
+    if (it == packages_.end()) {
+        // TODO
+        return const_cast<NonePackage &>(NONE_PKG);
+    }
+    return *it->second;
+}
+
 absl::Span<const MangledName> PackageDB::packages() const {
     return absl::MakeSpan(mangledNames);
 }

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -203,13 +203,12 @@ const PackageInfo &PackageDB::getPackageInfo(MangledName mangledName) const {
     return *it->second;
 }
 
-PackageInfo &PackageDB::getPackageInfo(MangledName mangledName) {
+PackageInfo *PackageDB::getPackageInfoNonConst(MangledName mangledName) {
     auto it = packages_.find(mangledName);
     if (it == packages_.end()) {
-        // TODO
-        return const_cast<NonePackage &>(NONE_PKG);
+        return nullptr;
     }
-    return *it->second;
+    return it->second.get();
 }
 
 absl::Span<const MangledName> PackageDB::packages() const {

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -37,7 +37,7 @@ public:
 
     const PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
     const PackageInfo &getPackageInfo(MangledName mangledName) const;
-    PackageInfo &getPackageInfo(MangledName mangledName);
+    PackageInfo *getPackageInfoNonConst(MangledName mangledName);
 
     // Lookup `PackageInfo` from the string representation of the un-mangled package name.
     const PackageInfo &getPackageInfo(const core::GlobalState &gs, std::string_view str) const;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -37,6 +37,7 @@ public:
 
     const PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
     const PackageInfo &getPackageInfo(MangledName mangledName) const;
+    PackageInfo &getPackageInfo(MangledName mangledName);
 
     // Lookup `PackageInfo` from the string representation of the un-mangled package name.
     const PackageInfo &getPackageInfo(const core::GlobalState &gs, std::string_view str) const;
@@ -70,6 +71,7 @@ public:
     // `app`.
     absl::Span<const core::NameRef> layers() const;
     const int layerIndex(core::NameRef layer) const;
+    // TODO(neil): this is more than just layering, also checks for strict dependencies. Maybe rename?
     const bool enforceLayering() const;
 
     const std::string_view errorHint() const;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -59,7 +59,7 @@ string buildValidLayersStr(const core::GlobalState &gs) {
     return result;
 }
 
-string strictDependenciesLevelToString(core::packages::StrictDependenciesLevel level) {
+string_view strictDependenciesLevelToString(core::packages::StrictDependenciesLevel level) {
     switch (level) {
         case core::packages::StrictDependenciesLevel::False:
             return "false";

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1555,6 +1555,8 @@ unique_ptr<PackageInfoImpl> createAndPopulatePackageInfo(core::GlobalState &gs, 
 }
 
 // Metadata for Tarjan's algorithm
+// https://www.cs.cmu.edu/~15451-f18/lectures/lec19-DFS-strong-components.pdf provides a good overview of the
+// algorithm.
 struct ComputeSCCsMetadata {
     int nextIndex = 1;
     int nextSCCId = 0;
@@ -1563,7 +1565,10 @@ struct ComputeSCCsMetadata {
     // The lowest index reachable from a given package (in the same SCC) by following any number of tree edges
     // and at most one back/cross edge
     UnorderedMap<core::packages::MangledName, int> lowLink;
+    // Fast way to check if a package is on the stack
     UnorderedMap<core::packages::MangledName, bool> onStack;
+    // As we visit packages, we push them onto the stack. Once we find the "root" of an SCC, we can use the stack to
+    // determine all packages in the SCC.
     std::vector<core::packages::MangledName> stack;
 };
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1665,6 +1665,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
                            thisPkg.show(ctx), "layer");
             e.addErrorLine(core::Loc(otherPkg.loc.file(), otherPkg.layer.value().second), "`{}`'s `{}` declared here",
                            otherPkg.show(ctx), "layer");
+            // TODO: Autocorrect to delete this import?
         }
     }
 
@@ -1680,6 +1681,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
                         "import", strictDependenciesLevelToString(otherPkgExpectedLevel));
             e.addErrorLine(core::Loc(otherPkg.loc.file(), otherPkg.strictDependenciesLevel.value().second),
                            "`{}`'s `{}` level declared here", otherPkg.show(ctx), "strict_dependencies");
+            // TODO: Autocorrect to delete this import?
         }
     }
 
@@ -1690,6 +1692,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
                             otherPkg.show(ctx), thisPkg.show(ctx), "strict_dependencies",
                             strictDependenciesLevelToString(thisPkg.strictDependenciesLevel.value().first));
             }
+            // TODO: Autocorrect to delete this import?
         }
     }
 }
@@ -1737,6 +1740,7 @@ void validatePackage(core::Context ctx) {
     if (ctx.file.data(ctx).originalSigil < core::StrictLevel::Strict) {
         if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::PackageFileMustBeStrict)) {
             e.setHeader("Package files must be at least `{}`", "# typed: strict");
+            // TODO(neil): Autocorrect to update the sigil?
         }
     }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1696,7 +1696,8 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     if (thisPkg.strictDependenciesLevel.value().first >= core::packages::StrictDependenciesLevel::LayeredDag) {
         if (thisPkg.sccID == otherPkg.sccID) {
             if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::StrictDependenciesViolation)) {
-                e.setHeader("Importing `{}` will put `{}` into a cycle, which is not valid at `{}` level `{}`",
+                e.setHeader("Strict Dependencies violation: Importing `{}` will put `{}` into a cycle, which is not "
+                            "valid at `{}` level `{}`",
                             otherPkg.show(ctx), thisPkg.show(ctx), "strict_dependencies",
                             strictDependenciesLevelToString(thisPkg.strictDependenciesLevel.value().first));
             }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -242,6 +242,7 @@ public:
 
     optional<pair<core::packages::StrictDependenciesLevel, core::LocOffsets>> strictDependenciesLevel = nullopt;
     optional<pair<core::NameRef, core::LocOffsets>> layer = nullopt;
+    // ID of the strongly-connected component that this package is in, according to its graph of import dependencies
     optional<int> sccID = nullopt;
 
     // PackageInfoImpl is the only implementation of PackageInfo
@@ -1620,7 +1621,7 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
 
 // Tarjan's algorithm for finding strongly connected components
 void computeSCCs(core::GlobalState &gs) {
-    Timer timeit(gs.tracer(), "computeSCCs");
+    Timer timeit(gs.tracer(), "packager::computeSCCs");
     ComputeSCCsMetadata metadata;
     auto allPackages = gs.packageDB().packages();
     for (auto package : allPackages) {
@@ -1688,7 +1689,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     if (thisPkg.strictDependenciesLevel.value().first >= core::packages::StrictDependenciesLevel::LayeredDag) {
         if (thisPkg.sccID == otherPkg.sccID) {
             if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::StrictDependenciesViolation)) {
-                e.setHeader("importing `{}` will put `{}` into a cycle, which is not valid at `{}` level `{}`",
+                e.setHeader("Importing `{}` will put `{}` into a cycle, which is not valid at `{}` level `{}`",
                             otherPkg.show(ctx), thisPkg.show(ctx), "strict_dependencies",
                             strictDependenciesLevelToString(thisPkg.strictDependenciesLevel.value().first));
             }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1632,6 +1632,7 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
 void computeSCCs(core::GlobalState &gs) {
     Timer timeit(gs.tracer(), "packager::computeSCCs");
     ComputeSCCsMetadata metadata;
+    metadata.stack.reserve(gs.packageDB().packages().size());
     auto allPackages = gs.packageDB().packages();
     for (auto package : allPackages) {
         if (metadata.index[package] == UNVISITED) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1648,8 +1648,8 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     ENFORCE(packageDB.getPackageForFile(ctx, ctx.file).exists())
     auto &thisPkg = PackageInfoImpl::from(packageDB.getPackageForFile(ctx, ctx.file));
     auto &otherPkg = PackageInfoImpl::from(packageDB.getPackageInfo(i.name.mangledName));
-    ENFORCE(thisPkg.sccID.has_value());
-    ENFORCE(otherPkg.sccID.has_value());
+    ENFORCE(thisPkg.sccID.has_value(), "computeSCCs should already have been called and set sccID");
+    ENFORCE(otherPkg.sccID.has_value(), "computeSCCs should already have been called and set sccID");
 
     if (!thisPkg.strictDependenciesLevel.has_value() || !otherPkg.strictDependenciesLevel.has_value() ||
         !thisPkg.layer.has_value() || !otherPkg.layer.has_value()) {

--- a/test/testdata/packager/dag/__package.rb
+++ b/test/testdata/packager/dag/__package.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 # typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
 
-class C < PackageSpec
+class Root < PackageSpec
   strict_dependencies 'layered_dag'
   layer 'business'
-
-  import A
 end

--- a/test/testdata/packager/dag/a/__package.rb
+++ b/test/testdata/packager/dag/a/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class A < PackageSpec
   strict_dependencies 'layered_dag'

--- a/test/testdata/packager/dag/a/__package.rb
+++ b/test/testdata/packager/dag/a/__package.rb
@@ -7,7 +7,7 @@ class A < PackageSpec
   strict_dependencies 'layered_dag'
   layer 'business'
 
-  import B # error: importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
+  import B # error: Importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
   import D # error: Unable to resolve constant `D`
   test_import C
 end

--- a/test/testdata/packager/dag/a/__package.rb
+++ b/test/testdata/packager/dag/a/__package.rb
@@ -5,7 +5,7 @@ class A < PackageSpec
   strict_dependencies 'layered_dag'
   layer 'business'
 
-  import B # error: Importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
+  import B # error: Strict Dependencies violation: Importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
   import D # error: Unable to resolve constant `D`
   test_import C
 end

--- a/test/testdata/packager/dag/a/__package.rb
+++ b/test/testdata/packager/dag/a/__package.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class A < PackageSpec
+  strict_dependencies 'layered_dag'
+  layer 'business'
+
+  import B # error: importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
+  import D # error: Unable to resolve constant `D`
+  test_import C
+end

--- a/test/testdata/packager/dag/b/__package.rb
+++ b/test/testdata/packager/dag/b/__package.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class B < PackageSpec
+  strict_dependencies 'layered'
+  layer 'business'
+
+  import A
+end

--- a/test/testdata/packager/dag/b/__package.rb
+++ b/test/testdata/packager/dag/b/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class B < PackageSpec
   strict_dependencies 'layered'

--- a/test/testdata/packager/dag/c/__package.rb
+++ b/test/testdata/packager/dag/c/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class C < PackageSpec
   strict_dependencies 'dag'

--- a/test/testdata/packager/dag/c/__package.rb
+++ b/test/testdata/packager/dag/c/__package.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class C < PackageSpec
+  strict_dependencies 'dag'
+  layer 'business'
+
+  import A # error: All of `C`'s `import`s must be `dag` or higher
+  test_import B
+end

--- a/test/testdata/packager/layered_dag/__package.rb
+++ b/test/testdata/packager/layered_dag/__package.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 # typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
 
-class C < PackageSpec
+class Root < PackageSpec
   strict_dependencies 'layered_dag'
   layer 'business'
-
-  import A
 end

--- a/test/testdata/packager/layered_dag/a/__package.rb
+++ b/test/testdata/packager/layered_dag/a/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class A < PackageSpec
   strict_dependencies 'layered_dag'

--- a/test/testdata/packager/layered_dag/a/__package.rb
+++ b/test/testdata/packager/layered_dag/a/__package.rb
@@ -5,6 +5,6 @@ class A < PackageSpec
   strict_dependencies 'layered_dag'
   layer 'business'
 
-  import B # error: Importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
+  import B # error: Strict Dependencies violation: Importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
   test_import C
 end

--- a/test/testdata/packager/layered_dag/a/__package.rb
+++ b/test/testdata/packager/layered_dag/a/__package.rb
@@ -7,6 +7,6 @@ class A < PackageSpec
   strict_dependencies 'layered_dag'
   layer 'business'
 
-  import B # error: importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
+  import B # error: Importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
   test_import C
 end

--- a/test/testdata/packager/layered_dag/a/__package.rb
+++ b/test/testdata/packager/layered_dag/a/__package.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class A < PackageSpec
+  strict_dependencies 'layered_dag'
+  layer 'business'
+
+  import B # error: importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies` level `layered_dag`
+  test_import C
+end

--- a/test/testdata/packager/layered_dag/b/__package.rb
+++ b/test/testdata/packager/layered_dag/b/__package.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class B < PackageSpec
+  strict_dependencies 'layered'
+  layer 'business'
+
+  import A
+end

--- a/test/testdata/packager/layered_dag/b/__package.rb
+++ b/test/testdata/packager/layered_dag/b/__package.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 # typed: strict
-# enable-packager: true
-# packager-layers: utility,power,business,api,service
 
 class B < PackageSpec
   strict_dependencies 'layered'

--- a/test/testdata/packager/layered_dag/c/__package.rb
+++ b/test/testdata/packager/layered_dag/c/__package.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# packager-layers: utility,power,business,api,service
+
+class C < PackageSpec
+  strict_dependencies 'layered_dag'
+  layer 'business'
+
+  import A
+end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -992,8 +992,8 @@ Note: `test_import`s are not checked for layering violations.
 If a package is at `strict_dependencies 'layered'` or stricter, all packages it
 imports must also be at `strict_dependencies 'layered'`.
 
-If a package is at `strict_dependencies 'layered_dag'` or stricter, it cannot
-be part of a cycle of dependencies. For example, the following is invalid:
+If a package is at `strict_dependencies 'layered_dag'` or stricter, it cannot be
+part of a cycle of dependencies. For example, the following is invalid:
 
 ```ruby
 class A < PackageSpec

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -981,6 +981,8 @@ imports must be in the same or lower layer. For example, given
 `--packager-layers util,lib,app`, all imports for a package with layer `lib`
 must either also have layer `lib`, or have layer `util` (but not layer `app`).
 
+Note: `test_import`s are not checked for layering violations.
+
 ## 3727
 
 > This error is specific to Stripe's custom `--stripe-packages` mode. If you are
@@ -1007,6 +1009,8 @@ end
 
 Additionally, if a package is at `strict_dependencies 'dag'`, all packages it
 imports must also be at `strict_dependencies 'dag'`.
+
+Note: `test_import`s are not checked for strict dependency violations.
 
 ## 4001
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -990,7 +990,7 @@ must either also have layer `lib`, or have layer `util` (but not layer `app`).
 If a package is at `strict_dependencies 'layered'` or stricter, all packages it
 imports must also be at `strict_dependencies 'layered'`.
 
-If a package is at `strict_dependencies 'layered_dag'` or stricter, it can not
+If a package is at `strict_dependencies 'layered_dag'` or stricter, it cannot
 be part of a cycle of dependencies. For example, the following is invalid:
 
 ```ruby

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -987,8 +987,26 @@ must either also have layer `lib`, or have layer `util` (but not layer `app`).
 > at Stripe, please see [go/modularity](http://go/modularity) and
 > [go/strict-dependencies](http://go/strict-dependencies) for more.
 
-If a package is at `strict_dependencies 'layered'`, all packages it imports must
-also be at `strict_dependencies 'layered'`.
+If a package is at `strict_dependencies 'layered'` or stricter, all packages it
+imports must also be at `strict_dependencies 'layered'`.
+
+If a package is at `strict_dependencies 'layered_dag'` or stricter, it can not
+be part of a cycle of dependencies. For example, the following is invalid:
+
+```ruby
+class A < PackageSpec
+  strict_dependencies 'layered_dag'
+  import B # error: importing B will put A into a cycle, which is not valid at strict_dependencies level layered_dag
+end
+
+class B < PackageSpec
+  strict_dependencies 'layered'
+  import A
+end
+```
+
+Additionally, if a package is at `strict_dependencies 'dag'`, all packages it
+imports must also be at `strict_dependencies 'dag'`.
 
 ## 4001
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Followup to #8243, implements the next two levels of checks.

The key part of this PR is implementing Tarjan's algorithm for computing strongly connected components, which we use see if any packages are in a cycle, and if yes, which import(s) brought them into the cycle. The algorithm stores the which SCC each package is part of directly on the `PackageInfoImpl` class.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Implement more of the packaging/layering system in sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
