### PR TITLE
refactor(namer): enhance type_member/type_template error handling and autocorrect

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2007,7 +2007,7 @@ public:
                     auto firstArgLoc = send->getPosArg(0).loc();
                     auto argsLoc = send->argsLoc();
                     auto replacementRange = core::Loc(ctx.file, firstArgLoc.endPos(), argsLoc.endPos());
-                    e.replaceWith("Retain only the first argument", replacementRange, "");
+                    e.replaceWith("Delete extra args", replacementRange, "");
                 }
                 auto send = ast::MK::Send0Block(asgn.loc, ast::MK::T(asgn.loc), core::Names::typeAlias(),
                                                 asgn.loc.copyWithZeroLength(),

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2007,8 +2007,7 @@ public:
                     auto firstArgLoc = send->getPosArg(0).loc();
                     auto argsLoc = send->argsLoc();
                     auto replacementRange = core::Loc(ctx.file, firstArgLoc.endPos(), argsLoc.endPos());
-                    e.replaceWith("Retain only the first argument", replacementRange, "",
-                                  ctx.locAt(firstArgLoc).source(ctx).value());
+                    e.replaceWith("Retain only the first argument", replacementRange, "");
                 }
                 auto send = ast::MK::Send0Block(asgn.loc, ast::MK::T(asgn.loc), core::Names::typeAlias(),
                                                 asgn.loc.copyWithZeroLength(),

--- a/test/testdata/namer/type_member_extra_args.rb.autocorrects.exp
+++ b/test/testdata/namer/type_member_extra_args.rb.autocorrects.exp
@@ -1,12 +1,13 @@
+# -- test/testdata/namer/type_member_extra_args.rb --
 # typed: true
 
 class A
   extend T::Sig
   extend T::Generic
 
-  X = type_member(:out, :extra)
+  X = type_member(:out)
 #                       ^^^^^^ error: Too many arguments in `type_member` definition for `X`
-  Y = type_template(:out, :extra)
+  Y = type_template(:out)
 #                         ^^^^^^ error: Too many arguments in `type_template` definition for `Y`
 
   sig {params(x: X).void}
@@ -14,3 +15,4 @@ class A
     T.reveal_type(x) # error: Revealed type: `T.untyped`
   end
 end
+# ------------------------------


### PR DESCRIPTION
This is a follow-up to my previous PR https://github.com/sorbet/sorbet/pull/8314 and is intended to improve a few areas based on feedback. The argument check was modified to use the proper helpers and the `std::` namespace references were removed from the calls to `move`. The test was expanded to use `T.reveal_type` to explicitly verify that the invalid type member becomes `T.untyped` when used in a method signature. I also included an `.exp` test to verify autocorrect output for invalid type definitions. The `Too many args in type definition` error message is now more specific about which type definition is failing, as well as interpolating the name of the bad constant. `e.replaceWith` was added to replace all arguments with the first argument if there are more than one. The final change is an improvement to the error location for `type_member` extra args. Previously, it would point to the whole method call. This change modifies it to be more consistent with similar errors by pointing directly to the bad arguments. Please let me know if I haven't properly captured the idea behind the autocorrect implementation.


### Motivation
Suggestions from jez on https://github.com/sorbet/sorbet/pull/8314


### Test plan

See included automated tests.