### PR TITLE
Refine error messages for partial overrides from `attr_accessor`

### DIFF
--- a/test/testdata/definition_validator/attr_accessor_override_error.rb
+++ b/test/testdata/definition_validator/attr_accessor_override_error.rb
@@ -1,0 +1,102 @@
+# typed: true
+
+module Fooable
+  extend T::Sig
+  extend T::Helpers
+  interface!
+
+  sig {abstract.returns(T.nilable(String))}
+  def foo; end
+end
+
+# This is incorrect: attr_accessor adds both a reader and a writer
+class BadFooable
+  extend T::Sig
+  include Fooable
+
+  sig {override.returns(T.nilable(String))}
+  attr_accessor :foo # error: Method `BadFooable#foo=` is marked `override` but the parent only defines a writer method
+end
+
+# This is correct: Separate reader and writer
+class GoodFooable
+  extend T::Sig
+  include Fooable
+
+  sig {override.returns(T.nilable(String))}
+  attr_reader :foo
+
+  sig {params(foo: T.nilable(String)).void}
+  attr_writer :foo
+end
+
+module WriterFooable
+  extend T::Sig
+  extend T::Helpers
+  interface!
+
+  sig {abstract.params(value: T.nilable(String)).void}
+  def foo=(value); end
+end
+
+# This is incorrect: attr_accessor adds both a reader and a writer
+class WriterOnlyBad # error: Missing definition for abstract method `WriterFooable#foo=` in `WriterOnlyBad`
+  extend T::Sig
+  include WriterFooable
+
+  sig {override.returns(String)}
+  attr_accessor :bar # error: Method `WriterOnlyBad#bar=` is marked `override` but the parent only defines a writer method
+# ^^^^^^^^^^^^^^^^^^ error: Method `WriterOnlyBad#bar` is marked `override` but the parent only defines a reader method
+end
+
+module PropReadable
+  extend T::Sig
+  extend T::Helpers
+  interface!
+
+  sig {abstract.returns(T.nilable(String))}
+  def prop_foo; end
+end
+
+# This is incorrect: It should error but doesn't yet because of a bug where props/const don't participate in override checking
+class BadPropReadable
+  extend T::Sig
+  include T::Props
+  include PropReadable
+  
+  prop :prop_foo, String # Should error: Method is marked `override` but the parent only defines a reader method
+end
+
+# This will be correct once props/const participate in override checking
+class GoodPropReadable
+  extend T::Sig
+  include T::Props
+  include PropReadable
+  
+  const :prop_foo, String
+end
+
+module PropWritable
+  extend T::Sig
+  extend T::Helpers
+  interface!
+
+  sig {abstract.params(value: String).void}
+  def prop_foo=(value); end
+end
+
+class BadPropWritable
+  extend T::Sig
+  include T::Props
+  include PropWritable
+  
+  prop :prop_foo, String # Should error: Method is marked `override` but the parent only defines a writer method
+end
+
+class GoodPropWritable
+  extend T::Sig
+  include T::Props
+  include PropWritable
+  
+  prop :prop_foo, String, writer: :private
+end


### PR DESCRIPTION
This PR modifies Sorbet's handling of overrides where a parent (interface, abstract class, or overridable method) defines only a reader or only a writer, but the child class uses `attr_accessor` (which creates both). We now produce **two** errors if an `attr_accessor :foo` mismatches the parent's definition. One error is for the reader side (`foo`), the other for the writer side (`foo=`). The messages mention "the parent only defines a writer method" (or "reader method"), so users clearly see **why** the override fails and **which** side is problematic. This change also makes sure that we skip override checks for UI-only synthesized methods that don’t represent actual code-level methods (flagged `isAttrBestEffortUIOnly`). 

The PR also includes a small improvement to cache `methodData` and flags, reducing repeated pointer dereferencing and slightly improving readability in the override validation flow.

### Motivation
Fixes #6312 and is a follow-up to address feedback from the previous PR #8400

### Test plan

See included automated tests. This includes `T::Props` (prop/const) tests to be forward-compatible and act as a reminder that the `attr_accessor` logic should apply to prop methods. Currently, this is blocked due to an existing bug that doesn't allow these methods to participate in override checking.