### PR TITLE
Move indexing logic from LSPTypechecker::initialize into runSlowPath

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -73,71 +73,31 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
     LSPFileUpdates updates;
 
     // Initialize the global state for the indexer
-    {
-        initialGS->trackUntyped = currentConfig.getClientConfig().enableHighlightUntyped;
-        // Temporarily replace error queue, as it asserts that the same thread that created it uses it and we're
-        // going to use it on typechecker thread for this one operation.
-        auto savedErrorQueue = initialGS->errorQueue;
-        initialGS->errorQueue = make_shared<core::ErrorQueue>(savedErrorQueue->logger, savedErrorQueue->tracer,
-                                                              make_shared<core::NullFlusher>());
-
-        vector<ast::ParsedFile> indexed;
-        Timer timeit(config->logger, "initial_index");
-        ShowOperation op(*config, ShowOperation::Kind::Indexing);
-        vector<core::FileRef> inputFiles;
-        unique_ptr<const OwnedKeyValueStore> ownedKvstore = cache::ownIfUnchanged(*initialGS, move(kvstore));
-        {
-            Timer timeit(config->logger, "reIndexFromFileSystem");
-            inputFiles = pipeline::reserveFiles(initialGS, config->opts.inputFileNames);
-            indexed.resize(initialGS->filesUsed());
-
-            auto asts = hashing::Hashing::indexAndComputeFileHashes(*initialGS, config->opts, *config->logger,
-                                                                    absl::Span<core::FileRef>(inputFiles), workers,
-                                                                    ownedKvstore);
-            // asts are in fref order, but we (currently) don't index and compute file hashes for payload files, so
-            // vector index != FileRef ID. Fix that by slotting them into `indexed`.
-            for (auto &ast : asts) {
-                int id = ast.file.id();
-                ENFORCE_NO_TIMER(id < indexed.size());
-                indexed[id] = move(ast);
-            }
-        }
-
-        cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(ownedKvstore)), config->opts, *initialGS,
-                                             workers, indexed);
-
-        ENFORCE_NO_TIMER(indexed.size() == initialGS->filesUsed());
-
-        updates.epoch = 0;
-        updates.typecheckingPath = TypecheckingPath::Slow;
-        updates.updatedFileIndexes = move(indexed);
-        updates.updatedGS = initialGS->deepCopy();
-
-        // Restore error queue, as initialGS will be used on the LSPLoop thread from now on.
-        initialGS->errorQueue = move(savedErrorQueue);
-    }
+    initialGS->trackUntyped = currentConfig.getClientConfig().enableHighlightUntyped;
 
     // We should always initialize with epoch 0.
-    this->initialized = true;
-    this->indexed = move(updates.updatedFileIndexes);
+    updates.epoch = 0;
+    updates.typecheckingPath = TypecheckingPath::Slow;
+    updates.updatedGS = std::move(initialGS);
+
     // Initialization typecheck is not cancelable.
     // TODO(jvilk): Make it preemptible.
-    auto committed = false;
+    SlowPathResult result;
     {
         const bool isIncremental = false;
         ErrorEpoch epoch(*errorReporter, updates.epoch, isIncremental, {});
         auto errorFlusher = make_shared<ErrorFlusherLSP>(updates.epoch, errorReporter);
-        committed = runSlowPath(move(updates), workers, errorFlusher, SlowPathMode::Init);
-        epoch.committed = committed;
+        result = runSlowPath(std::move(updates), std::move(kvstore), workers, errorFlusher, SlowPathMode::Init);
+        epoch.committed = result.committed;
     }
-    ENFORCE(committed);
+    ENFORCE(result.committed);
 
     // Unblock the indexer now that its state is fully initialized.
     {
         absl::MutexLock lck{queue.getMutex()};
 
         // ensure that the next task we process initializes the indexer
-        auto initTask = std::make_unique<IndexerInitializationTask>(*config, std::move(initialGS));
+        auto initTask = std::make_unique<IndexerInitializationTask>(*config, std::move(result.indexedState));
         queue.tasks().push_front(std::move(initTask));
     }
 
@@ -191,7 +151,9 @@ bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
             commitFileUpdates(updates, /* cancelable */ false);
             prodCategoryCounterInc("lsp.updates", "fastpath");
         } else {
-            committed = runSlowPath(move(updates), workers, errorFlusher, SlowPathMode::Cancelable);
+            auto result = runSlowPath(move(updates), nullptr, workers, errorFlusher, SlowPathMode::Cancelable);
+            committed = result.committed;
+            ENFORCE(result.indexedState == nullptr);
         }
         epoch.committed = committed;
     }
@@ -406,8 +368,12 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
     return epochManager.wasTypecheckingCanceled();
 }
 
-bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
-                                 shared_ptr<core::ErrorFlusher> errorFlusher, LSPTypechecker::SlowPathMode mode) {
+LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates updates,
+                                                           std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
+                                                           shared_ptr<core::ErrorFlusher> errorFlusher,
+                                                           LSPTypechecker::SlowPathMode mode) {
+    SlowPathResult result;
+
     ENFORCE(this_thread::get_id() == typecheckerThreadId,
             "runSlowPath can only be called from the typechecker thread.");
 
@@ -425,13 +391,60 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
 
     auto finalGS = move(updates.updatedGS.value());
     const uint32_t epoch = updates.epoch;
-    // Replace error queue with one that is owned by this thread.
-    finalGS->errorQueue =
-        make_shared<core::ErrorQueue>(finalGS->errorQueue->logger, finalGS->errorQueue->tracer, errorFlusher);
     auto &epochManager = *finalGS->epochManager;
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
     // cancelation feature is enabled.
-    const bool committed = epochManager.tryCommitEpoch(*finalGS, epoch, cancelable, preemptManager, [&]() -> void {
+    result.committed = epochManager.tryCommitEpoch(*finalGS, epoch, cancelable, preemptManager, [&]() -> void {
+        // Replace error queue with one that is owned by this thread.
+        auto savedErrorQueue = std::exchange(
+            finalGS->errorQueue,
+            make_shared<core::ErrorQueue>(finalGS->errorQueue->logger, finalGS->errorQueue->tracer, errorFlusher));
+
+        // We're initializing an empty global state from the kvstore, if it's valid.
+        if (mode == SlowPathMode::Init) {
+            ENFORCE(!this->initialized);
+            Timer timeit(config->logger, "initial_index");
+
+            ShowOperation op(*config, ShowOperation::Kind::Indexing);
+
+            std::unique_ptr<const OwnedKeyValueStore> ownedKvstore =
+                cache::ownIfUnchanged(*finalGS, std::move(kvstore));
+
+            {
+                Timer timeit(config->logger, "reIndexFromFileSystem");
+
+                auto inputFiles = pipeline::reserveFiles(finalGS, config->opts.inputFileNames);
+                this->indexed.clear();
+                this->indexed.resize(finalGS->filesUsed());
+
+                auto asts = hashing::Hashing::indexAndComputeFileHashes(*finalGS, config->opts, *config->logger,
+                                                                        absl::Span<core::FileRef>(inputFiles), workers,
+                                                                        ownedKvstore);
+                // asts are in fref order, but we (currently) don't index and compute file hashes for payload files, so
+                // vector index != FileRef ID. Fix that by slotting them into `indexed`.
+                for (auto &ast : asts) {
+                    int id = ast.file.id();
+                    ENFORCE_NO_TIMER(id < this->indexed.size());
+                    this->indexed[id] = std::move(ast);
+                }
+            }
+
+            cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(std::move(ownedKvstore)), config->opts,
+                                                 *finalGS, workers, indexed);
+
+            ENFORCE_NO_TIMER(indexed.size() == finalGS->filesUsed());
+
+            // At this point finalGS has a name table that's initialized enough for the indexer thread, so we make a
+            // copy to pass back over.
+            result.indexedState = finalGS->deepCopy();
+            result.indexedState->errorQueue = std::move(savedErrorQueue);
+
+            this->initialized = true;
+        } else {
+            // If we're not initializing, there's no need to hold on to the old error queue.
+            savedErrorQueue = nullptr;
+        }
+
         UnorderedSet<int> updatedFiles;
         vector<ast::ParsedFile> indexedCopies;
 
@@ -559,7 +572,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
     // Note: `gs` now holds the value of `finalGS`.
     gs->lspQuery = core::lsp::Query::noQuery();
 
-    if (committed) {
+    if (result.committed) {
         prodCategoryCounterInc("lsp.updates", "slowpath");
         timeit.setTag("canceled", "false");
         // No need to keep around cancelation state!
@@ -573,7 +586,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers,
         ENFORCE(cancelable);
         logger->debug("[Typechecker] Typecheck run for epoch {} was canceled.", updates.epoch);
     }
-    return committed;
+    return result;
 }
 
 void LSPTypechecker::commitFileUpdates(LSPFileUpdates &updates, bool couldBeCanceled) {

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -99,7 +99,7 @@ class LSPTypechecker final {
      *   the result will be committed, and the indexer needs a copy of the GlobalState to be taken after indexing, we
      *   return that copy as the result of the slow path.
      * - Cancelable indicates that the slow path may be canceled before it completes. As this mode does not require a
-     *   copy of the typechecker's GlobalState to be returned, and the slow path operation may be canceleld, we return a
+     *   copy of the typechecker's GlobalState to be returned, and the slow path operation may be canceled, we return a
      *   boolean indicating whether or not the result of the slow path was committed.
      */
     using SlowPathResult = std::variant<std::unique_ptr<core::GlobalState>, bool>;


### PR DESCRIPTION
This is a refactoring to move the logic for indexing out of `LSPTypechecker::initialize` and into `LSPTypechecker::runSlowPath`. This should have no impact to the current behavior, but does start to pave the way for reindexing in the slow path instead of holding on to a local cache of trees.

### Motivation
Working towards dropping the in-memory cache of indexed trees.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a Refactoring only.
