### PR TITLE
fix a formatting string mismatch

### DIFF
--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -145,7 +145,7 @@ void FoundMethodHash::sanityCheck() const {
 
 string FoundMethodHash::toString() const {
     return fmt::format("FoundMethodHash {{ ownerIdx = {}, ownerIsSymbol = {}, useSingletonClass = {}, nameHash = {}, "
-                       "arityHash = {}, isSelfMethod = {} }}",
+                       "arityHash = {} }}",
                        ownerIdx, ownerIsSymbol, useSingletonClass, nameHash._hashValue, arityHash._hashValue);
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This turned up when trying to compile Sorbet with C++20: we have six placeholders in the string but only 5 arguments.  AFAICT there's nothing to format for `isSelfMethod` so we should delete it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
