### PR TITLE
suppress errors for `AndType` directly

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -1053,7 +1053,6 @@ struct DispatchArgs {
 
     DispatchArgs withSelfAndThisRef(const TypePtr &newSelfRef) const;
     DispatchArgs withThisRef(const TypePtr &newThisRef) const;
-    DispatchArgs withErrorsSuppressed() const;
 };
 
 struct DispatchComponent {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -94,8 +94,13 @@ TypePtr OrType::getCallArguments(const GlobalState &gs, NameRef name) const {
 DispatchResult AndType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
     categoryCounterInc("dispatch_call", "andtype");
     // Tell dispatchCall to not produce any dispatch-related errors. They are very expensive to produce.
-    auto leftRet = left.dispatchCall(gs, args.withThisRef(left).withErrorsSuppressed());
-    auto rightRet = right.dispatchCall(gs, args.withThisRef(right).withErrorsSuppressed());
+    auto leftArgsNoErrors = args.withThisRef(left);
+    leftArgsNoErrors.suppressErrors = true;
+    auto leftRet = left.dispatchCall(gs, leftArgsNoErrors);
+
+    auto rightArgsNoErrors = args.withThisRef(right);
+    rightArgsNoErrors.suppressErrors = true;
+    auto rightRet = right.dispatchCall(gs, rightArgsNoErrors);
 
     // If either side is missing the method, dispatch to the other.
     auto leftOk = allComponentsPresent(leftRet);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1166,13 +1166,6 @@ DispatchArgs DispatchArgs::withThisRef(const TypePtr &newThisRef) const {
                         isPrivateOk, suppressErrors, enclosingMethodForSuper};
 }
 
-DispatchArgs DispatchArgs::withErrorsSuppressed() const {
-    return DispatchArgs{name,        locs,     numPosArgs,
-                        args,        selfType, fullType,
-                        thisType,    block,    originForUninitialized,
-                        isPrivateOk, true,     enclosingMethodForSuper};
-}
-
 DispatchResult DispatchResult::merge(const GlobalState &gs, DispatchResult::Combinator kind, DispatchResult &&left,
                                      DispatchResult &&right) {
     DispatchResult res;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The functional idea behind `withErrorsSuppressed` is a good one, but for:

```c++
  args.withThisRef(left).withErrorsSuppressed();
```

we are still generating a temporary object from the `withThisRef` that needs to have its destructor called, extra stack space, etc.  The compiler could be smart enough to see that the temporary object could be reused -- I think that sort of optimization is possible in Rust? -- but alas, we have to do things manually.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
