### PR TITLE
Parallelize `Packager::runIncremental`

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -255,7 +255,7 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
             // the package prefixes" with the later living in `pipeline::nameAndResolve` once again
             // (thus restoring the symmetry).
             // TODO(jez) Parallelize this
-            what = packager::Packager::runIncremental(gs, move(what));
+            what = packager::Packager::runIncremental(gs, move(what), workers);
         }
 #endif
         auto runIncrementalNamer = foundHashesForFiles.has_value() && !foundHashesForFiles->empty();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1757,7 +1757,6 @@ void Packager::run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::P
     }
 }
 
-// TODO(jez) Parallelize this
 vector<ast::ParsedFile> Packager::runIncremental(const core::GlobalState &gs, vector<ast::ParsedFile> files,
                                                  WorkerPool &workers) {
     // Note: This will only run if packages have not been changed (byte-for-byte equality).

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1758,7 +1758,8 @@ void Packager::run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::P
 }
 
 // TODO(jez) Parallelize this
-vector<ast::ParsedFile> Packager::runIncremental(const core::GlobalState &gs, vector<ast::ParsedFile> files) {
+vector<ast::ParsedFile> Packager::runIncremental(const core::GlobalState &gs, vector<ast::ParsedFile> files,
+                                                 WorkerPool &workers) {
     // Note: This will only run if packages have not been changed (byte-for-byte equality).
     // TODO(nroman-stripe) This could be further incrementalized to avoid processing all packages by
     // building in an understanding of the dependencies between packages.

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -45,7 +45,8 @@ public:
     static void run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
-    static std::vector<ast::ParsedFile> runIncremental(const core::GlobalState &gs, std::vector<ast::ParsedFile> files, WorkerPool &workers);
+    static std::vector<ast::ParsedFile> runIncremental(const core::GlobalState &gs, std::vector<ast::ParsedFile> files,
+                                                       WorkerPool &workers);
 
     static void dumpPackageInfo(const core::GlobalState &gs, std::string output);
 

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -45,7 +45,7 @@ public:
     static void run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
-    static std::vector<ast::ParsedFile> runIncremental(const core::GlobalState &gs, std::vector<ast::ParsedFile> files);
+    static std::vector<ast::ParsedFile> runIncremental(const core::GlobalState &gs, std::vector<ast::ParsedFile> files, WorkerPool &workers);
 
     static void dumpPackageInfo(const core::GlobalState &gs, std::string output);
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -805,7 +805,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     if (enablePackager) {
         absl::c_stable_partition(trees, [&](const auto &pf) { return pf.file.isPackage(*gs); });
-        trees = packager::Packager::runIncremental(*gs, move(trees));
+        trees = packager::Packager::runIncremental(*gs, move(trees), *workers);
         for (auto &tree : trees) {
             handler.addObserved(*gs, "package-tree", [&]() {
                 return fmt::format("# -- {} --\n{}", tree.file.data(*gs).path(), tree.tree.toString(*gs));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Per the tin. 
The change passes a worker pool into `Packager::runIncremental` and uses existing concurrency primitives to run the body of the function in parallel. Very similar to `Packager::run`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

![image](https://github.com/user-attachments/assets/527d251a-ff17-4786-856e-22fddd951793)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

This change also has been manually tested on Stripe's codebase. I didn't see any unexpected behaviors 
