### PR TITLE
Describe the difference between error_without_recovery and error

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -176,10 +176,14 @@ public:
         return cond;
     }
 
+    // Record a diagnostic error, and set internal state that will trigger a YYERROR on the next DIAGCHECK. Use this
+    // function if there's no reasonable tree that can be returned, as it will trigger the parser to throw away
+    // arbitrary amounts of the input tree, potentially leading to LSP taking the slow path unnecessarily.
     void error_without_recovery(ruby_parser::dclass err, core::LocOffsets loc, std::string data = "") {
         driver_->external_diagnostic(ruby_parser::dlevel::ERROR, err, loc.beginPos(), loc.endPos(), data);
     }
 
+    // Record a diagnostic only, don't modify any internal state that could cause the tree to be discarded.
     void error(ruby_parser::dclass err, core::LocOffsets loc, std::string data = "") {
         auto range = ruby_parser::diagnostic::range(loc.beginPos(), loc.endPos());
         driver_->diagnostics.emplace_back(ruby_parser::dlevel::ERROR, err, std::move(range), data);

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -176,9 +176,9 @@ public:
         return cond;
     }
 
-    // Record a diagnostic error, and set internal state that will trigger a YYERROR on the next DIAGCHECK. Use this
-    // function if there's no reasonable tree that can be returned, as it will trigger the parser to throw away
-    // arbitrary amounts of the input tree, potentially leading to LSP taking the slow path unnecessarily.
+    // Record a diagnostic error, and set internal state that will emit an `error` token on the next DIAGCHECK.
+    // Use this function if there's no reasonable tree that can be returned, as it will trigger the parser to
+    // throw away arbitrary amounts of the input tree, potentially leading to LSP taking the slow path unnecessarily.
     void error_without_recovery(ruby_parser::dclass err, core::LocOffsets loc, std::string data = "") {
         driver_->external_diagnostic(ruby_parser::dlevel::ERROR, err, loc.beginPos(), loc.endPos(), data);
     }

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -482,8 +482,11 @@ namespace ruby_parser {
 namespace bison {
 namespace TYPEDRUBY {
 
-// DIAGCHECK will force a parse error if any diagnostics have been recorded with
-// `error_without_recovery`.
+// DIAGCHECK will forcibly emit an error token for diagnostics which have been
+// recorded with `error_without_recovery` (which sets driver.pending_error).
+//
+// Normally, the error token is only shifted when Bison fails to find any
+// matching rules.
 #define DIAGCHECK() do { \
 	if (driver.pending_error) { \
 		driver.pending_error = false; \

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -482,6 +482,8 @@ namespace ruby_parser {
 namespace bison {
 namespace TYPEDRUBY {
 
+// DIAGCHECK will force a parse error if any diagnostics have been recorded with
+// `error_without_recovery`.
 #define DIAGCHECK() do { \
 	if (driver.pending_error) { \
 		driver.pending_error = false; \


### PR DESCRIPTION
Short docs to describe how `error_without_recovery` and `DIAGCHECK` interact.

### Motivation
Clarifying the situations where the two error functions should be used.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Docs change
