### PR TITLE
rewrite `ExpressionPtr` untagging for better codegen

### DIFF
--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -14,7 +14,7 @@ bool definesBehavior(const ExpressionPtr &expr) {
         expr,
 
         [&](const ast::ClassDef &klass) {
-            auto *id = ast::cast_tree<ast::UnresolvedIdent>(klass.name);
+            auto id = ast::cast_tree<ast::UnresolvedIdent>(klass.name);
             if (id && id->name == core::Names::singleton()) {
                 // class << self; We consider this
                 // behavior-defining. We could opt to recurse inside
@@ -52,20 +52,20 @@ bool definesBehavior(const ExpressionPtr &expr) {
 }
 
 bool BehaviorHelpers::checkClassDefinesBehavior(const ExpressionPtr &expr) {
-    auto *klass = ast::cast_tree<ast::ClassDef>(expr);
+    auto klass = ast::cast_tree<ast::ClassDef>(expr);
     ENFORCE(klass);
     return BehaviorHelpers::checkClassDefinesBehavior(*klass);
 }
 
 bool BehaviorHelpers::checkClassDefinesBehavior(const ast::ClassDef &klass) {
     for (auto &ancst : klass.ancestors) {
-        auto *cnst = ast::cast_tree<ast::ConstantLit>(ancst);
+        auto cnst = ast::cast_tree<ast::ConstantLit>(ancst);
         if (cnst && cnst->original != nullptr) {
             return true;
         }
     }
     for (auto &ancst : klass.singletonAncestors) {
-        auto *cnst = ast::cast_tree<ast::ConstantLit>(ancst);
+        auto cnst = ast::cast_tree<ast::ConstantLit>(ancst);
         if (cnst && cnst->original != nullptr) {
             return true;
         }

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -135,27 +135,27 @@ public:
     }
 
     static ExpressionPtr cpRef(ExpressionPtr &name) {
-        if (auto *nm = cast_tree<UnresolvedIdent>(name)) {
+        if (auto nm = cast_tree<UnresolvedIdent>(name)) {
             return make_expression<UnresolvedIdent>(nm->loc, nm->kind, nm->name);
-        } else if (auto *nm = cast_tree<ast::Local>(name)) {
+        } else if (auto nm = cast_tree<ast::Local>(name)) {
             return make_expression<ast::Local>(nm->loc, nm->localVariable);
         }
         Exception::notImplemented();
     }
 
     static ExpressionPtr Assign(core::LocOffsets loc, ExpressionPtr lhs, ExpressionPtr rhs) {
-        if (auto *s = cast_tree<ast::Send>(lhs)) {
+        if (auto s = cast_tree<ast::Send>(lhs)) {
             // the LHS might be a send of the form x.y=(), in which case we add the RHS to the arguments list and get
             // x.y=(rhs)
             s->addPosArg(std::move(rhs));
             return lhs;
-        } else if (auto *seq = cast_tree<ast::InsSeq>(lhs)) {
+        } else if (auto seq = cast_tree<ast::InsSeq>(lhs)) {
             // the LHS might be a sequence, which means that it's the result of a safe navigation operator, like
             //   { $t = x; if $t == nil then nil else $t.y=() }
             // in which case we just need to dril down into the else-case of the condition and add the rhs to the send
             //   { $t = x; if $t == nil then nil else $t.y=(rhs)
-            if (auto *cond = cast_tree<ast::If>(seq->expr)) {
-                if (auto *s = cast_tree<ast::Send>(cond->elsep)) {
+            if (auto cond = cast_tree<ast::If>(seq->expr)) {
+                if (auto s = cast_tree<ast::Send>(cond->elsep)) {
                     s->addPosArg(std::move(rhs));
                     return lhs;
                 }
@@ -455,7 +455,7 @@ public:
     }
 
     static bool isMagicClass(ExpressionPtr &expr) {
-        if (auto *recv = cast_tree<ConstantLit>(expr)) {
+        if (auto recv = cast_tree<ConstantLit>(expr)) {
             return recv->symbol == core::Symbols::Magic();
         } else {
             return false;
@@ -469,7 +469,7 @@ public:
     static core::NameRef arg2Name(const ExpressionPtr &arg) {
         auto *cursor = &arg;
         while (true) {
-            if (auto *local = cast_tree<UnresolvedIdent>(*cursor)) {
+            if (auto local = cast_tree<UnresolvedIdent>(*cursor)) {
                 ENFORCE(local->kind == UnresolvedIdent::Kind::Local);
                 return local->name;
             }
@@ -490,7 +490,7 @@ public:
     static ast::Local const *arg2Local(const ast::ExpressionPtr &arg) {
         auto *cursor = &arg;
         while (true) {
-            if (auto *local = ast::cast_tree<ast::Local>(*cursor)) {
+            if (auto local = ast::cast_tree<ast::Local>(*cursor)) {
                 // Buried deep within every argument is a Local
                 return local;
             }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -107,7 +107,7 @@ string ExpressionPtr::toStringWithTabs(const core::GlobalState &gs, int tabs) co
 }
 
 bool ExpressionPtr::isSelfReference() const {
-    if (auto *local = cast_tree<Local>(*this)) {
+    if (auto local = cast_tree<Local>(*this)) {
         return local->localVariable == core::LocalVariable::selfVariable();
     }
     return false;
@@ -320,7 +320,7 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
                 break;
             }
 
-            auto *orig = cast_tree<UnresolvedConstantLit>(nested->original);
+            auto orig = cast_tree<UnresolvedConstantLit>(nested->original);
             ENFORCE(orig);
             namesFailedToResolve.emplace_back(orig->cnst);
             nested = ast::cast_tree<ast::ConstantLit>(orig->scope);
@@ -328,7 +328,7 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
             ENFORCE(nested->symbol == core::Symbols::StubModule());
             ENFORCE(!nested->resolutionScopes->empty());
         }
-        auto *orig = cast_tree<UnresolvedConstantLit>(nested->original);
+        auto orig = cast_tree<UnresolvedConstantLit>(nested->original);
         ENFORCE(orig);
         namesFailedToResolve.emplace_back(orig->cnst);
         absl::c_reverse(namesFailedToResolve);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -158,7 +158,7 @@ void checkBlockRestArg(DesugarContext dctx, const MethodDef::ARGS_store &args) {
     }
 
     auto &rest = cast_tree_nonnull<RestArg>(*it);
-    if (auto *local = cast_tree<UnresolvedIdent>(rest.expr)) {
+    if (auto local = cast_tree<UnresolvedIdent>(rest.expr)) {
         if (local->name != core::Names::star()) {
             return;
         }
@@ -184,14 +184,14 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
         // This must have been a csend; That will have been desugared
         // into an insseq with an If in the expression.
         res = std::move(recv);
-        auto *is = cast_tree<InsSeq>(res);
+        auto is = cast_tree<InsSeq>(res);
         if (!is) {
             if (auto e = dctx.ctx.beginIndexerError(blockLoc, core::errors::Desugar::UnsupportedNode)) {
                 e.setHeader("No body in block");
             }
             return MK::EmptyTree();
         }
-        auto *iff = cast_tree<If>(is->expr);
+        auto iff = cast_tree<If>(is->expr);
         ENFORCE(iff != nullptr, "DesugarBlock: failed to find If");
         send = cast_tree<Send>(iff->elsep);
         ENFORCE(send != nullptr, "DesugarBlock: failed to find Send");
@@ -388,7 +388,7 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
 ExpressionPtr symbol2Proc(DesugarContext dctx, ExpressionPtr expr) {
     auto loc = expr.loc();
     core::NameRef temp = dctx.freshNameUnique(core::Names::blockPassTemp());
-    Literal *lit = cast_tree<Literal>(expr);
+    Literal lit = cast_tree<Literal>(expr);
     ENFORCE(lit && lit->isSymbol());
 
     // &:foo => {|*temp| (temp[0]).foo(*tmp[1, LONG_MAX]) }
@@ -567,12 +567,12 @@ ClassDef::RHS_store scopeNodeToBody(DesugarContext dctx, unique_ptr<parser::Node
 }
 
 Send *asTLet(ExpressionPtr &arg) {
-    auto *send = cast_tree<Send>(arg);
+    auto send = cast_tree<Send>(arg);
     if (send == nullptr || send->fun != core::Names::let() || send->numPosArgs() < 2) {
         return nullptr;
     }
 
-    auto *recv = cast_tree<UnresolvedConstantLit>(send->recv);
+    auto recv = cast_tree<UnresolvedConstantLit>(send->recv);
     if (recv == nullptr || recv->cnst != core::Names::Constants::T() || !isa_tree<EmptyTree>(recv->scope)) {
         return nullptr;
     }
@@ -878,7 +878,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     auto kwargs = node2TreeImpl(dctx, std::move(kwArray));
                     auto method = MK::Symbol(locZeroLen, send->method);
 
-                    if (auto *array = cast_tree<Array>(kwargs)) {
+                    if (auto array = cast_tree<Array>(kwargs)) {
                         DuplicateHashKeyCheck::checkSendArgs(dctx, 0, array->elems);
                     }
 
@@ -1201,8 +1201,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 } else {
                     auto andAndTemp = dctx.freshNameUnique(core::Names::andAnd());
 
-                    auto *lhsSend = ast::cast_tree<ast::Send>(lhs);
-                    auto *rhsSend = ast::cast_tree<ast::Send>(rhs);
+                    auto lhsSend = ast::cast_tree<ast::Send>(lhs);
+                    auto rhsSend = ast::cast_tree<ast::Send>(rhs);
 
                     ExpressionPtr thenp;
                     if (lhsSend != nullptr && rhsSend != nullptr) {
@@ -2158,7 +2158,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
 
                 auto varLoc = varExpr.loc();
                 auto var = core::NameRef::noName();
-                if (auto *id = cast_tree<UnresolvedIdent>(varExpr)) {
+                if (auto id = cast_tree<UnresolvedIdent>(varExpr)) {
                     if (id->kind == UnresolvedIdent::Kind::Local) {
                         var = id->name;
                         varExpr.reset(nullptr);
@@ -2321,7 +2321,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             [&](parser::Defined *defined) {
                 auto value = node2TreeImpl(dctx, std::move(defined->value));
                 auto loc = value.loc();
-                auto *ident = cast_tree<UnresolvedIdent>(value);
+                auto ident = cast_tree<UnresolvedIdent>(value);
                 if (ident &&
                     (ident->kind == UnresolvedIdent::Kind::Instance || ident->kind == UnresolvedIdent::Kind::Class)) {
                     auto methodName = ident->kind == UnresolvedIdent::Kind::Instance ? core::Names::definedInstanceVar()

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -995,8 +995,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         } else {
                             convertedBlock = node2TreeImpl(dctx, std::move(block));
                         }
-                        Literal *lit;
-                        if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol()) {
+                        if (auto lit = cast_tree<Literal>(convertedBlock); lit && lit->isSymbol()) {
                             res = MK::Send(loc, std::move(rec), send->method, send->methodLoc, numPosArgs,
                                            std::move(args), flags);
                             ast::cast_tree_nonnull<ast::Send>(res).setBlock(

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -902,7 +902,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         } else {
                             convertedBlock = node2TreeImpl(dctx, std::move(block));
                         }
-                        if (auto lit = cast_tree<Literal>(convertedBlock); lit->isSymbol()) {
+                        if (auto lit = cast_tree<Literal>(convertedBlock); lit && lit->isSymbol()) {
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                            std::move(sendargs), flags);
                             ast::cast_tree_nonnull<ast::Send>(res).setBlock(

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -235,8 +235,11 @@ core::NameRef maybeTypedSuper(DesugarContext dctx) {
 }
 
 bool isStringLit(DesugarContext dctx, ExpressionPtr &expr) {
-    Literal *lit;
-    return (lit = cast_tree<Literal>(expr)) && lit->isString();
+    if (auto lit = cast_tree<Literal>(expr)) {
+        return lit->isString();
+    }
+
+    return false;
 }
 
 ExpressionPtr mergeStrings(DesugarContext dctx, core::LocOffsets loc,
@@ -899,8 +902,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         } else {
                             convertedBlock = node2TreeImpl(dctx, std::move(block));
                         }
-                        Literal *lit;
-                        if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol()) {
+                        if (auto lit = cast_tree<Literal>(convertedBlock); lit->isSymbol()) {
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                            std::move(sendargs), flags);
                             ast::cast_tree_nonnull<ast::Send>(res).setBlock(

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -391,7 +391,7 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
 ExpressionPtr symbol2Proc(DesugarContext dctx, ExpressionPtr expr) {
     auto loc = expr.loc();
     core::NameRef temp = dctx.freshNameUnique(core::Names::blockPassTemp());
-    Literal lit = cast_tree<Literal>(expr);
+    auto lit = cast_tree<Literal>(expr);
     ENFORCE(lit && lit->isSymbol());
 
     // &:foo => {|*temp| (temp[0]).foo(*tmp[1, LONG_MAX]) }

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -12,7 +12,7 @@ private:
     T &subst;
 
     void substClassName(core::MutableContext ctx, ExpressionPtr &node) {
-        auto *constLit = cast_tree<UnresolvedConstantLit>(node);
+        auto constLit = cast_tree<UnresolvedConstantLit>(node);
         if (constLit == nullptr) { // uncommon case. something is strange
             if (isa_tree<EmptyTree>(node)) {
                 return;
@@ -41,7 +41,7 @@ private:
     }
 
     core::NameRef unwrapLiteralToName(ExpressionPtr &arg) {
-        auto *literal = cast_tree<Literal>(arg);
+        auto literal = cast_tree<Literal>(arg);
         if (literal == nullptr || !literal->isName()) {
             return core::NameRef::noName();
         }

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -287,7 +287,7 @@ private:
 
         for (auto &arg : cast_tree_nonnull<MethodDef>(v).args) {
             // Only OptionalArgs have subexpressions within them.
-            if (auto *optArg = cast_tree<OptionalArg>(arg)) {
+            if (auto optArg = cast_tree<OptionalArg>(arg)) {
                 CALL_MAP(optArg->default_, ctx.withOwner(cast_tree_nonnull<MethodDef>(v).symbol));
             }
         }
@@ -454,7 +454,7 @@ private:
 
         for (auto &arg : cast_tree_nonnull<Block>(v).args) {
             // Only OptionalArgs have subexpressions within them.
-            if (auto *optArg = cast_tree<OptionalArg>(arg)) {
+            if (auto optArg = cast_tree<OptionalArg>(arg)) {
                 CALL_MAP(optArg->default_, ctx);
             }
         }

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -409,13 +409,13 @@ public:
         return (this->ptr & SYNTHETIC_FLAG) != 0;
     }
 
-    template <class To> struct TaggedValue {
+    template <class To> struct UntaggedPtr {
     private:
         To *value;
         bool isValid;
 
     public:
-        explicit TaggedValue(To *p, bool valid) noexcept : value(p), isValid(valid) {}
+        explicit UntaggedPtr(To *p, bool valid) noexcept : value(p), isValid(valid) {}
 
         explicit operator bool() const noexcept {
             return isValid;
@@ -438,16 +438,16 @@ public:
         }
     };
 
-    template <class To> TaggedValue<To> as_instruction() {
+    template <class To> UntaggedPtr<To> as_instruction() {
         bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
         auto *ptr = isValid ? reinterpret_cast<To *>(get()) : nullptr;
-        return TaggedValue<To>(ptr, isValid);
+        return UntaggedPtr<To>(ptr, isValid);
     }
 
-    template <class To> TaggedValue<const To> as_instruction() const {
+    template <class To> UntaggedPtr<const To> as_instruction() const {
         bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
         auto *ptr = isValid ? reinterpret_cast<const To *>(get()) : nullptr;
-        return TaggedValue<const To>(ptr, isValid);
+        return UntaggedPtr<const To>(ptr, isValid);
     }
 
     void setSynthetic() noexcept {
@@ -462,14 +462,14 @@ template <class To> bool isa_instruction(const InstructionPtr &what) {
     return bool(what.as_instruction<To>());
 }
 
-template <class To> InstructionPtr::TaggedValue<To> cast_instruction(InstructionPtr &what) {
+template <class To> InstructionPtr::UntaggedPtr<To> cast_instruction(InstructionPtr &what) {
     static_assert(!std::is_pointer<To>::value, "To has to be a pointer");
     static_assert(std::is_assignable<Instruction *&, To *>::value,
                   "Ill Formed To, has to be a subclass of Instruction");
     return what.as_instruction<To>();
 }
 
-template <class To> InstructionPtr::TaggedValue<const To> cast_instruction(const InstructionPtr &what) {
+template <class To> InstructionPtr::UntaggedPtr<const To> cast_instruction(const InstructionPtr &what) {
     static_assert(!std::is_pointer<To>::value, "To has to be a pointer");
     static_assert(std::is_assignable<Instruction *&, To *>::value,
                   "Ill Formed To, has to be a subclass of Instruction");

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -7,6 +7,7 @@
 #include "core/LocalVariable.h"
 #include "core/NameRef.h"
 #include "core/Types.h"
+#include "core/UntaggedPtr.h"
 #include <climits>
 #include <memory>
 
@@ -409,45 +410,16 @@ public:
         return (this->ptr & SYNTHETIC_FLAG) != 0;
     }
 
-    template <class To> struct UntaggedPtr {
-    private:
-        To *value;
-        bool isValid;
-
-    public:
-        explicit UntaggedPtr(To *p, bool valid) noexcept : value(p), isValid(valid) {}
-
-        explicit operator bool() const noexcept {
-            return isValid;
-        }
-
-        To *operator->() const noexcept {
-            return value;
-        }
-
-        operator To *() const noexcept {
-            return value;
-        }
-
-        bool operator==(std::nullptr_t) const noexcept {
-            return value == nullptr;
-        }
-
-        bool operator!=(std::nullptr_t) const noexcept {
-            return value != nullptr;
-        }
-    };
-
-    template <class To> UntaggedPtr<To> as_instruction() {
+    template <class To> core::UntaggedPtr<To> as_instruction() {
         bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
         auto *ptr = isValid ? reinterpret_cast<To *>(get()) : nullptr;
-        return UntaggedPtr<To>(ptr, isValid);
+        return core::UntaggedPtr<To>(ptr, isValid);
     }
 
-    template <class To> UntaggedPtr<const To> as_instruction() const {
+    template <class To> core::UntaggedPtr<const To> as_instruction() const {
         bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
         auto *ptr = isValid ? reinterpret_cast<const To *>(get()) : nullptr;
-        return UntaggedPtr<const To>(ptr, isValid);
+        return core::UntaggedPtr<const To>(ptr, isValid);
     }
 
     void setSynthetic() noexcept {
@@ -462,14 +434,14 @@ template <class To> bool isa_instruction(const InstructionPtr &what) {
     return bool(what.as_instruction<To>());
 }
 
-template <class To> InstructionPtr::UntaggedPtr<To> cast_instruction(InstructionPtr &what) {
+template <class To> core::UntaggedPtr<To> cast_instruction(InstructionPtr &what) {
     static_assert(!std::is_pointer<To>::value, "To has to be a pointer");
     static_assert(std::is_assignable<Instruction *&, To *>::value,
                   "Ill Formed To, has to be a subclass of Instruction");
     return what.as_instruction<To>();
 }
 
-template <class To> InstructionPtr::UntaggedPtr<const To> cast_instruction(const InstructionPtr &what) {
+template <class To> core::UntaggedPtr<const To> cast_instruction(const InstructionPtr &what) {
     static_assert(!std::is_pointer<To>::value, "To has to be a pointer");
     static_assert(std::is_assignable<Instruction *&, To *>::value,
                   "Ill Formed To, has to be a subclass of Instruction");

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -63,7 +63,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
             // Ignore defaults for abstract methods, because abstract methods do not have bodies and are not called.
             if (!isAbstract) {
                 // Only emit conditional arg loading if the arg has a default
-                if (auto *opt = ast::cast_tree<ast::OptionalArg>(argExpr)) {
+                if (auto opt = ast::cast_tree<ast::OptionalArg>(argExpr)) {
                     auto [result, presentNext, defaultNext] =
                         walkDefault(cctx, i, argInfo, local, a->loc, opt->default_, presentCont, defaultCont);
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -124,7 +124,7 @@ bool isKernelLambda(ast::Send &s) {
     //
     // We could revisit this in the future but for now let's be conservative.
 
-    auto *cnst = ast::cast_tree<ast::ConstantLit>(s.recv);
+    auto cnst = ast::cast_tree<ast::ConstantLit>(s.recv);
     return cnst != nullptr && cnst->symbol == core::Symbols::Kernel();
 }
 
@@ -184,13 +184,13 @@ InstructionPtr maybeMakeTypeParameterAlias(CFGContext &cctx, ast::Send &s) {
 }
 
 ast::Send *isKernelProcOrLambda(ast::ExpressionPtr &expr) {
-    auto *send = ast::cast_tree<ast::Send>(expr);
+    auto send = ast::cast_tree<ast::Send>(expr);
     if (send == nullptr || send->hasNonBlockArgs() ||
         (send->fun != core::Names::lambda() && send->fun != core::Names::proc())) {
         return nullptr;
     }
 
-    auto *recv = ast::cast_tree<ast::ConstantLit>(send->recv);
+    auto recv = ast::cast_tree<ast::ConstantLit>(send->recv);
     if (recv == nullptr || recv->symbol != core::Symbols::Kernel()) {
         return nullptr;
     }
@@ -435,7 +435,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 synthesizeExpr(current, cctx.target, a.loc, make_insn<Ident>(aliasName));
 
                 if (a.original) {
-                    auto *orig = ast::cast_tree<ast::UnresolvedConstantLit>(a.original);
+                    auto orig = ast::cast_tree<ast::UnresolvedConstantLit>(a.original);
                     // Empirically, these are the only two cases we've needed so far to service the
                     // LSP requests we want (hover and completion), but that doesn't mean these are
                     // the **only** we'll ever want.
@@ -642,7 +642,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                                 continue;
                             }
 
-                            if (auto *opt = ast::cast_tree<ast::OptionalArg>(blockArgs[i])) {
+                            if (auto opt = ast::cast_tree<ast::OptionalArg>(blockArgs[i])) {
                                 auto *presentBlock = cctx.inWhat.freshBlock(bodyLoops);
                                 auto *missingBlock = cctx.inWhat.freshBlock(bodyLoops);
 
@@ -869,11 +869,11 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 unconditionalJump(elseBody, ensureBody, cctx.inWhat, a.loc);
 
                 for (auto &expr : a.rescueCases) {
-                    auto *rescueCase = ast::cast_tree<ast::RescueCase>(expr);
+                    auto rescueCase = ast::cast_tree<ast::RescueCase>(expr);
                     auto caseBody = cctx.inWhat.freshBlock(cctx.loops);
                     auto &exceptions = rescueCase->exceptions;
                     auto added = false;
-                    auto *local = ast::cast_tree<ast::Local>(rescueCase->var);
+                    auto local = ast::cast_tree<ast::Local>(rescueCase->var);
                     ENFORCE(local != nullptr, "rescue case var not a local?");
 
                     auto localVar = cctx.inWhat.enterLocal(local->localVariable);

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -22,7 +22,7 @@ bool shouldExtract(core::Context ctx, const ast::ExpressionPtr &what) {
         return false;
     }
 
-    if (auto *asgn = ast::cast_tree<ast::Assign>(what)) {
+    if (auto asgn = ast::cast_tree<ast::Assign>(what)) {
         return !ast::isa_tree<ast::UnresolvedConstantLit>(asgn->lhs);
     }
 
@@ -71,7 +71,7 @@ public:
         ENFORCE(classes.size() > classStack.back());
         ENFORCE(classes[classStack.back()] == nullptr);
 
-        auto *classDef = ast::cast_tree<ast::ClassDef>(tree);
+        auto classDef = ast::cast_tree<ast::ClassDef>(tree);
         auto inits = extractClassInit(ctx, classDef);
 
         core::MethodRef sym;

--- a/core/BUILD
+++ b/core/BUILD
@@ -20,6 +20,7 @@ cc_library(
     hdrs = [
         "KwPair.h",
         "NameSubstitution.h",
+        "UntaggedPtr.h",
         "core.h",
     ] + glob([
         "errors/*.h",

--- a/core/UntaggedPtr.h
+++ b/core/UntaggedPtr.h
@@ -1,0 +1,37 @@
+#ifndef SORBET_UNTAGGEDPTR_H
+#define SORBET_UNTAGGEDPTR_H
+
+namespace sorbet::core {
+
+template <class To> struct UntaggedPtr {
+private:
+    To *value;
+    bool isValid;
+
+public:
+    explicit UntaggedPtr(To *p, bool valid) noexcept : value(p), isValid(valid) {}
+
+    explicit operator bool() const noexcept {
+        return isValid;
+    }
+
+    To *operator->() const noexcept {
+        return value;
+    }
+
+    operator To *() const noexcept {
+        return value;
+    }
+
+    bool operator==(std::nullptr_t) const noexcept {
+        return value == nullptr;
+    }
+
+    bool operator!=(std::nullptr_t) const noexcept {
+        return value != nullptr;
+    }
+};
+
+} // namespace sorbet::core
+
+#endif // SORBET_UNTAGGEDPTR_H

--- a/core/UntaggedPtr.h
+++ b/core/UntaggedPtr.h
@@ -15,6 +15,10 @@ public:
         return isValid;
     }
 
+    To *get() const noexcept {
+        return value;
+    }
+
     To *operator->() const noexcept {
         return value;
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -463,7 +463,7 @@ constructOverrideAutocorrect(const core::Context ctx, const ast::ExpressionPtr &
         return nullopt;
     }
 
-    auto *blockBody = ast::cast_tree<ast::Send>(block->body);
+    auto blockBody = ast::cast_tree<ast::Send>(block->body);
     ENFORCE(blockBody != nullptr);
     auto insertLoc = ctx.locAt(blockBody->loc.copyWithZeroLength());
 
@@ -788,7 +788,7 @@ void validateSuperClass(core::Context ctx, const core::ClassOrModuleRef sym, con
         return;
     }
 
-    if (auto *cnst = ast::cast_tree<ast::ConstantLit>(classDef.ancestors.front())) {
+    if (auto cnst = ast::cast_tree<ast::ConstantLit>(classDef.ancestors.front())) {
         if (cnst->symbol == core::Symbols::todo()) {
             return;
         }
@@ -1047,7 +1047,7 @@ private:
 
         auto hasEmptyBody = classDef.rhs.empty();
         if (classDef.rhs.size() == 1) {
-            if (auto *mdef = ast::cast_tree<ast::MethodDef>(classDef.rhs[0])) {
+            if (auto mdef = ast::cast_tree<ast::MethodDef>(classDef.rhs[0])) {
                 hasEmptyBody = ast::isa_tree<ast::EmptyTree>(mdef->rhs);
             }
         }
@@ -1199,7 +1199,7 @@ public:
             return;
         }
 
-        auto *id = ast::cast_tree<ast::ConstantLit>(send.recv);
+        auto id = ast::cast_tree<ast::ConstantLit>(send.recv);
         if (id == nullptr || !id->symbol.exists() || !id->symbol.isClassOrModule()) {
             return;
         }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -33,7 +33,7 @@ bool isEmptyParseResult(const core::GlobalState &gs, const ast::ExpressionPtr &t
         return true;
     }
 
-    auto *classDef = ast::cast_tree<ast::ClassDef>(tree);
+    auto classDef = ast::cast_tree<ast::ClassDef>(tree);
     if (classDef == nullptr || classDef->symbol != core::Symbols::root()) {
         return false;
     }

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -492,7 +492,7 @@ class LocalNameInserter {
     }
 
     void walkConstantLit(core::MutableContext ctx, ast::ExpressionPtr &tree) {
-        if (auto *lit = ast::cast_tree<ast::UnresolvedConstantLit>(tree)) {
+        if (auto lit = ast::cast_tree<ast::UnresolvedConstantLit>(tree)) {
             walkConstantLit(ctx, lit->scope);
         } else if (ast::isa_tree<ast::EmptyTree>(tree) || ast::isa_tree<ast::ConstantLit>(tree)) {
             // Do nothing.

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -94,7 +94,7 @@ public:
     }
 
     void preTransformClassDef(core::Context ctx, const ast::ClassDef &original) {
-        auto *name = ast::cast_tree<ast::ConstantLit>(original.name);
+        auto name = ast::cast_tree<ast::ConstantLit>(original.name);
         if (name == nullptr) {
             return;
         }
@@ -166,7 +166,7 @@ public:
         // and now that we've processed all the ancestors, we should have created references for them all, so traverse
         // them once again...
         for (auto &ancst : original.ancestors) {
-            auto *cnst = ast::cast_tree<ast::ConstantLit>(ancst);
+            auto cnst = ast::cast_tree<ast::ConstantLit>(ancst);
             if (cnst == nullptr || cnst->original == nullptr) {
                 // ignore them if they're not statically-known ancestors (i.e. not constants)
                 continue;
@@ -308,7 +308,7 @@ public:
 
     void postTransformAssign(core::Context ctx, const ast::Assign &original) {
         // autogen only cares about constant assignments/definitions, so bail otherwise
-        auto *lhs = ast::cast_tree<ast::ConstantLit>(original.lhs);
+        auto lhs = ast::cast_tree<ast::ConstantLit>(original.lhs);
         if (lhs == nullptr || lhs->original == nullptr) {
             return;
         }
@@ -343,7 +343,7 @@ public:
         def.id = defs.size() - 1;
 
         // if the RHS is _also_ a constant, then this is an alias
-        auto *rhs = ast::cast_tree<ast::ConstantLit>(original.rhs);
+        auto rhs = ast::cast_tree<ast::ConstantLit>(original.rhs);
         if (rhs && rhs->symbol.exists() && !rhs->symbol.isTypeAlias(ctx)) {
             def.type = Definition::Type::Alias;
             // since this is a `post`- method, then we've already created a `Reference` for the constant on the
@@ -386,7 +386,7 @@ public:
         }
         // This means it's a `require`; mark it as such
         if (original.flags.isPrivateOk && original.fun == core::Names::require() && original.numPosArgs() == 1) {
-            auto *lit = ast::cast_tree<ast::Literal>(original.getPosArg(0));
+            auto lit = ast::cast_tree<ast::Literal>(original.getPosArg(0));
             if (lit && lit->isString()) {
                 requireStatements.emplace_back(lit->asString());
             }

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -165,17 +165,17 @@ void DefLocSaver::preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tr
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
     if (ast::isa_tree<ast::EmptyTree>(classDef.name)) {
         ENFORCE(classDef.symbol == core::Symbols::root());
-    } else if (auto *ident = ast::cast_tree<ast::UnresolvedIdent>(classDef.name)) {
+    } else if (auto ident = ast::cast_tree<ast::UnresolvedIdent>(classDef.name)) {
         ENFORCE(ident->name == core::Names::singleton());
     } else {
         // The `<root>` class we wrap all code with uses EmptyTree for the ClassDef::name field.
-        auto *lit = ast::cast_tree<ast::ConstantLit>(classDef.name);
+        auto lit = ast::cast_tree<ast::ConstantLit>(classDef.name);
         matchesQuery(ctx, lit, lspQuery, lit->symbol);
     }
 
     if (classDef.kind == ast::ClassDef::Kind::Class && !classDef.ancestors.empty() &&
         shouldLeaveAncestorForIDE(classDef.ancestors.front())) {
-        auto *lit = ast::cast_tree<ast::ConstantLit>(classDef.ancestors.front());
+        auto lit = ast::cast_tree<ast::ConstantLit>(classDef.ancestors.front());
         matchesQuery(ctx, lit, lspQuery, lit->symbol);
     }
 }

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -122,8 +122,8 @@ class LocSearchWalk {
         // that was desugared to an if inside the else. In that case, insert into the else would be invalid, so let's
         // skip it. If there's a more specific scope, we'll insert there, and if there isn't, we'll insert outside the
         // if.
-        if (const ast::If if_ = ast::cast_tree<ast::If>(node)) {
-            if (const ast::If elsif = ast::cast_tree<ast::If>(if_->elsep)) {
+        if (auto if_ = ast::cast_tree<ast::If>(node)) {
+            if (auto elsif = ast::cast_tree<ast::If>(if_->elsep)) {
                 if (elsif->loc.exists() && elsif->loc.contains(targetLoc.offsets())) {
                     return;
                 }

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -122,8 +122,8 @@ class LocSearchWalk {
         // that was desugared to an if inside the else. In that case, insert into the else would be invalid, so let's
         // skip it. If there's a more specific scope, we'll insert there, and if there isn't, we'll insert outside the
         // if.
-        if (const ast::If *if_ = ast::cast_tree<ast::If>(node)) {
-            if (const ast::If *elsif = ast::cast_tree<ast::If>(if_->elsep)) {
+        if (const ast::If if_ = ast::cast_tree<ast::If>(node)) {
+            if (const ast::If elsif = ast::cast_tree<ast::If>(if_->elsep)) {
                 if (elsif->loc.exists() && elsif->loc.contains(targetLoc.offsets())) {
                     return;
                 }

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -27,7 +27,7 @@ void LocalVarFinder::preTransformBlock(core::Context ctx, const ast::Block &bloc
 void LocalVarFinder::postTransformAssign(core::Context ctx, const ast::Assign &assign) {
     ENFORCE(!methodStack.empty());
 
-    auto *local = ast::cast_tree<ast::Local>(assign.lhs);
+    auto local = ast::cast_tree<ast::Local>(assign.lhs);
     if (local == nullptr) {
         return;
     }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -816,7 +816,7 @@ public:
 
     void preTransformClassDef(core::Context ctx, const ast::ClassDef &classDef) {
         if (classDef.kind == ast::ClassDef::Kind::Class && !classDef.ancestors.empty()) {
-            auto *lit = ast::cast_tree<ast::ConstantLit>(classDef.ancestors.front());
+            auto lit = ast::cast_tree<ast::ConstantLit>(classDef.ancestors.front());
             auto unresolvedPath = lit->fullUnresolvedPath(ctx);
             if (unresolvedPath.has_value()) {
                 unresolvedConstants.emplace_back(fmt::format(

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -95,7 +95,7 @@ class SymbolFinder {
     vector<optional<core::FoundModifier>> methodVisiStack = {nullopt};
 
     void findClassModifiers(core::Context ctx, core::FoundDefinitionRef klass, const ast::ExpressionPtr &line) {
-        auto *send = ast::cast_tree<ast::Send>(line);
+        auto send = ast::cast_tree<ast::Send>(line);
         if (send == nullptr) {
             return;
         }
@@ -146,7 +146,7 @@ class SymbolFinder {
     }
 
     core::FoundDefinitionRef defineScope(core::FoundDefinitionRef owner, const ast::ExpressionPtr &node) {
-        if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
+        if (auto id = ast::cast_tree<ast::ConstantLit>(node)) {
             // Already defined. Insert a foundname so we can reference it.
             auto sym = id->symbol;
             ENFORCE(sym.exists());
@@ -182,7 +182,7 @@ public:
         found.loc = klass.loc;
         found.declLoc = klass.declLoc;
 
-        auto *ident = ast::cast_tree<ast::UnresolvedIdent>(klass.name);
+        auto ident = ast::cast_tree<ast::UnresolvedIdent>(klass.name);
         if ((ident != nullptr) && ident->name == core::Names::singleton()) {
             found.owner = getOwner();
             found.name = ident->name;
@@ -342,7 +342,7 @@ public:
         }
 
         if (sendArgs.size() == 1) {
-            if (auto *array = ast::cast_tree<ast::Array>(sendArgs[0])) {
+            if (auto array = ast::cast_tree<ast::Array>(sendArgs[0])) {
                 for (auto &e : array->elems) {
                     addMethodModifier(ctx, modifierName, e);
                 }
@@ -501,7 +501,7 @@ public:
                 return core::NameRef::noName();
             }
             return sym->asSymbol();
-        } else if (auto *def = ast::cast_tree<ast::RuntimeMethodDefinition>(expr)) {
+        } else if (auto def = ast::cast_tree<ast::RuntimeMethodDefinition>(expr)) {
             return def->name;
         } else {
             ENFORCE(!ast::isa_tree<ast::MethodDef>(expr), "methods inside sends should be gone");
@@ -550,7 +550,7 @@ public:
         if (send->hasPosArgs() || send->block() != nullptr) {
             // If there are positional arguments, there might be a variance annotation
             if (send->numPosArgs() > 0) {
-                auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+                auto lit = ast::cast_tree<ast::Literal>(send->getPosArg(0));
                 if (lit != nullptr && lit->isSymbol()) {
                     found.varianceName = lit->asSymbol();
                     found.litLoc = lit->loc;
@@ -558,9 +558,9 @@ public:
             }
 
             if (send->block() != nullptr) {
-                if (const auto *hash = ast::cast_tree<ast::Hash>(send->block()->body)) {
+                if (const auto hash = ast::cast_tree<ast::Hash>(send->block()->body)) {
                     for (const auto &keyExpr : hash->keys) {
-                        const auto *key = ast::cast_tree<ast::Literal>(keyExpr);
+                        const auto key = ast::cast_tree<ast::Literal>(keyExpr);
                         if (key != nullptr && key->isSymbol()) {
                             switch (key->asSymbol().rawId()) {
                                 case core::Names::fixed().rawId():
@@ -597,7 +597,7 @@ public:
 
     // Returns `true` if `asgn` is a field declaration.
     bool handleFieldDeclaration(core::Context ctx, const ast::Assign &asgn) {
-        auto *uid = ast::cast_tree<ast::UnresolvedIdent>(asgn.lhs);
+        auto uid = ast::cast_tree<ast::UnresolvedIdent>(asgn.lhs);
         if (uid == nullptr) {
             return false;
         }
@@ -607,11 +607,11 @@ public:
         }
 
         auto *recur = &asgn.rhs;
-        while (auto *outer = ast::cast_tree<ast::InsSeq>(*recur)) {
+        while (auto outer = ast::cast_tree<ast::InsSeq>(*recur)) {
             recur = &outer->expr;
         }
 
-        auto *cast = ast::cast_tree<ast::Cast>(*recur);
+        auto cast = ast::cast_tree<ast::Cast>(*recur);
         if (cast == nullptr) {
             return false;
         }
@@ -641,12 +641,12 @@ public:
             return;
         }
 
-        auto *lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
+        auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
         if (lhs == nullptr) {
             return;
         }
 
-        auto *send = ast::cast_tree<ast::Send>(asgn.rhs);
+        auto send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send == nullptr) {
             fillAssign(ctx, asgn);
         } else if (!send->recv.isSelfReference()) {
@@ -1664,10 +1664,10 @@ class TreeSymbolizer {
                                      bool firstName) {
         auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node);
         if (constLit == nullptr) {
-            if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
+            if (auto id = ast::cast_tree<ast::ConstantLit>(node)) {
                 return id->symbol.dealias(ctx);
             }
-            if (auto *uid = ast::cast_tree<ast::UnresolvedIdent>(node)) {
+            if (auto uid = ast::cast_tree<ast::UnresolvedIdent>(node)) {
                 if (uid->kind != ast::UnresolvedIdent::Kind::Class || uid->name != core::Names::singleton()) {
                     if (auto e = ctx.beginError(node.loc(), core::errors::Namer::DynamicConstant)) {
                         e.setHeader("Unsupported constant scope");
@@ -1726,7 +1726,7 @@ public:
     void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
-        auto *ident = ast::cast_tree<ast::UnresolvedIdent>(klass.name);
+        auto ident = ast::cast_tree<ast::UnresolvedIdent>(klass.name);
 
         if ((ident != nullptr) && ident->name == core::Names::singleton()) {
             ENFORCE(ident->kind == ast::UnresolvedIdent::Kind::Class);
@@ -1888,9 +1888,9 @@ public:
 
     ast::ExpressionPtr handleTypeMemberDefinition(core::Context ctx, ast::ExpressionPtr tree) {
         auto &asgn = ast::cast_tree_nonnull<ast::Assign>(tree);
-        auto *send = ast::cast_tree<ast::Send>(asgn.rhs);
+        auto send = ast::cast_tree<ast::Send>(asgn.rhs);
         ENFORCE(send != nullptr);
-        const auto *typeName = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
+        const auto typeName = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
         ENFORCE(typeName != nullptr);
 
         if (!ctx.owner.isClassOrModule()) {
@@ -1984,9 +1984,9 @@ public:
             bool fixed = false;
             bool bounded = false;
 
-            if (const auto *hash = ast::cast_tree<ast::Hash>(send->block()->body)) {
+            if (const auto hash = ast::cast_tree<ast::Hash>(send->block()->body)) {
                 for (const auto &keyExpr : hash->keys) {
-                    const auto *key = ast::cast_tree<ast::Literal>(keyExpr);
+                    const auto key = ast::cast_tree<ast::Literal>(keyExpr);
                     if (key == nullptr || !key->isSymbol()) {
                         if (auto e = ctx.beginError(keyExpr.loc(), core::errors::Namer::InvalidTypeDefinition)) {
                             e.setHeader("Hash provided in block to `{}` must have symbol keys", send->fun.show(ctx));
@@ -2038,7 +2038,7 @@ public:
         }
 
         if (send->numPosArgs() > 0) {
-            auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+            auto lit = ast::cast_tree<ast::Literal>(send->getPosArg(0));
             if (!lit || !lit->isSymbol()) {
                 if (auto e = ctx.beginError(send->loc, core::errors::Namer::InvalidTypeDefinition)) {
                     e.setHeader("Invalid param, must be a :symbol");
@@ -2052,12 +2052,12 @@ public:
     void postTransformAssign(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &asgn = ast::cast_tree_nonnull<ast::Assign>(tree);
 
-        auto *lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
+        auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
         if (lhs == nullptr) {
             return;
         }
 
-        auto *send = ast::cast_tree<ast::Send>(asgn.rhs);
+        auto send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send == nullptr) {
             tree = handleAssignment(ctx, std::move(tree));
         } else if (!send->recv.isSelfReference()) {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -256,7 +256,7 @@ public:
             return;
         }
 
-        auto *lit = ast::cast_tree<ast::ConstantLit>(send.getPosArg(0));
+        auto lit = ast::cast_tree<ast::ConstantLit>(send.getPosArg(0));
         if (lit == nullptr || lit->symbol == core::Symbols::StubModule()) {
             // We don't raise an explicit error here, as this is one of two cases:
             //   1. Export is given a non-constant argument
@@ -544,7 +544,7 @@ public:
             return;
         }
 
-        auto *lit = ast::cast_tree<ast::ConstantLit>(send.getPosArg(0));
+        auto lit = ast::cast_tree<ast::ConstantLit>(send.getPosArg(0));
         if (lit == nullptr) {
             // We don't raise an explicit error here, for the same reasons as in PropagateVisibility::postTransformSend.
             return;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -526,9 +526,9 @@ ast::ExpressionPtr prependName(ast::ExpressionPtr scope) {
 
 bool startsWithPackageSpecRegistry(const ast::UnresolvedConstantLit *cnst) {
     while (cnst != nullptr) {
-        if (auto *scope = ast::cast_tree<ast::ConstantLit>(cnst->scope)) {
+        if (auto scope = ast::cast_tree<ast::ConstantLit>(cnst->scope)) {
             return scope->symbol == core::Symbols::PackageSpecRegistry();
-        } else if (auto *scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope)) {
+        } else if (auto scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope)) {
             return startsWithPackageSpecRegistry(scope);
         } else {
             return false;
@@ -826,7 +826,7 @@ public:
             return;
         }
 
-        auto *constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
+        auto constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
         if (constantLit == nullptr) {
             return;
         }
@@ -864,7 +864,7 @@ public:
             }
         }
 
-        auto *constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
+        auto constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
         if (constantLit == nullptr) {
             return;
         }
@@ -877,7 +877,7 @@ public:
             errorDepth++;
             return;
         }
-        auto *lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
+        auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
 
         if (lhs != nullptr && rootConsts == 0) {
             pushConstantLit(ctx, lhs);
@@ -961,7 +961,7 @@ private:
         auto prevDepth = namespaces.depth();
         while (lit != nullptr) {
             tmpNameParts.emplace_back(lit->cnst, lit->loc);
-            auto *scope = ast::cast_tree<ast::ConstantLit>(lit->scope);
+            auto scope = ast::cast_tree<ast::ConstantLit>(lit->scope);
             lit = ast::cast_tree<ast::UnresolvedConstantLit>(lit->scope);
             if (scope != nullptr) {
                 ENFORCE(lit == nullptr);
@@ -987,7 +987,7 @@ private:
             if (rootConsts == 0) {
                 namespaces.popName();
             }
-            auto *scope = ast::cast_tree<ast::ConstantLit>(lit->scope);
+            auto scope = ast::cast_tree<ast::ConstantLit>(lit->scope);
             lit = ast::cast_tree<ast::UnresolvedConstantLit>(lit->scope);
             if (scope != nullptr) {
                 ENFORCE(lit == nullptr);
@@ -1215,7 +1215,7 @@ struct PackageSpecBodyWalk {
             return;
         }
 
-        auto *nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
+        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
         if (nameTree == nullptr) {
             // Already reported an error
             return;
@@ -1339,7 +1339,7 @@ struct PackageSpecBodyWalk {
 
 private:
     optional<core::packages::StrictDependenciesLevel> parseStrictDependenciesOption(ast::ExpressionPtr &arg) {
-        auto *lit = ast::cast_tree<ast::Literal>(arg);
+        auto lit = ast::cast_tree<ast::Literal>(arg);
         if (!lit || !lit->isString()) {
             return nullopt;
         }
@@ -1360,7 +1360,7 @@ private:
 
     optional<core::NameRef> parseLayerOption(const core::GlobalState &gs, ast::ExpressionPtr &arg) {
         auto validLayers = gs.packageDB().layers();
-        auto *lit = ast::cast_tree<ast::Literal>(arg);
+        auto lit = ast::cast_tree<ast::Literal>(arg);
         if (!lit || !lit->isString()) {
             return nullopt;
         }
@@ -1393,7 +1393,7 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
             continue;
         }
 
-        auto *packageSpecClass = ast::cast_tree<ast::ClassDef>(rootStmt);
+        auto packageSpecClass = ast::cast_tree<ast::ClassDef>(rootStmt);
         if (packageSpecClass == nullptr) {
             // No error here; let this be reported in the tree walk later as a bad node type,
             // or at the end of this function if no PackageSpec is found.
@@ -1413,7 +1413,7 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
             continue;
         }
 
-        auto *nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
+        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
         if (!validatePackageName(ctx, nameTree)) {
             reportedError = true;
             continue;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -96,12 +96,12 @@ namespace {
  */
 
 bool isT(ast::ExpressionPtr &expr) {
-    auto *tMod = ast::cast_tree<ast::ConstantLit>(expr);
+    auto tMod = ast::cast_tree<ast::ConstantLit>(expr);
     return tMod && tMod->symbol == core::Symbols::T();
 }
 
 bool isTClassOf(ast::ExpressionPtr &expr) {
-    auto *send = ast::cast_tree<ast::Send>(expr);
+    auto send = ast::cast_tree<ast::Send>(expr);
 
     if (send == nullptr) {
         return false;
@@ -349,7 +349,7 @@ private:
 
             return result;
         }
-        if (auto *id = ast::cast_tree<ast::ConstantLit>(c.scope)) {
+        if (auto id = ast::cast_tree<ast::ConstantLit>(c.scope)) {
             auto sym = id->symbol;
             if (!sym.exists()) {
                 // Still waiting for scope to be resolved. Don't mark resolutionFailed yet, just
@@ -645,7 +645,7 @@ private:
             auto *cursor = out;
             bool isRootReference = false;
             while (cursor != nullptr) {
-                auto *original = ast::cast_tree<ast::UnresolvedConstantLit>(cursor->original);
+                auto original = ast::cast_tree<ast::UnresolvedConstantLit>(cursor->original);
                 if (original == nullptr) {
                     isRootReference = cursor->symbol == core::Symbols::root();
                     break;
@@ -733,7 +733,7 @@ private:
         bool alreadyReported = false;
         job.out->resolutionScopes = make_unique<ast::ConstantLit::ResolutionScopes>();
         auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(job.out->original);
-        if (auto *id = ast::cast_tree<ast::ConstantLit>(original.scope)) {
+        if (auto id = ast::cast_tree<ast::ConstantLit>(original.scope)) {
             auto originalScope = id->symbol.dealias(ctx);
             if (originalScope == core::Symbols::StubModule()) {
                 // If we were trying to resolve some literal like C::D but `C` itself was already stubbed,
@@ -1125,7 +1125,7 @@ private:
                 }
             }
 
-            auto *id = ast::cast_tree<ast::ConstantLit>(arg);
+            auto id = ast::cast_tree<ast::ConstantLit>(arg);
 
             if (id == nullptr || !id->symbol.exists()) {
                 if (auto e = gs.beginError(core::Loc(todo.file, send->loc),
@@ -1242,7 +1242,7 @@ private:
         auto blockLoc = core::Loc(todo.file, block->body.loc());
         core::ClassOrModuleRef symbol = core::Symbols::StubModule();
 
-        if (auto *constant = ast::cast_tree<ast::ConstantLit>(block->body)) {
+        if (auto constant = ast::cast_tree<ast::ConstantLit>(block->body)) {
             if (constant->symbol.exists() && constant->symbol.isClassOrModule()) {
                 symbol = constant->symbol.asClassOrModuleRef();
             }
@@ -1252,7 +1252,7 @@ private:
             ENFORCE(send);
 
             if (send->numPosArgs() == 1) {
-                if (auto *argClass = ast::cast_tree<ast::ConstantLit>(send->getPosArg(0))) {
+                if (auto argClass = ast::cast_tree<ast::ConstantLit>(send->getPosArg(0))) {
                     if (argClass->symbol.exists() && argClass->symbol.isClassOrModule()) {
                         if (argClass->symbol == owner) {
                             if (auto e = gs.beginError(blockLoc, core::errors::Resolver::InvalidRequiredAncestor)) {
@@ -1301,7 +1301,7 @@ private:
         job.isSuperclass = isSuperclass;
         job.isInclude = isInclude;
 
-        if (auto *cnst = ast::cast_tree<ast::ConstantLit>(ancestor)) {
+        if (auto cnst = ast::cast_tree<ast::ConstantLit>(ancestor)) {
             auto sym = cnst->symbol;
             if (sym.exists() && sym.isTypeAlias(ctx)) {
                 if (auto e = ctx.beginError(cnst->loc, core::errors::Resolver::DynamicSuperclass)) {
@@ -1336,11 +1336,11 @@ private:
     }
 
     void walkUnresolvedConstantLit(core::Context ctx, ast::ExpressionPtr &tree) {
-        if (auto *c = ast::cast_tree<ast::UnresolvedConstantLit>(tree)) {
+        if (auto c = ast::cast_tree<ast::UnresolvedConstantLit>(tree)) {
             walkUnresolvedConstantLit(ctx, c->scope);
             auto loc = c->loc;
             auto out = ast::make_expression<ast::ConstantLit>(loc, core::Symbols::noSymbol(), std::move(tree));
-            auto *constant = ast::cast_tree<ast::ConstantLit>(out);
+            auto constant = ast::cast_tree<ast::ConstantLit>(out);
             ConstantResolutionItem job{nesting_, constant};
             if (resolveConstantJob(ctx, job)) {
                 categoryCounterInc("resolve.constants.nonancestor", "firstpass");
@@ -1552,7 +1552,7 @@ public:
     void postTransformAssign(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &asgn = ast::cast_tree_nonnull<ast::Assign>(tree);
 
-        auto *id = ast::cast_tree<ast::ConstantLit>(asgn.lhs);
+        auto id = ast::cast_tree<ast::ConstantLit>(asgn.lhs);
         if (id == nullptr || !id->symbol.isStaticField(ctx)) {
             return;
         }
@@ -1583,7 +1583,7 @@ public:
             }
         }
 
-        auto *send = ast::cast_tree<ast::Send>(asgn.rhs);
+        auto send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send != nullptr && send->fun == core::Names::typeAlias()) {
             if (!send->hasBlock()) {
                 // if we have an invalid (i.e. nullary) call to TypeAlias, then we'll treat it as a type alias for
@@ -1625,7 +1625,7 @@ public:
             }
         }
 
-        auto *rhs = ast::cast_tree<ast::ConstantLit>(asgn.rhs);
+        auto rhs = ast::cast_tree<ast::ConstantLit>(asgn.rhs);
         if (rhs == nullptr) {
             return;
         }
@@ -2505,11 +2505,11 @@ class ResolveTypeMembersAndFieldsWalk {
         core::Loc lowerBoundTypeLoc;
         core::Loc upperBoundTypeLoc;
         if (rhs->block() != nullptr) {
-            if (const auto *hash = ast::cast_tree<ast::Hash>(rhs->block()->body)) {
+            if (const auto hash = ast::cast_tree<ast::Hash>(rhs->block()->body)) {
                 int i = -1;
                 for (const auto &keyExpr : hash->keys) {
                     i++;
-                    const auto *key = ast::cast_tree<ast::Literal>(keyExpr);
+                    const auto key = ast::cast_tree<ast::Literal>(keyExpr);
                     if (key == nullptr || !key->isSymbol()) {
                         // Namer reported an error already
                         continue;
@@ -2759,7 +2759,7 @@ class ResolveTypeMembersAndFieldsWalk {
     }
 
     ast::UnresolvedIdent *unwrapFieldAssign(ast::Assign &asgn) {
-        auto *uid = ast::cast_tree<ast::UnresolvedIdent>(asgn.lhs);
+        auto uid = ast::cast_tree<ast::UnresolvedIdent>(asgn.lhs);
         if (uid == nullptr) {
             return nullptr;
         }
@@ -2779,11 +2779,11 @@ class ResolveTypeMembersAndFieldsWalk {
         }
 
         auto *recur = &asgn.rhs;
-        while (auto *outer = ast::cast_tree<ast::InsSeq>(*recur)) {
+        while (auto outer = ast::cast_tree<ast::InsSeq>(*recur)) {
             recur = &outer->expr;
         }
 
-        auto *cast = ast::cast_tree<ast::Cast>(*recur);
+        auto cast = ast::cast_tree<ast::Cast>(*recur);
         if (cast == nullptr) {
             return false;
         }
@@ -2832,7 +2832,7 @@ class ResolveTypeMembersAndFieldsWalk {
 
         auto stringLoc = send.getPosArg(1).loc();
 
-        auto *literalNode = ast::cast_tree<ast::Literal>(send.getPosArg(1));
+        auto literalNode = ast::cast_tree<ast::Literal>(send.getPosArg(1));
         if (literalNode == nullptr) {
             if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
                 e.setHeader("`{}` only accepts string literals", method);
@@ -2948,7 +2948,7 @@ public:
         }
 
         for (const auto &ancestor : klass.ancestors) {
-            auto *ancestorCnst = ast::cast_tree<ast::ConstantLit>(ancestor);
+            auto ancestorCnst = ast::cast_tree<ast::ConstantLit>(ancestor);
             if (ancestorCnst == nullptr) {
                 continue;
             }
@@ -3062,11 +3062,11 @@ public:
     }
 
     void postTransformCast(core::Context ctx, ast::ExpressionPtr &tree) {
-        auto *cast = ast::cast_tree<ast::Cast>(tree);
+        auto cast = ast::cast_tree<ast::Cast>(tree);
         if (cast->cast == core::Names::assumeType()) {
             // This cast was not written by the user. Before we attempt to parse it as a type, let's
             // make sure that it's even possible to be valid.
-            auto *cnst = ast::cast_tree<ast::ConstantLit>(cast->typeExpr);
+            auto cnst = ast::cast_tree<ast::ConstantLit>(cast->typeExpr);
             ENFORCE(cnst != nullptr, "Rewriter should always use const for typeExpr, which should now be resolved");
 
             // Dealias to mimic how type_syntax parsing will work for constant lit node (e.g., want
@@ -3112,7 +3112,7 @@ public:
                 break;
         }
 
-        if (auto *id = ast::cast_tree<ast::ConstantLit>(send.recv)) {
+        if (auto id = ast::cast_tree<ast::ConstantLit>(send.recv)) {
             if (id->symbol != core::Symbols::T() && id->symbol != core::Symbols::T_NonForcingConstants()) {
                 return;
             }
@@ -3215,13 +3215,13 @@ public:
             return;
         }
 
-        auto *id = ast::cast_tree<ast::ConstantLit>(asgn.lhs);
+        auto id = ast::cast_tree<ast::ConstantLit>(asgn.lhs);
         if (id == nullptr || !id->symbol.exists()) {
             return;
         }
 
         auto sym = id->symbol;
-        auto *send = ast::cast_tree<ast::Send>(asgn.rhs);
+        auto send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send && (sym.isTypeAlias(ctx) || sym.isTypeMember())) {
             ENFORCE(!sym.isTypeMember() || send->recv.isSelfReference());
 

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -18,7 +18,7 @@ namespace {
 pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::ExpressionPtr &name) {
     core::LocOffsets loc;
     core::NameRef res;
-    if (auto *lit = ast::cast_tree<ast::Literal>(name)) {
+    if (auto lit = ast::cast_tree<ast::Literal>(name)) {
         if (lit->isSymbol()) {
             res = lit->asSymbol();
             loc = lit->loc;
@@ -63,7 +63,7 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Exp
 // either with no scope or with the root scope (i.e. `::T`). this might not actually refer to the `T` that we define for
 // users, but we don't know that information in the Rewriter passes.
 bool isT(const ast::ExpressionPtr &expr) {
-    auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+    auto t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     if (t == nullptr || t->cnst != core::Names::Constants::T()) {
         return false;
     }
@@ -71,7 +71,7 @@ bool isT(const ast::ExpressionPtr &expr) {
 }
 
 bool isTNilableOrUntyped(const ast::ExpressionPtr &expr) {
-    auto *send = ast::cast_tree<ast::Send>(expr);
+    auto send = ast::cast_tree<ast::Send>(expr);
     return send != nullptr && (send->fun == core::Names::nilable() || send->fun == core::Names::untyped()) &&
            isT(send->recv);
 }
@@ -121,7 +121,7 @@ ast::ExpressionPtr dupReturnsType(ast::Send *sharedSig) {
 void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, ast::Send *sig) {
     // Loop down the chain of recv's until we get to the inner 'sig' node.
     auto *block = sig->block();
-    auto *body = ast::cast_tree<ast::Send>(block->body);
+    auto body = ast::cast_tree<ast::Send>(block->body);
     auto *cur = body;
     while (cur != nullptr) {
         if (cur->fun == core::Names::typeParameters()) {
@@ -142,7 +142,7 @@ ast::ExpressionPtr toWriterSigForName(ast::Send *sharedSig, const core::NameRef 
 
     // There's a bit of work here because deepCopy gives us back an Expression when we know it's a Send.
     ast::ExpressionPtr sigExpr = sharedSig->deepCopy();
-    auto *sig = ast::cast_tree<ast::Send>(sigExpr);
+    auto sig = ast::cast_tree<ast::Send>(sigExpr);
     ENFORCE(sig != nullptr, "Just deep copied this, so it should be non-null");
 
     auto *body = findSendReturns(sig);

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -122,7 +122,7 @@ void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, ast::S
     // Loop down the chain of recv's until we get to the inner 'sig' node.
     auto *block = sig->block();
     auto body = ast::cast_tree<ast::Send>(block->body);
-    auto *cur = body;
+    auto cur = body;
     while (cur != nullptr) {
         if (cur->fun == core::Names::typeParameters()) {
             if (auto e = ctx.beginIndexerError(sig->loc, core::errors::Rewriter::BadAttrType)) {

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -14,14 +14,14 @@ bool isCommand(core::MutableContext ctx, ast::ClassDef *klass) {
     if (klass->kind != ast::ClassDef::Kind::Class || klass->ancestors.empty()) {
         return false;
     }
-    auto *cnst = ast::cast_tree<ast::UnresolvedConstantLit>(klass->ancestors.front());
+    auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(klass->ancestors.front());
     if (cnst == nullptr) {
         return false;
     }
     if (cnst->cnst != core::Names::Constants::Command()) {
         return false;
     }
-    auto *scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope);
+    auto scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope);
     if (scope == nullptr) {
         return false;
     }
@@ -45,7 +45,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     ast::ExpressionPtr *callptr = nullptr;
 
     for (auto &stat : klass->rhs) {
-        auto *mdef = ast::cast_tree<ast::MethodDef>(stat);
+        auto mdef = ast::cast_tree<ast::MethodDef>(stat);
         if (mdef == nullptr) {
             continue;
         }
@@ -70,7 +70,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     // This could in principle be `resolver::TypeSyntax::isSig`, but we don't
     // want to depend on the internals of the resolver, or accidentally rely on
     // passes that happen between here and the resolver.
-    auto *sig = ast::cast_tree<ast::Send>(klass->rhs[i - 1]);
+    auto sig = ast::cast_tree<ast::Send>(klass->rhs[i - 1]);
     if (sig == nullptr || sig->fun != core::Names::sig()) {
         return;
     }

--- a/rewriter/Concern.cc
+++ b/rewriter/Concern.cc
@@ -22,15 +22,15 @@ bool doesExtendConcern(core::MutableContext ctx, ast::ClassDef *klass) {
                 if (!send.hasPosArgs()) {
                     return;
                 }
-                auto *firstArg = ast::cast_tree<ast::UnresolvedConstantLit>(send.getPosArg(0));
+                auto firstArg = ast::cast_tree<ast::UnresolvedConstantLit>(send.getPosArg(0));
                 if (firstArg == nullptr) {
                     return;
                 }
-                auto *firstArgScope = ast::cast_tree<ast::UnresolvedConstantLit>(firstArg->scope);
+                auto firstArgScope = ast::cast_tree<ast::UnresolvedConstantLit>(firstArg->scope);
                 if (firstArgScope == nullptr) {
                     return;
                 }
-                auto *outerScope = ast::cast_tree<ast::UnresolvedConstantLit>(firstArgScope->scope);
+                auto outerScope = ast::cast_tree<ast::UnresolvedConstantLit>(firstArgScope->scope);
                 if (outerScope != nullptr) {
                     return;
                 }
@@ -69,7 +69,7 @@ void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
     vector<ast::ExpressionPtr> stats;
     ast::ExpressionPtr classMethodsNode;
     for (auto &stat : klass->rhs) {
-        if (auto *send = ast::cast_tree<ast::Send>(stat)) {
+        if (auto send = ast::cast_tree<ast::Send>(stat)) {
             if (send->fun == core::Names::classMethods()) { // class_methods do ... end
                 if (!send->hasBlock()) {
                     continue;
@@ -80,7 +80,7 @@ void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
                 if (classMethodsNode) {
                     // ClassMethods module already exists. Let's add the block as one of its members
                     auto *block = send->block();
-                    auto *classDef = ast::cast_tree<ast::ClassDef>(classMethodsNode);
+                    auto classDef = ast::cast_tree<ast::ClassDef>(classMethodsNode);
 
                     if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
                         for (auto &stat : insSeq->stats) {
@@ -110,12 +110,12 @@ void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
                 }
                 continue;
             }
-        } else if (auto *mod = ast::cast_tree<ast::ClassDef>(stat)) {
+        } else if (auto mod = ast::cast_tree<ast::ClassDef>(stat)) {
             auto name = ast::cast_tree<ast::UnresolvedConstantLit>(mod->name);
             if (name && name->cnst == core::Names::Constants::ClassMethods()) {
                 if (classMethodsNode) {
                     // ClassMethods module already exists. Let's add mod->rhs into existing module
-                    auto *classDef = ast::cast_tree<ast::ClassDef>(classMethodsNode);
+                    auto classDef = ast::cast_tree<ast::ClassDef>(classMethodsNode);
                     for (auto &elem : mod->rhs) {
                         classDef->rhs.emplace_back(std::move(elem));
                     }

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -43,7 +43,7 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     if (send->numPosArgs() < 2) {
         return empty;
     }
-    auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+    auto sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
     if (sym == nullptr || !sym->isSymbol()) {
         return empty;
     }
@@ -59,7 +59,7 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     }
 
     ast::ExpressionPtr optsTree = ASTUtil::mkKwArgsHash(send);
-    if (auto *opts = ast::cast_tree<ast::Hash>(optsTree)) {
+    if (auto opts = ast::cast_tree<ast::Hash>(optsTree)) {
         if (ASTUtil::hasHashValue(ctx, *opts, core::Names::default_())) {
             nilable = false;
         }

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -22,7 +22,7 @@ bool isMissingInitialize(const core::GlobalState &gs, const ast::Send *send) {
 
     auto block = send->block();
 
-    if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
+    if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
         auto methodDef = ast::cast_tree<ast::MethodDef>(insSeq->expr);
 
         if (methodDef && methodDef->name == core::Names::initialize()) {
@@ -77,7 +77,7 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
     ast::ClassDef::RHS_store body;
 
     for (auto &arg : send->posArgs()) {
-        auto *sym = ast::cast_tree<ast::Literal>(arg);
+        auto sym = ast::cast_tree<ast::Literal>(arg);
         if (!sym || !sym->isName()) {
             return empty;
         }
@@ -111,7 +111,7 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
 
     if (auto *block = send->block()) {
         // Steal the trees, because the run is going to remove the original send node from the tree anyway.
-        if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
+        if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
             for (auto &&stat : insSeq->stats) {
                 body.emplace_back(move(stat));
             }

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -42,12 +42,12 @@ vector<ast::ExpressionPtr> runDefDelegator(core::MutableContext ctx, const ast::
         return methodStubs;
     }
 
-    auto *accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+    auto accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
     if (!accessor || !accessor->isName()) {
         return methodStubs;
     }
 
-    auto *method = ast::cast_tree<ast::Literal>(send->getPosArg(1));
+    auto method = ast::cast_tree<ast::Literal>(send->getPosArg(1));
     if (!method || !method->isSymbol()) {
         return methodStubs;
     }
@@ -55,7 +55,7 @@ vector<ast::ExpressionPtr> runDefDelegator(core::MutableContext ctx, const ast::
     core::NameRef methodName = method->asSymbol();
 
     if (send->numPosArgs() == 3) {
-        auto *alias = ast::cast_tree<ast::Literal>(send->getPosArg(2));
+        auto alias = ast::cast_tree<ast::Literal>(send->getPosArg(2));
         if (!alias || !alias->isSymbol()) {
             return methodStubs;
         }
@@ -87,13 +87,13 @@ vector<ast::ExpressionPtr> runDefDelegators(core::MutableContext ctx, const ast:
         return methodStubs;
     }
 
-    auto *accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+    auto accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
     if (!accessor || !accessor->isName()) {
         return methodStubs;
     }
 
     for (int i = 1, numPosArgs = send->numPosArgs(); i < numPosArgs; ++i) {
-        auto *method = ast::cast_tree<ast::Literal>(send->getPosArg(i));
+        auto method = ast::cast_tree<ast::Literal>(send->getPosArg(i));
         // Skip method names that we don't understand, but continue to emit
         // desugared calls for the ones we do.
         if (!method || !method->isSymbol()) {

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -85,7 +85,7 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
 
     vector<ast::ExpressionPtr> methodStubs;
     for (auto &arg : send->posArgs()) {
-        auto *lit = ast::cast_tree<ast::Literal>(arg);
+        auto lit = ast::cast_tree<ast::Literal>(arg);
         if (!lit || !lit->isSymbol()) {
             return empty;
         }

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -27,7 +27,7 @@ optional<core::NameRef> getFieldName(core::MutableContext ctx, ast::Send &send) 
 }
 
 ast::Send *asFlatfileDo(ast::ExpressionPtr &stat) {
-    auto *send = ast::cast_tree<ast::Send>(stat);
+    auto send = ast::cast_tree<ast::Send>(stat);
     if (send != nullptr && send->hasBlock() && send->fun == core::Names::flatfile()) {
         return send;
     } else {
@@ -67,7 +67,7 @@ void Flatfiles::run(core::MutableContext ctx, ast::ClassDef *klass) {
     for (auto &stat : klass->rhs) {
         if (auto flatfileBlock = asFlatfileDo(stat)) {
             auto *block = flatfileBlock->block();
-            if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
+            if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
                 for (auto &stat : insSeq->stats) {
                     handleFieldDefinition(ctx, stat, methods);
                 }

--- a/rewriter/HasAttachedClass.cc
+++ b/rewriter/HasAttachedClass.cc
@@ -14,7 +14,7 @@ vector<ast::ExpressionPtr> HasAttachedClass::run(core::MutableContext ctx, bool 
 
     if (send->numPosArgs() > 0) {
         const auto &arg0 = send->posArgs()[0];
-        if (const auto *lit = ast::cast_tree<ast::Literal>(arg0)) {
+        if (const auto lit = ast::cast_tree<ast::Literal>(arg0)) {
             if (lit->isSymbol() && lit->asSymbol() == core::Names::contravariant()) {
                 if (auto e = ctx.beginIndexerError(arg0.loc(), core::errors::Rewriter::ContravariantHasAttachedClass)) {
                     e.setHeader("`{}` cannot be declared `{}`, only invariant or `{}`",

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -165,7 +165,7 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, const
         return;
     }
 
-    auto *bodyBlock = ast::cast_tree<ast::Send>(block->body);
+    auto bodyBlock = ast::cast_tree<ast::Send>(block->body);
     checkSigReturnType(ctx, bodyBlock);
 
     // walk through, find the `params()` invocation, and get its hash
@@ -177,7 +177,7 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, const
     // build a lookup table that maps from names to the types they have
     UnorderedMap<core::NameRef, const ast::ExpressionPtr *> argTypeMap;
     for (auto [key, value] : params->kwArgPairs()) {
-        auto *argName = ast::cast_tree<ast::Literal>(key);
+        auto argName = ast::cast_tree<ast::Literal>(key);
         if (argName->isSymbol()) {
             argTypeMap[argName->asSymbol()] = &value;
         }
@@ -185,7 +185,7 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, const
 
     UnorderedMap<core::NameRef, ArgKind> argKindMap;
     for (const auto &arg : methodDef->args) {
-        const auto *restArg = ast::cast_tree<ast::RestArg>(arg);
+        const auto restArg = ast::cast_tree<ast::RestArg>(arg);
         if (restArg == nullptr) {
             argKindMap[ast::MK::arg2Name(arg)] = ArgKind::Plain;
         } else if (ast::isa_tree<ast::KeywordArg>(restArg->expr)) {

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -63,7 +63,7 @@ vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send 
     }
 
     auto optionsTree = ASTUtil::mkKwArgsHash(send);
-    if (auto *options = ast::cast_tree<ast::Hash>(optionsTree)) {
+    if (auto options = ast::cast_tree<ast::Hash>(optionsTree)) {
         for (int i = 0; i < options->keys.size(); i++) {
             auto &key = options->keys[i];
             auto &value = options->values[i];
@@ -89,7 +89,7 @@ vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send 
 
     vector<ast::ExpressionPtr> result;
     for (int i = 0; i < symbolArgsBound; i++) {
-        auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(i));
+        auto lit = ast::cast_tree<ast::Literal>(send->getPosArg(i));
         if (!lit || !lit->isSymbol()) {
             return empty;
         }

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -46,7 +46,7 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
     }
 
     auto loc = send->loc;
-    auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+    auto sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
     if (!sym || !sym->isSymbol()) {
         return empty;
     }
@@ -59,7 +59,7 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
     ast::ExpressionPtr rules;
     rules = ASTUtil::mkKwArgsHash(send);
 
-    if (auto *hash = ast::cast_tree<ast::Hash>(rules)) {
+    if (auto hash = ast::cast_tree<ast::Hash>(rules)) {
         if (ASTUtil::hasTruthyHashValue(ctx, *hash, core::Names::immutable())) {
             isImmutable = true;
         }

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -87,7 +87,7 @@ vector<ast::ExpressionPtr> ModuleFunction::rewriteDefn(core::MutableContext ctx,
 
     // as well as a public static copy of the method signature
     if (prevStat) {
-        if (auto *sig = ast::cast_tree<ast::Send>(*prevStat)) {
+        if (auto sig = ast::cast_tree<ast::Send>(*prevStat)) {
             if (sig->fun == core::Names::sig()) {
                 stats.emplace_back(sig->deepCopy());
             }
@@ -95,7 +95,7 @@ vector<ast::ExpressionPtr> ModuleFunction::rewriteDefn(core::MutableContext ctx,
     }
     auto moduleCopy = expr.deepCopy();
     ENFORCE(moduleCopy, "Should be non-nil.");
-    auto *newDefn = ast::cast_tree<ast::MethodDef>(moduleCopy);
+    auto newDefn = ast::cast_tree<ast::MethodDef>(moduleCopy);
     newDefn->flags.isSelfMethod = true;
     newDefn->flags.isRewriterSynthesized = true;
     stats.emplace_back(move(moduleCopy));

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -16,17 +16,17 @@ namespace {
 // either with no scope or with the root scope (i.e. `::T`). this might not actually refer to the `T` that we define for
 // users, but we don't know that information in the Rewriter passes.
 bool isT(const ast::ExpressionPtr &expr) {
-    auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+    auto t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return t != nullptr && t->cnst == core::Names::Constants::T() && ast::MK::isRootScope(t->scope);
 }
 
 bool isTNilable(const ast::ExpressionPtr &expr) {
-    auto *nilable = ast::cast_tree<ast::Send>(expr);
+    auto nilable = ast::cast_tree<ast::Send>(expr);
     return nilable != nullptr && nilable->fun == core::Names::nilable() && isT(nilable->recv);
 }
 
 bool isTUntyped(const ast::ExpressionPtr &expr) {
-    auto *send = ast::cast_tree<ast::Send>(expr);
+    auto send = ast::cast_tree<ast::Send>(expr);
     return send != nullptr && send->fun == core::Names::untyped() && isT(send->recv);
 }
 
@@ -40,17 +40,17 @@ bool isTNilableTUntyped(const ast::ExpressionPtr &expr) {
 }
 
 bool isTStruct(const ast::ExpressionPtr &expr) {
-    auto *struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+    auto struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return struct_ != nullptr && struct_->cnst == core::Names::Constants::Struct() && isT(struct_->scope);
 }
 
 bool isTInexactStruct(const ast::ExpressionPtr &expr) {
-    auto *struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+    auto struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return struct_ != nullptr && struct_->cnst == core::Names::Constants::InexactStruct() && isT(struct_->scope);
 }
 
 bool isTImmutableStruct(const ast::ExpressionPtr &expr) {
-    auto *struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+    auto struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return struct_ != nullptr && struct_->cnst == core::Names::Constants::ImmutableStruct() && isT(struct_->scope);
 }
 
@@ -215,7 +215,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
         if (!send->hasPosArgs()) {
             return nullopt;
         }
-        auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+        auto sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
         if (!sym || !sym->isSymbol()) {
             return nullopt;
         }
@@ -264,7 +264,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
 
             bool addDefault = true;
             if (rulesTree != nullptr) {
-                auto *rules = ast::cast_tree<ast::Hash>(rulesTree);
+                auto rules = ast::cast_tree<ast::Hash>(rulesTree);
                 addDefault = !ASTUtil::hasHashValue(ctx, *rules, core::Names::default_());
             }
 
@@ -279,7 +279,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
     }
     // ----- Parse any extra options -----
     if (rulesTree) {
-        auto *rules = ast::cast_tree<ast::Hash>(rulesTree);
+        auto rules = ast::cast_tree<ast::Hash>(rulesTree);
         if (ASTUtil::hasTruthyHashValue(ctx, *rules, core::Names::immutable())) {
             ret.isImmutable = true;
         }
@@ -507,12 +507,12 @@ ast::ExpressionPtr ensureWithoutAccessors(const PropInfo &prop, const ast::Send 
     auto withoutAccessors = ast::MK::Symbol(send->loc, core::Names::withoutAccessors());
     auto true_ = ast::MK::True(send->loc);
 
-    auto *copy = ast::cast_tree<ast::Send>(result);
+    auto copy = ast::cast_tree<ast::Send>(result);
     if (copy->hasKwArgs() || !copy->hasPosArgs()) {
         // append to the inline keyword arguments of the send
         copy->addKwArg(move(withoutAccessors), move(true_));
     } else {
-        if (auto *hash = ast::cast_tree<ast::Hash>(copy->getPosArg(copy->numPosArgs() - 1))) {
+        if (auto hash = ast::cast_tree<ast::Hash>(copy->getPosArg(copy->numPosArgs() - 1))) {
             hash->keys.emplace_back(move(withoutAccessors));
             hash->values.emplace_back(move(true_));
         } else {
@@ -588,7 +588,7 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
     vector<PropInfo> props;
     UnorderedMap<core::NameRef, uint32_t> seenProps;
     for (auto &stat : klass->rhs) {
-        auto *send = ast::cast_tree<ast::Send>(stat);
+        auto send = ast::cast_tree<ast::Send>(stat);
         if (send == nullptr) {
             continue;
         }

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -8,18 +8,18 @@ namespace sorbet::rewriter {
 namespace {
 
 bool isTSigWithoutRuntime(ast::ExpressionPtr &expr) {
-    if (auto *cnst = ast::cast_tree<ast::ConstantLit>(expr)) {
+    if (auto cnst = ast::cast_tree<ast::ConstantLit>(expr)) {
         return cnst->symbol == core::Symbols::T_Sig_WithoutRuntime();
     } else {
-        auto *withoutRuntime = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+        auto withoutRuntime = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
         if (withoutRuntime == nullptr || withoutRuntime->cnst != core::Names::Constants::WithoutRuntime()) {
             return false;
         }
-        auto *sig = ast::cast_tree<ast::UnresolvedConstantLit>(withoutRuntime->scope);
+        auto sig = ast::cast_tree<ast::UnresolvedConstantLit>(withoutRuntime->scope);
         if (sig == nullptr || sig->cnst != core::Names::Constants::Sig()) {
             return false;
         }
-        auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(sig->scope);
+        auto t = ast::cast_tree<ast::UnresolvedConstantLit>(sig->scope);
         return t != nullptr && t->cnst == core::Names::Constants::T() && ast::MK::isRootScope(t->scope);
     }
 }

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -16,7 +16,7 @@ namespace sorbet::rewriter {
 namespace {
 
 bool isKeywordInitKey(const core::GlobalState &gs, const ast::ExpressionPtr &node) {
-    if (auto *lit = ast::cast_tree<ast::Literal>(node)) {
+    if (auto lit = ast::cast_tree<ast::Literal>(node)) {
         return lit->isSymbol() && lit->asSymbol() == core::Names::keywordInit();
     }
     return false;
@@ -101,7 +101,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
             return empty;
         }
 
-        if (auto *lit = ast::cast_tree<ast::Literal>(send->getKwValue(0))) {
+        if (auto lit = ast::cast_tree<ast::Literal>(send->getKwValue(0))) {
             if (lit->isTrue(ctx)) {
                 keywordInit = true;
             } else if (!lit->isFalse(ctx)) {
@@ -113,7 +113,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
     }
 
     for (auto &arg : send->posArgs()) {
-        auto *sym = ast::cast_tree<ast::Literal>(arg);
+        auto sym = ast::cast_tree<ast::Literal>(arg);
         if (!sym || !sym->isSymbol()) {
             return empty;
         }
@@ -182,7 +182,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
 
         if (auto *block = send->block()) {
             // Steal the trees, because the run is going to remove the original send node from the tree anyway.
-            if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
+            if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
                 for (auto &&stat : insSeq->stats) {
                     body.emplace_back(move(stat));
                 }

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -68,7 +68,7 @@ ast::Send *findSelfNew(ast::ExpressionPtr &assignRhs) {
             return nullptr;
         }
 
-        auto *magicSelfNew = rhs;
+        auto magicSelfNew = rhs;
         if (rhs->fun == core::Names::let()) {
             auto recv = ast::cast_tree<ast::UnresolvedConstantLit>(rhs->recv);
             if (recv == nullptr) {

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -23,14 +23,14 @@ bool isTEnum(core::MutableContext ctx, ast::ClassDef *klass) {
     if (klass->kind != ast::ClassDef::Kind::Class || klass->ancestors.empty()) {
         return false;
     }
-    auto *cnst = ast::cast_tree<ast::UnresolvedConstantLit>(klass->ancestors.front());
+    auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(klass->ancestors.front());
     if (cnst == nullptr) {
         return false;
     }
     if (cnst->cnst != core::Names::Constants::Enum()) {
         return false;
     }
-    auto *scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope);
+    auto scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope);
     if (scope == nullptr) {
         return false;
     }
@@ -41,7 +41,7 @@ bool isTEnum(core::MutableContext ctx, ast::ClassDef *klass) {
 }
 
 ast::Send *asEnumsDo(ast::ExpressionPtr &stat) {
-    auto *send = ast::cast_tree<ast::Send>(stat);
+    auto send = ast::cast_tree<ast::Send>(stat);
 
     if (send != nullptr && send->hasBlock() && send->fun == core::Names::enums()) {
         return send;
@@ -58,7 +58,7 @@ void badConst(core::MutableContext ctx, core::LocOffsets headerLoc, core::LocOff
 }
 
 ast::Send *findSelfNew(ast::ExpressionPtr &assignRhs) {
-    auto *rhs = ast::cast_tree<ast::Send>(assignRhs);
+    auto rhs = ast::cast_tree<ast::Send>(assignRhs);
     if (rhs != nullptr) {
         if (rhs->fun != core::Names::new_() && rhs->fun != core::Names::let()) {
             return nullptr;
@@ -92,7 +92,7 @@ ast::Send *findSelfNew(ast::ExpressionPtr &assignRhs) {
         return magicSelfNew;
     }
 
-    auto *cast = ast::cast_tree<ast::Cast>(assignRhs);
+    auto cast = ast::cast_tree<ast::Cast>(assignRhs);
     if (cast == nullptr) {
         return nullptr;
     }
@@ -107,12 +107,12 @@ struct ProcessStatResult {
 
 std::optional<ProcessStatResult> processStat(core::MutableContext ctx, ast::ClassDef *klass, ast::ExpressionPtr &stat,
                                              FromWhere fromWhere) {
-    auto *asgn = ast::cast_tree<ast::Assign>(stat);
+    auto asgn = ast::cast_tree<ast::Assign>(stat);
     if (asgn == nullptr) {
         return {};
     }
 
-    auto *lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs);
+    auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs);
     if (lhs == nullptr) {
         return {};
     }
@@ -140,7 +140,7 @@ std::optional<ProcessStatResult> processStat(core::MutableContext ctx, ast::Clas
     if (selfNew->numPosArgs() == 0 && selfNew->onlyPosArgs()) {
         serializeType = core::Types::String();
     } else if (selfNew->numPosArgs() == 1) {
-        if (auto *selfNewArg = ast::cast_tree<ast::Literal>(selfNew->getPosArg(0))) {
+        if (auto selfNewArg = ast::cast_tree<ast::Literal>(selfNew->getPosArg(0))) {
             // If the enum has exactly one variant that has a literal passed (ex. "a"),
             // then its type will be String("a"), but we want a ClassType as the return type.
             serializeType = core::Types::dropLiteral(ctx, selfNewArg->value);

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -10,10 +10,10 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
     // Go through all class definition statements and find all setups, tests and teardowns
     std::vector<ast::ExpressionPtr> testSends, setupAndTeardownSends;
     for (auto &stat : klass->rhs) {
-        if (auto *send = ast::cast_tree<ast::Send>(stat)) {
+        if (auto send = ast::cast_tree<ast::Send>(stat)) {
             if (send->fun == core::Names::test()) {
                 if (send->numPosArgs() == 1 && !send->hasKwArgs() && send->hasBlock()) {
-                    auto *arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+                    auto arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
 
                     if (arg0 && arg0->isString()) {
                         testSends.push_back(std::move(stat));
@@ -33,9 +33,9 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
 
     // Rewrite all test sends as method definitions
     for (auto &stat : testSends) {
-        auto *send = ast::cast_tree<ast::Send>(stat);
+        auto send = ast::cast_tree<ast::Send>(stat);
         auto loc = send->loc;
-        auto *arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+        auto arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
         auto *block = send->block();
 
         auto snake_case_name = absl::StrReplaceAll(arg0->asString().toString(ctx), {{" ", "_"}});
@@ -50,7 +50,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
     // rewrite as well. If there aren't any test sends, then emplace back the original statements into the class
     if (!testSends.empty()) {
         for (auto &stat : setupAndTeardownSends) {
-            auto *send = ast::cast_tree<ast::Send>(stat);
+            auto send = ast::cast_tree<ast::Send>(stat);
             auto loc = send->loc;
             auto block = send->block();
             auto method_name =

--- a/rewriter/TypeAssertion.cc
+++ b/rewriter/TypeAssertion.cc
@@ -7,7 +7,7 @@ namespace sorbet::rewriter {
 
 namespace {
 bool isT(const ast::ExpressionPtr &expr) {
-    auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+    auto t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     if (t == nullptr || t->cnst != core::Names::Constants::T()) {
         return false;
     }

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -256,7 +256,7 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
     bool explicitEmptyHash = false;
     if (send->hasKwSplat() || !send->hasKwArgs()) {
         if (auto hash = ast::cast_tree<ast::Hash>(send->hasKwSplat() ? *send->kwSplat()
-                                                                      : send->getPosArg(send->numPosArgs() - 1))) {
+                                                                     : send->getPosArg(send->numPosArgs() - 1))) {
             explicitEmptyHash = hash->keys.empty();
             for (auto i = 0; i < hash->keys.size(); ++i) {
                 keys.emplace_back(hash->keys[i].deepCopy());

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -219,7 +219,7 @@ ast::Send *ASTUtil::castSig(ast::ExpressionPtr &expr) {
         return nullptr;
     }
 
-    return castSigImpl(send);
+    return castSigImpl(send.get());
 }
 
 const ast::Send *ASTUtil::castSig(const ast::ExpressionPtr &expr) {
@@ -228,7 +228,7 @@ const ast::Send *ASTUtil::castSig(const ast::ExpressionPtr &expr) {
         return nullptr;
     }
 
-    return castSigImpl(send);
+    return castSigImpl(send.get());
 }
 
 ast::Send *ASTUtil::castSig(ast::Send *expr) {

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -54,7 +54,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
                              std::move(args));
     }
 
-    auto *ident = ast::cast_tree<ast::ConstantLit>(orig);
+    auto ident = ast::cast_tree<ast::ConstantLit>(orig);
     if (ident) {
         auto orig = dupType(ident->original);
         if (ident->original && !orig) {
@@ -63,7 +63,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol, std::move(orig));
     }
 
-    auto *arrayLit = ast::cast_tree<ast::Array>(orig);
+    auto arrayLit = ast::cast_tree<ast::Array>(orig);
     if (arrayLit != nullptr) {
         auto elems = ast::Array::ENTRY_store{};
         for (const auto &elem : arrayLit->elems) {
@@ -78,7 +78,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         return ast::MK::Array(arrayLit->loc, std::move(elems));
     }
 
-    auto *hashLit = ast::cast_tree<ast::Hash>(orig);
+    auto hashLit = ast::cast_tree<ast::Hash>(orig);
     if (hashLit != nullptr) {
         auto keys = ast::Hash::ENTRY_store{};
         auto values = ast::Hash::ENTRY_store{};
@@ -86,7 +86,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         for (size_t i = 0; i < hashLit->keys.size(); i++) {
             const auto &key = hashLit->keys[i];
 
-            auto *keyLit = ast::cast_tree<ast::Literal>(key);
+            auto keyLit = ast::cast_tree<ast::Literal>(key);
             if (keyLit == nullptr) {
                 return nullptr;
             }
@@ -104,17 +104,17 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         return ast::MK::Hash(hashLit->loc, std::move(keys), std::move(values));
     }
 
-    auto *cons = ast::cast_tree<ast::UnresolvedConstantLit>(orig);
+    auto cons = ast::cast_tree<ast::UnresolvedConstantLit>(orig);
     if (!cons) {
         return nullptr;
     }
 
-    auto *scopeCnst = ast::cast_tree<ast::UnresolvedConstantLit>(cons->scope);
+    auto scopeCnst = ast::cast_tree<ast::UnresolvedConstantLit>(cons->scope);
     if (!scopeCnst) {
         if (ast::isa_tree<ast::EmptyTree>(cons->scope)) {
             return ast::MK::UnresolvedConstant(cons->loc, ast::MK::EmptyTree(), cons->cnst);
         }
-        auto *id = ast::cast_tree<ast::ConstantLit>(cons->scope);
+        auto id = ast::cast_tree<ast::ConstantLit>(cons->scope);
         if (id == nullptr) {
             return nullptr;
         }
@@ -130,7 +130,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
 
 bool ASTUtil::hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name) {
     for (const auto &keyExpr : hash.keys) {
-        auto *key = ast::cast_tree<ast::Literal>(keyExpr);
+        auto key = ast::cast_tree<ast::Literal>(keyExpr);
         if (key && key->isSymbol() && key->asSymbol() == name) {
             return true;
         }
@@ -142,9 +142,9 @@ bool ASTUtil::hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash
     int i = -1;
     for (const auto &keyExpr : hash.keys) {
         i++;
-        auto *key = ast::cast_tree<ast::Literal>(keyExpr);
+        auto key = ast::cast_tree<ast::Literal>(keyExpr);
         if (key && key->isSymbol() && key->asSymbol() == name) {
-            auto *val = ast::cast_tree<ast::Literal>(hash.values[i]);
+            auto val = ast::cast_tree<ast::Literal>(hash.values[i]);
             if (!val) {
                 // All non-literals are truthy
                 return true;
@@ -163,7 +163,7 @@ pair<ast::ExpressionPtr, ast::ExpressionPtr> ASTUtil::extractHashValue(core::Mut
     int i = -1;
     for (auto &keyExpr : hash.keys) {
         i++;
-        auto *key = ast::cast_tree<ast::Literal>(keyExpr);
+        auto key = ast::cast_tree<ast::Literal>(keyExpr);
         if (key && key->isSymbol() && key->asSymbol() == name) {
             auto key = std::move(keyExpr);
             auto value = std::move(hash.values[i]);
@@ -198,7 +198,7 @@ template <typename T> T *castSigImpl(T *send) {
     }
     auto *block = send->block();
     ENFORCE(block);
-    auto *body = ast::cast_tree<ast::Send>(block->body);
+    auto body = ast::cast_tree<ast::Send>(block->body);
     while (body != nullptr && (body->fun == core::Names::checked() || body->fun == core::Names::onFailure() ||
                                body->fun == core::Names::override_() || body->fun == core::Names::overridable() ||
                                body->fun == core::Names::abstract())) {
@@ -214,7 +214,7 @@ template <typename T> T *castSigImpl(T *send) {
 } // namespace
 
 ast::Send *ASTUtil::castSig(ast::ExpressionPtr &expr) {
-    auto *send = ast::cast_tree<ast::Send>(expr);
+    auto send = ast::cast_tree<ast::Send>(expr);
     if (send == nullptr) {
         return nullptr;
     }
@@ -223,7 +223,7 @@ ast::Send *ASTUtil::castSig(ast::ExpressionPtr &expr) {
 }
 
 const ast::Send *ASTUtil::castSig(const ast::ExpressionPtr &expr) {
-    auto *send = ast::cast_tree<ast::Send>(expr);
+    auto send = ast::cast_tree<ast::Send>(expr);
     if (send == nullptr) {
         return nullptr;
     }
@@ -255,7 +255,7 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
     // handle a double-splat or a hash literal as the last argument
     bool explicitEmptyHash = false;
     if (send->hasKwSplat() || !send->hasKwArgs()) {
-        if (auto *hash = ast::cast_tree<ast::Hash>(send->hasKwSplat() ? *send->kwSplat()
+        if (auto hash = ast::cast_tree<ast::Hash>(send->hasKwSplat() ? *send->kwSplat()
                                                                       : send->getPosArg(send->numPosArgs() - 1))) {
             explicitEmptyHash = hash->keys.empty();
             for (auto i = 0; i < hash->keys.size(); ++i) {
@@ -293,7 +293,7 @@ namespace {
 
 // Returns `true` when the expression passed is an UnresolvedConstantLit with the name `Kernel` and no additional scope.
 bool isKernel(const ast::ExpressionPtr &expr) {
-    if (auto *constRecv = ast::cast_tree<ast::UnresolvedConstantLit>(expr)) {
+    if (auto constRecv = ast::cast_tree<ast::UnresolvedConstantLit>(expr)) {
         return ast::isa_tree<ast::EmptyTree>(constRecv->scope) && constRecv->cnst == core::Names::Constants::Kernel();
     }
     return false;
@@ -302,7 +302,7 @@ bool isKernel(const ast::ExpressionPtr &expr) {
 } // namespace
 
 ast::ExpressionPtr ASTUtil::thunkBody(core::MutableContext ctx, ast::ExpressionPtr &node) {
-    auto *send = ast::cast_tree<ast::Send>(node);
+    auto send = ast::cast_tree<ast::Send>(node);
     if (send == nullptr) {
         return nullptr;
     }

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -40,7 +40,7 @@ class Rewriterer {
 
 public:
     void postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
-        auto *classDef = ast::cast_tree<ast::ClassDef>(tree);
+        auto classDef = ast::cast_tree<ast::ClassDef>(tree);
 
         auto isClass = classDef->kind == ast::ClassDef::Kind::Class;
 
@@ -179,7 +179,7 @@ public:
     // NOTE: this case differs from the `Send` typecase branch in `postTransformClassDef` above, as it will apply to all
     // sends, not just those that are present in the RHS of a `ClassDef`.
     void postTransformSend(core::MutableContext ctx, ast::ExpressionPtr &tree) {
-        auto *send = ast::cast_tree<ast::Send>(tree);
+        auto send = ast::cast_tree<ast::Send>(tree);
 
         if (ClassNew::run(ctx, send)) {
             return;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is just #8475, but for `ExpressionPtr` and trees rather than `InstructionPtr` and CFG instructions.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
