### PR TITLE
Two fixes to "convert to singleton method" action

### DIFF
--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -44,7 +44,7 @@ public:
 
     const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const;
 };
-CheckSize(SendResponse, 80, 8);
+CheckSize(SendResponse, 88, 8);
 
 class IdentResponse final {
 public:

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -12,10 +12,12 @@ class SendResponse final {
 public:
     SendResponse(std::shared_ptr<core::DispatchResult> dispatchResult, InlinedVector<core::LocOffsets, 2> argLocOffsets,
                  core::NameRef callerSideName, core::MethodRef enclosingMethod, bool isPrivateOk, core::FileRef file,
-                 core::LocOffsets termLocOffsets, core::LocOffsets receiverLocOffsets, core::LocOffsets funLocOffsets)
+                 core::LocOffsets termLocOffsets, core::LocOffsets receiverLocOffsets, core::LocOffsets funLocOffsets,
+                 core::LocOffsets locOffsetsWithoutBlock)
         : dispatchResult(std::move(dispatchResult)), argLocOffsets(std::move(argLocOffsets)),
           callerSideName(callerSideName), enclosingMethod(enclosingMethod), isPrivateOk(isPrivateOk), file(file),
-          termLocOffsets(termLocOffsets), receiverLocOffsets(receiverLocOffsets), funLocOffsets(funLocOffsets){};
+          termLocOffsets(termLocOffsets), receiverLocOffsets(receiverLocOffsets), funLocOffsets(funLocOffsets),
+          locOffsetsWithoutBlock(locOffsetsWithoutBlock){};
     const std::shared_ptr<core::DispatchResult> dispatchResult;
     const InlinedVector<core::LocOffsets, 2> argLocOffsets;
     const core::NameRef callerSideName;
@@ -25,6 +27,7 @@ public:
     const core::LocOffsets termLocOffsets;
     const core::LocOffsets receiverLocOffsets;
     const core::LocOffsets funLocOffsets;
+    const core::LocOffsets locOffsetsWithoutBlock;
 
     core::Loc termLoc() const {
         return core::Loc(file, termLocOffsets);
@@ -34,6 +37,9 @@ public:
     }
     core::Loc funLoc() const {
         return core::Loc(file, funLocOffsets);
+    }
+    core::Loc locWithoutBlock() const {
+        return core::Loc(file, locOffsetsWithoutBlock);
     }
 
     const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1181,9 +1181,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         }
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx,
-                        core::lsp::SendResponse(retainedResult, send.argLocs, fun, ctx.owner.asMethodRef(),
-                                                send.isPrivateOk, ctx.file, bind.loc, send.receiverLoc, send.funLoc));
+                        ctx, core::lsp::SendResponse(retainedResult, send.argLocs, fun, ctx.owner.asMethodRef(),
+                                                     send.isPrivateOk, ctx.file, bind.loc, send.receiverLoc,
+                                                     send.funLoc, locWithoutBlock));
                 }
                 if (send.link) {
                     send.link->result = move(retainedResult);

--- a/main/lsp/ConvertToSingletonClassMethod.cc
+++ b/main/lsp/ConvertToSingletonClassMethod.cc
@@ -124,7 +124,7 @@ public:
         ENFORCE(edits.find(receiverLoc) == edits.end(), "Tried to edit the same call site twice...");
         edits[receiverLoc] = fmt::format("{}{}", owner.show(gs), sendResp->isPrivateOk ? "." : "");
 
-        auto receiverSource = sendResp->isPrivateOk ? "self"sv : sendResp->receiverLoc().source(gs).value();
+        auto receiverSource = string(sendResp->isPrivateOk ? "self" : sendResp->receiverLoc().source(gs).value());
         if (absl::StrContains(receiverSource, ";")) {
             // It never hurts to parenthesize an argument, it's still technically valid.
             //

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/kwarg_paren.A.rbedited
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/kwarg_paren.A.rbedited
@@ -7,7 +7,12 @@ class A
   end
 end
 
-A.example(A.new, x: (0)
+A.example(
+  A.new, x: (0)
+)
 
-A.example(A.new, x: begin
-       0)
+A.example(
+  A.new, x: begin
+       0
+  end
+)

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/nullary.A.rbedited
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/nullary.A.rbedited
@@ -34,4 +34,4 @@ end
 
 (T.unsafe(A.new)).nullary
 
-A.nullary(A.new + A.new)
+(A).nullary(A.new + A.new)

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.A.rbedited
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.A.rbedited
@@ -14,8 +14,8 @@ class A
   def example
     A.unary(self) # error: Not enough arguments provided
     A.unary(self, 0)
-    A.unary(self, 0)) {}
-    A.unary(self, 0)) do
+    A.unary(self, 0) {}
+    A.unary(self, 0) do
     end
   end
 
@@ -25,10 +25,12 @@ end
 
 A.unary(A.new) # error: Not enough arguments provided
 A.unary(A.new, 0)
-A.unary(A.new, 0)
-A.unary(A.new, 0)) do
+A.unary(
+  A.new, 0
+)
+A.unary(A.new, 0) do
 end
 
 (T.unsafe(A.new)).unary(0)
 
-A.unary(A.new + A.new, 0)
+(A).unary(A.new + A.new, 0)

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.A.rbedited
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.A.rbedited
@@ -34,3 +34,5 @@ end
 (T.unsafe(A.new)).unary(0)
 
 (A).unary(A.new + A.new, 0)
+
+(A).unary(A.new ; A.new, 0)

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.A.rbedited
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.A.rbedited
@@ -35,4 +35,4 @@ end
 
 (A).unary(A.new + A.new, 0)
 
-(A).unary(A.new ; A.new, 0)
+(A).unary((A.new ; A.new), 0)

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.rb
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/unary.rb
@@ -34,3 +34,5 @@ end
 (T.unsafe(A.new)).unary(0)
 
 (A.new + A.new).unary(0)
+
+(A.new ; A.new).unary(0)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Summary
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

1.  Compute convert_to_singleton_method with two edits

    The old mechanism for crafting the edit worked by completely reconstructing all
    the constituent parts, which had the nice property that there was one edit for
    one code action.

    The problem is that Sorbet doesn't currently track a location for "all the stuff
    inside the parens," only the location of the first arg and the location of the
    last arg. Normally those are the same but they're not the same in the case when
    either the first or the last arg is wrapped in parentheses:

    ```ruby
    foo((A), (Z))
         ^^^^^^
    ```

    Here, the range from the beginning of the first arg to the ending of the last
    arg does not include the parentheses. A previous change of mine attempted to
    make that be the case (7eb2d87f56aa543e6e6a139ec59c0ee9a6e3413c) but that ended
    up introducing a crash in resolver, and also made anything that actually did
    just want to deal with the what was inside the parens more cumbersome.

    We don't actually need a location for all the arguments, we just need to know
    where the first one is. If there are already arguments being passed, that's
    easy. If there aren't, it's a little tricky, because we have no location that
    tracks where an empty `()` in a method call is:

    ```ruby
    foo()
       ^^ nothing tracks this location
    ```

    So to avoid editing the file like `A.foo(self)()`, we have to attempt to detect
    that case on our own. We can assume that the empty `()` will be immediately
    after the `funLoc` if it's there at all, because `foo ()` means "pass one empty
    InsSeq argument to foo" instead of "call foo with zero arguments."

2.  Handle when the receiver has `;` in it

    If there's a `;` in the receiver, it might be a statement separator. It's
    not okay to have that statement separator hang out at the top-level of an
    argument list on a method call, so we have to parenthesize it.

    Chances are that it was already parenthesized in the receiver, but the
    `receiverLoc` does not include the parentheses, again for the same reason
    as described in the previous point.


### Motivation

Fixes #7343

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.