### PR TITLE
print options with `map_join`

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -676,26 +676,14 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                    "--print=<format>:<file>\n"
                    "Most of these formats are unstable, for internal-use only.\n\n"
                    "Stable: [");
-    auto first = true;
-    for (auto it = partitioned_print_options.begin(); it != stableEnd; it++) {
-        if (first) {
-            first = false;
-        } else {
-            fmt::format_to(std::back_inserter(print_help), ", ");
-        }
-        fmt::format_to(std::back_inserter(print_help), it->option);
-    }
+    fmt::format_to(
+        std::back_inserter(print_help), "{}",
+        fmt::map_join(partitioned_print_options.begin(), stableEnd, ", ", [](const auto &it) { return it.option; }));
     fmt::format_to(std::back_inserter(print_help), "]\n\n"
                                                    "Unstable: [");
-    first = true;
-    for (auto it = stableEnd; it != partitioned_print_options.end(); it++) {
-        if (first) {
-            first = false;
-        } else {
-            fmt::format_to(std::back_inserter(print_help), ", ");
-        }
-        fmt::format_to(std::back_inserter(print_help), it->option);
-    }
+    fmt::format_to(
+        std::back_inserter(print_help), "{}",
+        fmt::map_join(stableEnd, partitioned_print_options.end(), ", ", [](const auto &it) { return it.option; }));
     options.add_options(section)("p,print", to_string(print_help), cxxopts::value<vector<string>>(), "<format>");
     // }}}
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

C++20 + `fmt` was unhappy about the non-constant formatting strings we had in this code.  But there's a better primitive to print things that we can be using here that gets rid of the format string concern altogether, so let's use that.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
