### PR TITLE
Always return the kvstore from maybeCacheGlobalStateAndFiles

### DIFF
--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -189,7 +189,7 @@ unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore
                           sizeBytes, usedPercent);
     } else {
         prodCounterInc("cache.aborted");
-        OwnedKeyValueStore::abort(move(ownedKvstore));
+        kvstore = OwnedKeyValueStore::abort(move(ownedKvstore));
     }
 
     return kvstore;


### PR DESCRIPTION
When we abort writes in `maybeCacheGlobalStateAndjfiles`, we abort the writes and don't move the resulting store back into the `kvstore` pointer, which we then return. This PR changes that behavior, returning the store with the aborted writes so that it can still be used for subsequent cache lookups.

The tests change to reflect this: when stripe-packages are enabled, we see cache hits in the presence of a warm cache increase.

### Motivation
More caching.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
