### PR TITLE
Assorted improvements to "multiple times" prop error

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -571,6 +571,7 @@ public:
     };
     std::string show(const GlobalState &gs, ShowOptions options) const;
     std::string showValue(const GlobalState &gs) const;
+    static std::string showAsSymbolLiteral(const GlobalState &gs, NameRef name);
     uint32_t hash(const GlobalState &gs) const;
 
     bool equals(const NamedLiteralType &rhs) const;

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -82,14 +82,18 @@ string NamedLiteralType::showValue(const GlobalState &gs) const {
         case NamedLiteralType::LiteralTypeKind::String:
             return fmt::format("\"{}\"", absl::CEscape(asName().show(gs)));
         case NamedLiteralType::LiteralTypeKind::Symbol: {
-            auto shown = asName().show(gs);
+            return showAsSymbolLiteral(gs, asName());
+        }
+    }
+}
+
+string NamedLiteralType::showAsSymbolLiteral(const GlobalState &gs, NameRef name) {
+            auto shown = name.show(gs);
             if (absl::StrContains(shown, " ")) {
                 return fmt::format(":\"{}\"", absl::CEscape(shown));
             } else {
                 return fmt::format(":{}", shown);
             }
-        }
-    }
 }
 
 string IntegerLiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -88,12 +88,12 @@ string NamedLiteralType::showValue(const GlobalState &gs) const {
 }
 
 string NamedLiteralType::showAsSymbolLiteral(const GlobalState &gs, NameRef name) {
-            auto shown = name.show(gs);
-            if (absl::StrContains(shown, " ")) {
-                return fmt::format(":\"{}\"", absl::CEscape(shown));
-            } else {
-                return fmt::format(":{}", shown);
-            }
+    auto shown = name.show(gs);
+    if (absl::StrContains(shown, " ")) {
+        return fmt::format(":\"{}\"", absl::CEscape(shown));
+    } else {
+        return fmt::format(":{}", shown);
+    }
 }
 
 string IntegerLiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -609,8 +609,10 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
             auto it = seenProps.find(propInfo->name);
             if (it != seenProps.end()) {
                 if (auto e = ctx.beginIndexerError(propInfo->loc, core::errors::Rewriter::DuplicateProp)) {
-                    e.setHeader("{} is defined multiple times", propInfo->isImmutable ? "const" : "prop");
-                    e.addErrorLine(ctx.locAt(props[it->second].loc), "Previous definition is here");
+                    auto headerProp = fmt::format("{} {}", propInfo->isImmutable ? "const" : "prop",
+                                                  core::NamedLiteralType::showAsSymbolLiteral(ctx, propInfo->name));
+                    e.setHeader("The `{}` is defined multiple times", headerProp);
+                    e.addErrorLine(ctx.locAt(props[it->second].loc), "Originally defined here");
                 }
                 continue;
             }

--- a/test/testdata/rewriter/prop_duplicated.rb
+++ b/test/testdata/rewriter/prop_duplicated.rb
@@ -4,13 +4,16 @@ class A < T::Struct
 
   const :name, String
   prop :name, Integer
-# ^^^^^^^^^^^^^^^^^^^ error: prop is defined multiple times
+# ^^^^^^^^^^^^^^^^^^^ error: The `prop :name` is defined multiple times
 
   prop :age, Integer
   const :name, Float
-# ^^^^^^^^^^^^^^^^^^ error: const is defined multiple times
+# ^^^^^^^^^^^^^^^^^^ error: The `const :name` is defined multiple times
 
   const :age, Float
-# ^^^^^^^^^^^^^^^^^ error: const is defined multiple times
+# ^^^^^^^^^^^^^^^^^ error: The `const :age` is defined multiple times
 
+  prop :"foo 'bar", Integer
+  prop :"foo 'bar", Integer
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ error: The `prop :"foo \'bar"` is defined multiple times
 end

--- a/test/testdata/rewriter/prop_duplicated.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_duplicated.rb.rewrite-tree.exp
@@ -1,13 +1,14 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (<emptyTree>::<C T>::<C Struct>)
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:name, <emptyTree>::<C String>, :age, <emptyTree>::<C Integer>).void()
+      <self>.params(:name, <emptyTree>::<C String>, :age, <emptyTree>::<C Integer>, :"foo \'bar", <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<todo method>>(name:, age:, &<blk>)
+    def initialize<<todo method>>(name:, age:, foo 'bar:, &<blk>)
       begin
         @name = <cast:let>(name, <todo sym>, <emptyTree>::<C String>)
         @age = <cast:let>(age, <todo sym>, <emptyTree>::<C Integer>)
+        @foo 'bar = <cast:let>(foo 'bar, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end
@@ -36,6 +37,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @age = arg0
     end
 
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo 'bar<<todo method>>(&<blk>)
+      @foo 'bar
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo 'bar=<<todo method>>(arg0, &<blk>)
+      @foo 'bar = arg0
+    end
+
     <runtime method definition of initialize>
 
     <self>.const(:name, <emptyTree>::<C String>, :without_accessors, true)
@@ -53,5 +70,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.const(:name, <emptyTree>::<C Float>)
 
     <self>.const(:age, <emptyTree>::<C Float>)
+
+    <self>.prop(:"foo \'bar", <emptyTree>::<C Integer>, :without_accessors, true)
+
+    <runtime method definition of foo 'bar>
+
+    <runtime method definition of foo 'bar=>
+
+    <self>.prop(:"foo \'bar", <emptyTree>::<C Integer>)
   end
 end


### PR DESCRIPTION
1.  Mentions the name of the prop in the header

2.  The interpolated part of the error header uses backticks so that it
    will be colored cyan in the terminal.

3.  Starts the error header with a capital letter. All errors in Sorbet
    start with capital letters and end with no punctuation, except for
    parser errors, which all start with lowercase errors.

4.  Rewords the error line for consistency with other error lines.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Consistency with new error (see #8276)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.