### PR TITLE
Add an output iterator that only writes the nameHash of a SymbolHash

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -108,7 +108,7 @@ public:
     NameHashOutputIterator(container_type &container) : container{container} {}
 
     NameHashOutputIterator &operator=(const core::SymbolHash &symHash) {
-        container.push_back(symHash.nameHash);
+        container.emplace_back(symHash.nameHash);
         return *this;
     }
 


### PR DESCRIPTION
When using set intersection to determine the changed symbol hashes, we currently first collect all `SymbolHash` values that are common, then project out the `nameHash` field, and then finally dedupe and sort that vector. We can avoid creating the intermediate vector of `SymbolHash` values by adding a custom output iterator that only writes out the `nameHash` field. This saves us on the intermediate allocation, as well as the subsequent transform to project out all `nameHash` fields.


### Motivation
Performance of `fastPathFilesToTypecheck`, which is used to decide if we should take the fast or slow paths.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is an optimization, and shouldn't affect correctness.
