### PR TITLE
Don't try to format ignored files

### DIFF
--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -72,22 +72,18 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
     auto path = config.remoteName2Local(params->textDocument->uri);
 
     auto maybeFileContents = preprocessor.maybeGetFileContents(path);
-    std::string ignoredFileContents;
-    string_view sourceView;
-    if (maybeFileContents.has_value()) {
-        sourceView = maybeFileContents.value();
-    } else if (sorbet::FileOps::exists(path)) {
-        // If the requested file path isn't in the workspace,
-        // we won't be able to load it, in which case
-        // we leave sourceView as empty and this becomes a no-op
-
-        // In this case, the request is for a file that's
-        // not open in the IDE, so we read it from disk instead.
-        // We store it in `ignoredFileContents` to ensure that the
-        // `sourceView` points at valid data for its lifetime.
-        ignoredFileContents = sorbet::FileOps::read(path);
-        sourceView = ignoredFileContents;
+    if (!maybeFileContents.has_value()) {
+        // If we weren't already tracking the file, don't format it. If we were to load the file from disk and format
+        // it, we would be potentially loading a version that doesn't include any of the changes the client made, and
+        // formatting that version and sending it back would throw away any changes that had been made. In the future if
+        // we decide to track changes on ignored files, we could rethink returning an error here, but for now this is
+        // the safest response.
+        response->error =
+            make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest, "Unable to format ignored/unknown file");
+        config.output->write(move(response));
+        return;
     }
+    std::string_view sourceView = maybeFileContents.value();
 
     // Don't format `__package.rb` files, since currently formatting them
     // can potentially break some pay-server tooling


### PR DESCRIPTION
Currently we handle format requests for ignored files by loading those files from disk and formatting the version that's stored there. This is not correct behavior, as the client may have made changes that they're expecting us to track, and the file from disk will more than likely be out of date.

To fix the immediate behavior, this PR returns an error response to a formatting request if the file has been ignored or is outside of the workspace. Longer-term we could start tracking changes to documents that are ignored so that we format the correct version.

When testing with VSCode, this doesn't show an error to the user and instead just doesn't format the file.

### Motivation
Better LSP experience for ignored files when formatting is enabled.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
