### PR TITLE
Reduce packager allocations

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1485,10 +1485,11 @@ unique_ptr<PackageInfoImpl> createAndPopulatePackageInfo(core::GlobalState &gs, 
         populateMangledName(gs, visibleTo.first);
     }
 
-    auto extraPackageFilesDirectoryUnderscorePrefixes = gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes();
-    auto extraPackageFilesDirectorySlashDeprecatedPrefixes =
+    const auto &extraPackageFilesDirectoryUnderscorePrefixes =
+        gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes();
+    const auto &extraPackageFilesDirectorySlashDeprecatedPrefixes =
         gs.packageDB().extraPackageFilesDirectorySlashDeprecatedPrefixes();
-    auto extraPackageFilesDirectorySlashPrefixes = gs.packageDB().extraPackageFilesDirectorySlashPrefixes();
+    const auto &extraPackageFilesDirectorySlashPrefixes = gs.packageDB().extraPackageFilesDirectorySlashPrefixes();
 
     const auto numPrefixes = extraPackageFilesDirectoryUnderscorePrefixes.size() +
                              extraPackageFilesDirectorySlashDeprecatedPrefixes.size() +

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1504,34 +1504,31 @@ unique_ptr<PackageInfoImpl> createAndPopulatePackageInfo(core::GlobalState &gs, 
 
     for (const string &prefix : extraPackageFilesDirectoryUnderscorePrefixes) {
         // Project_FooBar -- munge with underscore
-        string additionalDirPath = absl::StrCat(prefix, dirNameFromShortName, "/");
-        info->packagePathPrefixes.emplace_back(std::move(additionalDirPath));
+        info->packagePathPrefixes.emplace_back(absl::StrCat(prefix, dirNameFromShortName, "/"));
     }
 
     for (const string &prefix : extraPackageFilesDirectorySlashDeprecatedPrefixes) {
         // project/Foo_bar -- convert camel-case to snake-case and munge with slash
-        std::stringstream ss;
-        ss << prefix;
+        std::string additionalDirPath;
+        additionalDirPath.reserve(prefix.size() + 2 * dirNameFromShortName.length() + 1);
+        additionalDirPath += prefix;
         for (int i = 0; i < dirNameFromShortName.length(); i++) {
             if (dirNameFromShortName[i] == '_') {
-                ss << '/';
+                additionalDirPath.push_back('/');
             } else if (i == 0 || dirNameFromShortName[i - 1] == '_') {
                 // Capitalizing first letter in each directory name to avoid conflicts with ignored directories,
                 // which tend to be all lower case
-                char upper = std::toupper(dirNameFromShortName[i]);
-                ss << std::move(upper);
+                additionalDirPath.push_back(std::toupper(dirNameFromShortName[i]));
             } else {
                 if (isupper(dirNameFromShortName[i])) {
-                    ss << '_'; // snake-case munging
+                    additionalDirPath.push_back('_'); // snake-case munging
                 }
 
-                char lower = std::tolower(dirNameFromShortName[i]);
-                ss << std::move(lower);
+                additionalDirPath.push_back(std::tolower(dirNameFromShortName[i]));
             }
         }
-        ss << '/';
+        additionalDirPath.push_back('/');
 
-        std::string additionalDirPath(ss.str());
         info->packagePathPrefixes.emplace_back(std::move(additionalDirPath));
     }
 


### PR DESCRIPTION
While looking at the region of a trace attributed to `findPackages`, @froydnj and I noticed a few things that could be improved with the current implementation:

- Vectors were being copied out of global state, despite the functions that return them returning a constant reference
- std::stringstream was used where a preallocated string would work
- Inserting packages into the packageDB was using `find` and then `[]` to assign, when it could use the single `insert` function that does both.

### Motivation
Performance of stripe-packages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This shouldn't change any behavior, only improve performance when stripe-packages is enabled.
