### PR TITLE
add an iterator type over kwarg pairs

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -900,15 +900,8 @@ public:
     void clearArgs();
 
     template <typename PtrT> struct KwPair {
-        absl::Span<PtrT> span;
-
-        PtrT &key() {
-            return span[0];
-        }
-
-        PtrT &value() {
-            return span[1];
-        }
+        PtrT &key;
+        PtrT &value;
     };
 
     // We're going to use this type to encapsulate both the span over the kwargs,
@@ -925,7 +918,7 @@ public:
         }
 
         KwPair<PtrT> operator*() {
-            return KwPair<PtrT>{span};
+            return KwPair<PtrT>{span[0], span[1]};
         }
 
         KwPairSpan &operator++() {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -910,10 +910,14 @@ public:
         absl::Span<PtrT> span;
 
         KwPairSpan begin() const {
+            ENFORCE(span.size() % 2 == 0);
+
             return KwPairSpan{span};
         }
 
         KwPairSpan end() const {
+            ENFORCE(span.size() % 2 == 0);
+
             return KwPairSpan{absl::MakeSpan(span.end(), span.end())};
         }
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -579,17 +579,15 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     argLocs.emplace_back(exp.loc());
                 }
 
-                for (auto pair : s.kwArgPairs()) {
-                    auto &key = pair.key();
-                    auto &val = pair.value();
+                for (auto [key, value] : s.kwArgPairs()) {
                     LocalRef keyTmp = cctx.newTemporary(core::Names::hashTemp());
                     LocalRef valTmp = cctx.newTemporary(core::Names::hashTemp());
                     current = walk(cctx.withTarget(keyTmp), key, current);
-                    current = walk(cctx.withTarget(valTmp), val, current);
+                    current = walk(cctx.withTarget(valTmp), value, current);
                     args.emplace_back(keyTmp);
                     args.emplace_back(valTmp);
                     argLocs.emplace_back(key.loc());
-                    argLocs.emplace_back(val.loc());
+                    argLocs.emplace_back(value.loc());
                 }
 
                 if (auto *exp = s.kwSplat()) {

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -579,10 +579,9 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     argLocs.emplace_back(exp.loc());
                 }
 
-                const auto kwEnd = s.numKwArgs();
-                for (auto argIdx = 0; argIdx < kwEnd; ++argIdx) {
-                    auto &key = s.getKwKey(argIdx);
-                    auto &val = s.getKwValue(argIdx);
+                for (auto pair : s.kwArgPairs()) {
+                    auto &key = pair.key();
+                    auto &val = pair.value();
                     LocalRef keyTmp = cctx.newTemporary(core::Names::hashTemp());
                     LocalRef valTmp = cctx.newTemporary(core::Names::hashTemp());
                     current = walk(cctx.withTarget(keyTmp), key, current);

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -268,9 +268,8 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                 typeArgSpec.loc = ctx.locAt(arg.loc());
             }
 
-            const auto numKwArgs = tsend->numKwArgs();
-            for (auto i = 0; i < numKwArgs; ++i) {
-                auto &kwkey = tsend->getKwKey(i);
+            for (auto pair : tsend->kwArgPairs()) {
+                auto &kwkey = pair.key();
                 if (auto e = ctx.beginError(kwkey.loc(), core::errors::Resolver::InvalidMethodSignature)) {
                     e.setHeader("Malformed `{}`: Type parameters are specified with symbols", "sig");
                 }
@@ -408,10 +407,9 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                     // TODO(trevor) add an error for this
                 }
 
-                auto end = send->numKwArgs();
-                for (auto i = 0; i < end; ++i) {
-                    auto &key = send->getKwKey(i);
-                    auto &value = send->getKwValue(i);
+                for (auto pair : send->kwArgPairs()) {
+                    auto &key = pair.key();
+                    auto &value = pair.value();
                     auto *lit = ast::cast_tree<ast::Literal>(key);
                     if (lit && lit->isSymbol()) {
                         core::NameRef name = lit->asSymbol();
@@ -460,10 +458,9 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                 }
 
                 if (send->hasKwArgs()) {
-                    auto end = send->numKwArgs();
-                    for (auto i = 0; i < end; ++i) {
-                        auto &key = send->getKwKey(i);
-                        auto &value = send->getKwValue(i);
+                    for (auto pair : send->kwArgPairs()) {
+                        auto &key = pair.key();
+                        auto &value = pair.value();
                         auto lit = ast::cast_tree<ast::Literal>(key);
                         if (lit && lit->isSymbol()) {
                             if (lit->asSymbol() == core::Names::allowIncompatible()) {
@@ -1398,10 +1395,9 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
             argLocs.emplace_back(arg.loc());
         }
 
-        const auto numKwArgs = s.numKwArgs();
-        for (auto i = 0; i < numKwArgs; ++i) {
-            auto &kw = s.getKwKey(i);
-            auto &val = s.getKwValue(i);
+        for (auto pair : s.kwArgPairs()) {
+            auto &kw = pair.key();
+            auto &val = pair.value();
 
             // Fill the keyword and val args in with a dummy type. We don't want to parse this as type
             // syntax because we already know it's garbage.

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -175,11 +175,10 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, const
     }
 
     // build a lookup table that maps from names to the types they have
-    auto numKwArgs = params->numKwArgs();
     UnorderedMap<core::NameRef, const ast::ExpressionPtr *> argTypeMap;
-    for (int i = 0; i < numKwArgs; ++i) {
-        auto *argName = ast::cast_tree<ast::Literal>(params->getKwKey(i));
-        auto *argVal = &params->getKwValue(i);
+    for (auto pair : params->kwArgPairs()) {
+        auto *argName = ast::cast_tree<ast::Literal>(pair.key());
+        auto *argVal = &pair.value();
         if (argName->isSymbol()) {
             argTypeMap[argName->asSymbol()] = argVal;
         }

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -176,11 +176,10 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, const
 
     // build a lookup table that maps from names to the types they have
     UnorderedMap<core::NameRef, const ast::ExpressionPtr *> argTypeMap;
-    for (auto pair : params->kwArgPairs()) {
-        auto *argName = ast::cast_tree<ast::Literal>(pair.key());
-        auto *argVal = &pair.value();
+    for (auto [key, value] : params->kwArgPairs()) {
+        auto *argName = ast::cast_tree<ast::Literal>(key);
         if (argName->isSymbol()) {
-            argTypeMap[argName->asSymbol()] = argVal;
+            argTypeMap[argName->asSymbol()] = &value;
         }
     }
 

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -149,9 +149,8 @@ vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Se
         }
     }
 
-    const auto numKwArgs = send->numKwArgs();
-    for (auto i = 0; i < numKwArgs; ++i) {
-        auto loc = send->getKwKey(i).loc().join(send->getKwValue(i).loc());
+    for (auto pair : send->kwArgPairs()) {
+        auto loc = pair.key().loc().join(pair.value().loc());
         if (auto e = ctx.beginIndexerError(loc, core::errors::Rewriter::BadModuleFunction)) {
             e.setHeader("Bad argument to `{}`: must be a symbol, string, method definition, or nothing",
                         "module_function");

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -149,8 +149,8 @@ vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Se
         }
     }
 
-    for (auto pair : send->kwArgPairs()) {
-        auto loc = pair.key().loc().join(pair.value().loc());
+    for (auto [key, value] : send->kwArgPairs()) {
+        auto loc = key.loc().join(value.loc());
         if (auto e = ctx.beginIndexerError(loc, core::errors::Rewriter::BadModuleFunction)) {
             e.setHeader("Bad argument to `{}`: must be a symbol, string, method definition, or nothing",
                         "module_function");

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -25,11 +25,11 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
             // T.proc.params takes inlined keyword argument pairs, and can't handle kwsplat
             ast::Send::ARGS_store args;
 
-            for (auto pair : send->kwArgPairs()) {
-                ENFORCE(ast::isa_tree<ast::Literal>(pair.key()));
-                args.emplace_back(pair.key().deepCopy());
+            for (auto [key, value] : send->kwArgPairs()) {
+                ENFORCE(ast::isa_tree<ast::Literal>(key));
+                args.emplace_back(key.deepCopy());
 
-                auto dupedValue = ASTUtil::dupType(pair.value());
+                auto dupedValue = ASTUtil::dupType(value);
                 if (dupedValue == nullptr) {
                     return nullptr;
                 }
@@ -247,9 +247,9 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
     ast::Hash::ENTRY_store keys;
     ast::Hash::ENTRY_store values;
 
-    for (auto pair : send->kwArgPairs()) {
-        keys.emplace_back(pair.key().deepCopy());
-        values.emplace_back(pair.value().deepCopy());
+    for (auto [key, value] : send->kwArgPairs()) {
+        keys.emplace_back(key.deepCopy());
+        values.emplace_back(value.deepCopy());
     }
 
     // handle a double-splat or a hash literal as the last argument

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -25,12 +25,11 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
             // T.proc.params takes inlined keyword argument pairs, and can't handle kwsplat
             ast::Send::ARGS_store args;
 
-            const auto numKwArgs = send->numKwArgs();
-            for (auto i = 0; i < numKwArgs; ++i) {
-                ENFORCE(ast::isa_tree<ast::Literal>(send->getKwKey(i)));
-                args.emplace_back(send->getKwKey(i).deepCopy());
+            for (auto pair : send->kwArgPairs()) {
+                ENFORCE(ast::isa_tree<ast::Literal>(pair.key()));
+                args.emplace_back(pair.key().deepCopy());
 
-                auto dupedValue = ASTUtil::dupType(send->getKwValue(i));
+                auto dupedValue = ASTUtil::dupType(pair.value());
                 if (dupedValue == nullptr) {
                     return nullptr;
                 }
@@ -248,10 +247,9 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
     ast::Hash::ENTRY_store keys;
     ast::Hash::ENTRY_store values;
 
-    const auto numKwArgs = send->numKwArgs();
-    for (auto i = 0; i < numKwArgs; ++i) {
-        keys.emplace_back(send->getKwKey(i).deepCopy());
-        values.emplace_back(send->getKwValue(i).deepCopy());
+    for (auto pair : send->kwArgPairs()) {
+        keys.emplace_back(pair.key().deepCopy());
+        values.emplace_back(pair.value().deepCopy());
     }
 
     // handle a double-splat or a hash literal as the last argument


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This abstraction makes the code a little tidier, and is epsilon faster, since the actual accessors in the loop are a lot less branchy -- the compiler was previously not able to combine the identical computations in figuring out where the key and value of the kwarg pair are.  Now we do all that work up front and the accesses in the loop can be seen as simply stepping through the memory associated with the kwarg pairs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
