### PR TITLE
Add missing static error for generic type application at `typed: false`

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -37,7 +37,7 @@ constexpr ErrorClass UntypedConstantSuggestion{7027, StrictLevel::Strict};
 // constexpr ErrorClass LazyResolve{7029, StrictLevel::True};
 constexpr ErrorClass MetaTypeDispatchCall{7030, StrictLevel::True};
 constexpr ErrorClass PrivateMethod{7031, StrictLevel::True};
-// constexpr ErrorClass GenericArgumentKeywordArgs{7032, StrictLevel::True};
+constexpr ErrorClass GenericArgumentKeywordArgs{7032, StrictLevel::True};
 constexpr ErrorClass KeywordArgHashWithoutSplat{7033, StrictLevel::True};
 constexpr ErrorClass UnnecessarySafeNavigation{7034, StrictLevel::True};
 constexpr ErrorClass TakesNoBlock{7035, StrictLevel::True};

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1750,7 +1750,7 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
 
             auto returnType = Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, applied->klass,
                                                         core::errors::Infer::GenericArgumentCountMismatch,
-                                                        core::errors::Resolver::GenericArgumentKeywordArgs);
+                                                        core::errors::Infer::GenericArgumentKeywordArgs);
             return DispatchResult(returnType, args.selfType, Symbols::T_Generic_squareBrackets());
         }
         case Names::bind().rawId():
@@ -2242,7 +2242,7 @@ public:
 
         res.returnType = Types::applyTypeArguments(gs, args.locs, args.numPosArgs, args.args, attachedClass,
                                                    core::errors::Infer::GenericArgumentCountMismatch,
-                                                   core::errors::Resolver::GenericArgumentKeywordArgs);
+                                                   core::errors::Infer::GenericArgumentKeywordArgs);
     }
 } T_Generic_squareBrackets;
 

--- a/test/testdata/resolver/generic_type_false_error.rb
+++ b/test/testdata/resolver/generic_type_false_error.rb
@@ -11,5 +11,5 @@ end
 sig {returns(T::Hash[y: String, z: Integer])} 
 #                    ^^^^^^^^^^^^^^^^^^^^^ error: Keyword arguments given to `Hash`
 def regression
-  {}
+  T::Array[Integer, x: Integer].new # We don't report the type syntax error for expressions in # typed: false files
 end


### PR DESCRIPTION
This change makes keyword arguments in generic types report errors at `# typed: false`, which is more consistent with other syntax errors. This was done by removing the `GenericArgumentKeywordArgs` error from `Infer`, since we can rely on the error in `resolver` instead. The error level was set to `StrictLevel::False`, and the error classes in `dispatchCall` and `T_Generic_squareBrackets` were updated to use the `resolver` errors.

**Update**: It was determined that simply changing the error level for `GenericArgumentKeywordArgs` in `resolver` was sufficient to address the issue.

### Motivation
Fixes #6796 


### Test plan

See included automated tests.
