### PR TITLE
Fix handling of `.override` in `attr_*` chains at end of signature

### DIFF
--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -200,7 +200,8 @@ template <typename T> T *castSigImpl(T *send) {
     auto *block = send->block();
     ENFORCE(block);
     auto *body = ast::cast_tree<ast::Send>(block->body);
-    while (body != nullptr && (body->fun == core::Names::checked() || body->fun == core::Names::onFailure())) {
+    while (body != nullptr && (body->fun == core::Names::checked() || body->fun == core::Names::onFailure() ||
+                               body->fun == core::Names::override_())) {
         body = ast::cast_tree<ast::Send>(body->recv);
     }
     if (body != nullptr && (body->fun == core::Names::void_() || body->fun == core::Names::returns())) {

--- a/test/testdata/rewriter/attr_override.rb
+++ b/test/testdata/rewriter/attr_override.rb
@@ -1,0 +1,29 @@
+# typed: strict
+
+class Foo
+  extend T::Sig
+
+  sig {returns(T.nilable(Integer))}
+  attr_accessor :method1, :method2, :method3, :method4
+end
+
+class FooChild < Foo
+  extend T::Sig
+
+  sig {void}
+  def initialize
+    @method1 = @method2 = @method3 = @method4 = T.let(nil, T.nilable(Integer))
+  end
+
+  sig {override.returns(T.nilable(Integer))}
+  attr_accessor :method1
+
+  sig {returns(T.nilable(Integer)).override}
+  attr_accessor :method2
+
+  sig {override.returns(T.nilable(Integer)).checked(:always)}
+  attr_accessor :method3
+
+  sig {returns(T.nilable(Integer)).override.checked(:always)}
+  attr_accessor :method4
+end


### PR DESCRIPTION
Added support for the `.override` modifier in method signatures when it appears at the end of the chain for `attr_reader`, `attr_writer`, and `attr_accessor`. Previously, the rewriter only handled `.override` correctly when it appeared at the beginning of the chain.

This was done by modifying `Util.cc` to ensure that `.override` is properly handled during signature chain traversal by adding a condition to identify it explicitly.

### Motivation
Fixes #4456: "Rewriter doesn't parse sigs with override"


### Test plan
Added a regression test in `test/testdata/rewriter/attr_override.rb` that verifies:

- `.override` works in different positions in the signature chain
- Combinations with other modifiers (like `.checked`) work properly

Locally tested with the UBSan and ASan config.