### PR TITLE
convert autogen to use `ConstTreeWalk`

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -348,7 +348,7 @@ public:
             def.type = Definition::Type::Alias;
             // since this is a `post`- method, then we've already created a `Reference` for the constant on the
             // RHS. Mark this `Definition` as an alias for it.
-            ENFORCE(!refMap.empty(rhs));
+            ENFORCE(!refMap.empty());
             def.aliased_ref = refMap[rhs];
         } else if (lhs->symbol.exists() && lhs->symbol.isTypeAlias(ctx)) {
             // if the LHS has already been annotated as a type alias by the namer, the definition is (by definition,
@@ -361,7 +361,7 @@ public:
 
         // We also should already have a `Reference` for the name of this constant (because this is running after the
         // pre-traversal of the constant) so find that
-        ENFORCE(!refMap.empty(lhs));
+        ENFORCE(!refMap.empty());
         auto &ref = refs[refMap[lhs].id()];
         // ...and mark that this is the defining ref for that one
         def.defining_ref = ref.id;

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -348,7 +348,7 @@ public:
             def.type = Definition::Type::Alias;
             // since this is a `post`- method, then we've already created a `Reference` for the constant on the
             // RHS. Mark this `Definition` as an alias for it.
-            ENFORCE(refMap.count(rhs));
+            ENFORCE(!refMap.empty(rhs));
             def.aliased_ref = refMap[rhs];
         } else if (lhs->symbol.exists() && lhs->symbol.isTypeAlias(ctx)) {
             // if the LHS has already been annotated as a type alias by the namer, the definition is (by definition,
@@ -361,7 +361,7 @@ public:
 
         // We also should already have a `Reference` for the name of this constant (because this is running after the
         // pre-traversal of the constant) so find that
-        ENFORCE(refMap.count(lhs));
+        ENFORCE(!refMap.empty(lhs));
         auto &ref = refs[refMap[lhs].id()];
         // ...and mark that this is the defining ref for that one
         def.defining_ref = ref.id;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Tidiness, `const`-ness, etc. etc.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
