### PR TITLE
Rework completion to thread a single resolved tree through

### DIFF
--- a/main/lsp/ConvertToSingletonClassMethod.cc
+++ b/main/lsp/ConvertToSingletonClassMethod.cc
@@ -62,9 +62,8 @@ unique_ptr<TextDocumentEdit> createMethodDefEdit(const core::GlobalState &gs, LS
     }
 
     if (definition.symbol.data(gs)->hasSig()) {
-        auto trees = typechecker.getResolved({file});
-        ENFORCE(!trees.empty());
-        auto &rootTree = trees[0].tree;
+        auto resolvedTree = typechecker.getResolved(file);
+        auto &rootTree = resolvedTree.tree;
 
         auto ctx = core::Context(gs, core::Symbols::root(), file);
         auto queryLoc = definition.termLoc.copyWithZeroLength();

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -155,9 +155,14 @@ public:
     const ast::ParsedFile &getIndexed(core::FileRef fref) const;
 
     /**
-     * Returns a copy of the indexed tree that has been run through the incremental resolver.
+     * Returns copies of the indexed trees that have been run through the incremental resolver.
      */
     std::vector<ast::ParsedFile> getResolved(absl::Span<const core::FileRef> frefs, WorkerPool &workers) const;
+
+    /**
+     * Returns a copy of the indexed tree that has been run through the incremental resolver.
+     */
+    ast::ParsedFile getResolved(core::FileRef fref, WorkerPool &workers) const;
 
     /**
      * Returns the currently active GlobalState.
@@ -229,7 +234,9 @@ public:
     LSPQueryResult query(const core::lsp::Query &q, const std::vector<core::FileRef> &filesForQuery) const;
     const ast::ParsedFile &getIndexed(core::FileRef fref) const;
     std::vector<ast::ParsedFile> getResolved(absl::Span<const core::FileRef> frefs) const;
+    ast::ParsedFile getResolved(core::FileRef fref) const;
     ast::ExpressionPtr getLocalVarTrees(core::FileRef fref) const;
+
     const core::GlobalState &state() const;
 
     void updateGsFromOptions(const DidChangeConfigurationParams &options) const;

--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -167,9 +167,8 @@ vector<unique_ptr<TextEdit>> moveMethod(LSPTypecheckerDelegate &typechecker, con
 
     auto fref = definition.termLoc.file();
 
-    auto trees = typechecker.getResolved({fref});
-    ENFORCE(!trees.empty());
-    auto &rootTree = trees[0].tree;
+    auto resolvedTree = typechecker.getResolved({fref});
+    auto &rootTree = resolvedTree.tree;
 
     auto sigAndMethodLocs = methodLocs(gs, rootTree, definition.symbol, fref);
     if (!sigAndMethodLocs.has_value()) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -668,13 +668,11 @@ vector<core::NameRef> localNamesForMethod(LSPTypecheckerDelegate &typechecker, c
 
 core::MethodRef firstMethodAfterQuery(LSPTypecheckerDelegate &typechecker, const core::Loc queryLoc) {
     const auto &gs = typechecker.state();
-    auto resolved = typechecker.getResolved({queryLoc.file()});
+    auto resolved = typechecker.getResolved(queryLoc.file());
 
     NextMethodFinder nextMethodFinder(queryLoc);
-    for (auto &t : resolved) {
-        auto ctx = core::Context(gs, core::Symbols::root(), t.file);
-        ast::ConstTreeWalk::apply(ctx, nextMethodFinder, t.tree);
-    }
+    auto ctx = core::Context(gs, core::Symbols::root(), resolved.file);
+    ast::ConstTreeWalk::apply(ctx, nextMethodFinder, resolved.tree);
 
     return nextMethodFinder.result();
 }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -575,13 +575,9 @@ vector<core::NameRef> allSimilarFields(const core::GlobalState &gs, core::ClassO
 }
 
 vector<core::NameRef> allSimilarFieldsForClass(LSPTypecheckerDelegate &typechecker, const core::ClassOrModuleRef klass,
-                                               const core::Loc queryLoc, ast::UnresolvedIdent::Kind kind,
-                                               string_view prefix) {
+                                               const core::Loc queryLoc, const ast::ParsedFile &resolved,
+                                               ast::UnresolvedIdent::Kind kind, string_view prefix) {
     const auto &gs = typechecker.state();
-    auto files = vector<core::FileRef>{};
-    for (auto loc : klass.data(gs)->locs()) {
-        files.emplace_back(loc.file());
-    }
 
     // We have an interesting problem here: the symbol table already stores
     // information about all the fields in a class, but we only populate the
@@ -589,7 +585,7 @@ vector<core::NameRef> allSimilarFieldsForClass(LSPTypecheckerDelegate &typecheck
     // way.  But we would like to provide completion for all fields, typed
     // or not.
     //
-    // The compromise we take is this: for each file that is < StrictLevel::Strict,
+    // The compromise we take is this: if the file is typed < StrictLevel::Strict,
     // we walk the AST to discover the fields in that class and we add those
     // results to the symbol table results.  We might discover duplicate information
     // (people might have declared instance variables as typed in StrictLevel::True
@@ -597,20 +593,11 @@ vector<core::NameRef> allSimilarFieldsForClass(LSPTypecheckerDelegate &typecheck
     // from which source.
     auto result = allSimilarFields(gs, klass, prefix);
 
-    files.erase(remove_if(files.begin(), files.end(),
-                          [&gs](auto f) { return f.data(gs).strictLevel >= core::StrictLevel::Strict; }),
-                files.end());
-
-    if (!files.empty()) {
-        auto resolved = typechecker.getResolved(files);
-
-        // Instantiate fieldFinder outside loop so that result accumulates over every time we TreeWalk::apply
+    if (resolved.file.data(gs).strictLevel < core::StrictLevel::Strict) {
         std::vector<core::NameRef> fields;
         FieldFinder fieldFinder(klass, kind, fields);
-        for (auto &t : resolved) {
-            auto ctx = core::Context(gs, core::Symbols::root(), t.file);
-            ast::ConstTreeWalk::apply(ctx, fieldFinder, t.tree);
-        }
+        auto ctx = core::Context(gs, core::Symbols::root(), resolved.file);
+        ast::ConstTreeWalk::apply(ctx, fieldFinder, resolved.tree);
 
         // TODO: this does prefix matching for instance/class variables, but our
         // completion for locals matches anywhere in the name
@@ -635,21 +622,13 @@ vector<core::NameRef> allSimilarFieldsForClass(LSPTypecheckerDelegate &typecheck
 }
 
 vector<core::NameRef> localNamesForMethod(LSPTypecheckerDelegate &typechecker, const core::MethodRef method,
-                                          const core::Loc queryLoc) {
+                                          const core::Loc queryLoc, const ast::ParsedFile &resolved) {
     const auto &gs = typechecker.state();
-    auto files = vector<core::FileRef>{};
-    for (auto loc : method.data(gs)->locs()) {
-        files.emplace_back(loc.file());
-    }
-    auto resolved = typechecker.getResolved(files);
 
-    // Instantiate localVarFinder outside loop so that result accumualates over every time we TreeWalk::apply
     std::vector<core::NameRef> result;
     LocalVarFinder localVarFinder(method, queryLoc, result);
-    for (auto &t : resolved) {
-        auto ctx = core::Context(gs, core::Symbols::root(), t.file);
-        ast::ConstTreeWalk::apply(ctx, localVarFinder, t.tree);
-    }
+    auto ctx = core::Context(gs, core::Symbols::root(), resolved.file);
+    ast::ConstTreeWalk::apply(ctx, localVarFinder, resolved.tree);
 
     fast_sort(result, [&gs](const auto &left, const auto &right) {
         // Sort by actual name, not by NameRef id
@@ -666,9 +645,9 @@ vector<core::NameRef> localNamesForMethod(LSPTypecheckerDelegate &typechecker, c
     return result;
 }
 
-core::MethodRef firstMethodAfterQuery(LSPTypecheckerDelegate &typechecker, const core::Loc queryLoc) {
+core::MethodRef firstMethodAfterQuery(LSPTypecheckerDelegate &typechecker, const core::Loc queryLoc,
+                                      const ast::ParsedFile &resolved) {
     const auto &gs = typechecker.state();
-    auto resolved = typechecker.getResolved(queryLoc.file());
 
     NextMethodFinder nextMethodFinder(queryLoc);
     auto ctx = core::Context(gs, core::Symbols::root(), resolved.file);
@@ -706,8 +685,8 @@ constexpr string_view suggestSigDocs =
 
 unique_ptr<CompletionItem> trySuggestSig(LSPTypecheckerDelegate &typechecker,
                                          const LSPClientConfiguration &clientConfig, core::SymbolRef what,
-                                         core::TypePtr receiverType, const core::Loc queryLoc, string_view prefix,
-                                         size_t sortIdx) {
+                                         core::TypePtr receiverType, const core::Loc queryLoc,
+                                         const ast::ParsedFile &resolved, string_view prefix, size_t sortIdx) {
     ENFORCE(receiverType != nullptr);
 
     // Completion with T::Sig::WithoutRuntime.sig / Sorbet::Private::Static.sig won't work because
@@ -720,7 +699,7 @@ unique_ptr<CompletionItem> trySuggestSig(LSPTypecheckerDelegate &typechecker,
     const auto markupKind = clientConfig.clientCompletionItemMarkupKind;
     const auto supportSnippets = clientConfig.clientCompletionItemSnippetSupport;
 
-    auto targetMethod = firstMethodAfterQuery(typechecker, queryLoc);
+    auto targetMethod = firstMethodAfterQuery(typechecker, queryLoc, resolved);
     if (!targetMethod.exists()) {
         return nullptr;
     }
@@ -776,10 +755,11 @@ unique_ptr<CompletionItem> trySuggestSig(LSPTypecheckerDelegate &typechecker,
 }
 
 unique_ptr<CompletionItem> trySuggestYardSnippet(LSPTypecheckerDelegate &typechecker,
-                                                 const LSPClientConfiguration &clientConfig, core::Loc queryLoc) {
+                                                 const LSPClientConfiguration &clientConfig, core::Loc queryLoc,
+                                                 const ast::ParsedFile &resolved) {
     const auto &gs = typechecker.state();
 
-    auto method = firstMethodAfterQuery(typechecker, queryLoc);
+    auto method = firstMethodAfterQuery(typechecker, queryLoc, resolved);
     if (!method.exists()) {
         return nullptr;
     }
@@ -1022,12 +1002,11 @@ unique_ptr<CompletionItem> CompletionTask::getCompletionItemForUntyped(const cor
     return item;
 }
 
-unique_ptr<CompletionItem> CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
-                                                                      core::DispatchResult &dispatchResult,
-                                                                      core::MethodRef maybeAlias,
-                                                                      const core::TypePtr &receiverType,
-                                                                      core::Loc queryLoc, string_view prefix,
-                                                                      size_t sortIdx, uint16_t totalArgs) const {
+unique_ptr<CompletionItem>
+CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker, core::DispatchResult &dispatchResult,
+                                           core::MethodRef maybeAlias, const core::TypePtr &receiverType,
+                                           core::Loc queryLoc, const ast::ParsedFile &resolved, string_view prefix,
+                                           size_t sortIdx, uint16_t totalArgs) const {
     const auto &gs = typechecker.state();
     ENFORCE(maybeAlias.exists());
     auto clientConfig = config.getClientConfig();
@@ -1041,7 +1020,8 @@ unique_ptr<CompletionItem> CompletionTask::getCompletionItemForMethod(LSPTypeche
     auto what = maybeAlias.data(gs)->dealiasMethod(gs);
 
     if (what == core::Symbols::sig()) {
-        if (auto item = trySuggestSig(typechecker, clientConfig, what, receiverType, queryLoc, prefix, sortIdx)) {
+        if (auto item =
+                trySuggestSig(typechecker, clientConfig, what, receiverType, queryLoc, resolved, prefix, sortIdx)) {
             return item;
         }
     }
@@ -1117,7 +1097,8 @@ CompletionTask::SearchParams CompletionTask::searchParamsForEmptyAssign(const co
 }
 
 vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypecheckerDelegate &typechecker,
-                                                                      SearchParams &params) {
+                                                                      SearchParams &params,
+                                                                      const ast::ParsedFile &resolved) {
     const auto &gs = typechecker.state();
 
     // ----- locals -----
@@ -1143,12 +1124,14 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
         }
 
         if (kind == ast::UnresolvedIdent::Kind::Local) {
-            vector<core::NameRef> locals = localNamesForMethod(typechecker, params.enclosingMethod, params.queryLoc);
+            vector<core::NameRef> locals =
+                localNamesForMethod(typechecker, params.enclosingMethod, params.queryLoc, resolved);
             similarLocals = allSimilarLocalNames(gs, locals, params.prefix);
         } else {
             auto klass = params.enclosingMethod.data(gs)->owner;
             ENFORCE(klass.exists());
-            similarLocals = allSimilarFieldsForClass(typechecker, klass, params.queryLoc, kind, params.prefix);
+            similarLocals =
+                allSimilarFieldsForClass(typechecker, klass, params.queryLoc, resolved, kind, params.prefix);
         }
     }
 
@@ -1209,7 +1192,7 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
             for (auto &similarMethod : dedupedSimilarMethods) {
                 items.push_back(getCompletionItemForMethod(
                     typechecker, *params.forMethods->dispatchResult, similarMethod.method, similarMethod.receiverType,
-                    params.queryLoc, params.prefix, items.size(), params.forMethods->totalArgs));
+                    params.queryLoc, resolved, params.prefix, items.size(), params.forMethods->totalArgs));
             }
         }
     }
@@ -1243,6 +1226,11 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
     }
     auto queryLoc = maybeQueryLoc.value();
 
+    auto resolved = typechecker.getResolved(queryLoc.file());
+    if (resolved.tree == nullptr) {
+        return response;
+    }
+
     auto result = LSPQuery::byLoc(config, typechecker, uri, pos, LSPMethod::TextDocumentCompletion, false);
 
     if (result.error) {
@@ -1256,7 +1244,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
     if (queryResponses.empty()) {
         auto prevTwoChars = queryLoc.adjust(gs, -2, 0);
         if (prevTwoChars.source(gs) == "##") {
-            auto item = trySuggestYardSnippet(typechecker, config.getClientConfig(), queryLoc);
+            auto item = trySuggestYardSnippet(typechecker, config.getClientConfig(), queryLoc, resolved);
             if (item != nullptr) {
                 items.emplace_back(std::move(item));
                 response->result = make_unique<CompletionList>(false, move(items));
@@ -1311,7 +1299,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
                 core::MethodRef{}, // do not suggest locals
                 scopes,
             };
-            items = this->getCompletionItems(typechecker, params);
+            items = this->getCompletionItems(typechecker, params, resolved);
         } else {
             // isPrivateOk indicates that we are calling (and therefore completing) a method on `self`.  In such a
             // case, it matters whether or not there is a syntactic receiver involved in the call.  In the latter
@@ -1336,7 +1324,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
                 enclosingMethod,
                 core::lsp::ConstantResponse::Scopes{}, // constants don't make sense here
             };
-            items = this->getCompletionItems(typechecker, params);
+            items = this->getCompletionItems(typechecker, params, resolved);
         }
     } else if (auto constantResp = resp->isConstant()) {
         SearchParams params;
@@ -1367,7 +1355,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
                 queryLoc, prefix, methodSearchParams, suggestKeywords, enclosingMethod, std::move(constantResp->scopes),
             };
         }
-        items = this->getCompletionItems(typechecker, params);
+        items = this->getCompletionItems(typechecker, params, resolved);
     } else if (auto identResp = resp->isIdent()) {
         auto varName = identResp->variable._name;
         auto prefix = varName.shortName(gs);
@@ -1394,7 +1382,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
                 identResp->enclosingMethod,
                 core::lsp::ConstantResponse::Scopes{identResp->enclosingMethod.data(gs)->owner},
             };
-            items = this->getCompletionItems(typechecker, params);
+            items = this->getCompletionItems(typechecker, params, resolved);
         } else if (termLocPrefix.source(gs) == prefix && !termLocPrefix.contains(queryLoc)) {
             // This is *probably* (but not definitely necessarily) an IdentResponse for an
             // assignment, with the cursor somewhere on the RHS of the `=` but before having typed
@@ -1404,7 +1392,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
             // This technically parses and comes back as an IdentResponse for the whole `x =`
             // assignment. Let's just toss that away and suggest with an empty prefix.
             auto params = searchParamsForEmptyAssign(gs, queryLoc, identResp->enclosingMethod, {});
-            items = this->getCompletionItems(typechecker, params);
+            items = this->getCompletionItems(typechecker, params, resolved);
         }
     }
 

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -42,8 +42,8 @@ class CompletionTask final : public LSPRequestTask {
     static SearchParams searchParamsForEmptyAssign(const core::GlobalState &gs, core::Loc queryLoc,
                                                    core::MethodRef enclosingMethod,
                                                    core::lsp::ConstantResponse::Scopes scopes);
-    std::vector<std::unique_ptr<CompletionItem>> getCompletionItems(LSPTypecheckerDelegate &typechecker,
-                                                                    SearchParams &params);
+    std::vector<std::unique_ptr<CompletionItem>>
+    getCompletionItems(LSPTypecheckerDelegate &typechecker, SearchParams &params, const ast::ParsedFile &resolved);
 
     std::unique_ptr<CompletionItem> getCompletionItemForUntyped(const core::GlobalState &gs, core::Loc queryLoc,
                                                                 size_t sortIdx, std::string_view message);
@@ -51,8 +51,9 @@ class CompletionTask final : public LSPRequestTask {
     std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
                                                                core::DispatchResult &dispatchResult,
                                                                core::MethodRef what, const core::TypePtr &receiverType,
-                                                               core::Loc queryLoc, std::string_view prefix,
-                                                               size_t sortIdx, uint16_t totalArgs) const;
+                                                               core::Loc queryLoc, const ast::ParsedFile &resolved,
+                                                               std::string_view prefix, size_t sortIdx,
+                                                               uint16_t totalArgs) const;
 
 public:
     CompletionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<CompletionParams> params);

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -14,13 +14,11 @@ namespace {
 
 core::MethodRef firstMethodAfterQuery(LSPTypecheckerDelegate &typechecker, const core::Loc queryLoc) {
     const auto &gs = typechecker.state();
-    auto resolved = typechecker.getResolved({queryLoc.file()});
+    auto resolved = typechecker.getResolved(queryLoc.file());
 
     NextMethodFinder nextMethodFinder(queryLoc);
-    for (auto &t : resolved) {
-        auto ctx = core::Context(gs, core::Symbols::root(), t.file);
-        ast::ConstTreeWalk::apply(ctx, nextMethodFinder, t.tree);
-    }
+    auto ctx = core::Context(gs, core::Symbols::root(), resolved.file);
+    ast::ConstTreeWalk::apply(ctx, nextMethodFinder, resolved.tree);
 
     return nextMethodFinder.result();
 }

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -317,10 +317,8 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
     UnorderedMap<core::SymbolRef, ASTSymbolInfo> defMapping;
     SymbolFileLocSaver saver{fref, defMapping};
     core::Context ctx{gs, core::Symbols::root(), fref};
-    auto resolved = typechecker.getResolved({fref});
-    for (auto &f : resolved) {
-        ast::ShallowWalk::apply(ctx, saver, f.tree);
-    }
+    auto resolved = typechecker.getResolved(fref);
+    ast::ShallowWalk::apply(ctx, saver, resolved.tree);
 
     for (auto ref : candidates) {
         auto data = symbolRef2DocumentSymbol(gs, ref, fref, defMapping, forced);


### PR DESCRIPTION
Rework the completion lsp task to thread a single resolved file through all of its completions, and add a version of `LSPTypechecker::getResolved` that can return a single file.

There were three cases where completion.cc was using `LSPTypechecker::getResolved`:

1. `firstMethodAfterQuery` - This call was already looking up the file associated with the query only, which we now pass in from the entry point method `runRequest`.
2. `localNamesForMethod` - This method was collecting resolved trees for all locs of the method that contains the query. It should be sufficient to pass in the resolved tree for the file the query comes from, as in the unlikely case of multiple implementations in different files, we would want to avoid including their locals in completion results.
3. `allSimilarFieldsForClass` - We were again iterating all files that contained the class definition, but if we're interested in completing field names we must be inside the definition of that class. Using that assumption, we can restrict this to the file related to the query and pass through the resolved tree that we fetch in `runRequest`. This has the added benefit of clarifying when we add untyped ivar/cvar names: only when the file we're running completion in is at a typed level that's less than strict.

### Motivation
Avoiding multiple repeated calls to `getResolved` in completion.cc. There is no caching for the resolved result so each call for the same file will copy the indexed tree and run it through the incremental resolver again.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a, this should only affect performance.

I did run this over Stripe's codebase and experimented with the paths that I've modified. I didn't notice any difference in behavior.
