### PR TITLE
use static format strings when dumping packages

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2040,7 +2040,7 @@ public:
 
     void operator()(std::string *out, core::packages::MangledName mangledName) const {
         const auto &pkg = gs.packageDB().getPackageInfo(mangledName);
-        out->append("{{");
+        out->append("{");
         out->append("\"name\":");
         fmt::format_to(back_inserter(*out), "\"{}\",",
                        absl::StrJoin(pkg.fullName(), "::", core::packages::NameFormatter(gs)));
@@ -2057,7 +2057,7 @@ public:
         if (it != packageFiles.end()) {
             fmt::format_to(back_inserter(*out), "{}", absl::StrJoin(it->second.testFiles, ",", FileListFormatter(gs)));
         }
-        out->append("]}}");
+        out->append("]}");
     }
 };
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2045,17 +2045,17 @@ public:
         fmt::format_to(back_inserter(*out), "\"{}\",",
                        absl::StrJoin(pkg.fullName(), "::", core::packages::NameFormatter(gs)));
         out->append("\"imports\":[");
-        fmt::format_to(back_inserter(*out), absl::StrJoin(pkg.imports(), ",", ImportFormatter(gs)));
+        fmt::format_to(back_inserter(*out), "{}", absl::StrJoin(pkg.imports(), ",", ImportFormatter(gs)));
         out->append("],\"testImports\":[");
-        fmt::format_to(back_inserter(*out), absl::StrJoin(pkg.testImports(), ",", ImportFormatter(gs)));
+        fmt::format_to(back_inserter(*out), "{}", absl::StrJoin(pkg.testImports(), ",", ImportFormatter(gs)));
         out->append("],\"files\":[");
         const auto it = packageFiles.find(mangledName);
         if (it != packageFiles.end()) {
-            fmt::format_to(back_inserter(*out), absl::StrJoin(it->second.files, ",", FileListFormatter(gs)));
+            fmt::format_to(back_inserter(*out), "{}", absl::StrJoin(it->second.files, ",", FileListFormatter(gs)));
         }
         out->append("], \"testFiles\":[");
         if (it != packageFiles.end()) {
-            fmt::format_to(back_inserter(*out), absl::StrJoin(it->second.testFiles, ",", FileListFormatter(gs)));
+            fmt::format_to(back_inserter(*out), "{}", absl::StrJoin(it->second.testFiles, ",", FileListFormatter(gs)));
         }
         out->append("]}}");
     }
@@ -2081,7 +2081,8 @@ void Packager::dumpPackageInfo(const core::GlobalState &gs, std::string outputFi
 
     fmt::memory_buffer out;
     fmt::format_to(back_inserter(out), "[");
-    fmt::format_to(back_inserter(out), absl::StrJoin(pkgDB.packages(), ",", PackageInfoFormatter(gs, packageFiles)));
+    fmt::format_to(back_inserter(out), "{}",
+                   absl::StrJoin(pkgDB.packages(), ",", PackageInfoFormatter(gs, packageFiles)));
     fmt::format_to(back_inserter(out), "]");
     FileOps::write(outputFile, fmt::to_string(out));
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

C++20 + `fmt` was unhappy about the non-constant format strings here.  I think there's a better way to rewrite this with `fmt::map_join`, but this is not performance-critical code, so let's just use a constant format string and be done with it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
