### PR TITLE
pack `ConstantLit` into 16 bytes, rather than 32

### DIFF
--- a/ast/Helpers.cc
+++ b/ast/Helpers.cc
@@ -60,13 +60,13 @@ bool BehaviorHelpers::checkClassDefinesBehavior(const ExpressionPtr &expr) {
 bool BehaviorHelpers::checkClassDefinesBehavior(const ast::ClassDef &klass) {
     for (auto &ancst : klass.ancestors) {
         auto cnst = ast::cast_tree<ast::ConstantLit>(ancst);
-        if (cnst && cnst->original != nullptr) {
+        if (cnst && cnst->original() != nullptr) {
             return true;
         }
     }
     for (auto &ancst : klass.singletonAncestors) {
         auto cnst = ast::cast_tree<ast::ConstantLit>(ancst);
-        if (cnst && cnst->original != nullptr) {
+        if (cnst && cnst->original() != nullptr) {
             return true;
         }
     }

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -99,7 +99,7 @@ public:
 
     static ExpressionPtr Constant(core::LocOffsets loc, core::SymbolRef symbol) {
         ENFORCE(symbol.exists());
-        return make_expression<ConstantLit>(loc, symbol, nullptr);
+        return make_expression<ConstantLit>(loc, symbol);
     }
 
     static ExpressionPtr Local(core::LocOffsets loc, core::NameRef name) {

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -164,8 +164,10 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
             if (exp->original) {
                 originalC = make_unique<UnresolvedConstantLit>(
                     exp->original->loc, deepCopy(avoid, exp->original->scope), exp->original->cnst);
+                return make_expression<ConstantLit>(exp->symbol(), move(originalC));
             }
-            return make_expression<ConstantLit>(exp->loc, exp->symbol(), move(originalC));
+
+            return make_expression<ConstantLit>(exp->loc, exp->symbol());
         }
 
         case Tag::ZSuperArgs: {

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -162,8 +162,8 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
             auto *exp = reinterpret_cast<const ConstantLit *>(tree);
             std::unique_ptr<UnresolvedConstantLit> originalC;
             if (auto *original = exp->original()) {
-                originalC = make_unique<UnresolvedConstantLit>(
-                    original->loc, deepCopy(avoid, original->scope), original->cnst);
+                originalC =
+                    make_unique<UnresolvedConstantLit>(original->loc, deepCopy(avoid, original->scope), original->cnst);
                 return make_expression<ConstantLit>(exp->symbol(), move(originalC));
             }
 

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -161,9 +161,9 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
         case Tag::ConstantLit: {
             auto *exp = reinterpret_cast<const ConstantLit *>(tree);
             std::unique_ptr<UnresolvedConstantLit> originalC;
-            if (exp->original) {
+            if (auto *original = exp->original()) {
                 originalC = make_unique<UnresolvedConstantLit>(
-                    exp->original->loc, deepCopy(avoid, exp->original->scope), exp->original->cnst);
+                    original->loc, deepCopy(avoid, original->scope), original->cnst);
                 return make_expression<ConstantLit>(exp->symbol(), move(originalC));
             }
 

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -167,7 +167,7 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
                 return make_expression<ConstantLit>(exp->symbol(), move(originalC));
             }
 
-            return make_expression<ConstantLit>(exp->loc, exp->symbol());
+            return make_expression<ConstantLit>(exp->loc(), exp->symbol());
         }
 
         case Tag::ZSuperArgs: {

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -280,14 +280,14 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
             if (a->symbol() != b->symbol()) {
                 return false;
             }
-            if (a->original && b->original) {
-                auto &alit = *a->original;
-                auto &blit = *b->original;
+            if (a->original() && b->original()) {
+                auto &alit = *a->original();
+                auto &blit = *b->original();
                 if (alit.cnst != blit.cnst) {
                     return false;
                 }
                 return structurallyEqual(gs, avoid, alit.scope, blit.scope, file);
-            } else if (!a->original && !b->original) {
+            } else if (!a->original() && !b->original()) {
                 // This occurs when the constant is created using MK::Constant instead of MK::UnresolvedConstant
                 // (original points to the UnresolvedConstantLit that created this ConstantLit)
                 return true;

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -318,7 +318,7 @@ ConstantLit::ConstantLit(core::SymbolRef symbol, std::unique_ptr<UnresolvedConst
 }
 
 ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original)
-    : loc_(loc), resolutionScopesOrSymbol(symbol), original(std::move(original)) {
+    : loc_(loc), resolutionScopesOrSymbol(symbol), original_(std::move(original)) {
     categoryCounterInc("trees", "resolvedconstantlit");
     _sanityCheck();
 }
@@ -345,14 +345,14 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
                 break;
             }
 
-            auto &orig = *nested->original;
+            auto &orig = *nested->original_;
             namesFailedToResolve.emplace_back(orig.cnst);
             nested = ast::cast_tree<ast::ConstantLit>(orig.scope);
             ENFORCE(nested);
             ENFORCE(nested->symbol() == core::Symbols::StubModule());
             ENFORCE(!nested->resolutionScopes()->empty());
         }
-        auto &orig = *nested->original;
+        auto &orig = *nested->original_;
         namesFailedToResolve.emplace_back(orig.cnst);
         absl::c_reverse(namesFailedToResolve);
     }
@@ -732,7 +732,7 @@ string ConstantLit::toStringWithTabs(const core::GlobalState &gs, int tabs) cons
     if (symbol().exists() && symbol() != core::Symbols::StubModule()) {
         return this->symbol().showFullName(gs);
     }
-    return "Unresolved: " + this->original->toStringWithTabs(gs, tabs);
+    return "Unresolved: " + this->original_->toStringWithTabs(gs, tabs);
 }
 
 string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) const {
@@ -744,7 +744,7 @@ string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) const {
                    this->symbol().showFullName(gs));
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "orig = {}\n",
-                   this->original ? this->original->showRaw(gs, tabs + 1) : "nullptr");
+                   this->original_ ? this->original_->showRaw(gs, tabs + 1) : "nullptr");
     // If resolutionScopes isn't null, it should not be empty.
     ENFORCE(resolutionScopes() == nullptr || !resolutionScopes()->empty());
     if (resolutionScopes() != nullptr && !resolutionScopes()->empty()) {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -98,7 +98,7 @@ template <> struct LocGetter<ConstantLit> {
         return reinterpret_cast<ConstantLit *>(ptr)->loc();
     }
 };
-}
+} // namespace
 
 core::LocOffsets ExpressionPtr::loc() const {
     auto *ptr = get();
@@ -309,8 +309,7 @@ UnresolvedConstantLit::UnresolvedConstantLit(core::LocOffsets loc, ExpressionPtr
     _sanityCheck();
 }
 
-ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol)
-    : storage(loc, symbol) {
+ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol) : storage(loc, symbol) {
     categoryCounterInc("trees", "resolvedconstantlit");
     _sanityCheck();
 }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -295,6 +295,14 @@ UnresolvedConstantLit::UnresolvedConstantLit(core::LocOffsets loc, ExpressionPtr
     _sanityCheck();
 }
 
+ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol)
+    : ConstantLit(loc, symbol, nullptr) {
+}
+
+ConstantLit::ConstantLit(core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original)
+    : ConstantLit(original->loc, symbol, std::move(original)) {
+}
+
 ConstantLit::ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original)
     : loc(loc), resolutionScopesOrSymbol(symbol), original(std::move(original)) {
     categoryCounterInc("trees", "resolvedconstantlit");

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1239,10 +1239,13 @@ public:
 private:
     ResolutionScopesOrSymbol resolutionScopesOrSymbol;
 
+    ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
+
 public:
     std::unique_ptr<UnresolvedConstantLit> original;
 
-    ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
+    ConstantLit(core::LocOffsets loc, core::SymbolRef symbol);
+    ConstantLit(core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1236,12 +1236,11 @@ EXPRESSION(ConstantLit) {
 private:
     const core::LocOffsets loc_;
     ResolutionScopesOrSymbol resolutionScopesOrSymbol;
+    std::unique_ptr<UnresolvedConstantLit> original_;
 
     ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
 
 public:
-    std::unique_ptr<UnresolvedConstantLit> original;
-
     ConstantLit(core::LocOffsets loc, core::SymbolRef symbol);
     ConstantLit(core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
 
@@ -1277,6 +1276,14 @@ public:
     // Marks this constant as unresolved and allocates a vector for `resolutionScopes`.
     void markUnresolved() {
         return resolutionScopesOrSymbol.markUnresolved();
+    }
+
+    UnresolvedConstantLit *original() {
+        return original_.get();
+    }
+
+    const UnresolvedConstantLit *original() const {
+        return original_.get();
     }
 
     void _sanityCheck();

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1145,7 +1145,7 @@ private:
     //
     // 2. A resolved constant.  We cheat a little bit here because this is actually encompassing
     //    both a constant that we are attempting to resolve and a constant that we have finished
-    //    resolving.  This requires 12 bytes of storage, 16 after alignment:
+    //    resolving.  This requires 16 bytes of storage due to alignment requirements:
     //
     //    struct ResolvedSymbol {
     //        core::SymbolRef sym;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1233,10 +1233,8 @@ public:
 CheckSize(ResolutionScopesOrSymbol, 8, 8);
 
 EXPRESSION(ConstantLit) {
-public:
-    const core::LocOffsets loc;
-
 private:
+    const core::LocOffsets loc_;
     ResolutionScopesOrSymbol resolutionScopesOrSymbol;
 
     ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, std::unique_ptr<UnresolvedConstantLit> original);
@@ -1254,6 +1252,10 @@ public:
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
     std::string nodeName() const;
     std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(core::Context ctx) const;
+
+    core::LocOffsets loc() const {
+        return loc_;
+    }
 
     core::SymbolRef symbol() const {
         return resolutionScopesOrSymbol.symbol();

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1229,85 +1229,85 @@ private:
 
         ~Storage() {
             switch (tag()) {
-            case Tag::KnownSymbol: {
-                // ptr1 just holds the raw ID for the symbol, so only delete LocOffsets.
-                auto *p = reinterpret_cast<core::LocOffsets *>(&ptr2);
-                p->~LocOffsets();
-                break;
-            }
-            case Tag::ResolvedSymbol: {
-                // ptr1 just holds the raw ID for the symbol.
-                auto *ucl = original();
-                delete ucl;
-                break;
-            }
-            case Tag::FailedResolutionSymbol: {
-                auto *scopes = resolutionScopes();
-                delete scopes;
-                auto *ucl = original();
-                delete ucl;
-                break;
-            }
+                case Tag::KnownSymbol: {
+                    // ptr1 just holds the raw ID for the symbol, so only delete LocOffsets.
+                    auto *p = reinterpret_cast<core::LocOffsets *>(&ptr2);
+                    p->~LocOffsets();
+                    break;
+                }
+                case Tag::ResolvedSymbol: {
+                    // ptr1 just holds the raw ID for the symbol.
+                    auto *ucl = original();
+                    delete ucl;
+                    break;
+                }
+                case Tag::FailedResolutionSymbol: {
+                    auto *scopes = resolutionScopes();
+                    delete scopes;
+                    auto *ucl = original();
+                    delete ucl;
+                    break;
+                }
             }
         }
 
         UnresolvedConstantLit *original() {
             switch (tag()) {
-            case Tag::KnownSymbol:
-                return nullptr;
-            case Tag::ResolvedSymbol:
-            case Tag::FailedResolutionSymbol:
-                return reinterpret_cast<UnresolvedConstantLit *>(ptr2);
+                case Tag::KnownSymbol:
+                    return nullptr;
+                case Tag::ResolvedSymbol:
+                case Tag::FailedResolutionSymbol:
+                    return reinterpret_cast<UnresolvedConstantLit *>(ptr2);
             }
         }
 
         const UnresolvedConstantLit *original() const {
             switch (tag()) {
-            case Tag::KnownSymbol:
-                return nullptr;
-            case Tag::ResolvedSymbol:
-            case Tag::FailedResolutionSymbol:
-                return reinterpret_cast<const UnresolvedConstantLit *>(ptr2);
+                case Tag::KnownSymbol:
+                    return nullptr;
+                case Tag::ResolvedSymbol:
+                case Tag::FailedResolutionSymbol:
+                    return reinterpret_cast<const UnresolvedConstantLit *>(ptr2);
             }
         }
 
         core::LocOffsets loc() const {
             switch (tag()) {
-            case Tag::KnownSymbol:
-                return *reinterpret_cast<const core::LocOffsets *>(&ptr2);
-            case Tag::ResolvedSymbol:
-            case Tag::FailedResolutionSymbol:
-                return original()->loc;
+                case Tag::KnownSymbol:
+                    return *reinterpret_cast<const core::LocOffsets *>(&ptr2);
+                case Tag::ResolvedSymbol:
+                case Tag::FailedResolutionSymbol:
+                    return original()->loc;
             }
         }
 
         core::SymbolRef symbol() const {
             switch (tag()) {
-            case Tag::KnownSymbol:
-            case Tag::ResolvedSymbol:
-                return core::SymbolRef::fromRaw(static_cast<uint32_t>(untaggedPtr1()));
-            case Tag::FailedResolutionSymbol:
-                return core::Symbols::StubModule();
+                case Tag::KnownSymbol:
+                case Tag::ResolvedSymbol:
+                    return core::SymbolRef::fromRaw(static_cast<uint32_t>(untaggedPtr1()));
+                case Tag::FailedResolutionSymbol:
+                    return core::Symbols::StubModule();
             }
         }
 
         std::vector<core::SymbolRef> *resolutionScopes() {
             switch (tag()) {
-            case Tag::KnownSymbol:
-            case Tag::ResolvedSymbol:
-                return nullptr;
-            case Tag::FailedResolutionSymbol:
-                return reinterpret_cast<std::vector<core::SymbolRef> *>(untaggedPtr1());
+                case Tag::KnownSymbol:
+                case Tag::ResolvedSymbol:
+                    return nullptr;
+                case Tag::FailedResolutionSymbol:
+                    return reinterpret_cast<std::vector<core::SymbolRef> *>(untaggedPtr1());
             }
         }
 
         const std::vector<core::SymbolRef> *resolutionScopes() const {
             switch (tag()) {
-            case Tag::KnownSymbol:
-            case Tag::ResolvedSymbol:
-                return nullptr;
-            case Tag::FailedResolutionSymbol:
-                return reinterpret_cast<const std::vector<core::SymbolRef> *>(untaggedPtr1());
+                case Tag::KnownSymbol:
+                case Tag::ResolvedSymbol:
+                    return nullptr;
+                case Tag::FailedResolutionSymbol:
+                    return reinterpret_cast<const std::vector<core::SymbolRef> *>(untaggedPtr1());
             }
         }
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -449,13 +449,15 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             },
             [&](ast::ConstantLit &a) {
                 auto aliasName = cctx.newTemporary(core::Names::cfgAlias());
+                auto loc = a.loc();
+
                 if (a.symbol() == core::Symbols::StubModule()) {
-                    current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(core::Symbols::untyped()));
+                    current->exprs.emplace_back(aliasName, loc, make_insn<Alias>(core::Symbols::untyped()));
                 } else {
-                    current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(a.symbol()));
+                    current->exprs.emplace_back(aliasName, loc, make_insn<Alias>(a.symbol()));
                 }
 
-                synthesizeExpr(current, cctx.target, a.loc, make_insn<Ident>(aliasName));
+                synthesizeExpr(current, cctx.target, loc, make_insn<Ident>(aliasName));
 
                 if (a.original) {
                     auto &orig = *a.original;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -459,8 +459,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
                 synthesizeExpr(current, cctx.target, loc, make_insn<Ident>(aliasName));
 
-                if (a.original) {
-                    auto &orig = *a.original;
+                if (a.original()) {
+                    auto &orig = *a.original();
                     // Empirically, these are the only two cases we've needed so far to service the
                     // LSP requests we want (hover and completion), but that doesn't mean these are
                     // the **only** we'll ever want.

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1451,7 +1451,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::ConstantLit: {
             auto &a = ast::cast_tree_nonnull<ast::ConstantLit>(what);
-            pickle(p, a.loc);
+            pickle(p, a.loc());
             p.putU4(a.symbol().rawId());
             // This encoding is the same encoding that would be used if we were
             // serializing an UnresolvedConstantLit as an ExpressionPtr, nullptr

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1456,11 +1456,12 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             // This encoding is the same encoding that would be used if we were
             // serializing an UnresolvedConstantLit as an ExpressionPtr, nullptr
             // and all.
-            if (a.original == nullptr) {
+            auto *original = a.original();
+            if (original == nullptr) {
                 p.putU4(0);
             } else {
                 p.putU4(uint32_t(ast::Tag::UnresolvedConstantLit));
-                pickle(p, *a.original);
+                pickle(p, *original);
             }
             break;
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1741,10 +1741,12 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             std::unique_ptr<ast::UnresolvedConstantLit> orig;
             if (litTag == uint32_t(ast::Tag::UnresolvedConstantLit)) {
                 orig = unpickleUnresolvedConstantLit(p, gs);
+                return ast::make_expression<ast::ConstantLit>(sym, std::move(orig));
             } else if (litTag != 0) {
                 Exception::raise("Unknown tag for `ConstantLit::original`: {}", litTag);
             }
-            return ast::make_expression<ast::ConstantLit>(loc, sym, std::move(orig));
+            ENFORCE(orig == nullptr);
+            return ast::make_expression<ast::ConstantLit>(loc, sym);
         }
         case ast::Tag::RuntimeMethodDefinition: {
             auto loc = unpickleLocOffsets(p);

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -273,7 +273,7 @@ public:
             return;
         }
 
-        auto entry = make_pair(original.loc, original.symbol());
+        auto entry = make_pair(original.loc(), original.symbol());
         if (seenRefsByLoc.contains(entry)) {
             return;
         }
@@ -283,12 +283,12 @@ public:
         auto &ref = refs.emplace_back();
         ref.id = refs.size() - 1;
         setNestingAndScope(ref, original);
-        ref.loc = original.loc;
+        ref.loc = original.loc();
 
         // the reference location is the location of constant, but this might get updated if the reference corresponds
         // to the definition of the constant, because in that case we'll later on extend the location to cover the whole
         // class or assignment
-        ref.definitionLoc = original.loc;
+        ref.definitionLoc = original.loc();
         ref.name = QualifiedName::fromFullName(constantName(ctx, original));
         auto sym = original.symbol();
         ref.sym = sym;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -102,8 +102,8 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
                   core::SymbolRef symbolBeforeDealias) {
     // Iterate. Ensures that we match "Foo" in "Foo::Bar" references.
     auto symbol = symbolBeforeDealias.dealias(ctx);
-    while (lit && symbol.exists() && lit->original) {
-        auto &unresolved = *lit->original;
+    while (lit && symbol.exists() && lit->original()) {
+        auto &unresolved = *lit->original();
         if (lspQuery.matchesLoc(ctx.locAt(lit->loc())) || lspQuery.matchesSymbol(symbol) ||
             lspQuery.matchesSymbol(symbolBeforeDealias)) {
             // This basically approximates the cfg::Alias case from Environment::processBinding.

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -104,7 +104,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
     auto symbol = symbolBeforeDealias.dealias(ctx);
     while (lit && symbol.exists() && lit->original) {
         auto &unresolved = *lit->original;
-        if (lspQuery.matchesLoc(ctx.locAt(lit->loc)) || lspQuery.matchesSymbol(symbol) ||
+        if (lspQuery.matchesLoc(ctx.locAt(lit->loc())) || lspQuery.matchesSymbol(symbol) ||
             lspQuery.matchesSymbol(symbolBeforeDealias)) {
             // This basically approximates the cfg::Alias case from Environment::processBinding.
             core::TypeAndOrigins tp;
@@ -128,7 +128,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             }
 
             auto enclosingMethod = enclosingMethodFromContext(ctx);
-            auto resp = core::lsp::ConstantResponse(symbolBeforeDealias, ctx.locAt(lit->loc), scopes, unresolved.cnst,
+            auto resp = core::lsp::ConstantResponse(symbolBeforeDealias, ctx.locAt(lit->loc()), scopes, unresolved.cnst,
                                                     tp, enclosingMethod);
             core::lsp::QueryResponse::pushQueryResponse(ctx, resp);
         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1702,7 +1702,7 @@ class TreeSymbolizer {
         // NameInserter should have created this symbol
         ENFORCE(existing.exists());
 
-        node = ast::make_expression<ast::ConstantLit>(constLit->loc, existing,
+        node = ast::make_expression<ast::ConstantLit>(existing,
                                                       node.toUnique<ast::UnresolvedConstantLit>());
         return existing;
     }
@@ -1823,8 +1823,7 @@ public:
 
         core::SymbolRef cnst = ctx.state.lookupStaticFieldSymbol(scope, lhs.cnst);
         ENFORCE(cnst.exists());
-        auto loc = lhs.loc;
-        asgn.lhs = ast::make_expression<ast::ConstantLit>(loc, cnst, asgn.lhs.toUnique<ast::UnresolvedConstantLit>());
+        asgn.lhs = ast::make_expression<ast::ConstantLit>(cnst, asgn.lhs.toUnique<ast::UnresolvedConstantLit>());
 
         return tree;
     }
@@ -1964,7 +1963,7 @@ public:
         // Simulates how squashNames in handleAssignment also creates a ConstantLit
         // (simpler than squashNames, because type members are not allowed to use any sort of
         // `A::B = type_member` syntax)
-        asgn.lhs = ast::make_expression<ast::ConstantLit>(asgn.lhs.loc(), sym,
+        asgn.lhs = ast::make_expression<ast::ConstantLit>(sym,
                                                           asgn.lhs.toUnique<ast::UnresolvedConstantLit>());
 
         if (send->hasKwArgs()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1702,8 +1702,7 @@ class TreeSymbolizer {
         // NameInserter should have created this symbol
         ENFORCE(existing.exists());
 
-        node = ast::make_expression<ast::ConstantLit>(existing,
-                                                      node.toUnique<ast::UnresolvedConstantLit>());
+        node = ast::make_expression<ast::ConstantLit>(existing, node.toUnique<ast::UnresolvedConstantLit>());
         return existing;
     }
 
@@ -1963,8 +1962,7 @@ public:
         // Simulates how squashNames in handleAssignment also creates a ConstantLit
         // (simpler than squashNames, because type members are not allowed to use any sort of
         // `A::B = type_member` syntax)
-        asgn.lhs = ast::make_expression<ast::ConstantLit>(sym,
-                                                          asgn.lhs.toUnique<ast::UnresolvedConstantLit>());
+        asgn.lhs = ast::make_expression<ast::ConstantLit>(sym, asgn.lhs.toUnique<ast::UnresolvedConstantLit>());
 
         if (send->hasKwArgs()) {
             const auto numKwArgs = send->numKwArgs();

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -384,7 +384,7 @@ public:
 
         // If the imported symbol comes from the test namespace, we must also be in the test namespace.
         if (otherFile.data(ctx).isPackagedTest() && !this->insideTestFile) {
-            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::UsedTestOnlyName)) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
                 e.setHeader("`{}` is defined in a test namespace and cannot be referenced in a non-test file",
                             litSymbol.show(ctx));
             }
@@ -408,7 +408,7 @@ public:
 
         // Did we use a constant that wasn't exported?
         if (!isExported && !db.allowRelaxedPackagerChecksFor(this->package.mangledName())) {
-            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::UsedPackagePrivateName)) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
                 auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
                 e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
                 auto definedHereLoc = litSymbol.loc(ctx);
@@ -441,7 +441,7 @@ public:
         auto importType = this->package.importsPackage(otherPackage);
         if (!importType.has_value()) {
             // We failed to import the package that defines the symbol
-            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::MissingImport)) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
                 auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
                 bool isTestImport = otherFile.data(ctx).isPackagedTest() || ctx.file.data(ctx).isPackagedTest();
                 auto strictDepsLevel = this->package.strictDependenciesLevel();
@@ -484,7 +484,7 @@ public:
             }
         } else if (*importType == core::packages::ImportType::Test && !this->insideTestFile) {
             // We used a symbol from a `test_import` in a non-test context
-            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::UsedTestOnlyName)) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
                 e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
                 auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
                 if (auto exp = this->package.addImport(ctx, pkg, false)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1577,9 +1577,8 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
         // Pre-resolve the super class. This makes it easier to detect that this is a package
         // spec-related class def in later passes without having to recursively walk up the constant
         // lit's scope to find if it starts with <PackageSpecRegistry>.
-        auto superClassLoc = packageSpecClass->ancestors[0].loc();
         packageSpecClass->ancestors[0] = ast::make_expression<ast::ConstantLit>(
-            superClassLoc, core::Symbols::PackageSpec(),
+            core::Symbols::PackageSpec(),
             packageSpecClass->ancestors[0].toUnique<ast::UnresolvedConstantLit>());
 
         info = make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree), ctx.locAt(packageSpecClass->loc),

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1578,8 +1578,7 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
         // spec-related class def in later passes without having to recursively walk up the constant
         // lit's scope to find if it starts with <PackageSpecRegistry>.
         packageSpecClass->ancestors[0] = ast::make_expression<ast::ConstantLit>(
-            core::Symbols::PackageSpec(),
-            packageSpecClass->ancestors[0].toUnique<ast::UnresolvedConstantLit>());
+            core::Symbols::PackageSpec(), packageSpecClass->ancestors[0].toUnique<ast::UnresolvedConstantLit>());
 
         info = make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree), ctx.locAt(packageSpecClass->loc),
                                             ctx.locAt(packageSpecClass->declLoc));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1319,7 +1319,7 @@ private:
             auto enclosingClass = ctx.owner.enclosingClass(ctx);
             auto nw = ast::MK::UnresolvedConstant(loc, std::move(ancestor), enclosingClass.data(ctx)->name);
             auto out =
-                ast::make_expression<ast::ConstantLit>(loc, enclosingClass, nw.toUnique<ast::UnresolvedConstantLit>());
+                ast::make_expression<ast::ConstantLit>(enclosingClass, nw.toUnique<ast::UnresolvedConstantLit>());
             job.ancestor = ast::cast_tree<ast::ConstantLit>(out);
             ancestor = std::move(out);
         } else if (ast::isa_tree<ast::EmptyTree>(ancestor)) {
@@ -1334,8 +1334,7 @@ private:
     void walkUnresolvedConstantLit(core::Context ctx, ast::ExpressionPtr &tree) {
         if (auto c = ast::cast_tree<ast::UnresolvedConstantLit>(tree)) {
             walkUnresolvedConstantLit(ctx, c->scope);
-            auto loc = c->loc;
-            auto out = ast::make_expression<ast::ConstantLit>(loc, core::Symbols::noSymbol(),
+            auto out = ast::make_expression<ast::ConstantLit>(core::Symbols::noSymbol(),
                                                               tree.toUnique<ast::UnresolvedConstantLit>());
             auto constant = ast::cast_tree<ast::ConstantLit>(out);
             ConstantResolutionItem job{nesting_, constant};

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -537,7 +537,7 @@ private:
 
     static core::ClassOrModuleRef stubConstant(core::MutableContext ctx, core::ClassOrModuleRef owner,
                                                ast::ConstantLit *out, bool possibleGenericType) {
-        auto symbol = ctx.state.enterClassSymbol(ctx.locAt(out->loc), owner, out->original->cnst);
+        auto symbol = ctx.state.enterClassSymbol(ctx.locAt(out->loc()), owner, out->original->cnst);
 
         auto data = symbol.data(ctx);
         data->setIsModule(true); // This is what would happen in finalizeAncestors
@@ -771,7 +771,7 @@ private:
                 if (ast::isa_tree<ast::EmptyTree>(original.scope)) {
                     for (const auto &[from, to] : COMMON_TYPOS) {
                         if (from == original.cnst) {
-                            e.didYouMean(to, ctx.locAt(job.out->loc));
+                            e.didYouMean(to, ctx.locAt(job.out->loc()));
                             foundCommonTypo = true;
                             break;
                         }
@@ -815,7 +815,7 @@ private:
                     }
                     for (auto suggestion : suggested) {
                         const auto replacement = suggestion.symbol.show(ctx);
-                        auto replaceLoc = ctx.locAt(job.out->loc);
+                        auto replaceLoc = ctx.locAt(job.out->loc());
                         if (replaceLoc.source(ctx) == replacement) {
                             // The replacement is the same as the original.
                             // This can happen for a number of reasons, usually due to things
@@ -929,10 +929,10 @@ private:
         }
 
         if (rhsSym.isTypeAlias(ctx)) {
-            if (auto e = ctx.beginError(it.rhs->loc, core::errors::Resolver::ReassignsTypeAlias)) {
+            if (auto e = ctx.beginError(it.rhs->loc(), core::errors::Resolver::ReassignsTypeAlias)) {
                 e.setHeader("Reassigning a type alias is not allowed");
                 e.addErrorLine(rhsSym.loc(ctx), "Originally defined here");
-                auto rhsLoc = ctx.locAt(it.rhs->loc);
+                auto rhsLoc = ctx.locAt(it.rhs->loc());
                 if (rhsLoc.exists()) {
                     e.replaceWith("Declare as type alias", rhsLoc, "T.type_alias {{ {} }}", rhsLoc.source(ctx).value());
                 }
@@ -1007,7 +1007,7 @@ private:
                 if (!lastRun) {
                     return false;
                 }
-                if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::DynamicSuperclass)) {
+                if (auto e = ctx.beginError(job.ancestor->loc(), core::errors::Resolver::DynamicSuperclass)) {
                     e.setHeader("Superclasses and mixins may not be type aliases");
                 }
                 resolved = stubSymbolForAncestor(job);
@@ -1024,7 +1024,7 @@ private:
                     }
                     return false;
                 }
-                if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::DynamicSuperclass)) {
+                if (auto e = ctx.beginError(job.ancestor->loc(), core::errors::Resolver::DynamicSuperclass)) {
                     e.setHeader("Superclasses and mixins may only use class aliases like `{}`", "A = Integer");
                 }
                 resolved = stubSymbolForAncestor(job);
@@ -1033,13 +1033,13 @@ private:
         }
 
         if (resolvedClass == job.klass) {
-            if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::CircularDependency)) {
+            if (auto e = ctx.beginError(job.ancestor->loc(), core::errors::Resolver::CircularDependency)) {
                 e.setHeader("Circular dependency: `{}` is a parent of itself", job.klass.show(ctx));
                 e.addErrorLine(resolvedClass.data(ctx)->loc(), "Class definition");
             }
             resolvedClass = stubSymbolForAncestor(job);
         } else if (resolvedClass.data(ctx)->derivesFrom(ctx, job.klass)) {
-            if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::CircularDependency)) {
+            if (auto e = ctx.beginError(job.ancestor->loc(), core::errors::Resolver::CircularDependency)) {
                 e.setHeader("Circular dependency: `{}` and `{}` are declared as parents of each other",
                             job.klass.show(ctx), resolvedClass.show(ctx));
                 e.addErrorLine(job.klass.data(ctx)->loc(), "One definition");
@@ -1064,7 +1064,7 @@ private:
                 auto allowsPayloadParentOverride = suppressPayloadSuperclassRedefinitionFor.contains(job.klass);
 
                 if (!allowsPayloadParentOverride) {
-                    if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::RedefinitionOfParents)) {
+                    if (auto e = ctx.beginError(job.ancestor->loc(), core::errors::Resolver::RedefinitionOfParents)) {
                         e.setHeader("Parent of class `{}` redefined from `{}` to `{}`", job.klass.show(ctx),
                                     job.klass.data(ctx)->superClass().show(ctx), resolvedClass.show(ctx));
                         if (!fileIsPayload && klassDefinedInPayload) {
@@ -1079,7 +1079,7 @@ private:
             }
         } else {
             if (!job.klass.data(ctx)->addMixin(ctx, resolvedClass, job.mixinIndex)) {
-                if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::IncludesNonModule)) {
+                if (auto e = ctx.beginError(job.ancestor->loc(), core::errors::Resolver::IncludesNonModule)) {
                     e.setHeader("Only modules can be `{}`d, but `{}` is a class", job.isInclude ? "include" : "extend",
                                 resolvedClass.show(ctx));
                     e.addErrorLine(resolvedClass.data(ctx)->loc(), "`{}` defined as a class here",
@@ -1131,7 +1131,7 @@ private:
                 }
                 continue;
             }
-            auto idLoc = core::Loc(todo.file, id->loc);
+            auto idLoc = core::Loc(todo.file, id->loc());
             if (!id->symbol().isClassOrModule()) {
                 if (auto e = gs.beginError(idLoc, core::errors::Resolver::InvalidMixinDeclaration)) {
                     e.setHeader("Argument to `{}` must be statically resolvable to a module", send->fun.show(gs));
@@ -1302,7 +1302,7 @@ private:
         if (auto cnst = ast::cast_tree<ast::ConstantLit>(ancestor)) {
             auto sym = cnst->symbol();
             if (sym.exists() && sym.isTypeAlias(ctx)) {
-                if (auto e = ctx.beginError(cnst->loc, core::errors::Resolver::DynamicSuperclass)) {
+                if (auto e = ctx.beginError(cnst->loc(), core::errors::Resolver::DynamicSuperclass)) {
                     e.setHeader("Superclasses and mixins may not be type aliases");
                 }
                 return;
@@ -1960,10 +1960,10 @@ public:
 
         for (auto &todos : todo) {
             fast_sort(todos.items, [](const ConstantResolutionItem &lhs, const ConstantResolutionItem &rhs) -> bool {
-                if (lhs.out->loc == rhs.out->loc) {
+                if (lhs.out->loc() == rhs.out->loc()) {
                     return constantDepth(lhs.out) < constantDepth(rhs.out);
                 }
-                return compareLocOffsets(lhs.out->loc, rhs.out->loc);
+                return compareLocOffsets(lhs.out->loc(), rhs.out->loc());
             });
         }
 
@@ -1972,10 +1972,10 @@ public:
 
         for (auto &todos : todoAncestors) {
             fast_sort(todos.items, [](const AncestorResolutionItem &lhs, const AncestorResolutionItem &rhs) -> bool {
-                if (lhs.ancestor->loc == rhs.ancestor->loc) {
+                if (lhs.ancestor->loc() == rhs.ancestor->loc()) {
                     return constantDepth(lhs.ancestor) < constantDepth(rhs.ancestor);
                 }
-                return compareLocOffsets(lhs.ancestor->loc, rhs.ancestor->loc);
+                return compareLocOffsets(lhs.ancestor->loc(), rhs.ancestor->loc());
             });
         }
 

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -696,14 +696,14 @@ optional<core::ClassOrModuleRef> parseTClassOf(core::Context ctx, const ast::Sen
     if (maybeAliased.isTypeAlias(ctx)) {
         if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
             e.setHeader("T.class_of can't be used with a T.type_alias");
-            maybeSuggestTClass(ctx, e, send.loc, obj->loc);
+            maybeSuggestTClass(ctx, e, send.loc, obj->loc());
         }
         return core::Symbols::untyped();
     }
     if (maybeAliased.isTypeMember()) {
         if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
             e.setHeader("T.class_of can't be used with a T.type_member");
-            maybeSuggestTClass(ctx, e, send.loc, obj->loc);
+            maybeSuggestTClass(ctx, e, send.loc, obj->loc());
         }
         return core::Symbols::untyped();
     }
@@ -711,7 +711,7 @@ optional<core::ClassOrModuleRef> parseTClassOf(core::Context ctx, const ast::Sen
     if (sym.isStaticField(ctx)) {
         if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
             e.setHeader("T.class_of can't be used with a constant field");
-            maybeSuggestTClass(ctx, e, send.loc, obj->loc);
+            maybeSuggestTClass(ctx, e, send.loc, obj->loc());
         }
         return core::Symbols::untyped();
     }
@@ -1145,10 +1145,10 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
                 auto level = klass.isLegacyStdlibGeneric() || klass == core::Symbols::Class()
                                  ? core::errors::Resolver::GenericClassWithoutTypeArgsStdlib
                                  : core::errors::Resolver::GenericClassWithoutTypeArgs;
-                if (auto e = ctx.beginError(i.loc, level)) {
+                if (auto e = ctx.beginError(i.loc(), level)) {
                     e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",
                                 klass.show(ctx));
-                    core::TypeErrorDiagnostics::insertTypeArguments(ctx, e, klass, ctx.locAt(i.loc));
+                    core::TypeErrorDiagnostics::insertTypeArguments(ctx, e, klass, ctx.locAt(i.loc()));
                 }
             }
             if (klass == core::Symbols::StubModule()) {
@@ -1209,7 +1209,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
                         // constructors like `Types::any` do not expect to see bound variables, and will panic.
                         result.type = core::make_type<core::SelfTypeParam>(sym);
                     } else {
-                        if (auto e = ctx.beginError(i.loc, core::errors::Resolver::TypeMemberScopeMismatch)) {
+                        if (auto e = ctx.beginError(i.loc(), core::errors::Resolver::TypeMemberScopeMismatch)) {
                             string typeSource = isTypeTemplate ? "type_template" : "type_member";
                             string typeStr = usedOnSourceClass ? symData->name.show(ctx) : sym.show(ctx);
 
@@ -1246,7 +1246,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
                     break;
                 }
                 case TypeSyntaxArgs::TypeMember::BannedInTypeAlias:
-                    if (auto e = ctx.beginError(i.loc, core::errors::Resolver::TypeAliasToTypeMember)) {
+                    if (auto e = ctx.beginError(i.loc(), core::errors::Resolver::TypeAliasToTypeMember)) {
                         const auto &owner = tm.data(ctx)->owner.asClassOrModuleRef().data(ctx);
                         auto memTem = owner->attachedClass(ctx).exists() ? "type_template" : "type_member";
                         e.setHeader("Defining a `{}` to a generic `{}` is not allowed", "type_alias", memTem);
@@ -1260,7 +1260,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
                     break;
                 case TypeSyntaxArgs::TypeMember::BannedInTypeMember:
                     // a type member has occurred in a context that doesn't allow them
-                    if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                    if (auto e = ctx.beginError(i.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                         auto flavor = isTypeTemplate ? "type_template"sv : "type_member"sv;
                         e.setHeader("`{}` `{}` is not allowed in this context", flavor, sym.show(ctx));
                     }
@@ -1268,14 +1268,14 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
                     break;
             }
         } else if (sym.isStaticField(ctx)) {
-            if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            if (auto e = ctx.beginError(i.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Constant `{}` is not a class or type alias", maybeAliased.show(ctx));
                 e.addErrorLine(sym.loc(ctx), "If you are trying to define a type alias, you should use `{}` here",
                                "T.type_alias");
             }
             result.type = core::Types::untypedUntracked();
         } else {
-            if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+            if (auto e = ctx.beginError(i.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Malformed type declaration. Not a class type `{}`", maybeAliased.show(ctx));
             }
             result.type = core::Types::untypedUntracked();

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -87,7 +87,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
             return nullptr;
         }
         if (orig == nullptr) {
-            return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol());
+            return ast::make_expression<ast::ConstantLit>(ident->loc(), ident->symbol());
         }
 
         return ast::make_expression<ast::ConstantLit>(ident->symbol(), std::move(orig));

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -82,8 +82,8 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
 
     auto ident = ast::cast_tree<ast::ConstantLit>(orig);
     if (ident) {
-        auto orig = dupUnresolvedConstantLit(ident->original.get());
-        if (ident->original && !orig) {
+        auto orig = dupUnresolvedConstantLit(ident->original());
+        if (ident->original() && !orig) {
             return nullptr;
         }
         if (orig == nullptr) {

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -86,7 +86,11 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         if (ident->original && !orig) {
             return nullptr;
         }
-        return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol(), std::move(orig));
+        if (orig == nullptr) {
+            return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol());
+        }
+
+        return ast::make_expression<ast::ConstantLit>(ident->symbol(), std::move(orig));
     }
 
     auto arrayLit = ast::cast_tree<ast::Array>(orig);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is roughly the same PR as #5931, except that jez was correct -- we do need to preserve location information even on known `core::SymbolRef` `ConstantLit`s, so this PR takes a slightly different approach to representing those.  You can think of this PR as just being a slight generalization of the `ResolutionScopesOrSymbol` approach taken in #8536 and #4954; we just have to represent a third state for known `ConstantLit`s.

The PR should be reviewable commit-by-commit; the only really tricky commit is the one that packs everything down to 16 bytes, but ideally there are enough comments and `ENFORCE`s to ensure that we didn't/won't make any mistakes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.