### PR TITLE
Add some missing methods to Reline::ANSI

### DIFF
--- a/rbi/stdlib/reline.rbi
+++ b/rbi/stdlib/reline.rbi
@@ -592,6 +592,8 @@ class Reline::ANSI
   def self.show_cursor; end
   def self.ungetc(c); end
   def self.win?; end
+  def self.set_default_key_bindings_ansi_cursor(config); end
+  def self.with_raw_input(); end
 end
 class Reline::ConfigEncodingConversionError < StandardError
 end


### PR DESCRIPTION
Stripe's internal missing methods infrastructure identified these methods that were missing from `Reline::ANSI`.

### Motivation
Keeping rbis up to date.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Rbi change only.
