### PR TITLE
use keyword arg iteration for type inference

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -4,6 +4,7 @@
 #include "common/common.h"
 #include "core/Context.h"
 #include "core/FoundDefinitions.h"
+#include "core/KwPair.h"
 #include "core/LocalVariable.h"
 #include "core/SymbolRef.h"
 #include "core/Types.h"
@@ -889,60 +890,16 @@ public:
     // Remove all arguments to the function, including the block argument.
     void clearArgs();
 
-    template <typename PtrT> struct KwPair {
-        PtrT &key;
-        PtrT &value;
-    };
-
-    // We're going to use this type to encapsulate both the span over the kwargs,
-    // and also as the iterator type over that selfsame span.
-    template <typename PtrT> struct KwPairSpan {
-        absl::Span<PtrT> span;
-
-        KwPairSpan begin() const {
-            ENFORCE(span.size() % 2 == 0);
-
-            return KwPairSpan{span};
-        }
-
-        KwPairSpan end() const {
-            ENFORCE(span.size() % 2 == 0);
-
-            return KwPairSpan{absl::MakeSpan(span.end(), span.end())};
-        }
-
-        KwPair<PtrT> operator*() {
-            return KwPair<PtrT>{span[0], span[1]};
-        }
-
-        KwPairSpan &operator++() {
-            span = span.subspan(2);
-            return *this;
-        }
-
-        KwPairSpan operator++(int) {
-            return KwPairSpan{span.subspan(2)};
-        }
-
-        bool operator==(const KwPairSpan &other) const {
-            return span.begin() == other.span.begin();
-        }
-
-        bool operator!=(const KwPairSpan &other) const {
-            return span.begin() != other.span.begin();
-        }
-    };
-
-    KwPairSpan<ExpressionPtr> kwArgPairs() {
+    core::KwPairSpan<ExpressionPtr> kwArgPairs() {
         const auto pairs = numKwArgs();
         auto i = args.begin() + numPosArgs_;
-        return KwPairSpan<ExpressionPtr>{absl::MakeSpan(i, i + pairs * 2)};
+        return core::KwPairSpan<ExpressionPtr>{absl::MakeSpan(i, i + pairs * 2)};
     }
 
-    KwPairSpan<const ExpressionPtr> kwArgPairs() const {
+    core::KwPairSpan<const ExpressionPtr> kwArgPairs() const {
         const auto pairs = numKwArgs();
         auto i = args.begin() + numPosArgs_;
-        return KwPairSpan<const ExpressionPtr>{absl::MakeSpan(i, i + pairs * 2)};
+        return core::KwPairSpan<const ExpressionPtr>{absl::MakeSpan(i, i + pairs * 2)};
     }
 
     // Get the ith keyword argument key. Indices begin at 0, regardless of the number of positional arguments.

--- a/core/BUILD
+++ b/core/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "Names_gen.cc",
     ],
     hdrs = [
+        "KwPair.h",
         "NameSubstitution.h",
         "core.h",
     ] + glob([

--- a/core/KwPair.h
+++ b/core/KwPair.h
@@ -1,0 +1,54 @@
+#ifndef SORBET_KWPAIR_H
+#define SORBET_KWPAIR_H
+
+#include "absl/types/span.h"
+
+namespace sorbet::core {
+
+template <typename PtrT> struct KwPair {
+    PtrT &key;
+    PtrT &value;
+};
+
+// We're going to use this type to encapsulate both the span over the kwargs,
+// and also as the iterator type over that selfsame span.
+template <typename PtrT> struct KwPairSpan {
+    absl::Span<PtrT> span;
+
+    KwPairSpan begin() const {
+        ENFORCE(span.size() % 2 == 0);
+
+        return KwPairSpan{span};
+    }
+
+    KwPairSpan end() const {
+        ENFORCE(span.size() % 2 == 0);
+
+        return KwPairSpan{absl::MakeSpan(span.end(), span.end())};
+    }
+
+    KwPair<PtrT> operator*() {
+        return KwPair<PtrT>{span[0], span[1]};
+    }
+
+    KwPairSpan &operator++() {
+        span = span.subspan(2);
+        return *this;
+    }
+
+    KwPairSpan operator++(int) {
+        return KwPairSpan{span.subspan(2)};
+    }
+
+    bool operator==(const KwPairSpan &other) const {
+        return span.begin() == other.span.begin();
+    }
+
+    bool operator!=(const KwPairSpan &other) const {
+        return span.begin() != other.span.begin();
+    }
+};
+
+} // namespace sorbet::core
+
+#endif // SORBET_KWPAIR_H


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a continuation of #8379, only now we're using it in `calls.cc` to represent iteration over kwargs that aren't in the AST.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
