### PR TITLE
use "Sorbet" rather than `srb` in our docs where appropriate

### DIFF
--- a/website/docs/abstract.md
+++ b/website/docs/abstract.md
@@ -364,7 +364,7 @@ A.bar
 This is hard to statically analyze, as it involves looking into the body of the
 `self.included` method, which might have arbitrary computation. As a compromise,
 Sorbet provides a new construct: `mixes_in_class_methods`. At runtime, it
-behaves as if we'd defined `self.included` like above, but will declare to `srb`
+behaves as if we'd defined `self.included` like above, but will declare to Sorbet
 statically what module is being extended.
 
 We can update our previous example to use `mixes_in_class_methods`, which lets

--- a/website/docs/abstract.md
+++ b/website/docs/abstract.md
@@ -364,8 +364,8 @@ A.bar
 This is hard to statically analyze, as it involves looking into the body of the
 `self.included` method, which might have arbitrary computation. As a compromise,
 Sorbet provides a new construct: `mixes_in_class_methods`. At runtime, it
-behaves as if we'd defined `self.included` like above, but will declare to Sorbet
-statically what module is being extended.
+behaves as if we'd defined `self.included` like above, but will declare to
+Sorbet statically what module is being extended.
 
 We can update our previous example to use `mixes_in_class_methods`, which lets
 Sorbet catch the runtime error about `bar` not being defined on `A`:

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -27,7 +27,7 @@ This is one of three docs aimed at helping answer common questions about Sorbet:
 1.  [Frequently Asked Questions](faq.md)
 1.  [Sorbet Error Reference](error-reference.md) (this doc)
 
-This page contains tips and tricks for common errors from `srb`.
+This page contains tips and tricks for common errors from Sorbet.
 
 ## 1001
 

--- a/website/docs/procs.md
+++ b/website/docs/procs.md
@@ -16,7 +16,7 @@ At present, all parameters are assumed to be required positional
 parameters—`T.proc` types cannot declare optional nor keyword parameters.
 
 Types of procs are not checked at all at runtime (whereas methods are), and
-serve only as hints to `srb` statically (and for documentation).
+serve only as hints to Sorbet statically (and for documentation).
 
 Here's a larger example:
 

--- a/website/docs/quickref.md
+++ b/website/docs/quickref.md
@@ -8,7 +8,7 @@ title: Quick Reference
 
 ## Enabling type checking
 
-To [enable static checking](static.md) with `srb`, add this line (called a
+To [enable static checking](static.md) with Sorbet, add this line (called a
 sigil) to the top of your Ruby file:
 
 ```ruby
@@ -46,10 +46,10 @@ class Main
 end
 ```
 
-Now `srb` **and** `sorbet-runtime` will check that our `Main.main` method is
+Now Sorbet **and** `sorbet-runtime` will check that our `Main.main` method is
 given only `String`s and returns only `Integer`s:
 
-- `srb` will do this with [static checks](static.md).
+- Sorbet will do this with [static checks](static.md).
 - `sorbet-runtime` will do this by wrapping `Main.main` with
   [dynamic checks](runtime.md) that run every time the method is called.
 

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -4,7 +4,7 @@ title: Enabling Runtime Checks
 ---
 
 As we've mentioned before, Sorbet is a [gradual](gradual.md) system: it can be
-turned on and off at will. This means the predictions `srb` makes statically can
+turned on and off at will. This means the predictions Sorbet makes statically can
 be wrong.
 
 That's why Sorbet also uses **runtime checks**: even if a static prediction was
@@ -75,7 +75,7 @@ large Ruby codebases like Stripe's. Type annotations in a codebase are near
 useless if developers don't trust them (consider how often YARD annotations fall
 out of sync with the code... 😰).
 
-Adding a `sig` to a method is only as good as the predictions it lets `srb` make
+Adding a `sig` to a method is only as good as the predictions it lets Sorbet make
 about a codebase. Wrong sigs are actively harmful. Specifically, when `sig`s in
 our codebase are wrong:
 

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -4,8 +4,8 @@ title: Enabling Runtime Checks
 ---
 
 As we've mentioned before, Sorbet is a [gradual](gradual.md) system: it can be
-turned on and off at will. This means the predictions Sorbet makes statically can
-be wrong.
+turned on and off at will. This means the predictions Sorbet makes statically
+can be wrong.
 
 That's why Sorbet also uses **runtime checks**: even if a static prediction was
 wrong, it will get checked during runtime, making things fail loudly and
@@ -75,9 +75,9 @@ large Ruby codebases like Stripe's. Type annotations in a codebase are near
 useless if developers don't trust them (consider how often YARD annotations fall
 out of sync with the code... 😰).
 
-Adding a `sig` to a method is only as good as the predictions it lets Sorbet make
-about a codebase. Wrong sigs are actively harmful. Specifically, when `sig`s in
-our codebase are wrong:
+Adding a `sig` to a method is only as good as the predictions it lets Sorbet
+make about a codebase. Wrong sigs are actively harmful. Specifically, when
+`sig`s in our codebase are wrong:
 
 - we can't use them to find code to refactor. Sorbet will think some code paths
   can never be reached when they actually can.

--- a/website/docs/sigs.md
+++ b/website/docs/sigs.md
@@ -215,10 +215,10 @@ sig {void}
 
 Using `void` instead of `returns(...)` does a number of things:
 
-- Statically, `srb` will let us return any value (for example, returning either
+- Statically, Sorbet will let us return any value (for example, returning either
   `5` or `nil` is valid).
 
-- Also statically, `srb` will error when typed code tries to inspect the result
+- Also statically, Sorbet will error when typed code tries to inspect the result
   of a `void` method.
 
 - In the runtime, `sorbet-runtime` will _throw away_ the result of our method,
@@ -340,7 +340,7 @@ calls:
 
   In a [gradual type system](gradual.md) like Sorbet, the static checks can be
   turned off at any time. Having [runtime-validated](runtime.md) type
-  annotations gives greater confidence in the predictions that `srb`
+  annotations gives greater confidence in the predictions that Sorbet
   [makes statically](static.md).
 
 - Type assertions in code would be inevitable.

--- a/website/docs/static.md
+++ b/website/docs/static.md
@@ -81,8 +81,8 @@ Each strictness level reports all errors at lower levels, plus new errors:
   [`# typed: strong`](strong.md) for more information.
 
 To recap: adding one of these comments to the top of a Ruby file controls which
-errors Sorbet reports or silences in that file. The strictness level only affects
-which errors are reported.
+errors Sorbet reports or silences in that file. The strictness level only
+affects which errors are reported.
 
 > **Note**: Method signatures in `# typed: false` files are _still parsed and
 > used_ by Sorbet if that method is called in other files. Specifically, adding

--- a/website/docs/static.md
+++ b/website/docs/static.md
@@ -3,7 +3,7 @@ id: static
 title: Enabling Static Checks
 ---
 
-This doc will cover how to enable and disable the **static checks** that `srb`
+This doc will cover how to enable and disable the **static checks** that Sorbet
 reports. Specifically, we'll look at how to toggle these checks...
 
 - ...within an entire **file**.
@@ -18,7 +18,7 @@ slap on a quick warning label:
 
 ## File-level granularity: strictness levels
 
-When run at the command line, `srb` roughly works like this:
+When run at the command line, Sorbet roughly works like this:
 
 1.  Read, parse, and analyze every Ruby file in a project.
 2.  Generate a list of errors within the project.
@@ -27,7 +27,7 @@ When run at the command line, `srb` roughly works like this:
 However, in step (3), most kinds of errors are _silenced_ by default, instead of
 being reported. To opt into _more_ checks, we use `# typed:` **sigils**[^sigil].
 A `# typed:` sigil is a comment placed at the top of a Ruby file, indicating to
-`srb` which errors to report and which to silence. These are the available
+Sorbet which errors to report and which to silence. These are the available
 sigils, each defining a **strictness level**:
 
 <!-- prettier-ignore-start -->
@@ -81,7 +81,7 @@ Each strictness level reports all errors at lower levels, plus new errors:
   [`# typed: strong`](strong.md) for more information.
 
 To recap: adding one of these comments to the top of a Ruby file controls which
-errors `srb` reports or silences in that file. The strictness level only affects
+errors Sorbet reports or silences in that file. The strictness level only affects
 which errors are reported.
 
 > **Note**: Method signatures in `# typed: false` files are _still parsed and
@@ -105,7 +105,7 @@ If you don't regenerate `hidden.rbi`, you are likely to encounter
 ## Method-level granularity: `sig`
 
 After enabling `# typed: true` in some files, we can opt individual methods into
-even more checks by adding signatures (or `sig`s) to them. For example `srb`
+even more checks by adding signatures (or `sig`s) to them. For example, Sorbet
 reports no errors in this file:
 
 ```ruby
@@ -140,7 +140,7 @@ log_env({timeout_len: 2000}, 'timeout_len') # => Expected `Symbol` but found `St
 In this example, we add a line like `sig {...}` above the `def log_env` line.
 This is a Sorbet method signature---it declares the parameter and return types
 of a method. By adding the `sig` to `log_env`, we opted this method into
-additional checks. Now `srb` reports this:
+additional checks. Now Sorbet reports this:
 
 ```plaintext
 Expected `Symbol` but found `String("timeout_len")` for argument `key`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed we used `srb` when advising a user on docs, and I think we want to be using "Sorbet" everywhere.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
