### PR TITLE
Support `type_parameters` redeclaration in suggested sig for generics

### DIFF
--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -205,6 +205,7 @@ public:
     std::string showRaw(const GlobalState &gs) const;
     std::string toString(const GlobalState &gs) const;
     std::string show(const GlobalState &gs) const;
+    std::string showAsSymbolLiteral(const GlobalState &gs) const;
 
     void enforceCorrectGlobalState(const GlobalState &gs) const;
     void sanityCheckSubstitution(const NameSubstitution &subst) const;

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -6,6 +6,7 @@
 #include "core/hashing/hashing.h"
 #include <numeric> // accumulate
 
+#include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
@@ -143,6 +144,16 @@ string NameRef::show(const GlobalState &gs) const {
             return dataCnst(gs)->original.show(gs);
     }
 }
+
+std::string NameRef::showAsSymbolLiteral(const GlobalState &gs) const {
+    auto shown = this->show(gs);
+    if (absl::StrContains(shown, " ")) {
+        return fmt::format(":\"{}\"", absl::CEscape(shown));
+    } else {
+        return fmt::format(":{}", shown);
+    }
+}
+
 string_view NameRef::shortName(const GlobalState &gs) const {
     switch (kind()) {
         case NameKind::UTF8: {

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -83,7 +83,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
         paramsString = fmt::format("params({}).", fmt::join(typeAndArgNames, ", "));
     }
 
-    auto oneline = sigCall.size() + flagString.size() + paramsString.size() + methodReturnType.size();
+    auto oneline = sigCall.size() + flagString.size() + paramsString.size() + methodReturnType.size() + 5;
     if (oneline <= MAX_PRETTY_WIDTH && typeAndArgNames.size() <= MAX_PRETTY_SIG_ARGS) {
         return fmt::format("{} {{ {}{}{}{} }}", sigCall, flagString, typeParamString, paramsString, methodReturnType);
     }

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -82,17 +82,8 @@ string NamedLiteralType::showValue(const GlobalState &gs) const {
         case NamedLiteralType::LiteralTypeKind::String:
             return fmt::format("\"{}\"", absl::CEscape(asName().show(gs)));
         case NamedLiteralType::LiteralTypeKind::Symbol: {
-            return showAsSymbolLiteral(gs, asName());
+            return name.showAsSymbolLiteral(gs);
         }
-    }
-}
-
-string NamedLiteralType::showAsSymbolLiteral(const GlobalState &gs, NameRef name) {
-    auto shown = name.show(gs);
-    if (absl::StrContains(shown, " ")) {
-        return fmt::format(":\"{}\"", absl::CEscape(shown));
-    } else {
-        return fmt::format(":{}", shown);
     }
 }
 
@@ -395,12 +386,8 @@ string TypeVar::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string TypeVar::show(const GlobalState &gs, ShowOptions options) const {
-    auto shown = sym.data(gs)->name.show(gs);
-    if (absl::StrContains(shown, " ")) {
-        return fmt::format("T.type_parameter(:{})", absl::CEscape(shown));
-    } else {
-        return fmt::format("T.type_parameter(:{})", shown);
-    }
+    auto symbolName = sym.data(gs)->name.showAsSymbolLiteral(gs);
+    return fmt::format("T.type_parameter({})", symbolName);
 }
 
 string AppliedType::toStringWithTabs(const GlobalState &gs, int tabs) const {

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -610,7 +610,7 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
             if (it != seenProps.end()) {
                 if (auto e = ctx.beginIndexerError(propInfo->loc, core::errors::Rewriter::DuplicateProp)) {
                     auto headerProp = fmt::format("{} {}", propInfo->isImmutable ? "const" : "prop",
-                                                  core::NamedLiteralType::showAsSymbolLiteral(ctx, propInfo->name));
+                                                  propInfo->name.showAsSymbolLiteral(ctx));
                     e.setHeader("The `{}` is defined multiple times", headerProp);
                     e.addErrorLine(ctx.locAt(props[it->second].loc), "Originally defined here");
                 }

--- a/test/testdata/infer/generics/conflicting_bounds_all.rb
+++ b/test/testdata/infer/generics/conflicting_bounds_all.rb
@@ -29,8 +29,8 @@ end
 sig {
   type_parameters(:U)
   .params(x: T.all(BadLower[T.type_parameter(:U)], BadUpper[T.type_parameter(:U)])).void
-  #                         ^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter(:<todo typeargument>)` is not a supertype of lower bound of type member `::BadLower::A`
-  #                                                         ^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter(:<todo typeargument>)` is not a subtype of upper bound of type member `::BadUpper::A`
+  #                         ^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter(:"<todo typeargument>")` is not a supertype of lower bound of type member `::BadLower::A`
+  #                                                         ^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter(:"<todo typeargument>")` is not a subtype of upper bound of type member `::BadUpper::A`
 }
 def example2(x)
   T.reveal_type(x) # error: `T.all(BadLower[T.untyped], BadUpper[T.untyped])`

--- a/test/testdata/infer/generics/t_class_of.rb
+++ b/test/testdata/infer/generics/t_class_of.rb
@@ -120,7 +120,7 @@ T.reveal_type(instance) # error: `ChildAFixedString`
 sig do
   type_parameters(:U)
     .params(klass: T.class_of(A)[T.type_parameter(:U), Integer])
-    #                            ^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter(:<todo typeargument>)` is not a subtype of upper bound of type member `::<Class:A>::<AttachedClass>
+    #                            ^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter(:"<todo typeargument>")` is not a subtype of upper bound of type member `::<Class:A>::<AttachedClass>
     .returns(T.type_parameter(:U))
 end
 def example4(klass)

--- a/test/testdata/infer/generics/type_params_redeclare.rb
+++ b/test/testdata/infer/generics/type_params_redeclare.rb
@@ -1,0 +1,27 @@
+# typed: true
+
+# One-line format
+class MyAbstractClass
+  extend T::Sig, T::Helpers
+  abstract!
+
+  sig {abstract.type_parameters(:U).params(x: T.type_parameter(:U)).returns(T.type_parameter(:U))}
+  def example(x); end
+end
+
+class MyClass < MyAbstractClass
+# error: Missing definition for abstract method `MyAbstractClass#example` in `MyClass`
+end
+
+# Multi-line format
+class MultiParamAbstractClass
+  extend T::Sig, T::Helpers
+  abstract!
+
+  sig {abstract.type_parameters(:U).params(a: T.type_parameter(:U), b: Integer, c: String, d: Float, e: Symbol).returns(T.type_parameter(:U))}
+  def example(a, b, c, d, e); end
+end
+
+class MultiParamConcreteClass < MultiParamAbstractClass
+# error: Missing definition for abstract method `MultiParamAbstractClass#example` in `MultiParamConcreteClass`
+end

--- a/test/testdata/infer/generics/type_params_redeclare.rb
+++ b/test/testdata/infer/generics/type_params_redeclare.rb
@@ -13,12 +13,12 @@ class MyClass < MyAbstractClass
 # error: Missing definition for abstract method `MyAbstractClass#example` in `MyClass`
 end
 
-# Multi-line format
+# Multi-line format with spaced symbols
 class MultiParamAbstractClass
   extend T::Sig, T::Helpers
   abstract!
 
-  sig {abstract.type_parameters(:U).params(a: T.type_parameter(:U), b: Integer, c: String, d: Float, e: Symbol).returns(T.type_parameter(:U))}
+  sig {abstract.type_parameters(:"foo bar").params(a: T.type_parameter(:"foo bar"), b: Integer, c: String, d: Float, e: Symbol).returns(T.type_parameter(:"foo bar"))}
   def example(a, b, c, d, e); end
 end
 

--- a/test/testdata/infer/generics/type_params_redeclare.rb.autocorrects.exp
+++ b/test/testdata/infer/generics/type_params_redeclare.rb.autocorrects.exp
@@ -1,0 +1,43 @@
+# -- test/testdata/infer/generics/type_params_redeclare.rb --
+# typed: true
+
+# One-line format
+class MyAbstractClass
+  extend T::Sig, T::Helpers
+  abstract!
+
+  sig {abstract.type_parameters(:U).params(x: T.type_parameter(:U)).returns(T.type_parameter(:U))}
+  def example(x); end
+end
+
+class MyClass < MyAbstractClass
+# error: Missing definition for abstract method `MyAbstractClass#example` in `MyClass`
+  sig { override.type_parameters(:U).params(x: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+  def example(x); end
+end
+
+# Multi-line format
+class MultiParamAbstractClass
+  extend T::Sig, T::Helpers
+  abstract!
+
+  sig {abstract.type_parameters(:U).params(a: T.type_parameter(:U), b: Integer, c: String, d: Float, e: Symbol).returns(T.type_parameter(:U))}
+  def example(a, b, c, d, e); end
+end
+
+class MultiParamConcreteClass < MultiParamAbstractClass
+# error: Missing definition for abstract method `MultiParamAbstractClass#example` in `MultiParamConcreteClass`
+  sig do
+    override
+    .type_parameters(:U).params(
+      a: T.type_parameter(:U),
+      b: Integer,
+      c: String,
+      d: Float,
+      e: Symbol
+    )
+    .returns(T.type_parameter(:U))
+  end
+  def example(a, b, c, d, e); end
+end
+# ------------------------------

--- a/test/testdata/infer/generics/type_params_redeclare.rb.autocorrects.exp
+++ b/test/testdata/infer/generics/type_params_redeclare.rb.autocorrects.exp
@@ -16,12 +16,12 @@ class MyClass < MyAbstractClass
   def example(x); end
 end
 
-# Multi-line format
+# Multi-line format with spaced symbols
 class MultiParamAbstractClass
   extend T::Sig, T::Helpers
   abstract!
 
-  sig {abstract.type_parameters(:U).params(a: T.type_parameter(:U), b: Integer, c: String, d: Float, e: Symbol).returns(T.type_parameter(:U))}
+  sig {abstract.type_parameters(:"foo bar").params(a: T.type_parameter(:"foo bar"), b: Integer, c: String, d: Float, e: Symbol).returns(T.type_parameter(:"foo bar"))}
   def example(a, b, c, d, e); end
 end
 
@@ -29,14 +29,15 @@ class MultiParamConcreteClass < MultiParamAbstractClass
 # error: Missing definition for abstract method `MultiParamAbstractClass#example` in `MultiParamConcreteClass`
   sig do
     override
-    .type_parameters(:U).params(
-      a: T.type_parameter(:U),
+    .type_parameters(:"foo bar")
+    .params(
+      a: T.type_parameter(:"foo bar"),
       b: Integer,
       c: String,
       d: Float,
       e: Symbol
     )
-    .returns(T.type_parameter(:U))
+    .returns(T.type_parameter(:"foo bar"))
   end
   def example(a, b, c, d, e); end
 end

--- a/test/testdata/infer/generics/type_var_upper_bound.rb
+++ b/test/testdata/infer/generics/type_var_upper_bound.rb
@@ -15,7 +15,7 @@ end
 sig do
   type_parameters(:U)
   .params(
-    x: Box[T.type_parameter(:U)], # error: `T.type_parameter(:<todo typeargument>)` is not a subtype of upper bound of type member `::Box::Elem`
+    x: Box[T.type_parameter(:U)], # error: `T.type_parameter(:"<todo typeargument>")` is not a subtype of upper bound of type member `::Box::Elem`
     y: T.type_parameter(:U),
   )
   .void

--- a/test/testdata/lsp/genericMethods.rb
+++ b/test/testdata/lsp/genericMethods.rb
@@ -30,28 +30,29 @@ def main
   foo = Foo.new
   v1 = foo.id(1)
 # ^ hover: Integer
-  #        ^ hover: sig { params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
+  #        ^ hover: sig { type_parameters(:A).params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
   #        ^ usage: id
   v2 = foo.id("1")
 # ^ hover: String
-  #        ^ hover: sig { params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
+  #        ^ hover: sig { type_parameters(:A).params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
   #        ^ usage: id
   v3 = Foo.id(1)
 # ^ hover: Integer
-  #        ^ hover: sig { params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
+  #        ^ hover: sig { type_parameters(:A).params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
   #        ^ usage: staticid
   v4 = Foo.id("1")
 # ^ hover: String
-  #        ^ hover: sig { params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
+  #        ^ hover: sig { type_parameters(:A).params(a: T.type_parameter(:A)).returns(T.type_parameter(:A)) }
   #        ^ usage: staticid
 
   v5 = Foo.block_id do
     #       ^ hover-line: 3 sig do
-    #       ^ hover-line: 4   params(
-    #       ^ hover-line: 5     blk: T.proc.returns(T.type_parameter(:U))
-    #       ^ hover-line: 6   )
-    #       ^ hover-line: 7   .returns(T.type_parameter(:U))
-    #       ^ hover-line: 8 end
+    #       ^ hover-line: 4   type_parameters(:U)
+    #       ^ hover-line: 5   .params(
+    #       ^ hover-line: 6     blk: T.proc.returns(T.type_parameter(:U))
+    #       ^ hover-line: 7   )
+    #       ^ hover-line: 8   .returns(T.type_parameter(:U))
+    #       ^ hover-line: 9 end
     #       ^ usage: block_id
     "1"
   end

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -14,11 +14,12 @@ def main
   breeds = dogs.map(&:breed)
   # ^ hover: T::Array[String]
   #             ^ hover-line: 3 sig do
-  #             ^ hover-line: 4   params(
-  #             ^ hover-line: 5     blk: T.proc.params(arg0: Dog).returns(T.type_parameter(:U))
-  #             ^ hover-line: 6   )
-  #             ^ hover-line: 7   .returns(T::Array[T.type_parameter(:U)])
-  #             ^ hover-line: 8 end
+  #             ^ hover-line: 4   type_parameters(:U)
+  #             ^ hover-line: 5   .params(
+  #             ^ hover-line: 6     blk: T.proc.params(arg0: Dog).returns(T.type_parameter(:U))
+  #             ^ hover-line: 7   )
+  #             ^ hover-line: 8   .returns(T::Array[T.type_parameter(:U)])
+  #             ^ hover-line: 9 end
   #                  ^ hover: sig { returns(String) }
   #                   ^ hover: sig { returns(String) }
 

--- a/test/testdata/lsp/hover_components.rb
+++ b/test/testdata/lsp/hover_components.rb
@@ -38,14 +38,15 @@ def example_any(x)
     #      ^ hover-line: 4 def foo(&blk); end
     #      ^ hover-line: 5 # B#foo:
     #      ^ hover-line: 6 sig do
-    #      ^ hover-line: 7   params(
-    #      ^ hover-line: 8     blk: T.proc.returns(T.type_parameter(:U))
-    #      ^ hover-line: 9   )
-    #      ^ hover-line: 10   .returns(T.type_parameter(:U))
-    #      ^ hover-line: 11 end
-    #      ^ hover-line: 12 def foo(&blk); end
-    #      ^ hover-line: 14 # result type:
-    #      ^ hover-line: 15 IFoo
+    #      ^ hover-line: 7   type_parameters(:U)
+    #      ^ hover-line: 8   .params(
+    #      ^ hover-line: 9     blk: T.proc.returns(T.type_parameter(:U))
+    #      ^ hover-line: 10   )
+    #      ^ hover-line: 11   .returns(T.type_parameter(:U))
+    #      ^ hover-line: 12 end
+    #      ^ hover-line: 13 def foo(&blk); end
+    #      ^ hover-line: 15 # result type:
+    #      ^ hover-line: 16 IFoo
     ""
   }
   # WRONG!
@@ -60,14 +61,15 @@ def example_all(x)
     #     ^ hover-line: 4 def foo(&blk); end
     #     ^ hover-line: 5 # B#foo:
     #     ^ hover-line: 6 sig do
-    #     ^ hover-line: 7   params(
-    #     ^ hover-line: 8     blk: T.proc.returns(T.type_parameter(:U))
-    #     ^ hover-line: 9   )
-    #     ^ hover-line: 10   .returns(T.type_parameter(:U))
-    #     ^ hover-line: 11 end
-    #     ^ hover-line: 12 def foo(&blk); end
-    #     ^ hover-line: 14 # result type:
-    #     ^ hover-line: 15 IFoo
+    #     ^ hover-line: 7   type_parameters(:U)
+    #     ^ hover-line: 8   .params(
+    #     ^ hover-line: 9     blk: T.proc.returns(T.type_parameter(:U))
+    #     ^ hover-line: 10   )
+    #     ^ hover-line: 11   .returns(T.type_parameter(:U))
+    #     ^ hover-line: 12 end
+    #     ^ hover-line: 13 def foo(&blk); end
+    #     ^ hover-line: 15 # result type:
+    #     ^ hover-line: 16 IFoo
     ""
   }
   # WRONG!

--- a/test/testdata/lsp/hover_constraint.rb
+++ b/test/testdata/lsp/hover_constraint.rb
@@ -6,22 +6,24 @@ def example(x)
   x.map do |elem|
     #^ hover-line: 2 # Array#map (overload.1):
     #^ hover-line: 3 sig do
-    #^ hover-line: 4   params(
-    #^ hover-line: 5     blk: T.proc.params(arg0: Integer).returns(T.type_parameter(:U))
-    #^ hover-line: 6   )
-    #^ hover-line: 7   .returns(T::Array[T.type_parameter(:U)])
-    #^ hover-line: 8 end
-    #^ hover-line: 9 def map (overload.1)(&blk); end
-    #^ hover-line: 10 # Enumerable#map (overload.1):
-    #^ hover-line: 11 sig do
-    #^ hover-line: 12   params(
-    #^ hover-line: 13     blk: T.proc.params(arg0: [String, Symbol]).returns(T.type_parameter(:U))
-    #^ hover-line: 14   )
-    #^ hover-line: 15   .returns(T::Array[T.type_parameter(:U)])
-    #^ hover-line: 16 end
-    #^ hover-line: 17 def map (overload.1)(&blk); end
-    #^ hover-line: 19 # result type:
-    #^ hover-line: 20 T::Array[T.any(Integer, [String, Symbol])]
+    #^ hover-line: 4   type_parameters(:U)
+    #^ hover-line: 5   .params(
+    #^ hover-line: 6     blk: T.proc.params(arg0: Integer).returns(T.type_parameter(:U))
+    #^ hover-line: 7   )
+    #^ hover-line: 8   .returns(T::Array[T.type_parameter(:U)])
+    #^ hover-line: 9 end
+    #^ hover-line: 10 def map (overload.1)(&blk); end
+    #^ hover-line: 11 # Enumerable#map (overload.1):
+    #^ hover-line: 12 sig do
+    #^ hover-line: 13   type_parameters(:U)
+    #^ hover-line: 14   .params(
+    #^ hover-line: 15     blk: T.proc.params(arg0: [String, Symbol]).returns(T.type_parameter(:U))
+    #^ hover-line: 16   )
+    #^ hover-line: 17   .returns(T::Array[T.type_parameter(:U)])
+    #^ hover-line: 18 end
+    #^ hover-line: 19 def map (overload.1)(&blk); end
+    #^ hover-line: 21 # result type:
+    #^ hover-line: 22 T::Array[T.any(Integer, [String, Symbol])]
     T.reveal_type(elem) # error: `T.any(Integer, [String, Symbol])`
   end
 end

--- a/test/testdata/lsp/hover_type_params_redeclare.rb
+++ b/test/testdata/lsp/hover_type_params_redeclare.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+class LongTypeParamsHoverTest
+  extend T::Sig
+
+  sig {type_parameters(:"very long spaced parameter name that will need to wrap")
+    .params(x: T.type_parameter(:"very long spaced parameter name that will need to wrap"))
+    .returns(T.type_parameter(:"very long spaced parameter name that will need to wrap"))}
+  def test_method(x)
+    # ^ hover-line: 2 sig do
+    # ^ hover-line: 3   type_parameters(:"very long spaced parameter name that will need to wrap")
+    # ^ hover-line: 4   .params(
+    # ^ hover-line: 5     x: T.type_parameter(:"very long spaced parameter name that will need to wrap")
+    # ^ hover-line: 6   )
+    # ^ hover-line: 7   .returns(T.type_parameter(:"very long spaced parameter name that will need to wrap"))
+    # ^ hover-line: 8 end
+    # ^ hover-line: 9 def test_method(x); end
+    x
+  end
+end


### PR DESCRIPTION
This PR makes sure that `type_parameters` are correctly included in sig autocorrect suggestions by updating `prettySigForMethod` to explicitly generate a `type_parameters` string when type arguments are present. The `oneline` length check was also adjusted to subtract the size of the `typeParamString`. This felt more like a judgment call to me—it seemed odd for the sig to become multi-line when the character count is effectively the same if you ignore the two extra spaces. That said, I'll gladly update my changes if it's expected for type parameters to factor into the length check for the purpose of the autocorrect suggestion.


### Motivation
Fixes #7257


### Test plan

See included automated tests.