### PR TITLE
add a `typedLevel` field in the file header for the v7 lite db

### DIFF
--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -34,6 +34,32 @@ void packString(mpack_writer_t *writer, string_view str) {
     mpack_write_str(writer, str.data(), str.size());
 }
 
+uint32_t MsgpackWriterBase::strictLevelToInt(core::StrictLevel strictLevel) {
+    uint32_t value = 0;
+    switch (strictLevel) {
+        case sorbet::core::StrictLevel::Ignore:
+            value = 1;
+            break;
+        case sorbet::core::StrictLevel::False:
+            value = 2;
+            break;
+        case sorbet::core::StrictLevel::True:
+            value = 3;
+            break;
+        case sorbet::core::StrictLevel::Strict:
+            value = 4;
+            break;
+        case sorbet::core::StrictLevel::Strong:
+            value = 5;
+            break;
+        default:
+            // Default value already set at 0.
+            break;
+    }
+
+    return value;
+}
+
 void MsgpackWriterBase::packBool(mpack_writer_t *writer, bool b) {
     if (b) {
         mpack_write_true(writer);
@@ -243,27 +269,7 @@ string MsgpackWriterFull::pack(core::Context ctx, ParsedFile &pf, const AutogenC
     {
         MsgpackArray headerArray(&writer, pfAttrs.size());
 
-        uint32_t value = 0;
-        switch (pf.tree.file.data(ctx).strictLevel) {
-            case sorbet::core::StrictLevel::Ignore:
-                value = 1;
-                break;
-            case sorbet::core::StrictLevel::False:
-                value = 2;
-                break;
-            case sorbet::core::StrictLevel::True:
-                value = 3;
-                break;
-            case sorbet::core::StrictLevel::Strict:
-                value = 4;
-                break;
-            case sorbet::core::StrictLevel::Strong:
-                value = 5;
-                break;
-            default:
-                // Default value already set at 0.
-                break;
-        }
+        uint32_t value = strictLevelToInt(pf.tree.file.data(ctx).strictLevel);
         mpack_write_u32(&writer, value);
 
         mpack_write_u32(&writer, pf.refs.size());

--- a/main/autogen/data/msgpack.h
+++ b/main/autogen/data/msgpack.h
@@ -3,6 +3,8 @@
 // has to go first because it violates our poisons
 #include "mpack/mpack.h"
 
+#include "core/StrictLevel.h"
+
 #include "main/autogen/data/definitions.h"
 #include "main/autogen/data/version.h"
 
@@ -23,6 +25,8 @@ protected:
     void packBool(mpack_writer_t *writer, bool b);
     void packReferenceRef(mpack_writer_t *writer, ReferenceRef ref);
     void packDefinitionRef(mpack_writer_t *writer, DefinitionRef ref);
+
+    uint32_t strictLevelToInt(core::StrictLevel strictLevel);
 
     virtual void packDefinition(mpack_writer_t *writer, core::Context ctx, ParsedFile &pf, Definition &def,
                                 const AutogenConfig &autogenCfg) = 0;

--- a/main/autogen/data/msgpack_lite.cc
+++ b/main/autogen/data/msgpack_lite.cc
@@ -138,6 +138,11 @@ string MsgpackWriterLite::pack(core::Context ctx, ParsedFile &pf, const AutogenC
     {
         MsgpackArray attributes(&writer, pfAttrs.size());
 
+        if (version >= 7) {
+            uint32_t value = strictLevelToInt(pf.tree.file.data(ctx).strictLevel);
+            mpack_write_u32(&writer, value);
+        }
+
         mpack_write_u32(&writer, pf.refs.size());
         mpack_write_u32(&writer, pf.defs.size());
         mpack_write_u32(&writer, symbols.size());
@@ -184,6 +189,7 @@ const map<int, vector<string>> MsgpackWriterLite::parsedFileAttrMap{{
                                                                     {
                                                                         7,
                                                                         {
+                                                                            "typed_level",
                                                                             "ref_count",
                                                                             "def_count",
                                                                             "sym_count",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is needed for some of Stripe's internal tools (and I am forgetful and didn't include it earlier).

This PR does write extra data, but due to the structure of the depdb, most tools do not need to know about this change, since they know what fields are in the file header from the list of file header attributes in the global header.  Those tools that do need to know about the change (`gen-packages`, basically) do not use the lite db for anything yet, so I feel like this is essentially a no-op change for those particular tools.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
