### PR TITLE
Fix a check in OwnedKeyValueStore::commit

### DIFF
--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -191,7 +191,7 @@ int OwnedKeyValueStore::commit() {
     int rc = 0;
     for (auto &txn : txnState->readers) {
         auto rci = mdb_txn_commit(txn.second);
-        if (rc != 0) {
+        if (rc == 0) {
             // Take the first non-zero rc
             rc = rci;
         }


### PR DESCRIPTION
In `OwnedKeyValueStore::commit` the return value of committing the transaction is assigned to `rc` only when the value of `rc` is non-zero. However, as `rc` is initialized to zero, this will never be true. I'm pretty sure the intention was to run the loop body while the value of `rc` was `0`, as the condition would become false the first time a transaction failed.

### Motivation
Ensuring that we see non-zero exit codes if they happen.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests should be sufficient, though I'm not sure we're testing conditions that could cause a transaction to fail to commit.
