### PR TITLE
use `const` more in RBI generation

### DIFF
--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1303,7 +1303,7 @@ RBIGenerator::RBIOutput RBIGenerator::runOnce(const core::GlobalState &gs, core:
     return exporter.emit();
 }
 
-void RBIGenerator::run(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
+void RBIGenerator::run(const core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
                        string outputDir, WorkerPool &workers) {
     absl::BlockingCounter threadBarrier(std::max(workers.size(), 1));
 
@@ -1339,7 +1339,7 @@ void RBIGenerator::run(core::GlobalState &gs, const UnorderedSet<core::ClassOrMo
     threadBarrier.Wait();
 }
 
-void RBIGenerator::runSinglePackage(core::GlobalState &gs,
+void RBIGenerator::runSinglePackage(const core::GlobalState &gs,
                                     const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
                                     core::packages::MangledName package, string outputDir, WorkerPool &workers) {
     auto output = runOnce(gs, package, packageNamespaces);

--- a/packager/rbi_gen.h
+++ b/packager/rbi_gen.h
@@ -24,11 +24,12 @@ public:
                              const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces);
 
     // Generate RBIs for all packages present in the package database of `gs`.
-    static void run(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
+    static void run(const core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
                     std::string outputDir, WorkerPool &workers);
 
     // Generate RBIs for a single package, provided as the mangled package name `package`.
-    static void runSinglePackage(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
+    static void runSinglePackage(const core::GlobalState &gs,
+                                 const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
                                  core::packages::MangledName package, std::string outputDir, WorkerPool &workers);
 };
 } // namespace sorbet::packager


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Everything downstream of these two functions already takes a `const GlobalState&`, so we should too.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If it compiles, it works.