### PR TITLE
fix: correct link to parser::Node header file

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -696,7 +696,7 @@ See [core/Symbols.h] and [core/SymbolRef.h] for more information.
 [infer]: #infer
 
 <!-- IRs -->
-[`parser::Node`]: #parser
+[`parser::Node`]: ../parser/Node.h 
 [`ast::Expression`]: ../ast/Trees.h
 [`cfg::CFG`]: ../cfg/CFG.h
 


### PR DESCRIPTION
Changes the `parser::Node` link from referencing the parser section of the documentation to referencing the actual `parser/Node.h` file.

### Motivation
The link to `parser::Node` just leads back to the parser section of the `internals.md` doc, rather than the actual source code for `Node`.


### Test plan
Purely changes documentation; tested that clicking the link works.
