### PR TITLE
Report different errors for generic argument issues in resolver and in infer

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -219,7 +219,7 @@ public:
     // something that look like type syntax in a method body.
     static TypePtr applyTypeArguments(const GlobalState &gs, const CallLocs &locs, uint16_t numPosArgs,
                                       const InlinedVector<const TypeAndOrigins *, 2> &args,
-                                      ClassOrModuleRef genericClass);
+                                      ClassOrModuleRef genericClass, bool inResolver);
 };
 
 struct Intrinsic {

--- a/core/Types.h
+++ b/core/Types.h
@@ -219,7 +219,8 @@ public:
     // something that look like type syntax in a method body.
     static TypePtr applyTypeArguments(const GlobalState &gs, const CallLocs &locs, uint16_t numPosArgs,
                                       const InlinedVector<const TypeAndOrigins *, 2> &args,
-                                      ClassOrModuleRef genericClass, bool inResolver);
+                                      ClassOrModuleRef genericClass, ErrorClass genericArgumentCountMismatchError,
+                                      ErrorClass genericArgumentKeywordArgsError);
 };
 
 struct Intrinsic {

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -83,6 +83,8 @@ constexpr ErrorClass HasAttachedClassIncluded{5074, StrictLevel::False};
 constexpr ErrorClass TypeAliasToTypeMember{5075, StrictLevel::False};
 constexpr ErrorClass TNilableArity{5076, StrictLevel::False};
 constexpr ErrorClass UnsupportedLiteralType{5077, StrictLevel::False};
+constexpr ErrorClass GenericArgumentCountMismatch{5078, StrictLevel::True};
+constexpr ErrorClass GenericArgumentKeywordArgs{5079, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1749,7 +1749,8 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
             }
 
             auto returnType = Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, applied->klass,
-                                                        /* inResolver */ false);
+                                                        core::errors::Infer::GenericArgumentCountMismatch,
+                                                        core::errors::Infer::GenericArgumentKeywordArgs);
             return DispatchResult(returnType, args.selfType, Symbols::T_Generic_squareBrackets());
         }
         case Names::bind().rawId():
@@ -2239,8 +2240,9 @@ public:
             return;
         }
 
-        res.returnType =
-            Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, attachedClass, /* inResolver */ false);
+        res.returnType = Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, attachedClass,
+                                                   core::errors::Infer::GenericArgumentCountMismatch,
+                                                   core::errors::Infer::GenericArgumentKeywordArgs);
     }
 } T_Generic_squareBrackets;
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1748,7 +1748,8 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
                 return badMetaTypeCall(gs, args, errLoc, this->wrapped);
             }
 
-            auto returnType = Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, applied->klass);
+            auto returnType = Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, applied->klass,
+                                                        /* inResolver */ false);
             return DispatchResult(returnType, args.selfType, Symbols::T_Generic_squareBrackets());
         }
         case Names::bind().rawId():
@@ -2238,7 +2239,8 @@ public:
             return;
         }
 
-        res.returnType = Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, attachedClass);
+        res.returnType =
+            Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, attachedClass, /* inResolver */ false);
     }
 } T_Generic_squareBrackets;
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1003,7 +1003,8 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
 // again by infer).
 
 TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, uint16_t numPosArgs,
-                                  const InlinedVector<const TypeAndOrigins *, 2> &args, ClassOrModuleRef genericClass) {
+                                  const InlinedVector<const TypeAndOrigins *, 2> &args, ClassOrModuleRef genericClass,
+                                  bool inResolver) {
     genericClass = genericClass.maybeUnwrapBuiltinGenericForwarder();
 
     int arity;
@@ -1020,7 +1021,9 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
         auto end = locs.args.back().endPos();
         core::Loc kwargsLoc{locs.file, begin, end};
 
-        if (auto e = gs.beginError(kwargsLoc, errors::Infer::GenericArgumentKeywordArgs)) {
+        auto errorClass =
+            inResolver ? errors::Resolver::GenericArgumentKeywordArgs : errors::Infer::GenericArgumentKeywordArgs;
+        if (auto e = gs.beginError(kwargsLoc, errorClass)) {
             e.setHeader("Keyword arguments given to `{}`", genericClass.show(gs));
             // offer an autocorrect to turn the keyword args into a hash if there is no double-splat
             if (numKwArgs % 2 == 0 && kwargsLoc.exists()) {
@@ -1044,7 +1047,9 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
         auto squareBracketsLoc = core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
         auto errLoc =
             !locs.args.empty() ? core::Loc(locs.file, locs.args.front().join(locs.args.back())) : squareBracketsLoc;
-        if (auto e = gs.beginError(errLoc, errors::Infer::GenericArgumentCountMismatch)) {
+        auto errorClass =
+            inResolver ? errors::Resolver::GenericArgumentCountMismatch : errors::Infer::GenericArgumentCountMismatch;
+        if (auto e = gs.beginError(errLoc, errorClass)) {
             if (arity == 0) {
                 if (genericClass.data(gs)->typeMembers().empty()) {
                     e.setHeader("`{}` is not a generic class, but was given type parameters", genericClass.show(gs));

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1004,7 +1004,8 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
 
 TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, uint16_t numPosArgs,
                                   const InlinedVector<const TypeAndOrigins *, 2> &args, ClassOrModuleRef genericClass,
-                                  bool inResolver) {
+                                  ErrorClass genericArgumentCountMismatchError,
+                                  ErrorClass genericArgumentKeywordArgsError) {
     genericClass = genericClass.maybeUnwrapBuiltinGenericForwarder();
 
     int arity;
@@ -1021,9 +1022,7 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
         auto end = locs.args.back().endPos();
         core::Loc kwargsLoc{locs.file, begin, end};
 
-        auto errorClass =
-            inResolver ? errors::Resolver::GenericArgumentKeywordArgs : errors::Infer::GenericArgumentKeywordArgs;
-        if (auto e = gs.beginError(kwargsLoc, errorClass)) {
+        if (auto e = gs.beginError(kwargsLoc, genericArgumentKeywordArgsError)) {
             e.setHeader("Keyword arguments given to `{}`", genericClass.show(gs));
             // offer an autocorrect to turn the keyword args into a hash if there is no double-splat
             if (numKwArgs % 2 == 0 && kwargsLoc.exists()) {
@@ -1047,9 +1046,7 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
         auto squareBracketsLoc = core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
         auto errLoc =
             !locs.args.empty() ? core::Loc(locs.file, locs.args.front().join(locs.args.back())) : squareBracketsLoc;
-        auto errorClass =
-            inResolver ? errors::Resolver::GenericArgumentCountMismatch : errors::Infer::GenericArgumentCountMismatch;
-        if (auto e = gs.beginError(errLoc, errorClass)) {
+        if (auto e = gs.beginError(errLoc, genericArgumentCountMismatchError)) {
             if (arity == 0) {
                 if (genericClass.data(gs)->typeMembers().empty()) {
                     e.setHeader("`{}` is not a generic class, but was given type parameters", genericClass.show(gs));

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1453,7 +1453,8 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
         auto genericClass = corrected.asClassOrModuleRef();
         ENFORCE_NO_TIMER(genericClass.exists());
         core::CallLocs locs{ctx.file, s.loc, s.recv.loc(), s.funLoc, argLocs};
-        auto out = core::Types::applyTypeArguments(ctx, locs, s.numPosArgs(), targs, genericClass);
+        auto out =
+            core::Types::applyTypeArguments(ctx, locs, s.numPosArgs(), targs, genericClass, /* inResolver */ true);
 
         if (out.isUntyped()) {
             // Using a generic untyped type here will lead to incorrect handling of global state hashing,

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1453,8 +1453,9 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
         auto genericClass = corrected.asClassOrModuleRef();
         ENFORCE_NO_TIMER(genericClass.exists());
         core::CallLocs locs{ctx.file, s.loc, s.recv.loc(), s.funLoc, argLocs};
-        auto out =
-            core::Types::applyTypeArguments(ctx, locs, s.numPosArgs(), targs, genericClass, /* inResolver */ true);
+        auto out = core::Types::applyTypeArguments(ctx, locs, s.numPosArgs(), targs, genericClass,
+                                                   core::errors::Resolver::GenericArgumentCountMismatch,
+                                                   core::errors::Resolver::GenericArgumentKeywordArgs);
 
         if (out.isUntyped()) {
             // Using a generic untyped type here will lead to incorrect handling of global state hashing,

--- a/test/cli/autocorrect-kwargs/test.out
+++ b/test/cli/autocorrect-kwargs/test.out
@@ -6,7 +6,7 @@ autocorrect-kwargs.rb:6: `returns` does not accept keyword arguments https://srb
      6 |sig {returns(foo: Integer, bar: String)}
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-autocorrect-kwargs.rb:13: Keyword arguments given to `Array` https://srb.help/7032
+autocorrect-kwargs.rb:13: Keyword arguments given to `Array` https://srb.help/5079
     13 |sig {returns(T::Array[foo: Integer])}
                               ^^^^^^^^^^^^
   Autocorrect: Done
@@ -14,7 +14,7 @@ autocorrect-kwargs.rb:13: Keyword arguments given to `Array` https://srb.help/70
     13 |sig {returns(T::Array[foo: Integer])}
                               ^^^^^^^^^^^^
 
-autocorrect-kwargs.rb:13: Wrong number of type parameters for `Array`. Expected: `1`, got: `0` https://srb.help/7010
+autocorrect-kwargs.rb:13: Wrong number of type parameters for `Array`. Expected: `1`, got: `0` https://srb.help/5078
     13 |sig {returns(T::Array[foo: Integer])}
                               ^^^^^^^^^^^^
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3324,6 +3324,16 @@ There are two options:
   move(direction)
   ```
 
+
+## 5078
+This error is functionally equivalent to error [7010](#7010). It is reported during the inference stage, while 5078 is reported during the resolver stage.
+
+For detailed information and examples, please refer to the documentation for error [7010](#7010).
+## 5079
+This error is functionally equivalent to error [7032](#7032). It is reported during the inference stage, while 5079 is reported during the resolver stage.
+
+For detailed information and examples, please refer to the documentation for error [7032](#7032).
+
 ## 6001
 
 Certain Ruby keywords like `break`, `next`, and `retry` can only be used inside

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3324,15 +3324,21 @@ There are two options:
   move(direction)
   ```
 
-
 ## 5078
-This error is functionally equivalent to error [7010](#7010). It is reported during the inference stage, while 5078 is reported during the resolver stage.
 
-For detailed information and examples, please refer to the documentation for error [7010](#7010).
+This error is functionally equivalent to error [7010](#7010). It is reported
+during the inference stage, while 5078 is reported during the resolver stage.
+
+For detailed information and examples, please refer to the documentation for
+error [7010](#7010).
+
 ## 5079
-This error is functionally equivalent to error [7032](#7032). It is reported during the inference stage, while 5079 is reported during the resolver stage.
 
-For detailed information and examples, please refer to the documentation for error [7032](#7032).
+This error is functionally equivalent to error [7032](#7032). It is reported
+during the inference stage, while 5079 is reported during the resolver stage.
+
+For detailed information and examples, please refer to the documentation for
+error [7032](#7032).
 
 ## 6001
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Previously resolver reported the `sorbet::core::errors::Infer::GenericArgumentCountMismatch` and `sorbet::core::errors::Infer::GenericArgumentKeywordArgs` errors. These are infer stage errors. 

The change creates copies of these errors with different error codes specifically for the resolver stage and updates their usage sites.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Pulling out a change from https://github.com/sorbet/sorbet/pull/7796
### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
