### PR TITLE
Move `--forcibly-silence-lsp-multiple-dir-error` to `LSP` section

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -519,6 +519,11 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         "files that do not exist on the client. References to files in these directories will be sent "
         "as `sorbet:` URIs to clients that understand them.",
         cxxopts::value<vector<string>>(), "<path>");
+    options.add_options(section)(
+        "forcibly-silence-lsp-multiple-dir-error",
+        "Allow the LSP to start with multiple `--dir` options by silencing the error. (WARNING: This flag does not "
+        "address the known issues with multiple directory support in LSP mode. You are likely to encounter unexpected "
+        "behavior.)");
     // }}}
 
     // ----- LSP FEATURES ------------------------------------------------- {{{
@@ -542,11 +547,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         "End users should prefer to use `--enable-all-beta-lsp-features`, instead.)");
     options.add_options(section)("enable-all-beta-lsp-features",
                                  "Enable (expected-to-be-non-crashy) early-access LSP features.");
-    options.add_options(section)(
-        "forcibly-silence-lsp-multiple-dir-error",
-        "Allow the LSP to start with multiple `--dir` options by silencing the error. (WARNING: This flag does not "
-        "address the known issues with multiple directory support in LSP mode. You are likely to encounter unexpected "
-        "behavior.)");
     // }}}
 
     // ----- PERFORMANCE -------------------------------------------------- {{{

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -215,6 +215,11 @@ Usage:
                                 the client. References to files in these directories will
                                 be sent as `sorbet:` URIs to clients that understand
                                 them.
+      --forcibly-silence-lsp-multiple-dir-error
+                                Allow the LSP to start with multiple `--dir` options by
+                                silencing the error. (WARNING: This flag does not address
+                                the known issues with multiple directory support in LSP
+                                mode. You are likely to encounter unexpected behavior.)
 
 ```
 
@@ -240,11 +245,6 @@ Usage:
       --enable-all-beta-lsp-features
                                 Enable (expected-to-be-non-crashy) early-access LSP
                                 features.
-      --forcibly-silence-lsp-multiple-dir-error
-                                Allow the LSP to start with multiple `--dir` options by
-                                silencing the error. (WARNING: This flag does not address
-                                the known issues with multiple directory support in LSP
-                                mode. You are likely to encounter unexpected behavior.)
 
 ```
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

LSP FEATURES was meant to be for things like things that the LSP specification allows that we're working on supporting better. This flag is not like that.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
