### PR TITLE
Avoid using `.at(0)` in getResolved

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -783,9 +783,15 @@ vector<ast::ParsedFile> LSPTypechecker::getResolved(absl::Span<const core::FileR
 ast::ParsedFile LSPTypechecker::getResolved(core::FileRef fref, WorkerPool &workers) const {
     std::vector<ast::ParsedFile> trees = this->getResolved(std::initializer_list<core::FileRef>{fref}, workers);
 
-    ENFORCE(trees.size() == 1);
-    // We explicitly use `.at(0)` so that we see a crash if the above ENFORCE is violated in a release build.
-    return std::move(trees.at(0));
+    if (trees.empty()) {
+        // This case can happen if the associated file ref was to a payload file, in which case the tree will be
+        // `nullptr` in `this->indexed` and not added to the vector produced by the multi-file version of
+        // `this-fgetResolved`.
+        return ast::ParsedFile{nullptr, fref};
+    } else {
+        ENFORCE(trees.size() == 1);
+        return std::move(trees.front());
+    }
 }
 
 const core::GlobalState &LSPTypechecker::state() const {


### PR DESCRIPTION
In #8553 we switched the behavior of `LSPTypechecker::getResolved` with a single file from producing a nullptr tree to crashing at runtime, under the assumption that we would never see that case. However, payload rbis are one case where this can happen, and we're seeing crashes as a result.

### Motivation
Fixing runtime crashes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I spent some time trying to write a protocol test for this, but am having trouble triggering the error from there. I'll continue working on it in a follow-up.