### PR TITLE
Uncomment build flags that work with emscripten now

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -53,13 +53,11 @@ build --host_cxxopt=-Wno-pass-failed # host build doesn't have enough optimizati
 # <command line>:1:9: and <built-in>:355:9: so sadly we turn them all off
 build --copt=-Wno-macro-redefined
 
-# TODO(jez) We will need these to build C++20, but emscripten doesn't even know about these options yet.
-# Leaving them commented out so we can uncomment them after upgrading emscripten.
-# build --host_cxxopt=-Wno-deprecated-anon-enum-enum-conversion
-# build --host_cxxopt=-Wno-deprecated-enum-enum-conversion
-# build --cxxopt=-Wno-deprecated-anon-enum-enum-conversion
-# build --cxxopt=-Wno-deprecated-enum-enum-conversion
-# build --cxxopt=-Wno-ambiguous-reversed-operator
+build --host_cxxopt=-Wno-deprecated-anon-enum-enum-conversion
+build --host_cxxopt=-Wno-deprecated-enum-enum-conversion
+build --cxxopt=-Wno-deprecated-anon-enum-enum-conversion
+build --cxxopt=-Wno-deprecated-enum-enum-conversion
+build --cxxopt=-Wno-ambiguous-reversed-operator
 
 # TODO(jez) Something between Clang 12 and Clang 15 seems to have introduced a
 # warning saying _never_ use unqualified `std` calls...


### PR DESCRIPTION
These build flags now work with emscripten, as we're nearly up to date.

### Motivation
Cleaning up a TODO related to the most recent emscripten update.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
