### PR TITLE
Add methods for getting strict deps level and layer to PackageInfo

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -81,6 +81,16 @@ public:
         return vector<VisibleTo>();
     }
 
+    optional<pair<core::packages::StrictDependenciesLevel, core::LocOffsets>> strictDependenciesLevel() const {
+        notImplemented();
+        return nullopt;
+    }
+
+    optional<pair<core::NameRef, core::LocOffsets>> layer() const {
+        notImplemented();
+        return nullopt;
+    }
+
     std::optional<ImportType> importsPackage(MangledName mangledName) const {
         notImplemented();
         return nullopt;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -54,6 +54,9 @@ public:
     virtual std::vector<std::vector<core::NameRef>> testImports() const = 0;
     virtual std::vector<VisibleTo> visibleTo() const = 0;
     virtual std::unique_ptr<PackageInfo> deepCopy() const = 0;
+    virtual std::optional<std::pair<core::packages::StrictDependenciesLevel, core::LocOffsets>>
+    strictDependenciesLevel() const = 0;
+    virtual std::optional<std::pair<core::NameRef, core::LocOffsets>> layer() const = 0;
     virtual core::Loc fullLoc() const = 0;
     virtual core::Loc declLoc() const = 0;
     virtual bool exists() const final;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

So we don't need to convert `PackageInfo` to `PackageInfoImpl` just to fetch these two. See #8469 for an example of where these methods are used.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.