### PR TITLE
Always print the `overload.n` on overloaded names

### DIFF
--- a/core/Names.cc
+++ b/core/Names.cc
@@ -102,12 +102,7 @@ string NameRef::toString(const GlobalState &gs) const {
             if (unique->uniqueNameKind == UniqueNameKind::Singleton) {
                 return fmt::format("<Class:{}>", unique->original.show(gs));
             } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
-                // We consider the first overload to be the second signature.
-                if (unique->num > 1) {
-                    return absl::StrCat(unique->original.show(gs), " (overload.", unique->num - 1, ")");
-                } else {
-                    return unique->original.show(gs);
-                }
+                return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
             } else if (unique->uniqueNameKind == UniqueNameKind::DesugarCsend) {
                 return fmt::format("<&{}>", unique->original.show(gs));
             }
@@ -134,12 +129,7 @@ string NameRef::show(const GlobalState &gs) const {
             if (unique->uniqueNameKind == UniqueNameKind::Singleton) {
                 return fmt::format("<Class:{}>", unique->original.show(gs));
             } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
-                // We consider the first overload to be the second signature.
-                if (unique->num > 1) {
-                    return absl::StrCat(unique->original.show(gs), " (overload.", unique->num - 1, ")");
-                } else {
-                    return unique->original.show(gs);
-                }
+                return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
             } else if (unique->uniqueNameKind == UniqueNameKind::MangleRename) {
                 return unique->original.show(gs);
             } else if (unique->uniqueNameKind == UniqueNameKind::TEnum) {

--- a/test/cli/at/test.out
+++ b/test/cli/at/test.out
@@ -1,7 +1,7 @@
 test/cli/at/at.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/e-rbi/test.out
+++ b/test/cli/e-rbi/test.out
@@ -1,7 +1,7 @@
 -e:1: Expected `Integer` but found `String("abc")` for argument `x` https://srb.help/7002
      1 |Foo.foo("abc")
                 ^^^^^
-  Expected `Integer` for argument `x` of method `Foo.foo (overload.1)`:
+  Expected `Integer` for argument `x` of method `Foo.foo (overload.2)`:
     --e-rbi.rbi:4:
      4 |      sig { params(x: Integer).returns(Integer) }
                            ^

--- a/test/cli/errors/test.out
+++ b/test/cli/errors/test.out
@@ -12,7 +12,7 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 test/cli/errors/errors.rb:15: Expected `T.any(T::Class[T.anything], Exception, String)` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
                   ^^^
-  Expected `T.any(T::Class[T.anything], Exception, String)` for argument `arg0` of method `Kernel#raise (overload.1)`:
+  Expected `T.any(T::Class[T.anything], Exception, String)` for argument `arg0` of method `Kernel#raise (overload.2)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
       NN |        arg0: T.any(T::Class[T.anything], Exception, String),
                   ^^^^
@@ -69,7 +69,7 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 test/cli/errors/errors.rb:15: Expected `T.any(T::Class[T.anything], Exception, String)` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
                   ^^^
-  Expected `T.any(T::Class[T.anything], Exception, String)` for argument `arg0` of method `Kernel#raise (overload.1)`:
+  Expected `T.any(T::Class[T.anything], Exception, String)` for argument `arg0` of method `Kernel#raise (overload.2)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
       NN |        arg0: T.any(T::Class[T.anything], Exception, String),
                   ^^^^
@@ -126,7 +126,7 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 test/cli/errors/errors.rb:15: Expected `T.any(T::Class[T.anything], Exception, String)` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
                   ^^^
-  Expected `T.any(T::Class[T.anything], Exception, String)` for argument `arg0` of method `Kernel#raise (overload.1)`:
+  Expected `T.any(T::Class[T.anything], Exception, String)` for argument `arg0` of method `Kernel#raise (overload.2)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
       NN |        arg0: T.any(T::Class[T.anything], Exception, String),
                   ^^^^

--- a/test/cli/folder-input-dir-and-file/test.out
+++ b/test/cli/folder-input-dir-and-file/test.out
@@ -1,7 +1,7 @@
 test/cli/folder-input-dir-and-file/foo.rb:4: Expected `Integer` but found `String("foo.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "foo.rb"
             ^^^^^^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^
@@ -13,7 +13,7 @@ test/cli/folder-input-dir-and-file/foo.rb:4: Expected `Integer` but found `Strin
 test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4: Expected `Integer` but found `String("baz.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "baz.rb"
             ^^^^^^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^
@@ -25,7 +25,7 @@ test/cli/folder-input-dir-and-file/input/subfolder/baz.rb:4: Expected `Integer` 
 test/cli/folder-input-dir-and-file/input/bar.rb:3: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      3 |1 + "bar.rb"
             ^^^^^^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/folder-input/test.out
+++ b/test/cli/folder-input/test.out
@@ -1,7 +1,7 @@
 test/cli/folder-input/folder-input.rb:4: Expected `Integer` but found `String("foo.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "foo.rb"
             ^^^^^^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^
@@ -13,7 +13,7 @@ test/cli/folder-input/folder-input.rb:4: Expected `Integer` but found `String("f
 test/cli/folder-input/input/subfolder/baz.rb:4: Expected `Integer` but found `String("baz.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "baz.rb"
             ^^^^^^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^
@@ -25,7 +25,7 @@ test/cli/folder-input/input/subfolder/baz.rb:4: Expected `Integer` but found `St
 test/cli/folder-input/input/input.rb:3: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      3 |1 + "bar.rb"
             ^^^^^^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/ignore-slash/test.out
+++ b/test/cli/ignore-slash/test.out
@@ -1,7 +1,7 @@
 bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "bar.rb"
             ^^^^^^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/ignore/test.out
+++ b/test/cli/ignore/test.out
@@ -1,7 +1,7 @@
 subfolder2/subfolder/bar.rb:4: Expected `Integer` but found `String("subfolder2/subfolder/bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "subfolder2/subfolder/bar.rb"
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^
@@ -13,7 +13,7 @@ subfolder2/subfolder/bar.rb:4: Expected `Integer` but found `String("subfolder2/
 bar.rb:4: Expected `Integer` but found `String("bar.rb")` for argument `arg0` https://srb.help/7002
      4 |1 + "bar.rb"
             ^^^^^^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/override-typed-bad/test.out
+++ b/test/cli/override-typed-bad/test.out
@@ -3,7 +3,7 @@ test/cli/override-typed-bad/override-typed-bad.rb: Useless override of strictnes
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^
@@ -16,7 +16,7 @@ Errors: 2
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^
@@ -29,7 +29,7 @@ Errors: 1
 test/cli/override-typed-bad/override-typed-bad.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/override-typed/test.out
+++ b/test/cli/override-typed/test.out
@@ -1,7 +1,7 @@
 test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^
@@ -13,7 +13,7 @@ Errors: 1
 ./test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^
@@ -25,7 +25,7 @@ Errors: 1
 test/cli/override-typed/override-typed.rb:1: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      1 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/remove-path-prefix-https/test.out
+++ b/test/cli/remove-path-prefix-https/test.out
@@ -1,7 +1,7 @@
 test/cli/remove-path-prefix-https/remove-path-prefix-https.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/remove-path-prefix-no-match/test.out
+++ b/test/cli/remove-path-prefix-no-match/test.out
@@ -1,7 +1,7 @@
 test/cli/remove-path-prefix-no-match/remove-path-prefix-no-match.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/remove-path-prefix/test.out
+++ b/test/cli/remove-path-prefix/test.out
@@ -1,7 +1,7 @@
 remove-path-prefix.rb:2: Expected `Integer` but found `String("s")` for argument `arg0` https://srb.help/7002
      2 |1 + "s"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/cli/suppress-error-code/test.out
+++ b/test/cli/suppress-error-code/test.out
@@ -1,7 +1,7 @@
 test/cli/suppress-error-code/suppress-error-code.rb:3: Expected `Integer` but found `String("1")` for argument `arg0` https://srb.help/7002
      3 |1 + "1"
             ^^^
-  Expected `Integer` for argument `arg0` of method `Integer#+`:
+  Expected `Integer` for argument `arg0` of method `Integer#+ (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED:
       NN |        arg0: Integer,
                   ^^^^

--- a/test/testdata/desugar/range.rb
+++ b/test/testdata/desugar/range.rb
@@ -82,10 +82,10 @@ def foo
 
   # Range.new
 
-  rn1 = Range.new # error: Not enough arguments provided for method `Range#initialize`. Expected: `2..3`, got: `0`
+  rn1 = Range.new # error: Not enough arguments provided for method `Range#initialize (overload.1)`. Expected: `2..3`, got: `0`
   T.reveal_type(rn1) # error: Revealed type: `T::Range[T.untyped]`
 
-  rn2 = Range.new(nil) # error: Not enough arguments provided for method `Range#initialize`. Expected: `2..3`, got: `1`
+  rn2 = Range.new(nil) # error: Not enough arguments provided for method `Range#initialize (overload.1)`. Expected: `2..3`, got: `1`
   T.reveal_type(rn2) # error: Revealed type: `T::Range[T.untyped]`
 
   rn3 = Range.new(1, 2)
@@ -129,7 +129,7 @@ def foo
   tr1 = T::Range.new # error: Method `new` does not exist on `T.class_of(T::Range)`
   T.reveal_type(tr1) # error: Revealed type: `T.untyped`
 
-  tr2 = T::Range[Integer].new # error: Not enough arguments provided for method `Range#initialize`. Expected: `2..3`, got: `0`
+  tr2 = T::Range[Integer].new # error: Not enough arguments provided for method `Range#initialize (overload.1)`. Expected: `2..3`, got: `0`
   T.reveal_type(tr2) # error: Revealed type: `T::Range[Integer]`
 
   tr3 = T::Range[Integer].new(1, 2)

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -158,14 +158,14 @@ def main
   #                        ^^^ hover-line: 7 BigFoo::LittleFoo1
 
   raise "error message"
-  # ^ hover-line: 2 # Kernel#raise (overload.1):
+  # ^ hover-line: 2 # Kernel#raise (overload.2):
   # ^ hover-line: 3 sig do
   # ^ hover-line: 4   params(
   # ^ hover-line: 5     arg0: T.any(T::Class[T.anything], Exception, String)
   # ^ hover-line: 6   )
   # ^ hover-line: 7   .returns(T.noreturn)
   # ^ hover-line: 8 end
-  # ^ hover-line: 9 def raise (overload.1)(arg0=…); end
+  # ^ hover-line: 9 def raise (overload.2)(arg0=…); end
   # ^ hover-line: 11 # result type:
   # ^ hover-line: 12 T.noreturn
 end

--- a/test/testdata/lsp/hover_constraint.rb
+++ b/test/testdata/lsp/hover_constraint.rb
@@ -4,22 +4,22 @@ extend T::Sig
 sig { params(x: T.any(T::Array[Integer], T::Hash[String, Symbol])).void }
 def example(x)
   x.map do |elem|
-    #^ hover-line: 2 # Array#map:
+    #^ hover-line: 2 # Array#map (overload.1):
     #^ hover-line: 3 sig do
     #^ hover-line: 4   params(
     #^ hover-line: 5     blk: T.proc.params(arg0: Integer).returns(T.type_parameter(:U))
     #^ hover-line: 6   )
     #^ hover-line: 7   .returns(T::Array[T.type_parameter(:U)])
     #^ hover-line: 8 end
-    #^ hover-line: 9 def map(&blk); end
-    #^ hover-line: 10 # Enumerable#map:
+    #^ hover-line: 9 def map (overload.1)(&blk); end
+    #^ hover-line: 10 # Enumerable#map (overload.1):
     #^ hover-line: 11 sig do
     #^ hover-line: 12   params(
     #^ hover-line: 13     blk: T.proc.params(arg0: [String, Symbol]).returns(T.type_parameter(:U))
     #^ hover-line: 14   )
     #^ hover-line: 15   .returns(T::Array[T.type_parameter(:U)])
     #^ hover-line: 16 end
-    #^ hover-line: 17 def map(&blk); end
+    #^ hover-line: 17 def map (overload.1)(&blk); end
     #^ hover-line: 19 # result type:
     #^ hover-line: 20 T::Array[T.any(Integer, [String, Symbol])]
     T.reveal_type(elem) # error: `T.any(Integer, [String, Symbol])`

--- a/test/testdata/rbi/exception.rb
+++ b/test/testdata/rbi/exception.rb
@@ -7,7 +7,7 @@ StandardError.new(:msg)
 ex = StandardError.new("bees")
 RuntimeError.new(ex)
 
-SystemCallError.new # error: Not enough arguments provided for method `SystemCallError.new`. Expected: `1`, got: `0`
+SystemCallError.new # error: Not enough arguments provided for method `SystemCallError.new (overload.1)`. Expected: `1`, got: `0`
 SystemCallError.new(1)
 SystemCallError.new(nil)
 SystemCallError.new("message")

--- a/test/testdata/resolver/enumerable_strict.rb
+++ b/test/testdata/resolver/enumerable_strict.rb
@@ -5,7 +5,7 @@ class A # error: Type `Elem` declared by parent `Enumerable` must be re-declared
   extend T::Sig
 
   sig {void}
-  def each # error: Implementation of abstract method `Enumerable#each` must explicitly name a block argument
-# ^^^^^^^^ error: Method `A#each` implements an abstract method `Enumerable#each` but is not declared with `override.`
+  def each # error: Implementation of abstract method `Enumerable#each (overload.1)` must explicitly name a block argument
+# ^^^^^^^^ error: Method `A#each` implements an abstract method `Enumerable#each (overload.1)` but is not declared with `override.`
   end
 end

--- a/test/testdata/resolver/type_member_parent_missing.rb
+++ b/test/testdata/resolver/type_member_parent_missing.rb
@@ -3,19 +3,19 @@
 
   class Foo1
 # ^^^^^^^^^^ error: Type `Elem` declared by parent `Enumerable` must be re-declared in `Foo1`
-# ^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each`
+# ^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each (overload.1)`
     include Enumerable
   end
 
   class Bar1 < Foo1
-# ^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each`
+# ^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each (overload.1)`
     Elem = type_member(:out)
   # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Type variance mismatch for `Elem` with parent `Foo1`. Child `Bar1` should be `invariant`, but it is `:out`
     #      ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(Bar1)`
   end
 
   class Foo2
-# ^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each`
+# ^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each (overload.1)`
     include Enumerable
     Elem = T.let(0, Integer)
   # ^^^^ error: Type variable `Elem` needs to be declared as a type_member or type_template, not a static-field
@@ -23,7 +23,7 @@
 
   class Bar2 < Foo2
 # ^^^^^^^^^^^^^^^^^ error: Type `Elem` declared by parent `Foo2` must be re-declared in `Bar2`
-# ^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each`
+# ^^^^^^^^^^^^^^^^^ error: Missing definition for abstract method `Enumerable#each (overload.1)`
     Elem = type_member(:out)
     #      ^^^^^^^^^^^^^^^^^ error: `Bar2::Elem` is a type member but `Foo2::Elem` is not a type member
     #      ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(Bar2)`


### PR DESCRIPTION
Following on from #8303, switch to always printing the `overload.n` suffix when printing the name of an overload.

### Motivation
Simplifying name printing, and making it easier to identify overloaded symbols.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
