### PR TITLE
use the fixed `selfVariable` rather than repeatedly re-entering it

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -985,7 +985,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 } else if (c.cast == core::Names::bind() || c.cast == core::Names::syntheticBind()) {
                     auto isSynthetic = c.cast == core::Names::syntheticBind();
                     if (c.arg.isSelfReference()) {
-                        auto self = cctx.inWhat.enterLocal(core::LocalVariable::selfVariable());
+                        auto self = LocalRef::selfVariable();
                         auto &inserted = current->exprs.emplace_back(
                             self, c.loc, make_insn<Cast>(tmp, argLoc, c.type, core::Names::cast()));
                         if (isSynthetic) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We enter a dedicated `LocalRef` for `self` at CFG construction time, we should just use that here.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.  There should be no change to exp files as a result of this.