### PR TITLE
Add extra information to the incremental decision timer

### DIFF
--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -66,7 +66,8 @@ public:
         // The number of files that would be checked in the fast path.
         size_t totalChanged = 0;
 
-        // True when we should use the incremental namer.
+        // True when we should use the incremental namer, which happens if a symbol name changed and we brought in
+        // additional related files to check.
         bool useIncrementalNamer = false;
 
         // Extra files that need to be typechecked because the file mentions the name of one of the changed symbols.

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -213,14 +213,13 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
 
     result.path = TypecheckingPath::Fast;
     logger.debug("Taking fast path");
-    timeit.setTag("path_chosen", "fast");
 
     // Using the incremental name indicates that we changed a symbol that affects an unrelated file, and thus traversed
     // the file table to determine if we can still take the fast path.
     if (result.files.useIncrementalNamer) {
-        timeit.setTag("name_hashes_changed", "true");
+        timeit.setTag("path_chosen", "fast+incremental_namer");
     } else {
-        timeit.setTag("name_hashes_changed", "false");
+        timeit.setTag("path_chosen", "fast");
     }
 
     return result;

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -214,6 +214,15 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
     result.path = TypecheckingPath::Fast;
     logger.debug("Taking fast path");
     timeit.setTag("path_chosen", "fast");
+
+    // Using the incremental name indicates that we changed a symbol that affects an unrelated file, and thus traversed
+    // the file table to determine if we can still take the fast path.
+    if (result.files.useIncrementalNamer) {
+        timeit.setTag("name_hashes_changed", "true");
+    } else {
+        timeit.setTag("name_hashes_changed", "false");
+    }
+
     return result;
 }
 


### PR DESCRIPTION
Use the value of the `useIncrementalNamer` field to decide if we report the `path_chosen` as `fast+incremental_namer` or `fast`. As `useIncrementalNamer` field is set when we also traverse the whole file table, we can use it to distinguish fast path decisions that we want to keep fast (like hover or autocomplete) from fast path decisions that might pull in unrelated files.

### Motivation
Adding additional information to inform stats.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a