### PR TITLE
add some `const &` to `auto` values to ensure we don't copy

### DIFF
--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -243,7 +243,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     if (dueToSafeNavigation && send != nullptr) {
                         if (auto e = ctx.state.beginError(locForUnreachable,
                                                           core::errors::Infer::UnnecessarySafeNavigation)) {
-                            auto ty = current.getAndFillTypeAndOrigin(send->args[0]);
+                            const auto &ty = current.getAndFillTypeAndOrigin(send->args[0]);
 
                             e.setHeader("Used `{}` operator on `{}`, which can never be nil", "&.", ty.type.show(ctx));
                             e.addErrorSection(ty.explainGot(ctx, current.locForUninitialized()));
@@ -315,7 +315,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                                               *ctx.state.suggestUnsafe, bexitLoc.source(ctx).value());
                             }
 
-                            auto ty = prevEnv.getTypeAndOrigin(cond.variable);
+                            const auto &ty = prevEnv.getTypeAndOrigin(cond.variable);
                             e.addErrorSection(ty.explainGot(ctx, prevEnv.locForUninitialized()));
                         }
 
@@ -364,7 +364,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         }
         if (!current.isDead) {
             ENFORCE(bb->firstDeadInstructionIdx == -1);
-            auto bexitTpo = current.getAndFillTypeAndOrigin(bb->bexit.cond);
+            const auto &bexitTpo = current.getAndFillTypeAndOrigin(bb->bexit.cond);
             if (bexitTpo.type.isUntyped()) {
                 auto what = core::errors::Infer::errorClassForUntyped(ctx, ctx.file, bexitTpo.type);
                 if (auto e = ctx.beginError(bb->bexit.loc, what)) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

C++'s decision to make `auto var = ...;` when the RHS returns a ref copy bites again.  Two of these don't matter, but one of these happens for every basic block in the CFG, so we should go a little faster.

This change also makes things consistent with nearly every other callsite.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
