### PR TITLE
don't materialize strings when splitting

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2869,7 +2869,7 @@ class ResolveTypeMembersAndFieldsWalk {
         // If this string _begins_ with `::`, then the first fragment will be an empty string; in multiple places
         // below, we'll check to find out whether the first part is `""` or not, which means we're testing whether
         // the string did or did not begin with `::`.
-        vector<string> parts = absl::StrSplit(shortName, "::");
+        vector<string_view> parts = absl::StrSplit(shortName, "::");
 
         core::SymbolRef current;
         for (auto part : parts) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This has two benefits: the immediate benefit of not copying the strings, and the benefit of not copying strings again in the loop just below this initialization.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
