### PR TITLE
Mostly remove vector references from core

### DIFF
--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -41,7 +41,7 @@ const string AutocorrectSuggestion::applySingleEditForTesting(const std::string_
 }
 
 UnorderedMap<FileRef, string> AutocorrectSuggestion::apply(const GlobalState &gs, FileSystem &fs,
-                                                           const vector<AutocorrectSuggestion> &autocorrects) {
+                                                           absl::Span<const AutocorrectSuggestion> autocorrects) {
     UnorderedMap<FileRef, string> sources;
     for (auto &autocorrect : autocorrects) {
         for (auto &edit : autocorrect.edits) {

--- a/core/AutocorrectSuggestion.h
+++ b/core/AutocorrectSuggestion.h
@@ -29,7 +29,7 @@ struct AutocorrectSuggestion {
     // to those files into a resulting string with all edits applied. Does not write those back out
     // to disk.
     static UnorderedMap<FileRef, std::string> apply(const GlobalState &gs, FileSystem &fs,
-                                                    const std::vector<AutocorrectSuggestion> &autocorrects);
+                                                    absl::Span<const AutocorrectSuggestion> autocorrects);
 };
 
 } // namespace sorbet::core

--- a/core/Error.h
+++ b/core/Error.h
@@ -79,10 +79,10 @@ struct ErrorSection {
     ErrorSection(std::string_view header) : header(header) {}
     ErrorSection(std::string_view header, const std::initializer_list<ErrorLine> &messages)
         : header(header), messages(messages) {}
-    ErrorSection(std::string_view header, const std::vector<ErrorLine> &messages)
-        : header(header), messages(messages) {}
+    ErrorSection(std::string_view header, absl::Span<const ErrorLine> messages)
+        : header(header), messages(messages.cbegin(), messages.cend()) {}
     ErrorSection(const std::initializer_list<ErrorLine> &messages) : ErrorSection("", messages) {}
-    ErrorSection(const std::vector<ErrorLine> &messages) : ErrorSection("", messages) {}
+    ErrorSection(absl::Span<const ErrorLine> messages) : ErrorSection("", messages) {}
     std::string toString(const GlobalState &gs) const;
 
     class NoOpCollector {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -147,7 +147,7 @@ MethodBuilder enterMethod(GlobalState &gs, ClassOrModuleRef klass, NameRef name)
 }
 
 struct ParentLinearizationInformation {
-    const InlinedVector<core::ClassOrModuleRef, 4> &mixins;
+    absl::Span<const core::ClassOrModuleRef> mixins;
     core::ClassOrModuleRef superClass;
     core::ClassOrModuleRef klass;
     InlinedVector<core::ClassOrModuleRef, 4> fullLinearizationSlow(core::GlobalState &gs);

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -334,7 +334,7 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, const TypeConstraint &tc) c
 }
 
 TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                              const std::vector<TypePtr> &targs) const {
+                              absl::Span<const TypePtr> targs) const {
     switch (tag()) {
         case Tag::BlamedUntyped:
         case Tag::UnresolvedAppliedType:

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -295,7 +295,7 @@ public:
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+                         absl::Span<const TypePtr> targs) const;
 
     // If this TypePtr `is_proxy_type`, returns its underlying type.
     TypePtr underlying(const GlobalState &gs) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -148,14 +148,14 @@ public:
     enum class Combinator { OR, AND };
 
     static TypePtr resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, ClassOrModuleRef fromWhat,
-                                        ClassOrModuleRef inWhat, const std::vector<TypePtr> &targs);
+                                        ClassOrModuleRef inWhat, absl::Span<const TypePtr> targs);
 
     static InlinedVector<TypeMemberRef, 4> alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
-                                                             const std::vector<TypePtr> &targs, ClassOrModuleRef asIf);
+                                                             absl::Span<const TypePtr> targs, ClassOrModuleRef asIf);
     // Extract the return value type from a proc.
     static TypePtr getProcReturnType(const GlobalState &gs, const TypePtr &procType);
     static TypePtr instantiate(const GlobalState &gs, const TypePtr &what, absl::Span<const TypeMemberRef> params,
-                               const std::vector<TypePtr> &targs);
+                               absl::Span<const TypePtr> targs);
     /** Replace all type variables in `what` with their instantiations.
      * Requires that `tc` has already been solved.
      */
@@ -175,7 +175,7 @@ public:
     /** Internal implementation. You should probably use any(). */
     static TypePtr lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
 
-    static TypePtr lubAll(const GlobalState &gs, const std::vector<TypePtr> &elements);
+    static TypePtr lubAll(const GlobalState &gs, absl::Span<const TypePtr> elements);
     static TypePtr arrayOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr rangeOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr hashOf(const GlobalState &gs, const TypePtr &elem);
@@ -218,8 +218,8 @@ public:
     // Called both from type_syntax.cc during sig parsing and from infer after encountering
     // something that look like type syntax in a method body.
     static TypePtr applyTypeArguments(const GlobalState &gs, const CallLocs &locs, uint16_t numPosArgs,
-                                      const InlinedVector<const TypeAndOrigins *, 2> &args,
-                                      ClassOrModuleRef genericClass, ErrorClass genericArgumentCountMismatchError,
+                                      absl::Span<const TypeAndOrigins *> args, ClassOrModuleRef genericClass,
+                                      ErrorClass genericArgumentCountMismatchError,
                                       ErrorClass genericArgumentKeywordArgsError);
 };
 
@@ -446,8 +446,8 @@ public:
 
     void _sanityCheck(const GlobalState &gs) const;
 
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
 };
 CheckSize(LambdaParam, 24, 8);
 
@@ -714,8 +714,8 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
@@ -774,8 +774,8 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -821,8 +821,8 @@ public:
     std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr underlying(const GlobalState &gs) const;
@@ -854,8 +854,8 @@ public:
     std::string showWithMoreInfo(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc, core::Polarity polarity) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -883,8 +883,8 @@ public:
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                         const std::vector<TypePtr> &targs) const;
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params, absl::Span<const TypePtr> targs)
+        const;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
 
@@ -967,7 +967,7 @@ struct CallLocs final {
     LocOffsets call;
     LocOffsets receiver;
     LocOffsets fun;
-    InlinedVector<LocOffsets, 2> &args;
+    absl::Span<const LocOffsets> args;
 };
 
 struct DispatchArgs {
@@ -991,7 +991,7 @@ struct DispatchArgs {
     NameRef name;
     const CallLocs &locs;
     uint16_t numPosArgs;
-    InlinedVector<const TypeAndOrigins *, 2> &args;
+    absl::Span<const TypeAndOrigins *> args;
     const TypePtr &selfType;
     const TypeAndOrigins &fullType;
     const TypePtr &thisType;

--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -7,7 +7,7 @@
 using namespace std;
 
 namespace sorbet::core::packages {
-MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::vector<std::string_view> &parts) {
+MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, absl::Span<const std::string_view> parts) {
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(parts, "_"), core::PACKAGE_SUFFIX);
 
@@ -16,7 +16,7 @@ MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::
     return MangledName(gs.enterNameConstant(packagerName));
 }
 
-MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::vector<core::NameRef> &parts) {
+MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, absl::Span<const core::NameRef> parts) {
     // Foo::Bar => Foo_Bar_Package
     auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(gs)), core::PACKAGE_SUFFIX);
 

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -19,9 +19,9 @@ public:
     MangledName() = default;
 
     // ["Foo", "Bar"] => :Foo_Bar_Package
-    static MangledName mangledNameFromParts(core::GlobalState &gs, const std::vector<std::string_view> &parts);
+    static MangledName mangledNameFromParts(core::GlobalState &gs, absl::Span<const std::string_view> parts);
     // [:Foo, :Bar] => :Foo_Bar_Package
-    static MangledName mangledNameFromParts(core::GlobalState &gs, const std::vector<core::NameRef> &parts);
+    static MangledName mangledNameFromParts(core::GlobalState &gs, absl::Span<const core::NameRef> parts);
     // "Foo::Bar" -> :Foo_Bar_Package
     static MangledName mangledNameFromHuman(const core::GlobalState &gs, std::string_view human);
 

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -10,7 +10,7 @@ using namespace std;
 namespace sorbet::core {
 
 TypePtr Types::instantiate(const GlobalState &gs, const TypePtr &what, absl::Span<const TypeMemberRef> params,
-                           const vector<TypePtr> &targs) {
+                           absl::Span<const TypePtr> targs) {
     ENFORCE(what != nullptr);
     auto t = what._instantiate(gs, params, targs);
     if (t) {
@@ -85,7 +85,7 @@ TypePtr TypeVar::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
 namespace {
 
 template <typename... MethodArgs>
-optional<vector<TypePtr>> instantiateElems(const vector<TypePtr> &elems, const MethodArgs &...methodArgs) {
+optional<vector<TypePtr>> instantiateElems(absl::Span<const TypePtr> elems, const MethodArgs &...methodArgs) {
     optional<vector<TypePtr>> newElems;
     int i = -1;
     for (auto &e : elems) {
@@ -117,7 +117,7 @@ optional<vector<TypePtr>> instantiateElems(const vector<TypePtr> &elems, const M
 // Matches the 4 used in the vector backing ClassOrModuleRef::typeMembers()
 using PolaritiesStore = InlinedVector<core::Polarity, 4>;
 
-optional<vector<TypePtr>> approximateElems(const vector<TypePtr> &elems, const GlobalState &gs,
+optional<vector<TypePtr>> approximateElems(absl::Span<const TypePtr> elems, const GlobalState &gs,
                                            const TypeConstraint &tc, PolaritiesStore &polarities) {
     optional<vector<TypePtr>> newElems;
     int i = -1;
@@ -150,7 +150,7 @@ optional<vector<TypePtr>> approximateElems(const vector<TypePtr> &elems, const G
 } // anonymous namespace
 
 TypePtr TupleType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                                const vector<TypePtr> &targs) const {
+                                absl::Span<const TypePtr> targs) const {
     optional<vector<TypePtr>> newElems = instantiateElems(this->elems, gs, params, targs);
     if (!newElems) {
         return nullptr;
@@ -176,7 +176,7 @@ TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc,
 };
 
 TypePtr ShapeType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                                const vector<TypePtr> &targs) const {
+                                absl::Span<const TypePtr> targs) const {
     optional<vector<TypePtr>> newValues = instantiateElems(this->values, gs, params, targs);
     if (!newValues) {
         return nullptr;
@@ -202,7 +202,7 @@ TypePtr ShapeType::_approximate(const GlobalState &gs, const TypeConstraint &tc,
 }
 
 TypePtr OrType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                             const vector<TypePtr> &targs) const {
+                             absl::Span<const TypePtr> targs) const {
     auto left = this->left._instantiate(gs, params, targs);
     auto right = this->right._instantiate(gs, params, targs);
     if (left || right) {
@@ -248,7 +248,7 @@ TypePtr OrType::_approximate(const GlobalState &gs, const TypeConstraint &tc, co
 }
 
 TypePtr AndType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                              const vector<TypePtr> &targs) const {
+                              absl::Span<const TypePtr> targs) const {
     auto left = this->left._instantiate(gs, params, targs);
     auto right = this->right._instantiate(gs, params, targs);
     if (left || right) {
@@ -294,7 +294,7 @@ TypePtr AndType::_approximate(const GlobalState &gs, const TypeConstraint &tc, c
 }
 
 TypePtr AppliedType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                                  const vector<TypePtr> &targs) const {
+                                  absl::Span<const TypePtr> targs) const {
     optional<vector<TypePtr>> newTargs = instantiateElems(this->targs, gs, params, targs);
     if (!newTargs) {
         return nullptr;
@@ -332,7 +332,7 @@ TypePtr AppliedType::_approximate(const GlobalState &gs, const TypeConstraint &t
 }
 
 TypePtr LambdaParam::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
-                                  const vector<TypePtr> &targs) const {
+                                  absl::Span<const TypePtr> targs) const {
     ENFORCE(params.size() == targs.size());
     for (auto &el : params) {
         if (el == this->definition) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -308,7 +308,7 @@ TypePtr Types::dropLiteral(const GlobalState &gs, const TypePtr &tp) {
     return tp;
 }
 
-TypePtr Types::lubAll(const GlobalState &gs, const vector<TypePtr> &elements) {
+TypePtr Types::lubAll(const GlobalState &gs, absl::Span<const TypePtr> elements) {
     TypePtr acc = Types::bottom();
     for (auto &el : elements) {
         acc = Types::lub(gs, acc, el);
@@ -616,7 +616,7 @@ void MetaType::_sanityCheck(const GlobalState &gs) const {
  * If some typeArgs are not present, return NoSymbol
  * */
 InlinedVector<TypeMemberRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
-                                                         const vector<TypePtr> &targs, ClassOrModuleRef asIf) {
+                                                         absl::Span<const TypePtr> targs, ClassOrModuleRef asIf) {
     ENFORCE(what == asIf || what.data(gs)->derivesFrom(gs, asIf) || asIf.data(gs)->derivesFrom(gs, what),
             "what={} asIf={}", what.data(gs)->name.showRaw(gs), asIf.data(gs)->name.showRaw(gs));
     InlinedVector<TypeMemberRef, 4> currentAlignment;
@@ -653,7 +653,7 @@ InlinedVector<TypeMemberRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, 
  * inWhat   - where the generic type is observed
  */
 TypePtr Types::resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, ClassOrModuleRef fromWhat,
-                                    ClassOrModuleRef inWhat, const vector<TypePtr> &targs) {
+                                    ClassOrModuleRef inWhat, absl::Span<const TypePtr> targs) {
     auto originalOwner = fromWhat;
 
     // TODO: the ENFORCE below should be above this conditional, but there is
@@ -847,7 +847,7 @@ TypePtr Types::widen(const GlobalState &gs, const TypePtr &type) {
 }
 
 namespace {
-vector<TypePtr> unwrapTypeVector(Context ctx, const vector<TypePtr> &elems) {
+vector<TypePtr> unwrapTypeVector(Context ctx, absl::Span<const TypePtr> elems) {
     std::vector<TypePtr> unwrapped;
     unwrapped.reserve(elems.size());
     for (auto &e : elems) {
@@ -998,7 +998,7 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
 // again by infer).
 
 TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, uint16_t numPosArgs,
-                                  const InlinedVector<const TypeAndOrigins *, 2> &args, ClassOrModuleRef genericClass,
+                                  absl::Span<const TypeAndOrigins *> args, ClassOrModuleRef genericClass,
                                   ErrorClass genericArgumentCountMismatchError,
                                   ErrorClass genericArgumentKeywordArgsError) {
     genericClass = genericClass.maybeUnwrapBuiltinGenericForwarder();

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -81,7 +81,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
     core::DispatchArgs dispatchArgs{snd->fun,
                                     locs,
                                     numPosArgs,
-                                    args,
+                                    absl::MakeSpan(args),
                                     snd->recv.type,
                                     {snd->recv.type, {originForFullType}},
                                     snd->recv.type,

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -986,8 +986,18 @@ core::TypePtr flatmapHack(core::Context ctx, const core::TypePtr &receiver, cons
         ctx.file, loc.offsets(), loc.offsets(), loc.offsets(), argLocs,
     };
 
-    core::DispatchArgs dispatchArgs{core::Names::flatten(), locs,    1,   args, recvType.type, recvType,
-                                    recvType.type,          nullptr, loc, true, false,         currentMethodName};
+    core::DispatchArgs dispatchArgs{core::Names::flatten(),
+                                    locs,
+                                    1,
+                                    absl::MakeSpan(args),
+                                    recvType.type,
+                                    recvType,
+                                    recvType.type,
+                                    nullptr,
+                                    loc,
+                                    true,
+                                    false,
+                                    currentMethodName};
 
     auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
     if (dispatched.main.errors.empty()) {
@@ -1041,7 +1051,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 // that we want to report all errors (suppressing nothing).
                 auto suppressErrors = false;
                 core::DispatchArgs dispatchArgs{send.fun,        locs,
-                                                send.numPosArgs, args,
+                                                send.numPosArgs, absl::MakeSpan(args),
                                                 recvType.type,   recvType,
                                                 recvType.type,   send.link,
                                                 ownerLoc,        send.isPrivateOk,
@@ -1435,7 +1445,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     core::DispatchArgs dispatchArgs{core::Names::squareBrackets(),
                                                     locs,
                                                     numPosArgs,
-                                                    args,
+                                                    absl::MakeSpan(args),
                                                     recvType.type,
                                                     recvType,
                                                     recvType.type,

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -137,7 +137,7 @@ struct Export {
 
     explicit Export(FullyQualifiedName &&fqn) : fqn(move(fqn)) {}
 
-    const vector<core::NameRef> &parts() const {
+    absl::Span<const core::NameRef> parts() const {
         return fqn.parts;
     }
 
@@ -160,7 +160,7 @@ class LexNext final {
     absl::Span<const core::NameRef> names;
 
 public:
-    LexNext(const vector<core::NameRef> &names) : names(names) {}
+    LexNext(absl::Span<const core::NameRef> names) : names(names) {}
 
     bool operator<(absl::Span<const core::NameRef> rhs) const {
         // Lexicographic comparison:

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1453,7 +1453,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
         auto genericClass = corrected.asClassOrModuleRef();
         ENFORCE_NO_TIMER(genericClass.exists());
         core::CallLocs locs{ctx.file, s.loc, s.recv.loc(), s.funLoc, argLocs};
-        auto out = core::Types::applyTypeArguments(ctx, locs, s.numPosArgs(), targs, genericClass,
+        auto out = core::Types::applyTypeArguments(ctx, locs, s.numPosArgs(), absl::MakeSpan(targs), genericClass,
                                                    core::errors::Resolver::GenericArgumentCountMismatch,
                                                    core::errors::Resolver::GenericArgumentKeywordArgs);
 


### PR DESCRIPTION
Switch more callsites to using spans, and remove vector references from some structures.

### Motivation
Using `absl::Span` in place of `vector`/`InlinedVector` references in function arguments allows them to accept anything that converts to a span, and also avoids the possibility of accidentally copying vectors.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
