### PR TITLE
Equate `T.attached_class (of A)` and `A` in final! classes

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2638,8 +2638,11 @@ class ResolveTypeMembersAndFieldsWalk {
         ENFORCE(lambdaParam != nullptr);
 
         if (isTodo(lambdaParam->lowerBound)) {
-            lambdaParam->upperBound = sym.data(ctx)->unsafeComputeExternalType(ctx);
-            lambdaParam->lowerBound = core::Types::bottom();
+            auto data = sym.data(ctx);
+            auto externalType = data->unsafeComputeExternalType(ctx);
+            lambdaParam->upperBound = externalType;
+            // Allow treating `T.attached_class` as the class itself in final classes
+            lambdaParam->lowerBound = data->flags.isFinal ? externalType : core::Types::bottom();
         }
 
         // If all of the singleton members have been resolved, attempt to

--- a/test/testdata/resolver/final_attached_class_fixed.rb
+++ b/test/testdata/resolver/final_attached_class_fixed.rb
@@ -1,0 +1,52 @@
+# typed: strict
+
+class Parent
+  extend T::Sig, T::Helpers
+  final!
+
+  sig(:final) { returns(T.attached_class) }
+  def self.make
+    if [true, false].sample
+      # expected and desired
+      Parent.new
+    else
+      # Also works because Child <: Parent and
+      # `T.attached_class` == `Parent` in this case
+      Child.new
+    end
+  end
+end
+
+class Child < Parent
+  #           ^^^^^^ error: `Parent` was declared as final
+  # We don't check type member bounds for attached class, because
+  # we assume we did it correctly, but it's not correct in this
+  # case
+  #
+  # I'm not really sure how to craft a test case that exhibits a soundness bug due to the lower bound being incompatible with the Parent lower bound, so instead this formulation just proves that the Child's lower bound is getting set to Child.
+  #
+  # In any case, the "declared as final" error is reported at #
+  # `typed: false` so we don't really _need_ another error to be
+  # reported for the bad bounds--in fact it's lucky that it's
+  # silenced because it's less confusing for the user (don't want
+  # to leak implementation details if we don't have to).
+
+  final!
+
+  sig(:final) { returns(T.attached_class) }
+  def self.make2
+    if [true, false].sample
+      return Parent.new # error: Expected `T.attached_class (of Child)` but found `Parent` for method result type
+    else
+      return Child.new
+    end
+  end
+end
+
+# Covariant type members default to their upper bound
+res = Parent.make
+T.reveal_type(res) # error: `Parent`
+res = Child.make
+T.reveal_type(res) # error: `Child`
+res = Child.make2
+T.reveal_type(res) # error: `Child`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Pointed out by a user


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

- [ ] Factor a helper
- [ ] Make sure that the helper does not need to be used elsewhere
- [ ] Write a test for the case when the class is generic
- [ ] Also make this apply to `T::Enum`, even though they're not really final
  (requires having the `<AttachedClass>` of the `MyEnum::X$1` classes to
  fix to `MyEnum` not to `MyEnum::X$1`)