### PR TITLE
Add an ENFORCE saying no EmptyTree

### DIFF
--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -27,7 +27,7 @@ private:
     static void jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc);
     static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InstructionPtr inst);
     static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
-    static BasicBlock *walkEmptyTreeInIf(CFGContext cctx, core::LocOffsets loc, BasicBlock *current);
+    static BasicBlock *walkEmptyTree(CFGContext cctx, core::LocOffsets loc, BasicBlock *current);
     static BasicBlock *walkBlockReturn(CFGContext cctx, core::LocOffsets loc, ast::ExpressionPtr &expr,
                                        BasicBlock *current);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -1034,7 +1034,10 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 ret = current;
             },
 
-            [&](const ast::EmptyTree &n) { ret = current; },
+            [&](const ast::EmptyTree &n) {
+                ENFORCE(false, "Should not walk to an EmptyTree--should be handled by parent");
+                ret = current;
+            },
 
             [&](const ast::ClassDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },
             [&](const ast::MethodDef &c) { Exception::raise("Should have been removed by FlattenWalk"); },

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -506,9 +506,15 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             [&](ast::InsSeq &a) {
                 for (auto &exp : a.stats) {
                     LocalRef temp = cctx.newTemporary(core::Names::statTemp());
+                    if (ast::isa_tree<ast::EmptyTree>(exp)) {
+                        // TODO(jez) You can move this above making the temporary, but doing it here
+                        // ensure that we don't mess up the numbers in exp files
+                        continue;
+                    }
                     current = walk(cctx.withTarget(temp), exp, current);
                 }
-                ret = walk(cctx, a.expr, current);
+                ret = ast::isa_tree<ast::EmptyTree>(a.expr) ? walkEmptyTree(cctx, a.loc, current)
+                                                            : walk(cctx, a.expr, current);
             },
             [&](ast::Send &s) {
                 LocalRef recv;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -244,7 +244,7 @@ BasicBlock *CFGBuilder::walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *curr
 
 // This doesn't actually "walk" an empty tree, because there's nothing interesting to walk in one.
 // Instead, if conforms to mostly the same interface that `walk` (i.e., returns a BasicBlock *);
-BasicBlock *CFGBuilder::walkEmptyTreeInIf(CFGContext cctx, core::LocOffsets nilLoc, BasicBlock *current) {
+BasicBlock *CFGBuilder::walkEmptyTree(CFGContext cctx, core::LocOffsets nilLoc, BasicBlock *current) {
     synthesizeExpr(current, cctx.target, nilLoc, make_insn<Literal>(core::Types::nilClass()));
     return current;
 }
@@ -392,9 +392,9 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 auto elseBlock = cctx.inWhat.freshBlock(cctx.loops);
                 conditionalJump(cont, ifSym, thenBlock, elseBlock, cctx.inWhat, a.cond.loc());
 
-                auto thenEnd = ast::isa_tree<ast::EmptyTree>(a.thenp) ? walkEmptyTreeInIf(cctx, a.loc, thenBlock)
+                auto thenEnd = ast::isa_tree<ast::EmptyTree>(a.thenp) ? walkEmptyTree(cctx, a.loc, thenBlock)
                                                                       : walk(cctx, a.thenp, thenBlock);
-                auto elseEnd = ast::isa_tree<ast::EmptyTree>(a.elsep) ? walkEmptyTreeInIf(cctx, a.loc, elseBlock)
+                auto elseEnd = ast::isa_tree<ast::EmptyTree>(a.elsep) ? walkEmptyTree(cctx, a.loc, elseBlock)
                                                                       : walk(cctx, a.elsep, elseBlock);
                 if (thenEnd != cctx.inWhat.deadBlock() || elseEnd != cctx.inWhat.deadBlock()) {
                     if (thenEnd == cctx.inWhat.deadBlock()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's basically always better to handle `EmptyTree` at the parent node, where
we're sure to have at least some `loc` which is better for the origin of a `nil`
value.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.