### PR TITLE
Update reline.rbi

### DIFF
--- a/rbi/stdlib/reline.rbi
+++ b/rbi/stdlib/reline.rbi
@@ -569,6 +569,7 @@ class Reline::IO
   def win?; end
   def reset_color_sequence; end
   def read_single_char(keyseq_timeout); end
+  RESET_COLOR = T.let(T.unsafe(nil), String)
 end
 class Reline::ANSI < Reline::IO
   def self.clear_screen; end

--- a/rbi/stdlib/reline.rbi
+++ b/rbi/stdlib/reline.rbi
@@ -563,6 +563,13 @@ class Reline::GeneralIO
   def self.ungetc(c); end
   def self.win?; end
 end
+class Reline::IO
+  def self.decide_io_gate; end
+  def dumb?; end
+  def win?; end
+  def reset_color_sequence; end
+  def read_single_char(keyseq_timeout); end
+end
 class Reline::ANSI < Reline::IO
   def self.clear_screen; end
   def self.cursor_pos; end

--- a/rbi/stdlib/reline.rbi
+++ b/rbi/stdlib/reline.rbi
@@ -563,7 +563,7 @@ class Reline::GeneralIO
   def self.ungetc(c); end
   def self.win?; end
 end
-class Reline::ANSI
+class Reline::ANSI < Reline::IO
   def self.clear_screen; end
   def self.cursor_pos; end
   def self.deprep(otio); end


### PR DESCRIPTION

> [!IMPORTANT]
> If you're encountering rbi issues after upgrading to a version of sorbet that includes this PR, please add the following flag to your sorbet config
> ```
> --suppress-payload-superclass-redefinition-for=Reline::ANSI
> ```


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Change the `reline.rbi` to use the correct inheritance for `Reline::ANSI` in Ruby 3.3.5.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In newest reline version, `ANSI` inherits from `IO`, instead of `Object`. This causes an incompatibility with Ruby 3.3.5, which uses the new version.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
