### PR TITLE
Add `JSON::Ext::ParserConfig` to `json.rbi`

### DIFF
--- a/rbi/stdlib/json.rbi
+++ b/rbi/stdlib/json.rbi
@@ -1007,6 +1007,8 @@ class JSON::Ext::Parser
   def source; end
 end
 
+class JSON::Ext::ParserConfig
+end
 
 # The base exception for [`JSON`](https://docs.ruby-lang.org/en/2.7.0/JSON.html)
 # errors.


### PR DESCRIPTION
cc @jez @jez-stripe 

Adds `JSON::Ext::ParserConfig` to `json.rbi`.

This class was introduced in v2.10.0 of the JSON gem (cf. https://github.com/ruby/json/pull/728). Because it's implemented in a C extension, it's invisible to Sorbet unless explicitly declared.

### Motivation
The class is explicitly referenced in the gem's Ruby code ([here](https://github.com/ruby/json/blob/aa5b7d6acb53a4596750e7d81894d95ee19d92ab/lib/json/ext.rb#L32)). Tapioca will generate the following code in the RBI file for the json gem:
```ruby
# source://json//lib/json/ext.rb#32
JSON::Ext::Parser::Config = JSON::Ext::ParserConfig
```

If the `JSON::Ext::ParserConfig` class is not declared, then the Tapioca-generated RBI file will cause the following Sorbet error:
```
sorbet/rbi/gems/json@2.10.1.rbi:1914: Unable to resolve constant ParserConfig https://srb.help/5002
    1914 |JSON::Ext::Parser::Config = JSON::Ext::ParserConfig
                                      ^^^^^^^^^^^^^^^^^^^^^^^
```

### Test plan
I'm not sure how to test this? However I did add a shim with the same contents as this PR's changes (i.e. just `class JSON::Ext::ParserConfig; end`) in my codebase and verified it fixed the Sorbet error.
