### PR TITLE
Remove getIndexed in UndoState, LSPTypechecker, and LSPTypecheckerDelegate

### DIFF
--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -67,7 +67,7 @@ class LSPTypechecker final {
      * not present in the name table of the indexer. This is a sparse diff of trees indexed by position in
      * this->indexed, and should be consulted before this->indexed when looking up trees. Pelase see the WARNING section
      * of the comment on this->indexed for more context about why. This lookup strategy is implemented by
-     * this->getIndexed. All of the trees in this map are valid to use with this->gs.
+     * this->getResolved. All of the trees in this map are valid to use with this->gs.
      */
     UnorderedMap<int, ast::ParsedFile> indexedFinalGS;
 
@@ -148,11 +148,6 @@ public:
      * need particularly fine-grained fidelity in the AST (precludes rewriter).
      */
     ast::ExpressionPtr getLocalVarTrees(core::FileRef fref) const;
-    /**
-     * Returns the most up-to-date indexed tree for the file ref. The tree will either come from this->indexed if it has
-     * not been modified since the LSP process has been initialized, or from this->indexedFinalGS if it has been.
-     */
-    const ast::ParsedFile &getIndexed(core::FileRef fref) const;
 
     /**
      * Returns copies of the indexed trees that have been run through the incremental resolver.
@@ -232,7 +227,6 @@ public:
     void typecheckOnFastPath(LSPFileUpdates updates, std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
     std::vector<std::unique_ptr<core::Error>> retypecheck(std::vector<core::FileRef> frefs) const;
     LSPQueryResult query(const core::lsp::Query &q, const std::vector<core::FileRef> &filesForQuery) const;
-    const ast::ParsedFile &getIndexed(core::FileRef fref) const;
     std::vector<ast::ParsedFile> getResolved(absl::Span<const core::FileRef> frefs) const;
     ast::ParsedFile getResolved(core::FileRef fref) const;
     ast::ExpressionPtr getLocalVarTrees(core::FileRef fref) const;

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -37,15 +37,4 @@ const std::unique_ptr<core::GlobalState> &UndoState::getEvictedGs() {
     return evictedGs;
 }
 
-const ast::ParsedFile &UndoState::getIndexed(core::FileRef fref) const {
-    const auto id = fref.id();
-
-    auto treeEvictedIndexed = evictedIndexed.find(id);
-    if (treeEvictedIndexed != evictedIndexed.end()) {
-        return treeEvictedIndexed->second;
-    }
-
-    return dummyParsedFile;
-}
-
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -19,9 +19,6 @@ class UndoState final {
     // Stores the index trees stored in `gs` that were evicted because the slow path operation replaced `gs`.
     UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
 
-    // Dummy ParsedFile that we return when the file requested by getIndexed is not available.
-    ast::ParsedFile dummyParsedFile{nullptr, core::FileRef()};
-
 public:
     // Epoch of the running slow path
     const uint32_t epoch;
@@ -44,11 +41,6 @@ public:
      * Retrieves the evicted global state.
      */
     const std::unique_ptr<core::GlobalState> &getEvictedGs();
-
-    /**
-     * Returns the indexed file
-     */
-    const ast::ParsedFile &getIndexed(core::FileRef fref) const;
 };
 
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
The `LSPTypechecker::getIndexed` function was only used by `LSPTypechecker::getResolved`, and all other methods with the same name are unused. Let's inline `getIdexed` into `getResolved, and remove the others.

### Motivation
Removing unused functions, and clarifying what needs the indexed tree cache in `LSPTypechecker`, and preparing for a refactoring that removes the vector of cached indexed trees from `LSPTypechecker`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a Removing unused code.
