### PR TITLE
Comment and refactor the CFG's simplify pass

### DIFF
--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -32,6 +32,10 @@ public:
     bool isCondSet() {
         return cond.variable.exists();
     }
+    // Returns true when this exit condition represents an unconditional branch.
+    bool isUnconditional() const {
+        return thenb == elseb;
+    }
     BlockExit() : cond(), thenb(nullptr), elseb(nullptr){};
 };
 

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -137,6 +137,9 @@ public:
      * The name here goes from using forwards or backwards edges as dependencies in topological sort.
      * This in indeed kind-a reverse to what order would node be in: for topological sort with forward edges
      * the entry point is going to be the last node in sorted array.
+     *
+     * This is a cached post-order traversal of the CFG from the entry node, which is why we traverse it in reverse when
+     * typechecking: the reversed post-order traversal ensures that we visit all nodes in data flow order.
      */
     std::vector<BasicBlock *> forwardsTopoSort;
     inline BasicBlock *entry() {


### PR DESCRIPTION
Add comments for each major decision in the simplify pass, and attempt to clarify some of the logic by restructuring it.

I'd recommend viewing the diff with whitespace changes turned off, as it makes it much easier to see that this PR is mostly adding comments.

### Motivation
Making it easier to reason about what the simplify pass is doing.

### Test plan
This change should be a no-op.
