### PR TITLE
Show the `T.attached_class` specificity note when the attached class is inside something else

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1371,6 +1371,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
 
     if (is_proxy_type(t1)) {
         if (is_proxy_type(t2)) {
+            // both are proxy
             bool result;
             // TODO: simply compare as memory regions
             typecase(
@@ -1486,13 +1487,13 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                                                          m2->wrapped, errorDetailsCollector);
                 });
             return result;
-            // both are proxy
         } else {
             // only 1st is proxy
             TypePtr und = t1.underlying(gs);
             return isSubTypeUnderConstraintSingle(gs, constr, mode, und, t2, errorDetailsCollector);
         }
     } else if (is_proxy_type(t2)) {
+        // only 2nd is proxy
         // non-proxies are never subtypes of proxies.
         return false;
     } else {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1065,6 +1065,33 @@ void doesNotDeriveFrom(const GlobalState &gs, ErrorSection::Collector &errorDeta
     errorDetailsCollector.addErrorDetails(move(subCollector));
 }
 
+void checkForAttachedClassHint(const GlobalState &gs, ErrorSection::Collector &errorDetailsCollector,
+                               const ClassType left, const SelfTypeParam right) {
+    if (right.definition.name(gs) != Names::Constants::AttachedClass()) {
+        return;
+    }
+
+    auto attachedClass = left.symbol.data(gs)->lookupSingletonClass(gs);
+    if (!attachedClass.exists()) {
+        return;
+    }
+
+    if (attachedClass != right.definition.owner(gs).asClassOrModuleRef()) {
+        return;
+    }
+
+    auto gotStr = left.show(gs);
+    auto expectedStr = right.show(gs);
+    auto subCollector = errorDetailsCollector.newCollector();
+    auto message = ErrorColors::format(
+        "`{}` is incompatible with `{}` because when this method is called on a subclass `{}` will represent a more "
+        "specific subclass, meaning `{}` will not be specific enough. See https://sorbet.org/docs/attached-class for "
+        "more.",
+        gotStr, expectedStr, expectedStr, gotStr);
+    subCollector.message = message;
+    errorDetailsCollector.addErrorDetails(move(subCollector));
+}
+
 void compareToUntyped(const GlobalState &gs, TypeConstraint &constr, const TypePtr &ty, const TypePtr &blame) {
     ENFORCE(blame.isUntyped());
     if (is_proxy_type(ty)) {
@@ -1178,8 +1205,15 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             if (!isSelfTypeT1) {
                 auto self2 = cast_type_nonnull<SelfTypeParam>(t2);
                 if (auto *lambdaParam = cast_type<LambdaParam>(self2.definition.resultType(gs))) {
-                    return Types::isSubTypeUnderConstraint(gs, constr, t1, lambdaParam->lowerBound, mode,
-                                                           errorDetailsCollector);
+                    auto result = Types::isSubTypeUnderConstraint(gs, constr, t1, lambdaParam->lowerBound, mode,
+                                                                  errorDetailsCollector);
+                    if constexpr (shouldAddErrorDetails) {
+                        if (!result && isa_type<ClassType>(t1)) {
+                            checkForAttachedClassHint(gs, errorDetailsCollector, cast_type_nonnull<ClassType>(t1),
+                                                      self2);
+                        }
+                    }
+                    return result;
                 } else {
                     return false;
                 }

--- a/test/cli/detailed-errors/attached_class.rb
+++ b/test/cli/detailed-errors/attached_class.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+class AttachedClassA
+  extend T::Sig
+
+  sig {returns(T.attached_class)}
+  def self.make
+    AttachedClassA.new
+  end
+end
+
+class AttachedClassB
+  extend T::Sig
+
+  sig {returns(T::Array[T.attached_class])}
+  def self.make
+    [AttachedClassB.new]
+  end
+end
+

--- a/test/cli/detailed-errors/test.out
+++ b/test/cli/detailed-errors/test.out
@@ -330,7 +330,7 @@ attached_class.rb:8: Expected `T.attached_class (of AttachedClassA)` but found `
     attached_class.rb:8:
      8 |    AttachedClassA.new
             ^^^^^^^^^^^^^^^^^^
-  Note:
+  Detailed explanation:
     `AttachedClassA` is incompatible with `T.attached_class (of AttachedClassA)` because when this method is called on a subclass `T.attached_class (of AttachedClassA)` will represent a more specific subclass, meaning `AttachedClassA` will not be specific enough. See https://sorbet.org/docs/attached-class for more.
 
 attached_class.rb:17: Expected `T::Array[T.attached_class (of AttachedClassB)]` but found `[AttachedClassB]` for method result type https://srb.help/7005
@@ -346,4 +346,5 @@ attached_class.rb:17: Expected `T::Array[T.attached_class (of AttachedClassB)]` 
             ^^^^^^^^^^^^^^^^^^^^
   Detailed explanation:
     `AttachedClassB` is not a subtype of `T.attached_class (of AttachedClassB)` for covariant type member `Array::Elem`
+      `AttachedClassB` is incompatible with `T.attached_class (of AttachedClassB)` because when this method is called on a subclass `T.attached_class (of AttachedClassB)` will represent a more specific subclass, meaning `AttachedClassB` will not be specific enough. See https://sorbet.org/docs/attached-class for more.
 Errors: 28

--- a/test/cli/detailed-errors/test.out
+++ b/test/cli/detailed-errors/test.out
@@ -318,4 +318,32 @@ tuples.rb:18: Expected `[Integer, String]` but found `[String("")]` for argument
     tuples.rb:18:
     18 |takes_tuple([''])
                     ^^^^
-Errors: 26
+
+attached_class.rb:8: Expected `T.attached_class (of AttachedClassA)` but found `AttachedClassA` for method result type https://srb.help/7005
+     8 |    AttachedClassA.new
+            ^^^^^^^^^^^^^^^^^^
+  Expected `T.attached_class (of AttachedClassA)` for result type of method `make`:
+    attached_class.rb:7:
+     7 |  def self.make
+          ^^^^^^^^^^^^^
+  Got `AttachedClassA` originating from:
+    attached_class.rb:8:
+     8 |    AttachedClassA.new
+            ^^^^^^^^^^^^^^^^^^
+  Note:
+    `AttachedClassA` is incompatible with `T.attached_class (of AttachedClassA)` because when this method is called on a subclass `T.attached_class (of AttachedClassA)` will represent a more specific subclass, meaning `AttachedClassA` will not be specific enough. See https://sorbet.org/docs/attached-class for more.
+
+attached_class.rb:17: Expected `T::Array[T.attached_class (of AttachedClassB)]` but found `[AttachedClassB]` for method result type https://srb.help/7005
+    17 |    [AttachedClassB.new]
+            ^^^^^^^^^^^^^^^^^^^^
+  Expected `T::Array[T.attached_class (of AttachedClassB)]` for result type of method `make`:
+    attached_class.rb:16:
+    16 |  def self.make
+          ^^^^^^^^^^^^^
+  Got `[AttachedClassB] (1-tuple)` originating from:
+    attached_class.rb:17:
+    17 |    [AttachedClassB.new]
+            ^^^^^^^^^^^^^^^^^^^^
+  Detailed explanation:
+    `AttachedClassB` is not a subtype of `T.attached_class (of AttachedClassB)` for covariant type member `Array::Elem`
+Errors: 28


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes #7746.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A user ran into this problem but the `T.attached_class` hint didn't show up because the `T.attached_class` was inside something else.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See the commits for the before/after.