### PR TITLE
use `cast_tree_nonnull` when manipulating `ConstantLit::original`

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -320,17 +320,15 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
                 break;
             }
 
-            auto orig = cast_tree<UnresolvedConstantLit>(nested->original);
-            ENFORCE(orig);
-            namesFailedToResolve.emplace_back(orig->cnst);
-            nested = ast::cast_tree<ast::ConstantLit>(orig->scope);
+            auto &orig = cast_tree_nonnull<UnresolvedConstantLit>(nested->original);
+            namesFailedToResolve.emplace_back(orig.cnst);
+            nested = ast::cast_tree<ast::ConstantLit>(orig.scope);
             ENFORCE(nested);
             ENFORCE(nested->symbol == core::Symbols::StubModule());
             ENFORCE(!nested->resolutionScopes->empty());
         }
-        auto orig = cast_tree<UnresolvedConstantLit>(nested->original);
-        ENFORCE(orig);
-        namesFailedToResolve.emplace_back(orig->cnst);
+        auto &orig = cast_tree_nonnull<UnresolvedConstantLit>(nested->original);
+        namesFailedToResolve.emplace_back(orig.cnst);
         absl::c_reverse(namesFailedToResolve);
     }
     auto prefix = nested->resolutionScopes->front();

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -458,16 +458,16 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 synthesizeExpr(current, cctx.target, a.loc, make_insn<Ident>(aliasName));
 
                 if (a.original) {
-                    auto orig = ast::cast_tree<ast::UnresolvedConstantLit>(a.original);
+                    auto &orig = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(a.original);
                     // Empirically, these are the only two cases we've needed so far to service the
                     // LSP requests we want (hover and completion), but that doesn't mean these are
                     // the **only** we'll ever want.
-                    if (ast::isa_tree<ast::ConstantLit>(orig->scope)) {
+                    if (ast::isa_tree<ast::ConstantLit>(orig.scope)) {
                         LocalRef deadSym = cctx.newTemporary(core::Names::keepForIde());
-                        current = walk(cctx.withTarget(deadSym), orig->scope, current);
-                    } else if (ast::isa_tree<ast::Send>(orig->scope)) {
+                        current = walk(cctx.withTarget(deadSym), orig.scope, current);
+                    } else if (ast::isa_tree<ast::Send>(orig.scope)) {
                         LocalRef deadSym = cctx.newTemporary(core::Names::keepForIde());
-                        current = walk(cctx.withTarget(deadSym), orig->scope, current);
+                        current = walk(cctx.withTarget(deadSym), orig.scope, current);
                     }
                 }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -537,8 +537,8 @@ private:
 
     static core::ClassOrModuleRef stubConstant(core::MutableContext ctx, core::ClassOrModuleRef owner,
                                                ast::ConstantLit *out, bool possibleGenericType) {
-        auto symbol = ctx.state.enterClassSymbol(ctx.locAt(out->loc), owner,
-                                                 ast::cast_tree<ast::UnresolvedConstantLit>(out->original)->cnst);
+        auto symbol = ctx.state.enterClassSymbol(
+            ctx.locAt(out->loc), owner, ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(out->original).cnst);
 
         auto data = symbol.data(ctx);
         data->setIsModule(true); // This is what would happen in finalizeAncestors
@@ -1690,7 +1690,7 @@ public:
         int depth = 0;
         ast::ConstantLit *scope = exp;
         while (scope->original && (scope = ast::cast_tree<ast::ConstantLit>(
-                                       ast::cast_tree<ast::UnresolvedConstantLit>(scope->original)->scope))) {
+                                       ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(scope->original).scope))) {
             depth += 1;
         }
         return depth;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This just makes things a little cleaner -- I think it's better style to use `cast_tree_nonnull` rather than `cast_tree` + pointer dereference.

It also makes some changes in the service of #5931 more obviously correct.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
