### PR TITLE
When converting from `test_import` to `import`, insert in correct location

### DIFF
--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -26,20 +26,6 @@ bool hasSeen(const UnorderedSet<Loc> &seen, Loc loc) {
     return false;
 }
 
-const string AutocorrectSuggestion::applySingleEditForTesting(const std::string_view source) const {
-    UnorderedSet<Loc> seen;
-
-    ENFORCE(edits.size() <= 1, "applySingleEditForTesting needs either 0 or 1 edits");
-
-    string replaced{source};
-    if (edits.size() == 1) {
-        auto start = edits.front().loc.beginPos();
-        auto end = edits.front().loc.endPos();
-        replaced = absl::StrCat(replaced.substr(0, start), edits.front().replacement, replaced.substr(end, -1));
-    }
-    return replaced;
-}
-
 UnorderedMap<FileRef, string> AutocorrectSuggestion::apply(const GlobalState &gs, FileSystem &fs,
                                                            const vector<AutocorrectSuggestion> &autocorrects) {
     UnorderedMap<FileRef, string> sources;

--- a/core/AutocorrectSuggestion.h
+++ b/core/AutocorrectSuggestion.h
@@ -21,10 +21,6 @@ struct AutocorrectSuggestion {
     AutocorrectSuggestion(std::string title, std::vector<Edit> edits, bool isDidYouMean = false)
         : title(title), edits(edits), isDidYouMean(isDidYouMean) {}
 
-    // Apply a single `AutocorrectSuggestion` that contains either zero or one edits to a string, yielding the
-    // autocorrected source.  This is useful for testing that an autocorrect does what we want.
-    const std::string applySingleEditForTesting(const std::string_view source) const;
-
     // Reads all the files to be edited, and then accumulates all the edits that need to be applied
     // to those files into a resulting string with all edits applied. Does not write those back out
     // to disk.

--- a/test/BUILD
+++ b/test/BUILD
@@ -162,6 +162,7 @@ cc_test(
         "//local_vars",
         "//packager",
         "//parser",
+        "//test/helpers",
         "@doctest//doctest",
         "@doctest//doctest:main",
     ],

--- a/test/cli/package-test-simple/test.out
+++ b/test/cli/package-test-simple/test.out
@@ -2,9 +2,12 @@ main_lib/lib.rb:8: Used `test_import` constant `Project::TestOnly::SomeHelper` i
      8 |  Project::TestOnly::SomeHelper.new
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    main_lib/__package.rb:7: Replace with `import Project::TestOnly`
+    main_lib/__package.rb:6: Insert `import Project::TestOnly`
+     6 |  import Project::Util
+                              ^
+    main_lib/__package.rb:7: Delete
      7 |  test_import Project::TestOnly
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     test_only/__package.rb:5: Defined here
      5 |class Project::TestOnly < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -789,6 +789,8 @@ TEST_CASE("Convert test_import to import") {
                           // This extra line is not great, but if we change the autocorrect to delete the '\n'
                           // after the test_import, the autocorrect show the next line in the preview, which would
                           // make the user think that entire next line will be deleted, which is incorrect.
+                          // TODO(neil): look into ways to modify the preview so we don't have this problem and we can
+                          // delete the '\n' too
                           "\n"
                           "end";
         ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Previously, when we suggested converting `test_import` to `import`, we would just leave it in the same location and give an edit that replaces `test_import` with `import`. This PR changes that to insert the `import` in the right location, and delete the `test_import`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Keep import list in `__package.rb` files sorted so that we don't need to manually sort it later.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
