### PR TITLE
rewrite `InstructionPtr` detagging for better cast codegen

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -108,28 +108,28 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
                 blockReads.add(bind.bind.variable.id());
             }
 
-            if (auto *v = cast_instruction<Ident>(bind.value)) {
+            if (auto v = cast_instruction<Ident>(bind.value)) {
                 blockReads.add(v->what.id());
-            } else if (auto *v = cast_instruction<Send>(bind.value)) {
+            } else if (auto v = cast_instruction<Send>(bind.value)) {
                 blockReads.add(v->recv.variable.id());
                 for (auto &arg : v->args) {
                     blockReads.add(arg.variable.id());
                 }
-            } else if (auto *v = cast_instruction<TAbsurd>(bind.value)) {
+            } else if (auto v = cast_instruction<TAbsurd>(bind.value)) {
                 blockReads.add(v->what.variable.id());
-            } else if (auto *v = cast_instruction<Return>(bind.value)) {
+            } else if (auto v = cast_instruction<Return>(bind.value)) {
                 blockReads.add(v->what.variable.id());
-            } else if (auto *v = cast_instruction<BlockReturn>(bind.value)) {
+            } else if (auto v = cast_instruction<BlockReturn>(bind.value)) {
                 blockReads.add(v->what.variable.id());
-            } else if (auto *v = cast_instruction<Cast>(bind.value)) {
+            } else if (auto v = cast_instruction<Cast>(bind.value)) {
                 blockReads.add(v->value.variable.id());
-            } else if (auto *v = cast_instruction<LoadSelf>(bind.value)) {
+            } else if (auto v = cast_instruction<LoadSelf>(bind.value)) {
                 blockReads.add(v->fallback.id());
-            } else if (auto *v = cast_instruction<SolveConstraint>(bind.value)) {
+            } else if (auto v = cast_instruction<SolveConstraint>(bind.value)) {
                 blockReads.add(v->send.id());
-            } else if (auto *v = cast_instruction<YieldLoadArg>(bind.value)) {
+            } else if (auto v = cast_instruction<YieldLoadArg>(bind.value)) {
                 blockReads.add(v->yieldParam.variable.id());
-            } else if (auto *v = cast_instruction<KeepAlive>(bind.value)) {
+            } else if (auto v = cast_instruction<KeepAlive>(bind.value)) {
                 blockReads.add(v->what.id());
             }
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -440,18 +440,14 @@ public:
 
     template <class To> TaggedValue<To> as_instruction() {
         bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
-        if (!isValid) {
-            return TaggedValue<To>(nullptr, isValid);
-        }
-        return TaggedValue<To>(reinterpret_cast<To *>(get()), isValid);
+        auto *ptr = isValid ? reinterpret_cast<To *>(get()) : nullptr;
+        return TaggedValue<To>(ptr, isValid);
     }
 
     template <class To> TaggedValue<const To> as_instruction() const {
         bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
-        if (!isValid) {
-            return TaggedValue<const To>(nullptr, isValid);
-        }
-        return TaggedValue<const To>(reinterpret_cast<const To *>(get()), isValid);
+        auto *ptr = isValid ? reinterpret_cast<const To *>(get()) : nullptr;
+        return TaggedValue<const To>(ptr, isValid);
     }
 
     void setSynthetic() noexcept {

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -339,6 +339,10 @@ class InstructionPtr final {
         return i;
     }
 
+    uint16_t tagMaybeZero() const noexcept {
+        return ptr & TAG_MASK;
+    }
+
 public:
     // Required for typecase
     template <class To> static bool isa(const InstructionPtr &insn);
@@ -405,6 +409,51 @@ public:
         return (this->ptr & SYNTHETIC_FLAG) != 0;
     }
 
+    template <class To> struct TaggedValue {
+    private:
+        To *value;
+        bool isValid;
+
+    public:
+        explicit TaggedValue(To *p, bool valid) noexcept : value(p), isValid(valid) {}
+
+        explicit operator bool() const noexcept {
+            return isValid;
+        }
+
+        To *operator->() const noexcept {
+            return value;
+        }
+
+        operator To *() const noexcept {
+            return value;
+        }
+
+        bool operator==(std::nullptr_t) const noexcept {
+            return value == nullptr;
+        }
+
+        bool operator!=(std::nullptr_t) const noexcept {
+            return value != nullptr;
+        }
+    };
+
+    template <class To> TaggedValue<To> as_instruction() {
+        bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
+        if (!isValid) {
+            return TaggedValue<To>(nullptr, isValid);
+        }
+        return TaggedValue<To>(reinterpret_cast<To *>(get()), isValid);
+    }
+
+    template <class To> TaggedValue<const To> as_instruction() const {
+        bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
+        if (!isValid) {
+            return TaggedValue<const To>(nullptr, isValid);
+        }
+        return TaggedValue<const To>(reinterpret_cast<const To *>(get()), isValid);
+    }
+
     void setSynthetic() noexcept {
         this->ptr |= SYNTHETIC_FLAG;
     }
@@ -414,31 +463,25 @@ public:
 };
 
 template <class To> bool isa_instruction(const InstructionPtr &what) {
-    return what != nullptr && what.tag() == InsnToTag<To>::value;
+    return bool(what.as_instruction<To>());
 }
 
-template <class To> To *cast_instruction(InstructionPtr &what) {
+template <class To> InstructionPtr::TaggedValue<To> cast_instruction(InstructionPtr &what) {
     static_assert(!std::is_pointer<To>::value, "To has to be a pointer");
     static_assert(std::is_assignable<Instruction *&, To *>::value,
                   "Ill Formed To, has to be a subclass of Instruction");
-    if (isa_instruction<To>(what)) {
-        return reinterpret_cast<To *>(what.get());
-    }
-    return nullptr;
+    return what.as_instruction<To>();
 }
 
-template <class To> const To *cast_instruction(const InstructionPtr &what) {
+template <class To> InstructionPtr::TaggedValue<const To> cast_instruction(const InstructionPtr &what) {
     static_assert(!std::is_pointer<To>::value, "To has to be a pointer");
     static_assert(std::is_assignable<Instruction *&, To *>::value,
                   "Ill Formed To, has to be a subclass of Instruction");
-    if (isa_instruction<To>(what)) {
-        return reinterpret_cast<const To *>(what.get());
-    }
-    return nullptr;
+    return what.as_instruction<To>();
 }
 
 template <class To> inline bool InstructionPtr::isa(const InstructionPtr &what) {
-    return isa_instruction<To>(what);
+    return bool(what.as_instruction<To>());
 }
 template <> inline bool InstructionPtr::isa<InstructionPtr>(const InstructionPtr &what) {
     return true;

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -226,7 +226,7 @@ void CFGBuilder::dealias(core::Context ctx, CFG &cfg) {
         }
 
         for (Binding &bind : bb->exprs) {
-            if (auto *i = cast_instruction<Ident>(bind.value)) {
+            if (auto i = cast_instruction<Ident>(bind.value)) {
                 i->what = maybeDealias(ctx, cfg, i->what, current);
             }
             if (mayHaveAlias.contains(bind.bind.variable.id())) {
@@ -244,22 +244,22 @@ void CFGBuilder::dealias(core::Context ctx, CFG &cfg) {
             if (!bind.value.isSynthetic()) {
                 // we don't allow dealiasing values into synthetic instructions
                 // as otherwise it fools dead code analysis.
-                if (auto *v = cast_instruction<Ident>(bind.value)) {
+                if (auto v = cast_instruction<Ident>(bind.value)) {
                     v->what = maybeDealias(ctx, cfg, v->what, current);
-                } else if (auto *v = cast_instruction<Send>(bind.value)) {
+                } else if (auto v = cast_instruction<Send>(bind.value)) {
                     v->recv = maybeDealias(ctx, cfg, v->recv.variable, current);
                     for (auto &arg : v->args) {
                         arg = maybeDealias(ctx, cfg, arg.variable, current);
                     }
-                } else if (auto *v = cast_instruction<TAbsurd>(bind.value)) {
+                } else if (auto v = cast_instruction<TAbsurd>(bind.value)) {
                     v->what = maybeDealias(ctx, cfg, v->what.variable, current);
-                } else if (auto *v = cast_instruction<Return>(bind.value)) {
+                } else if (auto v = cast_instruction<Return>(bind.value)) {
                     v->what = maybeDealias(ctx, cfg, v->what.variable, current);
                 }
             }
 
             // record new aliases
-            if (auto *i = cast_instruction<Ident>(bind.value)) {
+            if (auto i = cast_instruction<Ident>(bind.value)) {
                 current[bind.bind.variable] = i->what;
                 mayHaveAlias.add(i->what.id());
             }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -92,12 +92,12 @@ KnowledgeFilter::KnowledgeFilter(core::Context ctx, unique_ptr<cfg::CFG> &cfg) {
         changed = false;
         for (auto &bb : cfg->forwardsTopoSort) {
             for (auto &bind : bb->exprs) {
-                if (auto *id = cfg::cast_instruction<cfg::Ident>(bind.value)) {
+                if (auto id = cfg::cast_instruction<cfg::Ident>(bind.value)) {
                     if (isNeeded(bind.bind.variable) && !isNeeded(id->what)) {
                         used_vars[id->what.id()] = true;
                         changed = true;
                     }
-                } else if (auto *send = cfg::cast_instruction<cfg::Send>(bind.value)) {
+                } else if (auto send = cfg::cast_instruction<cfg::Send>(bind.value)) {
                     if (send->fun == core::Names::bang()) {
                         if (send->args.empty()) {
                             if (isNeeded(bind.bind.variable) && !isNeeded(send->recv.variable)) {
@@ -1813,9 +1813,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
         setTypeAndOrigin(bind.bind.variable, tp);
 
         clearKnowledge(ctx, bind.bind.variable, knowledgeFilter);
-        if (auto *send = cfg::cast_instruction<cfg::Send>(bind.value)) {
+        if (auto send = cfg::cast_instruction<cfg::Send>(bind.value)) {
             updateKnowledge(ctx, bind.bind.variable, ctx.locAt(bind.loc), send, knowledgeFilter);
-        } else if (auto *i = cfg::cast_instruction<cfg::Ident>(bind.value)) {
+        } else if (auto i = cfg::cast_instruction<cfg::Ident>(bind.value)) {
             propagateKnowledge(ctx, bind.bind.variable, i->what, knowledgeFilter);
         }
 

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -239,7 +239,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                 }
 
                 if (unreachableInstruction != nullptr) {
-                    auto *send = cfg::cast_instruction<cfg::Send>(*unreachableInstruction);
+                    auto send = cfg::cast_instruction<cfg::Send>(*unreachableInstruction);
                     if (dueToSafeNavigation && send != nullptr) {
                         if (auto e = ctx.state.beginError(locForUnreachable,
                                                           core::errors::Infer::UnnecessarySafeNavigation)) {
@@ -253,7 +253,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                         }
                     } else if (auto e =
                                    ctx.state.beginError(locForUnreachable, core::errors::Infer::DeadBranchInferencer)) {
-                        auto *ident = cfg::cast_instruction<cfg::Ident>(*unreachableInstruction);
+                        auto ident = cfg::cast_instruction<cfg::Ident>(*unreachableInstruction);
 
                         bool andAndOrOr = false;
                         if (ident != nullptr) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Consider the code for something we do all the time in CFG/infer:

```c++
if (auto *id = cfg::cast_instruction<cfg::Ident>(bind.value)) {
  // Code if this is a Ident
else if (auto *send = cfg::cast_instruction<cfg::Ident>(bind.value)) {
  // Code if this is a Send
}
// ...and so forth.
```

(This is not a random example; it comes from `KnowledgeFilter::KnowledgeFilter`, and we'll look at it a little more closely shortly.)

What do those `cast_instruction` do?  Each one will do several things:

1. Whether the contained tagged value is 0 (this is `isa_instruction`);
2. Whether the tagged value has a particular tag (also `isa_instruction`);
3. Extract the contained pointer if both of the above are true;
4. Otherwise, return `nullptr`.

And then we will check the returned value for `nullptr`-ness.  That's three (well, really two, because clang is clever -- see below) separate branches for each `cast_instruction`.

We can see all this in action when we look at the disassembly for `KnowledgeFilter::KnowledgeFilter` from a release build:

```
  # Load the tagged value in `InstructionPtr`.
  729229:       48 8b 4b 18             mov    0x18(%rbx),%rcx

  # Extract the tag from the low bits.
  72922d:       0f b6 c1                movzbl %cl,%eax

  # Extract the pointer itself.  Preserve the original value for reasons that will
  # become clear shortly
  729230:       48 89 cf                mov    %rcx,%rdi
  729233:       48 c1 ef 10             shr    $0x10,%rdi

  # This is an obtuse way to test the *original* value for 0 that cleverly does
  # "was the original value 0?" and "was the extracted value nullptr?" by
  # checking `ptr < 65536`.  Yay smart compilers.
  729237:       48 81 f9 00 00 01 00    cmp    $0x10000,%rcx
  72923e:       72 50                   jb     729290

  # cfg::Ident is 1, so test whether the tag is equal to that.
  729240:       83 f8 01                cmp    $0x1,%eax
  729243:       75 4b                   jne    729290

  ... skipping the cfg::Ident case codegen ... 

  # Another obtuse check, which is silly, because if we got here, we should really
  # already *know* that, but clang is not as smart as it could be.
  729290:       48 81 f9 00 00 01 00    cmp    $0x10000,%rcx
  729297:       72 87                   jb     729220

  # cfg::Send is 4, so test whether the tag is equal to that.
  729299:       83 f8 04                cmp    $0x4,%eax
  72929c:       75 82                   jne    729220

  ... skipping the cfg::Send case codegen ...
```

However, observe the following invariants on `InstructionPtr`:

1. The tagged value is 0 for an empty `InstructionPtr`: empty tag, empty pointer.
2. The tagged value has a non-zero pointer for any non-empty tag.

(We take advantage of these invariants in `operator==` and friends; see #5906.)

These invariants imply that we should be able to do `cast_instruction` in a single check: does this `InstructionPtr` have the tag that we are interested in?  If so, we have a valid (non-null!) pointer; otherwise, we should say we have `nullptr` (both for the completely empty case and the case where the tag does not match).  So:

1. Load value from memory.
2. Extract tag.
3. Extract pointer.
4. Check if tag is equal to the enum value we care about.

which should be shorter and faster.  Not massively so in the single `cast_instruction` case, but it should enable the codegen for any `else if` cases to not do redundant checks for `nullptr`-ness, which then enables fun things like jump table conversion.

This PR does exactly that, by introducing an intermediate representation for "untagged" values of a tagged pointer converted into a pointer for a particular value; that representation also carries around a notion of whether the contained pointer is actually valid.  Constructing this representation requires a single branch, which results in better codegen; for the same function as above on a release build with this PR:

```
  # Load the tagged value in `InstructionPtr`.
  728b89:       48 8b 56 18             mov    0x18(%rsi),%rdx

  # Extract the tag from the low bits.
  728b8d:       0f b6 c2                movzbl %dl,%eax

  # Extract the pointer itself.  Notice that we don't have to preserve the tagged value!
  728b90:       48 c1 ea 10             shr    $0x10,%rdx

  # Test whether the tag is equal to cfg::Ident, jump to the cfg::Send case if not.
  728b94:       48 83 f8 01             cmp    $0x1,%rax
  728b98:       75 46                   jne    728be0

  ... skipping the cfg::Ident case codegen ... 

  # Test whether the tag is equal to cfg::Send.  No redundant checks!
  728be0:       48 83 f8 04             cmp    $0x4,%rax
  728be4:       49 0f 45 d3             cmovne %r11,%rdx
  728be8:       75 96                   jne    728b80

  ... skipping the cfg::Send case codegen ...
```

The observant reader will note that we can apply this same trick to `TypePtr` and `ExpressionPtr`; my guess is that the checks for `TypePtr` are much more pervasive, so there actually might be a decent little speedup from all of this rearranging.  But even `ExpressionPtr` gets ad-hoc type-tested a fair amount, so maybe there will be gains in other places.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
