### PR TITLE
Improve error messages for `attr_accessor` overrides

### DIFF
--- a/test/testdata/definition_validator/attr_accessor_override_error.rb
+++ b/test/testdata/definition_validator/attr_accessor_override_error.rb
@@ -1,0 +1,49 @@
+# typed: true
+
+module Fooable
+  extend T::Sig
+  extend T::Helpers
+  interface!
+
+  sig {abstract.returns(T.nilable(String))}
+  def foo; end
+end
+
+# This is incorrect: attr_accessor adds both a reader and a writer
+class BadFooable
+  extend T::Sig
+  include Fooable
+  
+  sig {override.returns(T.nilable(String))}
+  attr_accessor :foo # error: Method `BadFooable#foo=` is marked `override` but the interface only defines a reader method
+end
+
+# This is correct: Separate reader and writer
+class GoodFooable
+  extend T::Sig
+  include Fooable
+  
+  sig {override.returns(T.nilable(String))}
+  attr_reader :foo
+
+  sig {params(foo: T.nilable(String)).void}
+  attr_writer :foo
+end
+
+module WriterFooable
+  extend T::Sig
+  extend T::Helpers
+  interface!
+
+  sig {abstract.params(value: T.nilable(String)).void}
+  def foo=(value); end
+end
+
+# This is incorrect: attr_accessor adds both a reader and a writer
+class WriterOnlyBad
+  extend T::Sig
+  include WriterFooable
+
+  sig {override.params(value: T.nilable(String)).void} # error: Unknown argument name `value`
+  attr_accessor :foo # error: Method `WriterOnlyBad#foo` is marked `override` but the interface only defines a writer method
+end


### PR DESCRIPTION
This PR improves Sorbet's error messages for cases where `attr_accessor` is used to override a method that only defines either a reader or a writer. Users implementing interfaces with `attr_accessor` will now see clear error messages that specify whether the issue is with the reader (`foo`) or the writer (`foo=`). To improve performance and readability in the override validation logic, repeated calls to `method.data(ctx)` were replaced with a single cached `methodData` variable. I also want to make note that this change may not be entirely relevant depending on the scope of the eventual rework of this part of Sorbet. (See https://github.com/sorbet/sorbet/pull/8328#issuecomment-2501629162)

### Motivation
Fixes #6312


### Test plan

See included automated tests.
