### PR TITLE
avoid generating errors if we weren't already generating them

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -107,9 +107,11 @@ DispatchResult AndType::dispatchCall(const GlobalState &gs, const DispatchArgs &
         return rightRet;
     }
     if (!rightOk && !leftOk) {
-        // Expensive case. Re-dispatch the calls with errors enabled so we can give the user an error.
-        leftRet = left.dispatchCall(gs, args.withThisRef(left));
-        rightRet = right.dispatchCall(gs, args.withThisRef(right));
+        if (!args.suppressErrors) {
+            // Expensive case. Re-dispatch the calls with errors enabled so we can give the user an error.
+            leftRet = left.dispatchCall(gs, args.withThisRef(left));
+            rightRet = right.dispatchCall(gs, args.withThisRef(right));
+        }
     }
 
     return DispatchResult::merge(gs, DispatchResult::Combinator::AND, std::move(leftRet), std::move(rightRet));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

cc @jvilk-stripe 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When we do method dispatch for an `AndType`, we first suppress errors when doing the recursive call; this was introduced in #3641 to avoid expensive error generation.

This works well for something like `T.all(Mixin, ActualClassWithTheMethod)`, but for something like `T.all(M1, M2, M3, M4, M5, ActualClassWithTheMethod)`, we are going to discover that M1 and M2 don't have the method, do the redispatch...and then when we're checking M3 + `T.all(M1, M2)`, we're going to discover that neither of *those* have the method, do a redispatch, and then do the same dance of check and re-dispatch on `T.all(M1, M2)`.  But we already *did* that.  And so on up the spine of the `T.all`.  This is accidentally exponential in the number of members of the `T.all`.

The fix is to not do the redispatch if we weren't generating errors in the first place.  I think we still do a bunch of duplicate typechecking in the error case, but even for the 60-element `T.all` in #4326, the typechecking with this fix is quite fast (like, 100ms for executing `sorbet testcase.rb` on a Stripe devbox fast).  So I'm not too worried about that.

Fixes #4326 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
