### PR TITLE
Save 4 bytes on every `ArgInfo` by deleting `rebind`

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1455,6 +1455,10 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
                        showRaw ? sym->rebind.toStringFullName(gs) : sym->rebind.showFullName(gs));
     }
 
+    if (sym->blockRebind.exists()) {
+        fmt::format_to(std::back_inserter(buf), " rebindTo {}", sym->blockRebind.showFullName(gs));
+    }
+
     ENFORCE(!absl::c_any_of(to_string(buf), [](char c) { return c == '\n'; }));
     fmt::format_to(std::back_inserter(buf), "\n");
     for (auto ta : sym->typeArguments()) {
@@ -1727,10 +1731,6 @@ string ArgInfo::toString(const GlobalState &gs) const {
     }
 
     fmt::format_to(std::back_inserter(buf), " @ {}", loc.showRaw(gs));
-
-    if (this->rebind.exists()) {
-        fmt::format_to(std::back_inserter(buf), " rebindTo {}", this->rebind.showFullName(gs));
-    }
 
     return to_string(buf);
 }
@@ -2163,7 +2163,6 @@ ArgInfo ArgInfo::deepCopy() const {
     result.type = this->type;
     result.loc = this->loc;
     result.name = this->name;
-    result.rebind = this->rebind;
     return result;
 }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -163,6 +163,7 @@ public:
     ClassOrModuleRef owner;
     NameRef name;
     ClassOrModuleRef rebind;
+    ClassOrModuleRef blockRebind;
     Flags flags;
     // We store an offset into the intrinsic table used by calls.cc; the only
     // wrinkle is that our offset here is the offset of the intrinsic + 1, so
@@ -198,7 +199,7 @@ private:
     SymbolRef::LOC_store locs_;
     std::unique_ptr<InlinedVector<TypeArgumentRef, 4>> typeArgs;
 };
-CheckSize(Method, 136, 8);
+CheckSize(Method, 144, 8);
 
 // Contains a field or a static field
 class Field final {

--- a/core/Types.h
+++ b/core/Types.h
@@ -32,8 +32,6 @@ public:
     using ArgFlags = core::ParsedArg::ArgFlags;
     ArgFlags flags;
     NameRef name;
-    // Stores the `.bind(...)` symbol if the `&blk` arg's type had one
-    ClassOrModuleRef rebind;
     Loc loc;
     TypePtr type;
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -612,7 +612,6 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
 
 void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
     p.putU4(a.name.rawId());
-    p.putU4(a.rebind.id());
     pickle(p, a.loc);
     p.putU1(a.flags.toU1());
     pickle(p, a.type);
@@ -621,7 +620,6 @@ void SerializerImpl::pickle(Pickler &p, const ArgInfo &a) {
 ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
     ArgInfo result;
     result.name = NameRef::fromRaw(*gs, p.getU4());
-    result.rebind = core::ClassOrModuleRef::fromRaw(p.getU4());
     result.loc = unpickleLoc(p);
     {
         uint8_t flags = p.getU1();
@@ -635,6 +633,7 @@ void SerializerImpl::pickle(Pickler &p, const Method &what) {
     p.putU4(what.owner.id());
     p.putU4(what.name.rawId());
     p.putU4(what.rebind.id());
+    p.putU4(what.blockRebind.id());
     p.putU4(what.flags.serialize());
     p.putU4(what.typeArguments().size());
     for (auto s : what.typeArguments()) {
@@ -657,6 +656,7 @@ Method SerializerImpl::unpickleMethod(UnPickler &p, const GlobalState *gs) {
     result.owner = ClassOrModuleRef::fromRaw(p.getU4());
     result.name = NameRef::fromRaw(*gs, p.getU4());
     result.rebind = ClassOrModuleRef::fromRaw(p.getU4());
+    result.blockRebind = ClassOrModuleRef::fromRaw(p.getU4());
     auto flagsU2 = static_cast<uint16_t>(p.getU4());
     Method::Flags flags;
     static_assert(sizeof(flags) == sizeof(flagsU2));

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1515,7 +1515,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
 
         TypePtr blockType = Types::resultTypeAsSeenFrom(gs, bspec.type, methodData->owner, symbol, targs);
         handleBlockType(gs, component, blockType);
-        component.rebind = bspec.rebind;
+        component.rebind = methodData->blockRebind;
         component.rebindLoc = bspec.loc;
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3725,7 +3725,7 @@ private:
                     arg.type = core::Types::untypedUntracked();
                 }
                 arg.loc = spec->nameLoc;
-                arg.rebind = spec->rebind;
+                methodInfo->blockRebind = spec->rebind;
                 sig.argTypes.erase(spec);
                 // Since methods always have (synthesized if necessary) block arguments,
                 // we need to record the explicit presence of a block arg from the sig here.

--- a/test/testdata/resolver/bind_class_of.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/bind_class_of.rb.symbol-table-raw.exp
@@ -7,6 +7,6 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U Test>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Test>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Test) @ Loc {file=test/testdata/resolver/bind_class_of.rb start=3:1 end=3:11}
     method <S <C <U Test>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/bind_class_of.rb start=3:1 end=9:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/bind_class_of.rb start=??? end=???}
-    method <S <C <U Test>> $1>#<U test> (blk) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/resolver/bind_class_of.rb start=7:3 end=7:22}
-      argument blk<block> -> T.proc.void @ Loc {file=test/testdata/resolver/bind_class_of.rb start=6:15 end=6:18} rebindTo ::<Class:Test>
+    method <S <C <U Test>> $1>#<U test> (blk) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/resolver/bind_class_of.rb start=7:3 end=7:22} rebindTo ::<Class:Test>
+      argument blk<block> -> T.proc.void @ Loc {file=test/testdata/resolver/bind_class_of.rb start=6:15 end=6:18}
 


### PR DESCRIPTION
This PR moves `rebind` information from `ArgInfo` to `Method` to optimize memory usage and align with better modeling of inference logic. Previously, every `ArgInfo` instance stored a 4-byte `rebind` field even though only block arguments needed it. Now, we store this as an 8-byte `blockRebind` field on `Method` where it logically belongs, since every method has exactly one block argument. While this increases the `Method` size from 136 to 144 bytes, I'm hoping that this would actually result in aggregate memory savings by removing the redundant fields from all of the `ArgInfo` instances. I really wanted to find a way to implement this without increasing the size of `Method`, but from what I understand, we need a dedicated spot to hold the block's `rebind` (distinct from `ArgInfo`) that round-trips in the `Method`'s pickle/unpickle code—though I may be missing some nuance here about how we could achieve this differently. Without storing this information somewhere that gets serialized, we'd lose `rebind` details for block arguments.


### Motivation
Fixes #6629


### Test plan
This does not include any new tests, but I did update the `bind_class_of` expectation test. If there were a regression or change that somehow stores `rebind` anywhere else, then the `resolver/bind_class_of` test would fail because the updated test expects the `rebind` to be on the `Method`. The `infer/rebind` test already covers method rebinding, block argument rebinding, and nested block rebinding.