### PR TITLE
lift out `end()` computation on `mixins()` loops

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -731,9 +731,9 @@ MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrMod
         return result;
     }
 
-    for (auto it = owner.data(gs)->mixins().begin(); it != owner.data(gs)->mixins().end(); ++it) {
-        ENFORCE(it->exists());
-        result = it->data(gs)->findMethod(gs, name);
+    for (auto sym : owner.data(gs)->mixins()) {
+        ENFORCE(sym.exists());
+        result = sym.data(gs)->findMethod(gs, name);
 
         if (result.exists() && result.data(gs)->flags.isOverloaded) {
             auto overloadName = gs.lookupNameUnique(UniqueNameKind::Overload, name, 1);
@@ -761,7 +761,7 @@ SymbolRef ClassOrModule::findParentMemberTransitiveInternal(const GlobalState &g
                                                             bool dealias) const {
     SymbolRef result;
     if (flags.isLinearizationComputed) {
-        for (auto it = this->mixins().begin(); it != this->mixins().end(); ++it) {
+        for (auto it = this->mixins().begin(), end = this->mixins().end(); it != end; ++it) {
             ENFORCE(it->exists());
             result = dealias ? it->data(gs)->findMember(gs, name) : it->data(gs)->findMemberNoDealias(name);
             if (result.exists()) {
@@ -769,7 +769,7 @@ SymbolRef ClassOrModule::findParentMemberTransitiveInternal(const GlobalState &g
             }
         }
     } else {
-        for (auto it = this->mixins().rbegin(); it != this->mixins().rend(); ++it) {
+        for (auto it = this->mixins().rbegin(), end = this->mixins().rend(); it != end; ++it) {
             ENFORCE(it->exists());
             result = it->data(gs)->findMemberTransitiveInternal(gs, name, maxDepth - 1, dealias);
             if (result.exists()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The compiler wasn't able to notice that `end()` is constant for the entire duration of the loop in `findParentMemberTransitiveInternal`, presumably because `InlinedVector::end` carries conditional logic, etc.

I noticed that `findParentMemberTransitiveInternal` was somewhat expensive when profiling a cut-down version of the testcase in #4326.  This change reduces instruction count as measured by cachegrind by ~0.5%, but is probably somewhat less effective on "real" codebases because namer/resolver/etc. would play a bigger role.  Still, performance improvements are performance improvements.

I changed the code in `findConcreteMethodTransitiveInternal` for similar reasons, though I didn't notice performance problems with it.  I opted to keep the `begin`/`end` treatment for `findParentMemberTransitiveInternal` for consistency's sake between the cases in that function.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
