### PR TITLE
Prevent crash when including `::Array` in`::Module`

### DIFF
--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -223,12 +223,13 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
     }
     for (auto mixin : sym.data(gs)->mixins()) {
         resolveTypeMembers(gs, mixin, typeAliases, resolved);
-        auto typeMembers = mixin.data(gs)->typeMembers();
-        for (auto tm : typeMembers) {
-            resolveTypeMember(gs, mixin, tm, sym, typeAliases);
+        if (sym != core::Symbols::Module()) {
+            auto typeMembers = mixin.data(gs)->typeMembers();
+            for (auto tm : typeMembers) {
+                resolveTypeMember(gs, mixin, tm, sym, typeAliases);
+            }
         }
     }
-
     // If this class has no type members, fix attached class early.
     if (sym.data(gs)->typeMembers().empty()) {
         sym.data(gs)->unsafeComputeExternalType(gs);

--- a/test/testdata/resolver/include_array_module.rb
+++ b/test/testdata/resolver/include_array_module.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+# You don't want to write code like this, but it used to result in a crash.
+class Module # error-with-dupes: Missing definition for abstract method `Enumerable#each`
+  include Array
+  #       ^^^^^ error: Only modules can be `include`d, but `Array` is a class
+
+  include String
+  #       ^^^^^^ error: Only modules can be `include`d, but `String` is a class
+
+  include Hash
+  #       ^^^^ error: Only modules can be `include`d, but `Hash` is a class
+end


### PR DESCRIPTION
The resolver previously crashed when attempting to include `::Array` in `::Module`. This change adds a check within the `addMixin` logic in `resolveAncestorJob` to specifically handle `Array` when validating includes. This prevents an invalid type construction that would lead to a sanity check failure during type inference.
 
### Motivation
Fixes #8208 

### Test plan

See included automated tests.