### PR TITLE
Restructure how overloads are stored in the symbol table

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1077,7 +1077,7 @@ bool matchesArityHash(const GlobalState &gs, ArityHash arityHash, MethodRef meth
     auto methodData = method.data(gs);
     // lookupMethodSymbolWithHash is called from namer, before resolver enters overloads.
     // It wants to be able to find the "namer version" of the method, not the overload.
-    return !methodData->name.isOverload(gs) &&
+    return !methodData->name.isOverloadName(gs) &&
            (methodData->methodArityHash(gs) == arityHash || (methodData->hasIntrinsic() && !methodData->hasSig()));
 }
 } // namespace

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1149,6 +1149,8 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
 
     if (name.kind() == NameKind::UNIQUE) {
         auto uniqueData = name.dataUnique(*this);
+        ENFORCE(uniqueData->uniqueNameKind != UniqueNameKind::Overload,
+                "Overloads should never be used in a context where MangleRename is possible");
         if (uniqueData->uniqueNameKind != UniqueNameKind::MangleRename) {
             return Symbols::noSymbol();
         }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1810,17 +1810,17 @@ NameRef GlobalState::nextMangledName(ClassOrModuleRef owner, NameRef origName) {
     return name;
 }
 
-void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef baseName, UniqueNameKind kind) {
-    auto origName = what.data(*this)->name;
+void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef origName, UniqueNameKind kind) {
     auto owner = what.data(*this)->owner;
     auto ownerData = owner.data(*this);
     auto &ownerMembers = ownerData->members();
     auto fnd = ownerMembers.find(origName);
     ENFORCE_NO_TIMER(fnd != ownerMembers.end());
     ENFORCE_NO_TIMER(fnd->second == what);
+    ENFORCE_NO_TIMER(what.data(*this)->name == origName);
     NameRef name;
     if (kind == UniqueNameKind::MangleRename) {
-        name = nextMangledName(owner, baseName);
+        name = nextMangledName(owner, origName);
     } else {
         // We don't loop in this case because we're not trying to find an actually unique name, we
         // just want to essentially move the existing, non-overloaded `what` out of the way to allow
@@ -1831,7 +1831,7 @@ void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef baseName, U
         // We know that there is no method with this name, because otherwise resolver would not have
         // called mangleRenameForOverload.
         ENFORCE_NO_TIMER(kind == UniqueNameKind::MangleRenameOverload);
-        name = freshNameUnique(UniqueNameKind::MangleRenameOverload, baseName, 1);
+        name = freshNameUnique(UniqueNameKind::MangleRenameOverload, origName, 1);
     }
     // Both branches of the above `if` condition should ENFORCE this (either due to the loop post
     // condition, or by way of the resolveMultiSignatureJob call site guaranteeing this).

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1100,17 +1100,6 @@ MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRe
             }
         }
 
-        auto lookupNameOverload = lookupNameUnique(UniqueNameKind::MangleRenameOverload, lookupName, 1);
-        if (lookupNameOverload.exists()) {
-            auto overloadIt = ownerScope->members().find(lookupNameOverload);
-            if (overloadIt != ownerScope->members().end() && overloadIt->second.isMethod()) {
-                auto resMethod = overloadIt->second.asMethodRef();
-                if (matchesArityHash(*this, arityHash, resMethod)) {
-                    return resMethod;
-                }
-            }
-        }
-
         lookupName = lookupNameUnique(UniqueNameKind::MangleRename, name, unique);
         if (!lookupName.exists()) {
             break;
@@ -1160,22 +1149,7 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
 
     if (name.kind() == NameKind::UNIQUE) {
         auto uniqueData = name.dataUnique(*this);
-        if (uniqueData->uniqueNameKind == UniqueNameKind::MangleRenameOverload) {
-            auto it = ownerScope->members().find(uniqueData->original);
-            ENFORCE_NO_TIMER(it != ownerScope->members().end());
-            // return it->second;
-            auto res = findRenamedSymbol(owner, it->second);
-            if (res.exists() && res.isMethod()) {
-                const auto &resData = res.asMethodRef().data(*this);
-                if (resData->flags.isOverloaded) {
-                    auto overloadedName = lookupNameUnique(UniqueNameKind::MangleRenameOverload, resData->name, 1);
-                    auto it = ownerScope->members().find(overloadedName);
-                    ENFORCE_NO_TIMER(it != ownerScope->members().end());
-                    res = it->second;
-                }
-            }
-            return res;
-        } else if (uniqueData->uniqueNameKind != UniqueNameKind::MangleRename) {
+        if (uniqueData->uniqueNameKind != UniqueNameKind::MangleRename) {
             return Symbols::noSymbol();
         }
         if (uniqueData->num == 1) {
@@ -1808,38 +1782,6 @@ NameRef GlobalState::nextMangledName(ClassOrModuleRef owner, NameRef origName) {
     return name;
 }
 
-void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef origName, UniqueNameKind kind) {
-    auto owner = what.data(*this)->owner;
-    auto ownerData = owner.data(*this);
-    auto &ownerMembers = ownerData->members();
-    auto fnd = ownerMembers.find(origName);
-    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
-    ENFORCE_NO_TIMER(fnd->second == what);
-    ENFORCE_NO_TIMER(what.data(*this)->name == origName);
-    NameRef name;
-    if (kind == UniqueNameKind::MangleRename) {
-        name = nextMangledName(owner, origName);
-    } else {
-        // We don't loop in this case because we're not trying to find an actually unique name, we
-        // just want to essentially move the existing, non-overloaded `what` out of the way to allow
-        // the first overload to have the name that `what` currently has. We also need to be able to
-        // map predictably between the new, overloaded symbol and the original it came from, so the
-        // unique name is always chosen using `1` for the `num` argument.
-        //
-        // We know that there is no method with this name, because otherwise resolver would not have
-        // called mangleRenameForOverload.
-        ENFORCE_NO_TIMER(kind == UniqueNameKind::MangleRenameOverload);
-        name = freshNameUnique(UniqueNameKind::MangleRenameOverload, origName, 1);
-    }
-    // Both branches of the above `if` condition should ENFORCE this (either due to the loop post
-    // condition, or by way of the resolveMultiSignatureJob call site guaranteeing this).
-    ENFORCE(!ownerData->findMember(*this, name).exists(), "would overwrite the Symbol with name {}",
-            name.showRaw(*this));
-    ownerMembers.erase(fnd);
-    ownerMembers[name] = what;
-    what.data(*this)->name = name;
-}
-
 // We have to use this mangle renaming logic to get old methods out of the way, because method
 // redefinitions are not an error at `typed: false`, which means that people can expect that their
 // redefined method will be given precedence when called in another (typed: true) file.
@@ -1847,10 +1789,21 @@ void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef origName, U
 // (Constant redefinition errors are always enforced at `# typed: false`, so we can afford to simply
 // define a new symbol with a mangled name, instead of mangling AND renaming constant symbols.)
 void GlobalState::mangleRenameMethod(MethodRef what, NameRef origName) {
-    mangleRenameMethodInternal(what, origName, UniqueNameKind::MangleRename);
-}
-void GlobalState::mangleRenameForOverload(MethodRef what, NameRef origName) {
-    mangleRenameMethodInternal(what, origName, UniqueNameKind::MangleRenameOverload);
+    auto owner = what.data(*this)->owner;
+    auto ownerData = owner.data(*this);
+    auto &ownerMembers = ownerData->members();
+    auto fnd = ownerMembers.find(origName);
+    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
+    ENFORCE_NO_TIMER(fnd->second == what);
+    ENFORCE_NO_TIMER(what.data(*this)->name == origName);
+    NameRef name = nextMangledName(owner, origName);
+    // Both branches of the above `if` condition should ENFORCE this (either due to the loop post
+    // condition, or by way of the resolveMultiSignatureJob call site guaranteeing this).
+    ENFORCE(!ownerData->findMember(*this, name).exists(), "would overwrite the Symbol with name {}",
+            name.showRaw(*this));
+    ownerMembers.erase(fnd);
+    ownerMembers[name] = what;
+    what.data(*this)->name = name;
 }
 
 // This method should be used sparingly, because using it correctly is tricky.

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1077,7 +1077,7 @@ bool matchesArityHash(const GlobalState &gs, ArityHash arityHash, MethodRef meth
     auto methodData = method.data(gs);
     // lookupMethodSymbolWithHash is called from namer, before resolver enters overloads.
     // It wants to be able to find the "namer version" of the method, not the overload.
-    return !methodData->flags.isOverloaded &&
+    return !methodData->name.isOverload(gs) &&
            (methodData->methodArityHash(gs) == arityHash || (methodData->hasIntrinsic() && !methodData->hasSig()));
 }
 } // namespace

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1355,11 +1355,9 @@ MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRe
 
 MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, core::NameRef originalName, uint32_t num,
                                               const vector<bool> &argsToKeep) {
-    NameRef name = num == 0 ? originalName : freshNameUnique(UniqueNameKind::Overload, originalName, num);
-    core::Loc loc = num == 0 ? original.data(*this)->loc()
-                             : sigLoc; // use original Loc for main overload so that we get right jump-to-def for it.
+    NameRef name = freshNameUnique(UniqueNameKind::Overload, originalName, num);
     auto owner = original.data(*this)->owner;
-    auto res = enterMethodSymbol(loc, owner, name);
+    auto res = enterMethodSymbol(sigLoc, owner, name);
     bool newMethod = res != original;
     const auto &resArguments = res.data(*this)->arguments;
     ENFORCE_NO_TIMER(newMethod || !resArguments.empty(), "must be at least the block arg");

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1810,17 +1810,17 @@ NameRef GlobalState::nextMangledName(ClassOrModuleRef owner, NameRef origName) {
     return name;
 }
 
-void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef origName, UniqueNameKind kind) {
+void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef baseName, UniqueNameKind kind) {
+    auto origName = what.data(*this)->name;
     auto owner = what.data(*this)->owner;
     auto ownerData = owner.data(*this);
     auto &ownerMembers = ownerData->members();
     auto fnd = ownerMembers.find(origName);
     ENFORCE_NO_TIMER(fnd != ownerMembers.end());
     ENFORCE_NO_TIMER(fnd->second == what);
-    ENFORCE_NO_TIMER(what.data(*this)->name == origName);
     NameRef name;
     if (kind == UniqueNameKind::MangleRename) {
-        name = nextMangledName(owner, origName);
+        name = nextMangledName(owner, baseName);
     } else {
         // We don't loop in this case because we're not trying to find an actually unique name, we
         // just want to essentially move the existing, non-overloaded `what` out of the way to allow
@@ -1831,7 +1831,7 @@ void GlobalState::mangleRenameMethodInternal(MethodRef what, NameRef origName, U
         // We know that there is no method with this name, because otherwise resolver would not have
         // called mangleRenameForOverload.
         ENFORCE_NO_TIMER(kind == UniqueNameKind::MangleRenameOverload);
-        name = freshNameUnique(UniqueNameKind::MangleRenameOverload, origName, 1);
+        name = freshNameUnique(UniqueNameKind::MangleRenameOverload, baseName, 1);
     }
     // Both branches of the above `if` condition should ENFORCE this (either due to the loop post
     // condition, or by way of the resolveMultiSignatureJob call site guaranteeing this).

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -172,7 +172,6 @@ public:
 
     NameRef nextMangledName(ClassOrModuleRef owner, NameRef origName);
     void mangleRenameMethod(MethodRef what, NameRef origName);
-    void mangleRenameForOverload(MethodRef what, NameRef origName);
     // NOTE: You likely want to use mangleRenameMethod not deleteMethodSymbol, unless you know what you're doing.
     // See the comment on the implementation for more.
     void deleteMethodSymbol(MethodRef what);
@@ -379,8 +378,6 @@ private:
 
     SymbolRef lookupSymbolWithKind(ClassOrModuleRef owner, NameRef name, SymbolRef::Kind kind,
                                    SymbolRef defaultReturnValue, bool ignoreKind = false) const;
-
-    void mangleRenameMethodInternal(MethodRef what, NameRef origName, UniqueNameKind kind);
 
     std::string toStringWithOptions(bool showFull, bool showRaw) const;
 };

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -177,7 +177,7 @@ public:
 
     NameRef prepend(GlobalState &gs, std::string_view s) const;
 
-    bool isOverload(const GlobalState &gs) const;
+    bool isOverloadName(const GlobalState &gs) const;
 
     bool isClassName(const GlobalState &gs) const;
 

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -177,6 +177,8 @@ public:
 
     NameRef prepend(GlobalState &gs, std::string_view s) const;
 
+    bool isOverload(const GlobalState &gs) const;
+
     bool isClassName(const GlobalState &gs) const;
 
     // Convenience method, because enums need to be special cased in more places than other kinds of

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -190,7 +190,7 @@ void NameRef::sanityCheck(const GlobalState &gs) const {
     }
 }
 
-bool NameRef::isOverload(const GlobalState &gs) const {
+bool NameRef::isOverloadName(const GlobalState &gs) const {
     if (kind() != NameKind::UNIQUE) {
         return false;
     }

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -102,7 +102,12 @@ string NameRef::toString(const GlobalState &gs) const {
             if (unique->uniqueNameKind == UniqueNameKind::Singleton) {
                 return fmt::format("<Class:{}>", unique->original.show(gs));
             } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
-                return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
+                // We consider the first overload to be the second signature.
+                if (unique->num > 1) {
+                    return absl::StrCat(unique->original.show(gs), " (overload.", unique->num - 1, ")");
+                } else {
+                    return unique->original.show(gs);
+                }
             } else if (unique->uniqueNameKind == UniqueNameKind::DesugarCsend) {
                 return fmt::format("<&{}>", unique->original.show(gs));
             }
@@ -129,7 +134,12 @@ string NameRef::show(const GlobalState &gs) const {
             if (unique->uniqueNameKind == UniqueNameKind::Singleton) {
                 return fmt::format("<Class:{}>", unique->original.show(gs));
             } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
-                return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
+                // We consider the first overload to be the second signature.
+                if (unique->num > 1) {
+                    return absl::StrCat(unique->original.show(gs), " (overload.", unique->num - 1, ")");
+                } else {
+                    return unique->original.show(gs);
+                }
             } else if (unique->uniqueNameKind == UniqueNameKind::MangleRename) {
                 return unique->original.show(gs);
             } else if (unique->uniqueNameKind == UniqueNameKind::TEnum) {

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -180,6 +180,14 @@ void NameRef::sanityCheck(const GlobalState &gs) const {
     }
 }
 
+bool NameRef::isOverload(const GlobalState &gs) const {
+    if (kind() != NameKind::UNIQUE) {
+        return false;
+    }
+
+    return dataUnique(gs)->uniqueNameKind == UniqueNameKind::Overload;
+}
+
 bool NameRef::isClassName(const GlobalState &gs) const {
     switch (kind()) {
         case NameKind::UTF8:

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -48,9 +48,6 @@ string NameRef::showRaw(const GlobalState &gs) const {
                 case UniqueNameKind::MangleRename:
                     kind = "M";
                     break;
-                case UniqueNameKind::MangleRenameOverload:
-                    kind = "V";
-                    break;
                 case UniqueNameKind::Singleton:
                     kind = "S";
                     break;
@@ -133,8 +130,7 @@ string NameRef::show(const GlobalState &gs) const {
                 return fmt::format("<Class:{}>", unique->original.show(gs));
             } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
                 return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
-            } else if (unique->uniqueNameKind == UniqueNameKind::MangleRename ||
-                       unique->uniqueNameKind == UniqueNameKind::MangleRenameOverload) {
+            } else if (unique->uniqueNameKind == UniqueNameKind::MangleRename) {
                 return unique->original.show(gs);
             } else if (unique->uniqueNameKind == UniqueNameKind::TEnum) {
                 // The entire goal of UniqueNameKind::TEnum is to have Name::show print the name as if on the
@@ -192,7 +188,6 @@ bool NameRef::isClassName(const GlobalState &gs) const {
             switch (dataUnique(gs)->uniqueNameKind) {
                 case UniqueNameKind::Singleton:
                 case UniqueNameKind::MangleRename:
-                case UniqueNameKind::MangleRenameOverload:
                 case UniqueNameKind::TEnum:
                 case UniqueNameKind::Struct:
                     return dataUnique(gs)->original.isClassName(gs);
@@ -239,7 +234,6 @@ bool NameRef::isValidConstantName(const GlobalState &gs) const {
                 case UniqueNameKind::Desugar:
                 case UniqueNameKind::Namer:
                 case UniqueNameKind::MangleRename:
-                case UniqueNameKind::MangleRenameOverload:
                 case UniqueNameKind::Singleton:
                 case UniqueNameKind::Overload:
                 case UniqueNameKind::TypeVarName:

--- a/core/Names.h
+++ b/core/Names.h
@@ -23,7 +23,6 @@ enum class UniqueNameKind : uint8_t {
     Desugar,
     Namer,
     MangleRename,
-    MangleRenameOverload,
     Singleton,
     Overload,
     TypeVarName,

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -722,6 +722,11 @@ MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrMod
     }
 
     MethodRef result = owner.data(gs)->findMethod(gs, name);
+    if (result.exists() && result.data(gs)->flags.isOverloaded) {
+        auto overloadName = gs.lookupNameUnique(UniqueNameKind::Overload, name, 1);
+        result = owner.data(gs)->findMethod(gs, overloadName);
+    }
+
     if (result.exists() && !result.data(gs)->flags.isAbstract) {
         return result;
     }
@@ -729,6 +734,12 @@ MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrMod
     for (auto it = owner.data(gs)->mixins().begin(); it != owner.data(gs)->mixins().end(); ++it) {
         ENFORCE(it->exists());
         result = it->data(gs)->findMethod(gs, name);
+
+        if (result.exists() && result.data(gs)->flags.isOverloaded) {
+            auto overloadName = gs.lookupNameUnique(UniqueNameKind::Overload, name, 1);
+            result = owner.data(gs)->findMethod(gs, overloadName);
+        }
+
         if (result.exists() && !result.data(gs)->flags.isAbstract) {
             return result;
         }

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -37,9 +37,6 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
                 case UniqueNameKind::MangleRename:
                     protoName.set_unique(com::stripe::rubytyper::Name::MANGLE_RENAME);
                     break;
-                case UniqueNameKind::MangleRenameOverload:
-                    protoName.set_unique(com::stripe::rubytyper::Name::MANGLE_RENAME_OVERLOAD);
-                    break;
                 case UniqueNameKind::Singleton:
                     protoName.set_unique(com::stripe::rubytyper::Name::SINGLETON);
                     break;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -360,10 +360,8 @@ struct GuessOverloadCandidate {
 MethodRef guessOverload(const GlobalState &gs, ClassOrModuleRef inClass, MethodRef primary, uint16_t numPosArgs,
                         InlinedVector<const TypeAndOrigins *, 2> &args, const vector<TypePtr> &targs, bool hasBlock) {
     counterInc("calls.overloaded_invocations");
-    MethodRef fallback = primary;
     vector<MethodRef> allCandidates;
 
-    allCandidates.emplace_back(primary);
     { // create candidates and sort them by number of arguments(stable by symbol id)
         size_t i = 0;
         MethodRef current = primary;
@@ -391,6 +389,8 @@ MethodRef guessOverload(const GlobalState &gs, ClassOrModuleRef inClass, MethodR
             return false;
         });
     }
+
+    MethodRef fallback = allCandidates.front();
 
     vector<GuessOverloadCandidate> allCandidatesWithConstraints;
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -1096,7 +1096,14 @@ private:
                 continue;
             }
 
-            auto concreteMethodRef = sym.data(ctx)->findConcreteMethodTransitive(ctx, proto.data(ctx)->name);
+            // Overload signatures all have unique names, so to find the name of the concrete implementation we need to
+            // use the original name, not the unique one.
+            auto protoName = proto.data(ctx)->name;
+            if (protoName.isOverload(ctx)) {
+                protoName = protoName.dataUnique(ctx)->original;
+            }
+
+            auto concreteMethodRef = sym.data(ctx)->findConcreteMethodTransitive(ctx, protoName);
             if (concreteMethodRef.exists()) {
                 continue;
             }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -504,7 +504,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
         auto superMethod = klassData->superClass().data(ctx)->findMethodTransitive(ctx, name);
         if (superMethod.exists()) {
             if (superMethod.data(ctx)->flags.isOverloaded) {
-                ENFORCE(!superMethod.data(ctx)->name.isOverload(ctx));
+                ENFORCE(!superMethod.data(ctx)->name.isOverloadName(ctx));
                 auto overload = ctx.state.lookupNameUnique(core::UniqueNameKind::Overload, name, 1);
                 superMethod = superMethod.data(ctx)->owner.data(ctx)->findMethod(ctx, overload);
                 ENFORCE(superMethod.exists());
@@ -517,7 +517,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
         auto superMethod = mixin.data(ctx)->findMethod(ctx, name);
         if (superMethod.exists()) {
             if (superMethod.data(ctx)->flags.isOverloaded) {
-                ENFORCE(!superMethod.data(ctx)->name.isOverload(ctx));
+                ENFORCE(!superMethod.data(ctx)->name.isOverloadName(ctx));
                 auto overload = ctx.state.lookupNameUnique(core::UniqueNameKind::Overload, name, 1);
                 superMethod = superMethod.data(ctx)->owner.data(ctx)->findMethod(ctx, overload);
                 ENFORCE(superMethod.exists());
@@ -1113,7 +1113,7 @@ private:
             // Overload signatures all have unique names, so to find the name of the concrete implementation we need to
             // use the original name, not the unique one.
             auto protoName = proto.data(ctx)->name;
-            if (protoName.isOverload(ctx)) {
+            if (protoName.isOverloadName(ctx)) {
                 protoName = protoName.dataUnique(ctx)->original;
             }
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -503,12 +503,26 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
     if (klassData->superClass().exists()) {
         auto superMethod = klassData->superClass().data(ctx)->findMethodTransitive(ctx, name);
         if (superMethod.exists()) {
+            if (superMethod.data(ctx)->flags.isOverloaded) {
+                ENFORCE(!superMethod.data(ctx)->name.isOverload(ctx));
+                auto overload = ctx.state.lookupNameUnique(core::UniqueNameKind::Overload, name, 1);
+                superMethod = superMethod.data(ctx)->owner.data(ctx)->findMethod(ctx, overload);
+                ENFORCE(superMethod.exists());
+            }
+
             overriddenMethods.emplace_back(superMethod);
         }
     }
     for (const auto &mixin : klassData->mixins()) {
         auto superMethod = mixin.data(ctx)->findMethod(ctx, name);
         if (superMethod.exists()) {
+            if (superMethod.data(ctx)->flags.isOverloaded) {
+                ENFORCE(!superMethod.data(ctx)->name.isOverload(ctx));
+                auto overload = ctx.state.lookupNameUnique(core::UniqueNameKind::Overload, name, 1);
+                superMethod = superMethod.data(ctx)->owner.data(ctx)->findMethod(ctx, overload);
+                ENFORCE(superMethod.exists());
+            }
+
             overriddenMethods.emplace_back(superMethod);
         }
     }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -18,17 +18,10 @@ bool Inference::willRun(core::Context ctx, core::LocOffsets loc, core::MethodRef
     }
 
     const auto &methodData = method.data(ctx);
-    auto name = methodData->name;
-    auto isMangleRenameOverload = name.kind() == core::NameKind::UNIQUE &&
-                                  name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload;
-    if (isMangleRenameOverload || methodData->flags.isOverloaded) {
+    if (methodData->flags.isOverloaded) {
         if (auto e = ctx.beginError(loc, core::errors::Infer::TypecheckOverloadBody)) {
             e.setHeader("Refusing to typecheck `{}` against an overloaded signature", method.show(ctx));
             auto overloadMethod = method;
-            if (isMangleRenameOverload) {
-                overloadMethod =
-                    methodData->owner.data(ctx)->findMember(ctx, name.dataUnique(ctx)->original).asMethodRef();
-            }
             e.addErrorLine(overloadMethod.data(ctx)->loc(), "Given an overloaded signature here");
             e.addErrorNote("Overloads are only supported in RBI files.\n"
                            "    To silence this error, mark this file `{}`\n"

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -972,6 +972,12 @@ vector<SimilarMethod> computeDedupedMethods(const core::GlobalState &gs, const c
         // Since each list is sorted by depth, taking the first elem dedups by depth within each name.
         auto similarMethod = similarMethods[0];
 
+        // We'll find all overloaded names as well as the original def's name, so if this is the original def of an
+        // overload chain, skip it.
+        if (similarMethod.method.data(gs)->flags.isOverloaded && !methodName.isOverload(gs)) {
+            continue;
+        }
+
         if (similarMethod.method.data(gs)->flags.isPrivate && !isPrivateOk) {
             continue;
         }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -963,8 +963,7 @@ vector<SimilarMethod> computeDedupedMethods(const core::GlobalState &gs, const c
 
     for (auto &[methodName, similarMethods] : similarMethodsByName) {
         if (methodName.kind() == core::NameKind::UNIQUE &&
-            (methodName.dataUnique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRename ||
-             methodName.dataUnique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload)) {
+            methodName.dataUnique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRename) {
             // It's possible we want to ignore more things here. But note that we *don't* want to ignore all
             // unique names, because we want each overload to show up but those use unique names.
             continue;

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -974,7 +974,7 @@ vector<SimilarMethod> computeDedupedMethods(const core::GlobalState &gs, const c
 
         // We'll find all overloaded names as well as the original def's name, so if this is the original def of an
         // overload chain, skip it.
-        if (similarMethod.method.data(gs)->flags.isOverloaded && !methodName.isOverload(gs)) {
+        if (similarMethod.method.data(gs)->flags.isOverloaded && !methodName.isOverloadName(gs)) {
             continue;
         }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1052,28 +1052,6 @@ private:
     core::MethodRef insertMethod(core::MutableContext ctx, const core::FoundMethod &method) {
         auto symbol = defineMethod(ctx, method);
         auto name = symbol.data(ctx)->name;
-        // TODO(trevor): should this check the symbol for the overloaded flag instead?
-        // if (name.kind() == core::NameKind::UNIQUE &&
-        //     name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload) {
-        //     // These name kinds are only created in resolver, which means that we must be running on
-        //     // the fast path but not with the incremental namer.
-        //     // If we let the rest of insertMethod run, it will mark this method as public even if it was
-        //     // already private. Then modifyMethod will attempt to mark a method private by name
-        //     // (instead of by name and arity hash), which will have the effect of NOT re-marking the
-        //     // MangleRenameOverload method as private (it will remain public). Then later in
-        //     // resolver, the visibility of the MangleRenameOverload is propagated to all overloads,
-        //     // which will make them all public.
-        //     //
-        //     // Any case where the visibility would have actually changed would have come via an
-        //     // edit, which would then trigger an incremental namer run. So we know that this
-        //     // typecheck is only for the purpose of e.g. answering a hover, and we don't actually
-        //     // need to mutate GlobalState for any changes. So we can just short circuit.
-        //     //
-        //     // One way to change this in the future might be to make FoundModifier attempt to record
-        //     // something about the method arity in addition to just the method's name. But for the
-        //     // time being this hack suffices. (See the commit where this comment was added a test)
-        //     return symbol;
-        // }
 
         // Methods defined at the top level default to private (on Object)
         // Also, the `initialize` method defaults to private

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1020,27 +1020,7 @@ private:
                 // existing one and create a new one
                 if (!isIntrinsic(sym.data(ctx))) {
                     paramMismatchErrors(ctx.withOwner(sym), declLoc, parsedArgs);
-
                     ctx.state.mangleRenameMethod(sym, method.name);
-
-                    // If the symbol we're mangling has overloads, we're in one of two situations:
-                    // 1. This is a symbol from a stdlib rbi,
-                    // 2. We've seen this symbol before, and are operating in incremental mode.
-                    // Either way, we can assume that the MangleOverload version of the name is present and defined on
-                    // the owner. We need to take care here and mangle the original definition, not the first entry
-                    // in the overload chain.
-                    if (sym.data(ctx)->flags.isOverloaded) {
-                        auto overloadName =
-                            ctx.state.lookupNameUnique(core::UniqueNameKind::MangleRenameOverload, method.name, 1);
-                        auto it = owner.data(ctx)->members().find(overloadName);
-                        ENFORCE(it != owner.data(ctx)->members().end());
-                        ENFORCE(it->second.kind() == core::SymbolRef::Kind::Method);
-
-                        // Mangle the original definition in a way that the resolver will pick up on later, when it's
-                        // also mangling the overload sigs.
-                        ctx.state.mangleRenameForOverload(it->second.asMethodRef(), sym.data(ctx)->name);
-                    }
-
                     // Re-enter a new symbol.
                     sym = ctx.state.enterMethodSymbol(declLoc, owner, method.name);
                 } else {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1020,7 +1020,27 @@ private:
                 // existing one and create a new one
                 if (!isIntrinsic(sym.data(ctx))) {
                     paramMismatchErrors(ctx.withOwner(sym), declLoc, parsedArgs);
+
                     ctx.state.mangleRenameMethod(sym, method.name);
+
+                    // If the symbol we're mangling has overloads, we're in one of two situations:
+                    // 1. This is a symbol from a stdlib rbi,
+                    // 2. We've seen this symbol before, and are operating in incremental mode.
+                    // Either way, we can assume that the MangleOverload version of the name is present and defined on
+                    // the owner. We need to take care here and mangle the original definition, not the first entry
+                    // in the overload chain.
+                    if (sym.data(ctx)->flags.isOverloaded) {
+                        auto overloadName =
+                            ctx.state.lookupNameUnique(core::UniqueNameKind::MangleRenameOverload, method.name, 1);
+                        auto it = owner.data(ctx)->members().find(overloadName);
+                        ENFORCE(it != owner.data(ctx)->members().end());
+                        ENFORCE(it->second.kind() == core::SymbolRef::Kind::Method);
+
+                        // Mangle the original definition in a way that the resolver will pick up on later, when it's
+                        // also mangling the overload sigs.
+                        ctx.state.mangleRenameForOverload(it->second.asMethodRef(), sym.data(ctx)->name);
+                    }
+
                     // Re-enter a new symbol.
                     sym = ctx.state.enterMethodSymbol(declLoc, owner, method.name);
                 } else {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1052,27 +1052,28 @@ private:
     core::MethodRef insertMethod(core::MutableContext ctx, const core::FoundMethod &method) {
         auto symbol = defineMethod(ctx, method);
         auto name = symbol.data(ctx)->name;
-        if (name.kind() == core::NameKind::UNIQUE &&
-            name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload) {
-            // These name kinds are only created in resolver, which means that we must be running on
-            // the fast path but not with the incremental namer.
-            // If we let the rest of insertMethod run, it will mark this method as public even if it was
-            // already private. Then modifyMethod will attempt to mark a method private by name
-            // (instead of by name and arity hash), which will have the effect of NOT re-marking the
-            // MangleRenameOverload method as private (it will remain public). Then later in
-            // resolver, the visibility of the MangleRenameOverload is propagated to all overloads,
-            // which will make them all public.
-            //
-            // Any case where the visibility would have actually changed would have come via an
-            // edit, which would then trigger an incremental namer run. So we know that this
-            // typecheck is only for the purpose of e.g. answering a hover, and we don't actually
-            // need to mutate GlobalState for any changes. So we can just short circuit.
-            //
-            // One way to change this in the future might be to make FoundModifier attempt to record
-            // something about the method arity in addition to just the method's name. But for the
-            // time being this hack suffices. (See the commit where this comment was added a test)
-            return symbol;
-        }
+        // TODO(trevor): should this check the symbol for the overloaded flag instead?
+        // if (name.kind() == core::NameKind::UNIQUE &&
+        //     name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload) {
+        //     // These name kinds are only created in resolver, which means that we must be running on
+        //     // the fast path but not with the incremental namer.
+        //     // If we let the rest of insertMethod run, it will mark this method as public even if it was
+        //     // already private. Then modifyMethod will attempt to mark a method private by name
+        //     // (instead of by name and arity hash), which will have the effect of NOT re-marking the
+        //     // MangleRenameOverload method as private (it will remain public). Then later in
+        //     // resolver, the visibility of the MangleRenameOverload is propagated to all overloads,
+        //     // which will make them all public.
+        //     //
+        //     // Any case where the visibility would have actually changed would have come via an
+        //     // edit, which would then trigger an incremental namer run. So we know that this
+        //     // typecheck is only for the purpose of e.g. answering a hover, and we don't actually
+        //     // need to mutate GlobalState for any changes. So we can just short circuit.
+        //     //
+        //     // One way to change this in the future might be to make FoundModifier attempt to record
+        //     // something about the method arity in addition to just the method's name. But for the
+        //     // time being this hack suffices. (See the commit where this comment was added a test)
+        //     return symbol;
+        // }
 
         // Methods defined at the top level default to private (on Object)
         // Also, the `initialize` method defaults to private
@@ -1498,7 +1499,6 @@ private:
         if (memberNameToHash.kind() == core::NameKind::UNIQUE) {
             auto &uniqueData = memberNameToHash.dataUnique(ctx);
             if (uniqueData->uniqueNameKind == core::UniqueNameKind::MangleRename ||
-                uniqueData->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload ||
                 uniqueData->uniqueNameKind == core::UniqueNameKind::Overload) {
                 memberNameToHash = uniqueData->original;
             }

--- a/proto/Name.proto
+++ b/proto/Name.proto
@@ -26,7 +26,7 @@ message Name {
          DEFAULT_ARG = 12;
          PACKAGER = 13;
          // PACKAGER_PRIVATE = 14;
-         MANGLE_RENAME_OVERLOAD = 15;
+         // MANGLE_RENAME_OVERLOAD = 15;
          STRUCT = 16;
     };
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4016,6 +4016,9 @@ public:
         bool isOverloaded = job.isOverloaded;
         auto originalName = mdef.symbol.data(ctx)->name;
 
+        // Propagate the overloadedness to the original definition's symbol.
+        mdef.symbol.data(ctx)->flags.isOverloaded = isOverloaded;
+
         // Unique overload names must have an index that's > 0 associated with them, so we start `i` at `0` to ensure
         // that the first iteration of the loop it's at `1`.
         int i = 0;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4016,17 +4016,9 @@ public:
         bool isOverloaded = job.isOverloaded;
         auto originalName = mdef.symbol.data(ctx)->name;
 
-        bool existingIsAlreadyMangled =
-            originalName.kind() == core::NameKind::UNIQUE &&
-            originalName.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload;
-        if (isOverloaded && !existingIsAlreadyMangled) {
-            ctx.state.mangleRenameForOverload(mdef.symbol, originalName);
-        }
-        if (existingIsAlreadyMangled) {
-            originalName = originalName.dataUnique(ctx)->original;
-        }
-
-        int i = -1;
+        // Unique overload names must have an index that's > 0 associated with them, so we start `i` at `0` to ensure
+        // that the first iteration of the loop it's at `1`.
+        int i = 0;
         std::optional<OverloadedMethodSigInformation> combinedInfo;
         std::vector<OverloadedMethodArgInformation> args;
         for (auto &sig : sigs) {
@@ -4039,7 +4031,7 @@ public:
 
                 overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());
                 overloadSym.data(ctx)->intrinsicOffset = mdef.symbol.data(ctx)->intrinsicOffset;
-                if (i != sigs.size() - 1) {
+                if (i != sigs.size()) {
                     overloadSym.data(ctx)->flags.isOverloaded = true;
                 }
             } else {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4031,6 +4031,7 @@ public:
 
                 overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());
                 overloadSym.data(ctx)->intrinsicOffset = mdef.symbol.data(ctx)->intrinsicOffset;
+                // We don't mark the last sig as overloaded to indicate that this is the last one in the chain.
                 if (i != sigs.size()) {
                     overloadSym.data(ctx)->flags.isOverloaded = true;
                 }

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -933,7 +933,6 @@ TEST_CASE_FIXTURE(ProtocolTest, "OverloadedStdlibSymbolWithMonkeyPatches") {
                                                              "\n"
                                                              "module ::Kernel\n"
                                                              "  def open(*args); end\n"
-                                                             "  module_function :open\n"
                                                              "end\n"
                                                              "")),
                            {});
@@ -956,11 +955,10 @@ TEST_CASE_FIXTURE(ProtocolTest, "OverloadedStdlibSymbolWithMonkeyPatches") {
     REQUIRE(absl::StartsWith(loc->uri, "sorbet:https://github.com/"));
 
     // Read and load in kernel.rbi
-    auto kernelRBIPath = absl::StrReplaceAll(loc->uri, {{"https://github.com/", "https%3A//github.com/"}});
-    auto kernelRBIText = readFile(kernelRBIPath);
+    auto kernelRBIText = readFile(loc->uri);
 
     // At this point we see a crash related to overload processing, prior to https://github.com/sorbet/sorbet/pull/8303
-    assertErrorDiagnostics(send(*openFile(kernelRBIPath, kernelRBIText)), {});
+    assertErrorDiagnostics(send(*openFile(loc->uri, kernelRBIText)), {});
 }
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -922,4 +922,45 @@ TEST_CASE_FIXTURE(ProtocolTest, "DidChangeConfigurationNotificationUpdatesHighli
                              });
 }
 
+TEST_CASE_FIXTURE(ProtocolTest, "OverloadedStdlibSymbolWithMonkeyPatches") {
+    const bool supportsMarkdown = false;
+    const bool supportsCodeActionResolve = true;
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->supportsSorbetURIs = true;
+    assertErrorDiagnostics(initializeLSP(supportsMarkdown, supportsCodeActionResolve, move(initOptions)), {});
+
+    assertErrorDiagnostics(send(*openFile("monkey_patch.rb", "# typed: false\n"
+                                                             "\n"
+                                                             "module ::Kernel\n"
+                                                             "  def open(*args); end\n"
+                                                             "  module_function :open\n"
+                                                             "end\n"
+                                                             "")),
+                           {});
+
+    assertErrorDiagnostics(send(*openFile("test.rb", "# typed: true\n"
+                                                     "\n"
+                                                     "class Test\n"
+                                                     "  def test()\n"
+                                                     "    self.send(:p)\n"
+                                                     "  end\n"
+                                                     "end\n"
+                                                     "")),
+                           {});
+
+    // Lookup the definition of `send` on the `self.send(:p)` line of `test.rb`.
+    auto locs = getDefinitions("test.rb", 4, 9);
+    REQUIRE_EQ(1, locs.size());
+    auto &loc = locs.front();
+    fmt::print("loc: {}\n", loc->uri);
+    REQUIRE(absl::StartsWith(loc->uri, "sorbet:https://github.com/"));
+
+    // Read and load in kernel.rbi
+    auto kernelRBIPath = absl::StrReplaceAll(loc->uri, {{"https://github.com/", "https%3A//github.com/"}});
+    auto kernelRBIText = readFile(kernelRBIPath);
+
+    // At this point we see a crash related to overload processing, prior to https://github.com/sorbet/sorbet/pull/8303
+    assertErrorDiagnostics(send(*openFile(kernelRBIPath, kernelRBIText)), {});
+}
+
 } // namespace sorbet::test::lsp

--- a/test/testdata/namer/array_sum.rb
+++ b/test/testdata/namer/array_sum.rb
@@ -12,7 +12,7 @@
 class Array
   extend T::Sig
   sig {returns(T.untyped)}
-  def sum; end
+  def sum; end # error: Method `Array#sum` redefined without matching argument count
 end
 
 T.reveal_type(T::Array[Integer].new.sum) # error: `T.untyped`


### PR DESCRIPTION
Currently, methods with overloaded signatures present move the original definition's symbol out of the way with a special `MangleRenameOverload` name and give the first overload the method's original name. All subsequent overload sigs are given separate unique `Overload` names to indicate that they are the additional overload sigs of the method. For example, after the following method has gone completely through the pipeline, three names will be present:

```ruby
sig { params(x: Integer).void } # 1
sig { params(x: Float).void }   # 2
def foo(x); end                 # 3
```

1. `<U foo>` - the first sig takes over the `def` on line 3's name
2. `<O <U foo> $1>` - the first overload signature of the symbol with name `foo`
3. `<V <U foo> $1>` - the original `def`, renamed with a `MangleRenameOverload` unique name

This naming convention is assumed in multiple places in sorbet, and there are cases where when it's detected that we're processing an overload name, we take its original and mangle it to find the `MangleRenameOverload` version.

If `foo` gets re-defined later with a different type, the mangling logic in the namer kicks in to adjust the existing definition. However, it only adjusts the first signature as the `def` has been mangled already, and we end up with a situation where the first name in the list is changed to `<M <U foo> $1>`, but all the other names related to the overloaded definition stay the same.

This can cause sorbet to crash when reprocessing stdlib rbis, as mangling the name for signature 1 only breaks the invariant that you can always get back to the `MangleRenameOverload` name by taking the name (or the original name in the case of an overload) and looking up the first `MangleRenameOverload` variant of it.

This PR addresses this problem by instead keeping the original definition named `<U foo>`, instead of mangling it and giving that name to the first signature. All signatures are then given overload names, so the naming scheme for the example above ends up like the following:

1. `<O <U foo> $1>`
2. `<O <U foo> $2>`
3. `<U foo>`

This brings with it the advantage that the normal name mangling behavior in the namer will preserve the invariants we would expect, when run in concert with the resolver. The namer will mangle the name of the `foo` method to `<M <U foo> $1>`, and the resolver will then introduce mangled overloads for each signature, which it does even when not running in incremental mode.

The one downside here is that the name `<U foo>` no longer points to something that's guaranteed to have a callable type associated with it. Now when types are going to be examined, the `isOverloaded` flag on the method must be checked to determine if it's necessary to start walking through the chain of overload signature names, as the original `def` is the owner of that name and not the first sig.

### Motivation
Simplifying the organization of overloads in the symbol table to avoid crashes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I had a heck of a time replicating this outside of Stripe's codebase. It requires multiple steps to setup and trigger, and I'm currently unsure how to replicate that with our test suite.