### PR TITLE
remove 8 bytes from `ConstantLit` by packing mutually exclusive fields

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -450,12 +450,12 @@ public:
             return true;
         }
         auto root = ast::cast_tree<ast::ConstantLit>(scope);
-        return root != nullptr && root->symbol == core::Symbols::root();
+        return root != nullptr && root->symbol() == core::Symbols::root();
     }
 
     static bool isMagicClass(ExpressionPtr &expr) {
         if (auto recv = cast_tree<ConstantLit>(expr)) {
-            return recv->symbol == core::Symbols::Magic();
+            return recv->symbol() == core::Symbols::Magic();
         } else {
             return false;
         }

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -165,7 +165,7 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
                 originalC = make_unique<UnresolvedConstantLit>(
                     exp->original->loc, deepCopy(avoid, exp->original->scope), exp->original->cnst);
             }
-            return make_expression<ConstantLit>(exp->loc, exp->symbol, move(originalC));
+            return make_expression<ConstantLit>(exp->loc, exp->symbol(), move(originalC));
         }
 
         case Tag::ZSuperArgs: {

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -277,7 +277,7 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
         case Tag::ConstantLit: {
             auto *a = reinterpret_cast<const ConstantLit *>(tree);
             auto *b = reinterpret_cast<const ConstantLit *>(other);
-            if (a->symbol != b->symbol) {
+            if (a->symbol() != b->symbol()) {
                 return false;
             }
             if (a->original && b->original) {

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -100,7 +100,7 @@ void UnresolvedConstantLit::_sanityCheck() {
 }
 
 void ConstantLit::_sanityCheck() {
-    ENFORCE(resolutionScopes == nullptr || !resolutionScopes->empty());
+    ENFORCE(resolutionScopes() == nullptr || !resolutionScopes()->empty());
 }
 
 void EmptyTree::_sanityCheck() {}

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -301,8 +301,7 @@ ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::uniq
     _sanityCheck();
 }
 
-optional<pair<core::SymbolRef, vector<core::NameRef>>>
-ConstantLit::fullUnresolvedPath(const core::Context ctx) const {
+optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolvedPath(const core::Context ctx) const {
     if (this->symbol() != core::Symbols::StubModule()) {
         return nullopt;
     }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -296,29 +296,31 @@ UnresolvedConstantLit::UnresolvedConstantLit(core::LocOffsets loc, ExpressionPtr
 }
 
 ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original)
-    : loc(loc), symbol(symbol), original(std::move(original)) {
+    : loc(loc), resolutionScopesOrSymbol(symbol), original(std::move(original)) {
     categoryCounterInc("trees", "resolvedconstantlit");
     _sanityCheck();
 }
 
-optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolvedPath(core::Context ctx) const {
-    if (this->symbol != core::Symbols::StubModule()) {
+optional<pair<core::SymbolRef, vector<core::NameRef>>>
+ConstantLit::fullUnresolvedPath(const core::Context ctx) const {
+    if (this->symbol() != core::Symbols::StubModule()) {
         return nullopt;
     }
+    ENFORCE(this->resolutionScopes() != nullptr && !this->resolutionScopes()->empty());
 
     vector<core::NameRef> namesFailedToResolve;
     auto *nested = this;
     {
         while (true) {
-            if (nested->resolutionScopes == nullptr || nested->resolutionScopes->empty()) [[unlikely]] {
+            if (nested->resolutionScopes() == nullptr || nested->resolutionScopes()->empty()) [[unlikely]] {
                 ENFORCE(false);
-                bool hasScopes = nested->resolutionScopes != nullptr;
+                bool hasScopes = nested->resolutionScopes() != nullptr;
                 fatalLogger->error(R"(msg="Bad fullUnresolvedPath" loc="{}" hasScopes={})",
                                    ctx.locAt(this->loc).showRaw(ctx), hasScopes);
                 fatalLogger->error("source=\"{}\"", absl::CEscape(ctx.file.data(ctx).source()));
             }
 
-            if (nested->resolutionScopes->front().exists()) {
+            if (nested->resolutionScopes()->front().exists()) {
                 break;
             }
 
@@ -326,14 +328,14 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
             namesFailedToResolve.emplace_back(orig.cnst);
             nested = ast::cast_tree<ast::ConstantLit>(orig.scope);
             ENFORCE(nested);
-            ENFORCE(nested->symbol == core::Symbols::StubModule());
-            ENFORCE(!nested->resolutionScopes->empty());
+            ENFORCE(nested->symbol() == core::Symbols::StubModule());
+            ENFORCE(!nested->resolutionScopes()->empty());
         }
         auto &orig = *nested->original;
         namesFailedToResolve.emplace_back(orig.cnst);
         absl::c_reverse(namesFailedToResolve);
     }
-    auto prefix = nested->resolutionScopes->front();
+    auto prefix = nested->resolutionScopes()->front();
     return make_pair(prefix, move(namesFailedToResolve));
 }
 
@@ -706,8 +708,8 @@ string UnresolvedConstantLit::showRaw(const core::GlobalState &gs, int tabs) con
 }
 
 string ConstantLit::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    if (symbol.exists() && symbol != core::Symbols::StubModule()) {
-        return this->symbol.showFullName(gs);
+    if (symbol().exists() && symbol() != core::Symbols::StubModule()) {
+        return this->symbol().showFullName(gs);
     }
     return "Unresolved: " + this->original->toStringWithTabs(gs, tabs);
 }
@@ -717,17 +719,17 @@ string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) const {
 
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(std::back_inserter(buf), "symbol = ({} {})\n", this->symbol.showKind(gs),
-                   this->symbol.showFullName(gs));
+    fmt::format_to(std::back_inserter(buf), "symbol = ({} {})\n", this->symbol().showKind(gs),
+                   this->symbol().showFullName(gs));
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "orig = {}\n",
                    this->original ? this->original->showRaw(gs, tabs + 1) : "nullptr");
     // If resolutionScopes isn't null, it should not be empty.
-    ENFORCE(resolutionScopes == nullptr || !resolutionScopes->empty());
-    if (resolutionScopes != nullptr && !resolutionScopes->empty()) {
+    ENFORCE(resolutionScopes() == nullptr || !resolutionScopes()->empty());
+    if (resolutionScopes() != nullptr && !resolutionScopes()->empty()) {
         printTabs(buf, tabs + 1);
         fmt::format_to(std::back_inserter(buf), "resolutionScopes = [{}]\n",
-                       fmt::map_join(*this->resolutionScopes, ", ", [&](auto sym) { return sym.showFullName(gs); }));
+                       fmt::map_join(*this->resolutionScopes(), ", ", [&](auto sym) { return sym.showFullName(gs); }));
     }
     printTabs(buf, tabs);
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1125,16 +1125,121 @@ public:
 };
 CheckSize(UnresolvedConstantLit, 24, 8);
 
+// For constants that failed resolution, this class will contain resolutionScopes
+// set to whatever nesting scope we estimate the constant could have been defined in.
+// For constants that resolve properly, this class will contain the resolved symbol.
+class ResolutionScopesOrSymbol final {
+public:
+    // We store tagged pointers as 64-bit values.
+    using tagged_storage = uint64_t;
+
+private:
+    enum class Tag {
+        Symbol = 1,
+        ResolutionScopes = 2,
+    };
+
+    static constexpr tagged_storage TAG_MASK = 0xffff;
+
+    static constexpr tagged_storage PTR_MASK = ~TAG_MASK;
+
+    tagged_storage ptr;
+
+    static tagged_storage tagPtr(Tag tag, tagged_storage ptr) {
+        // Store the tag in the lower 16 bits of the pointer, regardless of size.
+        auto val = static_cast<tagged_storage>(tag);
+        auto maskedPtr = ptr << 16;
+
+        return maskedPtr | val;
+    }
+
+    static tagged_storage tagSymbol(core::SymbolRef symbol) {
+        return tagPtr(Tag::Symbol, static_cast<tagged_storage>(symbol.rawId()));
+    }
+
+    static tagged_storage allocateResolutionScopes() {
+        return tagPtr(Tag::ResolutionScopes, reinterpret_cast<tagged_storage>(new std::vector<core::SymbolRef>()));
+    }
+
+    Tag tag() const {
+        ENFORCE(ptr != 0);
+        auto value = reinterpret_cast<tagged_storage>(ptr) & TAG_MASK;
+        return static_cast<Tag>(value);
+    }
+
+    tagged_storage untaggedPtr() const noexcept {
+        auto val = ptr & PTR_MASK;
+        return val >> 16;
+    }
+
+public:
+    ResolutionScopesOrSymbol() noexcept : ptr(tagSymbol(core::Symbols::noSymbol())) {}
+    ResolutionScopesOrSymbol(core::SymbolRef symbol) noexcept : ptr(tagSymbol(symbol)) {}
+
+    ResolutionScopesOrSymbol(const ResolutionScopesOrSymbol &) = delete;
+    ResolutionScopesOrSymbol &operator=(const ResolutionScopesOrSymbol &) = delete;
+    ResolutionScopesOrSymbol(ResolutionScopesOrSymbol &&other) = delete;
+
+    ResolutionScopesOrSymbol &operator=(ResolutionScopesOrSymbol &&other) noexcept {
+        if (tag() == Tag::ResolutionScopes) {
+            delete resolutionScopes();
+        }
+        this->ptr = other.ptr;
+        other.ptr = tagSymbol(core::Symbols::noSymbol());
+        return *this;
+    }
+
+    ~ResolutionScopesOrSymbol() {
+        if (tag() == Tag::ResolutionScopes) {
+            delete resolutionScopes();
+        }
+    }
+
+    void markUnresolved() {
+        if (tag() != Tag::ResolutionScopes) {
+            ptr = allocateResolutionScopes();
+        }
+    }
+
+    // Returns nullptr if this is a resolved symbol.
+    std::vector<core::SymbolRef> *resolutionScopes() {
+        if (tag() != Tag::ResolutionScopes) {
+            return nullptr;
+        }
+
+        auto ptr = untaggedPtr();
+        return reinterpret_cast<std::vector<core::SymbolRef> *>(ptr);
+    }
+
+    // Returns nullptr if this is a resolved symbol.
+    const std::vector<core::SymbolRef> *resolutionScopes() const {
+        if (tag() != Tag::ResolutionScopes) {
+            return nullptr;
+        }
+
+        auto ptr = untaggedPtr();
+        return reinterpret_cast<std::vector<core::SymbolRef> *>(ptr);
+    }
+
+    // Returns StubModule if this is an unresolved symbol.
+    core::SymbolRef symbol() const {
+        if (tag() != Tag::Symbol) {
+            return core::Symbols::StubModule();
+        }
+        auto symbolId = untaggedPtr();
+        return core::SymbolRef::fromRaw(static_cast<uint32_t>(symbolId));
+    }
+};
+CheckSize(ResolutionScopesOrSymbol, 8, 8);
+
 EXPRESSION(ConstantLit) {
 public:
     const core::LocOffsets loc;
 
-    core::SymbolRef symbol; // If this is a normal constant. This symbol may be already dealiased.
-    // For constants that failed resolution, symbol will be set to StubModule and resolutionScopes
-    // will be set to whatever nesting scope we estimate the constant could have been defined in.
-    // For resolved symbols, `resolutionScopes` is null.
-    using ResolutionScopes = InlinedVector<core::SymbolRef, 1>;
-    std::unique_ptr<ResolutionScopes> resolutionScopes;
+private:
+    ResolutionScopesOrSymbol resolutionScopesOrSymbol;
+
+public:
     std::unique_ptr<UnresolvedConstantLit> original;
 
     ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
@@ -1147,9 +1252,30 @@ public:
     std::string nodeName() const;
     std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(core::Context ctx) const;
 
+    core::SymbolRef symbol() const {
+        return resolutionScopesOrSymbol.symbol();
+    }
+
+    void setSymbol(core::SymbolRef symbol) {
+        resolutionScopesOrSymbol = symbol;
+    }
+
+    std::vector<core::SymbolRef> *resolutionScopes() {
+        return resolutionScopesOrSymbol.resolutionScopes();
+    }
+
+    const std::vector<core::SymbolRef> *resolutionScopes() const {
+        return resolutionScopesOrSymbol.resolutionScopes();
+    }
+
+    // Marks this constant as unresolved and allocates a vector for `resolutionScopes`.
+    void markUnresolved() {
+        return resolutionScopesOrSymbol.markUnresolved();
+    }
+
     void _sanityCheck();
 };
-CheckSize(ConstantLit, 32, 8);
+CheckSize(ConstantLit, 24, 8);
 
 EXPRESSION(ZSuperArgs) {
 public:

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1257,6 +1257,7 @@ public:
     }
 
     void setSymbol(core::SymbolRef symbol) {
+        ENFORCE(symbol != core::Symbols::StubModule());
         resolutionScopesOrSymbol = ResolutionScopesOrSymbol(symbol);
     }
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1134,7 +1134,7 @@ public:
     using tagged_storage = uint64_t;
 
 private:
-    enum class Tag {
+    enum class Tag : uint8_t {
         Symbol = 1,
         ResolutionScopes = 2,
     };

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1174,7 +1174,7 @@ private:
 
 public:
     ResolutionScopesOrSymbol() noexcept : ptr(tagSymbol(core::Symbols::noSymbol())) {}
-    ResolutionScopesOrSymbol(core::SymbolRef symbol) noexcept : ptr(tagSymbol(symbol)) {}
+    explicit ResolutionScopesOrSymbol(core::SymbolRef symbol) noexcept : ptr(tagSymbol(symbol)) {}
 
     ResolutionScopesOrSymbol(const ResolutionScopesOrSymbol &) = delete;
     ResolutionScopesOrSymbol &operator=(const ResolutionScopesOrSymbol &) = delete;
@@ -1257,7 +1257,7 @@ public:
     }
 
     void setSymbol(core::SymbolRef symbol) {
-        resolutionScopesOrSymbol = symbol;
+        resolutionScopesOrSymbol = ResolutionScopesOrSymbol(symbol);
     }
 
     std::vector<core::SymbolRef> *resolutionScopes() {

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -108,7 +108,7 @@ pair<LocalRef, bool> unresolvedIdent2Local(CFGContext cctx, const ast::Unresolve
 
 bool sendRecvIsT(ast::Send &s) {
     if (auto cnst = ast::cast_tree<ast::ConstantLit>(s.recv)) {
-        return cnst->symbol == core::Symbols::T();
+        return cnst->symbol() == core::Symbols::T();
     } else {
         return false;
     }
@@ -125,7 +125,7 @@ bool isKernelLambda(ast::Send &s) {
     // We could revisit this in the future but for now let's be conservative.
 
     auto cnst = ast::cast_tree<ast::ConstantLit>(s.recv);
-    return cnst != nullptr && cnst->symbol == core::Symbols::Kernel();
+    return cnst != nullptr && cnst->symbol() == core::Symbols::Kernel();
 }
 
 InstructionPtr maybeMakeTypeParameterAlias(CFGContext &cctx, ast::Send &s) {
@@ -191,7 +191,7 @@ ast::Send *isKernelProcOrLambda(ast::ExpressionPtr &expr) {
     }
 
     auto recv = ast::cast_tree<ast::ConstantLit>(send->recv);
-    if (recv == nullptr || recv->symbol != core::Symbols::Kernel()) {
+    if (recv == nullptr || recv->symbol() != core::Symbols::Kernel()) {
         return nullptr;
     }
 
@@ -449,10 +449,10 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             },
             [&](ast::ConstantLit &a) {
                 auto aliasName = cctx.newTemporary(core::Names::cfgAlias());
-                if (a.symbol == core::Symbols::StubModule()) {
+                if (a.symbol() == core::Symbols::StubModule()) {
                     current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(core::Symbols::untyped()));
                 } else {
-                    current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(a.symbol));
+                    current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(a.symbol()));
                 }
 
                 synthesizeExpr(current, cctx.target, a.loc, make_insn<Ident>(aliasName));
@@ -481,7 +481,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             [&](ast::Assign &a) {
                 LocalRef lhs;
                 if (auto lhsIdent = ast::cast_tree<ast::ConstantLit>(a.lhs)) {
-                    lhs = global2Local(cctx, lhsIdent->symbol);
+                    lhs = global2Local(cctx, lhsIdent->symbol());
                 } else if (auto lhsLocal = ast::cast_tree<ast::Local>(a.lhs)) {
                     lhs = cctx.inWhat.enterLocal(lhsLocal->localVariable);
                 } else if (auto ident = ast::cast_tree<ast::UnresolvedIdent>(a.lhs)) {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1452,7 +1452,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
         case ast::Tag::ConstantLit: {
             auto &a = ast::cast_tree_nonnull<ast::ConstantLit>(what);
             pickle(p, a.loc);
-            p.putU4(a.symbol.rawId());
+            p.putU4(a.symbol().rawId());
             // This encoding is the same encoding that would be used if we were
             // serializing an UnresolvedConstantLit as an ExpressionPtr, nullptr
             // and all.

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -595,13 +595,13 @@ core::LocOffsets getAncestorLoc(const core::GlobalState &gs, const ast::ClassDef
                                 const core::ClassOrModuleRef ancestor) {
     for (const auto &anc : classDef.ancestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
-        if (ancConst != nullptr && ancConst->symbol.dealias(gs) == ancestor) {
+        if (ancConst != nullptr && ancConst->symbol().dealias(gs) == ancestor) {
             return anc.loc();
         }
     }
     for (const auto &anc : classDef.singletonAncestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
-        if (ancConst != nullptr && ancConst->symbol.dealias(gs) == ancestor) {
+        if (ancConst != nullptr && ancConst->symbol().dealias(gs) == ancestor) {
             return anc.loc();
         }
     }
@@ -789,7 +789,7 @@ void validateSuperClass(core::Context ctx, const core::ClassOrModuleRef sym, con
     }
 
     if (auto cnst = ast::cast_tree<ast::ConstantLit>(classDef.ancestors.front())) {
-        if (cnst->symbol == core::Symbols::todo()) {
+        if (cnst->symbol() == core::Symbols::todo()) {
             return;
         }
     }
@@ -1200,11 +1200,11 @@ public:
         }
 
         auto id = ast::cast_tree<ast::ConstantLit>(send.recv);
-        if (id == nullptr || !id->symbol.exists() || !id->symbol.isClassOrModule()) {
+        if (id == nullptr || !id->symbol().exists() || !id->symbol().isClassOrModule()) {
             return;
         }
 
-        auto symbol = id->symbol.asClassOrModuleRef().data(ctx);
+        auto symbol = id->symbol().asClassOrModuleRef().data(ctx);
         if (!symbol->flags.isAbstract) {
             return;
         }
@@ -1219,9 +1219,9 @@ public:
         // there was no user defined .new method, which warrants an error.
         if (method_new.data(ctx)->owner == core::Symbols::Class()) {
             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::AbstractClassInstantiated)) {
-                auto symbolName = id->symbol.show(ctx);
+                auto symbolName = id->symbol().show(ctx);
                 e.setHeader("Attempt to instantiate abstract class `{}`", symbolName);
-                e.addErrorLine(id->symbol.loc(ctx), "`{}` defined here", symbolName);
+                e.addErrorLine(id->symbol().loc(ctx), "`{}` defined here", symbolName);
             }
         }
     }

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -121,9 +121,8 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             if (symbolBeforeDealias == core::Symbols::StubModule()) {
                 // If the symbol is an alias to a stub symbol, it actually resolved, and so it won't
                 // have resolutionScopes.
-                auto resolutionScopes = lit->resolutionScopes();
-                std::copy(resolutionScopes->begin(), resolutionScopes->end(), scopes.begin());
-
+                auto *resolutionScopes = lit->resolutionScopes();
+                scopes.insert(scopes.end(), resolutionScopes->begin(), resolutionScopes->end());
             } else {
                 scopes = {symbol.owner(ctx)};
             }

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -295,7 +295,7 @@ public:
         }
 
         if (auto constantLit = ast::cast_tree<ast::ConstantLit>(send.recv)) {
-            if (constantLit->symbol == core::Symbols::Regexp() && send.fun == core::Names::new_()) {
+            if (constantLit->symbol() == core::Symbols::Regexp() && send.fun == core::Names::new_()) {
                 ENFORCE(send.numPosArgs() >= 2);
                 skipLocRange(send.getPosArg(0).loc());
                 skipLocRange(send.getPosArg(1).loc());

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -148,7 +148,7 @@ class SymbolFinder {
     core::FoundDefinitionRef defineScope(core::FoundDefinitionRef owner, const ast::ExpressionPtr &node) {
         if (auto id = ast::cast_tree<ast::ConstantLit>(node)) {
             // Already defined. Insert a foundname so we can reference it.
-            auto sym = id->symbol;
+            auto sym = id->symbol();
             ENFORCE(sym.exists());
             return foundDefs->addSymbol(sym.asClassOrModuleRef());
         } else if (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node)) {
@@ -580,7 +580,7 @@ public:
 
         typecase(
             s.recv, [&](const ast::UnresolvedConstantLit &c) { result = c.cnst == core::Names::Constants::T(); },
-            [&](const ast::ConstantLit &c) { result = c.symbol == core::Symbols::T(); },
+            [&](const ast::ConstantLit &c) { result = c.symbol() == core::Symbols::T(); },
             [&](const ast::ExpressionPtr &_default) { result = false; });
 
         return result;
@@ -1665,7 +1665,7 @@ class TreeSymbolizer {
         auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node);
         if (constLit == nullptr) {
             if (auto id = ast::cast_tree<ast::ConstantLit>(node)) {
-                return id->symbol.dealias(ctx);
+                return id->symbol().dealias(ctx);
             }
             if (auto uid = ast::cast_tree<ast::UnresolvedIdent>(node)) {
                 if (uid->kind != ast::UnresolvedIdent::Kind::Class || uid->name != core::Names::singleton()) {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -257,7 +257,7 @@ public:
         }
 
         auto lit = ast::cast_tree<ast::ConstantLit>(send.getPosArg(0));
-        if (lit == nullptr || lit->symbol == core::Symbols::StubModule()) {
+        if (lit == nullptr || lit->symbol() == core::Symbols::StubModule()) {
             // We don't raise an explicit error here, as this is one of two cases:
             //   1. Export is given a non-constant argument
             //   2. The argument failed to resolve
@@ -265,17 +265,18 @@ public:
             return;
         }
 
-        if (lit->symbol.isClassOrModule()) {
-            auto sym = lit->symbol.asClassOrModuleRef();
-            checkExportPackage(ctx, send.loc, lit->symbol);
+        auto litSymbol = lit->symbol();
+        if (litSymbol.isClassOrModule()) {
+            auto sym = litSymbol.asClassOrModuleRef();
+            checkExportPackage(ctx, send.loc, litSymbol);
             recursiveExportSymbol(ctx, true, sym);
 
             // When exporting a symbol, we also export its parent namespace. This is a bit of a hack, and it would be
             // great to remove this, but this was the behavior of the previous packager implementation.
             exportParentNamespace(ctx, sym.data(ctx)->owner);
-        } else if (lit->symbol.isFieldOrStaticField()) {
-            auto sym = lit->symbol.asFieldRef();
-            checkExportPackage(ctx, send.loc, lit->symbol);
+        } else if (litSymbol.isFieldOrStaticField()) {
+            auto sym = litSymbol.asFieldRef();
+            checkExportPackage(ctx, send.loc, litSymbol);
             sym.data(ctx)->flags.isExported = true;
 
             // When exporting a field, we also export its parent namespace. This is a bit of a hack, and it would be
@@ -283,7 +284,7 @@ public:
             exportParentNamespace(ctx, sym.data(ctx)->owner);
         } else {
             std::string_view kind = ""sv;
-            switch (lit->symbol.kind()) {
+            switch (litSymbol.kind()) {
                 case core::SymbolRef::Kind::ClassOrModule:
                 case core::SymbolRef::Kind::FieldOrStaticField:
                     ENFORCE(false, "ClassOrModule and FieldOrStaticField marked not exportable");
@@ -304,8 +305,8 @@ public:
 
             if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidExport)) {
                 e.setHeader("Only classes, modules, or constants may be exported");
-                e.addErrorLine(lit->symbol.loc(ctx), "Defined here");
-                e.addErrorNote("`{}` is a `{}`", lit->symbol.show(ctx), kind);
+                e.addErrorLine(litSymbol.loc(ctx), "Defined here");
+                e.addErrorNote("`{}` is a `{}`", litSymbol.show(ctx), kind);
             }
         }
     }
@@ -369,11 +370,12 @@ public:
 
     void postTransformConstantLit(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &lit = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
-        if (!lit.symbol.isClassOrModule() && !lit.symbol.isFieldOrStaticField()) {
+        auto litSymbol = lit.symbol();
+        if (!litSymbol.isClassOrModule() && !litSymbol.isFieldOrStaticField()) {
             return;
         }
 
-        auto loc = lit.symbol.loc(ctx);
+        auto loc = litSymbol.loc(ctx);
 
         auto otherFile = loc.file();
         if (!otherFile.exists() || !otherFile.data(ctx).isPackaged()) {
@@ -384,7 +386,7 @@ public:
         if (otherFile.data(ctx).isPackagedTest() && !this->insideTestFile) {
             if (auto e = ctx.beginError(lit.loc, core::errors::Packager::UsedTestOnlyName)) {
                 e.setHeader("`{}` is defined in a test namespace and cannot be referenced in a non-test file",
-                            lit.symbol.show(ctx));
+                            litSymbol.show(ctx));
             }
             return;
         }
@@ -398,18 +400,18 @@ public:
         }
 
         bool isExported = false;
-        if (lit.symbol.isClassOrModule()) {
-            isExported = lit.symbol.asClassOrModuleRef().data(ctx)->flags.isExported;
-        } else if (lit.symbol.isFieldOrStaticField()) {
-            isExported = lit.symbol.asFieldRef().data(ctx)->flags.isExported;
+        if (litSymbol.isClassOrModule()) {
+            isExported = litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
+        } else if (litSymbol.isFieldOrStaticField()) {
+            isExported = litSymbol.asFieldRef().data(ctx)->flags.isExported;
         }
 
         // Did we use a constant that wasn't exported?
         if (!isExported && !db.allowRelaxedPackagerChecksFor(this->package.mangledName())) {
             if (auto e = ctx.beginError(lit.loc, core::errors::Packager::UsedPackagePrivateName)) {
                 auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
-                e.setHeader("`{}` resolves but is not exported from `{}`", lit.symbol.show(ctx), pkg.show(ctx));
-                auto definedHereLoc = lit.symbol.loc(ctx);
+                e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
+                auto definedHereLoc = litSymbol.loc(ctx);
                 if (definedHereLoc.file().data(ctx).isRBI()) {
                     e.addErrorSection(core::ErrorSection(
                         core::ErrorColors::format(
@@ -420,7 +422,7 @@ public:
                     e.addErrorLine(definedHereLoc, "Defined here");
                 }
 
-                auto symToExport = lit.symbol;
+                auto symToExport = litSymbol;
                 auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
                 if (enumClass.exists()) {
                     symToExport = enumClass;
@@ -451,7 +453,7 @@ public:
                     e.setHeader(
                         "`{}` resolves but its package is not imported. However, it cannot be automatically imported "
                         "because importing it would cause a layering violation",
-                        lit.symbol.show(ctx));
+                        lit.symbol().show(ctx));
                     ENFORCE(pkg.layer().has_value(), "causesLayeringViolation should return false if layer is not set");
                     ENFORCE(this->package.layer().has_value(),
                             "causesLayeringViolation should return false if layer is not set");
@@ -462,7 +464,7 @@ public:
                         pkg.layer().value().first.show(ctx));
                     // TODO(neil): link to a doc that would help the user resolve this.
                 } else {
-                    e.setHeader("`{}` resolves but its package is not imported", lit.symbol.show(ctx));
+                    e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
                     e.addErrorLine(pkg.declLoc(), "Exported from package here");
                     if (auto exp = this->package.addImport(ctx, pkg, isTestImport)) {
                         e.addAutocorrect(std::move(exp.value()));
@@ -483,7 +485,7 @@ public:
         } else if (*importType == core::packages::ImportType::Test && !this->insideTestFile) {
             // We used a symbol from a `test_import` in a non-test context
             if (auto e = ctx.beginError(lit.loc, core::errors::Packager::UsedTestOnlyName)) {
-                e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", lit.symbol.show(ctx));
+                e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
                 auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
                 if (auto exp = this->package.addImport(ctx, pkg, false)) {
                     e.addAutocorrect(std::move(exp.value()));
@@ -571,12 +573,12 @@ public:
             return;
         }
 
-        if (lit->symbol == core::Symbols::StubModule()) {
+        if (lit->symbol() == core::Symbols::StubModule()) {
             // An error was already reported in resolver when the StubModule was created.
             return;
         }
 
-        this->imports.emplace_back(lit->symbol, send.loc);
+        this->imports.emplace_back(lit->symbol(), send.loc);
     }
 
     void checkImports(core::Context ctx) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -673,7 +673,7 @@ ast::ExpressionPtr prependName(ast::ExpressionPtr scope) {
 
 bool startsWithPackageSpecRegistry(const ast::UnresolvedConstantLit &cnst) {
     if (auto scope = ast::cast_tree<ast::ConstantLit>(cnst.scope)) {
-        return scope->symbol == core::Symbols::PackageSpecRegistry();
+        return scope->symbol() == core::Symbols::PackageSpecRegistry();
     } else if (auto scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst.scope)) {
         return startsWithPackageSpecRegistry(*scope);
     } else {
@@ -1108,7 +1108,7 @@ private:
             lit = ast::cast_tree<ast::UnresolvedConstantLit>(lit->scope);
             if (scope != nullptr) {
                 ENFORCE(lit == nullptr);
-                ENFORCE(scope->symbol == core::Symbols::root());
+                ENFORCE(scope->symbol() == core::Symbols::root());
                 rootConsts++;
             }
         }
@@ -1134,7 +1134,7 @@ private:
             lit = ast::cast_tree<ast::UnresolvedConstantLit>(lit->scope);
             if (scope != nullptr) {
                 ENFORCE(lit == nullptr);
-                ENFORCE(scope->symbol == core::Symbols::root());
+                ENFORCE(scope->symbol() == core::Symbols::root());
                 rootConsts--;
             }
         }

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -97,7 +97,7 @@ bool isTProc(core::Context ctx, const ast::Send *send) {
     while (send != nullptr) {
         if (send->fun == core::Names::proc()) {
             if (auto rcv = ast::cast_tree<ast::ConstantLit>(send->recv)) {
-                return rcv->symbol == core::Symbols::T();
+                return rcv->symbol() == core::Symbols::T();
             }
         }
         send = ast::cast_tree<ast::Send>(send->recv);
@@ -122,7 +122,7 @@ bool TypeSyntax::isSig(core::Context ctx, const ast::Send &send) {
         return false;
     }
 
-    if (recv != nullptr && recv->symbol == core::Symbols::Sorbet_Private_Static()) {
+    if (recv != nullptr && recv->symbol() == core::Symbols::Sorbet_Private_Static()) {
         return true;
     }
 
@@ -614,7 +614,7 @@ void checkUnexpectedKwargs(core::Context ctx, const ast::Send &send) {
 core::ClassOrModuleRef sendLooksLikeBadTypeApplication(core::Context ctx, const ast::Send &send) {
     core::SymbolRef maybeScopeClass;
     if (auto recv = ast::cast_tree<ast::ConstantLit>(send.recv)) {
-        maybeScopeClass = recv->symbol;
+        maybeScopeClass = recv->symbol();
     } else if (send.recv.isSelfReference()) {
         // Let's not try to reinvent constant resolution here and just pick a heuristic that tends to
         // work in some cases and is simple.
@@ -692,7 +692,7 @@ optional<core::ClassOrModuleRef> parseTClassOf(core::Context ctx, const ast::Sen
         }
         return core::Symbols::untyped();
     }
-    auto maybeAliased = obj->symbol;
+    auto maybeAliased = obj->symbol();
     if (maybeAliased.isTypeAlias(ctx)) {
         if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
             e.setHeader("T.class_of can't be used with a T.type_alias");
@@ -1109,7 +1109,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
         result.type = core::make_type<core::ShapeType>(move(keys), move(values));
     } else if (ast::isa_tree<ast::ConstantLit>(expr)) {
         const auto &i = ast::cast_tree_nonnull<ast::ConstantLit>(expr);
-        auto maybeAliased = i.symbol;
+        auto maybeAliased = i.symbol();
         ENFORCE(maybeAliased.exists());
 
         if (maybeAliased.isTypeAlias(ctx)) {
@@ -1329,7 +1329,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
 
         core::SymbolRef appliedKlass;
         if (auto recvi = ast::cast_tree<ast::ConstantLit>(s.recv)) {
-            if (recvi->symbol == core::Symbols::T()) {
+            if (recvi->symbol() == core::Symbols::T()) {
                 if (auto res = interpretTCombinator(ctx, s, sigBeingParsed, args)) {
                     return move(res.value());
                 } else {
@@ -1337,7 +1337,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
                 }
             }
 
-            if (recvi->symbol == core::Symbols::Magic() && s.fun == core::Names::callWithSplat()) {
+            if (recvi->symbol() == core::Symbols::Magic() && s.fun == core::Names::callWithSplat()) {
                 if (auto e = ctx.beginError(s.recv.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Malformed type declaration: splats cannot be used in types");
                 }
@@ -1345,14 +1345,14 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
                 return result;
             }
 
-            appliedKlass = recvi->symbol;
+            appliedKlass = recvi->symbol();
         } else if (auto recvi = ast::cast_tree<ast::Send>(s.recv)) {
             if (recvi->fun != core::Names::classOf() || s.fun != core::Names::squareBrackets()) {
                 return reportUnknownTypeSyntaxError(ctx, s, move(result));
             }
 
             auto recviRecvi = ast::cast_tree<ast::ConstantLit>(recvi->recv);
-            if (recviRecvi == nullptr || recviRecvi->symbol != core::Symbols::T()) {
+            if (recviRecvi == nullptr || recviRecvi->symbol() != core::Symbols::T()) {
                 return reportUnknownTypeSyntaxError(ctx, s, move(result));
             }
 

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -108,7 +108,7 @@ ast::ExpressionPtr toWriterSigForName(ast::Send *sharedSig, const core::NameRef 
     ast::Send *cur = body;
     while (cur != nullptr) {
         auto recv = ast::cast_tree<ast::ConstantLit>(cur->recv);
-        if ((cur->recv.isSelfReference()) || (recv && recv->symbol == core::Symbols::Sorbet())) {
+        if ((cur->recv.isSelfReference()) || (recv && recv->symbol() == core::Symbols::Sorbet())) {
             auto loc = resultType.loc();
             auto params = ast::MK::Send0(loc, move(cur->recv), core::Names::params(), loc.copyWithZeroLength());
             ast::cast_tree_nonnull<ast::Send>(params).addKwArg(ast::MK::Symbol(nameLoc, name), move(resultType));

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -9,7 +9,7 @@ namespace {
 
 bool isTSigWithoutRuntime(ast::ExpressionPtr &expr) {
     if (auto cnst = ast::cast_tree<ast::ConstantLit>(expr)) {
-        return cnst->symbol == core::Symbols::T_Sig_WithoutRuntime();
+        return cnst->symbol() == core::Symbols::T_Sig_WithoutRuntime();
     } else {
         auto withoutRuntime = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
         if (withoutRuntime == nullptr || withoutRuntime->cnst != core::Names::Constants::WithoutRuntime()) {

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -23,7 +23,7 @@ unique_ptr<ast::UnresolvedConstantLit> dupUnresolvedConstantLit(const ast::Unres
         if (id == nullptr) {
             return nullptr;
         }
-        ENFORCE(id->symbol == core::Symbols::root());
+        ENFORCE(id->symbol() == core::Symbols::root());
         return make_unique<ast::UnresolvedConstantLit>(cons->loc, ASTUtil::dupType(cons->scope), cons->cnst);
     }
     auto scope = ASTUtil::dupType(cons->scope);
@@ -86,7 +86,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         if (ident->original && !orig) {
             return nullptr;
         }
-        return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol, std::move(orig));
+        return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol(), std::move(orig));
     }
 
     auto arrayLit = ast::cast_tree<ast::Array>(orig);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The description for #4954 still holds true, though this doesn't reduce Sorbet's memory consumption.

But, it does separate out an important piece of work for getting `ConstantLit` down to 16 bytes, rather than 32.  The sketch of how that's going to work is that `ConstantLit` has essentially three states:

1. `SymbolRef` + loc -- an internally created symbol
2. `SymbolRef` + `original` -- an `UnresolvedConstantLit` that was successfully resolved
3. `resolutionScopes` + `original` -- an `UnresolvedConstantLit` that we could not resolve

and through some tricky pointer tagging, all three of those can be packed into 16 bytes -- the locs for the latter two are stored in the original `UnresolvedConstantLit`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
