### PR TITLE
re-use `runSinglePackage` for the parallel RBI generator loop

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -918,7 +918,7 @@ int realmain(int argc, char *argv[]) {
 
             if (!opts.singlePackage.empty()) {
                 packager::RBIGenerator::runSinglePackage(*gs, packageNamespaces, gs->singlePackageImports->package,
-                                                         opts.packageRBIDir, *workers);
+                                                         opts.packageRBIDir);
             } else {
                 packager::RBIGenerator::run(*gs, packageNamespaces, opts.packageRBIDir, *workers);
             }

--- a/packager/rbi_gen.h
+++ b/packager/rbi_gen.h
@@ -30,7 +30,7 @@ public:
     // Generate RBIs for a single package, provided as the mangled package name `package`.
     static void runSinglePackage(const core::GlobalState &gs,
                                  const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
-                                 core::packages::MangledName package, std::string outputDir, WorkerPool &workers);
+                                 core::packages::MangledName package, std::string outputDir);
 };
 } // namespace sorbet::packager
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Just some code reuse and a tiny bit of cleanup that #8415 should have done.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
