### PR TITLE
Fix handling of `overridable` and `abstract` in attr_* chains

### DIFF
--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -201,7 +201,8 @@ template <typename T> T *castSigImpl(T *send) {
     ENFORCE(block);
     auto *body = ast::cast_tree<ast::Send>(block->body);
     while (body != nullptr && (body->fun == core::Names::checked() || body->fun == core::Names::onFailure() ||
-                               body->fun == core::Names::override_())) {
+                               body->fun == core::Names::override_() || body->fun == core::Names::overridable() ||
+                               body->fun == core::Names::abstract())) {
         body = ast::cast_tree<ast::Send>(body->recv);
     }
     if (body != nullptr && (body->fun == core::Names::void_() || body->fun == core::Names::returns())) {

--- a/test/testdata/rewriter/attr_override.rb
+++ b/test/testdata/rewriter/attr_override.rb
@@ -9,6 +9,8 @@ end
 
 class FooChild < Foo
   extend T::Sig
+  extend T::Helpers
+  abstract!
 
   sig {void}
   def initialize
@@ -26,4 +28,19 @@ class FooChild < Foo
 
   sig {returns(T.nilable(Integer)).override.checked(:always)}
   attr_accessor :method4
+
+  sig {returns(T.nilable(Integer)).overridable}
+  attr_accessor :method5
+
+  sig {returns(T.nilable(Integer)).abstract}
+  def method6; end
+end
+
+class FooGrandChild < FooChild
+  extend T::Sig
+
+  sig {override.returns(T.nilable(Integer))}
+  def method6
+    42
+  end
 end


### PR DESCRIPTION
Added conditions in `Util.cc` to explicitly identify `overridable` and `abstract` modifiers, as well as additional tests to verify proper functionality.

### Motivation
PR https://github.com/sorbet/sorbet/pull/8308 only partially fixed the issue. It did not account for the `overridable` or `abstract` modifiers. See: https://github.com/sorbet/sorbet/pull/8308#issuecomment-2492067279

Fixes #4456: "Rewriter doesn't parse sigs with override"


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.