### PR TITLE
remove public tagged pointer APIs from `ExpressionPtr`

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -136,10 +136,6 @@ public:
 
     ExpressionPtr(std::nullptr_t) noexcept : ExpressionPtr() {}
 
-    // Construction from a tagged pointer. This is needed for:
-    // * ResolveConstantsWalk::isFullyResolved
-    explicit ExpressionPtr(tagged_storage ptr) : ptr(ptr) {}
-
     ~ExpressionPtr() {
         if (ptr != 0) {
             deleteTagged(tag(), get());
@@ -188,12 +184,6 @@ public:
     void *get() const noexcept {
         auto val = ptr & PTR_MASK;
         return reinterpret_cast<void *>(val >> 16);
-    }
-
-    // Fetch the tagged pointer. This is needed for:
-    // * ResolveConstantsWalk::isFullyResolved
-    tagged_storage getTagged() const noexcept {
-        return ptr;
     }
 
     explicit operator bool() const noexcept {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -295,18 +295,14 @@ private:
     public:
         bool seenUnresolved = false;
 
-        void postTransformConstantLit(core::Context ctx, ast::ExpressionPtr &tree) {
-            auto &original = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
+        void postTransformConstantLit(core::Context ctx, const ast::ConstantLit &original) {
             seenUnresolved |= !isAlreadyResolved(ctx, original);
         };
     };
 
     static bool isFullyResolved(core::Context ctx, const ast::ExpressionPtr &expression) {
         ResolutionChecker checker;
-        ast::ExpressionPtr dummy(expression.getTagged());
-        ast::TreeWalk::apply(ctx, checker, dummy);
-        ENFORCE(dummy == expression);
-        dummy.release();
+        ast::ConstTreeWalk::apply(ctx, checker, expression);
         return !checker.seenUnresolved;
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We no longer need this now that we have `TreeWalk`/`ConstTreeWalk` in lieu of the `TreeMap` style of walking the AST.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I am pretty confident this is correct because I got the signature for `postTransformConstantLit` wrong at first and got test failures.