### PR TITLE
avoid accidentally quadratic erasing during overload resolution

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -479,26 +479,25 @@ MethodRef guessOverload(const GlobalState &gs, ClassOrModuleRef inClass, MethodR
     }
 
     { // keep only candidates that have a block iff we are passing one
-        for (auto it = leftCandidates.begin(); it != leftCandidates.end(); /* nothing*/) {
-            const auto &[candidate, _arity, constr] = *it;
+        auto it = std::remove_if(leftCandidates.begin(), leftCandidates.end(), [&gs, hasBlock](auto &c) -> bool {
+            const auto &[candidate, _arity, constr] = c;
             const auto &args = candidate.data(gs)->arguments;
             ENFORCE(!args.empty(), "Should at least have a block argument.");
             const auto &lastArg = args.back();
             auto mentionsBlockArg = !lastArg.isSyntheticBlockArgument();
             if (hasBlock) {
                 if (!mentionsBlockArg || lastArg.type == Types::nilClass()) {
-                    it = leftCandidates.erase(it);
-                    continue;
+                    return true;
                 }
             } else {
                 if (mentionsBlockArg && lastArg.type != nullptr &&
                     (!lastArg.type.isFullyDefined() || !Types::isSubType(gs, Types::nilClass(), lastArg.type))) {
-                    it = leftCandidates.erase(it);
-                    continue;
+                    return true;
                 }
             }
-            ++it;
-        }
+            return false;
+        });
+        leftCandidates.erase(it, leftCandidates.end());
     }
 
     { // keep only candidates with closest arity


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The accidental quadraticness is probably pretty small here, because we tend to not have a lot of candidates, but at the very least the code is more idiomatic now.  (And we don't have to worry about things like iterator invalidation due to erasure, etc.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
