### PR TITLE
Add visibility override validation with autocorrects

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -154,10 +154,9 @@ pair<std::string, std::string> formatSplat(const core::ArgInfo &arg, SplatKind k
     return rendered == left ? pair("", rendered) : pair(left, rendered);
 }
 
-optional<core::AutocorrectSuggestion> constructAllowIncompatibleAutocorrect(const core::Context ctx,
-                                                                            const ast::ExpressionPtr &tree,
-                                                                            const ast::MethodDef &methodDef,
-                                                                            const char what[], bool &didReport) {
+optional<core::AutocorrectSuggestion>
+constructAllowIncompatibleAutocorrect(const core::Context ctx, const ast::ExpressionPtr &tree,
+                                      const ast::MethodDef &methodDef, const std::string_view what, bool &didReport) {
     // With this design, we will report the autocorrect on the *first* reported error. There is a
     // case to be made that, from a UX perspective, the message should be attached to the *last*
     // error (the one that is most likely to be on the user's screen at the end). Due to how
@@ -206,7 +205,7 @@ optional<core::AutocorrectSuggestion> constructAllowIncompatibleAutocorrect(cons
 optional<core::AutocorrectSuggestion> constructAllowIncompatibleAutocorrect(const core::Context ctx,
                                                                             const ast::ExpressionPtr &tree,
                                                                             const ast::MethodDef &methodDef,
-                                                                            const char what[]) {
+                                                                            const std::string_view what) {
     bool _;
     return constructAllowIncompatibleAutocorrect(ctx, tree, methodDef, what, _);
 }
@@ -583,9 +582,8 @@ void validateCompatibleOverride(const core::Context ctx, const ast::ExpressionPt
             auto len = method.data(ctx)->flags.isPrivate ? 7 : 9;
             auto loc = ctx.locAt(methodDef.declLoc).adjustLen(ctx, -(len + 1), len);
             if (ctx.state.suggestUnsafe) {
-                // We don't want to pass `repeatedAutocorrect` here, because we want to overwrite
-                // with `allow_incompatible: true` if there are multiple errors.
-                e.maybeAddAutocorrect(constructAllowIncompatibleAutocorrect(ctx, tree, methodDef, ":visibility"));
+                e.maybeAddAutocorrect(
+                    constructAllowIncompatibleAutocorrect(ctx, tree, methodDef, ":visibility", reportedAutocorrect));
             } else if (loc.source(ctx) == modifier) {
                 e.replaceWith("Replace with public", loc, "public");
             }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -251,9 +251,10 @@ void validateCompatibleOverride(const core::Context ctx, const ast::ExpressionPt
         return;
     }
 
-    if ((method.data(ctx)->flags.isPrivate &&
-         (superMethod.data(ctx)->flags.isProtected || superMethod.data(ctx)->isMethodPublic())) ||
-        (method.data(ctx)->flags.isProtected && superMethod.data(ctx)->isMethodPublic())) {
+    if (!method.data(ctx)->flags.allowIncompatibleOverrideVisibility &&
+        ((method.data(ctx)->flags.isPrivate &&
+          (superMethod.data(ctx)->flags.isProtected || superMethod.data(ctx)->isMethodPublic())) ||
+         (method.data(ctx)->flags.isProtected && superMethod.data(ctx)->isMethodPublic()))) {
         if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
             auto modifier = method.data(ctx)->flags.isPrivate ? "private" : "protected";
             e.setHeader("Method `{}` is {} in `{}` but not in `{}`", method.data(ctx)->name.show(ctx), modifier,

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -172,6 +172,10 @@ optional<core::AutocorrectSuggestion> constructAllowIncompatibleAutocorrect(cons
 
     auto methodLoc = ctx.locAt(methodDef.declLoc);
 
+    // XXX cwong: This causes a duplicate error to be reported if the signature is syntactically
+    // malformed (e.g. `allow_incompatible: :bad`). There are a few ways to resolve this (e.g.
+    // have `findSignature` return an error vector and make it the caller's responsibility to
+    // display them).
     auto parsedSig = sig_finder::SigFinder::findSignature(ctx, tree, methodLoc.copyWithZeroLength());
     if (!parsedSig.has_value()) {
         return nullopt;

--- a/test/testdata/definition_validator/bad_method_visibility_override.rb
+++ b/test/testdata/definition_validator/bad_method_visibility_override.rb
@@ -1,0 +1,52 @@
+# typed: true
+
+class AbstractClassVisibility
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.returns(Object)}
+  def foo; end
+
+  sig {abstract.returns(Object)}
+  def bar; end
+
+  sig {abstract.returns(Object)}
+  private def baz; end
+
+  sig {abstract.returns(Object)}
+  protected def qux; end
+
+  sig {abstract.returns(Object)}
+  protected def quux; end
+
+  sig {abstract.returns(Object)}
+  private def quuz; end
+
+  sig {abstract.returns(Object)}
+  protected def corge; end
+end
+
+class ImplVisibility < AbstractClassVisibility
+  sig {override.returns(Object)}
+  protected def foo; end
+          # ^^^^^^^ error: Method `foo` is protected in `ImplVisibility` but not in `AbstractClassVisibility`
+  private def bar; end
+        # ^^^^^^^ error: Method `bar` is private in `ImplVisibility` but not in `AbstractClassVisibility`
+
+  sig {override.returns(Object)}
+  protected def baz; end
+
+  sig {override.returns(Object)}
+  private def qux; end
+        # ^^^^^^^ error: Method `qux` is private in `ImplVisibility` but not in `AbstractClassVisibility`
+
+  sig {override.returns(Object)}
+  protected def quux; end
+
+  sig {override.returns(Object)}
+  private def quuz; end
+
+  sig {override.returns(Object)}
+  protected def corge; end
+end

--- a/test/testdata/definition_validator/bad_method_visibility_override.rb.autocorrects.exp
+++ b/test/testdata/definition_validator/bad_method_visibility_override.rb.autocorrects.exp
@@ -1,0 +1,54 @@
+# -- test/testdata/definition_validator/bad_method_visibility_override.rb --
+# typed: true
+
+class AbstractClassVisibility
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.returns(Object)}
+  def foo; end
+
+  sig {abstract.returns(Object)}
+  def bar; end
+
+  sig {abstract.returns(Object)}
+  private def baz; end
+
+  sig {abstract.returns(Object)}
+  protected def qux; end
+
+  sig {abstract.returns(Object)}
+  protected def quux; end
+
+  sig {abstract.returns(Object)}
+  private def quuz; end
+
+  sig {abstract.returns(Object)}
+  protected def corge; end
+end
+
+class ImplVisibility < AbstractClassVisibility
+  sig {override.returns(Object)}
+  public def foo; end
+          # ^^^^^^^ error: Method `foo` is protected in `ImplVisibility` but not in `AbstractClassVisibility`
+  public def bar; end
+        # ^^^^^^^ error: Method `bar` is private in `ImplVisibility` but not in `AbstractClassVisibility`
+
+  sig {override.returns(Object)}
+  protected def baz; end
+
+  sig {override.returns(Object)}
+  public def qux; end
+        # ^^^^^^^ error: Method `qux` is private in `ImplVisibility` but not in `AbstractClassVisibility`
+
+  sig {override.returns(Object)}
+  protected def quux; end
+
+  sig {override.returns(Object)}
+  private def quuz; end
+
+  sig {override.returns(Object)}
+  protected def corge; end
+end
+# ------------------------------

--- a/test/testdata/resolver/allow_incompatible_visibility.rb
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb
@@ -9,7 +9,7 @@ end
 
 class ChildBad < Parent
   sig {override.returns(Integer)}
-  private def some_public_api; 1; end
+  private def some_public_api; 1; end # error: Method `some_public_api` is private in `ChildBad` but not in `Parent`
 end
 
 class ChildOkay < Parent

--- a/test/testdata/resolver/allow_incompatible_visibility.rb
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb
@@ -27,6 +27,7 @@ class ChildBadSymbol < Parent
   sig {override(allow_incompatible: :bad).returns(Integer)}
   #                                 ^^^^ error: `override(allow_incompatible: ...)` expects either `true` or `:visibility
   private def some_public_api; 0; end
+  #       ^^^^^^^^^^^^^^^^^^^ error: Method `some_public_api` is private in `ChildBadSymbol` but not in `Parent`
 end
 
 class ChildBoth1 < Parent

--- a/test/testdata/resolver/allow_incompatible_visibility.rb.autocorrects.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb.autocorrects.exp
@@ -10,7 +10,7 @@ end
 
 class ChildBad < Parent
   sig {override.returns(Integer)}
-  private def some_public_api; 1; end
+  public def some_public_api; 1; end # error: Method `some_public_api` is private in `ChildBad` but not in `Parent`
 end
 
 class ChildOkay < Parent
@@ -27,7 +27,7 @@ end
 class ChildBadSymbol < Parent
   sig {override(allow_incompatible: :bad).returns(Integer)}
   #                                 ^^^^ error: `override(allow_incompatible: ...)` expects either `true` or `:visibility
-  private def some_public_api; 0; end
+  public def some_public_api; 0; end
 end
 
 class ChildBoth1 < Parent

--- a/test/testdata/resolver/allow_incompatible_visibility.rb.autocorrects.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb.autocorrects.exp
@@ -28,6 +28,7 @@ class ChildBadSymbol < Parent
   sig {override(allow_incompatible: :bad).returns(Integer)}
   #                                 ^^^^ error: `override(allow_incompatible: ...)` expects either `true` or `:visibility
   public def some_public_api; 0; end
+  #       ^^^^^^^^^^^^^^^^^^^ error: Method `some_public_api` is private in `ChildBadSymbol` but not in `Parent`
 end
 
 class ChildBoth1 < Parent

--- a/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
@@ -23,26 +23,26 @@ class ::<root> < ::Object ()
     type-member(+) ::<Class:ChildBadTypes>::<AttachedClass> -> T.attached_class (of ChildBadTypes) @ test/testdata/resolver/allow_incompatible_visibility.rb:20
     method ::<Class:ChildBadTypes>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:20
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::ChildBoth1 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:32
-    method ::ChildBoth1#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:35
+  class ::ChildBoth1 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:33
+    method ::ChildBoth1#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:36
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::<Class:ChildBoth1>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:32
-    type-member(+) ::<Class:ChildBoth1>::<AttachedClass> -> T.attached_class (of ChildBoth1) @ test/testdata/resolver/allow_incompatible_visibility.rb:32
-    method ::<Class:ChildBoth1>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:32
+  class ::<Class:ChildBoth1>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:33
+    type-member(+) ::<Class:ChildBoth1>::<AttachedClass> -> T.attached_class (of ChildBoth1) @ test/testdata/resolver/allow_incompatible_visibility.rb:33
+    method ::<Class:ChildBoth1>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:33
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::ChildBoth2 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:38
-    method ::ChildBoth2#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:41
+  class ::ChildBoth2 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:39
+    method ::ChildBoth2#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:42
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::<Class:ChildBoth2>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:38
-    type-member(+) ::<Class:ChildBoth2>::<AttachedClass> -> T.attached_class (of ChildBoth2) @ test/testdata/resolver/allow_incompatible_visibility.rb:38
-    method ::<Class:ChildBoth2>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:38
+  class ::<Class:ChildBoth2>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:39
+    type-member(+) ::<Class:ChildBoth2>::<AttachedClass> -> T.attached_class (of ChildBoth2) @ test/testdata/resolver/allow_incompatible_visibility.rb:39
+    method ::<Class:ChildBoth2>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:39
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::ChildBoth3 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:44
-    method ::ChildBoth3#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:47
+  class ::ChildBoth3 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:45
+    method ::ChildBoth3#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:48
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::<Class:ChildBoth3>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:44
-    type-member(+) ::<Class:ChildBoth3>::<AttachedClass> -> T.attached_class (of ChildBoth3) @ test/testdata/resolver/allow_incompatible_visibility.rb:44
-    method ::<Class:ChildBoth3>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:44
+  class ::<Class:ChildBoth3>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:45
+    type-member(+) ::<Class:ChildBoth3>::<AttachedClass> -> T.attached_class (of ChildBoth3) @ test/testdata/resolver/allow_incompatible_visibility.rb:45
+    method ::<Class:ChildBoth3>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:45
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
   class ::ChildBoth4 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:50
     method ::ChildBoth4#some_public_api : private|override|allow_incompatible(:visibility) (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:53

--- a/test/testdata/resolver/allow_incompatible_visibility_unsafe.rb
+++ b/test/testdata/resolver/allow_incompatible_visibility_unsafe.rb
@@ -1,0 +1,58 @@
+# typed: true
+# enable-suggest-unsafe: true
+
+class Parent
+  extend T::Sig
+
+  sig {overridable.returns(Integer)}
+  def some_public_api; 0; end
+end
+
+class ChildBad < Parent
+  sig {override.returns(Integer)}
+  private def some_public_api; 1; end # error: Method `some_public_api` is private in `ChildBad` but not in `Parent`
+end
+
+class ChildOkay < Parent
+  sig {override(allow_incompatible: :visibility).returns(Integer)}
+  private def some_public_api; 1; end
+end
+
+# We want this to overwrite with `allow_incompatible: true` anyway.
+class ChildBadTypes < Parent
+  sig {override(allow_incompatible: :visibility).returns(String)}
+  private def some_public_api; ''; end
+  #       ^^^^^^^^^^^^^^^^^^^ error: Return type `String` does not match return type of overridable method `Parent#some_public_api`
+end
+
+# This one will overwrite to `allow_incompatible: :visibility`, but w/e
+class ChildBadSymbol < Parent
+  sig {override(allow_incompatible: :bad).returns(Integer)}
+  #                                 ^^^^ error-with-dupes: `override(allow_incompatible: ...)` expects one of `true`, `false`, or `:visibility
+  private def some_public_api; 0; end
+  #       ^^^^^^^^^^^^^^^^^^^ error: Method `some_public_api` is private in `ChildBadSymbol` but not in `Parent`
+end
+
+class ChildBoth1 < Parent
+  sig { override(allow_incompatible: true).override(allow_incompatible: :visibility).returns(Integer) }
+  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
+  private def some_public_api; 0; end
+end
+
+class ChildBoth2 < Parent
+  sig { override(allow_incompatible: :visibility).override(allow_incompatible: true).returns(Integer) }
+  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
+  private def some_public_api; 0; end
+end
+
+class ChildBoth3 < Parent
+  sig { returns(Integer).override(allow_incompatible: :visibility).override(allow_incompatible: true) }
+  #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
+  private def some_public_api; 0; end
+end
+
+# This should be rewritten to `allow_incompatible: true`
+class ChildBothErrors < Parent
+  sig { override.returns(String) }
+  private def some_public_api; ''; end
+end

--- a/test/testdata/resolver/allow_incompatible_visibility_unsafe.rb.autocorrects.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility_unsafe.rb.autocorrects.exp
@@ -1,0 +1,52 @@
+# -- test/testdata/resolver/allow_incompatible_visibility_unsafe.rb --
+# typed: true
+# enable-suggest-unsafe: true
+
+class Parent
+  extend T::Sig
+
+  sig {overridable.returns(Integer)}
+  def some_public_api; 0; end
+end
+
+class ChildBad < Parent
+  sig {override.returns(Integer)}
+  private def some_public_api; 1; end # error: Method `some_public_api` is private in `ChildBad` but not in `Parent`
+end
+
+class ChildOkay < Parent
+  sig {override(allow_incompatible: :visibility).returns(Integer)}
+  private def some_public_api; 1; end
+end
+
+class ChildBadTypes < Parent
+  sig {override(allow_incompatible: true).returns(String)}
+  private def some_public_api; ''; end
+  #       ^^^^^^^^^^^^^^^^^^^ error: Return type `String` does not match return type of overridable method `Parent#some_public_api`
+end
+
+class ChildBadSymbol < Parent
+  sig {override(allow_incompatible: :bad).returns(Integer)}
+  #                                 ^^^^ error-with-dupes: `override(allow_incompatible: ...)` expects one of `true`, `false`, or `:visibility
+  private def some_public_api; 0; end
+  #       ^^^^^^^^^^^^^^^^^^^ error: Method `some_public_api` is private in `ChildBadSymbol` but not in `Parent`
+end
+
+class ChildBoth1 < Parent
+  sig { override(allow_incompatible: :visibility).returns(Integer) }
+  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
+  private def some_public_api; 0; end
+end
+
+class ChildBoth2 < Parent
+  sig { override(allow_incompatible: true).returns(Integer) }
+  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
+  private def some_public_api; 0; end
+end
+
+class ChildBoth3 < Parent
+  sig { returns(Integer).override(allow_incompatible: true) }
+  #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
+  private def some_public_api; 0; end
+end
+# ------------------------------


### PR DESCRIPTION
This PR adds validation for visibility compatibility between parent and child classes, supporting `private` to `protected`/ `public` and `protected` to `public` overrides for both instance and class methods. It also adds autocorrect suggestions that default to removing `private` or `protected` from the child. The validation error mentions the specific method early, only mentions the method once, and mentions `private` before any potentially-long class name. Repeated calls to `data(ctx)` and `data(ctx)->loc()` have been extracted into reusable variables for consistency. Stripe's codebase exclusively uses the `private def foo; end` syntax, but I'd like to know if I'm overlooking any edge cases here. Particularly, I'm curious as to whether `private_class_method "class_bar"`  is something that should be considered or if the visibility information for string literals are already processed by Sorbet's parser before reaching the validator.

### Motivation
Fixes #5522 - This completes the work started in PR #5732, which has been inactive for a long time.

### Test plan

See included automated tests.
