### PR TITLE
remove `keepForCfg` since we can accomplish it in other ways

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -871,9 +871,6 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 auto ensureBody = cctx.inWhat.freshBlock(cctx.loops);
                 unconditionalJump(elseBody, ensureBody, cctx.inWhat, a.loc);
 
-                auto magic = cctx.newTemporary(core::Names::magic());
-                synthesizeExpr(current, magic, core::LocOffsets::none(), make_insn<Alias>(core::Symbols::Magic()));
-
                 for (auto &expr : a.rescueCases) {
                     auto *rescueCase = ast::cast_tree<ast::RescueCase>(expr);
                     auto caseBody = cctx.inWhat.freshBlock(cctx.loops);
@@ -901,13 +898,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                                    make_insn<Literal>(core::Types::nilClass()));
 
                     auto res = cctx.newTemporary(core::Names::keepForCfgTemp());
-                    auto isPrivateOk = false;
-                    auto args = {exceptionValue};
-                    auto argLocs = {what.loc()};
-                    synthesizeExpr(caseBody, res, rescueCase->loc,
-                                   make_insn<Send>(magic, rescueCase->loc, core::Names::keepForCfg(),
-                                                   core::LocOffsets::none(), args.size(), args, std::move(argLocs),
-                                                   isPrivateOk));
+                    synthesizeExpr(caseBody, res, rescueCase->loc, make_insn<KeepAlive>(exceptionValue));
 
                     if (exceptions.empty()) {
                         // rescue without a class catches StandardError

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -797,10 +797,6 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::defineTopClassOrModule())
                  .untypedArg(Names::arg0())
                  .buildWithResult(Types::void_());
-    // Synthesize <Magic>.<keep-for-cfg>(arg: T.untyped) => Void
-    method = enterMethod(*this, Symbols::MagicSingleton(), Names::keepForCfg())
-                 .untypedArg(Names::arg0())
-                 .buildWithResult(Types::void_());
     // Synthesize <Magic>.<retry>() => Void
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::retry()).buildWithResult(Types::void_());
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,7 +23,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 58;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 57;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 6;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 71;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -393,7 +393,6 @@ NameDef names[] = {
     {"args"},
     {"Elem", "Elem", true},
     {"keepForIde", "keep_for_ide"},
-    {"keepForCfg", "<keep-for-cfg>"},
     {"retry", "<retry>"},
     {"unresolvedAncestors", "<unresolved-ancestors>"},
     {"defineTopClassOrModule", "<define-top-class-or-module>"},

--- a/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
@@ -2,7 +2,6 @@ method ::Object#a {
 
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
-    <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -17,10 +16,10 @@ bb1[firstDead=-1]():
 
 # backedges
 # - bb0
-bb3[firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
-    <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
-    <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<exceptionValue>$4: Exception):
+    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
+    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
@@ -31,24 +30,24 @@ bb4[firstDead=2]():
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<exceptionValue>$4: StandardError, <magic>$6: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$4: StandardError):
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
+    <keepForCfgTemp>$6: T.untyped = <keep-alive> <exceptionValue>$4
     a: Integer(2) = 2
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1]():
-    <gotoDeadTemp>$11: TrueClass = true
-    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$10: TrueClass = true
+    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb7
 # - bb8
 bb9[firstDead=3](a: Integer(2)):
-    <statTemp>$14: Integer(3) = 3
-    <returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$14: Integer(3))
+    <statTemp>$13: Integer(3) = 3
+    <returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$13: Integer(3))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/rescue.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue.rb.cfg-text.exp
@@ -2,7 +2,6 @@ method ::Object#main {
 
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
-    <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -15,14 +14,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
-    <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: Object, <magic>$6: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: Object):
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
@@ -37,24 +36,24 @@ bb5[firstDead=-1](<self>: Object, <exceptionValue>$3: NilClass):
 # - bb5
 # - bb7
 # - bb8
-bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$15: T.nilable(TrueClass)):
-    <cfgAlias>$8: T.class_of(T) = alias <C T>
-    <rescueTemp>$2: T.untyped = <cfgAlias>$8: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
-    <throwAwayTemp>$16: T.untyped = <self>: Object.d()
-    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$14: T.nilable(TrueClass)):
+    <cfgAlias>$7: T.class_of(T) = alias <C T>
+    <rescueTemp>$2: T.untyped = <cfgAlias>$7: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
+    <throwAwayTemp>$15: T.untyped = <self>: Object.d()
+    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: Object, <exceptionValue>$3: StandardError, <magic>$6: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: Object, <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <keepForCfgTemp>$9: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: Object.b()
     <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
-    <gotoDeadTemp>$15: TrueClass = true
+    <gotoDeadTemp>$14: TrueClass = true
     <unconditional> -> bb6
 
 # backedges

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -166,7 +166,6 @@ method ::TestRescue#multiple_rescue {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -182,51 +181,51 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: NilClass):
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb11)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: NilClass):
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb11)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb11)
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb11)
 
 # backedges
 # - bb3
-bb8[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$13: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$14: T::Boolean = <cfgAlias>$13: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$14 -> (T::Boolean ? bb9 : bb10)
+bb8[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$13 -> (T::Boolean ? bb9 : bb10)
 
 # backedges
 # - bb8
-bb9[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+bb9[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$11: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <keepForCfgTemp>$10: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb11)
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb11)
 
 # backedges
 # - bb8
 bb10[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$16: TrueClass = true
-    <gotoDeadTemp>$16 -> (TrueClass ? bb1 : bb11)
+    <gotoDeadTemp>$15: TrueClass = true
+    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb11)
 
 # backedges
 # - bb6
@@ -243,7 +242,6 @@ method ::TestRescue#multiple_rescue_classes {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -258,45 +256,45 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$8: T.untyped = alias <C T.untyped>
-    <isaCheckTemp>$9: T.untyped = <cfgAlias>$8: T.untyped.===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
+bb3[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$7: T.untyped = alias <C T.untyped>
+    <isaCheckTemp>$8: T.untyped = <cfgAlias>$7: T.untyped.===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$8 -> (T.untyped ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: NilClass):
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb10)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: NilClass):
+    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb10)
 
 # backedges
 # - bb3
 # - bb8
-bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$3: Exception):
     baz: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: Exception = baz
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb10)
+    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb10)
 
 # backedges
 # - bb3
-bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$11: T.untyped = alias <C T.untyped>
-    <isaCheckTemp>$12: T.untyped = <cfgAlias>$11: T.untyped.===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$12 -> (T.untyped ? bb7 : bb9)
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$10: T.untyped = alias <C T.untyped>
+    <isaCheckTemp>$11: T.untyped = <cfgAlias>$10: T.untyped.===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$11 -> (T.untyped ? bb7 : bb9)
 
 # backedges
 # - bb8
 bb9[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$13: TrueClass = true
-    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb10)
+    <gotoDeadTemp>$12: TrueClass = true
+    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb10)
 
 # backedges
 # - bb6
@@ -312,7 +310,6 @@ method ::TestRescue#multiple_rescue_classes_varuse {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -327,52 +324,52 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
-    <cfgAlias>$9: T.class_of(LoadError) = alias <C LoadError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(LoadError).===(<exceptionValue>$4: Exception)
-    <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<exceptionValue>$4: Exception):
+    <cfgAlias>$8: T.class_of(LoadError) = alias <C LoadError>
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(LoadError).===(<exceptionValue>$4: Exception)
+    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue):
     <statTemp>$3: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](baz: NilClass, <gotoDeadTemp>$14: NilClass):
-    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb10)
+bb6[firstDead=-1](baz: NilClass, <gotoDeadTemp>$13: NilClass):
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb10)
 
 # backedges
 # - bb3
 # - bb8
-bb7[firstDead=-1](<exceptionValue>$4: T.any(LoadError, SocketError), <magic>$6: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$4: T.any(LoadError, SocketError)):
     baz: T.any(LoadError, SocketError) = <exceptionValue>$4
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb10)
+    <keepForCfgTemp>$6: T.untyped = <keep-alive> <exceptionValue>$4
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb10)
 
 # backedges
 # - bb3
-bb8[firstDead=-1](<exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
-    <cfgAlias>$12: T.class_of(SocketError) = alias <C SocketError>
-    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(SocketError).===(<exceptionValue>$4: Exception)
-    <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb9)
+bb8[firstDead=-1](<exceptionValue>$4: Exception):
+    <cfgAlias>$11: T.class_of(SocketError) = alias <C SocketError>
+    <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(SocketError).===(<exceptionValue>$4: Exception)
+    <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb9)
 
 # backedges
 # - bb8
 bb9[firstDead=-1]():
-    <gotoDeadTemp>$14: TrueClass = true
-    <gotoDeadTemp>$14 -> (TrueClass ? bb1 : bb10)
+    <gotoDeadTemp>$13: TrueClass = true
+    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb10)
 
 # backedges
 # - bb6
 # - bb7
 # - bb9
 bb10[firstDead=3](baz: T.nilable(T.any(LoadError, SocketError))):
-    <cfgAlias>$17: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: T.nilable(T.any(LoadError, SocketError)) = <cfgAlias>$17: T.class_of(T).reveal_type(baz: T.nilable(T.any(LoadError, SocketError)))
+    <cfgAlias>$16: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: T.nilable(T.any(LoadError, SocketError)) = <cfgAlias>$16: T.class_of(T).reveal_type(baz: T.nilable(T.any(LoadError, SocketError)))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(T.any(LoadError, SocketError))
     <unconditional> -> bb1
 
@@ -403,7 +400,7 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb13
-bb2[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$22: NilClass):
+bb2[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
@@ -416,26 +413,25 @@ bb3[firstDead=1](<block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfR
 
 # backedges
 # - bb2
-bb5[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$22: NilClass):
+bb5[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
     <self>: TestRescue = loadSelf(loop)
     ex: NilClass = nil
-    <magic>$17: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$15: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$15 -> (T.nilable(Exception) ? bb7 : bb8)
 
 # backedges
 # - bb5
 # - bb8
-bb7[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: Exception, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
+bb7[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: Exception, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
-    <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$15: Exception)
-    <isaCheckTemp>$21 -> (T::Boolean ? bb11 : bb12)
+    <cfgAlias>$19: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$20: T::Boolean = <cfgAlias>$19: T.class_of(StandardError).===(<exceptionValue>$15: Exception)
+    <isaCheckTemp>$20 -> (T::Boolean ? bb11 : bb12)
 
 # backedges
 # - bb5
-bb8[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
+bb8[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$13: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$15: T.nilable(Exception) = <get-current-exception>
@@ -443,33 +439,33 @@ bb8[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: So
 
 # backedges
 # - bb8
-bb10[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
+bb10[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
-    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb13)
+    <gotoDeadTemp>$21 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
-bb11[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: StandardError, <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$22: NilClass):
+bb11[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: StandardError, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
     ex: StandardError = <exceptionValue>$15
     <exceptionValue>$15: NilClass = nil
-    <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$15: NilClass)
-    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb13)
+    <keepForCfgTemp>$17: T.untyped = <keep-alive> <exceptionValue>$15
+    <gotoDeadTemp>$21 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
 bb12[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped):
     # outerLoops: 1
-    <gotoDeadTemp>$22: TrueClass = true
-    <gotoDeadTemp>$22 -> (TrueClass ? bb1 : bb13)
+    <gotoDeadTemp>$21: TrueClass = true
+    <gotoDeadTemp>$21 -> (TrueClass ? bb1 : bb13)
 
 # backedges
 # - bb10
 # - bb11
 # - bb12
-bb13[firstDead=1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$22: NilClass):
+bb13[firstDead=1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
-    <blockReturnTemp>$24: T.noreturn = blockreturn<loop> <blockReturnTemp>$13: T.untyped
+    <blockReturnTemp>$23: T.noreturn = blockreturn<loop> <blockReturnTemp>$13: T.untyped
     <unconditional> -> bb2
 
 }
@@ -478,7 +474,6 @@ method ::TestRescue#rescue_untyped_splat {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -493,40 +488,40 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$9: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$10: T.untyped = <self>: TestRescue.untyped_exceptions()
-    <exceptionClassTemp>$7: T.untyped = <cfgAlias>$9: T.class_of(<Magic>).<splat>(<statTemp>$10: T.untyped)
-    <isaCheckTemp>$12: T.untyped = <exceptionClassTemp>$7: T.untyped.===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$12 -> (T.untyped ? bb7 : bb8)
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$8: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$9: T.untyped = <self>: TestRescue.untyped_exceptions()
+    <exceptionClassTemp>$6: T.untyped = <cfgAlias>$8: T.class_of(<Magic>).<splat>(<statTemp>$9: T.untyped)
+    <isaCheckTemp>$11: T.untyped = <exceptionClassTemp>$6: T.untyped.===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$11 -> (T.untyped ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: NilClass):
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: NilClass):
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$3: Exception):
     e: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <cfgAlias>$14: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: Exception = <cfgAlias>$14: T.class_of(T).reveal_type(e: Exception)
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
+    <cfgAlias>$13: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: Exception = <cfgAlias>$13: T.class_of(T).reveal_type(e: Exception)
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$16: TrueClass = true
-    <gotoDeadTemp>$16 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$15: TrueClass = true
+    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -542,7 +537,6 @@ method ::TestRescue#rescue_typed_splat {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -557,40 +551,40 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$9: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$10: T::Array[T.class_of(Exception)] = <self>: TestRescue.typed_exceptions()
-    <exceptionClassTemp>$7: T::Array[T.class_of(Exception)] = <cfgAlias>$9: T.class_of(<Magic>).<splat>(<statTemp>$10: T::Array[T.class_of(Exception)])
-    <isaCheckTemp>$12: T::Boolean = <exceptionClassTemp>$7: T::Array[T.class_of(Exception)].===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$8: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$9: T::Array[T.class_of(Exception)] = <self>: TestRescue.typed_exceptions()
+    <exceptionClassTemp>$6: T::Array[T.class_of(Exception)] = <cfgAlias>$8: T.class_of(<Magic>).<splat>(<statTemp>$9: T::Array[T.class_of(Exception)])
+    <isaCheckTemp>$11: T::Boolean = <exceptionClassTemp>$6: T::Array[T.class_of(Exception)].===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: NilClass):
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: NilClass):
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$3: Exception):
     e: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <cfgAlias>$14: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: Exception = <cfgAlias>$14: T.class_of(T).reveal_type(e: Exception)
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
+    <cfgAlias>$13: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: Exception = <cfgAlias>$13: T.class_of(T).reveal_type(e: Exception)
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$16: TrueClass = true
-    <gotoDeadTemp>$16 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$15: TrueClass = true
+    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -606,7 +600,6 @@ method ::TestRescue#rescue_typed_splat {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -621,40 +614,40 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$9: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$10: [T.class_of(TypeError), T.class_of(ArgumentError)] = <self>: TestRescue.tuple_exceptions()
-    <exceptionClassTemp>$7: [T.class_of(TypeError), T.class_of(ArgumentError)] = <cfgAlias>$9: T.class_of(<Magic>).<splat>(<statTemp>$10: [T.class_of(TypeError), T.class_of(ArgumentError)])
-    <isaCheckTemp>$12: T::Boolean = <exceptionClassTemp>$7: [T.class_of(TypeError), T.class_of(ArgumentError)].===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$8: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$9: [T.class_of(TypeError), T.class_of(ArgumentError)] = <self>: TestRescue.tuple_exceptions()
+    <exceptionClassTemp>$6: [T.class_of(TypeError), T.class_of(ArgumentError)] = <cfgAlias>$8: T.class_of(<Magic>).<splat>(<statTemp>$9: [T.class_of(TypeError), T.class_of(ArgumentError)])
+    <isaCheckTemp>$11: T::Boolean = <exceptionClassTemp>$6: [T.class_of(TypeError), T.class_of(ArgumentError)].===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: NilClass):
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: NilClass):
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$3: Exception):
     e: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <cfgAlias>$14: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: Exception = <cfgAlias>$14: T.class_of(T).reveal_type(e: Exception)
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
+    <cfgAlias>$13: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: Exception = <cfgAlias>$13: T.class_of(T).reveal_type(e: Exception)
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$16: TrueClass = true
-    <gotoDeadTemp>$16 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$15: TrueClass = true
+    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -670,7 +663,6 @@ method ::TestRescue#parse_rescue_ensure {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -683,20 +675,321 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
+# - bb7
+# - bb8
+bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$13: T.nilable(TrueClass)):
+    <cfgAlias>$6: T.class_of(T) = alias <C T>
+    <rescueTemp>$2: T.untyped = <cfgAlias>$6: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
+    <throwAwayTemp>$14: T.untyped = <self>: TestRescue.bar()
+    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
+
+# backedges
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
+    <exceptionValue>$3: NilClass = nil
+    <keepForCfgTemp>$8: T.untyped = <keep-alive> <exceptionValue>$3
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
+    <unconditional> -> bb6
+
+# backedges
+# - bb3
+bb8[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <gotoDeadTemp>$13: TrueClass = true
+    <unconditional> -> bb6
+
+# backedges
+# - bb6
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
+    <unconditional> -> bb1
+
+}
+
+method ::TestRescue#parse_bug_rescue_empty_else {
+
+bb0[firstDead=-1]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
+
+# backedges
+# - bb6
+# - bb7
+# - bb8
+# - bb9
+bb1[firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0
+# - bb4
+bb3[firstDead=-1](<exceptionValue>$3: Exception):
+    <cfgAlias>$6: T.class_of(LoadError) = alias <C LoadError>
+    <isaCheckTemp>$7: T::Boolean = <cfgAlias>$6: T.class_of(LoadError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$7 -> (T::Boolean ? bb7 : bb8)
+
+# backedges
+# - bb0
+bb4[firstDead=-1]():
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
+
+# backedges
+# - bb4
+bb6[firstDead=-1](<gotoDeadTemp>$8: NilClass):
+    <gotoDeadTemp>$8 -> (NilClass ? bb1 : bb9)
+
+# backedges
+# - bb3
+bb7[firstDead=-1](<exceptionValue>$3: LoadError):
+    <exceptionValue>$3: NilClass = nil
+    <keepForCfgTemp>$4: T.untyped = <keep-alive> <exceptionValue>$3
+    <gotoDeadTemp>$8 -> (NilClass ? bb1 : bb9)
+
+# backedges
+# - bb3
+bb8[firstDead=-1]():
+    <gotoDeadTemp>$8: TrueClass = true
+    <gotoDeadTemp>$8 -> (TrueClass ? bb1 : bb9)
+
+# backedges
+# - bb6
+# - bb7
+# - bb8
+bb9[firstDead=1]():
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+}
+
+method ::TestRescue#parse_ruby_bug_12686 {
+
+bb0[firstDead=-1]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
+
+# backedges
+# - bb6
+# - bb7
+# - bb8
+# - bb9
+bb1[firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception):
+    <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
+    <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
+
+# backedges
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue):
+    <statTemp>$4: T.untyped = <self>: TestRescue.bar()
+    <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb6)
+
+# backedges
+# - bb4
+bb6[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$11: NilClass):
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+
+# backedges
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$5: StandardError):
+    <exceptionValue>$5: NilClass = nil
+    <keepForCfgTemp>$7: T.untyped = <keep-alive> <exceptionValue>$5
+    <statTemp>$4: NilClass = nil
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+
+# backedges
+# - bb3
+bb8[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
+    <gotoDeadTemp>$11: TrueClass = true
+    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
+
+# backedges
+# - bb6
+# - bb7
+# - bb8
+bb9[firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
+    <unconditional> -> bb1
+
+}
+
+method ::TestRescue#parse_rescue_mod {
+
+bb0[firstDead=-1]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
+
+# backedges
+# - bb6
+# - bb7
+# - bb8
+# - bb9
+bb1[firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
+
+# backedges
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue):
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
+
+# backedges
+# - bb4
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass):
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+
+# backedges
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
+    <exceptionValue>$3: NilClass = nil
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+
+# backedges
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
+    <gotoDeadTemp>$10: TrueClass = true
+    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
+
+# backedges
+# - bb6
+# - bb7
+# - bb8
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
+    <unconditional> -> bb1
+
+}
+
+method ::TestRescue#parse_resbody_list_var {
+
+bb0[firstDead=-1]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
+
+# backedges
+# - bb6
+# - bb7
+# - bb8
+# - bb9
+bb1[firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <exceptionClassTemp>$6: T.untyped = <self>: TestRescue.foo()
+    <isaCheckTemp>$8: T.untyped = <exceptionClassTemp>$6: T.untyped.===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$8 -> (T.untyped ? bb7 : bb8)
+
+# backedges
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue):
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
+
+# backedges
+# - bb4
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass):
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+
+# backedges
+# - bb3
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: Exception):
+    <exceptionValue>$3: NilClass = nil
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+
+# backedges
+# - bb3
+bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
+    <gotoDeadTemp>$10: TrueClass = true
+    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
+
+# backedges
+# - bb6
+# - bb7
+# - bb8
+bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
+    <unconditional> -> bb1
+
+}
+
+method ::TestRescue#parse_rescue_else_ensure {
+
+bb0[firstDead=-1]():
+    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
+
+# backedges
+# - bb6
+# - bb9
+bb1[firstDead=-1]():
+    <unconditional> -> bb1
+
+# backedges
+# - bb0
+# - bb4
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
+
+# backedges
+# - bb0
+bb4[firstDead=-1](<self>: TestRescue):
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
+    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
+    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
+
+# backedges
+# - bb4
+bb5[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: NilClass):
+    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
+    <unconditional> -> bb6
+
+# backedges
+# - bb5
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$14: T.nilable(TrueClass)):
@@ -707,9 +1000,9 @@ bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$9: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <keepForCfgTemp>$9: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
     <unconditional> -> bb6
 
@@ -727,317 +1020,10 @@ bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 }
 
-method ::TestRescue#parse_bug_rescue_empty_else {
-
-bb0[firstDead=-1]():
-    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$4: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
-
-# backedges
-# - bb6
-# - bb7
-# - bb8
-# - bb9
-bb1[firstDead=-1]():
-    <unconditional> -> bb1
-
-# backedges
-# - bb0
-# - bb4
-bb3[firstDead=-1](<exceptionValue>$3: Exception, <magic>$4: T.class_of(<Magic>)):
-    <cfgAlias>$7: T.class_of(LoadError) = alias <C LoadError>
-    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(LoadError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
-
-# backedges
-# - bb0
-bb4[firstDead=-1](<magic>$4: T.class_of(<Magic>)):
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
-
-# backedges
-# - bb4
-bb6[firstDead=-1](<gotoDeadTemp>$9: NilClass):
-    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
-
-# backedges
-# - bb3
-bb7[firstDead=-1](<exceptionValue>$3: LoadError, <magic>$4: T.class_of(<Magic>)):
-    <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$5: Sorbet::Private::Static::Void = <magic>$4: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
-
-# backedges
-# - bb3
-bb8[firstDead=-1]():
-    <gotoDeadTemp>$9: TrueClass = true
-    <gotoDeadTemp>$9 -> (TrueClass ? bb1 : bb9)
-
-# backedges
-# - bb6
-# - bb7
-# - bb8
-bb9[firstDead=1]():
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
-    <unconditional> -> bb1
-
-}
-
-method ::TestRescue#parse_ruby_bug_12686 {
-
-bb0[firstDead=-1]():
-    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
-
-# backedges
-# - bb6
-# - bb7
-# - bb8
-# - bb9
-bb1[firstDead=-1]():
-    <unconditional> -> bb1
-
-# backedges
-# - bb0
-# - bb4
-bb3[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
-    <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
-    <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
-
-# backedges
-# - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
-    <statTemp>$4: T.untyped = <self>: TestRescue.bar()
-    <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb6)
-
-# backedges
-# - bb4
-bb6[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: NilClass):
-    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
-
-# backedges
-# - bb3
-bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$5: StandardError, <magic>$7: T.class_of(<Magic>)):
-    <exceptionValue>$5: NilClass = nil
-    <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
-    <statTemp>$4: NilClass = nil
-    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
-
-# backedges
-# - bb3
-bb8[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
-    <gotoDeadTemp>$12: TrueClass = true
-    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
-
-# backedges
-# - bb6
-# - bb7
-# - bb8
-bb9[firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
-    <unconditional> -> bb1
-
-}
-
-method ::TestRescue#parse_rescue_mod {
-
-bb0[firstDead=-1]():
-    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
-
-# backedges
-# - bb6
-# - bb7
-# - bb8
-# - bb9
-bb1[firstDead=-1]():
-    <unconditional> -> bb1
-
-# backedges
-# - bb0
-# - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
-
-# backedges
-# - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
-
-# backedges
-# - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass):
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
-
-# backedges
-# - bb3
-bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
-    <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
-
-# backedges
-# - bb3
-bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$11: TrueClass = true
-    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
-
-# backedges
-# - bb6
-# - bb7
-# - bb8
-bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
-    <unconditional> -> bb1
-
-}
-
-method ::TestRescue#parse_resbody_list_var {
-
-bb0[firstDead=-1]():
-    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
-
-# backedges
-# - bb6
-# - bb7
-# - bb8
-# - bb9
-bb1[firstDead=-1]():
-    <unconditional> -> bb1
-
-# backedges
-# - bb0
-# - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <exceptionClassTemp>$7: T.untyped = <self>: TestRescue.foo()
-    <isaCheckTemp>$9: T.untyped = <exceptionClassTemp>$7: T.untyped.===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
-
-# backedges
-# - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
-
-# backedges
-# - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass):
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
-
-# backedges
-# - bb3
-bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
-
-# backedges
-# - bb3
-bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$11: TrueClass = true
-    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
-
-# backedges
-# - bb6
-# - bb7
-# - bb8
-bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
-    <unconditional> -> bb1
-
-}
-
-method ::TestRescue#parse_rescue_else_ensure {
-
-bb0[firstDead=-1]():
-    <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
-
-# backedges
-# - bb6
-# - bb9
-bb1[firstDead=-1]():
-    <unconditional> -> bb1
-
-# backedges
-# - bb0
-# - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
-    <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb8)
-
-# backedges
-# - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
-    <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
-    <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
-
-# backedges
-# - bb4
-bb5[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: NilClass):
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
-    <unconditional> -> bb6
-
-# backedges
-# - bb5
-# - bb7
-# - bb8
-bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$15: T.nilable(TrueClass)):
-    <cfgAlias>$8: T.class_of(T) = alias <C T>
-    <rescueTemp>$2: T.untyped = <cfgAlias>$8: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
-    <throwAwayTemp>$16: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
-
-# backedges
-# - bb3
-bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$6: T.class_of(<Magic>)):
-    <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
-    <unconditional> -> bb6
-
-# backedges
-# - bb3
-bb8[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
-    <gotoDeadTemp>$15: TrueClass = true
-    <unconditional> -> bb6
-
-# backedges
-# - bb6
-bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
-    <unconditional> -> bb1
-
-}
-
 method ::TestRescue#parse_rescue {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -1052,36 +1038,36 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass):
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass):
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$11: TrueClass = true
-    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$10: TrueClass = true
+    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -1097,7 +1083,6 @@ method ::TestRescue#parse_resbody_var {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -1112,36 +1097,36 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: NilClass):
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass):
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$11: TrueClass = true
-    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$10: TrueClass = true
+    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -1156,9 +1141,8 @@ bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
 method ::TestRescue#parse_resbody_var_1 {
 
 bb0[firstDead=-1]():
-    @ex$11: T.nilable(StandardError) = alias @ex
+    @ex$10: T.nilable(StandardError) = alias @ex
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -1173,38 +1157,38 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
-    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, @ex$10: T.nilable(StandardError)):
+    <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+bb4[firstDead=-1](<self>: TestRescue, @ex$10: T.nilable(StandardError)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: NilClass):
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: NilClass):
+    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, @ex$10: T.nilable(StandardError)):
     <rescueTemp>$2: StandardError = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    @ex$11: StandardError = <rescueTemp>$2
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
+    @ex$10: StandardError = <rescueTemp>$2
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$13: TrueClass = true
-    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$12: TrueClass = true
+    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -1221,7 +1205,6 @@ method ::TestRescue#parse_rescue_mod_op_assign {
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <statTemp>$3: NilClass = foo
-    <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -1236,36 +1219,36 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception, <magic>$7: T.class_of(<Magic>)):
-    <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
-    <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception):
+    <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
+    <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass):
     <statTemp>$4: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: NilClass):
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: NilClass):
+    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <exceptionValue>$5: StandardError, <magic>$7: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <exceptionValue>$5: StandardError):
     <exceptionValue>$5: NilClass = nil
-    <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
+    <keepForCfgTemp>$7: T.untyped = <keep-alive> <exceptionValue>$5
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
-    <gotoDeadTemp>$13: TrueClass = true
-    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$12: TrueClass = true
+    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -1283,7 +1266,6 @@ method ::TestRescue#parse_ruby_bug_12402 {
 
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
-    <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -1298,14 +1280,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](foo: NilClass, <exceptionValue>$3: Exception, <magic>$7: T.class_of(<Magic>)):
-    <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](foo: NilClass, <exceptionValue>$3: Exception):
+    <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
+bb4[firstDead=2](<self>: TestRescue):
     <statTemp>$5: T.untyped = <self>: TestRescue.bar()
     foo: T.noreturn = <self>: TestRescue.raise(<statTemp>$5: T.untyped)
     <exceptionValue>$3 = <get-current-exception>
@@ -1313,22 +1295,22 @@ bb4[firstDead=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
 
 # backedges
 # - bb4
-bb6[firstDead=0](foo: NilClass, <gotoDeadTemp>$12: NilClass):
-    <gotoDeadTemp>$12 -> (<nullptr> ? bb1 : bb9)
+bb6[firstDead=0](foo: NilClass, <gotoDeadTemp>$11: NilClass):
+    <gotoDeadTemp>$11 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<exceptionValue>$3: StandardError, <magic>$7: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <keepForCfgTemp>$7: T.untyped = <keep-alive> <exceptionValue>$3
     foo: NilClass = nil
-    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](foo: NilClass):
-    <gotoDeadTemp>$12: TrueClass = true
-    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$11: TrueClass = true
+    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -1346,7 +1328,6 @@ method ::TestRescue#parse_ruby_bug_12402_1 {
 bb0[firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <statTemp>$3: NilClass = foo
-    <magic>$9: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -1361,14 +1342,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: Exception, <magic>$9: T.class_of(<Magic>)):
-    <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
-    <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: Exception):
+    <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
+    <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>)):
+bb4[firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass):
     <statTemp>$7: T.untyped = <self>: TestRescue.bar()
     <statTemp>$4: T.noreturn = <self>: TestRescue.raise(<statTemp>$7: T.untyped)
     <exceptionValue>$5 = <get-current-exception>
@@ -1376,22 +1357,22 @@ bb4[firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$9: T.class_
 
 # backedges
 # - bb4
-bb6[firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$14: NilClass):
-    <gotoDeadTemp>$14 -> (<nullptr> ? bb1 : bb9)
+bb6[firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$13: NilClass):
+    <gotoDeadTemp>$13 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<statTemp>$3: NilClass, <exceptionValue>$5: StandardError, <magic>$9: T.class_of(<Magic>)):
+bb7[firstDead=-1](<statTemp>$3: NilClass, <exceptionValue>$5: StandardError):
     <exceptionValue>$5: NilClass = nil
-    <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
+    <keepForCfgTemp>$9: T.untyped = <keep-alive> <exceptionValue>$5
     <statTemp>$4: NilClass = nil
-    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
-    <gotoDeadTemp>$14: TrueClass = true
-    <gotoDeadTemp>$14 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$13: TrueClass = true
+    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -1412,7 +1393,6 @@ bb0[firstDead=-1]():
     []$3: T.untyped = <self>: TestRescue.foo()
     []$4: Integer(0) = 0
     <statTemp>$9: T.untyped = []$3: T.untyped.[]([]$4: Integer(0))
-    <magic>$17: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$13: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$13 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -1427,14 +1407,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: Exception, <magic>$17: T.class_of(<Magic>)):
-    <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$13: Exception)
-    <isaCheckTemp>$21 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: Exception):
+    <cfgAlias>$19: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$20: T::Boolean = <cfgAlias>$19: T.class_of(StandardError).===(<exceptionValue>$13: Exception)
+    <isaCheckTemp>$20 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>)):
+bb4[firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped):
     <statTemp>$15: T.untyped = <self>: TestRescue.bar()
     <statTemp>$12: T.noreturn = <self>: TestRescue.raise(<statTemp>$15: T.untyped)
     <exceptionValue>$13 = <get-current-exception>
@@ -1442,22 +1422,22 @@ bb4[firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTem
 
 # backedges
 # - bb4
-bb6[firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass, <gotoDeadTemp>$22: NilClass):
-    <gotoDeadTemp>$22 -> (<nullptr> ? bb1 : bb9)
+bb6[firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass, <gotoDeadTemp>$21: NilClass):
+    <gotoDeadTemp>$21 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <exceptionValue>$13: StandardError, <magic>$17: T.class_of(<Magic>)):
+bb7[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <exceptionValue>$13: StandardError):
     <exceptionValue>$13: NilClass = nil
-    <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)
+    <keepForCfgTemp>$17: T.untyped = <keep-alive> <exceptionValue>$13
     <statTemp>$12: NilClass = nil
-    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$21 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
-    <gotoDeadTemp>$22: TrueClass = true
-    <gotoDeadTemp>$22 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$21: TrueClass = true
+    <gotoDeadTemp>$21 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -2,7 +2,6 @@ method ::Object#foo {
 
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -18,14 +17,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$9 -> (T::Boolean ? bb10 : bb11)
+bb3[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: Exception):
+    <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$8 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1]():
     <returnMethodTemp>$2: Integer(1) = 1
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
@@ -40,26 +39,26 @@ bb5[firstDead=-1]():
 # - bb5
 bb6[firstDead=-1]():
     <returnMethodTemp>$2: Integer(3) = 3
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb12)
+    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb12)
 
 # backedges
 # - bb5
 bb7[firstDead=0]():
     <returnMethodTemp>$2 = nil
-    <gotoDeadTemp>$10 -> (<nullptr> ? bb1 : bb12)
+    <gotoDeadTemp>$9 -> (<nullptr> ? bb1 : bb12)
 
 # backedges
 # - bb3
-bb10[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+bb10[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb12)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
+    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb12)
 
 # backedges
 # - bb3
 bb11[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
-    <gotoDeadTemp>$10: TrueClass = true
-    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb12)
+    <gotoDeadTemp>$9: TrueClass = true
+    <gotoDeadTemp>$9 -> (TrueClass ? bb1 : bb12)
 
 # backedges
 # - bb6

--- a/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
@@ -2,7 +2,6 @@ method ::Object#foo {
 
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
-    <magic>$8: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -17,16 +16,16 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception, <magic>$8: T.class_of(<Magic>)):
-    <cfgAlias>$13: T.class_of(MyException) = alias <C MyException>
-    <statTemp>$11: MyException = <cfgAlias>$13: T.class_of(MyException).new()
-    <exceptionClassTemp>$10: T.class_of(MyException) = <statTemp>$11: MyException.class()
-    <isaCheckTemp>$14: T::Boolean = <exceptionClassTemp>$10: T.class_of(MyException).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$14 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception):
+    <cfgAlias>$12: T.class_of(MyException) = alias <C MyException>
+    <statTemp>$10: MyException = <cfgAlias>$12: T.class_of(MyException).new()
+    <exceptionClassTemp>$9: T.class_of(MyException) = <statTemp>$10: MyException.class()
+    <isaCheckTemp>$13: T::Boolean = <exceptionClassTemp>$9: T.class_of(MyException).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$13 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=3](<self>: Object, <magic>$8: T.class_of(<Magic>)):
+bb4[firstDead=3](<self>: Object):
     <cfgAlias>$7: T.class_of(MyException) = alias <C MyException>
     <statTemp>$5: MyException = <cfgAlias>$7: T.class_of(MyException).new()
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: MyException)
@@ -35,22 +34,22 @@ bb4[firstDead=3](<self>: Object, <magic>$8: T.class_of(<Magic>)):
 
 # backedges
 # - bb4
-bb6[firstDead=0](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$15: NilClass):
-    <gotoDeadTemp>$15 -> (<nullptr> ? bb1 : bb9)
+bb6[firstDead=0](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$14: NilClass):
+    <gotoDeadTemp>$14 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<exceptionValue>$3: MyException, <magic>$8: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$3: MyException):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$9: Sorbet::Private::Static::Void = <magic>$8: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
+    <keepForCfgTemp>$8: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: Integer(3) = 3
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$15: TrueClass = true
-    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$14: TrueClass = true
+    <gotoDeadTemp>$14 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6

--- a/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
@@ -2,7 +2,6 @@ method ::Object#foo {
 
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
-    <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -17,10 +16,10 @@ bb1[firstDead=-1]():
 
 # backedges
 # - bb0
-bb3[firstDead=-1](<self>: Object, <exceptionValue>$4: Exception, <magic>$6: T.class_of(<Magic>)):
-    <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
-    <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: Object, <exceptionValue>$4: Exception):
+    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
+    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
@@ -31,18 +30,18 @@ bb4[firstDead=2]():
 
 # backedges
 # - bb3
-bb7[firstDead=4](<exceptionValue>$4: StandardError, <magic>$6: T.class_of(<Magic>)):
+bb7[firstDead=4](<exceptionValue>$4: StandardError):
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <returnTemp>$11: Integer(2) = 2
-    <statTemp>$3: T.noreturn = return <returnTemp>$11: Integer(2)
+    <keepForCfgTemp>$6: T.untyped = <keep-alive> <exceptionValue>$4
+    <returnTemp>$10: Integer(2) = 2
+    <statTemp>$3: T.noreturn = return <returnTemp>$10: Integer(2)
     <unconditional> -> bb1
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<self>: Object):
-    <gotoDeadTemp>$12: TrueClass = true
-    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$11: TrueClass = true
+    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb8

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
@@ -2,7 +2,6 @@ method ::Object#foo {
 
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
-    <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -17,14 +16,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
-    <cfgAlias>$9: T.class_of(Exception) = alias <C Exception>
-    <isaCheckTemp>$10: TrueClass = <cfgAlias>$9: T.class_of(Exception).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$10 -> (TrueClass ? bb7 : bb8)
+bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception):
+    <cfgAlias>$8: T.class_of(Exception) = alias <C Exception>
+    <isaCheckTemp>$9: TrueClass = <cfgAlias>$8: T.class_of(Exception).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$9 -> (TrueClass ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=2](<self>: Object, <magic>$6: T.class_of(<Magic>)):
+bb4[firstDead=2](<self>: Object):
     <statTemp>$5: String("boop") = "boop"
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: String("boop"))
     <exceptionValue>$3 = <get-current-exception>
@@ -32,26 +31,26 @@ bb4[firstDead=2](<self>: Object, <magic>$6: T.class_of(<Magic>)):
 
 # backedges
 # - bb4
-bb6[firstDead=0](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$16: NilClass):
-    <gotoDeadTemp>$16 -> (<nullptr> ? bb1 : bb9)
+bb6[firstDead=0](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$15: NilClass):
+    <gotoDeadTemp>$15 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<exceptionValue>$3: Exception, <magic>$6: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$3: Exception):
     <rescueTemp>$2: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <cfgAlias>$14: T.class_of(MyClass) = alias <C MyClass>
-    <statTemp>$12: MyClass = <cfgAlias>$14: T.class_of(MyClass).new()
-    <statTemp>$11: Exception = <statTemp>$12: MyClass.foo=(<rescueTemp>$2: Exception)
+    <keepForCfgTemp>$6: T.untyped = <keep-alive> <exceptionValue>$3
+    <cfgAlias>$13: T.class_of(MyClass) = alias <C MyClass>
+    <statTemp>$11: MyClass = <cfgAlias>$13: T.class_of(MyClass).new()
+    <statTemp>$10: Exception = <statTemp>$11: MyClass.foo=(<rescueTemp>$2: Exception)
     <returnMethodTemp>$2: Integer(3) = 3
-    <gotoDeadTemp>$16 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=0](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$16 = true
-    <gotoDeadTemp>$16 -> (<nullptr> ? bb1 : bb9)
+    <gotoDeadTemp>$15 = true
+    <gotoDeadTemp>$15 -> (<nullptr> ? bb1 : bb9)
 
 # backedges
 # - bb6

--- a/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
@@ -2,7 +2,6 @@ method ::Object#a {
 
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -17,10 +16,10 @@ bb1[firstDead=-1]():
 
 # backedges
 # - bb0
-bb3[firstDead=-1](<exceptionValue>$3: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<exceptionValue>$3: Exception):
+    <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
@@ -31,16 +30,16 @@ bb4[firstDead=2]():
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<exceptionValue>$3: StandardError, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](<exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
+    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1]():
-    <gotoDeadTemp>$10: TrueClass = true
-    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$9: TrueClass = true
+    <gotoDeadTemp>$9 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb7

--- a/test/testdata/cfg/retry.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry.rb.cfg-text.exp
@@ -3,7 +3,6 @@ method ::Object#main {
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
-    <magic>$13: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
@@ -16,28 +15,28 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb10
-bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb2
 # - bb7
-bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$13: T.class_of(<Magic>)):
-    <cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$17: T::Boolean = <cfgAlias>$16: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
-    <isaCheckTemp>$17 -> (T::Boolean ? bb10 : bb11)
+bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception):
+    <cfgAlias>$15: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$16: T::Boolean = <cfgAlias>$15: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
+    <isaCheckTemp>$16 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
 # - bb2
-bb4[firstDead=-1](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: Object, try: Integer(0)):
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
     <ifTemp>$5 -> (T::Boolean ? bb5 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+bb5[firstDead=5](<self>: Object, try: Integer(0)):
     <statTemp>$9: Integer(0) = try
     <statTemp>$10: Integer(1) = 1
     try: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))
@@ -47,38 +46,38 @@ bb5[firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+bb6[firstDead=-1](<self>: Object, try: Integer(0)):
     <returnMethodTemp>$2: NilClass = nil
     <unconditional> -> bb7
 
 # backedges
 # - bb5
 # - bb6
-bb7[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb9)
 
 # backedges
 # - bb7
-bb9[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$24: NilClass):
-    <gotoDeadTemp>$24 -> (NilClass ? bb1 : bb12)
+bb9[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$23: NilClass):
+    <gotoDeadTemp>$23 -> (NilClass ? bb1 : bb12)
 
 # backedges
 # - bb3
-bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: StandardError, <magic>$13: T.class_of(<Magic>)):
+bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: StandardError):
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$14: Sorbet::Private::Static::Void = <magic>$13: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <statTemp>$20: String("rescue") = "rescue"
-    <statTemp>$18: NilClass = <self>: Object.puts(<statTemp>$20: String("rescue"))
-    <magic>$22: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$23: Sorbet::Private::Static::Void = <magic>$22: T.class_of(<Magic>).<retry>()
+    <keepForCfgTemp>$13: T.untyped = <keep-alive> <exceptionValue>$4
+    <statTemp>$19: String("rescue") = "rescue"
+    <statTemp>$17: NilClass = <self>: Object.puts(<statTemp>$19: String("rescue"))
+    <magic>$21: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$22: Sorbet::Private::Static::Void = <magic>$21: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb2
 
 # backedges
 # - bb3
 bb11[firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$24: TrueClass = true
-    <gotoDeadTemp>$24 -> (TrueClass ? bb1 : bb12)
+    <gotoDeadTemp>$23: TrueClass = true
+    <gotoDeadTemp>$23 -> (TrueClass ? bb1 : bb12)
 
 # backedges
 # - bb9

--- a/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
@@ -3,7 +3,6 @@ method ::Object#main {
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
-    <magic>$25: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
@@ -17,28 +16,28 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb13
 # - bb15
-bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb2
 # - bb10
-bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
-    <cfgAlias>$28: T.class_of(A) = alias <C A>
-    <isaCheckTemp>$29: T::Boolean = <cfgAlias>$28: T.class_of(A).===(<exceptionValue>$4: Exception)
-    <isaCheckTemp>$29 -> (T::Boolean ? bb13 : bb14)
+bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception):
+    <cfgAlias>$27: T.class_of(A) = alias <C A>
+    <isaCheckTemp>$28: T::Boolean = <cfgAlias>$27: T.class_of(A).===(<exceptionValue>$4: Exception)
+    <isaCheckTemp>$28 -> (T::Boolean ? bb13 : bb14)
 
 # backedges
 # - bb2
-bb4[firstDead=-1](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: Object, try: Integer(0)):
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
     <ifTemp>$5 -> (T::Boolean ? bb5 : bb6)
 
 # backedges
 # - bb4
-bb5[firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb5[firstDead=6](<self>: Object, try: Integer(0)):
     <statTemp>$9: Integer(0) = try
     <statTemp>$10: Integer(1) = 1
     try: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))
@@ -49,14 +48,14 @@ bb5[firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb6[firstDead=-1](<self>: Object, try: Integer(0)):
     <statTemp>$17: Integer(6) = 6
     <ifTemp>$15: T::Boolean = try: Integer(0).<(<statTemp>$17: Integer(6))
     <ifTemp>$15 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb6
-bb7[firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb7[firstDead=6](<self>: Object, try: Integer(0)):
     <statTemp>$19: Integer(0) = try
     <statTemp>$20: Integer(1) = 1
     try: Integer = <statTemp>$19: Integer(0).+(<statTemp>$20: Integer(1))
@@ -67,7 +66,7 @@ bb7[firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>
 
 # backedges
 # - bb6
-bb8[firstDead=-1](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb8[firstDead=-1](<self>: Object, try: Integer(0)):
     <returnMethodTemp>$2: NilClass = nil
     <unconditional> -> bb10
 
@@ -75,49 +74,49 @@ bb8[firstDead=-1](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic
 # - bb5
 # - bb7
 # - bb8
-bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0)):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb12)
 
 # backedges
 # - bb10
-bb12[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$46: NilClass):
-    <gotoDeadTemp>$46 -> (NilClass ? bb1 : bb17)
+bb12[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$45: NilClass):
+    <gotoDeadTemp>$45 -> (NilClass ? bb1 : bb17)
 
 # backedges
 # - bb3
-bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: A, <magic>$25: T.class_of(<Magic>)):
+bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: A):
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$26: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <statTemp>$32: String("rescue A ") = "rescue A "
-    <statTemp>$30: NilClass = <self>: Object.puts(<statTemp>$32: String("rescue A "))
-    <magic>$34: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$35: Sorbet::Private::Static::Void = <magic>$34: T.class_of(<Magic>).<retry>()
+    <keepForCfgTemp>$25: T.untyped = <keep-alive> <exceptionValue>$4
+    <statTemp>$31: String("rescue A ") = "rescue A "
+    <statTemp>$29: NilClass = <self>: Object.puts(<statTemp>$31: String("rescue A "))
+    <magic>$33: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$34: Sorbet::Private::Static::Void = <magic>$33: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb2
 
 # backedges
 # - bb3
-bb14[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <magic>$25: T.class_of(<Magic>)):
-    <cfgAlias>$38: T.class_of(B) = alias <C B>
-    <isaCheckTemp>$39: T::Boolean = <cfgAlias>$38: T.class_of(B).===(<exceptionValue>$4: Exception)
-    <isaCheckTemp>$39 -> (T::Boolean ? bb15 : bb16)
+bb14[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception):
+    <cfgAlias>$37: T.class_of(B) = alias <C B>
+    <isaCheckTemp>$38: T::Boolean = <cfgAlias>$37: T.class_of(B).===(<exceptionValue>$4: Exception)
+    <isaCheckTemp>$38 -> (T::Boolean ? bb15 : bb16)
 
 # backedges
 # - bb14
-bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B, <magic>$25: T.class_of(<Magic>)):
+bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B):
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$36: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <statTemp>$42: String("rescue B ") = "rescue B "
-    <statTemp>$40: NilClass = <self>: Object.puts(<statTemp>$42: String("rescue B "))
-    <magic>$44: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$45: Sorbet::Private::Static::Void = <magic>$44: T.class_of(<Magic>).<retry>()
+    <keepForCfgTemp>$35: T.untyped = <keep-alive> <exceptionValue>$4
+    <statTemp>$41: String("rescue B ") = "rescue B "
+    <statTemp>$39: NilClass = <self>: Object.puts(<statTemp>$41: String("rescue B "))
+    <magic>$43: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$44: Sorbet::Private::Static::Void = <magic>$43: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb2
 
 # backedges
 # - bb14
 bb16[firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$46: TrueClass = true
-    <gotoDeadTemp>$46 -> (TrueClass ? bb1 : bb17)
+    <gotoDeadTemp>$45: TrueClass = true
+    <gotoDeadTemp>$45 -> (TrueClass ? bb1 : bb17)
 
 # backedges
 # - bb12

--- a/test/testdata/cfg/retry_nested.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg-text.exp
@@ -3,7 +3,6 @@ method ::Object#main {
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
-    <magic>$42: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
@@ -18,51 +17,50 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb21
-bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
 # - bb2
 # - bb18
-bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
-    <cfgAlias>$45: T.class_of(B) = alias <C B>
-    <isaCheckTemp>$46: T::Boolean = <cfgAlias>$45: T.class_of(B).===(<exceptionValue>$4: Exception)
-    <isaCheckTemp>$46 -> (T::Boolean ? bb21 : bb22)
+bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <gotoDeadTemp>$39: NilClass):
+    <cfgAlias>$43: T.class_of(B) = alias <C B>
+    <isaCheckTemp>$44: T::Boolean = <cfgAlias>$43: T.class_of(B).===(<exceptionValue>$4: Exception)
+    <isaCheckTemp>$44 -> (T::Boolean ? bb21 : bb22)
 
 # backedges
 # - bb2
-bb4[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <statTemp>$7: String("top") = "top"
     <statTemp>$5: NilClass = <self>: Object.puts(<statTemp>$7: String("top"))
-    <magic>$29: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb5
 
 # backedges
 # - bb4
 # - bb16
-bb5[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb5[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb6 : bb7)
 
 # backedges
 # - bb5
 # - bb13
-bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: Exception, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
-    <cfgAlias>$32: T.class_of(A) = alias <C A>
-    <isaCheckTemp>$33: T::Boolean = <cfgAlias>$32: T.class_of(A).===(<exceptionValue>$8: Exception)
-    <isaCheckTemp>$33 -> (T::Boolean ? bb16 : bb17)
+bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: Exception, <gotoDeadTemp>$39: NilClass):
+    <cfgAlias>$31: T.class_of(A) = alias <C A>
+    <isaCheckTemp>$32: T::Boolean = <cfgAlias>$31: T.class_of(A).===(<exceptionValue>$8: Exception)
+    <isaCheckTemp>$32 -> (T::Boolean ? bb16 : bb17)
 
 # backedges
 # - bb5
-bb7[firstDead=-1](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: Object, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <statTemp>$11: Integer(3) = 3
     <ifTemp>$9: T::Boolean = try: Integer(0).<(<statTemp>$11: Integer(3))
     <ifTemp>$9 -> (T::Boolean ? bb8 : bb9)
 
 # backedges
 # - bb7
-bb8[firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb8[firstDead=6](<self>: Object, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <statTemp>$13: Integer(0) = try
     <statTemp>$14: Integer(1) = 1
     try: Integer = <statTemp>$13: Integer(0).+(<statTemp>$14: Integer(1))
@@ -73,14 +71,14 @@ bb8[firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>
 
 # backedges
 # - bb7
-bb9[firstDead=-1](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb9[firstDead=-1](<self>: Object, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <statTemp>$21: Integer(6) = 6
     <ifTemp>$19: T::Boolean = try: Integer(0).<(<statTemp>$21: Integer(6))
     <ifTemp>$19 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
 # - bb9
-bb10[firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb10[firstDead=6](<self>: Object, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <statTemp>$23: Integer(0) = try
     <statTemp>$24: Integer(1) = 1
     try: Integer = <statTemp>$23: Integer(0).+(<statTemp>$24: Integer(1))
@@ -91,7 +89,7 @@ bb10[firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic
 
 # backedges
 # - bb9
-bb11[firstDead=-1](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb11[firstDead=-1](<self>: Object, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <returnMethodTemp>$2: NilClass = nil
     <unconditional> -> bb13
 
@@ -99,60 +97,60 @@ bb11[firstDead=-1](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magi
 # - bb8
 # - bb10
 # - bb11
-bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb6 : bb15)
 
 # backedges
 # - bb13
-bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
-    <gotoDeadTemp>$40 -> (NilClass ? bb1 : bb18)
+bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: NilClass):
+    <gotoDeadTemp>$39 -> (NilClass ? bb1 : bb18)
 
 # backedges
 # - bb6
-bb16[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: A, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb16[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: A, <gotoDeadTemp>$39: NilClass):
     <exceptionValue>$8: NilClass = nil
-    <keepForCfgTemp>$30: Sorbet::Private::Static::Void = <magic>$29: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$8: NilClass)
-    <statTemp>$36: String("rescue A") = "rescue A"
-    <statTemp>$34: NilClass = <self>: Object.puts(<statTemp>$36: String("rescue A"))
-    <magic>$38: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$39: Sorbet::Private::Static::Void = <magic>$38: T.class_of(<Magic>).<retry>()
+    <keepForCfgTemp>$29: T.untyped = <keep-alive> <exceptionValue>$8
+    <statTemp>$35: String("rescue A") = "rescue A"
+    <statTemp>$33: NilClass = <self>: Object.puts(<statTemp>$35: String("rescue A"))
+    <magic>$37: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$38: Sorbet::Private::Static::Void = <magic>$37: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb5
 
 # backedges
 # - bb6
-bb17[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>)):
-    <gotoDeadTemp>$40: TrueClass = true
-    <gotoDeadTemp>$40 -> (TrueClass ? bb1 : bb18)
+bb17[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0)):
+    <gotoDeadTemp>$39: TrueClass = true
+    <gotoDeadTemp>$39 -> (TrueClass ? bb1 : bb18)
 
 # backedges
 # - bb15
 # - bb17
-bb18[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb18[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb20)
 
 # backedges
 # - bb18
-bb20[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$53: NilClass):
-    <gotoDeadTemp>$53 -> (NilClass ? bb1 : bb23)
+bb20[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$51: NilClass):
+    <gotoDeadTemp>$51 -> (NilClass ? bb1 : bb23)
 
 # backedges
 # - bb3
-bb21[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+bb21[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B, <gotoDeadTemp>$39: NilClass):
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$43: Sorbet::Private::Static::Void = <magic>$42: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
-    <statTemp>$49: String("rescue B ") = "rescue B "
-    <statTemp>$47: NilClass = <self>: Object.puts(<statTemp>$49: String("rescue B "))
-    <magic>$51: T.class_of(<Magic>) = alias <C <Magic>>
-    <retryTemp>$52: Sorbet::Private::Static::Void = <magic>$51: T.class_of(<Magic>).<retry>()
+    <keepForCfgTemp>$41: T.untyped = <keep-alive> <exceptionValue>$4
+    <statTemp>$47: String("rescue B ") = "rescue B "
+    <statTemp>$45: NilClass = <self>: Object.puts(<statTemp>$47: String("rescue B "))
+    <magic>$49: T.class_of(<Magic>) = alias <C <Magic>>
+    <retryTemp>$50: Sorbet::Private::Static::Void = <magic>$49: T.class_of(<Magic>).<retry>()
     <unconditional> -> bb2
 
 # backedges
 # - bb3
 bb22[firstDead=-1](<returnMethodTemp>$2: NilClass):
-    <gotoDeadTemp>$53: TrueClass = true
-    <gotoDeadTemp>$53 -> (TrueClass ? bb1 : bb23)
+    <gotoDeadTemp>$51: TrueClass = true
+    <gotoDeadTemp>$51 -> (TrueClass ? bb1 : bb23)
 
 # backedges
 # - bb20

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -2,7 +2,6 @@ method ::<Class:<root>>#<static-init> {
 
 bb0[firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
-    <magic>$14: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -15,14 +14,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, <magic>$14: T.class_of(<Magic>)):
-    <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$21 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    <cfgAlias>$19: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$20: T::Boolean = <cfgAlias>$19: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$20 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: T.class_of(<root>), <magic>$14: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: T.class_of(<root>)):
     <cfgAlias>$6: T.class_of(A) = alias <C A>
     <statTemp>$4: A = <cfgAlias>$6: T.class_of(A).new()
     <hashTemp>$8: Symbol(:z) = :z
@@ -40,26 +39,26 @@ bb4[firstDead=-1](<self>: T.class_of(<root>), <magic>$14: T.class_of(<Magic>)):
 # - bb4
 # - bb7
 # - bb8
-bb6[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$24: T.nilable(TrueClass)):
-    <cfgAlias>$16: T.class_of(T) = alias <C T>
-    e: T.untyped = <cfgAlias>$16: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
-    <statTemp>$27: String("done") = "done"
-    <throwAwayTemp>$25: NilClass = <self>: T.class_of(<root>).p(<statTemp>$27: String("done"))
-    <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$23: T.nilable(TrueClass)):
+    <cfgAlias>$15: T.class_of(T) = alias <C T>
+    e: T.untyped = <cfgAlias>$15: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
+    <statTemp>$26: String("done") = "done"
+    <throwAwayTemp>$24: NilClass = <self>: T.class_of(<root>).p(<statTemp>$26: String("done"))
+    <gotoDeadTemp>$23 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$3: StandardError, <magic>$14: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$14: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <statTemp>$23: String("whoops") = "whoops"
-    <returnMethodTemp>$2: NilClass = <self>: T.class_of(<root>).p(<statTemp>$23: String("whoops"))
+    <keepForCfgTemp>$17: T.untyped = <keep-alive> <exceptionValue>$3
+    <statTemp>$22: String("whoops") = "whoops"
+    <returnMethodTemp>$2: NilClass = <self>: T.class_of(<root>).p(<statTemp>$22: String("whoops"))
     <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
-    <gotoDeadTemp>$24: TrueClass = true
+    <gotoDeadTemp>$23: TrueClass = true
     <unconditional> -> bb6
 
 # backedges

--- a/test/testdata/cfg/uaf1.rb.cfg-text.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg-text.exp
@@ -32,7 +32,7 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb13
-bb2[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$14: NilClass):
+bb2[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
@@ -45,25 +45,24 @@ bb3[firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 
 # backedges
 # - bb2
-bb5[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$14: NilClass):
+bb5[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
     <self>: A = loadSelf(map)
-    <magic>$9: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb7 : bb8)
 
 # backedges
 # - bb5
 # - bb8
-bb7[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <exceptionValue>$8: Exception, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
+bb7[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <exceptionValue>$8: Exception, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
-    <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$13: T::Boolean = <cfgAlias>$12: T.class_of(StandardError).===(<exceptionValue>$8: Exception)
-    <isaCheckTemp>$13 -> (T::Boolean ? bb11 : bb12)
+    <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$8: Exception)
+    <isaCheckTemp>$12 -> (T::Boolean ? bb11 : bb12)
 
 # backedges
 # - bb5
-bb8[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
+bb8[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$7: Integer(1) = 1
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
@@ -71,33 +70,33 @@ bb8[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::V
 
 # backedges
 # - bb8
-bb10[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer(1), <gotoDeadTemp>$14: NilClass):
+bb10[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer(1), <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
-    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb13)
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
-bb11[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <exceptionValue>$8: StandardError, <magic>$9: T.class_of(<Magic>), <gotoDeadTemp>$14: NilClass):
+bb11[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <exceptionValue>$8: StandardError, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
     <exceptionValue>$8: NilClass = nil
-    <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$8: NilClass)
+    <keepForCfgTemp>$9: T.untyped = <keep-alive> <exceptionValue>$8
     <blockReturnTemp>$7: Integer(2) = 2
-    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb13)
+    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
 bb12[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer)):
     # outerLoops: 1
-    <gotoDeadTemp>$14: TrueClass = true
-    <gotoDeadTemp>$14 -> (TrueClass ? bb1 : bb13)
+    <gotoDeadTemp>$13: TrueClass = true
+    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb13)
 
 # backedges
 # - bb10
 # - bb11
 # - bb12
-bb13[firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer, <gotoDeadTemp>$14: NilClass):
+bb13[firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
-    <blockReturnTemp>$16: T.noreturn = blockreturn<map> <blockReturnTemp>$7: Integer
+    <blockReturnTemp>$15: T.noreturn = blockreturn<map> <blockReturnTemp>$7: Integer
     <unconditional> -> bb2
 
 }

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
@@ -2,7 +2,6 @@ method ::Object#main {
 
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -16,7 +15,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
-    <gotoDeadTemp>$6: TrueClass = true
+    <gotoDeadTemp>$5: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
@@ -29,9 +28,9 @@ bb4[firstDead=-1](<self>: Object):
 # backedges
 # - bb3
 # - bb4
-bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$6: T.nilable(TrueClass)):
-    <throwAwayTemp>$7: T.untyped = <self>: Object.b()
-    <gotoDeadTemp>$6 -> (T.nilable(TrueClass) ? bb1 : bb7)
+bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$5: T.nilable(TrueClass)):
+    <throwAwayTemp>$6: T.untyped = <self>: Object.b()
+    <gotoDeadTemp>$5 -> (T.nilable(TrueClass) ? bb1 : bb7)
 
 # backedges
 # - bb6

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -733,7 +733,6 @@ method ::Rescues#foo {
 
 bb0[firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
-    <magic>$11: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <self>: String = cast(<castTemp>$7: NilClass, String);
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
@@ -747,14 +746,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
-    <cfgAlias>$17: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$18: T::Boolean = <cfgAlias>$17: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$18 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
+    <cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$17: T::Boolean = <cfgAlias>$16: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$17 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: String, <magic>$11: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: String):
     <cfgAlias>$6: T.class_of(String) = alias <C String>
     keep_for_ide$5: T.class_of(String) = <cfgAlias>$6
     keep_for_ide$5: T.untyped = <keep-alive> keep_for_ide$5
@@ -769,26 +768,26 @@ bb4[firstDead=-1](<self>: String, <magic>$11: T.class_of(<Magic>)):
 # - bb4
 # - bb7
 # - bb8
-bb6[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$22: T.nilable(TrueClass)):
-    <cfgAlias>$13: T.class_of(T) = alias <C T>
-    <rescueTemp>$2: T.untyped = <cfgAlias>$13: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
-    <cfgAlias>$25: T.class_of(T) = alias <C T>
-    <throwAwayTemp>$23: String = <cfgAlias>$25: T.class_of(T).reveal_type(<self>: String)
-    <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$21: T.nilable(TrueClass)):
+    <cfgAlias>$12: T.class_of(T) = alias <C T>
+    <rescueTemp>$2: T.untyped = <cfgAlias>$12: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
+    <cfgAlias>$24: T.class_of(T) = alias <C T>
+    <throwAwayTemp>$22: String = <cfgAlias>$24: T.class_of(T).reveal_type(<self>: String)
+    <gotoDeadTemp>$21 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: String, <exceptionValue>$3: StandardError, <magic>$11: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: String, <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$15: Sorbet::Private::Static::Void = <magic>$11: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <cfgAlias>$20: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: String = <cfgAlias>$20: T.class_of(T).reveal_type(<self>: String)
+    <keepForCfgTemp>$14: T.untyped = <keep-alive> <exceptionValue>$3
+    <cfgAlias>$19: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: String = <cfgAlias>$19: T.class_of(T).reveal_type(<self>: String)
     <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
-    <gotoDeadTemp>$22: TrueClass = true
+    <gotoDeadTemp>$21: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
@@ -803,11 +802,10 @@ method ::Rescues#bar {
 
 bb0[firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
-    <magic>$11: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <self>: String = cast(<castTemp>$7: NilClass, String);
-    <self>: Integer = cast(<castTemp>$22: NilClass, Integer);
-    <self>: Float = cast(<castTemp>$31: NilClass, Float);
+    <self>: Integer = cast(<castTemp>$21: NilClass, Integer);
+    <self>: Float = cast(<castTemp>$30: NilClass, Float);
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
@@ -819,14 +817,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception, <magic>$11: T.class_of(<Magic>)):
-    <cfgAlias>$17: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$18: T::Boolean = <cfgAlias>$17: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
-    <isaCheckTemp>$18 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
+    <cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$17: T::Boolean = <cfgAlias>$16: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
+    <isaCheckTemp>$17 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: Float, <magic>$11: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: Float):
     <cfgAlias>$6: T.class_of(String) = alias <C String>
     keep_for_ide$5: T.class_of(String) = <cfgAlias>$6
     keep_for_ide$5: T.untyped = <keep-alive> keep_for_ide$5
@@ -841,36 +839,36 @@ bb4[firstDead=-1](<self>: Float, <magic>$11: T.class_of(<Magic>)):
 # - bb4
 # - bb7
 # - bb8
-bb6[firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$26: T.nilable(TrueClass)):
-    <cfgAlias>$13: T.class_of(T) = alias <C T>
-    <rescueTemp>$2: T.untyped = <cfgAlias>$13: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
-    <cfgAlias>$30: T.class_of(Float) = alias <C Float>
-    keep_for_ide$29: T.class_of(Float) = <cfgAlias>$30
-    keep_for_ide$29: T.untyped = <keep-alive> keep_for_ide$29
-    <castTemp>$31: T.any(Float, String, Integer) = <self>
-    <self>: Float = cast(<castTemp>$31: T.any(Float, String, Integer), Float);
-    <cfgAlias>$33: T.class_of(T) = alias <C T>
-    <throwAwayTemp>$27: Float = <cfgAlias>$33: T.class_of(T).reveal_type(<self>: Float)
-    <gotoDeadTemp>$26 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$25: T.nilable(TrueClass)):
+    <cfgAlias>$12: T.class_of(T) = alias <C T>
+    <rescueTemp>$2: T.untyped = <cfgAlias>$12: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
+    <cfgAlias>$29: T.class_of(Float) = alias <C Float>
+    keep_for_ide$28: T.class_of(Float) = <cfgAlias>$29
+    keep_for_ide$28: T.untyped = <keep-alive> keep_for_ide$28
+    <castTemp>$30: T.any(Float, String, Integer) = <self>
+    <self>: Float = cast(<castTemp>$30: T.any(Float, String, Integer), Float);
+    <cfgAlias>$32: T.class_of(T) = alias <C T>
+    <throwAwayTemp>$26: Float = <cfgAlias>$32: T.class_of(T).reveal_type(<self>: Float)
+    <gotoDeadTemp>$25 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: T.any(Float, String), <exceptionValue>$3: StandardError, <magic>$11: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: T.any(Float, String), <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$15: Sorbet::Private::Static::Void = <magic>$11: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
-    <cfgAlias>$21: T.class_of(Integer) = alias <C Integer>
-    keep_for_ide$20: T.class_of(Integer) = <cfgAlias>$21
-    keep_for_ide$20: T.untyped = <keep-alive> keep_for_ide$20
-    <castTemp>$22: T.any(Float, String) = <self>
-    <self>: Integer = cast(<castTemp>$22: T.any(Float, String), Integer);
-    <cfgAlias>$24: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: Integer = <cfgAlias>$24: T.class_of(T).reveal_type(<self>: Integer)
+    <keepForCfgTemp>$14: T.untyped = <keep-alive> <exceptionValue>$3
+    <cfgAlias>$20: T.class_of(Integer) = alias <C Integer>
+    keep_for_ide$19: T.class_of(Integer) = <cfgAlias>$20
+    keep_for_ide$19: T.untyped = <keep-alive> keep_for_ide$19
+    <castTemp>$21: T.any(Float, String) = <self>
+    <self>: Integer = cast(<castTemp>$21: T.any(Float, String), Integer);
+    <cfgAlias>$23: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: Integer = <cfgAlias>$23: T.class_of(T).reveal_type(<self>: Integer)
     <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
-    <gotoDeadTemp>$26: TrueClass = true
+    <gotoDeadTemp>$25: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
@@ -887,7 +885,6 @@ bb0[firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
     <cfgAlias>$5: T.class_of(T) = alias <C T>
     <statTemp>$3: Rescues = <cfgAlias>$5: T.class_of(T).reveal_type(<self>: Rescues)
-    <magic>$15: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$7: T.nilable(Exception) = <get-current-exception>
     <self>: String = cast(<castTemp>$11: NilClass, String);
     <exceptionValue>$7 -> (T.nilable(Exception) ? bb3 : bb4)
@@ -903,14 +900,14 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: Exception, <magic>$15: T.class_of(<Magic>)):
-    <cfgAlias>$18: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$19: T::Boolean = <cfgAlias>$18: T.class_of(StandardError).===(<exceptionValue>$7: Exception)
-    <isaCheckTemp>$19 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: Exception):
+    <cfgAlias>$17: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$18: T::Boolean = <cfgAlias>$17: T.class_of(StandardError).===(<exceptionValue>$7: Exception)
+    <isaCheckTemp>$18 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](<self>: String, <magic>$15: T.class_of(<Magic>)):
+bb4[firstDead=-1](<self>: String):
     <cfgAlias>$10: T.class_of(String) = alias <C String>
     keep_for_ide$9: T.class_of(String) = <cfgAlias>$10
     keep_for_ide$9: T.untyped = <keep-alive> keep_for_ide$9
@@ -923,23 +920,23 @@ bb4[firstDead=-1](<self>: String, <magic>$15: T.class_of(<Magic>)):
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: String, <gotoDeadTemp>$23: NilClass):
-    <gotoDeadTemp>$23 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=-1](<returnMethodTemp>$2: String, <gotoDeadTemp>$22: NilClass):
+    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](<self>: String, <exceptionValue>$7: StandardError, <magic>$15: T.class_of(<Magic>)):
+bb7[firstDead=-1](<self>: String, <exceptionValue>$7: StandardError):
     <exceptionValue>$7: NilClass = nil
-    <keepForCfgTemp>$16: Sorbet::Private::Static::Void = <magic>$15: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$7: NilClass)
-    <cfgAlias>$21: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: String = <cfgAlias>$21: T.class_of(T).reveal_type(<self>: String)
-    <gotoDeadTemp>$23 -> (NilClass ? bb1 : bb9)
+    <keepForCfgTemp>$15: T.untyped = <keep-alive> <exceptionValue>$7
+    <cfgAlias>$20: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: String = <cfgAlias>$20: T.class_of(T).reveal_type(<self>: String)
+    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.nilable(String)):
-    <gotoDeadTemp>$23: TrueClass = true
-    <gotoDeadTemp>$23 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$22: TrueClass = true
+    <gotoDeadTemp>$22 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -970,7 +967,7 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb13
-bb2[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$25: NilClass):
+bb2[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
@@ -983,10 +980,9 @@ bb3[firstDead=2](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRe
 
 # backedges
 # - bb2
-bb5[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$25: NilClass):
+bb5[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
     <self>: T.class_of(Rescues) = loadSelf(takes_block)
-    <magic>$17: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$9: T.nilable(Exception) = <get-current-exception>
     <self>: Integer = cast(<castTemp>$13: NilClass, Integer);
     <exceptionValue>$9 -> (T.nilable(Exception) ? bb7 : bb8)
@@ -994,15 +990,15 @@ bb5[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::
 # backedges
 # - bb5
 # - bb8
-bb7[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: Exception, <castTemp>$13: T.nilable(Integer), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
+bb7[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: Exception, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
-    <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$21: T::Boolean = <cfgAlias>$20: T.class_of(StandardError).===(<exceptionValue>$9: Exception)
-    <isaCheckTemp>$21 -> (T::Boolean ? bb11 : bb12)
+    <cfgAlias>$19: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$20: T::Boolean = <cfgAlias>$19: T.class_of(StandardError).===(<exceptionValue>$9: Exception)
+    <isaCheckTemp>$20 -> (T::Boolean ? bb11 : bb12)
 
 # backedges
 # - bb5
-bb8[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
+bb8[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
     <cfgAlias>$12: T.class_of(Integer) = alias <C Integer>
     keep_for_ide$11: T.class_of(Integer) = <cfgAlias>$12
@@ -1016,34 +1012,34 @@ bb8[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Sta
 
 # backedges
 # - bb8
-bb10[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: Integer, <gotoDeadTemp>$25: NilClass):
+bb10[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: Integer, <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
-    <gotoDeadTemp>$25 -> (NilClass ? bb1 : bb13)
+    <gotoDeadTemp>$24 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
-bb11[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <exceptionValue>$9: StandardError, <castTemp>$13: T.nilable(Integer), <magic>$17: T.class_of(<Magic>), <gotoDeadTemp>$25: NilClass):
+bb11[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <exceptionValue>$9: StandardError, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
     <exceptionValue>$9: NilClass = nil
-    <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$9: NilClass)
-    <cfgAlias>$23: T.class_of(T) = alias <C T>
-    <blockReturnTemp>$8: Integer = <cfgAlias>$23: T.class_of(T).reveal_type(<self>: Integer)
-    <gotoDeadTemp>$25 -> (NilClass ? bb1 : bb13)
+    <keepForCfgTemp>$17: T.untyped = <keep-alive> <exceptionValue>$9
+    <cfgAlias>$22: T.class_of(T) = alias <C T>
+    <blockReturnTemp>$8: Integer = <cfgAlias>$22: T.class_of(T).reveal_type(<self>: Integer)
+    <gotoDeadTemp>$24 -> (NilClass ? bb1 : bb13)
 
 # backedges
 # - bb7
 bb12[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <castTemp>$13: T.nilable(Integer)):
     # outerLoops: 1
-    <gotoDeadTemp>$25: TrueClass = true
-    <gotoDeadTemp>$25 -> (TrueClass ? bb1 : bb13)
+    <gotoDeadTemp>$24: TrueClass = true
+    <gotoDeadTemp>$24 -> (TrueClass ? bb1 : bb13)
 
 # backedges
 # - bb10
 # - bb11
 # - bb12
-bb13[firstDead=1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$25: NilClass):
+bb13[firstDead=1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
-    <blockReturnTemp>$27: T.noreturn = blockreturn<takes_block> <blockReturnTemp>$8: Integer
+    <blockReturnTemp>$26: T.noreturn = blockreturn<takes_block> <blockReturnTemp>$8: Integer
     <unconditional> -> bb2
 
 }

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -18,7 +18,6 @@ bb0[firstDead=-1]():
     <self>: ModuleMethods = cast(<self>: NilClass, ModuleMethods);
     final_attempt: T.untyped = load_arg(final_attempt)
     foo: T.untyped = load_arg(foo)
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb4)
 
@@ -33,36 +32,36 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: Exception, <magic>$5: T.class_of(<Magic>)):
-    <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
-    <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
+bb3[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: Exception):
+    <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
+    <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
 # - bb0
-bb4[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>)):
+bb4[firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: NilClass, <gotoDeadTemp>$10: NilClass):
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+bb6[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: NilClass, <gotoDeadTemp>$9: NilClass):
+    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
-bb7[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: StandardError, <magic>$5: T.class_of(<Magic>)):
+bb7[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: StandardError):
     e: StandardError = <exceptionValue>$4
     <exceptionValue>$4: NilClass = nil
-    <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$4
     err: StandardError = e
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb8[firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
-    <gotoDeadTemp>$10: TrueClass = true
-    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
+    <gotoDeadTemp>$9: TrueClass = true
+    <gotoDeadTemp>$9 -> (TrueClass ? bb1 : bb9)
 
 # backedges
 # - bb6
@@ -88,8 +87,8 @@ bb11[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: StandardError,
 # - bb10
 # - bb11
 bb13[firstDead=-1](is_successful: T::Boolean, ||$2: T.untyped):
-    <ifTemp>$14: T.untyped = ||$2
-    <ifTemp>$14 -> (T.untyped ? bb19 : bb20)
+    <ifTemp>$13: T.untyped = ||$2
+    <ifTemp>$13 -> (T.untyped ? bb19 : bb20)
 
 # backedges
 # - bb10
@@ -100,22 +99,22 @@ bb14[firstDead=-1](foo: T.untyped, err: StandardError, is_successful: FalseClass
 # backedges
 # - bb14
 bb15[firstDead=-1](foo: T.untyped, is_successful: FalseClass):
-    <ifTemp>$14: T.untyped = foo
-    <ifTemp>$14 -> (T.untyped ? bb19 : bb20)
+    <ifTemp>$13: T.untyped = foo
+    <ifTemp>$13 -> (T.untyped ? bb19 : bb20)
 
 # backedges
 # - bb14
 bb16[firstDead=0](err: StandardError, is_successful: FalseClass):
-    <ifTemp>$14 = err
-    <ifTemp>$14 -> (<nullptr> ? bb19 : bb20)
+    <ifTemp>$13 = err
+    <ifTemp>$13 -> (<nullptr> ? bb19 : bb20)
 
 # backedges
 # - bb13
 # - bb15
 # - bb16
 bb19[firstDead=-1](is_successful: T::Boolean):
-    <ifTemp>$19: T::Boolean = is_successful: T::Boolean.!()
-    <ifTemp>$19 -> (T::Boolean ? bb21 : bb22)
+    <ifTemp>$18: T::Boolean = is_successful: T::Boolean.!()
+    <ifTemp>$18 -> (T::Boolean ? bb21 : bb22)
 
 # backedges
 # - bb13


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have this special `<Magic>.<keep-for-cfg>` method that we call to ensure that certain exception-related values don't get deleted from the CFG.  After #5823 , we have enough tools in the CFG itself that we don't need to create `cfg::Send` instructions, which should make things slightly smaller overall and slightly faster -- you can see in the `.exp` changes that we have fewer incoming variables to blocks in some cases (though exception-handling blocks are relatively uncommon...).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
