### PR TITLE
Avoid a second traversal of the file table

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -253,9 +253,4 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
     return fastPathFilesToTypecheck(gs, config, updatedFiles, EMPTY_CONST_MAP);
 }
 
-LSPFileUpdates::FastPathFilesToTypecheckResult
-LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPConfiguration &config) const {
-    return fastPathFilesToTypecheck(gs, config, this->updatedFiles);
-}
-
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -28,8 +28,10 @@ public:
     // Indicates whether or not the incremental namer should be used on the fast path.
     bool fastPathUseIncrementalNamer = false;
 
-    // The paths of any additional files implicated in a fast path edit. This vector stores paths because file refs can
-    // change between deciding if it's possible to take the fast path and actually taking it.
+    // The paths of any additional files implicated in a fast path edit. This vector stores path
+    // strings because FileRef IDs might be different in the GlobalState used on the indexing thread
+    // and the typechecking thread, but the `LSPFileUpdates` structure must be valid to transfer
+    // ownership from one thread to the other.
     std::vector<std::string> fastPathExtraFiles;
 
     // Indicates that this update contains a new file. Is a hack for determining if combining two updates can take the

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -59,14 +59,14 @@ public:
     LSPFileUpdates copy() const;
 
     struct FastPathFilesToTypecheckResult {
-        // size_t is an index into the LSPFileUpdates::updatedFiles vector
-        UnorderedMap<core::FileRef, size_t> changedFiles;
+        // The number of files that would be checked in the fast path.
+        size_t totalChanged = 0;
 
-        // The names of all symbols changed by this set of updates
-        std::vector<core::WithoutUniqueNameHash> changedSymbolNameHashes;
+        // True when we should use the incremental namer.
+        bool useIncrementalNamer = false;
 
         // Extra files that need to be typechecked because the file mentions the name of one of the changed symbols.
-        std::vector<core::FileRef> extraFiles;
+        std::vector<std::string> extraFiles;
     };
 
     // It would be nice to have this accept `...<const core::File>...`

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -25,6 +25,18 @@ public:
 
     TypecheckingPath typecheckingPath = TypecheckingPath::Slow;
 
+    // The names of all the changed files involved in a fast path edit, and the index of their data in the
+    // `updatedFiles` vector. This vector stores paths because file refs can change between deciding if it's possible to
+    // take the fast path and actually taking it.
+    std::vector<std::pair<std::string, size_t>> fastPathChangedFiles;
+
+    // Indicates whether or not the incremental namer should be used on the fast path.
+    bool fastPathUseIncrementalNamer = false;
+
+    // The paths of any additional files implicated in a fast path edit. This vector stores paths because file refs can
+    // change between deciding if it's possible to take the fast path and actually taking it.
+    std::vector<std::string> fastPathExtraFiles;
+
     // Indicates that this update contains a new file. Is a hack for determining if combining two updates can take the
     // fast path.
     bool hasNewFiles = false;

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -21,6 +21,8 @@ public:
     uint32_t committedEditCount = 0;
 
     std::vector<std::shared_ptr<core::File>> updatedFiles;
+
+    // Indexed versions of `updatedFiles`, tied to the `initialGS` global state in the indexer.
     std::vector<ast::ParsedFile> updatedFileIndexes;
 
     TypecheckingPath typecheckingPath = TypecheckingPath::Slow;

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -25,11 +25,6 @@ public:
 
     TypecheckingPath typecheckingPath = TypecheckingPath::Slow;
 
-    // The names of all the changed files involved in a fast path edit, and the index of their data in the
-    // `updatedFiles` vector. This vector stores paths because file refs can change between deciding if it's possible to
-    // take the fast path and actually taking it.
-    std::vector<std::pair<std::string, size_t>> fastPathChangedFiles;
-
     // Indicates whether or not the incremental namer should be used on the fast path.
     bool fastPathUseIncrementalNamer = false;
 

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -87,9 +87,6 @@ public:
     fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPConfiguration &config,
                              const std::vector<std::shared_ptr<core::File>> &updatedFiles,
                              const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles);
-
-    FastPathFilesToTypecheckResult fastPathFilesToTypecheck(const core::GlobalState &gs,
-                                                            const LSPConfiguration &config) const;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -229,12 +229,18 @@ LSPIndexer::getTypecheckingPath(LSPFileUpdates &edit,
 
     LSPFileUpdates::FastPathFilesToTypecheckResult result;
     auto path = getTypecheckingPathInternal(result, edit.updatedFiles, evictedFiles);
-    if (path == TypecheckingPath::Fast) {
-        edit.fastPathUseIncrementalNamer = !result.changedSymbolNameHashes.empty();
+    switch (path) {
+        case TypecheckingPath::Fast: {
+            edit.fastPathUseIncrementalNamer = !result.changedSymbolNameHashes.empty();
 
-        for (auto fref : result.extraFiles) {
-            edit.fastPathExtraFiles.emplace_back(fref.data(*initialGS).path());
+            for (auto fref : result.extraFiles) {
+                edit.fastPathExtraFiles.emplace_back(fref.data(*initialGS).path());
+            }
+            break;
         }
+
+        case TypecheckingPath::Slow:
+            break;
     }
 
     return path;

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -230,12 +230,6 @@ LSPIndexer::getTypecheckingPath(LSPFileUpdates &edit,
     LSPFileUpdates::FastPathFilesToTypecheckResult result;
     auto path = getTypecheckingPathInternal(result, edit.updatedFiles, evictedFiles);
     if (path == TypecheckingPath::Fast) {
-        // If we're taking the fast path, that means that there's relevant information in `result` that we should stash
-        // away for the typechecker.
-        for (auto &[fref, idx] : result.changedFiles) {
-            edit.fastPathChangedFiles.emplace_back(fref.data(*initialGS).path(), idx);
-        }
-
         edit.fastPathUseIncrementalNamer = !result.changedSymbolNameHashes.empty();
 
         for (auto fref : result.extraFiles) {

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -57,7 +57,8 @@ class LSPIndexer final {
      * INVARIANT: `changedFiles` must have hashes computed.
      */
     TypecheckingPath
-    getTypecheckingPathInternal(const std::vector<std::shared_ptr<core::File>> &changedFiles,
+    getTypecheckingPathInternal(LSPFileUpdates::FastPathFilesToTypecheckResult &result,
+                                const std::vector<std::shared_ptr<core::File>> &changedFiles,
                                 const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
 
 public:

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -51,7 +51,7 @@ class LSPIndexer final {
      * It compares the file hashes in the files in `edit` to those in `evictedFiles` and `initialGS` (in that order).
      */
     TypecheckingPath
-    getTypecheckingPath(const LSPFileUpdates &edit,
+    getTypecheckingPath(LSPFileUpdates &edit,
                         const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
     /**
      * INVARIANT: `changedFiles` must have hashes computed.

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -53,12 +53,17 @@ class LSPIndexer final {
     TypecheckingPath
     getTypecheckingPath(LSPFileUpdates &edit,
                         const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
+
+    struct TypecheckingPathResult {
+        TypecheckingPath path = TypecheckingPath::Slow;
+        LSPFileUpdates::FastPathFilesToTypecheckResult files;
+    };
+
     /**
      * INVARIANT: `changedFiles` must have hashes computed.
      */
-    TypecheckingPath
-    getTypecheckingPathInternal(LSPFileUpdates::FastPathFilesToTypecheckResult &result,
-                                const std::vector<std::shared_ptr<core::File>> &changedFiles,
+    TypecheckingPathResult
+    getTypecheckingPathInternal(const std::vector<std::shared_ptr<core::File>> &changedFiles,
                                 const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
 
 public:

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -263,9 +263,9 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         changedFiles.insert(fref);
     }
 
-    UnorderedSet<core::FileRef> packageFiles;
-
     if (shouldRunIncrementalNamer) {
+        UnorderedSet<core::FileRef> packageFiles;
+
         for (auto fref : toTypecheck) {
             // Only need to re-run packager if we're going to delete constants and have to re-define
             // their visibility, which only happens if we're running incrementalNamer.
@@ -287,11 +287,11 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 }
             }
         }
-    }
 
-    for (auto packageFref : packageFiles) {
-        if (!changedFiles.contains(packageFref)) {
-            toTypecheck.emplace_back(packageFref);
+        for (auto packageFref : packageFiles) {
+            if (!changedFiles.contains(packageFref)) {
+                toTypecheck.emplace_back(packageFref);
+            }
         }
     }
 


### PR DESCRIPTION
Instead of re-discovering the files affected by a fast-path edit, store them on the `LSPFileUpdates` value so that they're available later. The one wrinkle here is that we can't store `core::FileRef` values as they're not stable between when we determine if the fast-path can be taken, and actually taking it. Instead, we store the original paths of the files, and rediscover their `core::FileRef` when type-checking on the fast path. This should be significantly faster than re-computing the extra modified files and traversing the file table.

### Motivation
Performance on the fast path.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This shouldn't change any existing behavior.
