### PR TITLE
Add a comment to `LexNext::operator<`'s implementation

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -172,6 +172,10 @@ public:
                 return false;
             }
         }
+
+        // This is where this implementation differs from `std::lexicographic_compare`: if one name is the prefix of
+        // another they're considered equal, wheras `std::lexicographic_compare` would return `true` if the LHS
+        // was shorter.
         return false;
     }
 


### PR DESCRIPTION
It's tempting to replace `LexNext::operator<` with a use of `std::lexicographic_compare`, but the implementations are subtly different: `LexNext::operator<` considers the case where name is the prefix of another to indicate that the two names are equal, whereas `std::lexicographic_compare` would consider the shorter one to be less.

### Motivation
Documentation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
