### PR TITLE
Avoid updating the file table on the slow path

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -299,21 +299,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     return toTypecheck;
 }
 
-namespace {
-ast::ParsedFile updateFile(core::GlobalState &gs, shared_ptr<core::File> file, const options::Options &opts) {
-    core::FileRef fref = gs.findFileByPath(file->path());
-    if (fref.exists()) {
-        gs.replaceFile(fref, std::move(file));
-    } else {
-        fref = gs.enterFile(std::move(file));
-    }
-    fref.data(gs).strictLevel = pipeline::decideStrictLevel(gs, fref, opts);
-    return pipeline::indexOne(opts, gs, fref);
-}
-} // namespace
-
-bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &ignore,
-                                 vector<ast::ParsedFile> &out) const {
+bool LSPTypechecker::copyIndexed(WorkerPool &workers, vector<ast::ParsedFile> &out) const {
     auto &logger = *config->logger;
     Timer timeit(logger, "slow_path.copy_indexes");
     shared_ptr<ConcurrentBoundedQueue<int>> fileq = make_shared<ConcurrentBoundedQueue<int>>(indexed.size());
@@ -324,7 +310,7 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
     const auto &epochManager = *gs->epochManager;
     shared_ptr<BlockingBoundedQueue<vector<ast::ParsedFile>>> resultq =
         make_shared<BlockingBoundedQueue<vector<ast::ParsedFile>>>(indexed.size());
-    workers.multiplexJob("copyParsedFiles", [fileq, resultq, &indexed = this->indexed, &ignore, &epochManager]() {
+    workers.multiplexJob("copyParsedFiles", [fileq, resultq, &indexed = this->indexed, &epochManager]() {
         vector<ast::ParsedFile> threadResult;
         int processedByThread = 0;
         int job;
@@ -337,7 +323,7 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
                     if (!epochManager.wasTypecheckingCanceled()) {
                         const auto &tree = indexed[job];
                         // Note: indexed entries for payload files don't have any contents.
-                        if (tree.tree && !ignore.contains(tree.file.id())) {
+                        if (tree.tree) {
                             threadResult.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
                         }
                     }
@@ -396,9 +382,6 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
     // cancelation feature is enabled.
     auto committed = epochManager.tryCommitEpoch(*finalGS, epoch, cancelable, preemptManager, [&]() -> void {
-        UnorderedSet<int> updatedFiles;
-        vector<ast::ParsedFile> indexedCopies;
-
         // Replace error queue with one that is owned by this thread.
         auto savedErrorQueue = std::exchange(
             finalGS->errorQueue,
@@ -452,17 +435,30 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                 // If we're not initializing, there's no need to hold on to the old error queue.
                 savedErrorQueue = nullptr;
 
-                // Index the updated files using finalGS.
+                // As finalGS is a copy of the indexer's GlobalState, all of the indexed trees in the update are valid
+                // with it. Additionally, the file table is guaranteed to be up-to-date, as it's also a copy of the
+                // indexer's file table. As a result, if there are updates to perform we can ignore updating our file
+                // table. We can't however skip re-indexing the updated files, as that's what will cause the indexer
+                // errors to show up in the editor.
                 if (!updates.updatedFiles.empty()) {
                     auto &gs = *finalGS;
-                    core::UnfreezeFileTable fileTableAccess(gs);
-                    for (auto &file : updates.updatedFiles) {
-                        auto parsedFile = updateFile(gs, std::move(file), config->opts);
-                        if (parsedFile.tree) {
-                            indexedCopies.emplace_back(ast::ParsedFile{parsedFile.tree.deepCopy(), parsedFile.file});
-                            updatedFiles.insert(parsedFile.file.id());
+
+                    // Verify that our file table is sane.
+                    if constexpr (debug_mode) {
+                        auto ix = -1;
+                        for (auto &file : updates.updatedFiles) {
+                            ++ix;
+                            auto fref = gs.findFileByPath(file->path());
+                            auto &parsedFile = updates.updatedFileIndexes[ix];
+                            ENFORCE_NO_TIMER(fref == parsedFile.file);
                         }
-                        updates.updatedFinalGSFileIndexes.push_back(move(parsedFile));
+                    }
+
+                    for (auto &parsedFile : updates.updatedFileIndexes) {
+                        auto ast = pipeline::indexOne(this->config->opts, gs, parsedFile.file);
+                        if (ast.tree != nullptr) {
+                            updates.updatedFinalGSFileIndexes.emplace_back(std::move(ast));
+                        }
                     }
                 }
 
@@ -477,7 +473,8 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
         // We use `gs` rather than the moved `finalGS` from this point forward.
 
         // Copy the indexes of unchanged files.
-        if (copyIndexed(workers, updatedFiles, indexedCopies)) {
+        vector<ast::ParsedFile> indexedCopies;
+        if (copyIndexed(workers, indexedCopies)) {
             // Canceled.
             return;
         }

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -117,9 +117,9 @@ class LSPTypechecker final {
     /** Commits the given file updates to LSPTypechecker. Does not send diagnostics. */
     void commitFileUpdates(LSPFileUpdates &updates, bool couldBeCanceled);
 
-    /** Deep copy all entries in `indexed` that contain ASTs, except for those with IDs in the ignore set. Returns true
-     * on success, false if the operation was canceled. */
-    bool copyIndexed(WorkerPool &workers, const UnorderedSet<int> &ignore, std::vector<ast::ParsedFile> &out) const;
+    /** Deep copy all entries in `indexed` that contain ASTs. Returns true on success, false if the operation was
+     * canceled. */
+    bool copyIndexed(WorkerPool &workers, std::vector<ast::ParsedFile> &out) const;
 
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -119,7 +119,7 @@ class LSPTypechecker final {
 
     /** Deep copy all entries in `indexed` that contain ASTs. Returns true on success, false if the operation was
      * canceled. */
-    bool copyIndexed(WorkerPool &workers, std::vector<ast::ParsedFile> &out) const;
+    ast::ParsedFilesOrCancelled copyIndexed(WorkerPool &workers) const;
 
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,


### PR DESCRIPTION
As the slow path receives a copy of the indexer's global state, and all of the updated files should be valid in that global state already, we shouldn't need to perform any file updates on the slow path. This PR removes the associated updating, and as an effect removes the filtering of updated files from `LSPIndexer::copyIndexed`.


### Motivation
Avoiding unnecessary work in the slow path.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I made the `debug_mode` check for valid file refs unconditional, and replaced the enforce with a check that would raise an exception on failure. From there, I tested that build on Stripe's codebase, and exercised the following workflows:
1. Opening rbis from the payload and triggering a slow path
2. Adding a new file and triggering the slow path
3. Modifying the class hierarchy
4. Refactoring an instance method into a singleton method
5. Find all references

The exception was never raised, giving me confidence that this is the right change.

For posterity, here's the diff that I applied while testing locally:

```diff
diff --git a/main/lsp/LSPTypechecker.cc b/main/lsp/LSPTypechecker.cc
index 52586a2a4..ead88645c 100644
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -444,13 +444,15 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                     auto &gs = *finalGS;

                     // Verify that our file table is sane.
-                    if constexpr (debug_mode) {
-                        auto ix = -1;
-                        for (auto &file : updates.updatedFiles) {
-                            ++ix;
-                            auto fref = gs.findFileByPath(file->path());
-                            auto &parsedFile = updates.updatedFileIndexes[ix];
-                            ENFORCE_NO_TIMER(fref == parsedFile.file);
+                    auto ix = -1;
+                    for (auto &file : updates.updatedFiles) {
+                        ++ix;
+                        auto fref = gs.findFileByPath(file->path());
+                        auto &parsedFile = updates.updatedFileIndexes[ix];
+                        if (fref != parsedFile.file) {
+                            Exception::raise("missing file present in the updates.\nindex: ({}){}\n file: ({}){}",
+                                             parsedFile.file.id(), parsedFile.file.data(gs).path(),
+                                             fref.id(), fref.data(gs).path());
                         }
                     }
```