### PR TITLE
mark a runtime-determined format string with `fmt::runtime`

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -1015,7 +1015,7 @@ private:
             [classOrModuleIndent](auto &line) -> string { return fmt::format("{}  {}", classOrModuleIndent, line); });
         auto indentedMethodDefinition = absl::StrJoin(indentedLines, "\n");
 
-        return core::AutocorrectSuggestion::Edit{insertAt, fmt::format(format, indentedMethodDefinition)};
+        return core::AutocorrectSuggestion::Edit{insertAt, fmt::format(fmt::runtime(format), indentedMethodDefinition)};
     }
 
     void validateAbstract(const core::Context ctx, core::ClassOrModuleRef sym, const ast::ClassDef &classDef) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

C++20 + `fmt` would like these strings to be marked with `fmt::runtime` as a way of verifying that yes, we really meant to pass a runtime-determined format string here.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
