### PR TITLE
give `ConstantLit::original` a real static type

### DIFF
--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -162,7 +162,8 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
             auto *exp = reinterpret_cast<const ConstantLit *>(tree);
             std::unique_ptr<UnresolvedConstantLit> originalC;
             if (exp->original) {
-                originalC = make_unique<UnresolvedConstantLit>(exp->original->loc, deepCopy(avoid, exp->original->scope), exp->original->cnst);
+                originalC = make_unique<UnresolvedConstantLit>(
+                    exp->original->loc, deepCopy(avoid, exp->original->scope), exp->original->cnst);
             }
             return make_expression<ConstantLit>(exp->loc, exp->symbol, move(originalC));
         }

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -160,9 +160,9 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
 
         case Tag::ConstantLit: {
             auto *exp = reinterpret_cast<const ConstantLit *>(tree);
-            ExpressionPtr originalC;
+            std::unique_ptr<UnresolvedConstantLit> originalC;
             if (exp->original) {
-                originalC = deepCopy(avoid, exp->original);
+                originalC = make_unique<UnresolvedConstantLit>(exp->original->loc, deepCopy(avoid, exp->original->scope), exp->original->cnst);
             }
             return make_expression<ConstantLit>(exp->loc, exp->symbol, move(originalC));
         }

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -281,7 +281,12 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
                 return false;
             }
             if (a->original && b->original) {
-                return structurallyEqual(gs, avoid, a->original, b->original, file);
+                auto &alit = *a->original;
+                auto &blit = *b->original;
+                if (alit.cnst != blit.cnst) {
+                    return false;
+                }
+                return structurallyEqual(gs, avoid, alit.scope, blit.scope, file);
             } else if (!a->original && !b->original) {
                 // This occurs when the constant is created using MK::Constant instead of MK::UnresolvedConstant
                 // (original points to the UnresolvedConstantLit that created this ConstantLit)

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -295,7 +295,7 @@ UnresolvedConstantLit::UnresolvedConstantLit(core::LocOffsets loc, ExpressionPtr
     _sanityCheck();
 }
 
-ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, ExpressionPtr original)
+ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original)
     : loc(loc), symbol(symbol), original(std::move(original)) {
     categoryCounterInc("trees", "resolvedconstantlit");
     _sanityCheck();
@@ -320,14 +320,14 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
                 break;
             }
 
-            auto &orig = cast_tree_nonnull<UnresolvedConstantLit>(nested->original);
+            auto &orig = *nested->original;
             namesFailedToResolve.emplace_back(orig.cnst);
             nested = ast::cast_tree<ast::ConstantLit>(orig.scope);
             ENFORCE(nested);
             ENFORCE(nested->symbol == core::Symbols::StubModule());
             ENFORCE(!nested->resolutionScopes->empty());
         }
-        auto &orig = cast_tree_nonnull<UnresolvedConstantLit>(nested->original);
+        auto &orig = *nested->original;
         namesFailedToResolve.emplace_back(orig.cnst);
         absl::c_reverse(namesFailedToResolve);
     }
@@ -707,7 +707,7 @@ string ConstantLit::toStringWithTabs(const core::GlobalState &gs, int tabs) cons
     if (symbol.exists() && symbol != core::Symbols::StubModule()) {
         return this->symbol.showFullName(gs);
     }
-    return "Unresolved: " + this->original.toStringWithTabs(gs, tabs);
+    return "Unresolved: " + this->original->toStringWithTabs(gs, tabs);
 }
 
 string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) const {
@@ -719,7 +719,7 @@ string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) const {
                    this->symbol.showFullName(gs));
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "orig = {}\n",
-                   this->original ? this->original.showRaw(gs, tabs + 1) : "nullptr");
+                   this->original ? this->original->showRaw(gs, tabs + 1) : "nullptr");
     // If resolutionScopes isn't null, it should not be empty.
     ENFORCE(resolutionScopes == nullptr || !resolutionScopes->empty());
     if (resolutionScopes != nullptr && !resolutionScopes->empty()) {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1137,9 +1137,9 @@ public:
     // For resolved symbols, `resolutionScopes` is null.
     using ResolutionScopes = InlinedVector<core::SymbolRef, 1>;
     std::unique_ptr<ResolutionScopes> resolutionScopes;
-    ExpressionPtr original;
+    std::unique_ptr<UnresolvedConstantLit> original;
 
-    ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, ExpressionPtr original);
+    ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -247,6 +247,25 @@ public:
         using std::swap;
         swap(this->ptr, other.ptr);
     }
+
+    template <typename E>
+    static ExpressionPtr fromUnique(std::unique_ptr<E> ptr) noexcept {
+        if (ptr == nullptr) {
+            return nullptr;
+        }
+        return ExpressionPtr(ExpressionToTag<E>::value, ptr.release());
+    }
+
+    template <typename E>
+    std::unique_ptr<E> toUnique() noexcept {
+        if (this->ptr == 0) {
+            return nullptr;
+        }
+        auto p = as_tree<E>();
+        ENFORCE(p);
+        release();
+        return std::unique_ptr<E>(p.get());
+    }
 };
 
 template <class E, typename... Args> ExpressionPtr make_expression(Args &&...args) {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -248,16 +248,14 @@ public:
         swap(this->ptr, other.ptr);
     }
 
-    template <typename E>
-    static ExpressionPtr fromUnique(std::unique_ptr<E> ptr) noexcept {
+    template <typename E> static ExpressionPtr fromUnique(std::unique_ptr<E> ptr) noexcept {
         if (ptr == nullptr) {
             return nullptr;
         }
         return ExpressionPtr(ExpressionToTag<E>::value, ptr.release());
     }
 
-    template <typename E>
-    std::unique_ptr<E> toUnique() noexcept {
+    template <typename E> std::unique_ptr<E> toUnique() noexcept {
         if (this->ptr == 0) {
             return nullptr;
         }

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -458,7 +458,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 synthesizeExpr(current, cctx.target, a.loc, make_insn<Ident>(aliasName));
 
                 if (a.original) {
-                    auto &orig = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(a.original);
+                    auto &orig = *a.original;
                     // Empirically, these are the only two cases we've needed so far to service the
                     // LSP requests we want (hover and completion), but that doesn't mean these are
                     // the **only** we'll ever want.

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1476,7 +1476,8 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
     }
 }
 
-unique_ptr<ast::UnresolvedConstantLit> SerializerImpl::unpickleUnresolvedConstantLit(UnPickler &p, const GlobalState &gs) {
+unique_ptr<ast::UnresolvedConstantLit> SerializerImpl::unpickleUnresolvedConstantLit(UnPickler &p,
+                                                                                     const GlobalState &gs) {
     auto loc = unpickleLocOffsets(p);
     NameRef cnst = unpickleNameRef(p);
     auto scope = unpickleExpr(p, gs);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -41,6 +41,7 @@ public:
     static void pickle(Pickler &p, core::LocOffsets loc);
     static void pickle(Pickler &p, core::Loc loc);
     static void pickle(Pickler &p, shared_ptr<const FileHash> fh);
+    static void pickle(Pickler &p, const ast::UnresolvedConstantLit &lit);
 
     static shared_ptr<File> unpickleFile(UnPickler &p);
     static UTF8Name unpickleUTF8Name(UnPickler &p, GlobalState &gs);
@@ -60,6 +61,7 @@ public:
     static ast::ExpressionPtr unpickleExpr(UnPickler &p, const GlobalState &);
     static NameRef unpickleNameRef(UnPickler &p);
     static unique_ptr<const FileHash> unpickleFileHash(UnPickler &p);
+    static unique_ptr<ast::UnresolvedConstantLit> unpickleUnresolvedConstantLit(UnPickler &p, const GlobalState &gs);
 
     SerializerImpl() = delete;
 };
@@ -1155,6 +1157,12 @@ ast::ExpressionPtr Serializer::loadTree(const core::GlobalState &gs, core::File 
     return SerializerImpl::unpickleExpr(p, gs);
 }
 
+void SerializerImpl::pickle(Pickler &p, const ast::UnresolvedConstantLit &lit) {
+    pickle(p, lit.loc);
+    p.putU4(lit.cnst.rawId());
+    pickle(p, lit.scope);
+}
+
 void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
     if (what == nullptr) {
         p.putU4(0);
@@ -1237,9 +1245,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::UnresolvedConstantLit: {
             auto &a = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(what);
-            pickle(p, a.loc);
-            p.putU4(a.cnst.rawId());
-            pickle(p, a.scope);
+            pickle(p, a);
             break;
         }
 
@@ -1447,7 +1453,12 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             auto &a = ast::cast_tree_nonnull<ast::ConstantLit>(what);
             pickle(p, a.loc);
             p.putU4(a.symbol.rawId());
-            pickle(p, a.original);
+            if (a.original == nullptr) {
+                p.putU4(0);
+            } else {
+                p.putU4(uint32_t(ast::Tag::UnresolvedConstantLit));
+                pickle(p, *a.original);
+            }
             break;
         }
 
@@ -1463,6 +1474,13 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             Exception::raise("Unimplemented AST Node: {}", what.nodeName());
             break;
     }
+}
+
+unique_ptr<ast::UnresolvedConstantLit> SerializerImpl::unpickleUnresolvedConstantLit(UnPickler &p, const GlobalState &gs) {
+    auto loc = unpickleLocOffsets(p);
+    NameRef cnst = unpickleNameRef(p);
+    auto scope = unpickleExpr(p, gs);
+    return std::make_unique<ast::UnresolvedConstantLit>(loc, std::move(scope), cnst);
 }
 
 ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const GlobalState &gs) {
@@ -1524,10 +1542,8 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             return ast::MK::If(loc, std::move(cond), std::move(thenp), std::move(elsep));
         }
         case ast::Tag::UnresolvedConstantLit: {
-            auto loc = unpickleLocOffsets(p);
-            NameRef cnst = unpickleNameRef(p);
-            auto scope = unpickleExpr(p, gs);
-            return ast::MK::UnresolvedConstant(loc, std::move(scope), cnst);
+            auto ptr = unpickleUnresolvedConstantLit(p, gs);
+            return ast::ExpressionPtr::fromUnique(std::move(ptr));
         }
         case ast::Tag::Local: {
             auto loc = unpickleLocOffsets(p);
@@ -1717,7 +1733,11 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
         case ast::Tag::ConstantLit: {
             auto loc = unpickleLocOffsets(p);
             auto sym = SymbolRef::fromRaw(p.getU4());
-            auto orig = unpickleExpr(p, gs);
+            auto litTag = p.getU4();
+            std::unique_ptr<ast::UnresolvedConstantLit> orig;
+            if (litTag == uint32_t(ast::Tag::UnresolvedConstantLit)) {
+                orig = unpickleUnresolvedConstantLit(p, gs);
+            }
             return ast::make_expression<ast::ConstantLit>(loc, sym, std::move(orig));
         }
         case ast::Tag::RuntimeMethodDefinition: {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1453,6 +1453,9 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             auto &a = ast::cast_tree_nonnull<ast::ConstantLit>(what);
             pickle(p, a.loc);
             p.putU4(a.symbol.rawId());
+            // This encoding is the same encoding that would be used if we were
+            // serializing an UnresolvedConstantLit as an ExpressionPtr, nullptr
+            // and all.
             if (a.original == nullptr) {
                 p.putU4(0);
             } else {
@@ -1738,6 +1741,8 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             std::unique_ptr<ast::UnresolvedConstantLit> orig;
             if (litTag == uint32_t(ast::Tag::UnresolvedConstantLit)) {
                 orig = unpickleUnresolvedConstantLit(p, gs);
+            } else if (litTag != 0) {
+                Exception::raise("Unknown tag for `ConstantLit::original`: {}", litTag);
             }
             return ast::make_expression<ast::ConstantLit>(loc, sym, std::move(orig));
         }

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -56,7 +56,7 @@ class AutogenWalk {
         vector<core::NameRef> out;
         auto *cnst = &cnstRef;
         while (cnst != nullptr && cnst->original != nullptr) {
-            auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(cnst->original);
+            auto &original = *cnst->original;
             out.emplace_back(original.cnst);
             cnst = ast::cast_tree<ast::ConstantLit>(original.scope);
 
@@ -211,7 +211,7 @@ public:
     bool isCBaseConstant(const ast::ConstantLit &cnstRef) {
         auto *cnst = &cnstRef;
         while (cnst != nullptr && cnst->original != nullptr) {
-            auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(cnst->original);
+            auto &original = *cnst->original;
             cnst = ast::cast_tree<ast::ConstantLit>(original.scope);
         }
         if (cnst && cnst->symbol == core::Symbols::root()) {

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -103,7 +103,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
     // Iterate. Ensures that we match "Foo" in "Foo::Bar" references.
     auto symbol = symbolBeforeDealias.dealias(ctx);
     while (lit && symbol.exists() && lit->original) {
-        auto &unresolved = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(lit->original);
+        auto &unresolved = *lit->original;
         if (lspQuery.matchesLoc(ctx.locAt(lit->loc)) || lspQuery.matchesSymbol(symbol) ||
             lspQuery.matchesSymbol(symbolBeforeDealias)) {
             // This basically approximates the cfg::Alias case from Environment::processBinding.

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1702,7 +1702,7 @@ class TreeSymbolizer {
         // NameInserter should have created this symbol
         ENFORCE(existing.exists());
 
-        node = ast::make_expression<ast::ConstantLit>(constLit->loc, existing, std::move(node));
+        node = ast::make_expression<ast::ConstantLit>(constLit->loc, existing, node.toUnique<ast::UnresolvedConstantLit>());
         return existing;
     }
 
@@ -1823,7 +1823,7 @@ public:
         core::SymbolRef cnst = ctx.state.lookupStaticFieldSymbol(scope, lhs.cnst);
         ENFORCE(cnst.exists());
         auto loc = lhs.loc;
-        asgn.lhs = ast::make_expression<ast::ConstantLit>(loc, cnst, std::move(asgn.lhs));
+        asgn.lhs = ast::make_expression<ast::ConstantLit>(loc, cnst, asgn.lhs.toUnique<ast::UnresolvedConstantLit>());
 
         return tree;
     }
@@ -1963,7 +1963,7 @@ public:
         // Simulates how squashNames in handleAssignment also creates a ConstantLit
         // (simpler than squashNames, because type members are not allowed to use any sort of
         // `A::B = type_member` syntax)
-        asgn.lhs = ast::make_expression<ast::ConstantLit>(asgn.lhs.loc(), sym, move(asgn.lhs));
+        asgn.lhs = ast::make_expression<ast::ConstantLit>(asgn.lhs.loc(), sym, asgn.lhs.toUnique<ast::UnresolvedConstantLit>());
 
         if (send->hasKwArgs()) {
             const auto numKwArgs = send->numKwArgs();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1702,7 +1702,8 @@ class TreeSymbolizer {
         // NameInserter should have created this symbol
         ENFORCE(existing.exists());
 
-        node = ast::make_expression<ast::ConstantLit>(constLit->loc, existing, node.toUnique<ast::UnresolvedConstantLit>());
+        node = ast::make_expression<ast::ConstantLit>(constLit->loc, existing,
+                                                      node.toUnique<ast::UnresolvedConstantLit>());
         return existing;
     }
 
@@ -1963,7 +1964,8 @@ public:
         // Simulates how squashNames in handleAssignment also creates a ConstantLit
         // (simpler than squashNames, because type members are not allowed to use any sort of
         // `A::B = type_member` syntax)
-        asgn.lhs = ast::make_expression<ast::ConstantLit>(asgn.lhs.loc(), sym, asgn.lhs.toUnique<ast::UnresolvedConstantLit>());
+        asgn.lhs = ast::make_expression<ast::ConstantLit>(asgn.lhs.loc(), sym,
+                                                          asgn.lhs.toUnique<ast::UnresolvedConstantLit>());
 
         if (send->hasKwArgs()) {
             const auto numKwArgs = send->numKwArgs();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1453,7 +1453,7 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
         // lit's scope to find if it starts with <PackageSpecRegistry>.
         auto superClassLoc = packageSpecClass->ancestors[0].loc();
         packageSpecClass->ancestors[0] = ast::make_expression<ast::ConstantLit>(
-            superClassLoc, core::Symbols::PackageSpec(), move(packageSpecClass->ancestors[0]));
+            superClassLoc, core::Symbols::PackageSpec(), packageSpecClass->ancestors[0].toUnique<ast::UnresolvedConstantLit>());
 
         info = make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree), ctx.locAt(packageSpecClass->loc),
                                             ctx.locAt(packageSpecClass->declLoc));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1453,7 +1453,8 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
         // lit's scope to find if it starts with <PackageSpecRegistry>.
         auto superClassLoc = packageSpecClass->ancestors[0].loc();
         packageSpecClass->ancestors[0] = ast::make_expression<ast::ConstantLit>(
-            superClassLoc, core::Symbols::PackageSpec(), packageSpecClass->ancestors[0].toUnique<ast::UnresolvedConstantLit>());
+            superClassLoc, core::Symbols::PackageSpec(),
+            packageSpecClass->ancestors[0].toUnique<ast::UnresolvedConstantLit>());
 
         info = make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree), ctx.locAt(packageSpecClass->loc),
                                             ctx.locAt(packageSpecClass->declLoc));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -343,7 +343,7 @@ private:
     }
 
     static core::SymbolRef resolveConstant(core::Context ctx, ConstantResolutionItem &job) {
-        auto &c = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(job.out->original);
+        auto &c = *job.out->original;
         if (ast::isa_tree<ast::EmptyTree>(c.scope)) {
             auto result = resolveLhs(ctx, job.scope, c.cnst);
 
@@ -433,7 +433,7 @@ private:
                     return true;
                 }
 
-                auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(cnst->original);
+                auto &original = *cnst->original;
                 if (original.cnst != *it) {
                     return false;
                 }
@@ -537,8 +537,7 @@ private:
 
     static core::ClassOrModuleRef stubConstant(core::MutableContext ctx, core::ClassOrModuleRef owner,
                                                ast::ConstantLit *out, bool possibleGenericType) {
-        auto symbol = ctx.state.enterClassSymbol(
-            ctx.locAt(out->loc), owner, ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(out->original).cnst);
+        auto symbol = ctx.state.enterClassSymbol(ctx.locAt(out->loc), owner, out->original->cnst);
 
         auto data = symbol.data(ctx);
         data->setIsModule(true); // This is what would happen in finalizeAncestors
@@ -607,7 +606,7 @@ private:
                 continue;
             }
 
-            auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(base->original);
+            auto &original = *base->original;
             if (importStubs.packageExportsConstant(prefix, original.cnst)) {
                 ENFORCE(cursor->scope.isClassOrModule());
                 return cursor->scope.asClassOrModuleRef();
@@ -645,7 +644,7 @@ private:
             auto *cursor = out;
             bool isRootReference = false;
             while (cursor != nullptr) {
-                auto original = ast::cast_tree<ast::UnresolvedConstantLit>(cursor->original);
+                auto original = cursor->original.get();
                 if (original == nullptr) {
                     isRootReference = cursor->symbol == core::Symbols::root();
                     break;
@@ -702,7 +701,7 @@ private:
                     auto loc = resolvedField.data(ctx)->loc();
                     if (auto e = ctx.state.beginError(loc, core::errors::Resolver::RecursiveTypeAlias)) {
                         e.setHeader("Unable to resolve right hand side of type alias `{}`", resolved.show(ctx));
-                        e.addErrorLine(ctx.locAt(job.out->original.loc()), "Type alias used here");
+                        e.addErrorLine(ctx.locAt(job.out->original->loc), "Type alias used here");
                     }
 
                     resolvedField.data(gs)->resultType = core::Types::untyped(resolved);
@@ -732,7 +731,7 @@ private:
 
         bool alreadyReported = false;
         job.out->resolutionScopes = make_unique<ast::ConstantLit::ResolutionScopes>();
-        auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(job.out->original);
+        auto &original = *job.out->original;
         if (auto id = ast::cast_tree<ast::ConstantLit>(original.scope)) {
             auto originalScope = id->symbol.dealias(ctx);
             if (originalScope == core::Symbols::StubModule()) {
@@ -768,7 +767,7 @@ private:
         // export site. Ignore resolution failures in the aliases/modules created by packaging to
         // avoid this resulting in duplicate errors.
         if (!constantNameMissing && !alreadyReported) {
-            if (auto e = ctx.beginError(job.out->original.loc(), core::errors::Resolver::StubConstant)) {
+            if (auto e = ctx.beginError(original.loc, core::errors::Resolver::StubConstant)) {
                 e.setHeader("Unable to resolve constant `{}`", original.cnst.show(ctx));
                 auto foundCommonTypo = false;
                 if (ast::isa_tree<ast::EmptyTree>(original.scope)) {
@@ -1310,10 +1309,8 @@ private:
                 return;
             }
             ENFORCE(sym.exists() ||
-                    ast::isa_tree<ast::ConstantLit>(
-                        ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(cnst->original).scope) ||
-                    ast::isa_tree<ast::EmptyTree>(
-                        ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(cnst->original).scope));
+                    ast::isa_tree<ast::ConstantLit>(cnst->original->scope) ||
+                    ast::isa_tree<ast::EmptyTree>(cnst->original->scope));
             if (isSuperclass && sym == core::Symbols::todo()) {
                 // This is the case where the superclass is empty, for example: `class A; end`
                 return;
@@ -1689,8 +1686,7 @@ public:
     static int constantDepth(ast::ConstantLit *exp) {
         int depth = 0;
         ast::ConstantLit *scope = exp;
-        while (scope->original && (scope = ast::cast_tree<ast::ConstantLit>(
-                                       ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(scope->original).scope))) {
+        while (scope->original && (scope = ast::cast_tree<ast::ConstantLit>(scope->original->scope))) {
             depth += 1;
         }
         return depth;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1320,7 +1320,7 @@ private:
             auto loc = ancestor.loc();
             auto enclosingClass = ctx.owner.enclosingClass(ctx);
             auto nw = ast::MK::UnresolvedConstant(loc, std::move(ancestor), enclosingClass.data(ctx)->name);
-            auto out = ast::make_expression<ast::ConstantLit>(loc, enclosingClass, std::move(nw));
+            auto out = ast::make_expression<ast::ConstantLit>(loc, enclosingClass, nw.toUnique<ast::UnresolvedConstantLit>());
             job.ancestor = ast::cast_tree<ast::ConstantLit>(out);
             ancestor = std::move(out);
         } else if (ast::isa_tree<ast::EmptyTree>(ancestor)) {
@@ -1336,7 +1336,7 @@ private:
         if (auto c = ast::cast_tree<ast::UnresolvedConstantLit>(tree)) {
             walkUnresolvedConstantLit(ctx, c->scope);
             auto loc = c->loc;
-            auto out = ast::make_expression<ast::ConstantLit>(loc, core::Symbols::noSymbol(), std::move(tree));
+            auto out = ast::make_expression<ast::ConstantLit>(loc, core::Symbols::noSymbol(), tree.toUnique<ast::UnresolvedConstantLit>());
             auto constant = ast::cast_tree<ast::ConstantLit>(out);
             ConstantResolutionItem job{nesting_, constant};
             if (resolveConstantJob(ctx, job)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1308,8 +1308,7 @@ private:
                 }
                 return;
             }
-            ENFORCE(sym.exists() ||
-                    ast::isa_tree<ast::ConstantLit>(cnst->original->scope) ||
+            ENFORCE(sym.exists() || ast::isa_tree<ast::ConstantLit>(cnst->original->scope) ||
                     ast::isa_tree<ast::EmptyTree>(cnst->original->scope));
             if (isSuperclass && sym == core::Symbols::todo()) {
                 // This is the case where the superclass is empty, for example: `class A; end`
@@ -1320,7 +1319,8 @@ private:
             auto loc = ancestor.loc();
             auto enclosingClass = ctx.owner.enclosingClass(ctx);
             auto nw = ast::MK::UnresolvedConstant(loc, std::move(ancestor), enclosingClass.data(ctx)->name);
-            auto out = ast::make_expression<ast::ConstantLit>(loc, enclosingClass, nw.toUnique<ast::UnresolvedConstantLit>());
+            auto out =
+                ast::make_expression<ast::ConstantLit>(loc, enclosingClass, nw.toUnique<ast::UnresolvedConstantLit>());
             job.ancestor = ast::cast_tree<ast::ConstantLit>(out);
             ancestor = std::move(out);
         } else if (ast::isa_tree<ast::EmptyTree>(ancestor)) {
@@ -1336,7 +1336,8 @@ private:
         if (auto c = ast::cast_tree<ast::UnresolvedConstantLit>(tree)) {
             walkUnresolvedConstantLit(ctx, c->scope);
             auto loc = c->loc;
-            auto out = ast::make_expression<ast::ConstantLit>(loc, core::Symbols::noSymbol(), tree.toUnique<ast::UnresolvedConstantLit>());
+            auto out = ast::make_expression<ast::ConstantLit>(loc, core::Symbols::noSymbol(),
+                                                              tree.toUnique<ast::UnresolvedConstantLit>());
             auto constant = ast::cast_tree<ast::ConstantLit>(out);
             ConstantResolutionItem job{nesting_, constant};
             if (resolveConstantJob(ctx, job)) {

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -8,6 +8,32 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
+namespace {
+ast::ExpressionPtr dupUnresolvedConstantLit(const ast::UnresolvedConstantLit *cons) {
+    if (!cons) {
+        return nullptr;
+    }
+
+    auto scopeCnst = ast::cast_tree<ast::UnresolvedConstantLit>(cons->scope);
+    if (!scopeCnst) {
+        if (ast::isa_tree<ast::EmptyTree>(cons->scope)) {
+            return ast::MK::UnresolvedConstant(cons->loc, ast::MK::EmptyTree(), cons->cnst);
+        }
+        auto id = ast::cast_tree<ast::ConstantLit>(cons->scope);
+        if (id == nullptr) {
+            return nullptr;
+        }
+        ENFORCE(id->symbol == core::Symbols::root());
+        return ast::MK::UnresolvedConstant(cons->loc, ASTUtil::dupType(cons->scope), cons->cnst);
+    }
+    auto scope = ASTUtil::dupType(cons->scope);
+    if (scope == nullptr) {
+        return nullptr;
+    }
+    return ast::MK::UnresolvedConstant(cons->loc, std::move(scope), cons->cnst);
+}
+}
+
 ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
     auto send = ast::cast_tree<ast::Send>(orig);
     if (send) {
@@ -56,7 +82,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
 
     auto ident = ast::cast_tree<ast::ConstantLit>(orig);
     if (ident) {
-        auto orig = dupType(ident->original);
+        auto orig = dupUnresolvedConstantLit(ident->original.get());
         if (ident->original && !orig) {
             return nullptr;
         }
@@ -104,28 +130,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         return ast::MK::Hash(hashLit->loc, std::move(keys), std::move(values));
     }
 
-    auto cons = ast::cast_tree<ast::UnresolvedConstantLit>(orig);
-    if (!cons) {
-        return nullptr;
-    }
-
-    auto scopeCnst = ast::cast_tree<ast::UnresolvedConstantLit>(cons->scope);
-    if (!scopeCnst) {
-        if (ast::isa_tree<ast::EmptyTree>(cons->scope)) {
-            return ast::MK::UnresolvedConstant(cons->loc, ast::MK::EmptyTree(), cons->cnst);
-        }
-        auto id = ast::cast_tree<ast::ConstantLit>(cons->scope);
-        if (id == nullptr) {
-            return nullptr;
-        }
-        ENFORCE(id->symbol == core::Symbols::root());
-        return ast::MK::UnresolvedConstant(cons->loc, dupType(cons->scope), cons->cnst);
-    }
-    auto scope = dupType(cons->scope);
-    if (scope == nullptr) {
-        return nullptr;
-    }
-    return ast::MK::UnresolvedConstant(cons->loc, std::move(scope), cons->cnst);
+    return dupUnresolvedConstantLit(ast::cast_tree<ast::UnresolvedConstantLit>(orig).get());
 }
 
 bool ASTUtil::hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name) {

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -32,7 +32,7 @@ unique_ptr<ast::UnresolvedConstantLit> dupUnresolvedConstantLit(const ast::Unres
     }
     return make_unique<ast::UnresolvedConstantLit>(cons->loc, std::move(scope), cons->cnst);
 }
-}
+} // namespace
 
 ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
     auto send = ast::cast_tree<ast::Send>(orig);
@@ -130,7 +130,8 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         return ast::MK::Hash(hashLit->loc, std::move(keys), std::move(values));
     }
 
-    return ast::ExpressionPtr::fromUnique(dupUnresolvedConstantLit(ast::cast_tree<ast::UnresolvedConstantLit>(orig).get()));
+    return ast::ExpressionPtr::fromUnique(
+        dupUnresolvedConstantLit(ast::cast_tree<ast::UnresolvedConstantLit>(orig).get()));
 }
 
 bool ASTUtil::hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name) {

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -86,7 +86,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         if (ident->original && !orig) {
             return nullptr;
         }
-        return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol, std::move(orig));
+        return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol, orig.toUnique<ast::UnresolvedConstantLit>());
     }
 
     auto arrayLit = ast::cast_tree<ast::Array>(orig);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`ConstantLit::original` is currently an `ExpressionPtr`.  However, if it is set (it can be `nullptr` for `ConstantLit`s that we create internally with known symbols), it is always an `UnresolvedConstantLit`.  We implicitly use this fact in various places -- `cast_tree` without checking for `nullptr` afterwards, `cast_tree_nonnull`, etc.

It would be nice to reflect that fact statically in the code for readability.  I also have plans for #4954 and its companion #5931, where it looks likely that to extract the actual space savings of #5931, we will have to do fancy pointer-tagging tricks with `ConstantLit::original`.  Those tricks are much easier to reason about -- and will require less mucking about with `ExpressionPtr` -- if we first make `ConstantLit::original` a known type.

This should be reviewable commit-by-commit, we're just fixing compile errors as we go along.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.