### PR TITLE
avoid unnecessary looping in `startsWithPackageSpecRegistry`

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -524,18 +524,14 @@ ast::ExpressionPtr prependName(ast::ExpressionPtr scope) {
     return scope;
 }
 
-bool startsWithPackageSpecRegistry(const ast::UnresolvedConstantLit *cnst) {
-    while (cnst != nullptr) {
-        if (auto scope = ast::cast_tree<ast::ConstantLit>(cnst->scope)) {
-            return scope->symbol == core::Symbols::PackageSpecRegistry();
-        } else if (auto scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope)) {
-            return startsWithPackageSpecRegistry(scope);
-        } else {
-            return false;
-        }
+bool startsWithPackageSpecRegistry(const ast::UnresolvedConstantLit &cnst) {
+    if (auto scope = ast::cast_tree<ast::ConstantLit>(cnst.scope)) {
+        return scope->symbol == core::Symbols::PackageSpecRegistry();
+    } else if (auto scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst.scope)) {
+        return startsWithPackageSpecRegistry(*scope);
+    } else {
+        return false;
     }
-
-    return false;
 }
 
 ast::ExpressionPtr prependRoot(ast::ExpressionPtr scope) {
@@ -1221,7 +1217,7 @@ struct PackageSpecBodyWalk {
             return;
         }
 
-        if (startsWithPackageSpecRegistry(nameTree)) {
+        if (startsWithPackageSpecRegistry(*nameTree)) {
             this->foundFirstPackageSpec = true;
         } else if (this->foundFirstPackageSpec) {
             if (auto e = ctx.beginError(classDef.declLoc, core::errors::Packager::MultiplePackagesInOneFile)) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Everything inside the loop returns, and `cnst` is never set inside the function, so the loop is unnecessary; the recursive call is performing the loop for us.  We just have to handle the `nullptr` case...except that this function is guaranteed to be called at first with a non-null pointer, and all recursive calls are non-null.  So we can eliminate an unnecessary check along the way as well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
