### PR TITLE
Remove useless `scope` parameter from `UnresolvedConstantParts` helper

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -217,9 +217,8 @@ public:
         return make_expression<UnresolvedConstantLit>(loc, std::move(scope), name);
     }
 
-    static ExpressionPtr UnresolvedConstantParts(core::LocOffsets loc, ExpressionPtr scope,
-                                                 const std::vector<core::NameRef> &parts) {
-        auto result = std::move(scope);
+    static ExpressionPtr UnresolvedConstantParts(core::LocOffsets loc, const std::vector<core::NameRef> &parts) {
+        auto result = EmptyTree();
         for (const auto part : parts) {
             result = UnresolvedConstant(loc, std::move(result), part);
         }
@@ -410,8 +409,7 @@ public:
     }
 
     static ExpressionPtr T_Boolean(core::LocOffsets loc) {
-        return UnresolvedConstantParts(loc, EmptyTree(),
-                                       {core::Names::Constants::T(), core::Names::Constants::Boolean()});
+        return UnresolvedConstantParts(loc, {core::Names::Constants::T(), core::Names::Constants::Boolean()});
     }
 
     static ExpressionPtr ZSuper(core::LocOffsets loc, core::NameRef method) {

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -18,7 +18,7 @@ ast::ExpressionPtr mkNilableEncryptedValue(core::MutableContext ctx, core::LocOf
         core::Names::Constants::Encryptable(), core::Names::Constants::EncryptedValue(),
     };
 
-    return ASTUtil::mkNilable(loc, ast::MK::UnresolvedConstantParts(loc, ast::MK::EmptyTree(), parts));
+    return ASTUtil::mkNilable(loc, ast::MK::UnresolvedConstantParts(loc, parts));
 }
 
 ast::ExpressionPtr mkNilableString(core::LocOffsets loc) {


### PR DESCRIPTION
### Motivation

Asked by @jez in https://github.com/sorbet/sorbet/pull/8470/files/2436c15c8446f1a0c11031835249cdf3a7788114#r1931355304.

### Test plan

See included automated tests.
