### PR TITLE
fix memory safety issues when building the "lite" depdb

### DIFF
--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -176,7 +176,7 @@ string ParsedFile::toMsgpack(core::Context ctx, int version, const AutogenConfig
 
         return write.pack(ctx, *this, autogenCfg);
     } else {
-        MsgpackWriter write(version);
+        MsgpackWriterFull write(version);
 
         return write.pack(ctx, *this, autogenCfg);
     }
@@ -186,7 +186,7 @@ string ParsedFile::msgpackGlobalHeader(int version, size_t numFiles, const Autog
     if (autogenCfg.msgpackSkipReferenceMetadata) {
         return MsgpackWriterLite::msgpackGlobalHeader(version, numFiles);
     } else {
-        return MsgpackWriter::msgpackGlobalHeader(version, numFiles);
+        return MsgpackWriterFull::msgpackGlobalHeader(version, numFiles);
     }
 }
 

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -9,7 +9,7 @@
 using namespace std;
 namespace sorbet::autogen {
 
-void MsgpackWriter::packName(mpack_writer_t *writer, core::NameRef nm) {
+void MsgpackWriterFull::packName(mpack_writer_t *writer, core::NameRef nm) {
     uint32_t id;
     typename decltype(symbolIds)::value_type v{nm, 0};
     auto [it, inserted] = symbolIds.insert(v);
@@ -23,7 +23,7 @@ void MsgpackWriter::packName(mpack_writer_t *writer, core::NameRef nm) {
     mpack_write_u32(writer, id);
 }
 
-void MsgpackWriter::packNames(mpack_writer_t *writer, vector<core::NameRef> &names) {
+void MsgpackWriterFull::packNames(mpack_writer_t *writer, vector<core::NameRef> &names) {
     mpack_start_array(writer, names.size());
     for (auto nm : names) {
         packName(writer, nm);
@@ -35,7 +35,7 @@ void packString(mpack_writer_t *writer, string_view str) {
     mpack_write_str(writer, str.data(), str.size());
 }
 
-void MsgpackWriter::packBool(mpack_writer_t *writer, bool b) {
+void MsgpackWriterFull::packBool(mpack_writer_t *writer, bool b) {
     if (b) {
         mpack_write_true(writer);
     } else {
@@ -43,7 +43,7 @@ void MsgpackWriter::packBool(mpack_writer_t *writer, bool b) {
     }
 }
 
-void MsgpackWriter::packReferenceRef(mpack_writer_t *writer, ReferenceRef ref) {
+void MsgpackWriterFull::packReferenceRef(mpack_writer_t *writer, ReferenceRef ref) {
     if (!ref.exists()) {
         mpack_write_nil(writer);
     } else {
@@ -51,7 +51,7 @@ void MsgpackWriter::packReferenceRef(mpack_writer_t *writer, ReferenceRef ref) {
     }
 }
 
-void MsgpackWriter::packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref) {
+void MsgpackWriterFull::packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref) {
     if (!ref.exists()) {
         mpack_write_nil(writer);
     } else {
@@ -59,7 +59,7 @@ void MsgpackWriter::packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref)
     }
 }
 
-void MsgpackWriter::packRange(mpack_writer_t *writer, uint32_t begin, uint32_t end) {
+void MsgpackWriterFull::packRange(mpack_writer_t *writer, uint32_t begin, uint32_t end) {
     if (version <= 4) {
         mpack_write_u64(writer, ((uint64_t)begin << 32) | end);
     } else {
@@ -76,7 +76,7 @@ void MsgpackWriter::packRange(mpack_writer_t *writer, uint32_t begin, uint32_t e
     }
 }
 
-void MsgpackWriter::packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
+void MsgpackWriterFull::packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
                                    const AutogenConfig &autogenCfg) {
     mpack_start_array(writer, defAttrs[version].size());
 
@@ -110,7 +110,7 @@ void MsgpackWriter::packDefinition(mpack_writer_t *writer, core::Context ctx, Pa
     mpack_finish_array(writer);
 }
 
-void MsgpackWriter::packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref) {
+void MsgpackWriterFull::packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref) {
     mpack_start_array(writer, refAttrs[version].size());
 
     // scope
@@ -155,7 +155,7 @@ void MsgpackWriter::packReference(mpack_writer_t *writer, core::Context ctx, Par
     mpack_finish_array(writer);
 }
 
-MsgpackWriter::MsgpackWriter(int version)
+MsgpackWriterFull::MsgpackWriterFull(int version)
     : version(assertValidVersion(version)), refAttrs(refAttrMap.at(version)), defAttrs(defAttrMap.at(version)),
       pfAttrs(parsedFileAttrMap.at(version)) {}
 
@@ -168,7 +168,7 @@ void writeSymbols(core::Context ctx, mpack_writer_t *writer, const vector<core::
     mpack_finish_array(writer);
 }
 
-string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg) {
+string MsgpackWriterFull::pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg) {
     char *body;
     size_t bodySize;
     mpack_writer_t writer;
@@ -337,7 +337,7 @@ string buildGlobalHeader(int version, int serializedVersion, size_t numFiles, co
     return header;
 }
 
-string MsgpackWriter::msgpackGlobalHeader(int version, size_t numFiles) {
+string MsgpackWriterFull::msgpackGlobalHeader(int version, size_t numFiles) {
     const vector<string> &pfAttrs = parsedFileAttrMap.at(version);
     const vector<string> &refAttrs = refAttrMap.at(version);
     const vector<string> &defAttrs = defAttrMap.at(version);
@@ -345,7 +345,7 @@ string MsgpackWriter::msgpackGlobalHeader(int version, size_t numFiles) {
     return buildGlobalHeader(version, version, numFiles, refAttrs, defAttrs, pfAttrs);
 }
 
-const map<int, vector<string>> MsgpackWriter::parsedFileAttrMap{
+const map<int, vector<string>> MsgpackWriterFull::parsedFileAttrMap{
     {
         5,
         {
@@ -367,7 +367,7 @@ const map<int, vector<string>> MsgpackWriter::parsedFileAttrMap{
     },
 };
 
-const map<int, vector<string>> MsgpackWriter::refAttrMap{
+const map<int, vector<string>> MsgpackWriterFull::refAttrMap{
     {5,
      {
          "scope",
@@ -396,7 +396,7 @@ const map<int, vector<string>> MsgpackWriter::refAttrMap{
      }},
 };
 
-const map<int, vector<string>> MsgpackWriter::defAttrMap{
+const map<int, vector<string>> MsgpackWriterFull::defAttrMap{
     {
         5,
         {

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -82,7 +82,7 @@ void MsgpackWriterFull::packRange(mpack_writer_t *writer, uint32_t begin, uint32
 
 void MsgpackWriterFull::packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
                                        const AutogenConfig &autogenCfg) {
-    mpack_start_array(writer, defAttrs[version].size());
+    mpack_start_array(writer, defAttrs.size());
 
     // raw_full_name
     auto raw_full_name = pf.showFullName(ctx, def.id);
@@ -115,7 +115,7 @@ void MsgpackWriterFull::packDefinition(mpack_writer_t *writer, core::Context ctx
 }
 
 void MsgpackWriterFull::packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref) {
-    mpack_start_array(writer, refAttrs[version].size());
+    mpack_start_array(writer, refAttrs.size());
 
     // scope
     packDefinitionRef(writer, ref.scope.id());

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -8,7 +8,7 @@
 
 namespace sorbet::autogen {
 
-class MsgpackWriter {
+class MsgpackWriterFull {
 protected:
     int version;
     const std::vector<std::string> &refAttrs;
@@ -41,7 +41,7 @@ protected:
     }
 
 public:
-    MsgpackWriter(int version);
+    MsgpackWriterFull(int version);
 
     static std::string msgpackGlobalHeader(int version, size_t numFiles);
     virtual std::string pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg);
@@ -49,7 +49,7 @@ public:
 
 // Lightweight version of writer that skips all reference metadata like expression ranges, inheritance information,
 // typing information, etc. Reduces size by ~37% for Stripe code.
-class MsgpackWriterLite : public MsgpackWriter {
+class MsgpackWriterLite : public MsgpackWriterFull {
 private:
     int version;
     const std::vector<std::string> &refAttrs;

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -8,7 +8,7 @@
 
 namespace sorbet::autogen {
 
-class MsgpackWriterFull {
+class MsgpackWriterBase {
 protected:
     int version;
     const std::vector<std::string> &refAttrs;
@@ -18,14 +18,25 @@ protected:
     std::vector<core::NameRef> symbols;
     UnorderedMap<core::NameRef, uint32_t> symbolIds;
 
+    void packName(mpack_writer_t *writer, core::NameRef nm);
+    void packNames(mpack_writer_t *writer, std::vector<core::NameRef> &names);
+    void packBool(mpack_writer_t *writer, bool b);
+
+    virtual void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
+                                const AutogenConfig &autogenCfg) = 0;
+    virtual void packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref) = 0;
+
+    MsgpackWriterBase(int version, const std::vector<std::string> &refAttrs, const std::vector<std::string> &defAttrs,
+                      const std::vector<std::string> &pfAttrs);
+};
+
+class MsgpackWriterFull : public MsgpackWriterBase {
+protected:
     static const std::map<int, std::vector<std::string>> refAttrMap;
     static const std::map<int, std::vector<std::string>> defAttrMap;
     static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
 
     // a bunch of helpers
-    void packName(mpack_writer_t *writer, core::NameRef nm);
-    void packNames(mpack_writer_t *writer, std::vector<core::NameRef> &names);
-    void packBool(mpack_writer_t *writer, bool b);
     void packReferenceRef(mpack_writer_t *writer, ReferenceRef ref);
     void packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref);
     void packRange(mpack_writer_t *writer, uint32_t begin, uint32_t end);
@@ -49,13 +60,8 @@ public:
 
 // Lightweight version of writer that skips all reference metadata like expression ranges, inheritance information,
 // typing information, etc. Reduces size by ~37% for Stripe code.
-class MsgpackWriterLite : public MsgpackWriterFull {
+class MsgpackWriterLite : public MsgpackWriterBase {
 private:
-    int version;
-    const std::vector<std::string> &refAttrs;
-    const std::vector<std::string> &defAttrs;
-    const std::vector<std::string> &pfAttrs;
-
     static const std::map<int, std::vector<std::string>> refAttrMap;
     static const std::map<int, std::vector<std::string>> defAttrMap;
     static const std::map<int, std::vector<std::string>> parsedFileAttrMap;

--- a/main/autogen/data/msgpack_lite.cc
+++ b/main/autogen/data/msgpack_lite.cc
@@ -11,7 +11,7 @@ namespace sorbet::autogen {
 
 void MsgpackWriterLite::packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
                                        const AutogenConfig &autogenCfg) {
-    mpack_start_array(writer, defAttrs[version].size());
+    mpack_start_array(writer, defAttrs.size());
 
     // raw_full_name
     auto raw_full_name = pf.showFullName(ctx, def.id);
@@ -29,7 +29,7 @@ void MsgpackWriterLite::packDefinition(mpack_writer_t *writer, core::Context ctx
 }
 
 void MsgpackWriterLite::packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref) {
-    mpack_start_array(writer, refAttrs[version].size());
+    mpack_start_array(writer, refAttrs.size());
 
     // name
     packNames(writer, ref.name.nameParts);

--- a/main/autogen/data/msgpack_lite.cc
+++ b/main/autogen/data/msgpack_lite.cc
@@ -47,8 +47,8 @@ void MsgpackWriterLite::packReference(mpack_writer_t *writer, core::Context ctx,
 }
 
 MsgpackWriterLite::MsgpackWriterLite(int version)
-    : MsgpackWriterFull(version), version(assertValidVersion(version)), refAttrs(refAttrMap.at(version)),
-      defAttrs(defAttrMap.at(version)), pfAttrs(parsedFileAttrMap.at(version)) {}
+    : MsgpackWriterBase(assertValidVersion(version), refAttrMap.at(version), defAttrMap.at(version),
+                        parsedFileAttrMap.at(version)) {}
 
 string MsgpackWriterLite::pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg) {
     char *body;

--- a/main/autogen/data/msgpack_lite.cc
+++ b/main/autogen/data/msgpack_lite.cc
@@ -47,7 +47,7 @@ void MsgpackWriterLite::packReference(mpack_writer_t *writer, core::Context ctx,
 }
 
 MsgpackWriterLite::MsgpackWriterLite(int version)
-    : MsgpackWriter(version), version(assertValidVersion(version)), refAttrs(refAttrMap.at(version)),
+    : MsgpackWriterFull(version), version(assertValidVersion(version)), refAttrs(refAttrMap.at(version)),
       defAttrs(defAttrMap.at(version)), pfAttrs(parsedFileAttrMap.at(version)) {}
 
 string MsgpackWriterLite::pack(core::Context ctx, ParsedFile &pf, const AutogenConfig &autogenCfg) {

--- a/test/cli/autogen-msgpack-lite/file_with_no_dot
+++ b/test/cli/autogen-msgpack-lite/file_with_no_dot
@@ -1,0 +1,10 @@
+# typed: true
+
+require_relative 'hotdog_generator'
+require_relative 'hotdog_consumer'
+
+puts 'This is indeed a ruby file'
+
+hotdogs = 5.times.flat_map { HotdogGenerator.make_hotdogs }
+
+HotdogConsumer.eat(hotdogs)

--- a/test/cli/autogen-msgpack-lite/hotdog_consumer.rb
+++ b/test/cli/autogen-msgpack-lite/hotdog_consumer.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+module HotdogConsumer
+  def self.eat(hotdogs); end
+end

--- a/test/cli/autogen-msgpack-lite/hotdog_generator.rb
+++ b/test/cli/autogen-msgpack-lite/hotdog_generator.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+module HotdogGenerator
+  def self.make_hotdogs; end
+end

--- a/test/cli/autogen-msgpack-lite/test.out
+++ b/test/cli/autogen-msgpack-lite/test.out
@@ -1,5 +1,5 @@
 --- autogen.txt start ---
-# ParsedFile: test/cli/autogen-path-prefix/file_with_no_dot
+# ParsedFile: test/cli/autogen-msgpack-lite/file_with_no_dot
 requires: []
 ## defs:
 [def id=0]
@@ -12,16 +12,16 @@ requires: []
  name=[HotdogGenerator]
  nesting=[]
  resolved=[HotdogGenerator]
- loc=autogen-path-prefix/file_with_no_dot:8
+ loc=autogen-msgpack-lite/file_with_no_dot:8
  is_defining_ref=0
 [ref id=1]
  scope=[]
  name=[HotdogConsumer]
  nesting=[]
  resolved=[HotdogConsumer]
- loc=autogen-path-prefix/file_with_no_dot:10
+ loc=autogen-msgpack-lite/file_with_no_dot:10
  is_defining_ref=0
-# ParsedFile: test/cli/autogen-path-prefix/hotdog_consumer.rb
+# ParsedFile: test/cli/autogen-msgpack-lite/hotdog_consumer.rb
 requires: []
 ## defs:
 [def id=0]
@@ -39,9 +39,9 @@ requires: []
  name=[HotdogConsumer]
  nesting=[]
  resolved=[HotdogConsumer]
- loc=autogen-path-prefix/hotdog_consumer.rb:3
+ loc=autogen-msgpack-lite/hotdog_consumer.rb:3
  is_defining_ref=1
-# ParsedFile: test/cli/autogen-path-prefix/hotdog_generator.rb
+# ParsedFile: test/cli/autogen-msgpack-lite/hotdog_generator.rb
 requires: []
 ## defs:
 [def id=0]
@@ -59,8 +59,8 @@ requires: []
  name=[HotdogGenerator]
  nesting=[]
  resolved=[HotdogGenerator]
- loc=autogen-path-prefix/hotdog_generator.rb:3
+ loc=autogen-msgpack-lite/hotdog_generator.rb:3
  is_defining_ref=1
 --- autogen.txt end ---
 
-6dbf3772d0c8000f9c773ab3bd0e5923c27d241a  autogen.msgpack
+c92b078e975a7a6676387c9416d9af62c6e86213  autogen.msgpack

--- a/test/cli/autogen-msgpack-lite/test.out
+++ b/test/cli/autogen-msgpack-lite/test.out
@@ -1,0 +1,66 @@
+--- autogen.txt start ---
+# ParsedFile: test/cli/autogen-path-prefix/file_with_no_dot
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+## refs:
+[ref id=0]
+ scope=[]
+ name=[HotdogGenerator]
+ nesting=[]
+ resolved=[HotdogGenerator]
+ loc=autogen-path-prefix/file_with_no_dot:8
+ is_defining_ref=0
+[ref id=1]
+ scope=[]
+ name=[HotdogConsumer]
+ nesting=[]
+ resolved=[HotdogConsumer]
+ loc=autogen-path-prefix/file_with_no_dot:10
+ is_defining_ref=0
+# ParsedFile: test/cli/autogen-path-prefix/hotdog_consumer.rb
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+[def id=1]
+ type=module
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[HotdogConsumer]
+## refs:
+[ref id=0]
+ scope=[]
+ name=[HotdogConsumer]
+ nesting=[]
+ resolved=[HotdogConsumer]
+ loc=autogen-path-prefix/hotdog_consumer.rb:3
+ is_defining_ref=1
+# ParsedFile: test/cli/autogen-path-prefix/hotdog_generator.rb
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+[def id=1]
+ type=module
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[HotdogGenerator]
+## refs:
+[ref id=0]
+ scope=[]
+ name=[HotdogGenerator]
+ nesting=[]
+ resolved=[HotdogGenerator]
+ loc=autogen-path-prefix/hotdog_generator.rb:3
+ is_defining_ref=1
+--- autogen.txt end ---
+
+6dbf3772d0c8000f9c773ab3bd0e5923c27d241a  autogen.msgpack

--- a/test/cli/autogen-msgpack-lite/test.sh
+++ b/test/cli/autogen-msgpack-lite/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eu
+
+main/sorbet --silence-dev-message --stop-after namer --autogen-version=6 \
+  -p autogen:autogen.txt -p autogen-msgpack:autogen.msgpack \
+  --autogen-msgpack-skip-reference-metadata \
+  --remove-path-prefix=test/cli/ \
+  test/cli/autogen-msgpack-lite \
+  test/cli/autogen-msgpack-lite/file_with_no_dot
+
+echo "--- autogen.txt start ---"
+cat autogen.txt
+echo "--- autogen.txt end ---"
+echo
+
+shasum autogen.msgpack
+

--- a/test/cli/autogen-path-prefix/test.out
+++ b/test/cli/autogen-path-prefix/test.out
@@ -63,4 +63,4 @@ requires: []
  is_defining_ref=1
 --- autogen.txt end ---
 
-6dbf3772d0c8000f9c773ab3bd0e5923c27d241a  autogen.msgpack
+c3d836ba9bc0b495f1febba8e83859935dcc1d6d  autogen.msgpack

--- a/test/cli/autogen_print_rbi/test.out
+++ b/test/cli/autogen_print_rbi/test.out
@@ -105,4 +105,4 @@ requires: []
  loc=test/cli/autogen_print_rbi/behavior_allowed.rbi:4
  is_defining_ref=1
 
-3edd3bac9519dd6fb62387f94cf4eeac0ff5d33e  autogen5.msgpack
+d359e4247f922bc0b467303a673e13ddb3e74fb1  autogen5.msgpack

--- a/test/cli/print_to_file_v5/test.out
+++ b/test/cli/print_to_file_v5/test.out
@@ -252,6 +252,6 @@ requires: []
  is_defining_ref=0
 --- autogen.txt end ---
 
-1e04100ab5481a15bb7d1cc185ce7169fcc3c917  autogen.msgpack
+aa766e0bd51761b7b3f5bd2130538f16b1335308  autogen.msgpack
 
 --print=cfg specified multiple times with inconsistent output options


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were seeing non-deterministic generation of the "lite" depdb at Stripe, which we eventually traced down to the two `mpack_start_array` calls when serializing defs and refs.  The actual lengths written in these calls are not actually used by any of the depdb consumers we have; the arrays here are artifacts of an earlier day when we thought the depdb could be parsed entirely with information stored in the depdb itself.  (Unfortunately, that proved too slow, and now all our parsing code is specialized on the version of the depdb, with fixed readers for all the interesting fields.)

Hold that thought, we'll come back to it.

I added a test for writing the "lite" depdb because we didn't have one.  I don't think the stacks here are any good, but you can see that something is going badly wrong:

https://buildkite.com/sorbet/sorbet/builds/33994#019461bb-7c0d-4851-b860-f4b2e8b0b3d1

I initially thought that maybe there was some weirdness in C++ name lookup, because `MsgpackWriterLite` has the same field names as its parent class...and initializes them in basically the same way.  So I refactored everything into a proper base class to convince myself that weird C++ name lookup rules were not the problem.

Unfortunately, that failed in roughly the same way:

https://buildkite.com/sorbet/sorbet/builds/33995#019461ca-d6ff-4c8a-a878-e60ac15ed497

which led to not indexing off the end of the vector of attribute names that we're storing. 🤦‍♂️ 

So we didn't need the refactor, but IMHO it's a nice cleanup.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
