### PR TITLE
drop `Context` arg from `get*TypeAndOrigin`

### DIFF
--- a/infer/environment.h
+++ b/infer/environment.h
@@ -215,9 +215,9 @@ public:
 
     // NB: you can't call this function on vars in the first basic block since
     // their type will be nullptr
-    const core::TypeAndOrigins &getTypeAndOrigin(core::Context ctx, cfg::LocalRef symbol) const;
+    const core::TypeAndOrigins &getTypeAndOrigin(cfg::LocalRef symbol) const;
 
-    const core::TypeAndOrigins &getAndFillTypeAndOrigin(core::Context ctx, cfg::VariableUseSite &symbol) const;
+    const core::TypeAndOrigins &getAndFillTypeAndOrigin(cfg::VariableUseSite &symbol) const;
 
     /*
      * Create an Environment out of this one that holds if final condition in

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -182,7 +182,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         current.setUninitializedVarsToNil(ctx, cfg->symbol.data(ctx)->loc());
 
         for (auto &blockArg : bb->args) {
-            current.getAndFillTypeAndOrigin(ctx, blockArg);
+            current.getAndFillTypeAndOrigin(blockArg);
         }
 
         visited[bb->id] = true;
@@ -243,7 +243,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     if (dueToSafeNavigation && send != nullptr) {
                         if (auto e = ctx.state.beginError(locForUnreachable,
                                                           core::errors::Infer::UnnecessarySafeNavigation)) {
-                            auto ty = current.getAndFillTypeAndOrigin(ctx, send->args[0]);
+                            auto ty = current.getAndFillTypeAndOrigin(send->args[0]);
 
                             e.setHeader("Used `{}` operator on `{}`, which can never be nil", "&.", ty.type.show(ctx));
                             e.addErrorSection(ty.explainGot(ctx, current.locForUninitialized()));
@@ -315,7 +315,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                                               *ctx.state.suggestUnsafe, bexitLoc.source(ctx).value());
                             }
 
-                            auto ty = prevEnv.getTypeAndOrigin(ctx, cond.variable);
+                            auto ty = prevEnv.getTypeAndOrigin(cond.variable);
                             e.addErrorSection(ty.explainGot(ctx, prevEnv.locForUninitialized()));
                         }
 
@@ -364,7 +364,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         }
         if (!current.isDead) {
             ENFORCE(bb->firstDeadInstructionIdx == -1);
-            auto bexitTpo = current.getAndFillTypeAndOrigin(ctx, bb->bexit.cond);
+            auto bexitTpo = current.getAndFillTypeAndOrigin(bb->bexit.cond);
             if (bexitTpo.type.isUntyped()) {
                 auto what = core::errors::Infer::errorClassForUntyped(ctx, ctx.file, bexitTpo.type);
                 if (auto e = ctx.beginError(bb->bexit.loc, what)) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This argument is unused.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
