### PR TITLE
Check every iteration of the fullUnresolvedPath loop

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -316,7 +316,7 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
                 fatalLogger->error("source=\"{}\"", absl::CEscape(ctx.file.data(ctx).source()));
             }
 
-            if (!nested->resolutionScopes->front().exists()) {
+            if (nested->resolutionScopes->front().exists()) {
                 break;
             }
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -305,16 +305,21 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
     if (this->symbol != core::Symbols::StubModule()) {
         return nullopt;
     }
-    if (this->resolutionScopes == nullptr || this->resolutionScopes->empty()) [[unlikely]] {
-        ENFORCE(false);
-        fatalLogger->error(R"(msg="Bad fullUnresolvedPath" path="{}")");
-        fatalLogger->error("source=\"{}\"", absl::CEscape(ctx.file.data(ctx).source()));
-    }
 
     vector<core::NameRef> namesFailedToResolve;
     auto *nested = this;
     {
-        while (!nested->resolutionScopes->front().exists()) {
+        while (true) {
+            if (nested->resolutionScopes == nullptr || nested->resolutionScopes->empty()) [[unlikely]] {
+                ENFORCE(false);
+                fatalLogger->error(R"(msg="Bad fullUnresolvedPath" path="{}")");
+                fatalLogger->error("source=\"{}\"", absl::CEscape(ctx.file.data(ctx).source()));
+            }
+
+            if (!nested->resolutionScopes->front().exists()) {
+                break;
+            }
+
             auto *orig = cast_tree<UnresolvedConstantLit>(nested->original);
             ENFORCE(orig);
             namesFailedToResolve.emplace_back(orig->cnst);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed some crashes that got past this log line, which means that the
crash is actually happening while evaluation something other than the
first iteration of the loop (which is definitely interesting...).

Adjusting the log line should finally get us a repro.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not possible to test, otherwise we wouldn't need the log line in the first
place.