### PR TITLE
rewrite `substClassName` as an explicit loop

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -12,17 +12,20 @@ private:
     T &subst;
 
     void substClassName(core::MutableContext ctx, ExpressionPtr &node) {
-        auto constLit = cast_tree<UnresolvedConstantLit>(node);
-        if (constLit == nullptr) { // uncommon case. something is strange
-            if (isa_tree<EmptyTree>(node)) {
+        ExpressionPtr *cur = &node;
+        while (true) {
+            auto constLit = cast_tree<UnresolvedConstantLit>(*cur);
+            if (constLit == nullptr) { // uncommon case. something is strange
+                if (isa_tree<EmptyTree>(*cur)) {
+                    return;
+                }
+                TreeWalk::apply(ctx, *this, *cur);
                 return;
             }
-            TreeWalk::apply(ctx, *this, node);
-            return;
-        }
 
-        substClassName(ctx, constLit->scope);
-        constLit->cnst = subst.substituteSymbolName(constLit->cnst);
+            constLit->cnst = subst.substituteSymbolName(constLit->cnst);
+            cur = &constLit->scope;
+        }
     }
 
     void substArg(core::MutableContext ctx, ExpressionPtr &argp) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I tried making this tail-recursive, but I think some of the intermediate calls made the compiler not do the right thing (at least on opt builds).  Writing it out as a loop makes things a little nicer, I think.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
