### PR TITLE
Use absl::Span in more places

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -220,12 +220,12 @@ void File::setIsOpenInClient(bool isOpenInClient) {
     this->flags.isOpenInClient = isOpenInClient;
 }
 
-vector<int> &File::lineBreaks() const {
+absl::Span<const int> File::lineBreaks() const {
     ENFORCE(this->sourceType != File::Type::TombStone);
     ENFORCE(this->sourceType != File::Type::NotYetRead);
     auto ptr = atomic_load(&lineBreaks_);
     if (ptr != nullptr) {
-        return *ptr;
+        return absl::MakeSpan(*ptr);
     } else {
         auto my = make_shared<vector<int>>(findLineBreaks(this->source_));
         atomic_compare_exchange_weak(&lineBreaks_, &ptr, my);
@@ -238,7 +238,7 @@ int File::lineCount() const {
 }
 
 string_view File::getLine(int i) const {
-    auto &lineBreaks = this->lineBreaks();
+    auto lineBreaks = this->lineBreaks();
     ENFORCE(i < lineBreaks.size());
     ENFORCE(i > 0);
     auto start = lineBreaks[i - 1] + 1;

--- a/core/Files.h
+++ b/core/Files.h
@@ -76,7 +76,7 @@ public:
     File(const File &other) = delete;
     File() = delete;
     std::unique_ptr<File> deepCopy(GlobalState &) const;
-    std::vector<int> &lineBreaks() const;
+    absl::Span<const int> lineBreaks() const;
     int lineCount() const;
     StrictLevel minErrorLevel() const;
 

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -286,38 +286,38 @@ public:
     }
 
     // See documentation on _nonClassConstants
-    const std::vector<FoundDefinitionRef> &nonClassConstants() const {
-        return _nonClassConstants;
+    absl::Span<const FoundDefinitionRef> nonClassConstants() const {
+        return absl::MakeSpan(_nonClassConstants);
     }
 
     // See documentation on _klasses
-    const std::vector<FoundClass> &klasses() const {
-        return _klasses;
+    absl::Span<const FoundClass> klasses() const {
+        return absl::MakeSpan(_klasses);
     }
 
     // See documentation on _methods
-    const std::vector<FoundMethod> &methods() const {
-        return _methods;
+    absl::Span<const FoundMethod> methods() const {
+        return absl::MakeSpan(_methods);
     }
 
     // See documentation on _modifiers
-    const std::vector<FoundModifier> &modifiers() const {
-        return _modifiers;
+    absl::Span<const FoundModifier> modifiers() const {
+        return absl::MakeSpan(_modifiers);
     }
 
     // See documentation on _fields
-    const std::vector<FoundField> &fields() const {
-        return _fields;
+    absl::Span<const FoundField> fields() const {
+        return absl::MakeSpan(_fields);
     }
 
     // See documentation on _staticFields
-    const std::vector<FoundStaticField> &staticFields() const {
-        return _staticFields;
+    absl::Span<const FoundStaticField> staticFields() const {
+        return absl::MakeSpan(_staticFields);
     }
 
     // See documentation on _typeMembers
-    const std::vector<FoundTypeMember> &typeMembers() const {
-        return _typeMembers;
+    absl::Span<const FoundTypeMember> typeMembers() const {
+        return absl::MakeSpan(_typeMembers);
     }
 
     friend FoundDefinitionRef;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2511,8 +2511,8 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     return result;
 }
 
-const vector<shared_ptr<File>> &GlobalState::getFiles() const {
-    return files;
+absl::Span<const shared_ptr<File>> GlobalState::getFiles() const {
+    return absl::MakeSpan(files);
 }
 
 MethodRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -293,7 +293,7 @@ public:
     void trace(std::string_view msg) const;
 
     std::unique_ptr<LocalSymbolTableHashes> hash() const;
-    const std::vector<std::shared_ptr<File>> &getFiles() const;
+    absl::Span<const std::shared_ptr<File>> getFiles() const;
 
     // Contains a string to be used as the base of the error URL.
     // The error code is appended to this string.

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -48,8 +48,9 @@ Loc::Detail Loc::offset2Pos(const File &file, uint32_t off) {
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
         ENFORCE_NO_TIMER(false);
     }
-    auto it = absl::c_lower_bound(file.lineBreaks(), off);
-    if (it == file.lineBreaks().begin()) {
+    auto lineBreaks = file.lineBreaks();
+    auto it = absl::c_lower_bound(lineBreaks, off);
+    if (it == lineBreaks.begin()) {
         pos.line = 1;
         pos.column = off + 1;
         return pos;
@@ -62,7 +63,7 @@ Loc::Detail Loc::offset2Pos(const File &file, uint32_t off) {
 
 optional<uint32_t> Loc::pos2Offset(const File &file, Loc::Detail pos) {
     auto l = pos.line - 1;
-    auto &lineBreaks = file.lineBreaks();
+    auto lineBreaks = file.lineBreaks();
     if (!(0 <= l && l < lineBreaks.size())) {
         return nullopt;
     }

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -1,5 +1,6 @@
 #include "core/packages/PackageDB.h"
 #include "absl/strings/match.h"
+#include "absl/types/span.h"
 #include "common/sort/sort.h"
 #include "core/AutocorrectSuggestion.h"
 #include "core/GlobalState.h"
@@ -16,14 +17,14 @@ public:
         return MangledName();
     }
 
-    const vector<core::NameRef> &fullName() const {
+    absl::Span<const core::NameRef> fullName() const {
         notImplemented();
-        return emptyName;
+        return absl::Span<const core::NameRef>();
     }
 
-    const vector<string> &pathPrefixes() const {
+    absl::Span<const string> pathPrefixes() const {
         notImplemented();
-        return prefixes;
+        return absl::Span<const string>();
     }
 
     unique_ptr<PackageInfo> deepCopy() const {
@@ -88,9 +89,6 @@ public:
     ~NonePackage() {}
 
 private:
-    const vector<string> prefixes;
-    const vector<core::NameRef> emptyName;
-
     void notImplemented() const {
         ENFORCE(false, "Not implemented for NonePackage");
     }
@@ -205,16 +203,16 @@ const PackageInfo &PackageDB::getPackageInfo(MangledName mangledName) const {
     return *it->second;
 }
 
-const vector<MangledName> &PackageDB::packages() const {
-    return mangledNames;
+absl::Span<const MangledName> PackageDB::packages() const {
+    return absl::MakeSpan(mangledNames);
 }
 
-const std::vector<std::string> &PackageDB::skipRBIExportEnforcementDirs() const {
-    return skipRBIExportEnforcementDirs_;
+absl::Span<const std::string> PackageDB::skipRBIExportEnforcementDirs() const {
+    return absl::MakeSpan(skipRBIExportEnforcementDirs_);
 }
 
-const std::vector<core::NameRef> &PackageDB::layers() const {
-    return layers_;
+absl::Span<const core::NameRef> PackageDB::layers() const {
+    return absl::MakeSpan(layers_);
 }
 
 const int PackageDB::layerIndex(core::NameRef layer) const {
@@ -227,16 +225,16 @@ const bool PackageDB::enforceLayering() const {
     return !layers_.empty();
 }
 
-const std::vector<std::string> &PackageDB::extraPackageFilesDirectoryUnderscorePrefixes() const {
-    return extraPackageFilesDirectoryUnderscorePrefixes_;
+absl::Span<const std::string> PackageDB::extraPackageFilesDirectoryUnderscorePrefixes() const {
+    return absl::MakeSpan(extraPackageFilesDirectoryUnderscorePrefixes_);
 }
 
-const std::vector<std::string> &PackageDB::extraPackageFilesDirectorySlashDeprecatedPrefixes() const {
-    return extraPackageFilesDirectorySlashDeprecatedPrefixes_;
+absl::Span<const std::string> PackageDB::extraPackageFilesDirectorySlashDeprecatedPrefixes() const {
+    return absl::MakeSpan(extraPackageFilesDirectorySlashDeprecatedPrefixes_);
 }
 
-const std::vector<std::string> &PackageDB::extraPackageFilesDirectorySlashPrefixes() const {
-    return extraPackageFilesDirectorySlashPrefixes_;
+absl::Span<const std::string> PackageDB::extraPackageFilesDirectorySlashPrefixes() const {
+    return absl::MakeSpan(extraPackageFilesDirectorySlashPrefixes_);
 }
 
 const std::string_view PackageDB::errorHint() const {

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -1,6 +1,8 @@
 #ifndef SORBET_CORE_PACKAGES_PACKAGEDB_H
 #define SORBET_CORE_PACKAGES_PACKAGEDB_H
 
+#include "absl/types/span.h"
+
 #include "common/common.h"
 #include "core/Files.h"
 #include "core/Names.h"
@@ -42,7 +44,7 @@ public:
     // Get mangled names for all packages.
     // Packages are ordered lexicographically with respect to the NameRef's that make up their
     // namespaces.
-    const std::vector<MangledName> &packages() const;
+    absl::Span<const MangledName> packages() const;
 
     PackageDB deepCopy() const;
 
@@ -59,14 +61,14 @@ public:
         return this->enabled_;
     }
 
-    const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes() const;
-    const std::vector<std::string> &extraPackageFilesDirectorySlashDeprecatedPrefixes() const;
-    const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes() const;
-    const std::vector<std::string> &skipRBIExportEnforcementDirs() const;
+    absl::Span<const std::string> extraPackageFilesDirectoryUnderscorePrefixes() const;
+    absl::Span<const std::string> extraPackageFilesDirectorySlashDeprecatedPrefixes() const;
+    absl::Span<const std::string> extraPackageFilesDirectorySlashPrefixes() const;
+    absl::Span<const std::string> skipRBIExportEnforcementDirs() const;
     // Possible layers for packages to be in. The layers are ordered lowest to highest.
     // Ie. {'util', 'app'} means that code in `app` can call code in `util`, but code in `util` cannot call code in
     // `app`.
-    const std::vector<core::NameRef> &layers() const;
+    absl::Span<const core::NameRef> layers() const;
     const int layerIndex(core::NameRef layer) const;
     const bool enforceLayering() const;
 

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -20,7 +20,7 @@ PackageInfo::~PackageInfo() {
     // see https://eli.thegreenplace.net/2010/11/13/pure-virtual-destructors-in-c
 }
 
-bool PackageInfo::lexCmp(const std::vector<core::NameRef> &lhs, const std::vector<core::NameRef> &rhs) {
+bool PackageInfo::lexCmp(absl::Span<const core::NameRef> lhs, absl::Span<const core::NameRef> rhs) {
     return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(),
                                         [](NameRef a, NameRef b) -> bool { return a.rawId() < b.rawId(); });
 }
@@ -29,7 +29,7 @@ ImportInfo ImportInfo::fromPackage(const core::GlobalState &gs, const PackageInf
     ImportInfo res;
     res.package = info.mangledName();
 
-    auto &thisName = info.fullName();
+    auto thisName = info.fullName();
 
     auto &db = gs.packageDB();
 
@@ -38,7 +38,7 @@ ImportInfo ImportInfo::fromPackage(const core::GlobalState &gs, const PackageInf
             continue;
         }
 
-        auto &fullName = db.getPackageInfo(pkg).fullName();
+        auto fullName = db.getPackageInfo(pkg).fullName();
         if (thisName.size() >= fullName.size()) {
             if (std::equal(fullName.begin(), fullName.end(), thisName.begin())) {
                 res.parentImports.emplace_back(pkg);
@@ -75,7 +75,7 @@ core::ClassOrModuleRef getParentNamespaceSym(const core::GlobalState &gs, const 
 }
 
 core::ClassOrModuleRef lookupNameOn(const core::GlobalState &gs, const core::ClassOrModuleRef root,
-                                    const std::vector<core::NameRef> &name) {
+                                    absl::Span<const core::NameRef> name) {
     auto curSym = root;
     if (!curSym.exists()) {
         return {};

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -1,6 +1,8 @@
 #ifndef SORBET_CORE_PACKAGES_PACKAGEINFO_H
 #define SORBET_CORE_PACKAGES_PACKAGEINFO_H
 
+#include "absl/types/span.h"
+
 #include "core/NameRef.h"
 #include "core/SymbolRef.h"
 #include "core/packages/MangledName.h"
@@ -45,8 +47,8 @@ struct VisibleTo {
 class PackageInfo {
 public:
     virtual MangledName mangledName() const = 0;
-    virtual const std::vector<core::NameRef> &fullName() const = 0;
-    virtual const std::vector<std::string> &pathPrefixes() const = 0;
+    virtual absl::Span<const core::NameRef> fullName() const = 0;
+    virtual absl::Span<const std::string> pathPrefixes() const = 0;
     virtual std::vector<std::vector<core::NameRef>> exports() const = 0;
     virtual std::vector<std::vector<core::NameRef>> imports() const = 0;
     virtual std::vector<std::vector<core::NameRef>> testImports() const = 0;
@@ -90,7 +92,7 @@ public:
 
     // Utilities:
 
-    static bool lexCmp(const std::vector<core::NameRef> &lhs, const std::vector<core::NameRef> &rhs);
+    static bool lexCmp(absl::Span<const core::NameRef> lhs, absl::Span<const core::NameRef> rhs);
 };
 
 // Information about the imports of a package. The imports are split into two categories, packages whose name falls

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -118,7 +118,7 @@ unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat
 }
 }; // namespace
 
-void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spdlog::logger &logger,
+void Hashing::computeFileHashes(absl::Span<const shared_ptr<core::File>> files, spdlog::logger &logger,
                                 WorkerPool &workers, const realmain::options::Options &opts) {
     Timer timeit(logger, "computeFileHashes");
     auto fileq = make_shared<ConcurrentBoundedQueue<size_t>>(files.size());

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -32,7 +32,7 @@ class Hashing final {
 public:
     // Computes file hashes for the given files, and stores them in the files. If supplied, attempts to retrieve hashes
     // from the key-value store. Returns 'true' if it had to compute any file hashes.
-    static void computeFileHashes(const std::vector<std::shared_ptr<core::File>> &files, spdlog::logger &logger,
+    static void computeFileHashes(absl::Span<const std::shared_ptr<core::File>> files, spdlog::logger &logger,
                                   WorkerPool &workers, const realmain::options::Options &opts);
 
     /**

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1121,7 +1121,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                             const auto &curPkg = ctx.state.packageDB().getPackageForFile(ctx, ctx.file);
                             if (curPkg.exists() && !curPkg.ownsSymbol(ctx, klass)) {
                                 if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PackagePrivateMethod)) {
-                                    auto &curPkgName = curPkg.fullName();
+                                    auto curPkgName = curPkg.fullName();
                                     // TODO (aadi-stripe, add name of owning package to message).
                                     e.setHeader(
                                         "Method `{}` on `{}` is package-private and cannot be called from package `{}`",

--- a/main/lsp/FieldFinder.cc
+++ b/main/lsp/FieldFinder.cc
@@ -6,8 +6,9 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-FieldFinder::FieldFinder(core::ClassOrModuleRef target, ast::UnresolvedIdent::Kind queryKind)
-    : targetClass(target), queryKind(queryKind) {
+FieldFinder::FieldFinder(core::ClassOrModuleRef target, ast::UnresolvedIdent::Kind queryKind,
+                         std::vector<core::NameRef> &result)
+    : targetClass(target), queryKind(queryKind), result_{result} {
     ENFORCE(queryKind != ast::UnresolvedIdent::Kind::Local);
 }
 
@@ -38,10 +39,6 @@ void FieldFinder::preTransformClassDef(core::Context ctx, const ast::ClassDef &c
 
 void FieldFinder::postTransformClassDef(core::Context ctx, const ast::ClassDef &classDef) {
     this->classStack.pop_back();
-}
-
-const vector<core::NameRef> &FieldFinder::result() const {
-    return this->result_;
 }
 
 }; // namespace sorbet::realmain::lsp

--- a/main/lsp/FieldFinder.h
+++ b/main/lsp/FieldFinder.h
@@ -13,16 +13,15 @@ private:
 
     std::vector<core::ClassOrModuleRef> classStack;
 
-    std::vector<core::NameRef> result_;
+    std::vector<core::NameRef> &result_;
 
 public:
-    FieldFinder(core::ClassOrModuleRef target, ast::UnresolvedIdent::Kind queryKind);
+    FieldFinder(core::ClassOrModuleRef target, ast::UnresolvedIdent::Kind queryKind,
+                std::vector<core::NameRef> &result);
 
     void postTransformUnresolvedIdent(core::Context ctx, const ast::UnresolvedIdent &ident);
     void preTransformClassDef(core::Context ctx, const ast::ClassDef &classDef);
     void postTransformClassDef(core::Context ctx, const ast::ClassDef &classDef);
-
-    const std::vector<core::NameRef> &result() const;
 };
 }; // namespace sorbet::realmain::lsp
 

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -71,9 +71,4 @@ void LocalVarFinder::postTransformClassDef(core::Context ctx, const ast::ClassDe
     this->methodStack.pop_back();
 }
 
-const vector<core::NameRef> &LocalVarFinder::result() const {
-    ENFORCE(this->methodStack.empty());
-    return this->result_;
-}
-
 }; // namespace sorbet::realmain::lsp

--- a/main/lsp/LocalVarFinder.h
+++ b/main/lsp/LocalVarFinder.h
@@ -15,10 +15,11 @@ class LocalVarFinder {
     // flattened at this point. (LSP code should try to make minimal assumptions to be robust to changes.)
     std::vector<core::MethodRef> methodStack;
 
-    std::vector<core::NameRef> result_;
+    std::vector<core::NameRef> &result_;
 
 public:
-    LocalVarFinder(core::MethodRef targetMethod, core::Loc queryLoc) : targetMethod(targetMethod), queryLoc(queryLoc) {}
+    LocalVarFinder(core::MethodRef targetMethod, core::Loc queryLoc, std::vector<core::NameRef> &result)
+        : targetMethod(targetMethod), queryLoc(queryLoc), result_{result} {}
 
     void postTransformAssign(core::Context ctx, const ast::Assign &assign);
     void preTransformBlock(core::Context ctx, const ast::Block &block);
@@ -26,8 +27,6 @@ public:
     void postTransformMethodDef(core::Context ctx, const ast::MethodDef &methodDef);
     void preTransformClassDef(core::Context ctx, const ast::ClassDef &classDef);
     void postTransformClassDef(core::Context ctx, const ast::ClassDef &classDef);
-
-    const std::vector<core::NameRef> &result() const;
 };
 }; // namespace sorbet::realmain::lsp
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -644,13 +644,13 @@ vector<core::NameRef> localNamesForMethod(LSPTypecheckerDelegate &typechecker, c
     auto resolved = typechecker.getResolved(files);
 
     // Instantiate localVarFinder outside loop so that result accumualates over every time we TreeWalk::apply
-    LocalVarFinder localVarFinder(method, queryLoc);
+    std::vector<core::NameRef> result;
+    LocalVarFinder localVarFinder(method, queryLoc, result);
     for (auto &t : resolved) {
         auto ctx = core::Context(gs, core::Symbols::root(), t.file);
         ast::ConstTreeWalk::apply(ctx, localVarFinder, t.tree);
     }
 
-    auto result = localVarFinder.result();
     fast_sort(result, [&gs](const auto &left, const auto &right) {
         // Sort by actual name, not by NameRef id
         if (left != right) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -605,12 +605,12 @@ vector<core::NameRef> allSimilarFieldsForClass(LSPTypecheckerDelegate &typecheck
         auto resolved = typechecker.getResolved(files);
 
         // Instantiate fieldFinder outside loop so that result accumulates over every time we TreeWalk::apply
-        FieldFinder fieldFinder(klass, kind);
+        std::vector<core::NameRef> fields;
+        FieldFinder fieldFinder(klass, kind, fields);
         for (auto &t : resolved) {
             auto ctx = core::Context(gs, core::Symbols::root(), t.file);
             ast::ConstTreeWalk::apply(ctx, fieldFinder, t.tree);
         }
-        auto fields = fieldFinder.result();
 
         // TODO: this does prefix matching for instance/class variables, but our
         // completion for locals matches anywhere in the name

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -114,7 +114,7 @@ constexpr int MAX_PRETTY_SIG_ARGS = 4;
 // iff a `def` would be this wide or wider, expand it to be a multi-line def.
 constexpr int MAX_PRETTY_WIDTH = 80;
 
-core::SymbolRef lookupFQN(const core::GlobalState &gs, const vector<core::NameRef> &fqn) {
+core::SymbolRef lookupFQN(const core::GlobalState &gs, absl::Span<const core::NameRef> fqn) {
     core::SymbolRef scope = core::Symbols::root();
     for (auto name : fqn) {
         if (scope.isClassOrModule()) {
@@ -1162,8 +1162,11 @@ private:
 
     static core::ClassOrModuleRef getPkgTestNamespace(const core::GlobalState &gs,
                                                       const core::packages::PackageInfo &pkg) {
-        vector<core::NameRef> fullName = pkg.fullName();
-        fullName.insert(fullName.begin(), core::Names::Constants::Test());
+        auto origName = pkg.fullName();
+        vector<core::NameRef> fullName;
+        fullName.reserve(origName.size() + 1);
+        fullName.push_back(core::Names::Constants::Test());
+        fullName.insert(fullName.end(), origName.begin(), origName.end());
         return lookupFQN(gs, fullName).asClassOrModuleRef();
     }
 
@@ -1261,7 +1264,7 @@ public:
 UnorderedSet<core::ClassOrModuleRef> RBIGenerator::buildPackageNamespace(core::GlobalState &gs, WorkerPool &workers) {
     const auto &packageDB = gs.packageDB();
 
-    auto &packages = packageDB.packages();
+    auto packages = packageDB.packages();
 
     if (packages.empty()) {
         Exception::raise("No packages found?");
@@ -1272,14 +1275,17 @@ UnorderedSet<core::ClassOrModuleRef> RBIGenerator::buildPackageNamespace(core::G
     UnorderedSet<core::ClassOrModuleRef> packageNamespaces;
     for (auto package : packages) {
         auto &pkg = packageDB.getPackageInfo(package);
-        vector<core::NameRef> fullName = pkg.fullName();
-        auto packageNamespace = lookupFQN(gs, fullName);
+        auto origName = pkg.fullName();
+        auto packageNamespace = lookupFQN(gs, origName);
         // Might not exist if package has no files.
         if (packageNamespace.exists()) {
             packageNamespaces.insert(packageNamespace.asClassOrModuleRef());
         }
 
-        fullName.insert(fullName.begin(), testNamespace);
+        vector<core::NameRef> fullName;
+        fullName.reserve(origName.size() + 1);
+        fullName.push_back(testNamespace);
+        fullName.insert(fullName.end(), origName.begin(), origName.end());
         auto testPackageNamespace = lookupFQN(gs, fullName);
         if (testPackageNamespace.exists()) {
             packageNamespaces.insert(testPackageNamespace.asClassOrModuleRef());
@@ -1302,7 +1308,7 @@ void RBIGenerator::run(core::GlobalState &gs, const UnorderedSet<core::ClassOrMo
     absl::BlockingCounter threadBarrier(std::max(workers.size(), 1));
 
     const auto &packageDB = gs.packageDB();
-    auto &packages = packageDB.packages();
+    auto packages = packageDB.packages();
     auto inputq = make_shared<ConcurrentBoundedQueue<core::packages::MangledName>>(packages.size());
     for (auto package : packages) {
         inputq->push(move(package), 1);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -402,7 +402,7 @@ private:
 
     struct PackageStub {
         core::packages::MangledName packageId;
-        vector<core::NameRef> fullName;
+        absl::Span<const core::NameRef> fullName;
 
         PackageStub(const core::packages::PackageInfo &info)
             : packageId{info.mangledName()}, fullName{info.fullName()} {}

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -571,7 +571,7 @@ vector<shared_ptr<RangeAssertion>> parseAssertionsForFile(const shared_ptr<core:
 
     auto source = file->source();
     auto filename = string(file->path());
-    auto &lineBreaks = file->lineBreaks();
+    auto lineBreaks = file->lineBreaks();
 
     for (auto lineBreak : lineBreaks) {
         // Ignore first line break entry.


### PR DESCRIPTION
Follow-up to #8360

We're returning const references to vectors in a lot of places, and if you don't remember to declare those results as `auto &` they'll end up being copied. As we're using `absl::Span` in other places already, let's use it in more places to avoid accidental copies.

Additionally, the LocalVarFinder and FieldFinders were copying their resulting vectors, when they could be given a reference to the result instead. Alternatively, we could refactor these to return a non-const reference and `std::move` the memory into its final location.

### Motivation
Performance, avoiding unnecessary vector copies.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No changes expected.
