### PR TITLE
add a test for trailing args in a block

### DIFF
--- a/test/testdata/desugar/block-implicit-rest-arg.rb
+++ b/test/testdata/desugar/block-implicit-rest-arg.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+call do |m, a,| # error: Method `call` does not exist
+  stuff # error: Method `stuff` does not exist
+end

--- a/test/testdata/desugar/block-implicit-rest-arg.rb.desugar-tree.exp
+++ b/test/testdata/desugar/block-implicit-rest-arg.rb.desugar-tree.exp
@@ -1,0 +1,5 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <self>.call() do |m, a|
+    <self>.stuff()
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This came up as a testcase on #8485.  A quick grep of Sorbet's tests indicated that we don't have any test coverage for what Prism calls "implicit rest args" (`do |x,y,|`), so we might as well add one.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
