### PR TITLE
Change CommandData to inherit from DataLite

### DIFF
--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -4345,6 +4345,14 @@ class Net::IMAP::Address < Struct
   def self.new(*_); end
 end
 
+class Net::IMAP::DataLite < Data
+  def initialize(data); end
+
+  def encode_with(coder); end
+
+  def init_with(coder); end
+end
+
 class Net::IMAP::CommandData < Net::IMAP::DataLite
   def initialize(data); end
 

--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -4345,7 +4345,7 @@ class Net::IMAP::Address < Struct
   def self.new(*_); end
 end
 
-class Net::IMAP::CommandData < Data
+class Net::IMAP::CommandData < Net::IMAP::DataLite
   def initialize(data); end
 
   def data; end


### PR DESCRIPTION
net-imap has [aliased](https://github.com/ruby/net-imap/blob/e4ef3eb724fe7eb036aef38b962d58b7b91cb3e6/lib/net/imap/data_lite.rb#L36) DataLite to Data.

Update to https://github.com/sorbet/sorbet/pull/8392.

Should fix typechecking throwing error `Parent of class Net::IMAP::CommandData redefined from Data to Net::IMAP::DataLite`.