### PR TITLE
accelerate searching for newlines in `findLineBreaks`

### DIFF
--- a/common/common.cc
+++ b/common/common.cc
@@ -486,17 +486,19 @@ uint32_t sorbet::nextPowerOfTwo(uint32_t v) {
 
 vector<int> sorbet::findLineBreaks(string_view s) {
     vector<int> res;
-    int i = -1;
     res.emplace_back(-1);
-    for (auto c : s) {
-        i++;
-        if (c == '\n') {
-            res.emplace_back(i);
+    size_t next_pos = 0;
+    while (true) {
+        auto pos = s.find_first_of('\n', next_pos);
+        if (pos == string_view::npos) {
+            break;
         }
+
+        res.emplace_back((int)pos);
+        next_pos = pos + 1;
     }
-    // We start at -1 so the last character of the file is actually i+1
-    res.emplace_back(i + 1);
-    ENFORCE(i + 1 == s.size());
+
+    res.emplace_back(s.size());
     return res;
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Using higher-level bulk operations on strings for things like "find character" is usually a better idea than character-by-character APIs.

This winds up being ~1% faster on large files in Stripe's codebase -- not much, but not bad either.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
