### PR TITLE
Switch getResolved accept an absl::Span

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -719,7 +719,7 @@ const ast::ParsedFile &LSPTypechecker::getIndexed(core::FileRef fref) const {
     return indexed[id];
 }
 
-vector<ast::ParsedFile> LSPTypechecker::getResolved(const vector<core::FileRef> &frefs, WorkerPool &workers) const {
+vector<ast::ParsedFile> LSPTypechecker::getResolved(absl::Span<const core::FileRef> frefs, WorkerPool &workers) const {
     ENFORCE(this_thread::get_id() == typecheckerThreadId, "Typechecker can only be used from the typechecker thread.");
     vector<ast::ParsedFile> updatedIndexed;
 
@@ -808,7 +808,7 @@ const ast::ParsedFile &LSPTypecheckerDelegate::getIndexed(core::FileRef fref) co
     return typechecker.getIndexed(fref);
 }
 
-std::vector<ast::ParsedFile> LSPTypecheckerDelegate::getResolved(const std::vector<core::FileRef> &frefs) const {
+std::vector<ast::ParsedFile> LSPTypecheckerDelegate::getResolved(absl::Span<const core::FileRef> frefs) const {
     return typechecker.getResolved(frefs, workers);
 }
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -148,7 +148,7 @@ public:
     /**
      * Returns a copy of the indexed tree that has been run through the incremental resolver.
      */
-    std::vector<ast::ParsedFile> getResolved(const std::vector<core::FileRef> &frefs, WorkerPool &workers) const;
+    std::vector<ast::ParsedFile> getResolved(absl::Span<const core::FileRef> frefs, WorkerPool &workers) const;
 
     /**
      * Returns the currently active GlobalState.
@@ -219,7 +219,7 @@ public:
     std::vector<std::unique_ptr<core::Error>> retypecheck(std::vector<core::FileRef> frefs) const;
     LSPQueryResult query(const core::lsp::Query &q, const std::vector<core::FileRef> &filesForQuery) const;
     const ast::ParsedFile &getIndexed(core::FileRef fref) const;
-    std::vector<ast::ParsedFile> getResolved(const std::vector<core::FileRef> &frefs) const;
+    std::vector<ast::ParsedFile> getResolved(absl::Span<const core::FileRef> frefs) const;
     ast::ExpressionPtr getLocalVarTrees(core::FileRef fref) const;
     const core::GlobalState &state() const;
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -668,8 +668,7 @@ vector<core::NameRef> localNamesForMethod(LSPTypecheckerDelegate &typechecker, c
 
 core::MethodRef firstMethodAfterQuery(LSPTypecheckerDelegate &typechecker, const core::Loc queryLoc) {
     const auto &gs = typechecker.state();
-    auto files = vector<core::FileRef>{queryLoc.file()};
-    auto resolved = typechecker.getResolved(files);
+    auto resolved = typechecker.getResolved({queryLoc.file()});
 
     NextMethodFinder nextMethodFinder(queryLoc);
     for (auto &t : resolved) {

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -14,8 +14,7 @@ namespace {
 
 core::MethodRef firstMethodAfterQuery(LSPTypecheckerDelegate &typechecker, const core::Loc queryLoc) {
     const auto &gs = typechecker.state();
-    auto files = vector<core::FileRef>{queryLoc.file()};
-    auto resolved = typechecker.getResolved(files);
+    auto resolved = typechecker.getResolved({queryLoc.file()});
 
     NextMethodFinder nextMethodFinder(queryLoc);
     for (auto &t : resolved) {


### PR DESCRIPTION
This allows us to avoid constructing vector temporaries when we're requesting a single file.

Here's the relevant section in the `absl::Span` docs that talks about how spans interact with `std::initializer_list` temporaries: https://github.com/abseil/abseil-cpp/blob/9c8d228a757b3461755e55872ae0005415fb29ea/absl/types/span.h#L272-L298. All existing calls to `getResolved` that weren't building up a vector of files in a loop were either already making a vector temporary with an initializer list, or had initialized one that way on the previous line.


### Motivation
Small memory savings.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
