### PR TITLE
Insert new imports in the correct position with regards to strictness

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -279,6 +279,92 @@ public:
     explicit PackageInfoImpl(const PackageInfoImpl &) = default;
     PackageInfoImpl &operator=(const PackageInfoImpl &) = delete;
 
+    // What order should these packages be in the import list?
+    // Returns -1 if a should come before b, 0 if they are equivalent, and 1 if a should come after b.
+    //
+    // This method replicates the logic used at Stripe to order packages and thus has all of the associated "quirks".
+    // In particular, the ordering in a given package is a function of the strictness level of the package, and it is
+    // not a simple "false < layered < layered_dag < dag" ordering. The ordering is as follows:
+    // For strictDependenciesLevel::False:
+    // - layering violations
+    // - imports to 'false' packages
+    // - imports to 'layered' or stricter packages
+    // For strictDependenciesLevel::Layered and LayeredDag:
+    // - layering violations
+    // - imports to 'false' packages
+    // - imports to 'layered' or 'layered_dag' packages
+    // - imports to 'dag' packages
+    // For strictDependenciesLevel::Dag:
+    // - layering violations
+    // - imports to 'false', 'layered', or 'layered_dag' packages
+    // - imports to 'dag' packages
+    // TODO(neil): explain the rationale behind this ordering
+    // Within each group by strictness, packages are sorted by alphabetical order.
+    // TODO(neil): implement alphabetical sort.
+    int orderByStrictness(const core::packages::PackageDB &packageDB, const PackageInfo &a,
+                          const PackageInfo &b) const {
+        if (!strictDependenciesLevel().has_value() || !a.strictDependenciesLevel().has_value() ||
+            !b.strictDependenciesLevel().has_value() || !a.layer().has_value() || !b.layer().has_value()) {
+            return 0;
+        }
+        // Layering violations always come first
+        if (causesLayeringViolation(packageDB, a)) {
+            if (causesLayeringViolation(packageDB, b)) {
+                return 0;
+            } else {
+                return -1;
+            }
+        }
+
+        auto aStrictDependenciesLevel = a.strictDependenciesLevel().value().first;
+        auto bStrictDependenciesLevel = b.strictDependenciesLevel().value().first;
+        switch (strictDependenciesLevel().value().first) {
+            case core::packages::StrictDependenciesLevel::False: {
+                // Sort order: Layering violations, false, layered or stricter
+                switch (aStrictDependenciesLevel) {
+                    case core::packages::StrictDependenciesLevel::False:
+                        return bStrictDependenciesLevel == core::packages::StrictDependenciesLevel::False ? 0 : -1;
+                    case core::packages::StrictDependenciesLevel::Layered:
+                    case core::packages::StrictDependenciesLevel::LayeredDag:
+                    case core::packages::StrictDependenciesLevel::Dag:
+                        return bStrictDependenciesLevel == core::packages::StrictDependenciesLevel::False ? 1 : 0;
+                }
+            }
+            case core::packages::StrictDependenciesLevel::Layered:
+            case core::packages::StrictDependenciesLevel::LayeredDag: {
+                // Sort order: Layering violations, false, layered or layered_dag, dag
+                switch (aStrictDependenciesLevel) {
+                    case core::packages::StrictDependenciesLevel::False:
+                        return bStrictDependenciesLevel == core::packages::StrictDependenciesLevel::False ? 0 : -1;
+                    case core::packages::StrictDependenciesLevel::Layered:
+                    case core::packages::StrictDependenciesLevel::LayeredDag:
+                        switch (bStrictDependenciesLevel) {
+                            case core::packages::StrictDependenciesLevel::False:
+                                return 1;
+                            case core::packages::StrictDependenciesLevel::Layered:
+                            case core::packages::StrictDependenciesLevel::LayeredDag:
+                                return 0;
+                            case core::packages::StrictDependenciesLevel::Dag:
+                                return -1;
+                        }
+                    case core::packages::StrictDependenciesLevel::Dag:
+                        return bStrictDependenciesLevel == core::packages::StrictDependenciesLevel::Dag ? 0 : 1;
+                }
+            }
+            case core::packages::StrictDependenciesLevel::Dag: {
+                // Sort order: Layering violations, false or layered or layered_dag, dag
+                switch (aStrictDependenciesLevel) {
+                    case core::packages::StrictDependenciesLevel::False:
+                    case core::packages::StrictDependenciesLevel::Layered:
+                    case core::packages::StrictDependenciesLevel::LayeredDag:
+                        return bStrictDependenciesLevel == core::packages::StrictDependenciesLevel::Dag ? -1 : 0;
+                    case core::packages::StrictDependenciesLevel::Dag:
+                        return bStrictDependenciesLevel == core::packages::StrictDependenciesLevel::Dag ? 0 : 1;
+                }
+            }
+        }
+    }
+
     optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
                                                     bool isTestImport) const {
         auto &info = PackageInfoImpl::from(pkg);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -321,12 +321,12 @@ public:
         }
 
         // Layering violations always come first
-        if (causesLayeringViolation(packageDB, a)) {
-            if (causesLayeringViolation(packageDB, b)) {
-                return 0;
-            } else {
-                return -1;
-            }
+        if (causesLayeringViolation(packageDB, a) && causesLayeringViolation(packageDB, b)) {
+            return 0;
+        } else if (causesLayeringViolation(packageDB, a) && !causesLayeringViolation(packageDB, b)) {
+            return -1;
+        } else if (!causesLayeringViolation(packageDB, a) && causesLayeringViolation(packageDB, b)) {
+            return 1;
         }
 
         auto aStrictDependenciesLevel = a.strictDependenciesLevel().value().first;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -298,8 +298,8 @@ public:
     // - layering violations
     // - imports to 'false', 'layered', or 'layered_dag' packages
     // - imports to 'dag' packages
-    // TODO(neil): explain the rationale behind this ordering
-    // Within each group by strictness, packages are sorted by alphabetical order.
+    // TODO(neil): explain the rationale behind this ordering (ie. why is not the simple "false < layered < layered_dag
+    // < dag" ordering)
     // TODO(neil): implement alphabetical sort.
     int orderByStrictness(const core::packages::PackageDB &packageDB, const PackageInfo &a,
                           const PackageInfo &b) const {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -406,7 +406,7 @@ public:
                 // Insert before the first import
                 core::Loc beforePackageName = {loc.file(), importedPackageNames.front().name.loc};
                 auto [beforeImport, numWhitespace] = beforePackageName.findStartOfLine(gs);
-                auto endOfPrevLine = beforePackageName.adjust(gs, -numWhitespace - 1, 0);
+                auto endOfPrevLine = beforeImport.adjust(gs, -numWhitespace - 1, 0);
                 insertionLoc =
                     core::Loc{loc.file(), endOfPrevLine.copyWithZeroLength().offsets().copyEndWithZeroLength()};
             } else {

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -23,6 +23,44 @@ string examplePackage = "class ExamplePackage < PackageSpec\nend\n";
 string examplePackagePath = "example/__package.rb";
 
 namespace sorbet {
+string makePackageRB(string name, string strictDeps, string layer, vector<string> imports = {},
+                     vector<string> exports = {}) {
+    string importList = "";
+    for (auto &import : imports) {
+        importList += fmt::format("  import {}\n", import);
+    }
+    return fmt::format("class {} < PackageSpec\n"
+                       "  strict_dependencies '{}'\n"
+                       "  layer '{}'\n"
+                       "{}"
+                       "end\n",
+                       name, strictDeps, layer, importList);
+}
+
+string falsePackageA = makePackageRB("FalsePackageA", "false", "lib");
+string falsePackageAPath = "falseA/__package.rb";
+
+string falsePackageB = makePackageRB("FalsePackageB", "false", "lib");
+string falsePackageBPath = "falseB/__package.rb";
+
+string layeredPackageA = makePackageRB("LayeredPackageA", "layered", "lib");
+string layeredPackageAPath = "layeredA/__package.rb";
+
+string layeredPackageB = makePackageRB("LayeredPackageB", "layered", "lib");
+string layeredPackageBPath = "layeredB/__package.rb";
+
+string layeredDagPackageA = makePackageRB("LayeredDagPackageA", "layered_dag", "lib");
+string layeredDagPackageAPath = "layered_dagA/__package.rb";
+
+string layeredDagPackageB = makePackageRB("LayeredDagPackageB", "layered_dag", "lib");
+string layeredDagPackageBPath = "layered_dagB/__package.rb";
+
+string dagPackageA = makePackageRB("DagPackageA", "dag", "lib");
+string dagPackageAPath = "dagA/__package.rb";
+
+string dagPackageB = makePackageRB("DagPackageB", "dag", "lib");
+string dagPackageBPath = "dagB/__package.rb";
+
 vector<ast::ParsedFile> enterPackages(core::GlobalState &gs, vector<pair<string, string>> packageSources) {
     vector<core::FileRef> files;
     {
@@ -244,6 +282,352 @@ TEST_CASE("Simple add export") {
     ENFORCE(addExport, "Expected to get an autocorrect from `addExport`");
     auto replaced = addExport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
+}
+
+// Tests with layering and strict dependencies checks on
+TEST_CASE("Add imports to strict_dependencies 'false' package") {
+    core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+    {
+        core::UnfreezeNameTable packageNS(gs);
+        core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
+        gs.setPackagerOptions({}, {}, {}, {}, {}, {"lib", "app"}, "");
+    }
+
+    string pkg_source = makePackageRB("MyPackage", "false", "app",
+                                      {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
+
+    auto parsedFiles = enterPackages(gs, {{"my_Package/__package.rb", pkg_source},
+                                          {falsePackageAPath, falsePackageA},
+                                          {layeredPackageAPath, layeredPackageA},
+                                          {layeredDagPackageAPath, layeredDagPackageA},
+                                          {dagPackageAPath, dagPackageA},
+                                          {falsePackageBPath, falsePackageB},
+                                          {layeredPackageBPath, layeredPackageB},
+                                          {layeredDagPackageBPath, layeredDagPackageB},
+                                          {dagPackageBPath, dagPackageB}});
+    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    ENFORCE(myPkg.exists());
+
+    {
+        auto &falsePkgB = getPackageForFile(gs, parsedFiles[5].file);
+        ENFORCE(falsePkgB.exists());
+        auto addImport = myPkg.addImport(gs, falsePkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "false", "app",
+                          {"FalsePackageA", "FalsePackageB", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &layeredPkgB = getPackageForFile(gs, parsedFiles[6].file);
+        ENFORCE(layeredPkgB.exists());
+        auto addImport = myPkg.addImport(gs, layeredPkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "false", "app",
+                          {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA", "LayeredPackageB"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &layeredDagPkgB = getPackageForFile(gs, parsedFiles[7].file);
+        ENFORCE(layeredDagPkgB.exists());
+        auto addImport = myPkg.addImport(gs, layeredDagPkgB, false);
+        string expected = makePackageRB(
+            "MyPackage", "false", "app",
+            {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA", "LayeredDagPackageB"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &dagPkgB = getPackageForFile(gs, parsedFiles[8].file);
+        ENFORCE(dagPkgB.exists());
+        auto addImport = myPkg.addImport(gs, dagPkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "false", "app",
+                          {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA", "DagPackageB"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+}
+
+TEST_CASE("Add imports to strict_dependencies 'layered' package") {
+    core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+    {
+        core::UnfreezeNameTable packageNS(gs);
+        core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
+        gs.setPackagerOptions({}, {}, {}, {}, {}, {"lib", "app"}, "");
+    }
+
+    string pkg_source = makePackageRB("MyPackage", "layered", "app",
+                                      {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
+
+    auto parsedFiles = enterPackages(gs, {{"my_Package/__package.rb", pkg_source},
+                                          {falsePackageAPath, falsePackageA},
+                                          {layeredPackageAPath, layeredPackageA},
+                                          {layeredDagPackageAPath, layeredDagPackageA},
+                                          {dagPackageAPath, dagPackageA},
+                                          {falsePackageBPath, falsePackageB},
+                                          {layeredPackageBPath, layeredPackageB},
+                                          {layeredDagPackageBPath, layeredDagPackageB},
+                                          {dagPackageBPath, dagPackageB}});
+    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    ENFORCE(myPkg.exists());
+
+    {
+        auto &falsePkgB = getPackageForFile(gs, parsedFiles[5].file);
+        ENFORCE(falsePkgB.exists());
+        auto addImport = myPkg.addImport(gs, falsePkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "layered", "app",
+                          {"FalsePackageA", "FalsePackageB", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &layeredPkgB = getPackageForFile(gs, parsedFiles[6].file);
+        ENFORCE(layeredPkgB.exists());
+        auto addImport = myPkg.addImport(gs, layeredPkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "layered", "app",
+                          {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "LayeredPackageB", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &layeredDagPkgB = getPackageForFile(gs, parsedFiles[7].file);
+        ENFORCE(layeredDagPkgB.exists());
+        auto addImport = myPkg.addImport(gs, layeredDagPkgB, false);
+        string expected = makePackageRB(
+            "MyPackage", "layered", "app",
+            {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "LayeredDagPackageB", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &dagPkgB = getPackageForFile(gs, parsedFiles[8].file);
+        ENFORCE(dagPkgB.exists());
+        auto addImport = myPkg.addImport(gs, dagPkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "layered", "app",
+                          {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA", "DagPackageB"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+}
+
+TEST_CASE("Add imports to strict_dependencies 'layered_dag' package") {
+    core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+    {
+        core::UnfreezeNameTable packageNS(gs);
+        core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
+        gs.setPackagerOptions({}, {}, {}, {}, {}, {"lib", "app"}, "");
+    }
+
+    string pkg_source = makePackageRB("MyPackage", "layered_dag", "app",
+                                      {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
+
+    auto parsedFiles = enterPackages(gs, {{"my_Package/__package.rb", pkg_source},
+                                          {falsePackageAPath, falsePackageA},
+                                          {layeredPackageAPath, layeredPackageA},
+                                          {layeredDagPackageAPath, layeredDagPackageA},
+                                          {dagPackageAPath, dagPackageA},
+                                          {falsePackageBPath, falsePackageB},
+                                          {layeredPackageBPath, layeredPackageB},
+                                          {layeredDagPackageBPath, layeredDagPackageB},
+                                          {dagPackageBPath, dagPackageB}});
+    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    ENFORCE(myPkg.exists());
+
+    {
+        auto &falsePkgB = getPackageForFile(gs, parsedFiles[5].file);
+        ENFORCE(falsePkgB.exists());
+        auto addImport = myPkg.addImport(gs, falsePkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "layered_dag", "app",
+                          {"FalsePackageA", "FalsePackageB", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &layeredPkgB = getPackageForFile(gs, parsedFiles[6].file);
+        ENFORCE(layeredPkgB.exists());
+        auto addImport = myPkg.addImport(gs, layeredPkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "layered_dag", "app",
+                          {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "LayeredPackageB", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &layeredDagPkgB = getPackageForFile(gs, parsedFiles[7].file);
+        ENFORCE(layeredDagPkgB.exists());
+        auto addImport = myPkg.addImport(gs, layeredDagPkgB, false);
+        string expected = makePackageRB(
+            "MyPackage", "layered_dag", "app",
+            {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "LayeredDagPackageB", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &dagPkgB = getPackageForFile(gs, parsedFiles[8].file);
+        ENFORCE(dagPkgB.exists());
+        auto addImport = myPkg.addImport(gs, dagPkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "layered_dag", "app",
+                          {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA", "DagPackageB"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+}
+
+TEST_CASE("Add imports to strict_dependencies 'dag' package") {
+    core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+    {
+        core::UnfreezeNameTable packageNS(gs);
+        core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
+        gs.setPackagerOptions({}, {}, {}, {}, {}, {"lib", "app"}, "");
+    }
+
+    string pkg_source = makePackageRB("MyPackage", "dag", "app",
+                                      {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
+
+    auto parsedFiles = enterPackages(gs, {{"my_Package/__package.rb", pkg_source},
+                                          {falsePackageAPath, falsePackageA},
+                                          {layeredPackageAPath, layeredPackageA},
+                                          {layeredDagPackageAPath, layeredDagPackageA},
+                                          {dagPackageAPath, dagPackageA},
+                                          {falsePackageBPath, falsePackageB},
+                                          {layeredPackageBPath, layeredPackageB},
+                                          {layeredDagPackageBPath, layeredDagPackageB},
+                                          {dagPackageBPath, dagPackageB}});
+    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    ENFORCE(myPkg.exists());
+
+    {
+        auto &falsePkgB = getPackageForFile(gs, parsedFiles[5].file);
+        ENFORCE(falsePkgB.exists());
+        auto addImport = myPkg.addImport(gs, falsePkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "dag", "app",
+                          {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "FalsePackageB", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &layeredPkgB = getPackageForFile(gs, parsedFiles[6].file);
+        ENFORCE(layeredPkgB.exists());
+        auto addImport = myPkg.addImport(gs, layeredPkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "dag", "app",
+                          {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "LayeredPackageB", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &layeredDagPkgB = getPackageForFile(gs, parsedFiles[7].file);
+        ENFORCE(layeredDagPkgB.exists());
+        auto addImport = myPkg.addImport(gs, layeredDagPkgB, false);
+        string expected = makePackageRB(
+            "MyPackage", "dag", "app",
+            {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "LayeredDagPackageB", "DagPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        auto &dagPkgB = getPackageForFile(gs, parsedFiles[8].file);
+        ENFORCE(dagPkgB.exists());
+        auto addImport = myPkg.addImport(gs, dagPkgB, false);
+        string expected =
+            makePackageRB("MyPackage", "dag", "app",
+                          {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA", "DagPackageB"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+}
+
+TEST_CASE("Edge cases") {
+    core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+    {
+        core::UnfreezeNameTable packageNS(gs);
+        core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
+        gs.setPackagerOptions({}, {}, {}, {}, {}, {"lib", "app"}, "");
+    }
+
+    string packageWithFakeImport = makePackageRB("HasFakeImport", "false", "app", {"FakeImport"});
+    string packageWithFakeImportPath = "has_fake_import/__package.rb";
+
+    string libPackage = makePackageRB("LibPackage", "false", "lib", {"FalsePackageA"});
+    string libPackagePath = "lib_pkg/__package.rb";
+
+    string appPackage = makePackageRB("AppPackage", "false", "app", {});
+    string appPackagePath = "app_pkg/__package.rb";
+
+    auto parsedFiles = enterPackages(gs, {{packageWithFakeImportPath, packageWithFakeImport},
+                                          {falsePackageAPath, falsePackageA},
+                                          {layeredPackageAPath, layeredPackageA},
+                                          {libPackagePath, libPackage},
+                                          {appPackagePath, appPackage}});
+
+    {
+        // Import list contains non-existent package
+        auto &fakeImportPkg = getPackageForFile(gs, parsedFiles[0].file);
+        ENFORCE(fakeImportPkg.exists());
+        auto &layeredPkgA = getPackageForFile(gs, parsedFiles[2].file);
+        ENFORCE(layeredPkgA.exists());
+
+        auto addImport = fakeImportPkg.addImport(gs, layeredPkgA, false);
+        string expected = makePackageRB("HasFakeImport", "false", "app", {"FakeImport", "LayeredPackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(packageWithFakeImport);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        // Import added to start of import list
+        auto &libPkg = getPackageForFile(gs, parsedFiles[3].file);
+        ENFORCE(libPkg.exists());
+        auto &appPkg = getPackageForFile(gs, parsedFiles[4].file);
+        ENFORCE(appPkg.exists());
+
+        auto addImport = libPkg.addImport(gs, appPkg, false);
+        string expected = makePackageRB("LibPackage", "false", "lib", {"AppPackage", "FalsePackageA"});
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(libPackage);
+        CHECK_EQ(expected, replaced);
+    }
 }
 
 } // namespace sorbet

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -4,6 +4,7 @@
 #include "ast/desugar/Desugar.h"
 #include "common/common.h"
 #include "common/concurrency/WorkerPool.h"
+#include "common/strings/formatting.h"
 #include "core/Error.h"
 #include "core/ErrorQueue.h"
 #include "core/NameSubstitution.h"
@@ -25,16 +26,14 @@ string examplePackagePath = "example/__package.rb";
 namespace sorbet {
 string makePackageRB(string name, string strictDeps, string layer, vector<string> imports = {},
                      vector<string> exports = {}) {
-    string importList = "";
-    for (auto &import : imports) {
-        importList += fmt::format("  import {}\n", import);
-    }
     return fmt::format("class {} < PackageSpec\n"
                        "  strict_dependencies '{}'\n"
                        "  layer '{}'\n"
                        "{}"
                        "end\n",
-                       name, strictDeps, layer, importList);
+                       name, strictDeps, layer, fmt::map_join(imports, "", [&](const auto &import) {
+                           return fmt::format("  import {}\n", import);
+                       }));
 }
 
 string falsePackageA = makePackageRB("FalsePackageA", "false", "lib");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Previously, we always suggested adding new imports to the end of the import list. This PR changes that to look at the strict dependencies level of the packages and inserts in the correct place. A future PR will ensure that the new import is inserted in the correct place with regards to alphabetical order.

Easiest to review commit-by-commit with `?w=1`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Keep import list in `__package.rb` files sorted so that we don't need to manually sort it later.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
