### PR TITLE
include a little more information for fatal `fullUnresolvedPath` errors

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -312,7 +312,9 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
         while (true) {
             if (nested->resolutionScopes == nullptr || nested->resolutionScopes->empty()) [[unlikely]] {
                 ENFORCE(false);
-                fatalLogger->error(R"(msg="Bad fullUnresolvedPath" loc="{}")", ctx.locAt(this->loc).showRaw(ctx));
+                bool hasScopes = nested->resolutionScopes != nullptr;
+                fatalLogger->error(R"(msg="Bad fullUnresolvedPath" loc="{}" hasScopes={})",
+                                   ctx.locAt(this->loc).showRaw(ctx), hasScopes);
                 fatalLogger->error("source=\"{}\"", absl::CEscape(ctx.file.data(ctx).source()));
             }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For safely rolling #8536 out, we need a little more information about what's happening with intermittent crashes that we see.  Ideally, all the crashes will now include `hasScopes=1` and #8536 will be fine.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
