### PR TITLE
add an option to stop after all indexing

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -234,6 +234,7 @@ const vector<StopAfterOptions> stop_after_options({
     {"desugarer", Phase::DESUGARER},
     {"rewriter", Phase::REWRITER},
     {"local-vars", Phase::LOCAL_VARS},
+    {"indexing", Phase::INDEXING},
     {"namer", Phase::NAMER},
     {"resolver", Phase::RESOLVER},
     {"cfg", Phase::CFG},

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -99,6 +99,7 @@ enum class Phase {
     DESUGARER,
     REWRITER,
     LOCAL_VARS,
+    INDEXING,
     NAMER,
     PACKAGER,
     RESOLVER,

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -788,6 +788,12 @@ int realmain(int argc, char *argv[]) {
             }
         }
 
+        if (opts.stopAfterPhase == options::Phase::INDEXING) {
+            for (auto &f : indexed) {
+                f.tree = nullptr;
+            }
+        }
+
         if (gs->runningUnderAutogen) {
 #ifdef SORBET_REALMAIN_MIN
             logger->warn("Autogen is disabled in sorbet-orig for faster builds");

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -159,7 +159,8 @@ Usage:
                                 because errors from earlier phases (like resolver) can
                                 cause errors downstream (in inferencer).
                                 Phases: [init, parser, desugarer, rewriter, local-vars,
-                                namer, resolver, cfg, inferencer] (default: inferencer)
+                                indexing, namer, resolver, cfg, inferencer] (default:
+                                inferencer)
 
 ```
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I have wanted this for a while (mostly for profiling indexing without cluttering things with typechecking), and since none of the prior-to-indexing phases work with `--stripe-packages`, this seems like a good time to add it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
