### PR TITLE
Follow symlinks

### DIFF
--- a/common/common.cc
+++ b/common/common.cc
@@ -276,7 +276,11 @@ bool sorbet::FileOps::isFileIgnored(string_view basePath, string_view filePath,
 }
 
 struct QuitToken {};
-using Job = variant<QuitToken, string>;
+struct JobParams {
+    string path;
+    int symlinkDepth;
+};
+using Job = variant<QuitToken, JobParams>;
 // We record all classes of exceptions we can throw separately, rather than one single `SorbetException`.
 //
 // We do this for two reasons: one is that when looking for a `catch` handler, C++ will only look for
@@ -289,6 +293,8 @@ using Job = variant<QuitToken, string>;
 // dynamic type of the original exception would be lost.
 using JobOutput = variant<std::monostate, sorbet::FileNotFoundException, sorbet::FileNotDirException, vector<string>>;
 
+const int MAX_SYMLINK_DEPTH = 40;
+
 void appendFilesInDir(string_view basePath, const string &path, const sorbet::UnorderedSet<string> &extensions,
                       sorbet::WorkerPool &workers, bool recursive, vector<string> &allPaths,
                       const std::vector<std::string> &absoluteIgnorePatterns,
@@ -298,10 +304,6 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
     auto resultq = make_shared<BlockingBoundedQueue<JobOutput>>(numWorkers);
     atomic<size_t> pendingJobs{0};
 
-    // Track the directories we've already seen to protect against infinite symlink loops.
-    std::unordered_set<ino_t> visited;
-    absl::Mutex visitedMutex;
-
     // The invariant that the code below must maintain is pendingJobs must be
     // at least as large as the number of items in jobq.  Therefore, once
     // pendingJobs is 0, whatever thread observes that can be assured that there
@@ -310,131 +312,124 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
     // In practice, all it takes to maintain this invariant is that pendingJobs
     // must be incremented prior to pushing work onto jobq.
     ++pendingJobs;
-    jobq->push(path, 1);
+    jobq->push(JobParams{path, 0}, 1);
 
-    workers.multiplexJob("options.findFiles",
-                         [numWorkers, jobq, resultq, &pendingJobs, &basePath, &extensions, &recursive,
-                          &absoluteIgnorePatterns, &relativeIgnorePatterns, &visited, &visitedMutex]() {
-                             Job job;
-                             vector<string> output;
+    workers.multiplexJob("options.findFiles", [numWorkers, jobq, resultq, &pendingJobs, &basePath, &extensions,
+                                               &recursive, &absoluteIgnorePatterns, &relativeIgnorePatterns]() {
+        Job job;
+        vector<string> output;
 
-                             try {
-                                 while (true) {
-                                     auto result = jobq->try_pop(job);
-                                     if (!result.gotItem()) {
-                                         continue;
-                                     }
-                                     if (std::holds_alternative<QuitToken>(job)) {
-                                         break;
-                                     }
+        try {
+            while (true) {
+                auto result = jobq->try_pop(job);
+                if (!result.gotItem()) {
+                    continue;
+                }
+                if (std::holds_alternative<QuitToken>(job)) {
+                    break;
+                }
 
-                                     auto *strvariant = std::get_if<string>(&job);
-                                     ENFORCE(strvariant != nullptr);
-                                     auto &path = *strvariant;
+                auto *jobParams = std::get_if<JobParams>(&job);
+                ENFORCE(jobParams != nullptr);
+                auto &path = jobParams->path;
+                int symlinkDepth = jobParams->symlinkDepth;
 
-                                     DIR *dir;
-                                     struct dirent *entry;
+                DIR *dir;
+                struct dirent *entry;
 
-                                     if ((dir = opendir(path.c_str())) == nullptr) {
-                                         switch (errno) {
-                                             case ENOTDIR: {
-                                                 throw sorbet::FileNotDirException();
-                                             }
-                                             default:
-                                                 // Mirrors other FileOps functions: Assume other errors are from
-                                                 // FileNotFound.
-                                                 auto msg = fmt::format("Couldn't open directory `{}`", path);
-                                                 throw sorbet::FileNotFoundException(msg);
-                                         }
-                                     }
+                if ((dir = opendir(path.c_str())) == nullptr) {
+                    switch (errno) {
+                        case ENOTDIR: {
+                            throw sorbet::FileNotDirException();
+                        }
+                        default:
+                            // Mirrors other FileOps functions: Assume other errors are from FileNotFound.
+                            auto msg = fmt::format("Couldn't open directory `{}`", path);
+                            throw sorbet::FileNotFoundException(msg);
+                    }
+                }
 
-                                     while ((entry = readdir(dir)) != nullptr) {
-                                         const auto namelen = strlen(entry->d_name);
-                                         string_view nameview{entry->d_name, namelen};
+                while ((entry = readdir(dir)) != nullptr) {
+                    const auto namelen = strlen(entry->d_name);
+                    string_view nameview{entry->d_name, namelen};
 
-                                         auto fullPath = fmt::format("{}/{}", path, nameview);
-                                         bool isDir = entry->d_type == DT_DIR;
-                                         ino_t inode = entry->d_ino;
+                    auto fullPath = fmt::format("{}/{}", path, nameview);
+                    bool isDir = entry->d_type == DT_DIR;
+                    int nextSymlinkDepth = symlinkDepth;
 
-                                         if (entry->d_type == DT_LNK) {
-                                             struct stat statbuf;
-                                             if (stat(fullPath.c_str(), &statbuf) == 0 && S_ISDIR(statbuf.st_mode)) {
-                                                 isDir = true;
-                                                 inode = statbuf.st_ino;
-                                             }
-                                         }
+                    if (entry->d_type == DT_LNK && sorbet::FileOps::dirExists(fullPath)) {
+                        isDir = true;
+                        ++nextSymlinkDepth;
+                        if (nextSymlinkDepth > MAX_SYMLINK_DEPTH) {
+                            continue;
+                        }
+                    }
 
-                                         if (isDir) {
-                                             if (!recursive) {
-                                                 continue;
-                                             }
-                                             if (nameview == "."sv || nameview == ".."sv) {
-                                                 continue;
-                                             }
-                                             {
-                                                 absl::MutexLock lock(&visitedMutex);
-                                                 if (!visited.insert(inode).second) {
-                                                     continue;
-                                                 }
-                                             }
-                                         } else {
-                                             auto dotLocation = nameview.rfind('.');
-                                             if (dotLocation == string_view::npos) {
-                                                 continue;
-                                             }
+                    if (isDir) {
+                        if (!recursive) {
+                            continue;
+                        }
+                        if (nameview == "."sv || nameview == ".."sv) {
+                            continue;
+                        }
+                    } else {
+                        auto dotLocation = nameview.rfind('.');
+                        if (dotLocation == string_view::npos) {
+                            continue;
+                        }
 
-                                             string_view ext = nameview.substr(dotLocation);
-                                             if (!extensions.contains(ext)) {
-                                                 continue;
-                                             }
-                                         }
+                        string_view ext = nameview.substr(dotLocation);
+                        if (!extensions.contains(ext)) {
+                            continue;
+                        }
+                    }
 
-                                         if (sorbet::FileOps::isFileIgnored(basePath, fullPath, absoluteIgnorePatterns,
-                                                                            relativeIgnorePatterns)) {
-                                             continue;
-                                         }
+                    if (sorbet::FileOps::isFileIgnored(basePath, fullPath, absoluteIgnorePatterns,
+                                                       relativeIgnorePatterns)) {
+                        continue;
+                    }
 
-                                         if (isDir) {
-                                             ++pendingJobs;
-                                             jobq->push(move(fullPath), 1);
-                                         } else {
-                                             output.push_back(move(fullPath));
-                                         }
-                                     }
+                    if (isDir) {
+                        ++pendingJobs;
+                        jobq->push(JobParams{move(fullPath), nextSymlinkDepth}, 1);
+                    } else {
+                        output.push_back(move(fullPath));
+                    }
+                }
 
-                                     closedir(dir);
+                closedir(dir);
 
-                                     // Now that we've finished with this directory, we can decrement.
-                                     auto remaining = --pendingJobs;
-                                     // If this thread is finished with the last job in the queue, then
-                                     // we can start signaling other threads that they need to quit.
-                                     if (remaining == 0) {
-                                         // Maintain the invariant, even though we're all done.
-                                         pendingJobs += numWorkers;
-                                         for (auto i = 0; i < numWorkers; ++i) {
-                                             jobq->push(QuitToken{}, 1);
-                                         }
-                                         break;
-                                     }
-                                 }
-                             } catch (sorbet::FileNotFoundException &e) {
-                                 resultq->push(e, 1);
-                                 pendingJobs += numWorkers;
-                                 for (auto i = 0; i < numWorkers; ++i) {
-                                     jobq->push(QuitToken{}, 1);
-                                 }
-                                 return;
-                             } catch (sorbet::FileNotDirException &e) {
-                                 resultq->push(e, 1);
-                                 pendingJobs += numWorkers;
-                                 for (auto i = 0; i < numWorkers; ++i) {
-                                     jobq->push(QuitToken{}, 1);
-                                 }
-                                 return;
-                             }
+                // Now that we've finished with this directory, we can decrement.
+                auto remaining = --pendingJobs;
+                // If this thread is finished with the last job in the queue, then
+                // we can start signaling other threads that they need to quit.
+                if (remaining == 0) {
+                    // Maintain the invariant, even though we're all done.
+                    pendingJobs += numWorkers;
+                    for (auto i = 0; i < numWorkers; ++i) {
+                        jobq->push(QuitToken{}, 1);
+                    }
+                    break;
+                }
+            }
+        } catch (sorbet::FileNotFoundException &e) {
+            resultq->push(e, 1);
+            pendingJobs += numWorkers;
+            for (auto i = 0; i < numWorkers; ++i) {
+                jobq->push(QuitToken{}, 1);
+            }
+            return;
+        } catch (sorbet::FileNotDirException &e) {
+            resultq->push(e, 1);
+            pendingJobs += numWorkers;
+            for (auto i = 0; i < numWorkers; ++i) {
+                jobq->push(QuitToken{}, 1);
+            }
+            return;
+        }
 
-                             resultq->push(move(output), 1);
-                         });
+        resultq->push(move(output), 1);
+    });
 
     {
         JobOutput threadResult;

--- a/common/common.cc
+++ b/common/common.cc
@@ -371,7 +371,7 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
                             continue;
                         }
                         {
-                            absl::MutexLock l(&visitedMutex);
+                            absl::MutexLock lock(&visitedMutex);
                             if (!visited.insert(inode).second) {
                                 continue;
                             }

--- a/test/cli/folder-input-symlink/input/dir-symlink
+++ b/test/cli/folder-input-symlink/input/dir-symlink
@@ -1,0 +1,1 @@
+../references

--- a/test/cli/folder-input-symlink/input/file-symlink.rb
+++ b/test/cli/folder-input-symlink/input/file-symlink.rb
@@ -1,0 +1,1 @@
+../references/file.rb

--- a/test/cli/folder-input-symlink/input/file.rb
+++ b/test/cli/folder-input-symlink/input/file.rb
@@ -1,0 +1,1 @@
+# input/file.rb

--- a/test/cli/folder-input-symlink/input/invalid-dir-symlink
+++ b/test/cli/folder-input-symlink/input/invalid-dir-symlink
@@ -1,0 +1,1 @@
+does-not-exist

--- a/test/cli/folder-input-symlink/input/invalid-file-symlink
+++ b/test/cli/folder-input-symlink/input/invalid-file-symlink
@@ -1,0 +1,1 @@
+does-not-exist.rb

--- a/test/cli/folder-input-symlink/references/file.rb
+++ b/test/cli/folder-input-symlink/references/file.rb
@@ -1,0 +1,1 @@
+# references/file.rb

--- a/test/cli/folder-input-symlink/test.out
+++ b/test/cli/folder-input-symlink/test.out
@@ -1,0 +1,19 @@
+{
+ "files": [
+  {
+   "path": "test/cli/folder-input-symlink/input/dir-symlink/file.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  },
+  {
+   "path": "test/cli/folder-input-symlink/input/file-symlink.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  },
+  {
+   "path": "test/cli/folder-input-symlink/input/file.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  }
+ ]
+}

--- a/test/cli/folder-input-symlink/test.sh
+++ b/test/cli/folder-input-symlink/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+main/sorbet --silence-dev-message -p file-table-json --no-stdlib --dir test/cli/folder-input-symlink/input


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR allows Sorbet to traverse symlinked directories.

This feature was previously discussed in #2450, #2465, and #6026. In previous discussions, the importance of detecting circular symlinks was emphasized. This requirement makes the implementation significantly more complicated.

#### First attempt

In order to track the directories that have been visited, we maintain an unordered set of inode indexes named `visited`:
* Each time we visit a new directory, we add it to the set of visited inodes.
* Each time we visit a symlink, we'll check if the symlink refers to a directory. We'll add the inode index of the directory to the visited nodes.
* A mutex, `visitedMutex`, is used to prevent concurrent access to `visited`.

#### Second attempt

The first implementation required a lock, which would have performance implications. The new implementation does not require a lock. It keeps track of the number of symlinks we've traversed. If that number exceeds a max, we'll stop traversing.

The trade-off here is that we might crawl the same directory more than once, but the loop will exit. Circular symlinks are an extreme edge case.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This issue has come up a few times, and it seems like most of the people proposing this feature have a similar use case.

Our repository is structured like this:
```
our_app_core/                     # a Rails engine, shared between both apps
our_app/                          # a Rails app that serves customers
our_app/vendor/gems/our_app_core  # a symlink to ../../../our_app_core
```

The `vendor/gems` directory contains symlinks to gems that live in the repository and are used by multiple applications that live in the repository.

Sorbet will actually traverse symlinked directories if you reference them with the `--dir` option. This configuration allows us to typecheck the application successfully:
```
--dir=.
--dir=./vendor/gems/our_app_core/app
--dir=./vendor/gems/our_app_core/lib
```

Unfortunately, this configuration is incompatible with the LSP's assertion that there can only be one root directory. This PR would allow us to have a single root directory.

I've created an alternative proposal that would work around this issue by bypassing the LSP's assertion that there can only be one root directory: https://github.com/sorbet/sorbet/pull/8318.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I wrote a CLI test for this functionality. I created a directory that contains:
* A normal file
* A symlink to a file
* A symlink to a directory
* An invalid symlink ending in `.rb`
* An invalid symlink that looks like a directory (no extension)

I wanted to write a test that demonstrates circular symlink behavior, but Bazel bails with:
```
ERROR: infinite symlink expansion detected
```

I manually tested circular symbolic link behavior and ensured that the loop exited. Here's how I created a circular symlink:

```sh
$ ln -s . circular-symlink
```
