### PR TITLE
Extend "module singleton mismatch" error to AppliedType

### DIFF
--- a/test/cli/detailed-errors/class_of.rb
+++ b/test/cli/detailed-errors/class_of.rb
@@ -8,3 +8,14 @@ def takes_t_class_ifoo(klass)
 end
 
 takes_t_class_ifoo(IFoo)
+
+module IFooWithTT
+  extend T::Generic
+  X = type_template(:out) {{fixed: Integer}}
+end;
+
+sig { params(klass: T::Class[IFooWithTT]).void }
+def takes_t_class_ifoo_with_tm(klass)
+end
+
+takes_t_class_ifoo_with_tm(IFooWithTT)

--- a/test/cli/detailed-errors/test.out
+++ b/test/cli/detailed-errors/test.out
@@ -146,7 +146,7 @@ class_of.rb:21: Expected `T::Class[IFooWithTT]` but found `T.class_of(IFooWithTT
     21 |takes_t_class_ifoo_with_tm(IFooWithTT)
                                    ^^^^^^^^^^
   Detailed explanation:
-    `T.class_of(IFooWithTT)` does not derive from `Class`
+    `T.class_of(IFooWithTT)` represents a module singleton class type, which is a `Module`, not a `Class`. See the `T.class_of` docs.
 
 shapes.rb:10: Expected `{a: Integer, b: String}` but found `{}` for argument `x` https://srb.help/7002
     10 |takes_shape({})

--- a/test/cli/detailed-errors/test.out
+++ b/test/cli/detailed-errors/test.out
@@ -120,6 +120,34 @@ intersection.rb:52: Argument does not have asserted type `T.all(M1, M2, M3, M4)`
       `C134` is not a subtype of `T.all(M1, M2)` (the left side of the `T.all`)
         `C134` is not a subtype of `M2` (the right side of the `T.all`)
 
+class_of.rb:10: Expected `T::Class[IFoo]` but found `T.class_of(IFoo)` for argument `klass` https://srb.help/7002
+    10 |takes_t_class_ifoo(IFoo)
+                           ^^^^
+  Expected `T::Class[IFoo]` for argument `klass` of method `Object#takes_t_class_ifoo`:
+    class_of.rb:6:
+     6 |sig { params(klass: T::Class[IFoo]).void }
+                     ^^^^^
+  Got `T.class_of(IFoo)` originating from:
+    class_of.rb:10:
+    10 |takes_t_class_ifoo(IFoo)
+                           ^^^^
+  Detailed explanation:
+    `T.class_of(IFoo)` represents a module singleton class type, which is a `Module`, not a `Class`. See the `T.class_of` docs.
+
+class_of.rb:21: Expected `T::Class[IFooWithTT]` but found `T.class_of(IFooWithTT)` for argument `klass` https://srb.help/7002
+    21 |takes_t_class_ifoo_with_tm(IFooWithTT)
+                                   ^^^^^^^^^^
+  Expected `T::Class[IFooWithTT]` for argument `klass` of method `Object#takes_t_class_ifoo_with_tm`:
+    class_of.rb:17:
+    17 |sig { params(klass: T::Class[IFooWithTT]).void }
+                     ^^^^^
+  Got `T.class_of(IFooWithTT)` originating from:
+    class_of.rb:21:
+    21 |takes_t_class_ifoo_with_tm(IFooWithTT)
+                                   ^^^^^^^^^^
+  Detailed explanation:
+    `T.class_of(IFooWithTT)` does not derive from `Class`
+
 shapes.rb:10: Expected `{a: Integer, b: String}` but found `{}` for argument `x` https://srb.help/7002
     10 |takes_shape({})
                     ^^
@@ -290,18 +318,4 @@ tuples.rb:18: Expected `[Integer, String]` but found `[String("")]` for argument
     tuples.rb:18:
     18 |takes_tuple([''])
                     ^^^^
-
-class_of.rb:10: Expected `T::Class[IFoo]` but found `T.class_of(IFoo)` for argument `klass` https://srb.help/7002
-    10 |takes_t_class_ifoo(IFoo)
-                           ^^^^
-  Expected `T::Class[IFoo]` for argument `klass` of method `Object#takes_t_class_ifoo`:
-    class_of.rb:6:
-     6 |sig { params(klass: T::Class[IFoo]).void }
-                     ^^^^^
-  Got `T.class_of(IFoo)` originating from:
-    class_of.rb:10:
-    10 |takes_t_class_ifoo(IFoo)
-                           ^^^^
-  Detailed explanation:
-    `T.class_of(IFoo)` represents a module singleton class type, which is a `Module`, not a `Class`. See the `T.class_of` docs.
-Errors: 25
+Errors: 26


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A user was confused, and the detailed error was not helpful enough because their
module had a type template.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See the commits for the before/after.