### PR TITLE
Don't duplicate conditional branches when outerLoops differs

### DIFF
--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -85,6 +85,11 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 bb->bexit.thenb->backEdges.emplace_back(bb);
                 thenb->backEdges.erase(remove(thenb->backEdges.begin(), thenb->backEdges.end(), bb),
                                        thenb->backEdges.end());
+                // Update unconditional jumps
+                if (thenb == elseb) {
+                    bb->bexit.elseb = bb->bexit.thenb;
+                }
+
                 changed = true;
                 sanityCheck(ctx, cfg);
                 continue;
@@ -97,6 +102,11 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 bb->bexit.elseb->backEdges.emplace_back(bb);
                 elseb->backEdges.erase(remove(elseb->backEdges.begin(), elseb->backEdges.end(), bb),
                                        elseb->backEdges.end());
+                // Update unconditional jumps
+                if (thenb == elseb) {
+                    bb->bexit.thenb = bb->bexit.elseb;
+                }
+
                 changed = true;
                 sanityCheck(ctx, cfg);
                 continue;

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -82,7 +82,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 bb->bexit.thenb != thenb->bexit.thenb) {
                 // shortcut then
                 bb->bexit.thenb = thenb->bexit.thenb;
-                thenb->bexit.thenb->backEdges.emplace_back(bb);
+                bb->bexit.thenb->backEdges.emplace_back(bb);
                 thenb->backEdges.erase(remove(thenb->backEdges.begin(), thenb->backEdges.end(), bb),
                                        thenb->backEdges.end());
                 changed = true;

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -61,7 +61,8 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                     changed = true;
                     sanityCheck(ctx, cfg);
                     continue;
-                } else if (thenb->bexit.cond.variable != LocalRef::blockCall() && thenb->exprs.empty()) {
+                } else if (thenb->bexit.cond.variable != LocalRef::blockCall() && thenb->exprs.empty() &&
+                           thenb->outerLoops == bb->outerLoops) {
                     // Don't remove block headers
                     bb->bexit.cond.variable = thenb->bexit.cond.variable;
                     bb->bexit.thenb = thenb->bexit.thenb;

--- a/test/testdata/cfg/duplicated_block_header_regression.rb
+++ b/test/testdata/cfg/duplicated_block_header_regression.rb
@@ -11,4 +11,4 @@ while found
   end
 end
 
-T.reveal_type(xyz) # error: Revealed type: `T.nilable(Integer)`
+T.reveal_type(xyz) # error: Revealed type: `Integer`

--- a/test/testdata/cfg/duplicated_block_header_regression.rb
+++ b/test/testdata/cfg/duplicated_block_header_regression.rb
@@ -1,0 +1,14 @@
+# typed: true
+extend T::Sig
+
+xyz = 0.to_i
+found = T.let(true, T::Boolean)
+
+while found
+  found = false
+  if [true, false].sample
+    found = true
+  end
+end
+
+T.reveal_type(xyz) # error: Revealed type: `T.nilable(Integer)`

--- a/test/testdata/cfg/duplicated_block_header_regression.rb.cfg-text.exp
+++ b/test/testdata/cfg/duplicated_block_header_regression.rb.cfg-text.exp
@@ -13,7 +13,7 @@ bb0[firstDead=-1]():
     keep_for_ide$12: T.untyped = <keep-alive> keep_for_ide$12
     <castTemp>$16: TrueClass = true
     found: T::Boolean = cast(<castTemp>$16: TrueClass, T::Boolean);
-    found -> (T::Boolean ? bb5 : bb4)
+    <unconditional> -> bb2
 
 # backedges
 # - bb4
@@ -21,23 +21,22 @@ bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
+# - bb0
 # - bb5
-bb2[firstDead=-1](xyz: NilClass, found: NilClass):
+bb2[firstDead=-1](xyz: Integer, found: T::Boolean):
     # outerLoops: 1
-    found -> (NilClass ? bb5 : bb4)
+    found -> (T::Boolean ? bb5 : bb4)
 
 # backedges
-# - bb0
 # - bb2
 # - bb6
-bb4[firstDead=3](xyz: T.nilable(Integer)):
+bb4[firstDead=3](xyz: Integer):
     <cfgAlias>$28: T.class_of(T) = alias <C T>
-    <statTemp>$26: T.nilable(Integer) = <cfgAlias>$28: T.class_of(T).reveal_type(xyz: T.nilable(Integer))
+    <statTemp>$26: Integer = <cfgAlias>$28: T.class_of(T).reveal_type(xyz: Integer)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0
 # - bb2
 # - bb6
 bb5[firstDead=-1](xyz: Integer, found: TrueClass):

--- a/test/testdata/cfg/duplicated_block_header_regression.rb.cfg-text.exp
+++ b/test/testdata/cfg/duplicated_block_header_regression.rb.cfg-text.exp
@@ -1,0 +1,61 @@
+method ::<Class:<root>>#<static-init> {
+
+bb0[firstDead=-1]():
+    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
+    <cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>
+    <cfgAlias>$8: T.class_of(T) = alias <C T>
+    <statTemp>$3: T.class_of(<root>) = <self>: T.class_of(<root>).extend(<cfgAlias>$6: T.class_of(T::Sig))
+    <statTemp>$10: Integer(0) = 0
+    xyz: Integer = <statTemp>$10: Integer(0).to_i()
+    <cfgAlias>$13: Runtime object representing type: T::Boolean = alias <C Boolean>
+    keep_for_ide$12: Runtime object representing type: T::Boolean = <cfgAlias>$13
+    <cfgAlias>$15: T.class_of(T) = alias <C T>
+    keep_for_ide$12: T.untyped = <keep-alive> keep_for_ide$12
+    <castTemp>$16: TrueClass = true
+    found: T::Boolean = cast(<castTemp>$16: TrueClass, T::Boolean);
+    found -> (T::Boolean ? bb5 : bb4)
+
+# backedges
+# - bb4
+bb1[firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb5
+bb2[firstDead=-1](xyz: NilClass, found: NilClass):
+    # outerLoops: 1
+    found -> (NilClass ? bb5 : bb4)
+
+# backedges
+# - bb0
+# - bb2
+# - bb6
+bb4[firstDead=3](xyz: T.nilable(Integer)):
+    <cfgAlias>$28: T.class_of(T) = alias <C T>
+    <statTemp>$26: T.nilable(Integer) = <cfgAlias>$28: T.class_of(T).reveal_type(xyz: T.nilable(Integer))
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+# backedges
+# - bb0
+# - bb2
+# - bb6
+bb5[firstDead=-1](xyz: Integer, found: TrueClass):
+    # outerLoops: 1
+    found: FalseClass = false
+    <arrayTemp>$23: TrueClass = true
+    <arrayTemp>$24: FalseClass = false
+    <magic>$25: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$22: [TrueClass, FalseClass] = <magic>$25: T.class_of(<Magic>).<build-array>(<arrayTemp>$23: TrueClass, <arrayTemp>$24: FalseClass)
+    <ifTemp>$21: T::Boolean = <statTemp>$22: [TrueClass, FalseClass].sample()
+    <ifTemp>$21 -> (T::Boolean ? bb6 : bb2)
+
+# backedges
+# - bb5
+bb6[firstDead=-1](xyz: Integer, found: FalseClass):
+    # outerLoops: 1
+    found: TrueClass = true
+    found -> (TrueClass ? bb5 : bb4)
+
+}
+


### PR DESCRIPTION
During the simplify pass in CFG construction, one simplification that we consider is when we have an unconditional jump to a block with no statements and a conditional branch. If that case happens, we duplicate the branch condition of that empty block in the parent with the unconditional branch. In many cases this is a good optimization to make as it will potentially remove blocks whose only purpose was to hold a conditional branch. However, for block headers this duplication logic can invalidate the forward topo sort traversal, as we drop the original unconditional branch to the loop header, but still process it in an order that would suggest it's a successor of the block that inherited it's condition.

To fix this issue, this PR requires that the `outerLoops` values that are computed for each block match before allowing this simplification, as that encodes our requirement that we don't duplicate block headers.

Here's a picture of the CFG for the test case from #8283 before this change, showing the entry point into the loop being duplicated in block `0`, but also present in block `2`:

![tmp xDw2zbj85e](https://github.com/user-attachments/assets/07c01a09-cf9b-47a5-abc3-d8dc539ba924)

And after this PR, block `2` remains a direct successor of the entry block `0`, despite not having any statements:

![tmp hbonnlK68K](https://github.com/user-attachments/assets/10442f6d-11a0-4c2f-aad8-384919308146)

The test case from #8283 is added as the first commit, and the final commit amends that case to show both the more precise type, and CFG changes.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #8283

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
