### PR TITLE
Shrink BasicBlock by 8 bytes

### DIFF
--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -57,8 +57,6 @@ class BasicBlock final {
 public:
     std::vector<VariableUseSite> args;
     int id = 0;
-    int fwdId = -1;
-    int bwdId = -1;
     struct Flags {
         bool isLoopHeader : 1;
         bool wasJumpDestination : 1;

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -20,7 +20,7 @@ private:
     static void removeDeadAssigns(core::Context ctx, const CFG::ReadsAndWrites &RnW, CFG &cfg,
                                   const std::vector<UIntSet> &blockArgs);
     static void markLoopHeaders(core::Context ctx, CFG &cfg);
-    static int topoSortFwd(std::vector<BasicBlock *> &target, int nextFree, BasicBlock *currentBB);
+    static std::vector<int> topoSortFwd(std::vector<BasicBlock *> &target, int numBlocks, BasicBlock *currentBB);
     static void conditionalJump(BasicBlock *from, LocalRef cond, BasicBlock *thenb, BasicBlock *elseb, CFG &inWhat,
                                 core::LocOffsets loc);
     static void unconditionalJump(BasicBlock *from, BasicBlock *to, CFG &inWhat, core::LocOffsets loc);

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -152,7 +152,6 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
 
 void CFGBuilder::fillInTopoSorts(core::Context ctx, CFG &cfg) {
     // A map from the index space of the basicBlocks index to forwardsTopoSort index.
-    cfg.forwardsTopoSort.reserve(cfg.maxBasicBlockId);
     auto forwardsIds = topoSortFwd(cfg.forwardsTopoSort, cfg.maxBasicBlockId, cfg.entry());
 
     // Remove unreachable blocks (which were not found by the toposort)

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -151,16 +151,15 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
 }
 
 void CFGBuilder::fillInTopoSorts(core::Context ctx, CFG &cfg) {
-    auto &target1 = cfg.forwardsTopoSort;
-    target1.resize(cfg.basicBlocks.size());
-    int count = topoSortFwd(target1, 0, cfg.entry());
-    cfg.forwardsTopoSort.resize(count);
+    // A map from the index space of the basicBlocks index to forwardsTopoSort index.
+    cfg.forwardsTopoSort.reserve(cfg.maxBasicBlockId);
+    auto forwardsIds = topoSortFwd(cfg.forwardsTopoSort, cfg.maxBasicBlockId, cfg.entry());
 
     // Remove unreachable blocks (which were not found by the toposort)
     for (auto &bb : cfg.basicBlocks) {
-        if (bb->fwdId == -1) {
+        if (forwardsIds[bb->id] == -1) {
             for (auto &prev : bb->backEdges) {
-                ENFORCE(prev->fwdId == -1);
+                ENFORCE(forwardsIds[prev->id] == -1);
             }
 
             bb->bexit.thenb->backEdges.erase(
@@ -171,13 +170,15 @@ void CFGBuilder::fillInTopoSorts(core::Context ctx, CFG &cfg) {
                 bb->bexit.elseb->backEdges.end());
         }
     }
-    cfg.basicBlocks.erase(
-        remove_if(cfg.basicBlocks.begin(), cfg.basicBlocks.end(), [](auto &bb) -> bool { return bb->fwdId == -1; }),
-        cfg.basicBlocks.end());
+    cfg.basicBlocks.erase(remove_if(cfg.basicBlocks.begin(), cfg.basicBlocks.end(),
+                                    [&forwardsIds](auto &bb) -> bool { return forwardsIds[bb->id] == -1; }),
+                          cfg.basicBlocks.end());
 
     // needed to find loop headers.
     for (auto &bb : cfg.basicBlocks) {
-        fast_sort(bb->backEdges, [](const BasicBlock *a, const BasicBlock *b) -> bool { return a->fwdId > b->fwdId; });
+        fast_sort(bb->backEdges, [&forwardsIds](const BasicBlock *a, const BasicBlock *b) -> bool {
+            return forwardsIds[a->id] > forwardsIds[b->id];
+        });
     }
 }
 

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -514,11 +514,11 @@ std::vector<int> CFGBuilder::topoSortFwd(vector<BasicBlock *> &target, int numBl
             }
 
             case WorkItem::Event::Exit: {
-                if (forwardIndex[block->id] == PROCESSING) {
-                    forwardIndex[block->id] = target.size();
-                    target.emplace_back(block);
-                    work.pop_back();
-                }
+                ENFORCE(forwardIndex[block->id] == PROCESSING);
+
+                forwardIndex[block->id] = target.size();
+                target.emplace_back(block);
+                work.pop_back();
 
                 break;
             }


### PR DESCRIPTION
We don't use the `bwdId` field on `BasicBlock`, and `fwdId` is only valid while we're constructing the `forwardsTopoSort`. Instead, let's track the forward ids in a separate table with the same size as the max block id, so that we can reclaim that memory after the topo sort is complete.

Additionally, re-implement the topo sort with an explicit work queue, to avoid using stack space proportional to the longest path in the CFG.

### Motivation
Tightening up memory usage in the CFG.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
This should be a no-op on functionality, and only free up some memory.
