### PR TITLE
fix: show docs for all method definitions on hover

### DIFF
--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -91,11 +91,14 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         // Don't want to show hover results if we're hovering over, e.g., the arguments, and there's nothing there.
         if (s->funLoc().exists() && s->funLoc().contains(queryLoc)) {
             auto start = s->dispatchResult.get();
-            if (start != nullptr && start->main.method.exists() && !start->main.receiver.isUntyped()) {
-                auto loc = start->main.method.data(gs)->loc();
-                if (loc.exists()) {
-                    documentationLocations.emplace_back(loc);
+            while (start != nullptr) {
+                if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
+                    auto loc = start->main.method.data(gs)->loc();
+                    if (loc.exists()) {
+                        documentationLocations.emplace_back(loc);
+                    }
                 }
+                start = start->secondary.get();
             }
 
             if (s->dispatchResult->main.method.exists() &&

--- a/test/testdata/lsp/hover_multiple_methods.rb
+++ b/test/testdata/lsp/hover_multiple_methods.rb
@@ -1,0 +1,19 @@
+  # typed: true
+  extend T::Sig
+
+  class A
+    # A#foo docs
+    def foo; end
+  end
+
+  class B
+    # B#foo docs
+    def foo; end
+  end
+
+  sig { params(x: T.any(A, B)).void }
+  def example(x)
+    x.foo
+    # ^ hover: A#foo docs
+    # ^ hover: B#foo docs
+  end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->



### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Resolves #8533 -> shows documentation for _all_ possible method definitions on hover, rather than just whichever is found first.

Before:
<img width="194" alt="before" src="https://github.com/user-attachments/assets/fbd70d52-4493-40c4-9d97-c43a8adb7046" />

After:
<img width="190" alt="Screenshot 2025-02-19 at 5 29 53 PM" src="https://github.com/user-attachments/assets/26223c32-da23-47c4-a492-3b1c51d4b3a7" />


### Test plan
See included automated tests.
