### PR TITLE
Validate `type_member` args before symbol manipulation

### DIFF
--- a/test/testdata/namer/type_member_extra_args.rb
+++ b/test/testdata/namer/type_member_extra_args.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  extend T::Generic
+
+  X = type_member(:out, :extra) # error: Too many args in type definition
+  Y = type_member # This is valid - no args
+  Z = type_member(:out) # This is valid - one arg
+end


### PR DESCRIPTION
Sorbet was crashing before it could even hit the "Too many args in type definition" error because it was using `ENFORCE` to assume the type member symbol exists and updates `asgn.lhs` to reference it before it even does the check for the number of positional arguments. This change modifies the `handleTypeMemberDefinition` method in `namer.cc` so that the validation step happens before any symbol manipulation.

### Motivation
Fixes #6780: "ENFORCE failure when giving extra arg to type_member"


### Test plan

See included automated tests.
