### PR TITLE
Small PackageInfo::addImport refactors

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -307,6 +307,7 @@ public:
 
             // Defensively guard against the first export loc or the package's loc being invalid.
             if (exportLoc <= 0 || exportLoc >= file_source.size()) {
+                ENFORCE(false, "Failed to find a valid starting loc");
                 return nullopt;
             }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -287,7 +287,7 @@ public:
             return nullopt;
         }
 
-        core::Loc insertionLoc = loc.adjust(gs, core::INVALID_POS_LOC, core::INVALID_POS_LOC);
+        auto insertionLoc = core::Loc::none(loc.file());
         // first let's try adding it to the end of the imports.
         if (!importedPackageNames.empty()) {
             auto lastOffset = importedPackageNames.back().name.loc;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -304,7 +304,7 @@ public:
             }
             // we want to find the end of the last non-empty line, so
             // let's do something gross: walk backward until we find non-whitespace
-            const auto &file_source = loc.file().data(gs).source();
+            std::string_view file_source = loc.file().data(gs).source();
             while (isspace(file_source[exportLoc])) {
                 exportLoc--;
                 // this shouldn't happen in a well-formatted

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -278,12 +278,10 @@ public:
     optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
                                                     bool isTestImport) const {
         auto &info = PackageInfoImpl::from(pkg);
-        for (auto &import : importedPackageNames) {
-            if (import.name != info.name) {
-                continue;
-            }
-            if (!isTestImport && import.type == ImportType::Test) {
-                return convertTestImport(gs, info, core::Loc(fullLoc().file(), import.name.loc));
+        auto it = absl::c_find_if(importedPackageNames, [&info](auto &import) { return import.name == info.name; });
+        if (it != importedPackageNames.end()) {
+            if (!isTestImport && it->type == ImportType::Test) {
+                return convertTestImport(gs, info, core::Loc(fullLoc().file(), it->name.loc));
             }
             // we already import this, and if so, don't return an autocorrect
             return nullopt;


### PR DESCRIPTION
While investigating an invalid autocorrect produced by `PackageInfo::addImport`, I noticed a few things that we could clean up. The most substantial of these changes was to switch to computing the offset when no imports are present by using a signed int64, as that allows us to be a bit more defensive by rejecting cases where the package definition or last export have a zero or invalid loc present.

### Motivation
Avoiding potential issues with autocorrect locations.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
