### PR TITLE
Rework how the file table api interacts with shared_ptr values

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1730,7 +1730,7 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
     return name;
 }
 
-FileRef GlobalState::enterFile(const shared_ptr<File> &file) {
+FileRef GlobalState::enterFile(shared_ptr<File> file) {
     ENFORCE_NO_TIMER(!fileTableFrozen);
 
     SLOW_DEBUG_ONLY(for (auto &f
@@ -1742,9 +1742,10 @@ FileRef GlobalState::enterFile(const shared_ptr<File> &file) {
         }
     })
 
-    files.emplace_back(file);
+    auto path = file->path();
+    files.emplace_back(std::move(file));
     auto ret = FileRef(filesUsed() - 1);
-    fileRefByPath[string(file->path())] = ret;
+    fileRefByPath[path] = ret;
     return ret;
 }
 
@@ -1753,16 +1754,15 @@ FileRef GlobalState::enterFile(string_view path, string_view source) {
         make_shared<File>(string(path.begin(), path.end()), string(source.begin(), source.end()), File::Type::Normal));
 }
 
-FileRef GlobalState::enterNewFileAt(const shared_ptr<File> &file, FileRef id) {
+FileRef GlobalState::enterNewFileAt(shared_ptr<File> file, FileRef id) {
     ENFORCE_NO_TIMER(!fileTableFrozen);
     ENFORCE_NO_TIMER(id.id() < this->files.size());
     ENFORCE_NO_TIMER(this->files[id.id()]->sourceType == File::Type::NotYetRead);
     ENFORCE_NO_TIMER(this->files[id.id()]->path() == file->path());
 
     // was a tombstone before.
-    this->files[id.id()] = file;
-    FileRef result(id);
-    return result;
+    this->files[id.id()] = std::move(file);
+    return id;
 }
 
 FileRef GlobalState::reserveFileRef(string path) {
@@ -2334,10 +2334,10 @@ void GlobalState::markAsPayload() {
     }
 }
 
-void GlobalState::replaceFile(FileRef whatFile, const shared_ptr<File> &withWhat) {
+void GlobalState::replaceFile(FileRef whatFile, shared_ptr<File> withWhat) {
     ENFORCE_NO_TIMER(whatFile.id() < filesUsed());
     ENFORCE_NO_TIMER(whatFile.dataAllowingUnsafe(*this).path() == withWhat->path());
-    files[whatFile.id()] = withWhat;
+    files[whatFile.id()] = std::move(withWhat);
 }
 
 FileRef GlobalState::findFileByPath(string_view path) const {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -154,10 +154,10 @@ public:
     NameRef lookupNameConstant(std::string_view original) const;
 
     FileRef enterFile(std::string_view path, std::string_view source);
-    FileRef enterFile(const std::shared_ptr<File> &file);
-    FileRef enterNewFileAt(const std::shared_ptr<File> &file, FileRef id);
+    FileRef enterFile(std::shared_ptr<File> file);
+    FileRef enterNewFileAt(std::shared_ptr<File> file, FileRef id);
     FileRef reserveFileRef(std::string path);
-    void replaceFile(FileRef whatFile, const std::shared_ptr<File> &withWhat);
+    void replaceFile(FileRef whatFile, std::shared_ptr<File> withWhat);
     static std::unique_ptr<GlobalState> markFileAsTombStone(std::unique_ptr<GlobalState>, FileRef fref);
     FileRef findFileByPath(std::string_view path) const;
 

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -53,7 +53,7 @@ TEST_CASE("TestOffset2Pos2Offset") {
     for (auto &tc : cases) {
         auto name = string("case: ") + to_string(i);
         INFO(name);
-        FileRef f = gs.enterFile(move(name), tc.src);
+        FileRef f = gs.enterFile(name, tc.src);
 
         auto detail = Loc::offset2Pos(f.data(gs), tc.off.value());
 
@@ -103,7 +103,7 @@ TEST_CASE("TestPos2OffsetNull") {
     int i = 0;
     for (auto &tc : cases) {
         auto name = string("case: ") + to_string(i);
-        FileRef f = gs.enterFile(move(name), tc.src);
+        FileRef f = gs.enterFile(name, tc.src);
 
         auto actualOffset = Loc::pos2Offset(f.data(gs), Loc::Detail{tc.line, tc.col});
 
@@ -117,7 +117,7 @@ TEST_CASE("Errors") {
     GlobalState gs(errorQueue);
     gs.initEmpty();
     UnfreezeFileTable fileTableAccess(gs);
-    FileRef f = gs.enterFile(string("a/foo.rb"), string("def foo\n  hi\nend\n"));
+    FileRef f = gs.enterFile("a/foo.rb", string("def foo\n  hi\nend\n"));
     if (auto e = gs.beginError(Loc{f, 0, 3}, errors::Internal::InternalError)) {
         e.setHeader("Use of metavariable: `{}`", "foo");
     }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -96,7 +96,7 @@ core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<cor
     lgs->suppressPayloadSuperclassRedefinitionFor = hashingOpts.suppressPayloadSuperclassRedefinitionFor;
     {
         core::UnfreezeFileTable fileTableAccess(*lgs);
-        auto fref = lgs->enterFile(forWhat);
+        auto fref = lgs->enterFile(std::move(forWhat));
         fref.data(*lgs).strictLevel = realmain::pipeline::decideStrictLevel(*lgs, fref, opts());
         return fref;
     }

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -303,11 +303,11 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPoo
             auto fref = initialGS->findFileByPath(file->path());
             if (fref.exists()) {
                 newlyEvictedFiles[fref] = initialGS->getFiles()[fref.id()];
-                initialGS->replaceFile(fref, file);
+                initialGS->replaceFile(fref, std::move(file));
             } else {
                 // This file update adds a new file to GlobalState.
                 update.hasNewFiles = true;
-                fref = initialGS->enterFile(file);
+                fref = initialGS->enterFile(std::move(file));
                 fref.data(*initialGS).strictLevel = pipeline::decideStrictLevel(*initialGS, fref, config->opts);
             }
             frefs.emplace_back(fref);

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -303,11 +303,11 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPoo
             auto fref = initialGS->findFileByPath(file->path());
             if (fref.exists()) {
                 newlyEvictedFiles[fref] = initialGS->getFiles()[fref.id()];
-                initialGS->replaceFile(fref, std::move(file));
+                initialGS->replaceFile(fref, file);
             } else {
                 // This file update adds a new file to GlobalState.
                 update.hasNewFiles = true;
-                fref = initialGS->enterFile(std::move(file));
+                fref = initialGS->enterFile(file);
                 fref.data(*initialGS).strictLevel = pipeline::decideStrictLevel(*initialGS, fref, config->opts);
             }
             frefs.emplace_back(fref);

--- a/main/lsp/test/error_reporter_test.cc
+++ b/main/lsp/test/error_reporter_test.cc
@@ -76,11 +76,10 @@ TEST_CASE("NotifiesVSCodeWhenFileHasErrors") {
     auto cs = makeConfig();
     ErrorReporter er(cs);
     auto epoch = 0;
-    auto file = make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch);
     core::FileRef fref;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        fref = gs->enterFile(file);
+        fref = gs->enterFile(make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch));
     }
     auto outputVector = dynamic_pointer_cast<LSPOutputToVector>(cs->output);
 
@@ -113,11 +112,10 @@ TEST_CASE("ReportsEmptyErrorsToVSCodeIfFilePreviouslyHadErrors") {
     ErrorReporter er(cs);
     auto epoch = 0;
     auto newEpoch = 1;
-    auto file = make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch);
     core::FileRef fref;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        fref = gs->enterFile(file);
+        fref = gs->enterFile(make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch));
     }
 
     auto outputVector = dynamic_pointer_cast<LSPOutputToVector>(cs->output);
@@ -154,11 +152,10 @@ TEST_CASE("DoesNotReportToVSCodeWhenFileNeverHadErrors") {
     ErrorReporter er(cs);
     auto epoch = 0;
     auto newEpoch = 1;
-    auto file = make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch);
     core::FileRef fref;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        fref = gs->enterFile(file);
+        fref = gs->enterFile(make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch));
     }
     auto outputVector = dynamic_pointer_cast<LSPOutputToVector>(cs->output);
     vector<unique_ptr<core::Error>> emptyErrorList;
@@ -183,11 +180,10 @@ TEST_CASE("ErrorReporterIgnoresErrorsFromOldEpochs") {
     auto initialEpoch = 0;
     auto slowPathEpoch = 1;
     auto latestEpoch = 2;
-    auto file = make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, initialEpoch);
     core::FileRef fref;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        fref = gs->enterFile(file);
+        fref = gs->enterFile(make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, initialEpoch));
     }
     auto outputVector = dynamic_pointer_cast<LSPOutputToVector>(cs->output);
     vector<unique_ptr<core::Error>> emptyErrorList;
@@ -222,11 +218,10 @@ TEST_CASE("FirstAndLastLatencyReporting") {
     auto cs = makeConfig();
     ErrorReporter er(cs);
     auto epoch = 0;
-    auto file = make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch);
     core::FileRef fref;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        fref = gs->enterFile(file);
+        fref = gs->enterFile(make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch));
     }
     auto outputVector = dynamic_pointer_cast<LSPOutputToVector>(cs->output);
 
@@ -275,11 +270,10 @@ TEST_CASE("FirstAndLastLatencyAboutEqualWhenNoErrors") {
     auto cs = makeConfig();
     ErrorReporter er(cs);
     auto epoch = 0;
-    auto file = make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch);
     core::FileRef fref;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        fref = gs->enterFile(file);
+        fref = gs->enterFile(make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch));
     }
 
     vector<unique_ptr<core::Error>> emptyErrorList;
@@ -317,11 +311,10 @@ TEST_CASE("FirstAndLastLatencyNotReportedWhenEpochIsCancelled") {
     auto cs = makeConfig();
     ErrorReporter er(cs);
     auto epoch = 0;
-    auto file = make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch);
     core::FileRef fref;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        fref = gs->enterFile(file);
+        fref = gs->enterFile(make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch));
     }
     auto outputVector = dynamic_pointer_cast<LSPOutputToVector>(cs->output);
 
@@ -351,14 +344,12 @@ TEST_CASE("filesWithErrorsSince") {
     ErrorReporter er(cs);
     auto epoch = 0;
     auto requestedEpoch = 3;
-    auto file = make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch);
-    auto fileWithoutErrors = make_shared<core::File>("bar.rb", "bar", core::File::Type::Normal, epoch);
     core::FileRef fref;
     core::FileRef frefWithoutErrors;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        fref = gs->enterFile(file);
-        frefWithoutErrors = gs->enterFile(fileWithoutErrors);
+        fref = gs->enterFile(make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch));
+        frefWithoutErrors = gs->enterFile(make_shared<core::File>("bar.rb", "bar", core::File::Type::Normal, epoch));
     }
 
     vector<unique_ptr<core::Error>> errors;
@@ -396,17 +387,14 @@ TEST_CASE("Global error limit") {
 
     ErrorReporter er(cs);
     auto epoch = 0;
-    auto file1 = make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch);
-    auto file2 = make_shared<core::File>("bar.rb", "bar", core::File::Type::Normal, epoch);
-    auto file3 = make_shared<core::File>("baz.rb", "baz", core::File::Type::Normal, epoch);
     core::FileRef fref1;
     core::FileRef fref2;
     core::FileRef fref3;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        fref1 = gs->enterFile(file1);
-        fref2 = gs->enterFile(file2);
-        fref3 = gs->enterFile(file3);
+        fref1 = gs->enterFile(make_shared<core::File>("foo.rb", "foo", core::File::Type::Normal, epoch));
+        fref2 = gs->enterFile(make_shared<core::File>("bar.rb", "bar", core::File::Type::Normal, epoch));
+        fref3 = gs->enterFile(make_shared<core::File>("baz.rb", "baz", core::File::Type::Normal, epoch));
     }
 
     vector<unique_ptr<core::Error>> errorsFile1;

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -64,7 +64,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     vector<core::FileRef> inputFiles;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
-        auto file = gs->enterFile(string("fuzz.rb"), inputData);
+        auto file = gs->enterFile("fuzz.rb", inputData);
         inputFiles.emplace_back(file);
         file.data(*gs).strictLevel = core::StrictLevel::True;
     }


### PR DESCRIPTION
The methods that manage the file table on `GlobalState` currently accept `const std::shared_ptr<core::File> &` values. This means that every time we enter a file into the file table we will at a minimum copy the `shared_ptr` in `enterFile` which will increment the ref count, and then destroy the original in the caller which will decrement the ref count. While this isn't huge, it is atomic modifications of the shared ref count that aren't necessary.

Instead, let's have the operations that accept new `std::shared_ptr<core::File>` values accept the shared_ptr by value, as this gives the caller control over whether or not it will move the shared pointer or copy it.

### Motivation
Avoiding atomic operations where possible.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
