### PR TITLE
use a single hashtable in SCC computations

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1618,15 +1618,12 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
             // too.
             auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
             pkgLink = std::min(pkgLink, importInfo.lowLink);
-        } else {
-            auto &importInfo = metadata.nodeMap[i.name.mangledName];
-            if (importInfo.onStack) {
-                // This is a back edge (edge to ancestor) or cross edge (edge to a different subtree). Since we can only
-                // follow at most one back/cross edge, the best update we can make to lowlink of the current package is the
-                // child's index.
-                auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
-                pkgLink = std::min(pkgLink, importInfo.index);
-            }
+        } else if (importInfo.onStack) {
+            // This is a back edge (edge to ancestor) or cross edge (edge to a different subtree). Since we can only
+            // follow at most one back/cross edge, the best update we can make to lowlink of the current package is the
+            // child's index.
+            auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
+            pkgLink = std::min(pkgLink, importInfo.index);
         }
         // If the child package is already visited and not on the stack, it's in a different SCC, so no update to the
         // lowlink.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1589,11 +1589,14 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
         return;
     }
     auto &pkgInfo = PackageInfoImpl::from(*pkgInfoPtr);
-    metadata.nodeMap[pkgName].index = metadata.nextIndex;
-    metadata.nodeMap[pkgName].lowLink = metadata.nextIndex;
-    metadata.nextIndex++;
-    metadata.stack.push_back(pkgName);
-    metadata.nodeMap[pkgName].onStack = true;
+    {
+        auto &info = metadata.nodeMap[pkgName];
+        info.index = metadata.nextIndex;
+        info.lowLink = metadata.nextIndex;
+        metadata.nextIndex++;
+        metadata.stack.push_back(pkgName);
+        info.onStack = true;
+    }
     for (auto &i : pkgInfo.importedPackageNames) {
         if (i.type == ImportType::Test) {
             continue;
@@ -1620,7 +1623,8 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
         // lowlink.
     }
 
-    if (metadata.nodeMap[pkgName].index == metadata.nodeMap[pkgName].lowLink) {
+    auto &ourInfo = metadata.nodeMap[pkgName];
+    if (ourInfo.index == ourInfo.lowLink) {
         // This is the root of an SCC. This means that all packages on the stack from this package to the top of the top
         // of the stack are in the same SCC. Pop the stack until we reach the root of the SCC, and assign them the same
         // SCC ID.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1616,12 +1616,16 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
             }
             // Since we can follow any number of tree edges for lowLink, the lowLink of child is valid for this package
             // too.
+            //
+            // Note that we cannot use `infoAtEntry` here because it might have been invalidated.
             auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
             pkgLink = std::min(pkgLink, importInfo.lowLink);
         } else if (importInfo.onStack) {
             // This is a back edge (edge to ancestor) or cross edge (edge to a different subtree). Since we can only
             // follow at most one back/cross edge, the best update we can make to lowlink of the current package is the
             // child's index.
+            //
+            // Note that we cannot use `infoAtEntry` here because it might have been invalidated.
             auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
             pkgLink = std::min(pkgLink, importInfo.index);
         }
@@ -1629,6 +1633,8 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
         // lowlink.
     }
 
+    // We cannot re-use `infoAtEntry` here because `nodeMap` might have been re-allocated and
+    // invalidate our reference.
     auto &ourInfo = metadata.nodeMap[pkgName];
     if (ourInfo.index == ourInfo.lowLink) {
         // This is the root of an SCC. This means that all packages on the stack from this package to the top of the top

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1614,12 +1614,15 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
             // too.
             auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
             pkgLink = std::min(pkgLink, importInfo.lowLink);
-        } else if (metadata.nodeMap[i.name.mangledName].onStack) {
-            // This is a back edge (edge to ancestor) or cross edge (edge to a different subtree). Since we can only
-            // follow at most one back/cross edge, the best update we can make to lowlink of the current package is the
-            // child's index.
-            auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
-            pkgLink = std::min(pkgLink, metadata.nodeMap[i.name.mangledName].index);
+        } else {
+            auto &importInfo = metadata.nodeMap[i.name.mangledName];
+            if (importInfo.onStack) {
+                // This is a back edge (edge to ancestor) or cross edge (edge to a different subtree). Since we can only
+                // follow at most one back/cross edge, the best update we can make to lowlink of the current package is the
+                // child's index.
+                auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
+                pkgLink = std::min(pkgLink, importInfo.index);
+            }
         }
         // If the child package is already visited and not on the stack, it's in a different SCC, so no update to the
         // lowlink.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1604,14 +1604,16 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
         if (metadata.nodeMap[i.name.mangledName].index == UNVISITED) {
             // This is a tree edge (ie. a forward edge that we haven't visited yet).
             strongConnect(gs, metadata, i.name.mangledName);
-            if (metadata.nodeMap[i.name.mangledName].index == UNVISITED) {
+
+            auto &importInfo = metadata.nodeMap[i.name.mangledName];
+            if (importInfo.index == UNVISITED) {
                 // This is to handle early return above.
                 continue;
             }
             // Since we can follow any number of tree edges for lowLink, the lowLink of child is valid for this package
             // too.
             auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
-            pkgLink = std::min(pkgLink, metadata.nodeMap[i.name.mangledName].lowLink);
+            pkgLink = std::min(pkgLink, importInfo.lowLink);
         } else if (metadata.nodeMap[i.name.mangledName].onStack) {
             // This is a back edge (edge to ancestor) or cross edge (edge to a different subtree). Since we can only
             // follow at most one back/cross edge, the best update we can make to lowlink of the current package is the

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1590,13 +1590,13 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
         return;
     }
     auto &pkgInfo = PackageInfoImpl::from(*pkgInfoPtr);
-    {
-        infoAtEntry.index = metadata.nextIndex;
-        infoAtEntry.lowLink = metadata.nextIndex;
-        metadata.nextIndex++;
-        metadata.stack.push_back(pkgName);
-        infoAtEntry.onStack = true;
-    }
+
+    infoAtEntry.index = metadata.nextIndex;
+    infoAtEntry.lowLink = metadata.nextIndex;
+    metadata.nextIndex++;
+    metadata.stack.push_back(pkgName);
+    infoAtEntry.onStack = true;
+
     for (auto &i : pkgInfo.importedPackageNames) {
         if (i.type == ImportType::Test) {
             continue;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1652,8 +1652,9 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
 void computeSCCs(core::GlobalState &gs) {
     Timer timeit(gs.tracer(), "packager::computeSCCs");
     ComputeSCCsMetadata metadata;
-    metadata.stack.reserve(gs.packageDB().packages().size());
     auto allPackages = gs.packageDB().packages();
+    metadata.stack.reserve(allPackages.size());
+    metadata.nodeMap.reserve(allPackages.size());
     for (auto package : allPackages) {
         if (metadata.nodeMap[package].index == UNVISITED) {
             strongConnect(gs, metadata, package);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1560,17 +1560,21 @@ unique_ptr<PackageInfoImpl> createAndPopulatePackageInfo(core::GlobalState &gs, 
 // https://www.cs.cmu.edu/~15451-f18/lectures/lec19-DFS-strong-components.pdf provides a good overview of the
 // algorithm.
 const int UNVISITED = 0;
+struct NodeInfo {
+    // A given package's index in the DFS traversal; ie. when it was first visited. The default value of 0 means the
+    // package hasn't been visited yet.
+    int index = UNVISITED;
+    // The lowest index reachable from a given package (in the same SCC) by following any number of tree edges
+    // and at most one back/cross edge
+    int lowLink = 0;
+    // Fast way to check if a package is on the stack
+    bool onStack = false;
+};
+
 struct ComputeSCCsMetadata {
     int nextIndex = 1;
     int nextSCCId = 0;
-    // A given package's index in the DFS traversal; ie. when it was first visited. The default value of 0 means the
-    // package hasn't been visited yet.
-    UnorderedMap<core::packages::MangledName, int> index;
-    // The lowest index reachable from a given package (in the same SCC) by following any number of tree edges
-    // and at most one back/cross edge
-    UnorderedMap<core::packages::MangledName, int> lowLink;
-    // Fast way to check if a package is on the stack
-    UnorderedMap<core::packages::MangledName, bool> onStack;
+    UnorderedMap<core::packages::MangledName, NodeInfo> nodeMap;
     // As we visit packages, we push them onto the stack. Once we find the "root" of an SCC, we can use the stack to
     // determine all packages in the SCC.
     std::vector<core::packages::MangledName> stack;
@@ -1585,38 +1589,38 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
         return;
     }
     auto &pkgInfo = PackageInfoImpl::from(*pkgInfoPtr);
-    metadata.index[pkgName] = metadata.nextIndex;
-    metadata.lowLink[pkgName] = metadata.nextIndex;
+    metadata.nodeMap[pkgName].index = metadata.nextIndex;
+    metadata.nodeMap[pkgName].lowLink = metadata.nextIndex;
     metadata.nextIndex++;
     metadata.stack.push_back(pkgName);
-    metadata.onStack[pkgName] = true;
+    metadata.nodeMap[pkgName].onStack = true;
     for (auto &i : pkgInfo.importedPackageNames) {
         if (i.type == ImportType::Test) {
             continue;
         }
-        if (metadata.index[i.name.mangledName] == UNVISITED) {
+        if (metadata.nodeMap[i.name.mangledName].index == UNVISITED) {
             // This is a tree edge (ie. a forward edge that we haven't visited yet).
             strongConnect(gs, metadata, i.name.mangledName);
-            if (metadata.index[i.name.mangledName] == UNVISITED) {
+            if (metadata.nodeMap[i.name.mangledName].index == UNVISITED) {
                 // This is to handle early return above.
                 continue;
             }
             // Since we can follow any number of tree edges for lowLink, the lowLink of child is valid for this package
             // too.
-            auto &pkgLink = metadata.lowLink[pkgName];
-            pkgLink = std::min(pkgLink, metadata.lowLink[i.name.mangledName]);
-        } else if (metadata.onStack[i.name.mangledName]) {
+            auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
+            pkgLink = std::min(pkgLink, metadata.nodeMap[i.name.mangledName].lowLink);
+        } else if (metadata.nodeMap[i.name.mangledName].onStack) {
             // This is a back edge (edge to ancestor) or cross edge (edge to a different subtree). Since we can only
             // follow at most one back/cross edge, the best update we can make to lowlink of the current package is the
             // child's index.
-            auto &pkgLink = metadata.lowLink[pkgName];
-            pkgLink = std::min(pkgLink, metadata.index[i.name.mangledName]);
+            auto &pkgLink = metadata.nodeMap[pkgName].lowLink;
+            pkgLink = std::min(pkgLink, metadata.nodeMap[i.name.mangledName].index);
         }
         // If the child package is already visited and not on the stack, it's in a different SCC, so no update to the
         // lowlink.
     }
 
-    if (metadata.index[pkgName] == metadata.lowLink[pkgName]) {
+    if (metadata.nodeMap[pkgName].index == metadata.nodeMap[pkgName].lowLink) {
         // This is the root of an SCC. This means that all packages on the stack from this package to the top of the top
         // of the stack are in the same SCC. Pop the stack until we reach the root of the SCC, and assign them the same
         // SCC ID.
@@ -1624,7 +1628,7 @@ void strongConnect(core::GlobalState &gs, ComputeSCCsMetadata &metadata, core::p
         do {
             poppedPkgName = metadata.stack.back();
             metadata.stack.pop_back();
-            metadata.onStack[poppedPkgName] = false;
+            metadata.nodeMap[poppedPkgName].onStack = false;
             PackageInfoImpl &poppedPkgInfo =
                 PackageInfoImpl::from(*(gs.packageDB().getPackageInfoNonConst(poppedPkgName)));
             poppedPkgInfo.sccID = metadata.nextSCCId;
@@ -1642,7 +1646,7 @@ void computeSCCs(core::GlobalState &gs) {
     metadata.stack.reserve(gs.packageDB().packages().size());
     auto allPackages = gs.packageDB().packages();
     for (auto package : allPackages) {
-        if (metadata.index[package] == UNVISITED) {
+        if (metadata.nodeMap[package].index == UNVISITED) {
             strongConnect(gs, metadata, package);
         }
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This ought to be slightly better space-wise, almost certainly better cache-wise, and it enables a number of performance-related improvements aimed at eliminating duplicate hashtable lookups.

Limited testing on pay-server indicates that SCC computation is ~2x faster after this series.

You should be able to review commit-by-commit.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
