### PR TITLE
Also send Timers' tags to the --web-trace-file

### DIFF
--- a/common/timers/Timer.h
+++ b/common/timers/Timer.h
@@ -38,7 +38,7 @@ public:
     // Don't report timer when it gets destructed.
     void cancel();
 
-    // Add a tag to the statsd metrics for this timer. Will not appear in traces.
+    // Add a tag to the statsd metrics for this timer. Will show up as additional "args" in a JSON trace
     void setTag(ConstExprStr name, ConstExprStr value);
 
     // Creates a new timer with the same start time, tags, args, and name.

--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -153,13 +153,22 @@ bool Tracing::storeTraces(const CounterState &counters, const string &fileName) 
         writer.String("tid");
         writer.Int(timing.threadId);
 
-        if (timing.args != nullptr && !timing.args->empty()) {
+        if ((timing.args != nullptr && !timing.args->empty()) || (timing.tags != nullptr && !timing.tags->empty())) {
             writer.String("args");
 
             writer.StartObject();
-            for (const auto &[key, value] : *timing.args) {
-                writer.String(key);
-                writer.String(value);
+            // Puts all tags and args in the same namespace, and does not check for overlaps.
+            if (timing.args != nullptr && !timing.args->empty()) {
+                for (const auto &[key, value] : *timing.args) {
+                    writer.String(key);
+                    writer.String(value);
+                }
+            }
+            if (timing.tags != nullptr && !timing.tags->empty()) {
+                for (const auto &[key, value] : *timing.tags) {
+                    writer.String(key);
+                    writer.String(value);
+                }
             }
             writer.EndObject();
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

It's not clear to me why we weren't doing this before.

We don't programmatically compute or ingest `--web-trace-file` output at
Stripe--it's only for manual debugging, so this should not make any
critical workflows slower.

Importantly, it's not actively computing or storing any new information:
this information was already being stored on all these timers for the
sake of statsd tagging.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Right now, if you generate a `--web-trace-file`, you can't see what each `LSPTask::run` span corresponds to, even though we're already setting a tag on the corresponding timer—we only make these things show up in the JSON output if it's in the `args` (which is only on construction—you can't add args after construction).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test in prod.