### PR TITLE
disable counting types altogether

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -30,6 +30,8 @@ namespace {
 // large amount of types; see test/testdata/infer/is_subtype_timeout.rb for an example.
 // Recording counters for these types can take up a substantial amount of time for such
 // tests, and so we disable counting them altogether even in debug builds.
+//
+// If you want to compute a histogram of types, flip this to true and rebuild.
 constexpr bool countTypeAllocations = false;
 void recordAllocatedType(ConstExprStr kind) {
     if constexpr (countTypeAllocations) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -25,6 +25,19 @@ namespace sorbet::core {
 
 using namespace std;
 
+namespace {
+// We create types pretty freely during inference, and even small programs can create a
+// large amount of types; see test/testdata/infer/is_subtype_timeout.rb for an example.
+// Recording counters for these types can take up a substantial amount of time for such
+// tests, and so we disable counting them altogether even in debug builds.
+constexpr bool countTypeAllocations = false;
+void recordAllocatedType(ConstExprStr kind) {
+    if constexpr (countTypeAllocations) {
+        categoryCounterInc("types.allocated", kind);
+    }
+}
+} // namespace
+
 TypePtr Types::top() {
     return make_type<ClassType>(Symbols::top());
 }
@@ -359,7 +372,7 @@ std::optional<int> Types::getProcArity(const AppliedType &type) {
 }
 
 ClassType::ClassType(ClassOrModuleRef symbol) : symbol(symbol) {
-    categoryCounterInc("types.allocated", "classtype");
+    recordAllocatedType("classtype");
     ENFORCE(symbol.exists());
 }
 
@@ -373,9 +386,9 @@ void sanityCheckProxyType(const GlobalState &gs, TypePtr underlying) {
 NamedLiteralType::NamedLiteralType(ClassOrModuleRef klass, NameRef val)
     : name(val), literalKind(klass == Symbols::String() ? LiteralTypeKind::String : LiteralTypeKind::Symbol) {
     if (klass == Symbols::String()) {
-        categoryCounterInc("types.allocated", "literaltype.string");
+        recordAllocatedType("literaltype.string");
     } else {
-        categoryCounterInc("types.allocated", "literaltype.symbol");
+        recordAllocatedType("literaltype.symbol");
     }
     ENFORCE(klass == Symbols::String() || klass == Symbols::Symbol());
 }
@@ -400,7 +413,7 @@ TypePtr NamedLiteralType::underlying(const GlobalState &gs) const {
 }
 
 IntegerLiteralType::IntegerLiteralType(int64_t val) : value(val) {
-    categoryCounterInc("types.allocated", "literalintegertype");
+    recordAllocatedType("literalintegertype");
 }
 
 TypePtr IntegerLiteralType::underlying(const GlobalState &gs) const {
@@ -408,7 +421,7 @@ TypePtr IntegerLiteralType::underlying(const GlobalState &gs) const {
 }
 
 FloatLiteralType::FloatLiteralType(double val) : value(val) {
-    categoryCounterInc("types.allocated", "floatliteraltype");
+    recordAllocatedType("floatliteraltype");
 }
 
 TypePtr FloatLiteralType::underlying(const GlobalState &gs) const {
@@ -416,12 +429,12 @@ TypePtr FloatLiteralType::underlying(const GlobalState &gs) const {
 }
 
 TupleType::TupleType(vector<TypePtr> elements) : elems(move(elements)) {
-    categoryCounterInc("types.allocated", "tupletype");
+    recordAllocatedType("tupletype");
     histogramInc("tupletype.elems", this->elems.size());
 }
 
 AndType::AndType(const TypePtr &left, const TypePtr &right) : left(move(left)), right(move(right)) {
-    categoryCounterInc("types.allocated", "andtype");
+    recordAllocatedType("andtype");
 }
 
 void NamedLiteralType::_sanityCheck(const GlobalState &gs) const {
@@ -456,7 +469,7 @@ bool FloatLiteralType::equals(const FloatLiteralType &rhs) const {
 }
 
 OrType::OrType(const TypePtr &left, const TypePtr &right) : left(move(left)), right(move(right)) {
-    categoryCounterInc("types.allocated", "ortype");
+    recordAllocatedType("ortype");
 }
 
 void TupleType::_sanityCheck(const GlobalState &gs) const {
@@ -472,7 +485,7 @@ ShapeType::ShapeType(vector<TypePtr> keys, vector<TypePtr> values) : keys(move(k
                     : this->keys) {
         ENFORCE(isa_type<NamedLiteralType>(k) || isa_type<IntegerLiteralType>(k) || isa_type<FloatLiteralType>(k));
     };);
-    categoryCounterInc("types.allocated", "shapetype");
+    recordAllocatedType("shapetype");
     histogramInc("shapetype.keys", this->keys.size());
 }
 
@@ -558,7 +571,7 @@ void ShapeType::_sanityCheck(const GlobalState &gs) const {
 }
 
 AliasType::AliasType(SymbolRef other) : symbol(other) {
-    categoryCounterInc("types.allocated", "aliastype");
+    recordAllocatedType("aliastype");
 }
 
 void AndType::_sanityCheck(const GlobalState &gs) const {
@@ -708,7 +721,7 @@ bool TypeVar::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const {
 }
 
 MetaType::MetaType(const TypePtr &wrapped) : wrapped(move(wrapped)) {
-    categoryCounterInc("types.allocated", "metattype");
+    recordAllocatedType("metattype");
 }
 
 bool MetaType::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const {
@@ -720,7 +733,7 @@ TypePtr MetaType::underlying(const GlobalState &gs) const {
 }
 
 TypeVar::TypeVar(TypeArgumentRef sym) : sym(sym) {
-    categoryCounterInc("types.allocated", "typevar");
+    recordAllocatedType("typevar");
 }
 
 void TypeVar::_sanityCheck(const GlobalState &gs) const {
@@ -747,11 +760,11 @@ bool AppliedType::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) con
 
 LambdaParam::LambdaParam(const TypeMemberRef definition, TypePtr lowerBound, TypePtr upperBound)
     : definition(definition), lowerBound(lowerBound), upperBound(upperBound) {
-    categoryCounterInc("types.allocated", "lambdatypeparam");
+    recordAllocatedType("lambdatypeparam");
 }
 
 SelfTypeParam::SelfTypeParam(const SymbolRef definition) : definition(definition) {
-    categoryCounterInc("types.allocated", "selftypeparam");
+    recordAllocatedType("selftypeparam");
 }
 
 bool LambdaParam::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const {
@@ -803,10 +816,10 @@ TypePtr TupleType::elementType(const GlobalState &gs) const {
 }
 
 SelfType::SelfType() {
-    categoryCounterInc("types.allocated", "selftype");
+    recordAllocatedType("selftype");
 };
 AppliedType::AppliedType(ClassOrModuleRef klass, vector<TypePtr> targs) : klass(klass), targs(std::move(targs)) {
-    categoryCounterInc("types.allocated", "appliedtype");
+    recordAllocatedType("appliedtype");
     histogramInc("appliedtype.targs", this->targs.size());
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

As the comment in `types.cc` says.  I would like `is_subtype_timeout` to stop spuriously timing out on my Stripe devbox; I believe we have also seen timeouts from this test in CI, and it would be nice for those timeouts to go away as well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
