### PR TITLE
Handle block arg destructuring with trailing comma

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -349,6 +349,7 @@ NameDef names[] = {
     {"blockBreakAssign", "<block-break-assign>"},
     {"arg", "<arg>"},
     {"kwargs", "<kwargs>"},
+    {"restargs", "<restargs>"},
     {"blkArg", "<blk>"},
     {"blockGiven_p", "block_given?"},
     {"anonymousBlock", "<anonymous-block>"},

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1498,6 +1498,12 @@ public:
         return make_unique<Restarg>(loc, nm, nameLoc);
     }
 
+    unique_ptr<Node> implicit_restarg(const token *trailingComma) {
+        auto loc = tokLoc(trailingComma).copyEndWithZeroLength();
+        auto name = core::Names::restargs();
+        return make_unique<Restarg>(loc, name, loc);
+    }
+
     unique_ptr<Node> self_(const token *tok) {
         return make_unique<Self>(tokLoc(tok));
     }
@@ -2593,6 +2599,11 @@ ForeignPtr restarg(SelfPtr builder, const token *star, const token *name) {
     return build->toForeign(build->restarg(star, name));
 }
 
+ForeignPtr implicit_restarg(SelfPtr builder, const token *trailingComma) {
+    auto build = cast_builder(builder);
+    return build->toForeign(build->implicit_restarg(trailingComma));
+}
+
 ForeignPtr self_(SelfPtr builder, const token *tok) {
     auto build = cast_builder(builder);
     return build->toForeign(build->self_(tok));
@@ -2838,6 +2849,7 @@ struct ruby_parser::builder Builder::interface = {
     regexp_options,
     rescue_body,
     restarg,
+    implicit_restarg,
     self_,
     shadowarg,
     splat,

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -2623,6 +2623,11 @@ opt_block_args_tail:
                       $$ = args;
                     }
                 | f_arg tCOMMA
+                    {
+                      auto &args = $1;
+                      args->emplace_back(driver.build.implicit_restarg(self, $2));
+                      $$ = args;
+                    }
                 | f_arg tCOMMA                       f_rest_arg tCOMMA f_arg opt_block_args_tail
                     {
                       auto &args = $1;

--- a/parser/parser/include/ruby_parser/builder.hh
+++ b/parser/parser/include/ruby_parser/builder.hh
@@ -170,6 +170,7 @@ struct builder {
     ForeignPtr (*rescue_body)(SelfPtr builder, const token *rescue, ForeignPtr excList, const token *assoc,
                               ForeignPtr excVar, const token *then, ForeignPtr body);
     ForeignPtr (*restarg)(SelfPtr builder, const token *star, const token *name);
+    ForeignPtr (*implicit_restarg)(SelfPtr builder, const token *trailingComma);
     ForeignPtr (*self_)(SelfPtr builder, const token *tok);
     ForeignPtr (*shadowarg)(SelfPtr builder, const token *name);
     ForeignPtr (*splat)(SelfPtr builder, const token *star, ForeignPtr arg);

--- a/test/testdata/desugar/block-implicit-rest-arg.rb.desugar-tree.exp
+++ b/test/testdata/desugar/block-implicit-rest-arg.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  <self>.call() do |m, a|
+  <self>.call() do |m, a, *<restargs>|
     <self>.stuff()
   end
 end

--- a/test/testdata/parser/implicit_block_rest_arg.rb
+++ b/test/testdata/parser/implicit_block_rest_arg.rb
@@ -7,7 +7,7 @@ def example(opts)
     T.reveal_type(k) # error: `[String, Integer] (2-tuple)`
   end
   opts.each do |k,|
-    T.reveal_type(k) # error: `[String, Integer] (2-tuple)`
+    T.reveal_type(k) # error: `String`
   end
   opts.each do |k, _|
     T.reveal_type(k) # error: `String`

--- a/test/testdata/parser/implicit_block_rest_arg.rb
+++ b/test/testdata/parser/implicit_block_rest_arg.rb
@@ -1,0 +1,15 @@
+# typed: true
+extend T::Sig
+
+sig {params(opts: T::Hash[String, Integer]).void}
+def example(opts)
+  opts.each do |k|
+    T.reveal_type(k) # error: `[String, Integer] (2-tuple)`
+  end
+  opts.each do |k,|
+    T.reveal_type(k) # error: `[String, Integer] (2-tuple)`
+  end
+  opts.each do |k, _|
+    T.reveal_type(k) # error: `String`
+  end
+end

--- a/test/testdata/parser/implicit_block_rest_arg.rb.desugar-tree.exp
+++ b/test/testdata/parser/implicit_block_rest_arg.rb.desugar-tree.exp
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       opts.each() do |k|
         <emptyTree>::<C T>.reveal_type(k)
       end
-      opts.each() do |k|
+      opts.each() do |k, *<restargs>|
         <emptyTree>::<C T>.reveal_type(k)
       end
       opts.each() do |k, _|

--- a/test/testdata/parser/implicit_block_rest_arg.rb.desugar-tree.exp
+++ b/test/testdata/parser/implicit_block_rest_arg.rb.desugar-tree.exp
@@ -1,0 +1,21 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+  <self>.sig() do ||
+    <self>.params(:opts, <emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C String>, <emptyTree>::<C Integer>)).void()
+  end
+
+  def example<<todo method>>(opts, &<blk>)
+    begin
+      opts.each() do |k|
+        <emptyTree>::<C T>.reveal_type(k)
+      end
+      opts.each() do |k|
+        <emptyTree>::<C T>.reveal_type(k)
+      end
+      opts.each() do |k, _|
+        <emptyTree>::<C T>.reveal_type(k)
+      end
+    end
+  end
+end

--- a/test/whitequark/test_block_arg_combinations_7.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_7.parse-tree-whitequark.exp
@@ -1,4 +1,5 @@
 s(:block,
   s(:send, nil, :f),
   s(:args,
-    s(:arg, :a)), nil)
+    s(:arg, :a),
+    s(:restarg, :<restargs>)), nil)

--- a/test/whitequark/test_multiple_args_with_trailing_comma_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_multiple_args_with_trailing_comma_0.parse-tree-whitequark.exp
@@ -2,4 +2,5 @@ s(:block,
   s(:send, nil, :f),
   s(:args,
     s(:arg, :a),
-    s(:arg, :b)), nil)
+    s(:arg, :b),
+    s(:restarg, :<restargs>)), nil)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The Ruby VM treats a trailing comma in a block spec different from it not being
there.

Fixes #6407


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The commit show the behavior before and after the change.