### PR TITLE
ensure `TypeSyntaxArgs` uses the smallest datatype for storage

### DIFF
--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -64,7 +64,7 @@ struct ParsedSig {
 struct TypeSyntaxArgs {
     const bool allowSelfType;
     const bool allowRebind;
-    enum class TypeMember {
+    enum class TypeMember : uint8_t {
         Allowed,
         BannedInTypeMember,
         BannedInTypeAlias,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This shrinks `TypeSyntaxArgs` storage down to 8 bytes (from 16), which makes more efficient argument passing, etc. etc.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
