### PR TITLE
Take a pass through uses of `error_without_recovery`

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -412,7 +412,7 @@ public:
         core::LocOffsets loc = receiver->loc.join(selectorLoc);
         if ((dot != nullptr) && dot->view() == "&.") {
             if (masgn) {
-                error_without_recovery(ruby_parser::dclass::CSendInLHSOfMAsgn, tokLoc(dot));
+                error(ruby_parser::dclass::CSendInLHSOfMAsgn, tokLoc(dot));
             }
             return make_unique<CSend>(loc, std::move(receiver), method, selectorLoc, sorbet::parser::NodeVec());
         }

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -928,7 +928,7 @@ public:
         core::LocOffsets loc = head->loc.join(tokLoc(end));
 
         if (isLiteralNode(*(head->definee.get()))) {
-            error_without_recovery(ruby_parser::dclass::SingletonLiteral, head->definee->loc);
+            error(ruby_parser::dclass::SingletonLiteral, head->definee->loc);
         }
         checkReservedForNumberedParameters(head->name.toString(gs_), declLoc);
 

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -533,7 +533,7 @@ public:
         }
         if (callargs != nullptr && !callargs->empty()) {
             if (auto *bp = parser::cast_node<BlockPass>(callargs->back().get())) {
-                error_without_recovery(ruby_parser::dclass::BlockAndBlockarg, bp->loc);
+                error(ruby_parser::dclass::BlockAndBlockarg, bp->loc);
             } else if (auto *fa = parser::cast_node<ForwardedArgs>(callargs->back().get())) {
                 error_without_recovery(ruby_parser::dclass::BlockAndBlockarg, fa->loc);
             }

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -535,7 +535,7 @@ public:
             if (auto *bp = parser::cast_node<BlockPass>(callargs->back().get())) {
                 error(ruby_parser::dclass::BlockAndBlockarg, bp->loc);
             } else if (auto *fa = parser::cast_node<ForwardedArgs>(callargs->back().get())) {
-                error_without_recovery(ruby_parser::dclass::BlockAndBlockarg, fa->loc);
+                error(ruby_parser::dclass::BlockAndBlockarg, fa->loc);
             }
         }
 

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1739,7 +1739,7 @@ public:
 
     bool hasCircularArgumentReferences(const Node *node, std::string_view name) {
         if (name == driver_->current_arg_stack.top()) {
-            error_without_recovery(ruby_parser::dclass::CircularArgumentReference, node->loc, std::string(name));
+            error(ruby_parser::dclass::CircularArgumentReference, node->loc, std::string(name));
             return true;
         }
         return false;

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -286,7 +286,7 @@ public:
             }
         }
         if (forwardArg && restArg) {
-            error_without_recovery(ruby_parser::dclass::ForwardArgAfterRestArg, args[0].get()->loc);
+            error(ruby_parser::dclass::ForwardArgAfterRestArg, args[0].get()->loc);
         }
     }
 

--- a/test/testdata/parser/error_recovery/block_arg_and_block.rb
+++ b/test/testdata/parser/error_recovery/block_arg_and_block.rb
@@ -2,7 +2,7 @@
 
 [1,2,3].each do |x|
   foo(&bar) do puts(x) end
-#     ^^^^         error: both block argument and literal block are passed
-#      ^^^         error: Method `bar` does not exist
-# ^^^^^^^^^^^^^^^^ error: Method `foo` does not exist
+#     ^^^^                 error: both block argument and literal block are passed
+#      ^^^                 error: Method `bar` does not exist
+# ^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `foo` does not exist
 end

--- a/test/testdata/parser/error_recovery/block_arg_and_block.rb
+++ b/test/testdata/parser/error_recovery/block_arg_and_block.rb
@@ -2,5 +2,7 @@
 
 [1,2,3].each do |x|
   foo(&bar) do end
-    # ^^^^ error: both block argument and literal block are passed
+#     ^^^^         error: both block argument and literal block are passed
+#      ^^^         error: Method `bar` does not exist
+# ^^^^^^^^^^^^^^^^ error: Method `foo` does not exist
 end

--- a/test/testdata/parser/error_recovery/block_arg_and_block.rb
+++ b/test/testdata/parser/error_recovery/block_arg_and_block.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 [1,2,3].each do |x|
-  foo(&bar) do end
+  foo(&bar) do puts(x) end
 #     ^^^^         error: both block argument and literal block are passed
 #      ^^^         error: Method `bar` does not exist
 # ^^^^^^^^^^^^^^^^ error: Method `foo` does not exist

--- a/test/testdata/parser/error_recovery/block_arg_and_block.rb
+++ b/test/testdata/parser/error_recovery/block_arg_and_block.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+[1,2,3].each do |x|
+  foo(&bar) do end
+    # ^^^^ error: both block argument and literal block are passed
+end

--- a/test/testdata/parser/error_recovery/block_arg_and_block.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/block_arg_and_block.rb.desugar-tree.exp
@@ -1,7 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   [1, 2, 3].each() do |x|
     ::<Magic>.<call-with-block>(<self>, :foo, <self>.bar()) do ||
-      <emptyTree>
+      <self>.puts(x)
     end
   end
 end

--- a/test/testdata/parser/error_recovery/block_arg_and_block.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/block_arg_and_block.rb.desugar-tree.exp
@@ -1,0 +1,5 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  [1, 2, 3].each() do |x|
+    <emptyTree>
+  end
+end

--- a/test/testdata/parser/error_recovery/block_arg_and_block.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/block_arg_and_block.rb.desugar-tree.exp
@@ -1,5 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   [1, 2, 3].each() do |x|
-    <emptyTree>
+    ::<Magic>.<call-with-block>(<self>, :foo, <self>.bar()) do ||
+      <emptyTree>
+    end
   end
 end

--- a/test/testdata/parser/error_recovery/circular_argument_reference.rb
+++ b/test/testdata/parser/error_recovery/circular_argument_reference.rb
@@ -4,5 +4,5 @@
               #      ^      error: circular argument reference x
               # ^           error: unmatched "|"
               #           ^ error: missing arg to "|" operator
-              #      ^      error: Method `x` does not exist
+              #        ^    error: Method `+` does not exist
 end

--- a/test/testdata/parser/error_recovery/circular_argument_reference.rb
+++ b/test/testdata/parser/error_recovery/circular_argument_reference.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+[1,2,3].each do |x = x + 1|
+              #      ^      error: circular argument reference x
+              # ^           error: unmatched "|"
+              #           ^ error: missing arg to "|" operator
+              #      ^      error: Method `x` does not exist
+end

--- a/test/testdata/parser/error_recovery/circular_argument_reference.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/circular_argument_reference.rb.desugar-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <self>.x().+(1).|(<emptyTree>::<C <ErrorNode>>)
+end

--- a/test/testdata/parser/error_recovery/circular_argument_reference.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/circular_argument_reference.rb.desugar-tree.exp
@@ -1,3 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  <self>.x().+(1).|(<emptyTree>::<C <ErrorNode>>)
+  [1, 2, 3].each() do ||
+    x = x.+(1).|(<emptyTree>::<C <ErrorNode>>)
+  end
 end

--- a/test/testdata/parser/error_recovery/csend_masgn.rb
+++ b/test/testdata/parser/error_recovery/csend_masgn.rb
@@ -2,5 +2,7 @@
 
 [1,2,3].each do |x|
   x&.y, = 10
- # ^^ error: &. inside multiple assignment
+ # ^^  error: &. inside multiple assignment
+ # ^^  error: Used `&.` operator on `Integer`
+ #   ^ error: Setter method `y=` does not exist
 end

--- a/test/testdata/parser/error_recovery/csend_masgn.rb
+++ b/test/testdata/parser/error_recovery/csend_masgn.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+[1,2,3].each do |x|
+  x&.y, = 10
+ # ^^ error: &. inside multiple assignment
+end

--- a/test/testdata/parser/error_recovery/csend_masgn.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/csend_masgn.rb.desugar-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  nil
+end

--- a/test/testdata/parser/error_recovery/csend_masgn.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/csend_masgn.rb.desugar-tree.exp
@@ -1,3 +1,17 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  nil
+  [1, 2, 3].each() do |x|
+    begin
+      <assignTemp>$2 = 10
+      <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 1, 0)
+      begin
+        <assignTemp>$4 = x
+        if ::NilClass.===(<assignTemp>$4)
+          ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$4)
+        else
+          <assignTemp>$4.y=(<assignTemp>$3.[](0))
+        end
+      end
+      <assignTemp>$2
+    end
+  end
 end

--- a/test/testdata/parser/error_recovery/forward_args.rb
+++ b/test/testdata/parser/error_recovery/forward_args.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+def foo(*, ...)
+      # ^ error: ... after rest argument
+  [1,2,3].each { |x| _1 }
+                   # ^^ error: can't use numbered
+end

--- a/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
@@ -1,0 +1,5 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def foo<<todo method>>(**, *<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+    <emptyTree>
+  end
+end

--- a/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
@@ -1,5 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def foo<<todo method>>(**, *<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
-    <emptyTree>
+    [1, 2, 3].each() do |_1|
+      _1
+    end
   end
 end

--- a/test/testdata/parser/error_recovery/forward_args_with_block.rb
+++ b/test/testdata/parser/error_recovery/forward_args_with_block.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+def test(...)
+  [1,2,3].each do
+    foo(...) do end
+      # ^^^ error: both block argument and literal block are passed
+  end
+end

--- a/test/testdata/parser/error_recovery/forward_args_with_block.rb
+++ b/test/testdata/parser/error_recovery/forward_args_with_block.rb
@@ -3,6 +3,7 @@
 def test(...)
   [1,2,3].each do
     foo(...) do end
-      # ^^^ error: both block argument and literal block are passed
+  #     ^^^         error: both block argument and literal block are passed
+  # ^^^^^^^^^^^^^^^ error: Splats are only supported where the size
   end
 end

--- a/test/testdata/parser/error_recovery/forward_args_with_block.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/forward_args_with_block.rb.desugar-tree.exp
@@ -1,0 +1,7 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def test<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+    [1, 2, 3].each() do ||
+      <emptyTree>
+    end
+  end
+end

--- a/test/testdata/parser/error_recovery/forward_args_with_block.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/forward_args_with_block.rb.desugar-tree.exp
@@ -1,7 +1,9 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def test<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
     [1, 2, 3].each() do ||
-      <emptyTree>
+      ::<Magic>.<call-with-splat-and-block>(<self>, :foo, [].concat(<fwd-args>.to_a()).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>) do ||
+        <emptyTree>
+      end
     end
   end
 end

--- a/test/testdata/parser/error_recovery/singleton_method_literal.rb
+++ b/test/testdata/parser/error_recovery/singleton_method_literal.rb
@@ -2,6 +2,7 @@
 
 def (10).test()
    # ^^ error: cannot define a singleton method for a literal
+   # ^^ error: `def EXPRESSION.method` is only supported for `def self.method`
   [1,2,3].each do |x|
     x
   end

--- a/test/testdata/parser/error_recovery/singleton_method_literal.rb
+++ b/test/testdata/parser/error_recovery/singleton_method_literal.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+def (10).test()
+   # ^^ error: cannot define a singleton method for a literal
+  [1,2,3].each do |x|
+    x
+  end
+end

--- a/test/testdata/parser/error_recovery/singleton_method_literal.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/singleton_method_literal.rb.desugar-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  nil
+end

--- a/test/testdata/parser/error_recovery/singleton_method_literal.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/singleton_method_literal.rb.desugar-tree.exp
@@ -1,3 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  nil
+  def self.test<<todo method>>(&<blk>)
+    [1, 2, 3].each() do |x|
+      x
+    end
+  end
 end


### PR DESCRIPTION
As `error_without_recovery` just marks state that says "raise a parse error the next time DIAGCHECK is used", uses of it can cause somewhat surprisingly far reaching tree pruning.

This PR changes some uses of `error_without_recovery` into `error`, which will help avoid the situation where too much tree gets thrown out when a typo is encountered. The remaining cases either caused crashes in later passes when given non-trivial inputs or were related to pattern matching, and have been left alone.

Each case that's flipped from `error_without_recovery` to `error` is accompanied by a new test with a desugar-tree expectation, and the following commit contains the switch and the updates to the test.

### Motivation
Improving the chances that intermediate edits take the fast path instead of the slow path while using LSP.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
