### PR TITLE
use spans for structural equality

### DIFF
--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -1,3 +1,4 @@
+#include "absl/algorithm/container.h"
 #include "absl/strings/escaping.h"
 #include "absl/types/span.h"
 #include "ast/ast.h"
@@ -14,15 +15,7 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Exp
 
 bool structurallyEqualSpan(const core::GlobalState &gs, const void *avoid, absl::Span<const ExpressionPtr> a,
                            absl::Span<const ExpressionPtr> b, const core::FileRef file) {
-    if (a.size() != b.size()) {
-        return false;
-    }
-    for (size_t i = 0; i < a.size(); i++) {
-        if (!structurallyEqual(gs, avoid, a[i], b[i], file)) {
-            return false;
-        }
-    }
-    return true;
+    return absl::c_equal(a, b, [&](const auto &a, const auto &b) { return structurallyEqual(gs, avoid, a, b, file); });
 }
 
 class StructurallyEqualError {};


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

No sense using templated functions here if we don't have to.  Should be a little faster too, since we don't have to do the check on inlined/outlined vector on every iteration.

The `c_equal` changes are just a bonus cleanup while we're in the area.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
