### PR TITLE
Change the origin of non-synthetic assignments

### DIFF
--- a/core/LocalVariable.cc
+++ b/core/LocalVariable.cc
@@ -24,7 +24,10 @@ bool LocalVariable::isSyntheticTemporary() const {
            _name == Names::arrayTemp() || _name == Names::rescueTemp() || _name == Names::exceptionValue() ||
            _name == Names::exceptionClassTemp() || _name == Names::gotoDeadTemp() || _name == Names::isaCheckTemp() ||
            _name == Names::throwAwayTemp() || _name == Names::castTemp() || _name == Names::finalReturn() ||
-           _name == Names::cfgAlias() || _name == Names::magic();
+           _name == Names::cfgAlias() || _name == Names::magic() || _name == Names::argPresent() ||
+           _name == Names::blkArg() || _name == Names::blockBreak() || _name == Names::blockBreakAssign() ||
+           _name == Names::blockPreCallTemp() || _name == Names::keepForCfgTemp() || _name == Names::keepForIde() ||
+           _name == Names::retryTemp();
 }
 
 bool LocalVariable::isAliasForGlobal(const GlobalState &gs) const {

--- a/core/LocalVariable.cc
+++ b/core/LocalVariable.cc
@@ -24,10 +24,7 @@ bool LocalVariable::isSyntheticTemporary() const {
            _name == Names::arrayTemp() || _name == Names::rescueTemp() || _name == Names::exceptionValue() ||
            _name == Names::exceptionClassTemp() || _name == Names::gotoDeadTemp() || _name == Names::isaCheckTemp() ||
            _name == Names::throwAwayTemp() || _name == Names::castTemp() || _name == Names::finalReturn() ||
-           _name == Names::cfgAlias() || _name == Names::magic() || _name == Names::argPresent() ||
-           _name == Names::blkArg() || _name == Names::blockBreak() || _name == Names::blockBreakAssign() ||
-           _name == Names::blockPreCallTemp() || _name == Names::keepForCfgTemp() || _name == Names::keepForIde() ||
-           _name == Names::retryTemp();
+           _name == Names::cfgAlias() || _name == Names::magic();
 }
 
 bool LocalVariable::isAliasForGlobal(const GlobalState &gs) const {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1197,7 +1197,12 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
             [&](cfg::Ident &i) {
                 const core::TypeAndOrigins &typeAndOrigin = getTypeAndOrigin(ctx, i.what);
                 tp.type = typeAndOrigin.type;
-                tp.origins = typeAndOrigin.origins;
+                if (!bind.bind.variable.isSyntheticTemporary(inWhat)) {
+                    // This `cfg::Ident` was an actual ast::Assign that the user wrote, not just an ast::Local
+                    tp.origins.emplace_back(ctx.locAt(bind.loc));
+                } else {
+                    tp.origins = typeAndOrigin.origins;
+                }
 
                 if (lspQueryMatch && !bind.value.isSynthetic()) {
                     core::lsp::QueryResponse::pushQueryResponse(

--- a/test/cli/autocorrect-payload/test.out
+++ b/test/cli/autocorrect-payload/test.out
@@ -1,11 +1,11 @@
 # typed: true
 
-T.let(FOO, T.nilable(Integer)) = 10 # TODO Also fix this autocorrect
+FOO = 10 # TODO Also fix this autocorrect
 
-a = FOO
+a = T.let(FOO, T.nilable(Integer))
 [].each { |i| a = nil }
 
-b = Float::INFINITY
+b = T.let(Float::INFINITY, T.nilable(Float))
 [].each { |i| b = nil }
 
 c = T.let(10, T.nilable(Integer))

--- a/test/cli/suggest_unsafe_dead/test.out
+++ b/test/cli/suggest_unsafe_dead/test.out
@@ -158,6 +158,10 @@ suggest_unsafe_dead.rb:89: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:88: Replaced with `T.unsafe(this)`
     88 |    unless this
                    ^^^^
+  Got `A` originating from:
+    suggest_unsafe_dead.rb:87:
+    87 |    this = self
+                   ^^^^
 Errors: 11
 
 --------------------------------------------------------------------------

--- a/test/testdata/infer/pinning_static_field.rb.autocorrects.exp
+++ b/test/testdata/infer/pinning_static_field.rb.autocorrects.exp
@@ -3,7 +3,7 @@
 
 StaticField1 = T.let(0, Integer)
 def example1
-  x = StaticField1
+  x = T.let(StaticField1, T.any(FalseClass, Integer))
   1.times do
     x = false # error: Changing the type of a variable is not permitted in loops and blocks
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #8261

Sorbet will make `cfg::Ident` instructions in response to both `ast::Assign`
nodes with a source of a variable (`x = y`) and also `ast::Local` nodes (`y`).

Sorbet previously said that the "origin" of `x` above was the same as the origin
of `y`. But when `x` is not a synthetic temporary, and was instead some
assignment that the user actually wrote, we should treat the origin of `x` as
the instruction itself in that case.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [ ] @jez Write a test