### PR TITLE
Add static errors for bad prop names and attributes

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -244,7 +244,7 @@ class T::Props::Decorator
     nil
   end
 
-  SAFE_NAME = T.let(/\A[A-Za-z_][A-Za-z0-9_-]*\z/.freeze, Regexp, checked: false)
+  SAFE_NAME = T.let(/\A[A-Za-z_][A-Za-z0-9_]*\z/.freeze, Regexp, checked: false)
 
   # Used to validate both prop names and serialized forms
   sig {params(name: T.any(Symbol, String)).void.checked(:never)}

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -18,43 +18,44 @@ namespace {
 pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::ExpressionPtr &name) {
     core::LocOffsets loc;
     core::NameRef res;
+
     if (auto *lit = ast::cast_tree<ast::Literal>(name)) {
-        if (lit->isSymbol()) {
-            res = lit->asSymbol();
-            loc = lit->loc;
-            ENFORCE(ctx.locAt(loc).exists());
-            ENFORCE(ctx.locAt(loc).source(ctx).value().size() > 1 && ctx.locAt(loc).source(ctx).value()[0] == ':');
-            loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos()};
-        } else if (lit->isString()) {
-            core::NameRef nameRef = lit->asString();
-            auto shortName = nameRef.shortName(ctx);
-            bool validAttr = (isalpha(shortName.front()) || shortName.front() == '_') &&
+        if (lit->isSymbol() || lit->isString()) {
+            res = lit->isSymbol() ? lit->asSymbol() : lit->asString();
+            auto shortName = res.shortName(ctx);
+            bool validAttr = !shortName.empty() && (isalpha(shortName.front()) || shortName.front() == '_') &&
                              absl::c_all_of(shortName, [](char c) { return isalnum(c) || c == '_'; });
-            if (validAttr) {
-                res = nameRef;
-            } else {
+            if (!validAttr) {
                 if (auto e = ctx.beginIndexerError(name.loc(), core::errors::Rewriter::BadAttrArg)) {
                     e.setHeader("Bad attribute name \"{}\"", absl::CEscape(shortName));
                 }
-                res = core::Names::empty();
+                return make_pair(core::Names::empty(), name.loc());
             }
             loc = lit->loc;
-            DEBUG_ONLY({
-                auto l = ctx.locAt(loc);
-                ENFORCE(l.exists());
-                auto source = l.source(ctx).value();
-                ENFORCE(source.size() > 2);
-                ENFORCE(source[0] == '"' || source[0] == '\'');
-                auto lastChar = source[source.size() - 1];
-                ENFORCE(lastChar == '"' || lastChar == '\'');
-            });
-            loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos() - 1};
+            if (lit->isSymbol()) {
+                ENFORCE(ctx.locAt(loc).exists());
+                ENFORCE(!ctx.locAt(loc).source(ctx).value().empty() && ctx.locAt(loc).source(ctx).value()[0] == ':');
+                loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos()};
+            } else {
+                DEBUG_ONLY({
+                    auto l = ctx.locAt(loc);
+                    ENFORCE(l.exists());
+                    auto source = l.source(ctx).value();
+                    ENFORCE(source.size() > 2);
+                    ENFORCE(source[0] == '"' || source[0] == '\'');
+                    auto lastChar = source[source.size() - 1];
+                    ENFORCE(lastChar == '"' || lastChar == '\'');
+                });
+                loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos() - 1};
+            }
         }
     }
+
     if (!res.exists()) {
         if (auto e = ctx.beginIndexerError(name.loc(), core::errors::Rewriter::BadAttrArg)) {
             e.setHeader("arg must be a Symbol or String");
         }
+        return make_pair(res, name.loc());
     }
     return make_pair(res, loc);
 }

--- a/test/testdata/rewriter/prop_bad_name.rb
+++ b/test/testdata/rewriter/prop_bad_name.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+class A < T::Struct
+  prop :'with-hyphen', Integer
+  #      ^^^^^^^^^^^ error: Bad prop name "with-hyphen"
+  prop :$dollar, Integer
+  #     ^^^^^^^ error: Bad prop name "$dollar"
+  prop :"", Integer
+  #     error: Bad prop name ""
+  prop "not_a_symbol", String
+  #    ^^^^^^^^^^^^^^ error: Expected `Symbol` but found `String("not_a_symbol")` for argument `name`
+end
+
+class B
+  attr_reader :'with-hyphen'
+  #           ^^^^^^^^^^^^^^ error: Bad attribute name "with-hyphen"
+  attr_reader :$dollar
+  #           ^^^^^^^^ error: Bad attribute name "$dollar"
+  attr_reader :""
+  #           ^^^ error: Bad attribute name ""
+end

--- a/test/testdata/rewriter/quoted_symbol_error.rb
+++ b/test/testdata/rewriter/quoted_symbol_error.rb
@@ -4,9 +4,10 @@ class A < T::Struct
   prop :'foo', Integer
   prop :"bar", Integer
   prop :"", Integer
+#     error: Bad prop name ""
   prop :"#{A.name}", Integer
 end
 
-a = A.new(foo: 0, bar: 1) # error: Missing required keyword argument `` for method `A#initialize`
+a = A.new(foo: 0, bar: 1)
 a.foo = '' # error: Assigning a value to `foo` that does not match expected type `Integer`
 a.bar = '' # error: Assigning a value to `bar` that does not match expected type `Integer`


### PR DESCRIPTION
Previously, props and attributes with invalid names (like those containing hyphens, empty strings) would only fail at runtime. This change adds static validation at the `#typed true` level to catch these issues earlier. The validation follows the same rules as Ruby's `rb_is_attr_name` function and the runtime `SAFE_NAME` regex. The regex has been (very) slightly modified to reject prop names that contain hyphens during runtime. This change also updates the `quoted_symbol_error` test (#6314) to add an error expectation for one case that had an invalid prop name.

`prop :'with-hyphen', Integer` will now throw this error with the runtime change:

`Invalid prop name in A: with-hyphen (ArgumentError)`

As opposed to:

`invalid attribute name 'with-hyphen' (NameError)`


### Motivation
Fixes #6414 - errors are more consistent with `sorbet-runtime` results


### Test plan

See included automated tests.
