### PR TITLE
Store signature metadata on the original overload def, not on overload sigs

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -722,11 +722,6 @@ MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrMod
     }
 
     MethodRef result = owner.data(gs)->findMethod(gs, name);
-    if (result.exists() && result.data(gs)->flags.isOverloaded) {
-        auto overloadName = gs.lookupNameUnique(UniqueNameKind::Overload, name, 1);
-        result = owner.data(gs)->findMethod(gs, overloadName);
-    }
-
     if (result.exists() && !result.data(gs)->flags.isAbstract) {
         return result;
     }
@@ -734,12 +729,6 @@ MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrMod
     for (auto it = owner.data(gs)->mixins().begin(); it != owner.data(gs)->mixins().end(); ++it) {
         ENFORCE(it->exists());
         result = it->data(gs)->findMethod(gs, name);
-
-        if (result.exists() && result.data(gs)->flags.isOverloaded) {
-            auto overloadName = gs.lookupNameUnique(UniqueNameKind::Overload, name, 1);
-            result = owner.data(gs)->findMethod(gs, overloadName);
-        }
-
         if (result.exists() && !result.data(gs)->flags.isAbstract) {
             return result;
         }


### PR DESCRIPTION
As a follow-up to #8303, set the method flags on the original method when signatures mark it as abstract, overridable, etc. instead of assuming that they're always on the first overload's signature. This simplifies many cases where we were needing to check if the method found was an overload, and then looking again for the first overload's signature so that we could determine if the symbol was abstract, etc.

### Motivation
Simplifying the internal handling of symbols with overloaded signatures.

### Test plan
This shouldn't affect any existing tests: it's only reorganizing internal datastructures.
