### PR TITLE
add a `--web-trace-file-strict` option for producing valid JSON

### DIFF
--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -198,9 +198,8 @@ bool Tracing::storeTraces(const CounterState &counters, const string &fileName, 
     // continually append new entries to the file.
     if (strict) {
         result.Put(']');
-    } else {
-        result.Put('\n');
     }
+    result.Put('\n');
 
     FileOps::append(fileName, result.GetString());
     return true;

--- a/common/web_tracer_framework/tracing.cc
+++ b/common/web_tracer_framework/tracing.cc
@@ -36,7 +36,7 @@ void endLine(rapidjson::StringBuffer &result, rapidjson::Writer<rapidjson::Strin
 
 // Super rudimentary support for outputting trace files in Google's Trace Event Format
 // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
-bool Tracing::storeTraces(const CounterState &counters, const string &fileName) {
+bool Tracing::storeTraces(const CounterState &counters, const string &fileName, bool strict) {
     rapidjson::StringBuffer result;
     rapidjson::Writer<rapidjson::StringBuffer> writer(result);
 
@@ -193,8 +193,14 @@ bool Tracing::storeTraces(const CounterState &counters, const string &fileName) 
         endLine(result, writer);
     }
 
-    // Explicitly don't put matching closing ], so that we can open it up and start appending to it if it exists.
-    result.Put('\n');
+    // Strict generation is useful when generating this file for non-Perfetto tools; non-strict
+    // is useful for general forgetfulness and for doing tracing when LSP is active, as LSP will
+    // continually append new entries to the file.
+    if (strict) {
+        result.Put(']');
+    } else {
+        result.Put('\n');
+    }
 
     FileOps::append(fileName, result.GetString());
     return true;

--- a/common/web_tracer_framework/tracing.h
+++ b/common/web_tracer_framework/tracing.h
@@ -8,7 +8,7 @@ class Tracing {
 public:
     Tracing() = delete;
 
-    static bool storeTraces(const CounterState &counters, const std::string &fileName);
+    static bool storeTraces(const CounterState &counters, const std::string &fileName, bool strict = false);
 };
 } // namespace sorbet::web_tracer_framework
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -554,6 +554,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options(section)("web-trace-file",
                                  "Generate a trace into <file> in the Trace Event Format (used by chrome://tracing)",
                                  cxxopts::value<string>()->default_value(empty.webTraceFile), "<file>");
+    options.add_options(section)("web-trace-file-strict", "Whether to close the toplevel array in `--web-trace-file`",
+                                 cxxopts::value<bool>());
     options.add_options(section)("cache-dir", "Use <dir> to cache certain data. Will create <dir> if it does not exist",
                                  cxxopts::value<string>()->default_value(empty.cacheDir), "<dir>");
     options.add_options(section)("max-cache-size-bytes",
@@ -1107,6 +1109,7 @@ void readOptions(Options &opts,
         opts.metricsPrefix = raw["metrics-prefix"].as<string>();
         opts.debugLogFile = raw["debug-log-file"].as<string>();
         opts.webTraceFile = raw["web-trace-file"].as<string>();
+        opts.webTraceFileStrict = raw["web-trace-file-strict"].as<bool>();
         {
             // parse extra sfx/datadog tags
             auto stringToParse = raw["metrics-extra-tags"].as<string>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -258,6 +258,7 @@ struct Options {
     std::string inlineInput; // passed via -e
     std::string debugLogFile;
     std::string webTraceFile;
+    bool webTraceFileStrict = false;
     std::string inlineRBIInput; // passed via --e-rbi
 
     // Path to an RBI whose contents should be minimized by subtracting parts that Sorbet already

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -914,7 +914,7 @@ int realmain(int argc, char *argv[]) {
         StatsD::submitCounters(counters, opts.statsdHost, opts.statsdPort, prefix + ".counters");
     }
     if (!opts.webTraceFile.empty()) {
-        web_tracer_framework::Tracing::storeTraces(counters, opts.webTraceFile);
+        web_tracer_framework::Tracing::storeTraces(counters, opts.webTraceFile, opts.webTraceFileStrict);
     }
 
     if (!opts.metricsFile.empty()) {

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -253,6 +253,7 @@ Usage:
 ```plaintext
       --web-trace-file <file>   Generate a trace into <file> in the Trace Event Format
                                 (used by chrome://tracing) (default: "")
+      --web-trace-file-strict   Whether to close the toplevel array in `--web-trace-file`
       --cache-dir <dir>         Use <dir> to cache certain data. Will create <dir> if it
                                 does not exist (default: "")
       --max-cache-size-bytes <bytes>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`--web-trace-file` was originally written to be pretty general:

1. Data is appended to the file, rather than overwriting the file;
2. The toplevel array that contains JSON trace data is not terminated so we can easily do the above.

The latter is within the spec for trace data (indeed, [bugs have been filed against the online viewer](https://github.com/google/perfetto/issues/926) for breaking that contract), but it makes processing trace files with JSON tooling inconvenient.  

I suppose that the appending mode is convenient if you want to compare before-and-after profiles (?).  I personally was surprised to open up `tracing.cc` and discover that the code actually appended to the file in the first place, as I've never used this functionality.

But this PR proposes that if you want to do that, it's up to you to merge the trace files yourself -- let's optimize for the convenience of all consumers instead.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
