### PR TITLE
Prevent duplicate method override errors

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -480,6 +480,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
     auto name = method.data(ctx)->name;
     auto klassData = klass.data(ctx);
     InlinedVector<core::MethodRef, 4> overriddenMethods;
+    core::MethodRef mostSpecificImpl;
 
     // Matches the behavior of the runtime checks
     // NOTE(jez): I don't think this check makes all that much sense, but I haven't thought about it.
@@ -487,16 +488,6 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
     if (klassData->flags.isInterface && method.data(ctx)->flags.isProtected) {
         if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::NonPublicAbstract)) {
             e.setHeader("Interface method `{}` cannot be protected", method.show(ctx));
-        }
-    }
-
-    if (method.data(ctx)->flags.isAbstract && klassData->isSingletonClass(ctx)) {
-        auto attached = klassData->attachedClass(ctx);
-        if (attached.exists() && attached.data(ctx)->isModule()) {
-            if (auto e =
-                    ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::StaticAbstractModuleMethod)) {
-                e.setHeader("Static methods in a module cannot be abstract");
-            }
         }
     }
 
@@ -527,7 +518,38 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
         }
     }
 
-    if (overriddenMethods.size() == 0 && method.data(ctx)->flags.isOverride &&
+    // Find most specific implementation based on override flag
+    if (method.data(ctx)->flags.isOverride) {
+        // If marked with override, try concrete implementation first
+        for (auto &overriddenMethod : overriddenMethods) {
+            if (!overriddenMethod.data(ctx)->flags.isAbstract) {
+                mostSpecificImpl = overriddenMethod;
+                break;
+            }
+        }
+    }
+
+    // If no implementation found yet, use first abstract method
+    if (!mostSpecificImpl.exists()) {
+        for (auto &overriddenMethod : overriddenMethods) {
+            if (overriddenMethod.data(ctx)->flags.isAbstract) {
+                mostSpecificImpl = overriddenMethod;
+                break;
+            }
+        }
+    }
+
+    if (method.data(ctx)->flags.isAbstract && klassData->isSingletonClass(ctx)) {
+        auto attached = klassData->attachedClass(ctx);
+        if (attached.exists() && attached.data(ctx)->isModule()) {
+            if (auto e =
+                    ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::StaticAbstractModuleMethod)) {
+                e.setHeader("Static methods in a module cannot be abstract");
+            }
+        }
+    }
+
+    if (overriddenMethods.empty() && method.data(ctx)->flags.isOverride &&
         !method.data(ctx)->flags.isIncompatibleOverride) {
         if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
             e.setHeader("Method `{}` is marked `{}` but does not override anything", method.show(ctx), "override");
@@ -577,11 +599,14 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
                 }
             }
         }
-        if ((overriddenMethod.data(ctx)->flags.isAbstract || overriddenMethod.data(ctx)->flags.isOverridable ||
-             (overriddenMethod.data(ctx)->hasSig() && method.data(ctx)->flags.isOverride)) &&
+        if ((overriddenMethod == mostSpecificImpl ||
+             (method.data(ctx)->name == core::Names::initialize() && overriddenMethod.data(ctx)->flags.isAbstract &&
+              overriddenMethod.enclosingClass(ctx).data(ctx)->flags.isInterface)) &&
             !method.data(ctx)->flags.isIncompatibleOverride && !isRBI &&
             !method.data(ctx)->flags.isRewriterSynthesized &&
-            overriddenMethod != core::Symbols::BasicObject_initialize()) {
+            overriddenMethod != core::Symbols::BasicObject_initialize() &&
+            (overriddenMethod.data(ctx)->flags.isAbstract || overriddenMethod.data(ctx)->flags.isOverridable ||
+             overriddenMethod.data(ctx)->hasSig())) {
             // We only ignore BasicObject#initialize for backwards compatibility.
             // One day, we may want to build something like overridable(allow_incompatible: true)
             // and mark certain methods in the standard library as possible to be overridden incompatibly,

--- a/test/testdata/definition_validator/duplicate_override_warning.rb
+++ b/test/testdata/definition_validator/duplicate_override_warning.rb
@@ -1,0 +1,34 @@
+# typed: true
+class Module; include T::Sig; end
+
+module Runnable
+  extend T::Helpers
+  interface!
+
+  sig {abstract.void}
+  def run; end
+end
+
+module Parent
+  include Runnable
+
+  sig {override.void}
+  def run; end
+end
+
+class Child1
+  include Parent
+  
+  sig {override.params(x: Integer).void}
+  def run(x); end # 💥 note Parent#run vs Runnable#run in error
+# ^^^^^^^^^^ error: Override of method `Parent#run` must accept no more than `0` required argument(s)
+end
+
+class Child2
+  include Parent
+  
+  sig {params(x: Integer).void}
+  def run(x); end
+# ^^^^^^^^^^ error: Implementation of abstract method `Runnable#run` must accept no more than `0` required argument(s)
+# ^^^^^^^^^^ error: Method `Child2#run` implements an abstract method `Runnable#run` but is not declared with `override.`
+end


### PR DESCRIPTION
When a method overrides both a concrete implementation and implements an interface method, Sorbet was validating against both implementations, leading to duplicate and potentially confusing errors. This PR introduces `mostSpecificImpl` to avoid any unnecessary checks and redundant errors by determining exactly one method signature to validate against. For methods marked with `override`, `mostSpecificImpl` is set to the first non-abstract method found in the inheritance chain. For methods without `override`, `mostSpecificImpl` is set to the first abstract method found. For `initialize` methods, we validate against interface requirements regardless of `mostSpecificImpl`.

This could easily be configured to help with #6892 by having Sorbet say that you can’t override an existing method and make it abstract, but I think that it would be better to go with the second idea to make it more idiomatic. I can either update this PR to include the first option, or give the second one a go in a new PR.

### Motivation
Fixes #6564: Duplicate error message in override checking


### Test plan

See included automated tests. The existing `resolver/interface_initialize` test makes sure that `initialize` methods properly validate against interface requirements.