### PR TITLE
remove `keepDef` and `keepSelfDef` as vestiges of an earlier age

### DIFF
--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -80,8 +80,7 @@ bool BehaviorHelpers::checkEmptyDeep(const ExpressionPtr &expr) {
         expr,
 
         [&](const ast::Send &send) {
-            result = send.fun == core::Names::keepDef() || send.fun == core::Names::keepSelfDef() ||
-                     send.fun == core::Names::include() || send.fun == core::Names::extend();
+            result = send.fun == core::Names::include() || send.fun == core::Names::extend();
         },
 
         [&](const ast::EmptyTree &) { result = true; },

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -393,8 +393,6 @@ NameDef names[] = {
     {"args"},
     {"Elem", "Elem", true},
     {"keepForIde", "keep_for_ide"},
-    {"keepDef", "keep_def"},
-    {"keepSelfDef", "keep_self_def"},
     {"keepForCfg", "<keep-for-cfg>"},
     {"retry", "<retry>"},
     {"unresolvedAncestors", "<unresolved-ancestors>"},

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -503,8 +503,6 @@ public:
             return sym->asSymbol();
         } else if (auto *def = ast::cast_tree<ast::RuntimeMethodDefinition>(expr)) {
             return def->name;
-        } else if (auto send = ast::cast_tree<ast::Send>(expr)) {
-            return core::NameRef::noName();
         } else {
             ENFORCE(!ast::isa_tree<ast::MethodDef>(expr), "methods inside sends should be gone");
             return core::NameRef::noName();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1038,11 +1038,6 @@ struct PackageSpecBodyWalk {
     void postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
 
-        // Ignore methods
-        if (send.fun == core::Names::keepDef() || send.fun == core::Names::keepSelfDef()) {
-            return;
-        }
-
         // Disallowed methods
         if (send.fun == core::Names::extend() || send.fun == core::Names::include()) {
             if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidPackageExpression)) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We removed the need for `keep*Def` in non-compiled files in #5810.  And now all files are not compiled (😢 ), so we don't need to have handling for it cluttering up the codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
