### PR TITLE
Delete MetaType::_approximate

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -922,7 +922,6 @@ public:
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
 
-    TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr underlying(const GlobalState &gs) const;
 };
 CheckSize(MetaType, 16, 8);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -715,11 +715,6 @@ bool MetaType::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const 
     return false;
 }
 
-TypePtr MetaType::_approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const {
-    // dispatchCall is invoked on them in resolver
-    return nullptr;
-}
-
 TypePtr MetaType::underlying(const GlobalState &gs) const {
     return Types::Object();
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The default implementation of the `GENERATE_CALL__approximate` function
is to `return nullptr` if there is no case, so this code is redundant.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a