### PR TITLE
don't allocate vectors for `UnresolvedConstantParts` calls

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -217,7 +217,7 @@ public:
         return make_expression<UnresolvedConstantLit>(loc, std::move(scope), name);
     }
 
-    static ExpressionPtr UnresolvedConstantParts(core::LocOffsets loc, const std::vector<core::NameRef> &parts) {
+    static ExpressionPtr UnresolvedConstantParts(core::LocOffsets loc, absl::Span<const core::NameRef> parts) {
         auto result = EmptyTree();
         for (const auto part : parts) {
             result = UnresolvedConstant(loc, std::move(result), part);

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -409,7 +409,8 @@ public:
     }
 
     static ExpressionPtr T_Boolean(core::LocOffsets loc) {
-        return UnresolvedConstantParts(loc, {core::Names::Constants::T(), core::Names::Constants::Boolean()});
+        static constexpr core::NameRef parts[2] = {core::Names::Constants::T(), core::Names::Constants::Boolean()};
+        return UnresolvedConstantParts(loc, parts);
     }
 
     static ExpressionPtr ZSuper(core::LocOffsets loc, core::NameRef method) {

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -12,7 +12,7 @@ namespace sorbet::rewriter {
 namespace {
 
 ast::ExpressionPtr mkNilableEncryptedValue(core::MutableContext ctx, core::LocOffsets loc) {
-    auto parts = vector<core::NameRef>{
+    static constexpr core::NameRef parts[6] = {
         core::Names::Constants::Opus(),        core::Names::Constants::DB(),
         core::Names::Constants::Model(),       core::Names::Constants::Mixins(),
         core::Names::Constants::Encryptable(), core::Names::Constants::EncryptedValue(),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is pretty minor, but we don't particularly care about vector-ness of the parts: we care about linear memory-ness of the parts.  And that means the callers can be relatively simpler as well.

(This will be a little more useful if we add more `UnresolvedConstantParts` calls in a followup.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
