### PR TITLE
The rdoc rbi for the Inline class defines `self.new` twice

### DIFF
--- a/rbi/stdlib/rdoc.rbi
+++ b/rbi/stdlib/rdoc.rbi
@@ -7753,16 +7753,6 @@ end
 # [`Inline`](https://docs.ruby-lang.org/en/2.6.0/RDoc/RD/Inline.html) keeps
 # track of markup and labels to create proper links.
 class RDoc::RD::Inline
-  # Creates a new
-  # [`Inline`](https://docs.ruby-lang.org/en/2.6.0/RDoc/RD/Inline.html) for
-  # `rdoc` and `reference`.
-  #
-  # `rdoc` may be another
-  # [`Inline`](https://docs.ruby-lang.org/en/2.6.0/RDoc/RD/Inline.html) or a
-  # [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html). If `reference`
-  # is not given it will use the text from `rdoc`.
-  def self.new(rdoc, reference); end
-
   def ==(other); end
 
   # Appends `more` to this inline. `more` may be a


### PR DESCRIPTION
The `RDoc::RD::Inline` class in rdoc.rbi defines `self.new` twice, once at line 7764:
https://github.com/sorbet/sorbet/blob/cc57c9f9acf043af811d745fb599e232cc087322/rbi/stdlib/rdoc.rbi#L7756-L7764

and once at line 7794

https://github.com/sorbet/sorbet/blob/cc57c9f9acf043af811d745fb599e232cc087322/rbi/stdlib/rdoc.rbi#L7786-L7794

Let's standardize on the definition on 7794, as it adds a default argument to the signature.


### Motivation
Ensuring that we're not accidentally mangling names in the payload.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
