### PR TITLE
delete old version handling for `-p autogen`

### DIFF
--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -88,11 +88,7 @@ string ParsedFile::toString(const core::GlobalState &gs, int version) const {
                 type = "alias"sv;
                 break;
             case Definition::Type::TypeAlias:
-                if (version <= 2) {
-                    type = "casgn"sv;
-                } else {
-                    type = "typealias"sv;
-                }
+                type = "typealias"sv;
                 break;
         }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Noticed this while reading through some code.  We can never have autogen version <= 2 nowadays, so delete some dead code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
