### PR TITLE
track the defining loc for subclasses

### DIFF
--- a/main/autogen/subclasses.h
+++ b/main/autogen/subclasses.h
@@ -7,16 +7,28 @@ namespace sorbet::autogen {
 
 class Subclasses final {
 public:
-    using Entries = UnorderedSet<core::ClassOrModuleRef>;
+    // A set of child classes for a particular parent.
+    struct ChildInfo {
+        std::optional<core::Loc> defining_ref;
+
+        void mergeDefiningRefWith(core::Loc loc);
+    };
+
+    using Entries = UnorderedMap<core::ClassOrModuleRef, ChildInfo>;
+
     struct SubclassInfo {
+        // This is weird, because this is information about the *parent*, not the child.
         ClassKind classKind = ClassKind::Module;
         Entries entries;
 
         SubclassInfo() = default;
         SubclassInfo(ClassKind classKind, Entries entries) : classKind(classKind), entries(std::move(entries)){};
     };
+
+    // Map between the subclass seen to information about the parent class
     using Map = UnorderedMap<core::SymbolRef, SubclassInfo>;
 
+    static void mergeInto(Entries &out, const Entries &entries);
     static std::optional<Subclasses::Map> listAllSubclasses(core::Context ctx, const ParsedFile &pf,
                                                             const std::vector<std::string> &absoluteIgnorePatterns,
                                                             const std::vector<std::string> &relativeIgnorePattern);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -321,7 +321,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
 
             for (const auto &[parentRef, children] : *el.subclasses) {
                 auto &childEntry = childMap[parentRef];
-                childEntry.entries.insert(children.entries.begin(), children.entries.end());
+                autogen::Subclasses::mergeInto(childEntry.entries, children.entries);
                 childEntry.classKind = children.classKind;
             }
         }

--- a/test/cli/autogen-subclasses/a.rb
+++ b/test/cli/autogen-subclasses/a.rb
@@ -1,7 +1,10 @@
 # typed: true
 
 module Opus
-  class DupChild < Parent; end
+  class DupChild < Parent
+    def defines_behavior
+    end
+  end
   class Child < Parent; end
   class IgnoredChild < IgnoredParent; end
 end

--- a/test/cli/autogen-subclasses/a.rb
+++ b/test/cli/autogen-subclasses/a.rb
@@ -26,8 +26,6 @@ end
 
 class OtherChild < NonexistentParent; end
 
-class Opus::DupChild < Opus::Parent; end # Only appears once in output
-
 class Opus::Risk::Model::Mixins::RiskSafeMachine; end
 
 class FooSafeMachine < Opus::Risk::Model::Mixins::RiskSafeMachine; end

--- a/test/cli/autogen-subclasses/dup_child.rb
+++ b/test/cli/autogen-subclasses/dup_child.rb
@@ -1,0 +1,12 @@
+module Opus
+  # Should only appear once in output
+  class DupChild
+    class Spec
+      interesting_dsl_class DupChild
+
+      module NamespacedMixinThing
+      end
+    end
+  end
+end
+

--- a/test/cli/autogen-subclasses/test.out
+++ b/test/cli/autogen-subclasses/test.out
@@ -12,4 +12,4 @@ module Opus::Mixin
  module Opus::MixedModule a.rb
 class Opus::Parent
  class Opus::Child a.rb
- class Opus::DupChild dup_child.rb
+ class Opus::DupChild a.rb

--- a/test/cli/autogen-subclasses/test.out
+++ b/test/cli/autogen-subclasses/test.out
@@ -12,4 +12,4 @@ module Opus::Mixin
  module Opus::MixedModule a.rb
 class Opus::Parent
  class Opus::Child a.rb
- class Opus::DupChild a.rb
+ class Opus::DupChild dup_child.rb


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The subclass path information can be useful, but with `--uniquely-defined-behavior`, it's generally more so if the path given is the actual definition of the class, rather than some random reference to the class.

You can see a diff of `subclasses.txt` on Stripe's codebase here (Stripe employees only):

http://go/gist/froydnj/e776bb94996a3a1b97040f28effa96c7

I did not check all of the (many!) changes, but eyeballing them, it looks as if classes are now tied to their defining file, rather than some file with a random reference to that class.

cc @aadi-stripe 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
