### PR TITLE
add an ast node for `self`

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -139,6 +139,8 @@ public:
             return make_expression<UnresolvedIdent>(nm->loc, nm->kind, nm->name);
         } else if (auto nm = cast_tree<ast::Local>(name)) {
             return make_expression<ast::Local>(nm->loc, nm->localVariable);
+        } else if (auto self = cast_tree<ast::Self>(name)) {
+            return make_expression<ast::Self>(self->loc);
         }
         Exception::notImplemented();
     }

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -179,7 +179,7 @@ public:
     }
 
     static ExpressionPtr Self(core::LocOffsets loc) {
-        return make_expression<ast::Local>(loc, core::LocalVariable::selfVariable());
+        return make_expression<ast::Self>(loc);
     }
 
     static ExpressionPtr InsSeq(core::LocOffsets loc, InsSeq::STATS_store stats, ExpressionPtr expr) {

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -186,6 +186,11 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
             auto *exp = reinterpret_cast<const RuntimeMethodDefinition *>(tree);
             return make_expression<RuntimeMethodDefinition>(exp->loc, exp->name, exp->isSelfMethod);
         }
+
+        case Tag::Self: {
+            auto *exp = reinterpret_cast<const Self *>(tree);
+            return make_expression<Self>(exp->loc);
+        }
     }
 }
 

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -314,6 +314,10 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
             auto *b = reinterpret_cast<const RuntimeMethodDefinition *>(other);
             return a->name == b->name && a->isSelfMethod == b->isSelfMethod;
         }
+
+        case Tag::Self: {
+            return true;
+        }
     }
 }
 

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -247,4 +247,7 @@ void RuntimeMethodDefinition::_sanityCheck() {
     ENFORCE(name.exists());
 }
 
+void Self::_sanityCheck() {
+}
+
 } // namespace sorbet::ast

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -44,6 +44,7 @@ void ExpressionPtr::_sanityCheck() const {
         SANITY_CHECK(Block)
         SANITY_CHECK(InsSeq)
         SANITY_CHECK(RuntimeMethodDefinition)
+        SANITY_CHECK(Self)
     }
 #undef SANITY_CHECK
 }

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -247,7 +247,6 @@ void RuntimeMethodDefinition::_sanityCheck() {
     ENFORCE(name.exists());
 }
 
-void Self::_sanityCheck() {
-}
+void Self::_sanityCheck() {}
 
 } // namespace sorbet::ast

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -51,6 +51,7 @@ namespace sorbet::ast {
         CASE_STATEMENT(CASE_BODY, Block)                   \
         CASE_STATEMENT(CASE_BODY, InsSeq)                  \
         CASE_STATEMENT(CASE_BODY, RuntimeMethodDefinition) \
+        CASE_STATEMENT(CASE_BODY, Self)                    \
     }
 
 void ExpressionPtr::deleteTagged(Tag tag, void *ptr) noexcept {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -119,7 +119,7 @@ void ExpressionPtr::resetToEmpty(EmptyTree *expr) noexcept {
 bool isa_reference(const ExpressionPtr &what) {
     return isa_tree<Local>(what) || isa_tree<UnresolvedIdent>(what) || isa_tree<RestArg>(what) ||
            isa_tree<KeywordArg>(what) || isa_tree<OptionalArg>(what) || isa_tree<BlockArg>(what) ||
-           isa_tree<ShadowArg>(what);
+           isa_tree<ShadowArg>(what) || isa_tree<Self>(what);
 }
 
 /** https://git.corp.stripe.com/gist/nelhage/51564501674174da24822e60ad770f64

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -371,6 +371,11 @@ RuntimeMethodDefinition::RuntimeMethodDefinition(core::LocOffsets loc, core::Nam
     _sanityCheck();
 }
 
+Self::Self(core::LocOffsets loc) : loc(loc) {
+    categoryCounterInc("trees", "self");
+    _sanityCheck();
+}
+
 EmptyTree::EmptyTree() : loc(core::LocOffsets::none()) {
     categoryCounterInc("trees", "emptytree");
     _sanityCheck();
@@ -997,6 +1002,14 @@ std::string RuntimeMethodDefinition::showRaw(const core::GlobalState &gs, int ta
     return this->toStringWithTabs(gs, tabs);
 }
 
+std::string Self::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
+    return "<self>";
+}
+
+std::string Self::showRaw(const core::GlobalState &gs, int tabs) const {
+    return "Self";
+}
+
 const ast::Block *Send::block() const {
     if (hasBlock()) {
         auto block = ast::cast_tree<ast::Block>(this->args.back());
@@ -1460,6 +1473,10 @@ string BlockArg::nodeName() const {
 
 string RuntimeMethodDefinition::nodeName() const {
     return "RuntimeMethodDefinition";
+}
+
+string Self::nodeName() const {
+    return "Self";
 }
 
 ParsedFilesOrCancelled::ParsedFilesOrCancelled() : trees(nullopt){};

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -217,6 +217,7 @@ Rescue::Rescue(core::LocOffsets loc, ExpressionPtr body, RESCUE_CASE_store rescu
 
 Local::Local(core::LocOffsets loc, core::LocalVariable localVariable1) : loc(loc), localVariable(localVariable1) {
     categoryCounterInc("trees", "local");
+    ENFORCE(localVariable != core::LocalVariable::selfVariable(), "use a Self node");
     _sanityCheck();
 }
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -108,10 +108,7 @@ string ExpressionPtr::toStringWithTabs(const core::GlobalState &gs, int tabs) co
 }
 
 bool ExpressionPtr::isSelfReference() const {
-    if (auto local = cast_tree<Local>(*this)) {
-        return local->localVariable == core::LocalVariable::selfVariable();
-    }
-    return false;
+    return isa_tree<Self>(*this);
 }
 
 void ExpressionPtr::resetToEmpty(EmptyTree *expr) noexcept {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -66,6 +66,7 @@ enum class Tag {
     Block,
     InsSeq,
     RuntimeMethodDefinition,
+    Self,
 };
 
 // A mapping from tree type to its corresponding tag.
@@ -1216,6 +1217,23 @@ public:
     void _sanityCheck();
 };
 CheckSize(RuntimeMethodDefinition, 16, 8);
+
+EXPRESSION(Self) {
+public:
+    const core::LocOffsets loc;
+
+    Self(core::LocOffsets loc);
+
+    ExpressionPtr deepCopy() const;
+    bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
+    std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
+    std::string nodeName() const;
+
+    void _sanityCheck();
+};
+CheckSize(Self, 8, 8);
 
 EXPRESSION(EmptyTree) {
 public:

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -88,59 +88,58 @@ public:
     GENERATE_CALL_MEMBER(postTransform##X, Exception::raise("should never be called. Incorrect use of TreeMap?"); \
                          return nullptr, arg_types)
 
-#define GENERATE_METAPROGRAMMING_FOR(arg_types...)                                                          \
-    GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedIdent, arg_types, VISITOR_ARG_TYPE(UnresolvedIdent)); \
-    GENERATE_HAS_MEMBER_VISITOR(preTransformLocal, arg_types, VISITOR_ARG_TYPE(Local));                     \
-    GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedConstantLit, arg_types,                               \
-                                VISITOR_ARG_TYPE(UnresolvedConstantLit));                                   \
-    GENERATE_HAS_MEMBER_VISITOR(preTransformConstantLit, arg_types, VISITOR_ARG_TYPE(ConstantLit));         \
-    GENERATE_HAS_MEMBER_VISITOR(preTransformLiteral, arg_types, VISITOR_ARG_TYPE(Literal));                 \
-    GENERATE_HAS_MEMBER_VISITOR(preTransformRuntimeMethodDefinition, arg_types,                             \
-                                VISITOR_ARG_TYPE(RuntimeMethodDefinition));                                 \
-    GENERATE_HAS_MEMBER_VISITOR(preTransformSelf, arg_types,                                                \
-                                VISITOR_ARG_TYPE(Self));                                                    \
-                                                                                                            \
-    GENERATE_POSTPONE_PRECLASS(ExpressionPtr, arg_types, VISITOR_ARG_TYPE(ExpressionPtr));                  \
-    GENERATE_POSTPONE_PRECLASS(ClassDef, arg_types, VISITOR_ARG_TYPE(ClassDef));                            \
-    GENERATE_POSTPONE_PRECLASS(MethodDef, arg_types, VISITOR_ARG_TYPE(MethodDef));                          \
-    GENERATE_POSTPONE_PRECLASS(If, arg_types, VISITOR_ARG_TYPE(If));                                        \
-    GENERATE_POSTPONE_PRECLASS(While, arg_types, VISITOR_ARG_TYPE(While));                                  \
-    GENERATE_POSTPONE_PRECLASS(Break, arg_types, VISITOR_ARG_TYPE(Break));                                  \
-    GENERATE_POSTPONE_PRECLASS(Retry, arg_types, VISITOR_ARG_TYPE(Retry));                                  \
-    GENERATE_POSTPONE_PRECLASS(Next, arg_types, VISITOR_ARG_TYPE(Next));                                    \
-    GENERATE_POSTPONE_PRECLASS(Return, arg_types, VISITOR_ARG_TYPE(Return));                                \
-    GENERATE_POSTPONE_PRECLASS(RescueCase, arg_types, VISITOR_ARG_TYPE(RescueCase));                        \
-    GENERATE_POSTPONE_PRECLASS(Rescue, arg_types, VISITOR_ARG_TYPE(Rescue));                                \
-    GENERATE_POSTPONE_PRECLASS(Assign, arg_types, VISITOR_ARG_TYPE(Assign));                                \
-    GENERATE_POSTPONE_PRECLASS(Send, arg_types, VISITOR_ARG_TYPE(Send));                                    \
-    GENERATE_POSTPONE_PRECLASS(Hash, arg_types, VISITOR_ARG_TYPE(Hash));                                    \
-    GENERATE_POSTPONE_PRECLASS(Array, arg_types, VISITOR_ARG_TYPE(Array));                                  \
-    GENERATE_POSTPONE_PRECLASS(Block, arg_types, VISITOR_ARG_TYPE(Block));                                  \
-    GENERATE_POSTPONE_PRECLASS(InsSeq, arg_types, VISITOR_ARG_TYPE(InsSeq));                                \
-    GENERATE_POSTPONE_PRECLASS(Cast, arg_types, VISITOR_ARG_TYPE(Cast));                                    \
-                                                                                                            \
-    GENERATE_POSTPONE_POSTCLASS(ClassDef, arg_types, VISITOR_ARG_TYPE(ClassDef));                           \
-    GENERATE_POSTPONE_POSTCLASS(MethodDef, arg_types, VISITOR_ARG_TYPE(MethodDef));                         \
-    GENERATE_POSTPONE_POSTCLASS(If, arg_types, VISITOR_ARG_TYPE(If));                                       \
-    GENERATE_POSTPONE_POSTCLASS(While, arg_types, VISITOR_ARG_TYPE(While));                                 \
-    GENERATE_POSTPONE_POSTCLASS(Break, arg_types, VISITOR_ARG_TYPE(Break));                                 \
-    GENERATE_POSTPONE_POSTCLASS(Retry, arg_types, VISITOR_ARG_TYPE(Retry));                                 \
-    GENERATE_POSTPONE_POSTCLASS(Next, arg_types, VISITOR_ARG_TYPE(Next));                                   \
-    GENERATE_POSTPONE_POSTCLASS(Return, arg_types, VISITOR_ARG_TYPE(Return));                               \
-    GENERATE_POSTPONE_POSTCLASS(RescueCase, arg_types, VISITOR_ARG_TYPE(RescueCase));                       \
-    GENERATE_POSTPONE_POSTCLASS(Rescue, arg_types, VISITOR_ARG_TYPE(Rescue));                               \
-    GENERATE_POSTPONE_POSTCLASS(UnresolvedIdent, arg_types, VISITOR_ARG_TYPE(UnresolvedIdent));             \
-    GENERATE_POSTPONE_POSTCLASS(Assign, arg_types, VISITOR_ARG_TYPE(Assign));                               \
-    GENERATE_POSTPONE_POSTCLASS(Send, arg_types, VISITOR_ARG_TYPE(Send));                                   \
-    GENERATE_POSTPONE_POSTCLASS(Hash, arg_types, VISITOR_ARG_TYPE(Hash));                                   \
-    GENERATE_POSTPONE_POSTCLASS(Array, arg_types, VISITOR_ARG_TYPE(Array));                                 \
-    GENERATE_POSTPONE_POSTCLASS(Local, arg_types, VISITOR_ARG_TYPE(Local));                                 \
-    GENERATE_POSTPONE_POSTCLASS(Literal, arg_types, VISITOR_ARG_TYPE(Literal));                             \
-    GENERATE_POSTPONE_POSTCLASS(UnresolvedConstantLit, arg_types, VISITOR_ARG_TYPE(UnresolvedConstantLit)); \
-    GENERATE_POSTPONE_POSTCLASS(ConstantLit, arg_types, VISITOR_ARG_TYPE(ConstantLit));                     \
-    GENERATE_POSTPONE_POSTCLASS(Block, arg_types, VISITOR_ARG_TYPE(Block));                                 \
-    GENERATE_POSTPONE_POSTCLASS(InsSeq, arg_types, VISITOR_ARG_TYPE(InsSeq));                               \
-    GENERATE_POSTPONE_POSTCLASS(Cast, arg_types, VISITOR_ARG_TYPE(Cast));                                   \
+#define GENERATE_METAPROGRAMMING_FOR(arg_types...)                                                              \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedIdent, arg_types, VISITOR_ARG_TYPE(UnresolvedIdent));     \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformLocal, arg_types, VISITOR_ARG_TYPE(Local));                         \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedConstantLit, arg_types,                                   \
+                                VISITOR_ARG_TYPE(UnresolvedConstantLit));                                       \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformConstantLit, arg_types, VISITOR_ARG_TYPE(ConstantLit));             \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformLiteral, arg_types, VISITOR_ARG_TYPE(Literal));                     \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformRuntimeMethodDefinition, arg_types,                                 \
+                                VISITOR_ARG_TYPE(RuntimeMethodDefinition));                                     \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformSelf, arg_types, VISITOR_ARG_TYPE(Self));                           \
+                                                                                                                \
+    GENERATE_POSTPONE_PRECLASS(ExpressionPtr, arg_types, VISITOR_ARG_TYPE(ExpressionPtr));                      \
+    GENERATE_POSTPONE_PRECLASS(ClassDef, arg_types, VISITOR_ARG_TYPE(ClassDef));                                \
+    GENERATE_POSTPONE_PRECLASS(MethodDef, arg_types, VISITOR_ARG_TYPE(MethodDef));                              \
+    GENERATE_POSTPONE_PRECLASS(If, arg_types, VISITOR_ARG_TYPE(If));                                            \
+    GENERATE_POSTPONE_PRECLASS(While, arg_types, VISITOR_ARG_TYPE(While));                                      \
+    GENERATE_POSTPONE_PRECLASS(Break, arg_types, VISITOR_ARG_TYPE(Break));                                      \
+    GENERATE_POSTPONE_PRECLASS(Retry, arg_types, VISITOR_ARG_TYPE(Retry));                                      \
+    GENERATE_POSTPONE_PRECLASS(Next, arg_types, VISITOR_ARG_TYPE(Next));                                        \
+    GENERATE_POSTPONE_PRECLASS(Return, arg_types, VISITOR_ARG_TYPE(Return));                                    \
+    GENERATE_POSTPONE_PRECLASS(RescueCase, arg_types, VISITOR_ARG_TYPE(RescueCase));                            \
+    GENERATE_POSTPONE_PRECLASS(Rescue, arg_types, VISITOR_ARG_TYPE(Rescue));                                    \
+    GENERATE_POSTPONE_PRECLASS(Assign, arg_types, VISITOR_ARG_TYPE(Assign));                                    \
+    GENERATE_POSTPONE_PRECLASS(Send, arg_types, VISITOR_ARG_TYPE(Send));                                        \
+    GENERATE_POSTPONE_PRECLASS(Hash, arg_types, VISITOR_ARG_TYPE(Hash));                                        \
+    GENERATE_POSTPONE_PRECLASS(Array, arg_types, VISITOR_ARG_TYPE(Array));                                      \
+    GENERATE_POSTPONE_PRECLASS(Block, arg_types, VISITOR_ARG_TYPE(Block));                                      \
+    GENERATE_POSTPONE_PRECLASS(InsSeq, arg_types, VISITOR_ARG_TYPE(InsSeq));                                    \
+    GENERATE_POSTPONE_PRECLASS(Cast, arg_types, VISITOR_ARG_TYPE(Cast));                                        \
+                                                                                                                \
+    GENERATE_POSTPONE_POSTCLASS(ClassDef, arg_types, VISITOR_ARG_TYPE(ClassDef));                               \
+    GENERATE_POSTPONE_POSTCLASS(MethodDef, arg_types, VISITOR_ARG_TYPE(MethodDef));                             \
+    GENERATE_POSTPONE_POSTCLASS(If, arg_types, VISITOR_ARG_TYPE(If));                                           \
+    GENERATE_POSTPONE_POSTCLASS(While, arg_types, VISITOR_ARG_TYPE(While));                                     \
+    GENERATE_POSTPONE_POSTCLASS(Break, arg_types, VISITOR_ARG_TYPE(Break));                                     \
+    GENERATE_POSTPONE_POSTCLASS(Retry, arg_types, VISITOR_ARG_TYPE(Retry));                                     \
+    GENERATE_POSTPONE_POSTCLASS(Next, arg_types, VISITOR_ARG_TYPE(Next));                                       \
+    GENERATE_POSTPONE_POSTCLASS(Return, arg_types, VISITOR_ARG_TYPE(Return));                                   \
+    GENERATE_POSTPONE_POSTCLASS(RescueCase, arg_types, VISITOR_ARG_TYPE(RescueCase));                           \
+    GENERATE_POSTPONE_POSTCLASS(Rescue, arg_types, VISITOR_ARG_TYPE(Rescue));                                   \
+    GENERATE_POSTPONE_POSTCLASS(UnresolvedIdent, arg_types, VISITOR_ARG_TYPE(UnresolvedIdent));                 \
+    GENERATE_POSTPONE_POSTCLASS(Assign, arg_types, VISITOR_ARG_TYPE(Assign));                                   \
+    GENERATE_POSTPONE_POSTCLASS(Send, arg_types, VISITOR_ARG_TYPE(Send));                                       \
+    GENERATE_POSTPONE_POSTCLASS(Hash, arg_types, VISITOR_ARG_TYPE(Hash));                                       \
+    GENERATE_POSTPONE_POSTCLASS(Array, arg_types, VISITOR_ARG_TYPE(Array));                                     \
+    GENERATE_POSTPONE_POSTCLASS(Local, arg_types, VISITOR_ARG_TYPE(Local));                                     \
+    GENERATE_POSTPONE_POSTCLASS(Literal, arg_types, VISITOR_ARG_TYPE(Literal));                                 \
+    GENERATE_POSTPONE_POSTCLASS(UnresolvedConstantLit, arg_types, VISITOR_ARG_TYPE(UnresolvedConstantLit));     \
+    GENERATE_POSTPONE_POSTCLASS(ConstantLit, arg_types, VISITOR_ARG_TYPE(ConstantLit));                         \
+    GENERATE_POSTPONE_POSTCLASS(Block, arg_types, VISITOR_ARG_TYPE(Block));                                     \
+    GENERATE_POSTPONE_POSTCLASS(InsSeq, arg_types, VISITOR_ARG_TYPE(InsSeq));                                   \
+    GENERATE_POSTPONE_POSTCLASS(Cast, arg_types, VISITOR_ARG_TYPE(Cast));                                       \
     GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition, arg_types, VISITOR_ARG_TYPE(RuntimeMethodDefinition)); \
     GENERATE_POSTPONE_POSTCLASS(Self, arg_types, VISITOR_ARG_TYPE(Self));
 

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -97,6 +97,8 @@ public:
     GENERATE_HAS_MEMBER_VISITOR(preTransformLiteral, arg_types, VISITOR_ARG_TYPE(Literal));                 \
     GENERATE_HAS_MEMBER_VISITOR(preTransformRuntimeMethodDefinition, arg_types,                             \
                                 VISITOR_ARG_TYPE(RuntimeMethodDefinition));                                 \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformSelf, arg_types,                                                \
+                                VISITOR_ARG_TYPE(Self));                                                    \
                                                                                                             \
     GENERATE_POSTPONE_PRECLASS(ExpressionPtr, arg_types, VISITOR_ARG_TYPE(ExpressionPtr));                  \
     GENERATE_POSTPONE_PRECLASS(ClassDef, arg_types, VISITOR_ARG_TYPE(ClassDef));                            \
@@ -139,7 +141,8 @@ public:
     GENERATE_POSTPONE_POSTCLASS(Block, arg_types, VISITOR_ARG_TYPE(Block));                                 \
     GENERATE_POSTPONE_POSTCLASS(InsSeq, arg_types, VISITOR_ARG_TYPE(InsSeq));                               \
     GENERATE_POSTPONE_POSTCLASS(Cast, arg_types, VISITOR_ARG_TYPE(Cast));                                   \
-    GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition, arg_types, VISITOR_ARG_TYPE(RuntimeMethodDefinition));
+    GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition, arg_types, VISITOR_ARG_TYPE(RuntimeMethodDefinition)); \
+    GENERATE_POSTPONE_POSTCLASS(Self, arg_types, VISITOR_ARG_TYPE(Self));
 
 // Used to indicate that TreeMap has already reported location for this exception
 struct ReportedRubyException {
@@ -492,6 +495,10 @@ private:
         CALL_POST(RuntimeMethodDefinition);
     }
 
+    return_type mapSelf(arg_type v, CTX ctx) {
+        CALL_POST(Self);
+    }
+
     return_type mapIt(arg_type what, CTX ctx) {
         if (what == nullptr) {
             if constexpr (Kind == TreeMapKind::Map) {
@@ -624,6 +631,9 @@ private:
 
                 case Tag::RuntimeMethodDefinition:
                     return mapRuntimeMethodDefinition(Funcs::pass(what), ctx);
+
+                case Tag::Self:
+                    return mapSelf(Funcs::pass(what), ctx);
             }
         } catch (SorbetException &e) {
             auto loc = what.loc();

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -559,7 +559,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     }
 
                     auto &posArg0 = s.getPosArg(0);
-                    if (!ast::isa_tree<ast::Local>(posArg0) && !ast::isa_tree<ast::UnresolvedIdent>(posArg0)) {
+                    if (!ast::isa_tree<ast::Local>(posArg0) && !ast::isa_tree<ast::UnresolvedIdent>(posArg0) && !ast::isa_tree<ast::Self>(posArg0)) {
                         if (auto e = cctx.ctx.beginError(s.loc, core::errors::CFG::MalformedTAbsurd)) {
                             // Providing a send is the most common way T.absurd is misused, so we provide a
                             // little extra hint in the error message in that case.

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -559,7 +559,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     }
 
                     auto &posArg0 = s.getPosArg(0);
-                    if (!ast::isa_tree<ast::Local>(posArg0) && !ast::isa_tree<ast::UnresolvedIdent>(posArg0) && !ast::isa_tree<ast::Self>(posArg0)) {
+                    if (!ast::isa_tree<ast::Local>(posArg0) && !ast::isa_tree<ast::UnresolvedIdent>(posArg0) &&
+                        !ast::isa_tree<ast::Self>(posArg0)) {
                         if (auto e = cctx.ctx.beginError(s.loc, core::errors::CFG::MalformedTAbsurd)) {
                             // Providing a send is the most common way T.absurd is misused, so we provide a
                             // little extra hint in the error message in that case.

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -479,6 +479,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 ret = current;
             },
             [&](const ast::Self &a) {
+                // We still model `self` in the CFG as a local variable, to support `bind`
                 current->exprs.emplace_back(cctx.target, a.loc, make_insn<Ident>(LocalRef::selfVariable()));
                 ret = current;
             },

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -478,6 +478,10 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                                             make_insn<Ident>(cctx.inWhat.enterLocal(a.localVariable)));
                 ret = current;
             },
+            [&](const ast::Self &a) {
+                current->exprs.emplace_back(cctx.target, a.loc, make_insn<Ident>(LocalRef::selfVariable()));
+                ret = current;
+            },
             [&](ast::Assign &a) {
                 LocalRef lhs;
                 if (auto lhsIdent = ast::cast_tree<ast::ConstantLit>(a.lhs)) {

--- a/core/LocalVariable.cc
+++ b/core/LocalVariable.cc
@@ -6,6 +6,11 @@ template class std::vector<sorbet::core::LocalVariable>;
 using namespace std;
 
 namespace sorbet::core {
+
+LocalVariable::LocalVariable(NameRef name, uint32_t unique) : _name(name), unique(unique) {
+    ENFORCE(name != Names::selfLocal() || unique == 0);
+}
+
 bool LocalVariable::exists() const {
     return _name.exists();
 }

--- a/core/LocalVariable.h
+++ b/core/LocalVariable.h
@@ -16,7 +16,7 @@ public:
     // in the scope of a block with a non-zero scope id.
     uint32_t unique;
 
-    LocalVariable(NameRef name, uint32_t unique) : _name(name), unique(unique) {}
+    LocalVariable(NameRef name, uint32_t unique);
 
     LocalVariable() = default;
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1459,6 +1459,12 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             break;
         }
 
+        case ast::Tag::Self: {
+            auto &a = ast::cast_tree_nonnull<ast::Self>(what);
+            pickle(p, a.loc);
+            break;
+        }
+
         default:
             Exception::raise("Unimplemented AST Node: {}", what.nodeName());
             break;
@@ -1725,6 +1731,10 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             NameRef name = unpickleNameRef(p);
             auto isSelfMethod = p.getU1();
             return ast::make_expression<ast::RuntimeMethodDefinition>(loc, name, isSelfMethod);
+        }
+        case ast::Tag::Self: {
+            auto loc = unpickleLocOffsets(p);
+            return ast::make_expression<ast::Self>(loc);
         }
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3052,10 +3052,8 @@ public:
         }
     }
 
-    void postTransformLocal(core::Context ctx, ast::ExpressionPtr &tree) {
-        auto &local = ast::cast_tree_nonnull<ast::Local>(tree);
+    void postTransformSelf(core::Context ctx, ast::ExpressionPtr &tree) {
         if (trackDependencies_ && nestedBlockCounts.back() > 0 &&
-            local.localVariable == core::LocalVariable::selfVariable() &&
             !ctx.owner.enclosingClass(ctx).data(ctx)->typeMembers().empty()) {
             dependencies_.emplace_back(ctx.owner);
         }

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1468,14 +1468,12 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
         result.type = core::Types::untypedUntracked();
     } else if (ast::isa_tree<ast::Local>(expr)) {
         const auto &slf = ast::cast_tree_nonnull<ast::Local>(expr);
-        if (expr.isSelfReference()) {
-            result.type = ctxOwnerData->selfType(ctx);
-        } else {
-            if (auto e = ctx.beginError(slf.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-                e.setHeader("Unsupported type syntax");
-            }
-            result.type = core::Types::untypedUntracked();
+        if (auto e = ctx.beginError(slf.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            e.setHeader("Unsupported type syntax");
         }
+        result.type = core::Types::untypedUntracked();
+    } else if (ast::isa_tree<ast::Self>(expr)) {
+        result.type = ctxOwnerData->selfType(ctx);
     } else if (ast::isa_tree<ast::Literal>(expr)) {
         const auto &lit = ast::cast_tree_nonnull<ast::Literal>(expr);
         core::TypePtr underlying;

--- a/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
@@ -17,9 +17,7 @@ ClassDef{
       rhs = Rescue{
         body = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U a>
           block = nullptr
           pos_args = 0
@@ -36,9 +34,7 @@ ClassDef{
             }
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U b>
               block = nullptr
               pos_args = 0
@@ -49,9 +45,7 @@ ClassDef{
         ]
         else = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U c>
           block = nullptr
           pos_args = 0
@@ -60,9 +54,7 @@ ClassDef{
         }
         ensure = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U d>
           block = nullptr
           pos_args = 0
@@ -114,18 +106,14 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U puts>
       block = nullptr
       pos_args = 1
       args = [
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U foo>
           block = nullptr
           pos_args = 0

--- a/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
@@ -63,9 +63,7 @@ ClassDef{
               ],
               expr = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U raise>
                 block = nullptr
                 pos_args = 1
@@ -88,9 +86,7 @@ ClassDef{
                 stats = [
                   Send{
                     flags = {privateOk}
-                    recv = Local{
-                      localVariable = <U <self>>
-                    }
+                    recv = Self
                     fun = <U puts>
                     block = nullptr
                     pos_args = 1
@@ -112,9 +108,7 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U main>
       block = nullptr
       pos_args = 0

--- a/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
@@ -19,9 +19,7 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U foo>
       block = Block {
         args = [
@@ -42,9 +40,7 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U foo>
       block = Block {
         args = [
@@ -97,9 +93,7 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U foo>
       block = Block {
         args = [
@@ -136,9 +130,7 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U foo>
       block = Block {
         args = [
@@ -159,9 +151,7 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U foo>
       block = Block {
         args = [
@@ -214,9 +204,7 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U foo>
       block = Block {
         args = [
@@ -373,9 +361,7 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U foo>
       block = Block {
         args = [

--- a/test/testdata/desugar/opasgn_accessor.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/opasgn_accessor.rb.desugar-tree-raw.exp
@@ -21,9 +21,7 @@ ClassDef{
       rhs = [
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U extend>
           block = nullptr
           pos_args = 1
@@ -40,18 +38,14 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U sig>
           block = Block {
             args = [
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -82,9 +76,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U attr_accessor>
           block = nullptr
           pos_args = 1

--- a/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
+++ b/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
@@ -9,9 +9,7 @@ ClassDef{
   rhs = [
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U extend>
       block = nullptr
       pos_args = 1
@@ -28,9 +26,7 @@ ClassDef{
 
     Send{
       flags = {privateOk}
-      recv = Local{
-        localVariable = <U <self>>
-      }
+      recv = Self
       fun = <U sig>
       block = Block {
         args = [
@@ -39,9 +35,7 @@ ClassDef{
           flags = {}
           recv = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U params>
             block = nullptr
             pos_args = 0

--- a/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
@@ -29,9 +29,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -53,9 +51,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -81,9 +77,7 @@ ClassDef{
             stats = [
               Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U p>
                 block = nullptr
                 pos_args = 1
@@ -96,9 +90,7 @@ ClassDef{
             ],
             expr = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U p>
               block = nullptr
               pos_args = 1
@@ -125,9 +117,7 @@ ClassDef{
             stats = [
               Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U p>
                 block = nullptr
                 pos_args = 1
@@ -140,9 +130,7 @@ ClassDef{
             ],
             expr = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U p>
               block = nullptr
               pos_args = 1
@@ -165,9 +153,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -189,9 +175,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -211,9 +195,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -282,9 +264,7 @@ ClassDef{
             block = nullptr
             pos_args = 4
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<super> }
               Local{
                 localVariable = <U <blk>>
@@ -314,9 +294,7 @@ ClassDef{
             block = nullptr
             pos_args = 3
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<super> }
               Local{
                 localVariable = <U <blk>>
@@ -349,9 +327,7 @@ ClassDef{
             block = nullptr
             pos_args = 3
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<super> }
               Local{
                 localVariable = <U <blk>>
@@ -388,9 +364,7 @@ ClassDef{
             block = nullptr
             pos_args = 4
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<super> }
               Local{
                 localVariable = <U <blk>>
@@ -434,9 +408,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<super> }
@@ -481,9 +453,7 @@ ClassDef{
             block = nullptr
             pos_args = 3
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<super> }
               Local{
                 localVariable = <U <blk>>
@@ -523,9 +493,7 @@ ClassDef{
             block = nullptr
             pos_args = 3
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<super> }
               Local{
                 localVariable = <U blk>
@@ -560,9 +528,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 3
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                   Literal{ value = :<untypedSuper> }
                   Local{
                     localVariable = <U <blk>>
@@ -619,9 +585,7 @@ ClassDef{
             block = nullptr
             pos_args = 3
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<untypedSuper> }
               Local{
                 localVariable = <U <blk>>

--- a/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
@@ -31,9 +31,7 @@ ClassDef{
             block = nullptr
             pos_args = 6
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<untypedSuper> }
               Local{
                 localVariable = <U <blk>>
@@ -52,18 +50,14 @@ ClassDef{
         ],
         expr = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U <untypedSuper>>
           block = Block {
             args = [
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -118,9 +112,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -158,9 +150,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -181,9 +171,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -242,9 +230,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -300,9 +286,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -323,9 +307,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -404,9 +386,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -465,9 +445,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -488,9 +466,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -576,9 +552,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -655,9 +629,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -678,9 +650,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -768,9 +738,7 @@ ClassDef{
             block = nullptr
             pos_args = 6
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<untypedSuper> }
               Local{
                 localVariable = <U blk>
@@ -789,18 +757,14 @@ ClassDef{
         ],
         expr = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U <untypedSuper>>
           block = Block {
             args = [
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -855,9 +819,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -895,9 +857,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -918,9 +878,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -979,9 +937,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -1037,9 +993,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -1060,9 +1014,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -1141,9 +1093,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -1202,9 +1152,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -1225,9 +1173,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -1313,9 +1259,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -1392,9 +1336,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -1415,9 +1357,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -1509,9 +1449,7 @@ ClassDef{
             block = nullptr
             pos_args = 6
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<untypedSuper> }
               Local{
                 localVariable = <U <blk>>
@@ -1538,18 +1476,14 @@ ClassDef{
         ],
         expr = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U <untypedSuper>>
           block = Block {
             args = [
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -1616,9 +1550,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -1667,9 +1599,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -1690,9 +1620,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -1766,9 +1694,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -1835,9 +1761,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -1858,9 +1782,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -1954,9 +1876,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -2026,9 +1946,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -2049,9 +1967,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -2152,9 +2068,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -2242,9 +2156,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -2265,9 +2177,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -2368,9 +2278,7 @@ ClassDef{
             block = nullptr
             pos_args = 6
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<untypedSuper> }
               Local{
                 localVariable = <U <blk>>
@@ -2404,18 +2312,14 @@ ClassDef{
         ],
         expr = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U <untypedSuper>>
           block = Block {
             args = [
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -2487,9 +2391,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -2545,9 +2447,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -2568,9 +2468,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -2649,9 +2547,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -2725,9 +2621,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -2748,9 +2642,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -2849,9 +2741,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -2928,9 +2818,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -2951,9 +2839,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -3059,9 +2945,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -3156,9 +3040,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -3179,9 +3061,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -3293,9 +3173,7 @@ ClassDef{
             block = nullptr
             pos_args = 6
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<untypedSuper> }
               Local{
                 localVariable = <U <blk>>
@@ -3353,18 +3231,14 @@ ClassDef{
         ],
         expr = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U <untypedSuper>>
           block = Block {
             args = [
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -3464,9 +3338,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -3546,9 +3418,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -3569,9 +3439,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -3678,9 +3546,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -3778,9 +3644,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -3801,9 +3665,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -3930,9 +3792,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -4033,9 +3893,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -4056,9 +3914,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -4192,9 +4048,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -4313,9 +4167,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -4336,9 +4188,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -4472,9 +4322,7 @@ ClassDef{
             block = nullptr
             pos_args = 6
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<untypedSuper> }
               Local{
                 localVariable = <U blk>
@@ -4501,18 +4349,14 @@ ClassDef{
         ],
         expr = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U <untypedSuper>>
           block = Block {
             args = [
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -4579,9 +4423,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -4630,9 +4472,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -4653,9 +4493,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -4729,9 +4567,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -4798,9 +4634,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -4821,9 +4655,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -4917,9 +4749,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -4989,9 +4819,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -5012,9 +4840,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -5115,9 +4941,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -5205,9 +5029,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -5228,9 +5050,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -5331,9 +5151,7 @@ ClassDef{
             block = nullptr
             pos_args = 6
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<untypedSuper> }
               Local{
                 localVariable = <U blk>
@@ -5367,18 +5185,14 @@ ClassDef{
         ],
         expr = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U <untypedSuper>>
           block = Block {
             args = [
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -5450,9 +5264,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -5508,9 +5320,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -5531,9 +5341,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -5612,9 +5420,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -5688,9 +5494,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -5711,9 +5515,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -5812,9 +5614,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -5891,9 +5691,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -5914,9 +5712,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -6022,9 +5818,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -6119,9 +5913,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -6142,9 +5934,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -6256,9 +6046,7 @@ ClassDef{
             block = nullptr
             pos_args = 6
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<untypedSuper> }
               Local{
                 localVariable = <U blk>
@@ -6316,18 +6104,14 @@ ClassDef{
         ],
         expr = Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U <untypedSuper>>
           block = Block {
             args = [
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -6427,9 +6211,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -6509,9 +6291,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -6532,9 +6312,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -6641,9 +6419,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -6741,9 +6517,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -6764,9 +6538,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -6893,9 +6665,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -6996,9 +6766,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -7019,9 +6787,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }
@@ -7155,9 +6921,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<untypedSuper> }
@@ -7276,9 +7040,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U puts>
               block = nullptr
               pos_args = 1
@@ -7299,9 +7061,7 @@ ClassDef{
               block = nullptr
               pos_args = 1
               args = [
-                Local{
-                  localVariable = <U <self>>
-                }
+                Self
               ]
             }
             Literal{ value = :<untypedSuper> }

--- a/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
@@ -33,9 +33,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -56,9 +54,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -72,9 +68,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -100,9 +94,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -123,9 +115,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -139,9 +129,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -167,9 +155,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -195,9 +181,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -215,9 +199,7 @@ ClassDef{
             stats = [
               Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U p>
                 block = nullptr
                 pos_args = 1
@@ -230,9 +212,7 @@ ClassDef{
             ],
             expr = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U p>
               block = nullptr
               pos_args = 1
@@ -259,9 +239,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -287,9 +265,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -307,9 +283,7 @@ ClassDef{
             stats = [
               Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U p>
                 block = nullptr
                 pos_args = 1
@@ -322,9 +296,7 @@ ClassDef{
             ],
             expr = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U p>
               block = nullptr
               pos_args = 1
@@ -351,9 +323,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -382,9 +352,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -398,9 +366,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -426,9 +392,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -457,9 +421,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -473,9 +435,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -501,9 +461,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -540,9 +498,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -554,9 +510,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U p>
             block = nullptr
             pos_args = 1
@@ -580,9 +534,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U void>
               block = nullptr
               pos_args = 0
@@ -592,9 +544,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -609,9 +559,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U extend>
           block = nullptr
           pos_args = 1
@@ -670,9 +618,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -693,9 +639,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -709,9 +653,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U <super>>
             block = nullptr
             pos_args = 1
@@ -737,9 +679,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -760,9 +700,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -776,9 +714,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U <super>>
             block = nullptr
             pos_args = 0
@@ -805,9 +741,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -833,9 +767,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -851,9 +783,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U <super>>
             block = nullptr
             pos_args = 0
@@ -884,9 +814,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -912,9 +840,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -930,9 +856,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U <super>>
             block = nullptr
             pos_args = 1
@@ -962,9 +886,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -993,9 +915,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -1027,9 +947,7 @@ ClassDef{
                 block = nullptr
                 pos_args = 1
                 args = [
-                  Local{
-                    localVariable = <U <self>>
-                  }
+                  Self
                 ]
               }
               Literal{ value = :<super> }
@@ -1067,9 +985,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -1098,9 +1014,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -1114,9 +1028,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U <super>>
             block = nullptr
             pos_args = 0
@@ -1154,9 +1066,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -1193,9 +1103,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -1215,9 +1123,7 @@ ClassDef{
             block = nullptr
             pos_args = 3
             args = [
-              Local{
-                localVariable = <U <self>>
-              }
+              Self
               Literal{ value = :<super> }
               Local{
                 localVariable = <U blk>
@@ -1238,9 +1144,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U void>
               block = nullptr
               pos_args = 0
@@ -1250,9 +1154,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -1274,9 +1176,7 @@ ClassDef{
               ]
               body = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U <untypedSuper>>
                 block = nullptr
                 pos_args = 0
@@ -1329,9 +1229,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U void>
               block = nullptr
               pos_args = 0
@@ -1341,9 +1239,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -1355,9 +1251,7 @@ ClassDef{
             } }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U <untypedSuper>>
             block = nullptr
             pos_args = 0
@@ -1368,9 +1262,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U extend>
           block = nullptr
           pos_args = 1

--- a/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
@@ -94,9 +94,7 @@ ClassDef{
             ],
             expr = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U proc>
               block = Block {
                 args = [

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -96,9 +96,7 @@ InsSeq{
             ],
             expr = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U proc>
               block = Block {
                 args = [

--- a/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
@@ -46,9 +46,7 @@ InsSeq{
             cond = Literal{ value = 1 }
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U has_while>
               block = nullptr
               pos_args = 0
@@ -106,9 +104,7 @@ InsSeq{
             }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U loop>
             block = Block {
               args = [
@@ -129,9 +125,7 @@ InsSeq{
             }]
           rhs = Send{
             flags = {privateOk}
-            recv = Local{
-              localVariable = <U <self>>
-            }
+            recv = Self
             fun = <U loop>
             block = Block {
               args = [

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1090,9 +1090,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 0
@@ -1102,9 +1100,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -1116,9 +1112,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -1133,9 +1127,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 3
@@ -1151,9 +1143,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 4
@@ -1173,9 +1163,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U optional>
           block = nullptr
           pos_args = 3
@@ -1191,9 +1179,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U optional>
           block = nullptr
           pos_args = 2
@@ -1220,9 +1206,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U optional>
           block = nullptr
           pos_args = 2
@@ -1245,9 +1229,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U optional>
           block = nullptr
           pos_args = 2
@@ -1271,9 +1253,7 @@ ClassDef{
               args = [
                 Send{
                   flags = {privateOk}
-                  recv = Local{
-                    localVariable = <U <self>>
-                  }
+                  recv = Self
                   fun = <U how_many_cases>
                   block = nullptr
                   pos_args = 0
@@ -1309,9 +1289,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U optional>
           block = nullptr
           pos_args = 2
@@ -1358,9 +1336,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -1417,9 +1393,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -1488,9 +1462,7 @@ ClassDef{
             ]
             body = Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -1516,9 +1488,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -1579,9 +1549,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {privateOk}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -1606,9 +1574,7 @@ ClassDef{
           }
           pos_args = 1
           args = [
-            Local{
-              localVariable = <U <self>>
-            }
+            Self
           ]
         }
 
@@ -1636,9 +1602,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U extend>
           block = nullptr
           pos_args = 1
@@ -1655,9 +1619,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U include>
           block = nullptr
           pos_args = 1
@@ -1674,9 +1636,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -1740,9 +1700,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -1799,9 +1757,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -1870,9 +1826,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -1941,9 +1895,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -2036,9 +1988,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -2095,9 +2045,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -2166,9 +2114,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -2240,9 +2186,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -2341,9 +2285,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -2419,9 +2361,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -2528,9 +2468,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -2585,9 +2523,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -2642,9 +2578,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -2701,9 +2635,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -2772,9 +2704,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -2831,9 +2761,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -2904,9 +2832,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3007,9 +2933,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3096,9 +3020,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -3155,9 +3077,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3228,9 +3148,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3331,9 +3249,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3420,9 +3336,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -3479,9 +3393,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3552,9 +3464,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3655,9 +3565,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3744,9 +3652,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -3803,9 +3709,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3876,9 +3780,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -3975,9 +3877,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -4072,9 +3972,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -4131,9 +4029,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -4202,9 +4098,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -4273,9 +4167,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -4368,9 +4260,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -4427,9 +4317,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -4498,9 +4386,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -4557,9 +4443,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -4618,9 +4502,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U include>
           block = nullptr
           pos_args = 1
@@ -4637,9 +4519,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4662,9 +4542,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4697,9 +4575,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4720,9 +4596,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4758,9 +4632,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4800,9 +4672,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4823,9 +4693,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U const>
           block = nullptr
           pos_args = 2
@@ -4844,9 +4712,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4874,9 +4740,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4902,9 +4766,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4945,9 +4807,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -4960,9 +4820,7 @@ ClassDef{
             Literal{ value = :foreign }
             Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U proc>
               block = Block {
                 args = [
@@ -4987,9 +4845,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -5002,9 +4858,7 @@ ClassDef{
             Literal{ value = :foreign }
             Send{
               flags = {privateOk}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U proc>
               block = Block {
                 args = [
@@ -5026,9 +4880,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -5051,9 +4903,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 2
@@ -5088,9 +4938,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 3
@@ -5117,9 +4965,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U prop>
           block = nullptr
           pos_args = 3
@@ -5217,9 +5063,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -5276,9 +5120,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -5347,9 +5189,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -5406,9 +5246,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -5467,9 +5305,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U include>
           block = nullptr
           pos_args = 1
@@ -5490,9 +5326,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U token_prop>
           block = nullptr
           pos_args = 0
@@ -5508,9 +5342,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U created_prop>
           block = nullptr
           pos_args = 0
@@ -5588,9 +5420,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -5647,9 +5477,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -5718,9 +5546,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -5765,9 +5591,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U include>
           block = nullptr
           pos_args = 1
@@ -5788,9 +5612,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U timestamped_token_prop>
           block = nullptr
           pos_args = 0
@@ -5806,9 +5628,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U created_prop>
           block = nullptr
           pos_args = 0
@@ -5924,9 +5744,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -6005,9 +5823,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -6103,9 +5919,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -6212,9 +6026,7 @@ ClassDef{
               flags = {}
               recv = Send{
                 flags = {}
-                recv = Local{
-                  localVariable = <U <self>>
-                }
+                recv = Self
                 fun = <U params>
                 block = nullptr
                 pos_args = 0
@@ -6349,9 +6161,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -6430,9 +6240,7 @@ ClassDef{
             ]
             body = Send{
               flags = {}
-              recv = Local{
-                localVariable = <U <self>>
-              }
+              recv = Self
               fun = <U returns>
               block = nullptr
               pos_args = 1
@@ -6516,9 +6324,7 @@ ClassDef{
 
         Send{
           flags = {privateOk}
-          recv = Local{
-            localVariable = <U <self>>
-          }
+          recv = Self
           fun = <U include>
           block = nullptr
           pos_args = 1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Something like ~30%+ of local variables in Stripe's codebase are just `self`, since we explicitly fill in the implicit `self` in e.g. sends during Desugar:

https://github.com/sorbet/sorbet/blob/726c812304567c910eaf46ae499e335ad09f02ad/ast/desugar/Desugar.cc#L727-L733

so we could save a bit of memory by having `self` represented by an explicit AST node so we don't have to store the `LocalVariable` that's identical across every instance of `self`.  (I guess it would be even better to not store the `loc` at all for such things, but I think that gets a little more complicated.)  It might also make various bits of namer and resolver faster, because `isSelfReference` is now just a tag test, rather than tag test + other comparisons.

Some things get a little more complicated (it's not enough to check for `Local`, we need to remember `Self` in a couple of places), but other things get more straightforward -- I think all the changes in `resolver/**/*.cc` are improvements.

You can review this more-or-less commit-by-commit: each commit is attacking a particular set of problems, starting with the build issues induced by the first commit and going from there.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
