### PR TITLE
add initial changes for v7 depdb

### DIFF
--- a/main/autogen/data/BUILD
+++ b/main/autogen/data/BUILD
@@ -21,3 +21,19 @@ cc_library(
         "@com_github_ludocode_mpack",
     ],
 )
+
+cc_test(
+    name = "data_test",
+    size = "small",
+    srcs = glob(["test/*.cc"]),
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//tools:__pkg__"],
+    deps = [
+        ":data",
+        "@doctest//doctest",
+        "@doctest//doctest:main",
+    ],
+)

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -174,7 +174,8 @@ string MsgpackWriterFull::pack(core::Context ctx, ParsedFile &pf, const AutogenC
 
         // requires
         {
-            MsgpackArray requires(&writer, pf.requireStatements.size());
+            MsgpackArray
+                requires(&writer, pf.requireStatements.size());
             for (auto nm : pf.requireStatements) {
                 packString(&writer, nm.show(ctx));
             }
@@ -222,7 +223,6 @@ string MsgpackWriterFull::pack(core::Context ctx, ParsedFile &pf, const AutogenC
         mpack_writer_destroy(&temporaryWriter);
         mpack_write_object_bytes(&writer, temporary, temporarySize);
         MPACK_FREE(temporary);
-
     }
 
     mpack_writer_destroy(&writer);
@@ -237,24 +237,24 @@ string MsgpackWriterFull::pack(core::Context ctx, ParsedFile &pf, const AutogenC
 
         uint32_t value = 0;
         switch (pf.tree.file.data(ctx).strictLevel) {
-        case sorbet::core::StrictLevel::Ignore:
-            value = 1;
-            break;
-        case sorbet::core::StrictLevel::False:
-            value = 2;
-            break;
-        case sorbet::core::StrictLevel::True:
-            value = 3;
-            break;
-        case sorbet::core::StrictLevel::Strict:
-            value = 4;
-            break;
-        case sorbet::core::StrictLevel::Strong:
-            value = 5;
-            break;
-        default:
-            // Default value already set at 0.
-            break;
+            case sorbet::core::StrictLevel::Ignore:
+                value = 1;
+                break;
+            case sorbet::core::StrictLevel::False:
+                value = 2;
+                break;
+            case sorbet::core::StrictLevel::True:
+                value = 3;
+                break;
+            case sorbet::core::StrictLevel::Strict:
+                value = 4;
+                break;
+            case sorbet::core::StrictLevel::Strong:
+                value = 5;
+                break;
+            default:
+                // Default value already set at 0.
+                break;
         }
         mpack_write_u32(&writer, value);
 

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -53,7 +53,7 @@ MsgpackWriterBase::MsgpackWriterBase(int version, const std::vector<std::string>
                                      const std::vector<std::string> &defAttrs, const std::vector<std::string> &pfAttrs)
     : version(version), refAttrs(refAttrs), defAttrs(defAttrs), pfAttrs(pfAttrs) {}
 
-void MsgpackWriterFull::packReferenceRef(mpack_writer_t *writer, ReferenceRef ref) {
+void MsgpackWriterBase::packReferenceRef(mpack_writer_t *writer, ReferenceRef ref) {
     if (!ref.exists()) {
         mpack_write_nil(writer);
     } else {
@@ -61,7 +61,7 @@ void MsgpackWriterFull::packReferenceRef(mpack_writer_t *writer, ReferenceRef re
     }
 }
 
-void MsgpackWriterFull::packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref) {
+void MsgpackWriterBase::packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref) {
     if (!ref.exists()) {
         mpack_write_nil(writer);
     } else {

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -149,7 +149,7 @@ MsgpackWriterFull::MsgpackWriterFull(int version)
     : MsgpackWriterBase(assertValidVersion(version), refAttrMap.at(version), defAttrMap.at(version),
                         parsedFileAttrMap.at(version)) {}
 
-void writeSymbols(core::Context ctx, mpack_writer_t *writer, const vector<core::NameRef> &symbols) {
+void MsgpackWriterBase::writeSymbols(core::Context ctx, mpack_writer_t *writer, const vector<core::NameRef> &symbols) {
     MsgpackArray scope(writer, symbols.size());
     for (auto sym : symbols) {
         auto str = sym.shortName(ctx);

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -338,6 +338,16 @@ const map<int, vector<string>> MsgpackWriterFull::parsedFileAttrMap{
             "body_size",
         },
     },
+    {
+        7,
+        {
+            "typed_level",
+            "ref_count",
+            "def_count",
+            "sym_count",
+            "body_size",
+        },
+    },
 };
 
 const map<int, vector<string>> MsgpackWriterFull::refAttrMap{
@@ -354,21 +364,44 @@ const map<int, vector<string>> MsgpackWriterFull::refAttrMap{
          "is_defining_ref",
          "parent_of",
      }},
+    {7,
+     {
+         "scope",
+         "name",
+         "nesting",
+         "expr_range_start",
+         "expr_range_len",
+         "expr_pos_range_start",
+         "expr_pos_range_len",
+         "resolved",
+         "is_defining_ref",
+         "parent_of",
+     }},
 };
 
-const map<int, vector<string>> MsgpackWriterFull::defAttrMap{
-    {
-        6,
-        {
-            "raw_full_name",
-            "type",
-            "defines_behavior",
-            "is_empty",
-            "parent_ref",
-            "aliased_ref",
-            "defining_ref",
-        },
-    },
-};
+const map<int, vector<string>> MsgpackWriterFull::defAttrMap{{
+                                                                 6,
+                                                                 {
+                                                                     "raw_full_name",
+                                                                     "type",
+                                                                     "defines_behavior",
+                                                                     "is_empty",
+                                                                     "parent_ref",
+                                                                     "aliased_ref",
+                                                                     "defining_ref",
+                                                                 },
+                                                             },
+                                                             {
+                                                                 7,
+                                                                 {
+                                                                     "raw_full_name",
+                                                                     "type",
+                                                                     "defines_behavior",
+                                                                     "is_empty",
+                                                                     "parent_ref",
+                                                                     "aliased_ref",
+                                                                     "defining_ref",
+                                                                 },
+                                                             }};
 
 } // namespace sorbet::autogen

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -80,7 +80,11 @@ void MsgpackWriterFull::packRange(mpack_writer_t *writer, uint32_t begin, uint32
 
 void MsgpackWriterFull::packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
                                        const AutogenConfig &autogenCfg) {
-    MsgpackArray defsArray(writer, defAttrs.size());
+    std::optional<MsgpackArray> defsArray;
+
+    if (version <= 6) {
+        defsArray.emplace(writer, defAttrs.size());
+    }
 
     // raw_full_name
     auto raw_full_name = pf.showFullName(ctx, def.id);
@@ -112,7 +116,11 @@ void MsgpackWriterFull::packDefinition(mpack_writer_t *writer, core::Context ctx
 }
 
 void MsgpackWriterFull::packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref) {
-    MsgpackArray refArray(writer, refAttrs.size());
+    std::optional<MsgpackArray> refArray;
+
+    if (version <= 6) {
+        refArray.emplace(writer, refAttrs.size());
+    }
 
     // scope
     packDefinitionRef(writer, ref.scope.id());

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -30,6 +30,19 @@ protected:
 
     MsgpackWriterBase(int version, const std::vector<std::string> &refAttrs, const std::vector<std::string> &defAttrs,
                       const std::vector<std::string> &pfAttrs);
+
+    class MsgpackArray {
+        mpack_writer_t *writer;
+
+    public:
+        MsgpackArray(mpack_writer_t *writer, size_t sz) : writer(writer) {
+            mpack_start_array(writer, sz);
+        }
+
+        ~MsgpackArray() {
+            mpack_finish_array(writer);
+        }
+    };
 };
 
 class MsgpackWriterFull : public MsgpackWriterBase {

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -51,10 +51,6 @@ protected:
 
 class MsgpackWriterFull : public MsgpackWriterBase {
 protected:
-    static const std::map<int, std::vector<std::string>> refAttrMap;
-    static const std::map<int, std::vector<std::string>> defAttrMap;
-    static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
-
     // a bunch of helpers
     void packRange(mpack_writer_t *writer, uint32_t begin, uint32_t end);
     virtual void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
@@ -65,6 +61,10 @@ protected:
     }
 
 public:
+    static const std::map<int, std::vector<std::string>> refAttrMap;
+    static const std::map<int, std::vector<std::string>> defAttrMap;
+    static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
+
     MsgpackWriterFull(int version);
 
     static std::string msgpackGlobalHeader(int version, size_t numFiles);
@@ -75,10 +75,6 @@ public:
 // typing information, etc. Reduces size by ~37% for Stripe code.
 class MsgpackWriterLite : public MsgpackWriterBase {
 private:
-    static const std::map<int, std::vector<std::string>> refAttrMap;
-    static const std::map<int, std::vector<std::string>> defAttrMap;
-    static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
-
     static int assertValidVersion(int version) {
         // Lite Msgpack writer is only supported after version 6.
         static_assert(AutogenVersion::MIN_VERSION >= 6);
@@ -90,6 +86,10 @@ private:
     void packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref);
 
 public:
+    static const std::map<int, std::vector<std::string>> refAttrMap;
+    static const std::map<int, std::vector<std::string>> defAttrMap;
+    static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
+
     MsgpackWriterLite(int version);
 
     static std::string msgpackGlobalHeader(int version, size_t numFiles);

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -26,6 +26,8 @@ protected:
                                 const AutogenConfig &autogenCfg) = 0;
     virtual void packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref) = 0;
 
+    void writeSymbols(core::Context ctx, mpack_writer_t *writer, const std::vector<core::NameRef> &symbols);
+
     static int validateVersion(int version, int lo, int hi);
 
     MsgpackWriterBase(int version, const std::vector<std::string> &refAttrs, const std::vector<std::string> &defAttrs,
@@ -95,7 +97,6 @@ public:
 };
 
 void packString(mpack_writer_t *writer, std::string_view str);
-void writeSymbols(core::Context ctx, mpack_writer_t *writer, const std::vector<core::NameRef> &symbols);
 std::string buildGlobalHeader(int version, int serializedVersion, size_t numFiles,
                               const std::vector<std::string> &refAttrs, const std::vector<std::string> &defAttrs,
                               const std::vector<std::string> &pfAttrs);

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -21,6 +21,8 @@ protected:
     void packName(mpack_writer_t *writer, core::NameRef nm);
     void packNames(mpack_writer_t *writer, std::vector<core::NameRef> &names);
     void packBool(mpack_writer_t *writer, bool b);
+    void packReferenceRef(mpack_writer_t *writer, ReferenceRef ref);
+    void packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref);
 
     virtual void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
                                 const AutogenConfig &autogenCfg) = 0;
@@ -54,8 +56,6 @@ protected:
     static const std::map<int, std::vector<std::string>> parsedFileAttrMap;
 
     // a bunch of helpers
-    void packReferenceRef(mpack_writer_t *writer, ReferenceRef ref);
-    void packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref);
     void packRange(mpack_writer_t *writer, uint32_t begin, uint32_t end);
     virtual void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
                                 const AutogenConfig &autogenCfg);

--- a/main/autogen/data/msgpack_lite.cc
+++ b/main/autogen/data/msgpack_lite.cc
@@ -11,7 +11,11 @@ namespace sorbet::autogen {
 
 void MsgpackWriterLite::packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
                                        const AutogenConfig &autogenCfg) {
-    MsgpackArray defArray(writer, defAttrs.size());
+    std::optional<MsgpackArray> defArray;
+
+    if (version <= 6) {
+        defArray.emplace(writer, defAttrs.size());
+    }
 
     // raw_full_name
     auto raw_full_name = pf.showFullName(ctx, def.id);
@@ -41,7 +45,11 @@ void MsgpackWriterLite::packDefinition(mpack_writer_t *writer, core::Context ctx
 }
 
 void MsgpackWriterLite::packReference(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Reference &ref) {
-    MsgpackArray refArray(writer, refAttrs.size());
+    std::optional<MsgpackArray> refArray;
+
+    if (version <= 6) {
+        refArray.emplace(writer, refAttrs.size());
+    }
 
     // scope
     if (version >= 7) {

--- a/main/autogen/data/test/msgpack_test.cc
+++ b/main/autogen/data/test/msgpack_test.cc
@@ -1,0 +1,61 @@
+#include "doctest/doctest.h"
+// has to go first as it violates our requirements
+#include "absl/algorithm/container.h"
+#include "common/sort/sort.h"
+#include "main/autogen/data/msgpack.h"
+
+using namespace std;
+namespace sorbet::autogen {
+
+void validateAttrMap(const std::map<int, std::vector<std::string>> &hugeMap,
+                     const std::map<int, std::vector<std::string>> &liteMap) {
+    vector<int> hugeKeys;
+    vector<int> liteKeys;
+
+    absl::c_transform(hugeMap, std::back_inserter(hugeKeys), [](const auto &e) { return e.first; });
+    absl::c_transform(liteMap, std::back_inserter(liteKeys), [](const auto &e) { return e.first; });
+
+    fast_sort(hugeKeys);
+    fast_sort(liteKeys);
+
+    vector<int> keyDiff;
+    absl::c_set_symmetric_difference(hugeKeys, liteKeys, std::back_inserter(keyDiff));
+    CHECK(keyDiff.empty());
+
+    for (auto &version : hugeKeys) {
+        auto hugeAttrsIt = hugeMap.find(version);
+        auto liteAttrsIt = liteMap.find(version);
+        REQUIRE_NE(hugeAttrsIt, hugeMap.end());
+        REQUIRE_NE(liteAttrsIt, liteMap.end());
+
+        auto &hugeAttrs = hugeAttrsIt->second;
+        auto &liteAttrs = liteAttrsIt->second;
+
+        // The lite attributes should occur in the same order as those in the
+        // regular version.
+        vector<vector<string>::const_iterator> hugeAttrsPtrs;
+        absl::c_transform(liteAttrs, std::back_inserter(hugeAttrsPtrs), [&hugeAttrs](const auto &e) {
+            auto it = absl::c_find(hugeAttrs, e);
+            CHECK_NE(it, hugeAttrs.end());
+            return it;
+        });
+
+        CHECK(absl::c_is_sorted(hugeAttrsPtrs));
+    }
+}
+
+TEST_SUITE("Autogen") {
+    TEST_CASE("msgpack defs") {
+        validateAttrMap(MsgpackWriterFull::defAttrMap, MsgpackWriterLite::defAttrMap);
+    }
+
+    TEST_CASE("msgpack refs") {
+        validateAttrMap(MsgpackWriterFull::refAttrMap, MsgpackWriterLite::refAttrMap);
+    }
+
+    TEST_CASE("msgpack parsed files") {
+        validateAttrMap(MsgpackWriterFull::parsedFileAttrMap, MsgpackWriterLite::parsedFileAttrMap);
+    }
+}
+
+} // namespace sorbet::autogen

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -62,6 +62,7 @@ compilation_database(
         "//main:sorbet-orig",
         "//main/autogen:autogen",
         "//main/autogen/data:data",
+        "//main/autogen/data:data_test",
         "//main/cache:cache",
         "//main/cache:cache-orig",
         "//main/lsp:error_reporter_test",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We discovered that the "lite" depdb doesn't have enough information to do other useful things with, so we're adding that information here.  Thanks to not writing array headers for defs/refs in v7, the additional information only represents a ~10% size increase.  And since we're not writing array headers for defs/refs in the regular depdb anymore, the size of that one will decrease ~5%.

We also added some tests to enforce consistency between the regular and lite versions; more suggestions welcome.

I'm not bumping the max supported version here because there might be subsequent changes based on testing.

I recommend reviewing commit-by-commit; `clang-format` got very confused with some of the formatting changes, and the RAII changes also require indenting large chunks of code.  Reviewing with whitespace differences turned off might help too.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
