### PR TITLE
Avoid one extra string allocation in ShowOperation

### DIFF
--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -9,14 +9,14 @@ using namespace std;
 
 namespace {
 
-unique_ptr<LSPMessage> makeShowOperation(std::string operationName, std::string description,
+unique_ptr<LSPMessage> makeShowOperation(std::string_view operationName, std::string_view description,
                                          SorbetOperationStatus status) {
     return make_unique<LSPMessage>(make_unique<NotificationMessage>(
         "2.0", LSPMethod::SorbetShowOperation,
-        make_unique<SorbetShowOperationParams>(move(operationName), move(description), status)));
+        make_unique<SorbetShowOperationParams>(std::string(operationName), std::string(description), status)));
 }
 
-string_view kindToOperationName(ShowOperation::Kind kind) {
+constexpr string_view kindToOperationName(ShowOperation::Kind kind) {
     switch (kind) {
         case ShowOperation::Kind::Indexing:
             return "Indexing";
@@ -37,7 +37,7 @@ string_view kindToOperationName(ShowOperation::Kind kind) {
     }
 }
 
-string_view kindToDescription(ShowOperation::Kind kind) {
+constexpr string_view kindToDescription(ShowOperation::Kind kind) {
     switch (kind) {
         case ShowOperation::Kind::Indexing:
             return "Indexing files...";

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -69,7 +69,8 @@ ShowOperation::ShowOperation(const LSPConfiguration &config, Kind kind)
 
 ShowOperation::~ShowOperation() {
     if (config.getClientConfig().enableOperationNotifications) {
-        config.output->write(makeShowOperation(this->operationName, this->description, SorbetOperationStatus::End));
+        config.output->write(makeShowOperation(std::move(this->operationName), std::move(this->description),
+                                               SorbetOperationStatus::End));
     }
 }
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -9,14 +9,14 @@ using namespace std;
 
 namespace {
 
-unique_ptr<LSPMessage> makeShowOperation(std::string_view operationName, std::string_view description,
+unique_ptr<LSPMessage> makeShowOperation(std::string operationName, std::string description,
                                          SorbetOperationStatus status) {
     return make_unique<LSPMessage>(make_unique<NotificationMessage>(
         "2.0", LSPMethod::SorbetShowOperation,
-        make_unique<SorbetShowOperationParams>(std::string(operationName), std::string(description), status)));
+        make_unique<SorbetShowOperationParams>(move(operationName), move(description), status)));
 }
 
-constexpr string_view kindToOperationName(ShowOperation::Kind kind) {
+string_view kindToOperationName(ShowOperation::Kind kind) {
     switch (kind) {
         case ShowOperation::Kind::Indexing:
             return "Indexing";
@@ -37,7 +37,7 @@ constexpr string_view kindToOperationName(ShowOperation::Kind kind) {
     }
 }
 
-constexpr string_view kindToDescription(ShowOperation::Kind kind) {
+string_view kindToDescription(ShowOperation::Kind kind) {
     switch (kind) {
         case ShowOperation::Kind::Indexing:
             return "Indexing files...";

--- a/main/lsp/ShowOperation.h
+++ b/main/lsp/ShowOperation.h
@@ -13,8 +13,8 @@ class LSPConfiguration;
  */
 class ShowOperation final {
     const LSPConfiguration &config;
-    const std::string_view operationName;
-    const std::string_view description;
+    const std::string operationName;
+    const std::string description;
 
 public:
     enum class Kind {

--- a/main/lsp/ShowOperation.h
+++ b/main/lsp/ShowOperation.h
@@ -13,8 +13,8 @@ class LSPConfiguration;
  */
 class ShowOperation final {
     const LSPConfiguration &config;
-    const std::string operationName;
-    const std::string description;
+    const std::string_view operationName;
+    const std::string_view description;
 
 public:
     enum class Kind {


### PR DESCRIPTION
We make a copy of the `string_view`s for both the operation name and description when constructing a `ShowOperation`, but then copy those strings every time they're used to construct a message. We can move both strings when constructing the message in the destructor, as they'll never be used again.

Alternatively, we can hold a `string_view` for the operation name and description in the `ShowOperation` instance and copy it when necessary, but I think that moving in the destructor is a more targeted change.

### Motivation
Avoiding allocations

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
