### PR TITLE
Add a note on how to update a single cli test

### DIFF
--- a/test/cli/cli_test.bzl
+++ b/test/cli/cli_test.bzl
@@ -42,6 +42,7 @@ def cli_tests(suite_name, scripts, tags = []):
 
 def _cli_test(name, script, tags = []):
     test_name = "test_{}".format(name)
+    update_name = "update_{}".format(name)
 
     script_path = "{}/{}".format(name, script)
 
@@ -66,7 +67,7 @@ def _cli_test(name, script, tags = []):
     native.sh_test(
         name = test_name,
         srcs = ["test_one.sh"],
-        args = ["$(location {})".format(script_path), "$(location {})".format(output)],
+        args = ["$(location {})".format(script_path), "$(location {})".format(output), update_name],
         data = [
             script_path,
             ":run_{}".format(name),
@@ -76,8 +77,6 @@ def _cli_test(name, script, tags = []):
         size = "medium",
         tags = tags,
     )
-
-    update_name = "update_{}".format(name)
 
     native.sh_test(
         name = update_name,

--- a/test/cli/test_one.sh
+++ b/test/cli/test_one.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 script="$1"
 expect="$2"
+update="$3"
 
 export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_15_0_7/bin/llvm-symbolizer
 
@@ -9,6 +10,9 @@ if ! diff "$expect" -u <("$script"); then
 ================================================================================
 There were differences in the captured output when running this CLI test.
 To make this output the expected output, run this and commit the changes:
+./bazel test //test/cli:$3
+
+To update all cli tests in bulk, run this and commit the changes:
 ./bazel test //test/cli:update
 EOF
   exit 1


### PR DESCRIPTION
Currently when a cli test fails we output the command to update all of them. While this does work, those tests can take a while to complete and it would be nice to see the target for updating the single test in the error message.

This PR updates the output from `test/cli/test_one.sh` to also include the name of the update target for the single test.

### Motivation
Test update ergonomics.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This PR is modifying testing infrastructure only.
