### PR TITLE
indexAndComputeFileHashes can take a regular reference

### DIFF
--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -166,12 +166,12 @@ void Hashing::computeFileHashes(absl::Span<const shared_ptr<core::File>> files, 
     }
 }
 
-vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::GlobalState> &gs,
+vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(core::GlobalState &gs,
                                                            const realmain::options::Options &opts,
                                                            spdlog::logger &logger, absl::Span<core::FileRef> files,
                                                            WorkerPool &workers,
                                                            const unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    auto asts = realmain::pipeline::index(*gs, files, opts, workers, kvstore);
+    auto asts = realmain::pipeline::index(gs, files, opts, workers, kvstore);
     ENFORCE_NO_TIMER(asts.size() == files.size());
 
     // Below, we rewrite ASTs to an empty GlobalState and use them for hashing.
@@ -182,7 +182,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
 
     logger.trace("Computing state hashes for {} files", asts.size());
 
-    const core::GlobalState &sharedGs = *gs;
+    const core::GlobalState &sharedGs = gs;
     auto resultq =
         make_shared<BlockingBoundedQueue<vector<pair<core::FileRef, unique_ptr<const core::FileHash>>>>>(asts.size());
     Timer timeit(logger, "computeFileHashes");
@@ -226,7 +226,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
              result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
             if (result.gotItem()) {
                 for (auto &a : threadResult) {
-                    a.first.data(*gs).setFileHash(move(a.second));
+                    a.first.data(gs).setFileHash(move(a.second));
                 }
             }
         }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -182,11 +182,10 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(core::GlobalState &gs
 
     logger.trace("Computing state hashes for {} files", asts.size());
 
-    const core::GlobalState &sharedGs = gs;
     auto resultq =
         make_shared<BlockingBoundedQueue<vector<pair<core::FileRef, unique_ptr<const core::FileHash>>>>>(asts.size());
     Timer timeit(logger, "computeFileHashes");
-    workers.multiplexJob("lspStateHash", [fileq, resultq, &asts, &sharedGs, &logger, &opts]() {
+    workers.multiplexJob("lspStateHash", [fileq, resultq, &asts, &sharedGs = std::as_const(gs), &logger, &opts]() {
         unique_ptr<Timer> timeit;
         vector<pair<core::FileRef, unique_ptr<const core::FileHash>>> threadResult;
         int processedByThread = 0;

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -49,7 +49,7 @@ public:
      * Note: ASTs are returned in `FileRef` order (not input order).
      */
     static std::vector<ast::ParsedFile>
-    indexAndComputeFileHashes(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &opts,
+    indexAndComputeFileHashes(core::GlobalState &gs, const realmain::options::Options &opts,
                               spdlog::logger &logger, absl::Span<core::FileRef> files, WorkerPool &workers,
                               const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 };

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -49,8 +49,8 @@ public:
      * Note: ASTs are returned in `FileRef` order (not input order).
      */
     static std::vector<ast::ParsedFile>
-    indexAndComputeFileHashes(core::GlobalState &gs, const realmain::options::Options &opts,
-                              spdlog::logger &logger, absl::Span<core::FileRef> files, WorkerPool &workers,
+    indexAndComputeFileHashes(core::GlobalState &gs, const realmain::options::Options &opts, spdlog::logger &logger,
+                              absl::Span<core::FileRef> files, WorkerPool &workers,
                               const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 };
 } // namespace sorbet::hashing

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -334,7 +334,7 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPoo
         // which one it will be.
         initialGS->errorQueue = make_shared<core::ErrorQueue>(
             initialGS->errorQueue->logger, initialGS->errorQueue->tracer, make_shared<core::NullFlusher>());
-        auto trees = hashing::Hashing::indexAndComputeFileHashes(initialGS, config->opts, *config->logger,
+        auto trees = hashing::Hashing::indexAndComputeFileHashes(*initialGS, config->opts, *config->logger,
                                                                  absl::Span<core::FileRef>(frefs), workers, kvstore);
         update.updatedFileIndexes.resize(trees.size());
         for (auto &ast : trees) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -91,8 +91,9 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
             inputFiles = pipeline::reserveFiles(initialGS, config->opts.inputFileNames);
             indexed.resize(initialGS->filesUsed());
 
-            auto asts = hashing::Hashing::indexAndComputeFileHashes(
-                *initialGS, config->opts, *config->logger, absl::Span<core::FileRef>(inputFiles), workers, ownedKvstore);
+            auto asts = hashing::Hashing::indexAndComputeFileHashes(*initialGS, config->opts, *config->logger,
+                                                                    absl::Span<core::FileRef>(inputFiles), workers,
+                                                                    ownedKvstore);
             // asts are in fref order, but we (currently) don't index and compute file hashes for payload files, so
             // vector index != FileRef ID. Fix that by slotting them into `indexed`.
             for (auto &ast : asts) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -92,7 +92,7 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
             indexed.resize(initialGS->filesUsed());
 
             auto asts = hashing::Hashing::indexAndComputeFileHashes(
-                initialGS, config->opts, *config->logger, absl::Span<core::FileRef>(inputFiles), workers, ownedKvstore);
+                *initialGS, config->opts, *config->logger, absl::Span<core::FileRef>(inputFiles), workers, ownedKvstore);
             // asts are in fref order, but we (currently) don't index and compute file hashes for payload files, so
             // vector index != FileRef ID. Fix that by slotting them into `indexed`.
             for (auto &ast : asts) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -689,7 +689,7 @@ int realmain(int argc, char *argv[]) {
                 inputFilesSpan = inputFilesSpan.subspan(numPackageFiles);
 
                 if (!opts.storeState.empty() || opts.forceHashing) {
-                    indexed = hashing::Hashing::indexAndComputeFileHashes(gs, opts, *logger, inputPackageFiles,
+                    indexed = hashing::Hashing::indexAndComputeFileHashes(*gs, opts, *logger, inputPackageFiles,
                                                                           *workers, kvstore);
                 } else {
                     indexed = pipeline::index(*gs, inputPackageFiles, opts, *workers, kvstore);
@@ -711,7 +711,7 @@ int realmain(int argc, char *argv[]) {
             auto nonPackageIndexed =
                 (!opts.storeState.empty() || opts.forceHashing)
                     // Calculate file hashes alongside indexing when --store-state is specified for LSP mode
-                    ? hashing::Hashing::indexAndComputeFileHashes(gs, opts, *logger, inputFilesSpan, *workers, kvstore)
+                    ? hashing::Hashing::indexAndComputeFileHashes(*gs, opts, *logger, inputFilesSpan, *workers, kvstore)
                     : pipeline::index(*gs, inputFilesSpan, opts, *workers, kvstore);
 
             // Cache these before any pipeline::package rewrites, so that the cache is still usable


### PR DESCRIPTION
The `hashing::indexAndComputeFileHashes` function currently accepts a reference to a `std::unique_ptr<core::GlobalState> &`, where it could accept a `core::GlobalState &`. The value of the unique pointer is never modified in that function, so accepting a reference to the underlying value puts fewer constraints on the caller's context.

### Motivation
Clearing up caching apis.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
