### PR TITLE
pass `fullType` by reference in `DispatchArgs`

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -993,7 +993,7 @@ struct DispatchArgs {
     uint16_t numPosArgs;
     InlinedVector<const TypeAndOrigins *, 2> &args;
     const TypePtr &selfType;
-    const TypeAndOrigins fullType;
+    const TypeAndOrigins &fullType;
     const TypePtr &thisType;
     const std::shared_ptr<const SendAndBlockLink> &block;
     Loc originForUninitialized;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1718,12 +1718,13 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
             }
 
             // The Ruby VM treats `initialize` as private by default, but allows calling it directly within `new`.
+            const TypeAndOrigins wrappedFullType{wrapped, args.fullType.origins};
             auto innerArgs = DispatchArgs{Names::initialize(),
                                           args.locs,
                                           args.numPosArgs,
                                           args.args,
                                           wrapped,
-                                          {wrapped, args.fullType.origins},
+                                          wrappedFullType,
                                           wrapped,
                                           args.block,
                                           args.originForUninitialized,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This field never changes as we pass it down through dispatch -- especially through `T.any` or `T.all` -- and we shouldn't be copying the whole thing as we go.  (It might even be profitable to package several of these fields up into a structure and just pass a reference to that structure in `DispatchArgs`, as at least `fullType` and `originForUninitialized` appear to be used mostly for error cases.)

This change reduces instruction count as measured by cachegrind by 10% (!) on a cut-down version of the testcase in #4326.  That testcase is slightly pathological in how much dispatching takes place, but I am mildly optimistic that this change would actually result in a small reduction in typechecking time on Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
