### PR TITLE
use raw pointers in `DispatchArgs` for efficiency/clarity's sake

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -995,7 +995,7 @@ struct DispatchArgs {
     const TypePtr &selfType;
     const TypeAndOrigins &fullType;
     const TypePtr &thisType;
-    const std::shared_ptr<const SendAndBlockLink> &block;
+    const SendAndBlockLink *const block;
     Loc originForUninitialized;
     bool isPrivateOk;
     // Do not produce dispatch-related errors while evaluating the call. This is a performance optimization, as there

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2608,8 +2608,7 @@ private:
     }
 
     static void simulateCall(const GlobalState &gs, const TypeAndOrigins *receiver, const DispatchArgs &innerArgs,
-                             shared_ptr<SendAndBlockLink> link, TypePtr passedInBlockType, Loc callLoc, Loc blockLoc,
-                             DispatchResult &res) {
+                             TypePtr passedInBlockType, Loc callLoc, Loc blockLoc, DispatchResult &res) {
         auto dispatched = receiver->type.dispatchCall(gs, innerArgs);
         // We use isSubTypeUnderConstraint here with a TypeConstraint, so that we discover the correct generic bounds
         // as we do the subtyping check.
@@ -2756,7 +2755,7 @@ public:
             Magic_callWithBlock::typeToProc(gs, *args.args[2], args.locs.file, args.locs.call, args.locs.args[2],
                                             args.locs.fun, args.originForUninitialized, args.suppressErrors);
         std::optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
-        auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity));
+        core::SendAndBlockLink link{fn, Magic_callWithBlock::argInfoByArity(blockArity)};
         res.main.constr = make_unique<TypeConstraint>();
 
         DispatchArgs innerArgs{fn,
@@ -2766,14 +2765,13 @@ public:
                                receiver->type,
                                *receiver,
                                receiver->type,
-                               link,
+                               &link,
                                args.originForUninitialized,
                                args.isPrivateOk,
                                args.suppressErrors,
                                args.enclosingMethodForSuper};
 
-        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, link, finalBlockType, args.argLoc(2), args.callLoc(),
-                                          res);
+        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, finalBlockType, args.argLoc(2), args.callLoc(), res);
     }
 } Magic_callWithBlock;
 
@@ -2871,7 +2869,7 @@ public:
             Magic_callWithBlock::typeToProc(gs, *args.args[4], args.locs.file, args.locs.call, args.locs.args[4],
                                             args.locs.fun, args.originForUninitialized, args.suppressErrors);
         std::optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
-        auto link = make_shared<core::SendAndBlockLink>(fn, Magic_callWithBlock::argInfoByArity(blockArity));
+        core::SendAndBlockLink link{fn, Magic_callWithBlock::argInfoByArity(blockArity)};
         res.main.constr = make_unique<TypeConstraint>();
 
         DispatchArgs innerArgs{fn,
@@ -2881,14 +2879,13 @@ public:
                                receiver->type,
                                *receiver,
                                receiver->type,
-                               link,
+                               &link,
                                args.originForUninitialized,
                                args.isPrivateOk,
                                args.suppressErrors,
                                args.enclosingMethodForSuper};
 
-        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, link, finalBlockType, args.argLoc(4), args.callLoc(),
-                                          res);
+        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, finalBlockType, args.argLoc(4), args.callLoc(), res);
     }
 } Magic_callWithSplatAndBlock;
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -85,7 +85,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
                                     snd->recv.type,
                                     {snd->recv.type, {originForFullType}},
                                     snd->recv.type,
-                                    snd->link,
+                                    snd->link.get(),
                                     originForUninitialized,
                                     snd->isPrivateOk,
                                     suppressErrors,

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1043,7 +1043,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 core::DispatchArgs dispatchArgs{send.fun,        locs,
                                                 send.numPosArgs, args,
                                                 recvType.type,   recvType,
-                                                recvType.type,   send.link,
+                                                recvType.type,   send.link.get(),
                                                 ownerLoc,        send.isPrivateOk,
                                                 suppressErrors,  inWhat.symbol.data(ctx)->name};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
@@ -1431,7 +1431,6 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     const auto numPosArgs = 1;
                     const auto suppressErrors = true;
                     const auto isPrivateOk = true;
-                    const std::shared_ptr<const core::SendAndBlockLink> block = nullptr;
                     core::DispatchArgs dispatchArgs{core::Names::squareBrackets(),
                                                     locs,
                                                     numPosArgs,
@@ -1439,7 +1438,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                                     recvType.type,
                                                     recvType,
                                                     recvType.type,
-                                                    block,
+                                                    nullptr,
                                                     ctx.locAt(bind.loc),
                                                     isPrivateOk,
                                                     suppressErrors,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

So, imagine you have:

```c++
struct SendAndBlockLink {
  ...
};

struct Send {
  std::shared_ptr<SendAndBlockLink> link;
  ...
};

struct DispatchArgs {
  const std::shared_ptr<const SendAndBlockLink> &block;
  ...
};

// Somewhere in your code...
DispatchArgs args{send->link, ...}
```

what happens on that last line?

The obvious to the point of C++ 101 intent is that we take a reference to `send->link`.  Straightforward, right?  And that would be what happens if `block` had been of type `const std::shared_ptr<SendAndBlockLink>&`.  But since the `shared_ptr` is storing a pointer to a _`const`_ object, the types for the kind of references we need are different.  So there needs to be a temporary `std::shared_ptr<const SendAndBlockLink>` constructed from a `std::shared_ptr<SendAndBlockLink>` and then we can take a reference to that temporary object -- and then destroy the temporary `shared_ptr` when we are done.  (This also happens completely invisibly to the user, as you can see.)

This is obviously unnecessary overhead, which is bad.  That is not the actual problem here (though we'd like to avoid it).

Welcome to the fun of language arcana.  How long does that temporary object last?  We really want it to last as long as `args` is live, rather than just be live for the construction of `args`.  If the lifetime of the temporary object ended once `args` was constructed -- but before `args` was used -- any use of `args.block` would be the equivalent of use-after-free.

C++ recognizes that this sort of thing needs to happen automatically in some cases; it's called "lifetime extension".  The lifetime of the temporary object we construct is magically declared to be longer than `args` itself.

Due to the rules of the language, the lifetime extension is automatically applied only when we initialize `DispatchArgs` via brace-initialization.  If we were to, say, give `DispatchArgs` a proper constructor, lifetime extension would no longer apply and [we would get a litany of confusing ASan errors about stack-use-after-scope](https://buildkite.com/sorbet/sorbet/builds/33874).

IIRC, we need to give (the Sorbet version of) `DispatchArgs` a proper constructor to make certain things work in C++20 -- or at least we did, once upon a time, maybe that's no longer necessary -- and I think it'd be nice to a) eliminate the performance issue involved in constructing an entirely new `shared_ptr` object and b) eliminate this completely arcane behavior.  Both of these considerations apply independently of whether we still need the constructor IMHO.

Hence this PR.  I know we don't love raw pointers in Sorbet, but I think the alternatives are worse: things like:

```c++
const auto &block = *reinterpret_cast<std::shared_ptr<const core::SendAndBlockLink>*>(std::addressof(send.link));
```

when initializing call dispatch in inference ([which does work](https://buildkite.com/sorbet/sorbet/builds/33880)!  but that build also shows that we'd need to apply similar behavior in other contexts too.  I think I prefer the raw pointers, all things considered).  It's also nice that we don't have to heap allocate things for splat calls in `calls.cc` anymore.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Efficiency/clarity.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
