### PR TITLE
Rename the payload from `getNameTablePayload` to `getSorbetPayload`

### DIFF
--- a/payload/binary/binary.h
+++ b/payload/binary/binary.h
@@ -2,6 +2,6 @@
 #define SORBET_PAYLOAD_H
 
 #include "common/common.h"
-extern const uint8_t *const getNameTablePayload;
+extern const uint8_t *const getSorbetPayload;
 
 #endif // SORBET_PAYLOAD_H

--- a/payload/binary/empty.cc
+++ b/payload/binary/empty.cc
@@ -1,3 +1,3 @@
 #include "common/common.h"
 
-extern const uint8_t *const getNameTablePayload = nullptr;
+extern const uint8_t *const getSorbetPayload = nullptr;

--- a/payload/binary/tools/gen_state_payload.cc
+++ b/payload/binary/tools/gen_state_payload.cc
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
         classfile << (int)c;
     }
     classfile << "};\n";
-    classfile << "extern const uint8_t * const getNameTablePayload = (const uint8_t * const)&nameTablePayload;" << '\n';
+    classfile << "extern const uint8_t * const getSorbetPayload = (const uint8_t * const)&nameTablePayload;" << '\n';
 
     classfile.close();
 

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -16,13 +16,13 @@ void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain:
         return;
     }
 
-    const uint8_t *const nameTablePayload = getNameTablePayload;
-    if (nameTablePayload == nullptr) {
+    const uint8_t *const payload = getSorbetPayload;
+    if (payload == nullptr) {
         Timer timeit(gs->tracer(), "read_global_state.source");
         sorbet::rbi::populateRBIsInto(gs);
     } else {
         Timer timeit(gs->tracer(), "read_global_state.binary");
-        core::serialize::Serializer::loadGlobalState(*gs, nameTablePayload);
+        core::serialize::Serializer::loadGlobalState(*gs, payload);
     }
     ENFORCE(gs->utf8NamesUsed() < core::GlobalState::PAYLOAD_MAX_UTF8_NAME_COUNT,
             "Payload defined `{}` UTF8 names, which is greater than the expected maximum of `{}`. Consider updating "

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -154,7 +154,7 @@ TEST_CASE("CloneSubstitutePayload") {
     auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
     sorbet::core::GlobalState gs(errorQueue);
-    sorbet::core::serialize::Serializer::loadGlobalState(gs, getNameTablePayload);
+    sorbet::core::serialize::Serializer::loadGlobalState(gs, getSorbetPayload);
 
     auto c1 = gs.deepCopy();
     auto c2 = gs.deepCopy();

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -95,7 +95,7 @@ TEST_CASE("WhitequarkParserTest") {
     if (BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false)) {
         gs.initEmpty();
     } else {
-        core::serialize::Serializer::loadGlobalState(gs, getNameTablePayload);
+        core::serialize::Serializer::loadGlobalState(gs, getSorbetPayload);
     }
     // Parser
     vector<core::FileRef> files;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -370,7 +370,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     if (BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false)) {
         gs->initEmpty();
     } else {
-        core::serialize::Serializer::loadGlobalState(*gs, getNameTablePayload);
+        core::serialize::Serializer::loadGlobalState(*gs, getSorbetPayload);
     }
 
     if (BooleanPropertyAssertion::getValue("enable-suggest-unsafe", assertions).value_or(false)) {


### PR DESCRIPTION
As pointed out on #8467, it's a little confusing to have the binary payload named `getNameTablePayload` and also have a separate code path for deserializaing only the name table. To fix this, let's rename that constant. I've selected `getSorbetPayload` here as a straw man, and would be happy to change to something more specific like `getGlobalStatePayload` etc.

### Motivation
Updating historical name choices to better reflect the current state of sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
