### PR TITLE
feat: detect duplicate members in struct definitions

### DIFF
--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -74,6 +74,15 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
     ast::Send::ARGS_store sigArgs;
     ast::ClassDef::RHS_store body;
 
+    if (auto dup = ASTUtil::findDuplicateArg(ctx, send)) {
+        if (auto e = ctx.beginError(dup->secondLoc, core::errors::Rewriter::InvalidStructMember)) {
+            e.setHeader("Duplicate member '{}' in Data definition", dup->name.show(ctx));
+            e.addErrorLine(ctx.locAt(dup->firstLoc), "First occurrence of '{}' in Data definition",
+                           dup->name.show(ctx));
+        }
+        return empty;
+    }
+
     for (auto &arg : send->posArgs()) {
         auto sym = ast::cast_tree<ast::Literal>(arg);
         if (!sym || !sym->isName()) {

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -76,8 +76,8 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
 
     if (auto dup = ASTUtil::findDuplicateArg(ctx, send)) {
         if (auto e = ctx.beginError(dup->secondLoc, core::errors::Rewriter::InvalidStructMember)) {
-            e.setHeader("Duplicate member '{}' in Data definition", dup->name.show(ctx));
-            e.addErrorLine(ctx.locAt(dup->firstLoc), "First occurrence of '{}' in Data definition",
+            e.setHeader("Duplicate member `{}` in Data definition", dup->name.show(ctx));
+            e.addErrorLine(ctx.locAt(dup->firstLoc), "First occurrence of `{}` in Data definition",
                            dup->name.show(ctx));
         }
         return empty;

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -112,8 +112,8 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
 
     if (auto dup = ASTUtil::findDuplicateArg(ctx, send)) {
         if (auto e = ctx.beginError(dup->secondLoc, core::errors::Rewriter::InvalidStructMember)) {
-            e.setHeader("Duplicate member '{}' in Struct definition", dup->name.show(ctx));
-            e.addErrorLine(ctx.locAt(dup->firstLoc), "First occurrence of '{}' in Struct definition",
+            e.setHeader("Duplicate member `{}` in Struct definition", dup->name.show(ctx));
+            e.addErrorLine(ctx.locAt(dup->firstLoc), "First occurrence of `{}` in Struct definition",
                            dup->name.show(ctx));
         }
         return empty;

--- a/rewriter/util/Util.h
+++ b/rewriter/util/Util.h
@@ -47,6 +47,12 @@ public:
     // 4. Prelude::Opus::Command as `expr` would not match {Constants::Opus(), Constants::Command()}
     static bool isRootScopedSyntacticConstant(const ast::ExpressionPtr &expr,
                                               absl::Span<const core::NameRef> constantName);
+    struct DuplicateArg {
+        core::NameRef name;
+        core::LocOffsets firstLoc;
+        core::LocOffsets secondLoc;
+    };
+    static std::optional<DuplicateArg> findDuplicateArg(core::MutableContext ctx, const ast::Send *send);
 
     ASTUtil() = delete;
 };

--- a/test/testdata/rewriter/data_duplicate_args.rb
+++ b/test/testdata/rewriter/data_duplicate_args.rb
@@ -13,4 +13,3 @@ class TestData
   
     ValidData3 = Data.define(:foo, "bar")
   end
-  

--- a/test/testdata/rewriter/data_duplicate_args.rb
+++ b/test/testdata/rewriter/data_duplicate_args.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+class TestData
+    DuplicateData1 = Data.define(:foo, :foo) # error: Duplicate member 'foo' in Data definition
+  
+    DuplicateData2 = Data.define(:foo, 'foo') # error: Duplicate member 'foo' in Data definition
+  
+    DuplicateData3 = Data.define("FooDataDup", :foo, :bar, :foo) # error: Duplicate member 'foo' in Data definition
+  
+    ValidData1 = Data.define(:foo, :bar)
+  
+    ValidData2 = Data.define("FooData", :foo, :bar)
+  
+    ValidData3 = Data.define(:foo, "bar")
+  end
+  

--- a/test/testdata/rewriter/data_duplicate_args.rb
+++ b/test/testdata/rewriter/data_duplicate_args.rb
@@ -1,15 +1,18 @@
 # typed: true
 
 class TestData
-    DuplicateData1 = Data.define(:foo, :foo) # error: Duplicate member 'foo' in Data definition
-  
-    DuplicateData2 = Data.define(:foo, 'foo') # error: Duplicate member 'foo' in Data definition
-  
-    DuplicateData3 = Data.define("FooDataDup", :foo, :bar, :foo) # error: Duplicate member 'foo' in Data definition
-  
-    ValidData1 = Data.define(:foo, :bar)
-  
-    ValidData2 = Data.define("FooData", :foo, :bar)
-  
-    ValidData3 = Data.define(:foo, "bar")
-  end
+  DuplicateData1 = Data.define(:foo, :foo)
+  #                                  ^^^^ error: Duplicate member 'foo' in Data definition
+
+  DuplicateData2 = Data.define(:foo, 'foo')
+  #                                  ^^^^^ error: Duplicate member 'foo' in Data definition
+
+  DuplicateData3 = Data.define("FooDataDup", :foo, :bar, :foo)
+  #                                                      ^^^^ error: Duplicate member 'foo' in Data definition
+
+  ValidData1 = Data.define(:foo, :bar)
+
+  ValidData2 = Data.define("FooData", :foo, :bar)
+
+  ValidData3 = Data.define(:foo, "bar")
+end

--- a/test/testdata/rewriter/data_duplicate_args.rb
+++ b/test/testdata/rewriter/data_duplicate_args.rb
@@ -2,13 +2,13 @@
 
 class TestData
   DuplicateData1 = Data.define(:foo, :foo)
-  #                                  ^^^^ error: Duplicate member 'foo' in Data definition
+  #                                  ^^^^ error: Duplicate member `foo` in Data definition
 
   DuplicateData2 = Data.define(:foo, 'foo')
-  #                                  ^^^^^ error: Duplicate member 'foo' in Data definition
+  #                                  ^^^^^ error: Duplicate member `foo` in Data definition
 
   DuplicateData3 = Data.define("FooDataDup", :foo, :bar, :foo)
-  #                                                      ^^^^ error: Duplicate member 'foo' in Data definition
+  #                                                      ^^^^ error: Duplicate member `foo` in Data definition
 
   ValidData1 = Data.define(:foo, :bar)
 

--- a/test/testdata/rewriter/struct_duplicate_args.rb
+++ b/test/testdata/rewriter/struct_duplicate_args.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+class TestStructs
+    DuplicateStruct1 = Struct.new(:foo, :foo) # error: Duplicate member 'foo' in Struct definition
+
+    DuplicateStruct2 = Struct.new(:foo, 'foo') # error: Duplicate member 'foo' in Struct definition
+  
+    DuplicateStruct3 = Struct.new("FooStructDup", :foo, :bar, :foo) # error: Duplicate member 'foo' in Struct definition
+  
+    DuplicateStruct4 = Struct.new(:foo, :bar, :foo, keyword_init: true) # error: Duplicate member 'foo' in Struct definition
+  
+    ValidStruct1 = Struct.new(:foo, :bar)
+  
+    ValidStruct2 = Struct.new("FooStruct", :foo, :bar)
+  
+    ValidStruct3 = Struct.new(:foo, "bar")
+  
+    ValidStruct4 = Struct.new(:foo, :bar, keyword_init: true)
+  
+  end
+ 

--- a/test/testdata/rewriter/struct_duplicate_args.rb
+++ b/test/testdata/rewriter/struct_duplicate_args.rb
@@ -1,20 +1,20 @@
 # typed: true
 
 class TestStructs
-    DuplicateStruct1 = Struct.new(:foo, :foo) # error: Duplicate member 'foo' in Struct definition
+  DuplicateStruct1 = Struct.new(:foo, :foo) # error: Duplicate member 'foo' in Struct definition
 
-    DuplicateStruct2 = Struct.new(:foo, 'foo') # error: Duplicate member 'foo' in Struct definition
-  
-    DuplicateStruct3 = Struct.new("FooStructDup", :foo, :bar, :foo) # error: Duplicate member 'foo' in Struct definition
-  
-    DuplicateStruct4 = Struct.new(:foo, :bar, :foo, keyword_init: true) # error: Duplicate member 'foo' in Struct definition
-  
-    ValidStruct1 = Struct.new(:foo, :bar)
-  
-    ValidStruct2 = Struct.new("FooStruct", :foo, :bar)
-  
-    ValidStruct3 = Struct.new(:foo, "bar")
-  
-    ValidStruct4 = Struct.new(:foo, :bar, keyword_init: true)
-  
-  end
+  DuplicateStruct2 = Struct.new(:foo, 'foo') # error: Duplicate member 'foo' in Struct definition
+
+  DuplicateStruct3 = Struct.new("FooStructDup", :foo, :bar, :foo) # error: Duplicate member 'foo' in Struct definition
+
+  DuplicateStruct4 = Struct.new(:foo, :bar, :foo, keyword_init: true) # error: Duplicate member 'foo' in Struct definition
+
+  ValidStruct1 = Struct.new(:foo, :bar)
+
+  ValidStruct2 = Struct.new("FooStruct", :foo, :bar)
+
+  ValidStruct3 = Struct.new(:foo, "bar")
+
+  ValidStruct4 = Struct.new(:foo, :bar, keyword_init: true)
+
+end

--- a/test/testdata/rewriter/struct_duplicate_args.rb
+++ b/test/testdata/rewriter/struct_duplicate_args.rb
@@ -18,4 +18,3 @@ class TestStructs
     ValidStruct4 = Struct.new(:foo, :bar, keyword_init: true)
   
   end
- 

--- a/test/testdata/rewriter/struct_duplicate_args.rb
+++ b/test/testdata/rewriter/struct_duplicate_args.rb
@@ -1,13 +1,17 @@
 # typed: true
 
 class TestStructs
-  DuplicateStruct1 = Struct.new(:foo, :foo) # error: Duplicate member 'foo' in Struct definition
+  DuplicateStruct1 = Struct.new(:foo, :foo)
+  #                                   ^^^^ error: Duplicate member 'foo' in Struct definition
 
-  DuplicateStruct2 = Struct.new(:foo, 'foo') # error: Duplicate member 'foo' in Struct definition
+  DuplicateStruct2 = Struct.new(:foo, 'foo')
+  #                                   ^^^^^ error: Duplicate member 'foo' in Struct definition
 
-  DuplicateStruct3 = Struct.new("FooStructDup", :foo, :bar, :foo) # error: Duplicate member 'foo' in Struct definition
+  DuplicateStruct3 = Struct.new("FooStructDup", :foo, :bar, :foo)
+  #                                                         ^^^^ error: Duplicate member 'foo' in Struct definition
 
-  DuplicateStruct4 = Struct.new(:foo, :bar, :foo, keyword_init: true) # error: Duplicate member 'foo' in Struct definition
+  DuplicateStruct4 = Struct.new(:foo, :bar, :foo, keyword_init: true)
+  #                                         ^^^^ error: Duplicate member 'foo' in Struct definition
 
   ValidStruct1 = Struct.new(:foo, :bar)
 
@@ -16,5 +20,4 @@ class TestStructs
   ValidStruct3 = Struct.new(:foo, "bar")
 
   ValidStruct4 = Struct.new(:foo, :bar, keyword_init: true)
-
 end

--- a/test/testdata/rewriter/struct_duplicate_args.rb
+++ b/test/testdata/rewriter/struct_duplicate_args.rb
@@ -2,16 +2,16 @@
 
 class TestStructs
   DuplicateStruct1 = Struct.new(:foo, :foo)
-  #                                   ^^^^ error: Duplicate member 'foo' in Struct definition
+  #                                   ^^^^ error: Duplicate member `foo` in Struct definition
 
   DuplicateStruct2 = Struct.new(:foo, 'foo')
-  #                                   ^^^^^ error: Duplicate member 'foo' in Struct definition
+  #                                   ^^^^^ error: Duplicate member `foo` in Struct definition
 
   DuplicateStruct3 = Struct.new("FooStructDup", :foo, :bar, :foo)
-  #                                                         ^^^^ error: Duplicate member 'foo' in Struct definition
+  #                                                         ^^^^ error: Duplicate member `foo` in Struct definition
 
   DuplicateStruct4 = Struct.new(:foo, :bar, :foo, keyword_init: true)
-  #                                         ^^^^ error: Duplicate member 'foo' in Struct definition
+  #                                         ^^^^ error: Duplicate member `foo` in Struct definition
 
   ValidStruct1 = Struct.new(:foo, :bar)
 


### PR DESCRIPTION
Detects duplicate arguments in struct definitions. Note that there's a simpler way to do this where we'd only catch errors of the `Struct.new(:foo, :foo)` variety (and not those involving strings), but we could remove the functionality where we handle strings in addition to symbols.

On this note - is there any specific reason _why_ we previously bailed on line 117 if it's not a symbol? Curious because I'm not 100% sure this change does not have implications beyond detecting duplicate args.


### Motivation
Fixes https://github.com/sorbet/sorbet/issues/8275


### Test plan
See included automated tests.
