### PR TITLE
disable compile-time checking for `ENFORCE` format strings

### DIFF
--- a/common/exception/Exception.h
+++ b/common/exception/Exception.h
@@ -59,10 +59,10 @@ public:
     }
     template <typename... TArgs>
     [[noreturn]] static inline bool enforce_handler(std::string_view check, std::string_view file, int line,
-                                                    fmt::format_string<TArgs...> message, TArgs &&...args)
+                                                    std::string_view message, TArgs &&...args)
         __attribute__((noreturn)) {
         raise("{}:{} enforced condition {} has failed: {}", file, line, check,
-              fmt::format(message, std::forward<TArgs>(args)...));
+              fmt::format(fmt::runtime(message), std::forward<TArgs>(args)...));
     }
 };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I don't love this change, but with the macro layering of `ENFORCE`/`ENFORCE_NO_TIMER` + macro varargs + C++20 `fmt` compile-time format string checking, it's hard to make everything work together just so.  My suspicion is that a lot of ENFORCE messages aren't really using the full power of format strings.  If they are, they will probably be correct, and if they're not, well, it's debugging code, and we can live with people debugging their debugging messages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
