### PR TITLE
Fix a use-after-free in textDocument/formatting

### DIFF
--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -72,6 +72,7 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
     auto path = config.remoteName2Local(params->textDocument->uri);
 
     auto maybeFileContents = preprocessor.maybeGetFileContents(path);
+    std::string ignoredFileContents;
     string_view sourceView;
     if (maybeFileContents.has_value()) {
         sourceView = maybeFileContents.value();
@@ -81,8 +82,11 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
         // we leave sourceView as empty and this becomes a no-op
 
         // In this case, the request is for a file that's
-        // not open in the IDE, so we read it from disk instead
-        sourceView = sorbet::FileOps::read(path);
+        // not open in the IDE, so we read it from disk instead.
+        // We store it in `ignoredFileContents` to ensure that the
+        // `sourceView` points at valid data for its lifetime.
+        ignoredFileContents = sorbet::FileOps::read(path);
+        sourceView = ignoredFileContents;
     }
 
     // Don't format `__package.rb` files, since currently formatting them


### PR DESCRIPTION
When formatting an ignored file we read the file from disk so that we have something to send to rubyfmt. However, we were returning the content as a `std::string_view` to the read `std::string` contents, which we then free at the end of the block.

This PR fixes the issue by persisting the `std::string` that's read to the end of the function, avoiding any corruption introduced by referring to freed data.

### Motivation
Fixing a rubyfmt crash.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We have tests for formatting results, but for this case we need to format something explicitly ignored. I've tested this change out on pay-server, and am not really sure it's worth trying to put a regression test in place.