### PR TITLE
run `scripts/bin/remote-script` with the correct Ruby version

### DIFF
--- a/tools/scripts/remote-script
+++ b/tools/scripts/remote-script
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# cd so we pick up pay-server's .ruby-version, not Sorbet's .ruby-version.
+cd $HOME/stripe/pay-server
+
 # We have to manually specify --dir because remote-script hard-codes pay-server for backwards compatibility.
 #    https://git.corp.stripe.com/stripe-internal/pay-server/pull/196272/files#diff-3476184fa78de8564df28ff68cf18631R89
 # I think we should fix remote-script to stop doing that.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I kept having to change Sorbet's `.ruby-version` to run `./tools/scripts/remote-script ./tools/scripts/format_cxx.sh $FILES`.  No more!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
