### PR TITLE
Remove the nullptr reference in the cfg::Send constructor

### DIFF
--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -119,9 +119,10 @@ string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) 
 }
 
 Send::Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-           const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk)
+           const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk,
+           const shared_ptr<core::SendAndBlockLink> &link)
     : isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
-      argLocs(std::move(argLocs)), link(nullptr) {
+      argLocs(std::move(argLocs)), link(move(link)) {
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
             args.size());
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -119,10 +119,9 @@ string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) 
 }
 
 Send::Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-           const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk,
-           const shared_ptr<core::SendAndBlockLink> &link)
+           const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk)
     : isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
-      argLocs(std::move(argLocs)), link(move(link)) {
+      argLocs(std::move(argLocs)), link(nullptr) {
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
             args.size());
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -120,7 +120,7 @@ string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) 
 
 Send::Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
            const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk,
-           const shared_ptr<core::SendAndBlockLink> &link)
+           shared_ptr<core::SendAndBlockLink> link)
     : isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
       argLocs(std::move(argLocs)), link(move(link)) {
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -120,15 +120,8 @@ public:
     std::shared_ptr<core::SendAndBlockLink> link;
 
     Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-         const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs,
-         bool isPrivateOk = false);
-
-    Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-         const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk,
-         const std::shared_ptr<core::SendAndBlockLink> &link)
-        : Send(recv, receiverLoc, fun, funLoc, numPosArgs, args, std::move(argLocs), isPrivateOk) {
-        this->link = link;
-    }
+         const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk = false,
+         const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
 
     core::LocOffsets locWithoutBlock(core::LocOffsets bindLoc);
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -99,7 +99,7 @@ INSN(SolveConstraint) : public Instruction {
 public:
     LocalRef send;
     std::shared_ptr<core::SendAndBlockLink> link;
-    SolveConstraint(const std::shared_ptr<core::SendAndBlockLink> &link, LocalRef send) : send(send), link(link) {
+    SolveConstraint(std::shared_ptr<core::SendAndBlockLink> link, LocalRef send) : send(send), link(std::move(link)) {
         categoryCounterInc("cfg", "solveconstraint");
     };
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
@@ -121,7 +121,7 @@ public:
 
     Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
          const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk = false,
-         const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
+         std::shared_ptr<core::SendAndBlockLink> link = nullptr);
 
     core::LocOffsets locWithoutBlock(core::LocOffsets bindLoc);
 
@@ -216,7 +216,7 @@ INSN(LoadYieldParams) : public Instruction {
 public:
     std::shared_ptr<core::SendAndBlockLink> link;
 
-    LoadYieldParams(const std::shared_ptr<core::SendAndBlockLink> &link) : link(link) {
+    LoadYieldParams(std::shared_ptr<core::SendAndBlockLink> link) : link(std::move(link)) {
         categoryCounterInc("cfg", "loadyieldparams");
     };
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -120,8 +120,15 @@ public:
     std::shared_ptr<core::SendAndBlockLink> link;
 
     Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-         const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk = false,
-         const std::shared_ptr<core::SendAndBlockLink> &link = nullptr);
+         const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs,
+         bool isPrivateOk = false);
+
+    Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
+         const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk,
+         const std::shared_ptr<core::SendAndBlockLink> &link)
+        : Send(recv, receiverLoc, fun, funLoc, numPosArgs, args, std::move(argLocs), isPrivateOk) {
+        this->link = link;
+    }
 
     core::LocOffsets locWithoutBlock(core::LocOffsets bindLoc);
 

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -59,7 +59,7 @@ public:
     CFGContext withBlockBreakTarget(LocalRef blockBreakTarget);
     CFGContext withLoopBreakTarget(LocalRef blockBreakTarget);
     CFGContext withLoopScope(BasicBlock *nextScope, BasicBlock *breakScope, bool insideRubyBlock = false);
-    CFGContext withSendAndBlockLink(const std::shared_ptr<core::SendAndBlockLink> &link);
+    CFGContext withSendAndBlockLink(std::shared_ptr<core::SendAndBlockLink> link);
 
     LocalRef newTemporary(core::NameRef name);
 

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -210,9 +210,9 @@ CFGContext CFGContext::withLoopScope(BasicBlock *nextScope, BasicBlock *breakSco
     return ret;
 }
 
-CFGContext CFGContext::withSendAndBlockLink(const shared_ptr<core::SendAndBlockLink> &link) {
+CFGContext CFGContext::withSendAndBlockLink(shared_ptr<core::SendAndBlockLink> link) {
     auto ret = CFGContext(*this);
-    ret.link = link;
+    ret.link = std::move(link);
     return ret;
 }
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -682,32 +682,32 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                         auto newCctx = cctx.withTarget(blockrv)
                                            .withBlockBreakTarget(cctx.target)
                                            .withLoopScope(headerBlock, postBlock, true)
-                                           .withSendAndBlockLink(std::move(link));
+                                           .withSendAndBlockLink(link);
                         if (isKernelLambda(s)) {
                             newCctx.isInsideLambda = true;
                         }
                         blockLast = walk(newCctx, s.block()->body, argBlock);
-                        if (blockLast != cctx.inWhat.deadBlock()) {
-                            LocalRef dead = cctx.newTemporary(core::Names::blockReturnTemp());
+                    }
+                    if (blockLast != cctx.inWhat.deadBlock()) {
+                        LocalRef dead = cctx.newTemporary(core::Names::blockReturnTemp());
 
-                            core::LocOffsets blockReturnLoc = s.block()->loc;
-                            if (blockLast->exprs.empty() || isa_instruction<LoadSelf>(blockLast->exprs.back().value) ||
-                                isa_instruction<YieldLoadArg>(blockLast->exprs.back().value)) {
-                                auto blockEndPos = blockReturnLoc.copyEndWithZeroLength();
-                                auto endKwLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -3, 3);
-                                auto endBraceLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -1, 1);
-                                if (endKwLoc.source(cctx.ctx) == "end") {
-                                    blockReturnLoc = endKwLoc.offsets();
-                                } else if (endBraceLoc.source(cctx.ctx) == "}") {
-                                    blockReturnLoc = endBraceLoc.offsets();
-                                }
-                            } else {
-                                blockReturnLoc = blockLast->exprs.back().loc;
+                        core::LocOffsets blockReturnLoc = s.block()->loc;
+                        if (blockLast->exprs.empty() || isa_instruction<LoadSelf>(blockLast->exprs.back().value) ||
+                            isa_instruction<YieldLoadArg>(blockLast->exprs.back().value)) {
+                            auto blockEndPos = blockReturnLoc.copyEndWithZeroLength();
+                            auto endKwLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -3, 3);
+                            auto endBraceLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -1, 1);
+                            if (endKwLoc.source(cctx.ctx) == "end") {
+                                blockReturnLoc = endKwLoc.offsets();
+                            } else if (endBraceLoc.source(cctx.ctx) == "}") {
+                                blockReturnLoc = endBraceLoc.offsets();
                             }
-
-                            synthesizeExpr(blockLast, dead, blockReturnLoc,
-                                           make_insn<BlockReturn>(std::move(newCctx.link), blockrv));
+                        } else {
+                            blockReturnLoc = blockLast->exprs.back().loc;
                         }
+
+                        synthesizeExpr(blockLast, dead, blockReturnLoc,
+                                       make_insn<BlockReturn>(std::move(link), blockrv));
                     }
 
                     unconditionalJump(blockLast, headerBlock, cctx.inWhat, s.loc);


### PR DESCRIPTION
Avoid making a short-lived reference to a shared_ptr of nullptr. While our use of this was fine in context, if a refactoring were to persist that reference instead of clone the shared_ptr, we'd be referencing a temporary object that wouldn't outlive the `Send` constructor. Avoiding this case by accepting the `shared_ptr` by value makes this case impossible, and also gives control over the reference count to the caller.

I've refactored builder_walk.cc slightly to take advantage of this (and would recommend reviewing with whitespace changes turned off), as it's the only place where we're making use of the changes to how we accept `std::shared_ptr<SendAndBlocLink>` arguments. All calls stay the same, but the final use of the locally-constructed `link` pointer can be moved into the context, avoiding one final manipulation of the reference count. This is definitely not necessary, and reverting that change will keep the existing behavior exactly the same in terms of refcount manipulation.

This change is inspired by https://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/ which argues for only passing smart pointers by value when you intend to take ownership, and that's exactly what we're doing here.

### Motivation
Refactoring to avoid c++ footguns.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
