### PR TITLE
fix stack-use-after-scope issues with `TypeAndOrigins` references

### DIFF
--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -78,12 +78,14 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
     auto originForUninitialized = core::Loc::none();
     auto originForFullType = core::Loc::none();
     auto suppressErrors = true;
+    core::TypeAndOrigins wrappedFullType{snd->recv.type, {originForFullType}};
+
     core::DispatchArgs dispatchArgs{snd->fun,
                                     locs,
                                     numPosArgs,
                                     args,
                                     snd->recv.type,
-                                    {snd->recv.type, {originForFullType}},
+                                    wrappedFullType,
                                     snd->recv.type,
                                     snd->link.get(),
                                     originForUninitialized,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change is needed for #8431 to work properly, for all the reasons discussed in #8422, but applied to temporary `TypeAndOrigin` objects instead of `std::shared_ptr` ones.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
