### PR TITLE
remove `SendAndBlockLink::duplicate()`

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -937,7 +937,6 @@ public:
 
     SendAndBlockLink(NameRef fun, std::vector<ArgInfo::ArgFlags> &&argFlags);
     std::optional<int> fixedArity() const;
-    std::shared_ptr<SendAndBlockLink> duplicate();
 };
 
 class TypeAndOrigins final {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -781,11 +781,6 @@ TypePtr AndType::make_shared(const TypePtr &left, const TypePtr &right) {
 SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags)
     : argFlags(move(argFlags)), fun(fun) {}
 
-shared_ptr<SendAndBlockLink> SendAndBlockLink::duplicate() {
-    auto copy = *this;
-    return make_shared<SendAndBlockLink>(move(copy));
-}
-
 optional<int> SendAndBlockLink::fixedArity() const {
     optional<int> arity = 0;
     for (auto &arg : argFlags) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This method is unused.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
