### PR TITLE
Migrate to a newer LMDB release

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -72,10 +72,13 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "lmdb",
-        url = "https://github.com/DarkDimius/lmdb/archive/75766ec2b663b360be8eea9730a7adc0d252ce7e.zip",
-        sha256 = "bd120470d62c6f3433f80bb9841f09f158924081eb0c3236da6e8d1a0976eccc",
+        url = "https://github.com/LMDB/lmdb/archive/da9aeda08c3ff710a0d47d61a079f5a905b0a10a.zip",
+        sha256 = "893a324b60c6465edcf7feb7dafacb3d5f5803649f1b5de6f453b3a6d9e2bb97",
         build_file = "@com_stripe_ruby_typer//third_party:lmdb.BUILD",
-        strip_prefix = "lmdb-75766ec2b663b360be8eea9730a7adc0d252ce7e",
+        strip_prefix = "lmdb-da9aeda08c3ff710a0d47d61a079f5a905b0a10a",
+        patches = [
+            "@com_stripe_ruby_typer//third_party:lmdb/strdup.patch",
+        ],
     )
 
     http_archive(

--- a/third_party/lmdb/README.md
+++ b/third_party/lmdb/README.md
@@ -1,0 +1,12 @@
+# [strdup.patch](./strdup.patch)
+
+Eliminates usage of strdup from mdb.c.
+
+`strdup` internally uses glibc malloc to allocate the returned `char *`.
+This means that if application is using some other allocator,
+say jemalloc, `free`-ing result of `strdup` is an undefined behavior.
+
+## References
+- https://stackoverflow.com/questions/32944390/what-is-the-rationale-for-not-including-strdup-in-the-c-standard
+- jemalloc/jemalloc#365
+- rust-lang/rust#9925

--- a/third_party/lmdb/strdup.patch
+++ b/third_party/lmdb/strdup.patch
@@ -1,0 +1,33 @@
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+index 8ffb47c..e7589fd 100644
+--- libraries/liblmdb/mdb.c
++++ libraries/liblmdb/mdb.c
+@@ -5673,7 +5673,13 @@ mdb_env_open(MDB_env *env, const char *path, unsigned int flags, mdb_mode_t mode
+ 	}
+ #endif
+ 
+-	env->me_path = strdup(path);
++	size_t path_len = strlen(path) + 1;
++	env->me_path = malloc(path_len);
++	if (env->me_path == NULL) {
++	    rc = ENOMEM;
++	    goto leave;
++	}
++	memcpy(env->me_path, path, path_len);
+ 	env->me_dbxs = calloc(env->me_maxdbs, sizeof(MDB_dbx));
+ 	env->me_dbflags = calloc(env->me_maxdbs, sizeof(uint16_t));
+ 	env->me_dbiseqs = calloc(env->me_maxdbs, sizeof(unsigned int));
+@@ -10954,9 +10960,12 @@ int mdb_dbi_open(MDB_txn *txn, const char *name, unsigned int flags, MDB_dbi *db
+ 			return EACCES;
+ 	}
+ 
++	size_t name_len = strlen(name) + 1;
++	namedup = malloc(name_len);
+ 	/* Done here so we cannot fail after creating a new DB */
+-	if ((namedup = strdup(name)) == NULL)
++	if (namedup == NULL)
+ 		return ENOMEM;
++	memcpy(namedup, name, name_len);
+ 
+ 	if (rc) {
+ 		/* MDB_NOTFOUND and MDB_CREATE: Create new DB */


### PR DESCRIPTION
Update our LMDB dependency to track https://github.com/LMDB/lmdb. As we were only ahead by one commit to remove uses of `strdup` in `mdb_env_open`, I opted to pull that commit out into a patch that we apply during the build process. As there was some documentation about why we were replacing uses of `strdup` in the [commit on Dmitry's fork of lmdb](https://github.com/DarkDimius/lmdb/commit/75766ec2b663b360be8eea9730a7adc0d252ce7e), I moved that information into a README in the `third_party/lmdb` directory.

### Motivation
Keeping up to date.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
