### PR TITLE
Make --no-stdlib and --cache-dir incompatible

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1046,7 +1046,13 @@ void readOptions(Options &opts,
         }
 
         opts.noErrorCount = raw["no-error-count"].as<bool>();
+
         opts.noStdlib = raw["no-stdlib"].as<bool>();
+        if (opts.noStdlib && !opts.cacheDir.empty()) {
+            logger->error("--no-stdlib is incompatible with --cache-dir. Ignoring cache");
+            opts.cacheDir = "";
+        }
+
         opts.minimizeRBI = raw["minimize-to-rbi"].as<string>();
         if (!opts.minimizeRBI.empty() && !opts.print.MinimizeRBI.enabled) {
             logger->error("--minimize-to-rbi must also include --print=minimized-rbi");

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -11,6 +11,7 @@ namespace sorbet::payload {
 void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
                               const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     if (kvstore) {
+        ENFORCE(!options.noStdlib, "--no-stdlib and --cache-dir are incompatible");
         auto maybeGsBytes = kvstore->read(core::serialize::Serializer::GLOBAL_STATE_KEY);
         if (maybeGsBytes.data != nullptr) {
             Timer timeit(gs->tracer(), "read_global_state.kvstore");

--- a/test/cli/index-cache-invalidation/test.sh
+++ b/test/cli/index-cache-invalidation/test.sh
@@ -11,7 +11,7 @@ mkdir "$dir/cache"
 echo "class A; end" >> "$dir/a.rb"
 touch "$dir"{b,c,d}
 echo ====first run====
-main/sorbet --silence-dev-message --no-stdlib --cache-dir "$dir/" "$dir/a.rb" "$dir"{b,c,d} 2>&1
+main/sorbet --silence-dev-message --cache-dir "$dir/" "$dir/a.rb" "$dir"{b,c,d} 2>&1
 echo '# comment' >> "$dir/a.rb"
 echo ====after change====
-main/sorbet --silence-dev-message --no-stdlib --cache-dir "$dir/" "$dir/a.rb" "$dir"{b,c,d} 2>&1
+main/sorbet --silence-dev-message --cache-dir "$dir/" "$dir/a.rb" "$dir"{b,c,d} 2>&1

--- a/test/cli/no-stdlib-caching/test.out
+++ b/test/cli/no-stdlib-caching/test.out
@@ -1,0 +1,30 @@
+test.rb:3: Revealed type: `T.class_of(Net::BufferedIO)` https://srb.help/7014
+     3 |T.reveal_type(Net::BufferedIO)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `T.class_of(Net::BufferedIO)` originating from:
+    test.rb:3:
+     3 |T.reveal_type(Net::BufferedIO)
+                      ^^^^^^^^^^^^^^^
+Errors: 1
+--no-stdlib is incompatible with --cache-dir. Ignoring cache
+test.rb:3: Unable to resolve constant `BufferedIO` https://srb.help/5002
+     3 |T.reveal_type(Net::BufferedIO)
+                      ^^^^^^^^^^^^^^^
+
+test.rb:3: Revealed type: `T.untyped` https://srb.help/7014
+     3 |T.reveal_type(Net::BufferedIO)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `T.untyped` originating from:
+    test.rb:3:
+     3 |T.reveal_type(Net::BufferedIO)
+                      ^^^^^^^^^^^^^^^
+
+test.rb:3: Too many arguments provided for method `T.reveal_type`. Expected: `0`, got: `1` https://srb.help/7004
+     3 |T.reveal_type(Net::BufferedIO)
+                      ^^^^^^^^^^^^^^^
+    ???: `reveal_type` defined here
+  Autocorrect: Use `-a` to autocorrect
+    test.rb:3: Delete
+     3 |T.reveal_type(Net::BufferedIO)
+                      ^^^^^^^^^^^^^^^
+Errors: 3

--- a/test/cli/no-stdlib-caching/test.rb
+++ b/test/cli/no-stdlib-caching/test.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+T.reveal_type(Net::BufferedIO)

--- a/test/cli/no-stdlib-caching/test.sh
+++ b/test/cli/no-stdlib-caching/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(mktemp -d)"
+trap 'rm -rf "$dir"' EXIT
+
+cp ./test/cli/no-stdlib-caching/test.rb "$dir"
+
+main/sorbet --silence-dev-message --cache-dir="$dir/cache" "$dir" 2>&1 || true
+main/sorbet --silence-dev-message --no-stdlib --cache-dir="$dir/cache" "$dir" 2>&1 || true
+


### PR DESCRIPTION
The `--no-stdlib` flag might be ignored in the case that `--cache-dir` is used, and the cached global state was not created with `--no-stdlib` passed. It's easier to assume that all cached global states start from the payload, which requires us to mark these two flags as incompatible.

An alternative approach would be to include a hash of flags that affect the global state and validate them as part of loading from the cache, but as the `--no-stdlib` flag doesn't get a lot of use it's easier to instead prohibit the combination.

### Motivation

Removing an odd interaction between `--no-stdlib` and `--cache-dir`, and clearing the way for #8467.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
