### PR TITLE
Don't allocate the intersection, just check if it's empty

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -50,6 +50,32 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     return copy;
 }
 
+namespace {
+
+// Returns `true` if the two containers share a value, and `false` otherwise. This requires that the two containers are
+// sorted, which is also a requirement of using `absl::c_set_intersetion`, so this is a drop-in replacement when the
+// resulting set isn't needed.
+template <typename C1, typename C2> bool intersects(const C1 &left, const C2 &right) {
+    auto leftIt = left.begin();
+    auto rightIt = right.begin();
+
+    while (leftIt != left.end() && rightIt != right.end()) {
+        if (*leftIt == *rightIt) {
+            return true;
+        }
+
+        if (*leftIt < *rightIt) {
+            ++leftIt;
+        } else {
+            ++rightIt;
+        }
+    }
+
+    return false;
+}
+
+} // namespace
+
 LSPFileUpdates::FastPathFilesToTypecheckResult
 LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPConfiguration &config,
                                          const vector<shared_ptr<core::File>> &updatedFiles,
@@ -114,9 +140,6 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
         return result;
     }
 
-    vector<core::WithoutUniqueNameHash> intersection;
-    intersection.reserve(result.changedSymbolNameHashes.size());
-
     int i = -1;
     for (auto &oldFile : gs.getFiles()) {
         i++;
@@ -140,11 +163,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
         }
 
         ENFORCE(oldFile->getFileHash() != nullptr);
-        const auto &oldHash = *oldFile->getFileHash();
-        intersection.clear();
-        absl::c_set_intersection(result.changedSymbolNameHashes, oldHash.usages.nameHashes,
-                                 std::back_inserter(intersection));
-        if (intersection.empty()) {
+        if (!intersects(result.changedSymbolNameHashes, oldFile->getFileHash()->usages.nameHashes)) {
             continue;
         }
 


### PR DESCRIPTION
As a follow-up to #8307, avoid allocating a vector entirely, as we only need to know if the intersection is empty, not what it contains.

### Motivation
Removing allocations from the fast-path decision path.

### Test plan
This is only a performance improvement.
