### PR TITLE
Switch SymbolHash to use std::tie's lexicographic ordering

### DIFF
--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -88,7 +88,8 @@ struct SymbolHash {
         : nameHash(nameHash), symbolHash(symbolHash) {}
 
     inline bool operator<(const SymbolHash &h) const noexcept {
-        return this->nameHash < h.nameHash || (!(h.nameHash < this->nameHash) && this->symbolHash < h.symbolHash);
+        // Take advantage of lexicographic ordering with std::tie
+        return std::tie(this->nameHash, this->symbolHash) < std::tie(h.nameHash, h.symbolHash);
     }
 };
 CheckSize(SymbolHash, 8, 4);


### PR DESCRIPTION
The implementation of `SymbolHash::operator<` on master generates a comparison that includes multiple jumps, while using the lexicographic ordering that `std::tie` implements avoids this by using a single conditional move at the end. Given that integer comparisons are cheap, this seems like a win for a pretty hot function.

https://godbolt.org/z/6f56cdTof

### Motivation
Performance, though this is definitely a micro-optimization that I don't expect to see show up on charts.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
