### PR TITLE
Allow multiple root directories

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -21,7 +21,7 @@ namespace {
 
 string getRootPath(const shared_ptr<LSPOutput> &output, const options::Options &opts,
                    const shared_ptr<spdlog::logger> &logger) {
-    if (opts.rawInputDirNames.size() != 1) {
+    if (!opts.lspMultipleDirEnabled && opts.rawInputDirNames.size() != 1) {
         auto msg =
             fmt::format("Sorbet's language server requires a single input directory. However, {} are configured: [{}]",
                         opts.rawInputDirNames.size(), absl::StrJoin(opts.rawInputDirNames, ", "));

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -21,10 +21,13 @@ namespace {
 
 string getRootPath(const shared_ptr<LSPOutput> &output, const options::Options &opts,
                    const shared_ptr<spdlog::logger> &logger) {
-    if (!opts.lspMultipleDirEnabled && opts.rawInputDirNames.size() != 1) {
-        auto msg =
-            fmt::format("Sorbet's language server requires a single input directory. However, {} are configured: [{}]",
-                        opts.rawInputDirNames.size(), absl::StrJoin(opts.rawInputDirNames, ", "));
+    if (opts.rawInputDirNames.empty() ||
+        (opts.rawInputDirNames.size() > 1 && !opts.forciblySilenceLspMultipleDirError)) {
+        string msg = opts.forciblySilenceLspMultipleDirError
+                         ? "Sorbet's language server requires at least one input directory."
+                         : "Sorbet's language server requires a single input directory.";
+        msg += fmt::format(" However, {} are configured: [{}]", opts.rawInputDirNames.size(),
+                           absl::StrJoin(opts.rawInputDirNames, ", "));
         logger->error(msg);
         auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
         output->write(make_unique<LSPMessage>(

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -209,7 +209,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
     const auto &opts = config->opts;
     auto &logger = config->logger;
     if (!opts.disableWatchman) {
-        if (opts.rawInputDirNames.size() != 1 || !opts.rawInputFileNames.empty()) {
+        if (!opts.lspMultipleDirEnabled && (opts.rawInputDirNames.size() != 1 || !opts.rawInputFileNames.empty())) {
             auto msg = "Watchman support currently only works when Sorbet is run with a single input directory. If "
                        "Watchman is not needed, run Sorbet with `--disable-watchman`.";
             logger->error(msg);

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -209,9 +209,14 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
     const auto &opts = config->opts;
     auto &logger = config->logger;
     if (!opts.disableWatchman) {
-        if (!opts.lspMultipleDirEnabled && (opts.rawInputDirNames.size() != 1 || !opts.rawInputFileNames.empty())) {
-            auto msg = "Watchman support currently only works when Sorbet is run with a single input directory. If "
-                       "Watchman is not needed, run Sorbet with `--disable-watchman`.";
+        if (opts.rawInputDirNames.empty() ||
+            (opts.rawInputDirNames.size() > 1 && !opts.forciblySilenceLspMultipleDirError) ||
+            !opts.rawInputFileNames.empty()) {
+            string msg =
+                opts.forciblySilenceLspMultipleDirError
+                    ? "Watchman support requires at least one input directory and does not accept input files."
+                    : "Watchman support currently only works when Sorbet is run with a single input directory.";
+            msg += " If Watchman is not needed, run Sorbet with `--disable-watchman`.";
             logger->error(msg);
             auto params = make_unique<ShowMessageParams>(MessageType::Error, msg);
             config->output->write(make_unique<LSPMessage>(

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -548,14 +548,17 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
 
     options.add_options(section)("enable-experimental-lsp-extract-to-variable",
                                  "Enable experimental LSP feature: Extract To Variable");
-    options.add_options(section)("enable-experimental-lsp-multiple-dir",
-                                 "Enable experimental LSP feature: Multiple --dir options");
     options.add_options(section)(
         "enable-all-experimental-lsp-features",
         "Enable every experimental LSP feature. (WARNING: can be crashy; for developer use only. "
         "End users should prefer to use `--enable-all-beta-lsp-features`, instead.)");
     options.add_options(section)("enable-all-beta-lsp-features",
                                  "Enable (expected-to-be-non-crashy) early-access LSP features.");
+    options.add_options(section)(
+        "forcibly-silence-lsp-multiple-dir-error",
+        "Allow the LSP to start with multiple `--dir` options by silencing the error. (WARNING: This flag does not "
+        "address the known issues with multiple directory support in LSP mode. You are likely to encounter unexpected "
+        "behavior.)");
     // }}}
 
     // ----- PERFORMANCE -------------------------------------------------- {{{
@@ -948,7 +951,7 @@ void readOptions(Options &opts,
         opts.lspDocumentHighlightEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-highlight"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
-        opts.lspMultipleDirEnabled = raw["enable-experimental-lsp-multiple-dir"].as<bool>();
+        opts.forciblySilenceLspMultipleDirError = raw["forcibly-silence-lsp-multiple-dir-error"].as<bool>();
         opts.rubyfmtPath = raw["rubyfmt-path"].as<string>();
         if (enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>()) {
             if (!FileOps::exists(opts.rubyfmtPath)) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -548,6 +548,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
 
     options.add_options(section)("enable-experimental-lsp-extract-to-variable",
                                  "Enable experimental LSP feature: Extract To Variable");
+    options.add_options(section)("enable-experimental-lsp-multiple-dir",
+                                 "Enable experimental LSP feature: Multiple --dir options");
     options.add_options(section)(
         "enable-all-experimental-lsp-features",
         "Enable every experimental LSP feature. (WARNING: can be crashy; for developer use only. "
@@ -946,6 +948,7 @@ void readOptions(Options &opts,
         opts.lspDocumentHighlightEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-highlight"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
+        opts.lspMultipleDirEnabled = raw["enable-experimental-lsp-multiple-dir"].as<bool>();
         opts.rubyfmtPath = raw["rubyfmt-path"].as<string>();
         if (enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>()) {
             if (!FileOps::exists(opts.rubyfmtPath)) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -255,6 +255,7 @@ struct Options {
     bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
     bool lspExtractToVariableEnabled = false;
+    bool lspMultipleDirEnabled = false;
     // Enables out-of-order reference checking
     bool outOfOrderReferenceChecksEnabled = false;
     core::TrackUntyped trackUntyped = core::TrackUntyped::Nowhere;

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -255,7 +255,7 @@ struct Options {
     bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
     bool lspExtractToVariableEnabled = false;
-    bool lspMultipleDirEnabled = false;
+    bool forciblySilenceLspMultipleDirError = false;
     // Enables out-of-order reference checking
     bool outOfOrderReferenceChecksEnabled = false;
     core::TrackUntyped trackUntyped = core::TrackUntyped::Nowhere;

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -78,5 +78,5 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.stripePackages, opts.stripePackages);
     CHECK_EQ(empty.forceHashing, opts.forceHashing);
     CHECK_EQ(empty.lspErrorCap, opts.lspErrorCap);
-    CHECK_EQ(empty.lspMultipleDirEnabled, opts.lspMultipleDirEnabled);
+    CHECK_EQ(empty.forciblySilenceLspMultipleDirError, opts.forciblySilenceLspMultipleDirError);
 }

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -78,4 +78,5 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.stripePackages, opts.stripePackages);
     CHECK_EQ(empty.forceHashing, opts.forceHashing);
     CHECK_EQ(empty.lspErrorCap, opts.lspErrorCap);
+    CHECK_EQ(empty.lspMultipleDirEnabled, opts.lspMultipleDirEnabled);
 }

--- a/test/cli/lsp-requires-input-dir/test.out
+++ b/test/cli/lsp-requires-input-dir/test.out
@@ -8,6 +8,11 @@ Content-Length: 177
 
 {"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory. However, 2 are configured: [foo, bar]"}}
 --------------------------------------------------------------------------
+Sorbet's language server requires at least one input directory. However, 0 are configured: []
+Content-Length: 173
+
+{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires at least one input directory. However, 0 are configured: []"}}
+--------------------------------------------------------------------------
 Content-Length: 638
 
 {"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":[".",":","@","#"]},"definitionProvider":true,"typeDefinitionProvider":true,"implementationProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":true,"workspaceSymbolProvider":true,"codeActionProvider":{"codeActionKinds":["quickfix","source.fixAll.sorbet","refactor.extract","refactor.rewrite"],"resolveProvider":true},"documentFormattingProvider":false,"renameProvider":{"prepareProvider":true},"sorbetShowSymbolProvider":true}}}Content-Length: 65

--- a/test/cli/lsp-requires-input-dir/test.out
+++ b/test/cli/lsp-requires-input-dir/test.out
@@ -1,8 +1,15 @@
 Sorbet's language server requires a single input directory. However, 0 are configured: []
 Content-Length: 169
 
-{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory. However, 0 are configured: []"}}--------------------------------------------------------------------------
+{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory. However, 0 are configured: []"}}
+--------------------------------------------------------------------------
 Sorbet's language server requires a single input directory. However, 2 are configured: [foo, bar]
 Content-Length: 177
 
 {"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Sorbet's language server requires a single input directory. However, 2 are configured: [foo, bar]"}}
+--------------------------------------------------------------------------
+Content-Length: 638
+
+{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":[".",":","@","#"]},"definitionProvider":true,"typeDefinitionProvider":true,"implementationProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":true,"workspaceSymbolProvider":true,"codeActionProvider":{"codeActionKinds":["quickfix","source.fixAll.sorbet","refactor.extract","refactor.rewrite"],"resolveProvider":true},"documentFormattingProvider":false,"renameProvider":{"prepareProvider":true},"sorbetShowSymbolProvider":true}}}Content-Length: 65
+
+{"jsonrpc":"2.0","id":1,"requestMethod":"shutdown","result":null}

--- a/test/cli/lsp-requires-input-dir/test.sh
+++ b/test/cli/lsp-requires-input-dir/test.sh
@@ -27,11 +27,19 @@ fi
 echo
 echo --------------------------------------------------------------------------
 
+if "$old_pwd/main/sorbet" --silence-dev-message --lsp --disable-watchman --forcibly-silence-lsp-multiple-dir-error 2>&1; then
+  echo "expected to fail, but it didn't!"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+
 in_pipe="$(mktemp -u)"
 mkfifo -m 600 "$in_pipe"
 trap "rm $in_pipe" exit
 
-"$old_pwd/main/sorbet" --silence-dev-message --lsp --disable-watchman --enable-experimental-lsp-multiple-dir foo bar < "$in_pipe" &
+"$old_pwd/main/sorbet" --silence-dev-message --lsp --disable-watchman --forcibly-silence-lsp-multiple-dir-error foo bar < "$in_pipe" &
 sorbet_pid=$!
 
 # This should be

--- a/test/cli/lsp-requires-input-dir/test.sh
+++ b/test/cli/lsp-requires-input-dir/test.sh
@@ -7,6 +7,7 @@ if main/sorbet --silence-dev-message --lsp --disable-watchman test/cli/lsp-requi
   exit 1
 fi
 
+echo
 echo --------------------------------------------------------------------------
 
 tmpdir=$(mktemp -d)
@@ -22,3 +23,23 @@ if "$old_pwd/main/sorbet" --silence-dev-message --lsp --disable-watchman foo bar
   echo "expected to fail, but it didn't!"
   exit 1
 fi
+
+echo
+echo --------------------------------------------------------------------------
+
+in_pipe="$(mktemp -u)"
+mkfifo -m 600 "$in_pipe"
+trap "rm $in_pipe" exit
+
+"$old_pwd/main/sorbet" --silence-dev-message --lsp --disable-watchman --enable-experimental-lsp-multiple-dir foo bar < "$in_pipe" &
+sorbet_pid=$!
+
+# This should be
+# exec {IN_FD}>"$in_pipe"
+# but mac os has ancient version of bash.
+exec 100>"$in_pipe"
+IN_FD=100
+
+echo -e 'Content-Length: 2053\r\n\r\n{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":1,"rootPath":"/Users/jvilk/stripe/pay-server","rootUri":"file:///Users/jvilk/stripe/pay-server","capabilities":{"workspace":{"applyEdit":true,"workspaceEdit":{"documentChanges":true},"didChangeConfiguration":{"dynamicRegistration":true},"didChangeWatchedFiles":{"dynamicRegistration":true},"symbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]}},"executeCommand":{"dynamicRegistration":true},"configuration":true,"workspaceFolders":true},"textDocument":{"publishDiagnostics":{"relatedInformation":true},"synchronization":{"dynamicRegistration":true,"willSave":true,"willSaveWaitUntil":true,"didSave":true},"completion":{"dynamicRegistration":true,"contextSupport":true,"completionItem":{"snippetSupport":true,"commitCharactersSupport":true,"documentationFormat":["markdown","plaintext"]},"completionItemKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]}},"hover":{"dynamicRegistration":true,"contentFormat":["markdown","plaintext"]},"signatureHelp":{"dynamicRegistration":true,"signatureInformation":{"documentationFormat":["markdown","plaintext"]}},"definition":{"dynamicRegistration":true},"references":{"dynamicRegistration":true},"documentHighlight":{"dynamicRegistration":true},"documentSymbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]}},"codeAction":{"dynamicRegistration":true},"codeLens":{"dynamicRegistration":true},"formatting":{"dynamicRegistration":true},"rangeFormatting":{"dynamicRegistration":true},"onTypeFormatting":{"dynamicRegistration":true},"rename":{"dynamicRegistration":true},"documentLink":{"dynamicRegistration":true},"typeDefinition":{"dynamicRegistration":true},"implementation":{"dynamicRegistration":true},"colorProvider":{"dynamicRegistration":true}}},"trace":"off","workspaceFolders":[{"uri":"file:///Users/jvilk/stripe/pay-server","name":"pay-server"}]}}Content-Length: 52\r\n\r\n{"jsonrpc":"2.0","method":"initialized","params":{}}Content-Length: 58\r\n\r\n{"jsonrpc":"2.0","id":1,"method":"shutdown","params":null}Content-Length: 47\r\n\r\n{"jsonrpc":"2.0","method":"exit","params":null}'>&"$IN_FD"
+# Should exit cleanly.
+wait $sorbet_pid

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -233,8 +233,6 @@ Usage:
                                 Enable experimental LSP feature: Signature Help
       --enable-experimental-lsp-extract-to-variable
                                 Enable experimental LSP feature: Extract To Variable
-      --enable-experimental-lsp-multiple-dir
-                                Enable experimental LSP feature: Multiple --dir options
       --enable-all-experimental-lsp-features
                                 Enable every experimental LSP feature. (WARNING: can be
                                 crashy; for developer use only. End users should prefer
@@ -242,6 +240,11 @@ Usage:
       --enable-all-beta-lsp-features
                                 Enable (expected-to-be-non-crashy) early-access LSP
                                 features.
+      --forcibly-silence-lsp-multiple-dir-error
+                                Allow the LSP to start with multiple `--dir` options by
+                                silencing the error. (WARNING: This flag does not address
+                                the known issues with multiple directory support in LSP
+                                mode. You are likely to encounter unexpected behavior.)
 
 ```
 

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -233,6 +233,8 @@ Usage:
                                 Enable experimental LSP feature: Signature Help
       --enable-experimental-lsp-extract-to-variable
                                 Enable experimental LSP feature: Extract To Variable
+      --enable-experimental-lsp-multiple-dir
+                                Enable experimental LSP feature: Multiple --dir options
       --enable-all-experimental-lsp-features
                                 Enable every experimental LSP feature. (WARNING: can be
                                 crashy; for developer use only. End users should prefer


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR adds a flag: `--enable-experimental-lsp-multiple-dir`. This flag can be used to bypass the LSP's assertion that there's only one `--dir`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Some of our repositories look like this:
```
our_app_core/                     # a Rails engine, shared between both apps
our_app/                          # a Rails app that serves customers
our_app/vendor/gems/our_app_core  # a symlink to ../../../our_app_core
```

Sorbet doesn't crawl symlinks, unless you explicitly add them as a `--dir`.  So, with the following configuration, the Sorbet CLI works fine:

```
--dir=.
--dir=./vendor/gems/our_app_core/app
--dir=./vendor/gems/our_app_core/lib
```

Unfortunately, this configuration is incompatible with the LSP, which doesn't run with more than one `--dir` option. If we bypass the check to ensure that there's only one `--dir` flag, the LSP works perfectly for our use case.

I've created an alternative proposal that would solve this problem by implementing symlink traversal: https://github.com/sorbet/sorbet/pull/8319.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added a CLI test that shows the language sever starting successfully multiple input dirs are provided and the `--enable-experimental-lsp-multiple-dir` is provided.