### PR TITLE
don't eagerly construct the format string when calling `replaceWith`

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -945,7 +945,7 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
                                    "T.unsafe");
                     auto locSource = loc.source(gs);
                     if (locSource.has_value()) {
-                        e.replaceWith("Wrap in `T.unsafe`", loc, fmt::format("T.unsafe({})", locSource.value()));
+                        e.replaceWith("Wrap in `T.unsafe`", loc, "T.unsafe({})", locSource.value());
                     }
                 }
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We get this confusing error on this line when trying to use C++20:

```
core/types/types.cc:948:66: error: call to consteval function 'fmt::basic_format_string<char>::basic_format_string<std::string, 0>' is not a constant expression
                        e.replaceWith("Wrap in `T.unsafe`", loc, fmt::format("T.unsafe({})", locSource.value()));
                                                                 ^
/pay/cache/.cache/bazel/_bazel_froydnj/43032b6fe8f177634e26ef4e054799af/external/llvm_toolchain_15_0_7_llvm/bin/../include/c++/v1/optional:344:16: note: read of non-constexpr variable 'locSource' is not allowed in a constant expression
        return this->__engaged_;
               ^
/pay/cache/.cache/bazel/_bazel_froydnj/43032b6fe8f177634e26ef4e054799af/external/llvm_toolchain_15_0_7_llvm/bin/../include/c++/v1/optional:1016:20: note: in call to '&locSource->has_value()'
        if (!this->has_value())
                   ^
core/types/types.cc:948:104: note: in call to '&locSource->value()'
                        e.replaceWith("Wrap in `T.unsafe`", loc, fmt::format("T.unsafe({})", locSource.value()));
                                                                                                       ^
core/types/types.cc:946:26: note: declared here
                    auto locSource = loc.source(gs);
                         ^
```

What this is really trying to tell use is that we're calling `fmt::format` to produce a string to use as the formatting template.  But this is, rightly, not a compile-time constant.  It's generally bad to use non-compile-time constants as formatting templates and `fmt` is trying to let us know that with terrible error messages courtesy of the C++ compiler.

The fix is instead to just let `replaceWith` do the formatting here, as it does in every other call.  The `"T.unsafe({})"` string is then recognized as a compile-time constant and everything is happy.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
