### PR TITLE
Move vector allocation out of a loop over all files

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -114,6 +114,9 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
         return result;
     }
 
+    vector<core::WithoutUniqueNameHash> intersection;
+    intersection.reserve(result.changedSymbolNameHashes.size());
+
     int i = -1;
     for (auto &oldFile : gs.getFiles()) {
         i++;
@@ -138,7 +141,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
 
         ENFORCE(oldFile->getFileHash() != nullptr);
         const auto &oldHash = *oldFile->getFileHash();
-        vector<core::WithoutUniqueNameHash> intersection;
+        intersection.clear();
         absl::c_set_intersection(result.changedSymbolNameHashes, oldHash.usages.nameHashes,
                                  std::back_inserter(intersection));
         if (intersection.empty()) {


### PR DESCRIPTION
We know the maximum size of the intersection vector, and we can use that knowledge to amortize the allocation across the loop over all files in the project. This will avoid thrashing the heap if there is a popular name in the project, and should mean that the only additional allocations come from emplacing file refs in `extraFiles`.

### Motivation
Performance.

### Test plan
This should be a no-op, and we don't have a way to test for reductions in
allocation.
