### PR TITLE
do visibility propagation in-place

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -319,14 +319,14 @@ public:
         setPackageLocs(ctx, original.name.loc(), original.symbol);
     }
 
-    static ast::ParsedFile run(core::GlobalState &gs, ast::ParsedFile f) {
+    static void run(core::GlobalState &gs, ast::ParsedFile &f) {
         if (!f.file.data(gs).isPackage()) {
-            return f;
+            return;
         }
 
         auto pkgName = gs.packageDB().getPackageNameForFile(f.file);
         if (!pkgName.exists()) {
-            return f;
+            return;
         }
 
         const auto &package = gs.packageDB().getPackageInfo(pkgName);
@@ -356,8 +356,6 @@ public:
                 pass.recursiveExportSymbol(gs, true, pkgTestRoot);
             }
         }
-
-        return f;
     }
 };
 
@@ -636,7 +634,7 @@ std::vector<ast::ParsedFile> VisibilityChecker::run(core::GlobalState &gs, Worke
     {
         Timer timeit(gs.tracer(), "visibility_checker.propagate_visibility");
         for (auto &f : files) {
-            f = PropagateVisibility::run(gs, std::move(f));
+            PropagateVisibility::run(gs, f);
         }
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It is epsilon faster to do this all in place rather than move the `ParsedFile` into a temporary object, only to move the temporary object back into the original location.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
