### PR TITLE
Add a test to demonstrate symlinked directory behavior

### DIFF
--- a/test/cli/folder-input-symlink/test.out
+++ b/test/cli/folder-input-symlink/test.out
@@ -1,0 +1,60 @@
+------------------------------------------------------------------------
+{
+ "files": [
+  {
+   "path": "./bar.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  },
+  {
+   "path": "./foo.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  }
+ ]
+}
+------------------------------------------------------------------------
+{
+ "files": [
+  {
+   "path": "./bar.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  },
+  {
+   "path": "./foo.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  },
+  {
+   "path": "./references/bar.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  },
+  {
+   "path": "./references/lib/baz.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  }
+ ]
+}
+------------------------------------------------------------------------
+{
+ "files": [
+  {
+   "path": "./bar.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  },
+  {
+   "path": "./foo.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  },
+  {
+   "path": "./references/lib/baz.rb",
+   "strict": "False",
+   "min_error_level": "Max"
+  }
+ ]
+}

--- a/test/cli/folder-input-symlink/test.sh
+++ b/test/cli/folder-input-symlink/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+sorbet="$(pwd)/main/sorbet"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf $tmp' EXIT
+
+cd "$tmp"
+mkdir -p input references/lib
+touch input/foo.rb references/bar.rb references/lib/baz.rb
+
+cd input
+ln -s ../references references
+ln -s ../references/bar.rb bar.rb
+
+echo '------------------------------------------------------------------------'
+"$sorbet" --silence-dev-message -p file-table-json --no-stdlib --dir .
+
+echo '------------------------------------------------------------------------'
+"$sorbet" --silence-dev-message -p file-table-json --no-stdlib --dir . --dir ./references
+
+echo '------------------------------------------------------------------------'
+"$sorbet" --silence-dev-message -p file-table-json --no-stdlib --dir . --dir ./references/lib


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR adds a CLI test to document the behavior of symlinked directories.

See also:
* https://github.com/sorbet/sorbet/issues/2450
* https://github.com/sorbet/sorbet/pull/2465
* https://github.com/sorbet/sorbet/pull/6026
* https://github.com/sorbet/sorbet/pull/8319
* https://github.com/sorbet/sorbet/pull/8318

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet doesn't crawl symlinked directories unless you reference them explicitly using `--dir`. It's not clear if this behavior is intentional, but it is useful for some projects.

For example, our repository is structured like this:
```
our_app_core/                     # a Rails engine, shared between both apps
our_app/                          # a Rails app that serves customers
our_app/vendor/gems/our_app_core  # a symlink to ../../../our_app_core
```

The `vendor/gems` directory contains symlinks to gems that live in the repository and are used by multiple applications that live in the repository.

The goal of this PR is to document the current behavior and prevent regressions in the future.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

I created a new CLI test. This test creates the directory structure on the fly, because some step in the build process seems to replace symlinked directories with hard copies.