### PR TITLE
Handle test imports correctly even with layering and strict dependencies not enabled

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -311,15 +311,6 @@ public:
             return 0;
         }
 
-        // Test imports always come last, and aren't sorted by `strict_dependencies`
-        if (aIsTestImport && bIsTestImport) {
-            return 0;
-        } else if (aIsTestImport && !bIsTestImport) {
-            return 1;
-        } else if (!aIsTestImport && bIsTestImport) {
-            return -1;
-        }
-
         // Layering violations always come first
         if (causesLayeringViolation(packageDB, a) && causesLayeringViolation(packageDB, b)) {
             return 0;
@@ -392,6 +383,14 @@ public:
                         // we already import this, and if so, don't return an autocorrect
                         return nullopt;
                     }
+                }
+
+                // Test imports always come last, and aren't sorted by `strict_dependencies`
+                if (isTestImport) {
+                    importToInsertAfter = &import.name;
+                    continue;
+                } else if (import.type == core::packages::ImportType::Test) {
+                    continue;
                 }
 
                 if (!gs.packageDB().enforceLayering()) {

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -205,9 +205,9 @@ TEST_CASE("Add import to package with imports and test imports") {
     string expected = "class MyPackage < PackageSpec\n"
                       "  import A\n"
                       "  import B\n"
+                      "  import ExamplePackage\n"
                       "  test_import C\n"
                       "  test_import D\n"
-                      "  import ExamplePackage\n"
                       "end\n";
 
     auto parsedFiles =

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -191,7 +191,7 @@ TEST_CASE("Add import with only existing exports") {
     CHECK_EQ(expected, replaced);
 }
 
-TEST_CASE("Add import to package with imports and test imports") {
+TEST_CASE("Add import and test_import to package with imports and test imports") {
     core::GlobalState gs(errorQueue);
     gs.initEmpty();
 
@@ -202,14 +202,6 @@ TEST_CASE("Add import to package with imports and test imports") {
                         "  test_import D\n"
                         "end\n";
 
-    string expected = "class MyPackage < PackageSpec\n"
-                      "  import A\n"
-                      "  import B\n"
-                      "  import ExamplePackage\n"
-                      "  test_import C\n"
-                      "  test_import D\n"
-                      "end\n";
-
     auto parsedFiles =
         enterPackages(gs, {{examplePackagePath, examplePackage}, {"my_package/__package.rb", pkg_source}});
     auto &examplePkg = getPackageForFile(gs, parsedFiles[0].file);
@@ -217,10 +209,33 @@ TEST_CASE("Add import to package with imports and test imports") {
     ENFORCE(examplePkg.exists());
     ENFORCE(myPkg.exists());
 
-    auto addImport = myPkg.addImport(gs, examplePkg, false);
-    ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
-    auto replaced = addImport->applySingleEditForTesting(pkg_source);
-    CHECK_EQ(expected, replaced);
+    {
+        string expected = "class MyPackage < PackageSpec\n"
+                          "  import A\n"
+                          "  import B\n"
+                          "  import ExamplePackage\n"
+                          "  test_import C\n"
+                          "  test_import D\n"
+                          "end\n";
+        auto addImport = myPkg.addImport(gs, examplePkg, false);
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
+
+    {
+        string expected = "class MyPackage < PackageSpec\n"
+                          "  import A\n"
+                          "  import B\n"
+                          "  test_import C\n"
+                          "  test_import D\n"
+                          "  test_import ExamplePackage\n"
+                          "end\n";
+        auto addImport = myPkg.addImport(gs, examplePkg, true);
+        ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+        auto replaced = addImport->applySingleEditForTesting(pkg_source);
+        CHECK_EQ(expected, replaced);
+    }
 }
 
 TEST_CASE("Add test import with only existing exports") {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

In #8465, we changed the import autocorrect to insert new imports in a sorted manner. However, the code for ordering test imports was behind an `enforceLayering` check, even though we don't need `strict_dependencies` or layering to order those.

This PR moves that part earlier, so we can maintain the test import order even when those checks are not enabled.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See before/after commits