### PR TITLE
do a single lookup for pkginfo when computing SCCs

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1575,11 +1575,12 @@ struct ComputeSCCsMetadata {
 // DFS traversal for Tarjan's algorithm starting from pkgName, along with keeping track of some metadata needed for
 // detecting SCCs.
 void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::packages::MangledName pkgName) {
-    if (!gs.packageDB().getPackageInfoNonConst(pkgName)) {
+    auto *pkgInfoPtr = gs.packageDB().getPackageInfoNonConst(pkgName);
+    if (!pkgInfoPtr) {
         // This is to handle the case where the user imports a package that doesn't exist.
         return;
     }
-    auto &pkgInfo = PackageInfoImpl::from(*(gs.packageDB().getPackageInfoNonConst(pkgName)));
+    auto &pkgInfo = PackageInfoImpl::from(*pkgInfoPtr);
     metadata.index[pkgName] = metadata.nextIndex;
     metadata.lowLink[pkgName] = metadata.nextIndex;
     metadata.nextIndex++;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change eliminates duplicate work and makes the pointer dereference more obviously safe, because we already checked for `nullptr`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
