### PR TITLE
Manage LSPFileUpdates values through a unique_ptr

### DIFF
--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -62,6 +62,13 @@ public:
      */
     LSPFileUpdates copy() const;
 
+    LSPFileUpdates() = default;
+    LSPFileUpdates(LSPFileUpdates &&other) = default;
+    LSPFileUpdates &operator=(LSPFileUpdates &&other) = default;
+
+    LSPFileUpdates(const LSPFileUpdates &other) = delete;
+    LSPFileUpdates &operator=(const LSPFileUpdates &other) = delete;
+
     struct FastPathFilesToTypecheckResult {
         // The number of files that would be checked in the fast path.
         size_t totalChanged = 0;

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -284,9 +284,10 @@ void LSPIndexer::initialize(IndexerInitializationTask &task, std::unique_ptr<cor
     this->initialGS = std::move(initialGS);
 }
 
-LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPool &workers) {
+std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPool &workers) {
     Timer timeit(config->logger, "LSPIndexer::commitEdit");
-    LSPFileUpdates update;
+    auto result = std::make_unique<LSPFileUpdates>();
+    auto &update = *result;
     update.epoch = edit.epoch;
     update.editCount = edit.mergeCount + 1;
     update.updatedFiles = move(edit.updates);
@@ -408,10 +409,10 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPoo
     pendingTypecheckUpdates.cancellationExpected = false;
     pendingTypecheckUpdates.preemptionsExpected = 0;
 
-    return update;
+    return result;
 }
 
-LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
+std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
     ENFORCE(edit.updates.size() <= config->opts.lspMaxFilesOnFastPath, "Too many files to index serially");
     return commitEdit(edit, *emptyWorkers);
 }

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -90,8 +90,8 @@ public:
      * Commits the given edit to `initialGS`, and returns a canonical LSPFileUpdates object containing indexed trees
      * and file hashes. Also handles canceling the running slow path.
      */
-    LSPFileUpdates commitEdit(SorbetWorkspaceEditParams &edit, WorkerPool &workers);
-    LSPFileUpdates commitEdit(SorbetWorkspaceEditParams &edit);
+    std::unique_ptr<LSPFileUpdates> commitEdit(SorbetWorkspaceEditParams &edit, WorkerPool &workers);
+    std::unique_ptr<LSPFileUpdates> commitEdit(SorbetWorkspaceEditParams &edit);
 
     /**
      * Retrieves the file ref for the given file, if exists.

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -86,7 +86,7 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
         const bool isIncremental = false;
         ErrorEpoch epoch(*errorReporter, updates.epoch, isIncremental, {});
         auto errorFlusher = make_shared<ErrorFlusherLSP>(updates.epoch, errorReporter);
-        auto result = runSlowPath(std::move(updates), std::move(kvstore), workers, errorFlusher, SlowPathMode::Init);
+        auto result = runSlowPath(updates, std::move(kvstore), workers, errorFlusher, SlowPathMode::Init);
         epoch.committed = true;
         ENFORCE(std::holds_alternative<std::unique_ptr<core::GlobalState>>(result));
         initialGS = std::move(std::get<std::unique_ptr<core::GlobalState>>(result));
@@ -104,11 +104,11 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
     config->logger->error("Resuming");
 }
 
-bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
+bool LSPTypechecker::typecheck(std::unique_ptr<LSPFileUpdates> updates, WorkerPool &workers,
                                vector<unique_ptr<Timer>> diagnosticLatencyTimers) {
     ENFORCE(this_thread::get_id() == typecheckerThreadId, "Typechecker can only be used from the typechecker thread.");
     ENFORCE(this->initialized);
-    if (updates.canceledSlowPath) {
+    if (updates->canceledSlowPath) {
         // This update canceled the last slow path, so we should have undo state to restore to go to the point _before_
         // that slow path. This should always be the case, but let's not crash release builds.
         ENFORCE(cancellationUndoState != nullptr);
@@ -126,12 +126,12 @@ bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
             }
 
             cancellationUndoState = nullptr;
-            auto fastPathDecision = updates.typecheckingPath;
+            auto fastPathDecision = updates->typecheckingPath;
             // Retypecheck all of the files that previously had errors.
-            updates.mergeOlder(getNoopUpdate(oldFilesWithErrors));
+            updates->mergeOlder(*getNoopUpdate(oldFilesWithErrors));
             // The merge operation resets `fastPathDecision`, but we know that retypechecking unchanged files
             // has no influence on the fast path decision.
-            updates.typecheckingPath = fastPathDecision;
+            updates->typecheckingPath = fastPathDecision;
         } else {
             config->logger->debug("[Typechecker] Error: UndoState is missing for update that canceled slow path!");
         }
@@ -139,19 +139,19 @@ bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
 
     vector<core::FileRef> filesTypechecked;
     bool committed = true;
-    const bool isFastPath = updates.typecheckingPath == TypecheckingPath::Fast;
-    sendTypecheckInfo(*config, *gs, SorbetTypecheckRunStatus::Started, updates.typecheckingPath, {});
+    const bool isFastPath = updates->typecheckingPath == TypecheckingPath::Fast;
+    sendTypecheckInfo(*config, *gs, SorbetTypecheckRunStatus::Started, updates->typecheckingPath, {});
     {
-        ErrorEpoch epoch(*errorReporter, updates.epoch, isFastPath, move(diagnosticLatencyTimers));
+        ErrorEpoch epoch(*errorReporter, updates->epoch, isFastPath, move(diagnosticLatencyTimers));
 
-        auto errorFlusher = make_shared<ErrorFlusherLSP>(updates.epoch, errorReporter);
+        auto errorFlusher = make_shared<ErrorFlusherLSP>(updates->epoch, errorReporter);
         if (isFastPath) {
             bool isNoopUpdateForRetypecheck = false;
-            filesTypechecked = runFastPath(updates, workers, errorFlusher, isNoopUpdateForRetypecheck);
-            commitFileUpdates(updates, /* cancelable */ false);
+            filesTypechecked = runFastPath(*updates, workers, errorFlusher, isNoopUpdateForRetypecheck);
+            commitFileUpdates(*updates, /* cancelable */ false);
             prodCategoryCounterInc("lsp.updates", "fastpath");
         } else {
-            auto result = runSlowPath(move(updates), nullptr, workers, errorFlusher, SlowPathMode::Cancelable);
+            auto result = runSlowPath(*updates, nullptr, workers, errorFlusher, SlowPathMode::Cancelable);
             ENFORCE(std::holds_alternative<bool>(result));
             committed = std::get<bool>(result);
         }
@@ -159,7 +159,7 @@ bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
     }
 
     sendTypecheckInfo(*config, *gs, committed ? SorbetTypecheckRunStatus::Ended : SorbetTypecheckRunStatus::Cancelled,
-                      updates.typecheckingPath, move(filesTypechecked));
+                      updates->typecheckingPath, move(filesTypechecked));
     return committed;
 }
 
@@ -368,7 +368,7 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
     return epochManager.wasTypecheckingCanceled();
 }
 
-LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates updates,
+LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updates,
                                                            std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
                                                            shared_ptr<core::ErrorFlusher> errorFlusher,
                                                            LSPTypechecker::SlowPathMode mode) {
@@ -718,8 +718,9 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const std::vecto
     return LSPQueryResult{queryCollector->drainQueryResponses(), nullptr};
 }
 
-LSPFileUpdates LSPTypechecker::getNoopUpdate(std::vector<core::FileRef> frefs) const {
-    LSPFileUpdates noop;
+std::unique_ptr<LSPFileUpdates> LSPTypechecker::getNoopUpdate(std::vector<core::FileRef> frefs) const {
+    auto result = std::make_unique<LSPFileUpdates>();
+    auto &noop = *result;
     noop.typecheckingPath = TypecheckingPath::Fast;
     // Epoch isn't important for this update.
     noop.epoch = 0;
@@ -732,15 +733,15 @@ LSPFileUpdates LSPTypechecker::getNoopUpdate(std::vector<core::FileRef> frefs) c
         noop.updatedFileIndexes.push_back({(index.tree ? index.tree.deepCopy() : nullptr), index.file});
         noop.updatedFiles.push_back(gs->getFiles()[fref.id()]);
     }
-    return noop;
+    return result;
 }
 
 std::vector<std::unique_ptr<core::Error>> LSPTypechecker::retypecheck(vector<core::FileRef> frefs,
                                                                       WorkerPool &workers) const {
-    LSPFileUpdates updates = getNoopUpdate(move(frefs));
+    auto updates = getNoopUpdate(move(frefs));
     auto errorCollector = make_shared<core::ErrorCollector>();
     bool isNoopUpdateForRetypecheck = true;
-    runFastPath(updates, workers, errorCollector, isNoopUpdateForRetypecheck);
+    runFastPath(*updates, workers, errorCollector, isNoopUpdateForRetypecheck);
 
     return errorCollector->drainErrors();
 }
@@ -841,12 +842,12 @@ void LSPTypecheckerDelegate::resumeTaskQueue(InitializedTask &task) {
     this->queue.resume();
 }
 
-void LSPTypecheckerDelegate::typecheckOnFastPath(LSPFileUpdates updates,
+void LSPTypecheckerDelegate::typecheckOnFastPath(std::unique_ptr<LSPFileUpdates> updates,
                                                  vector<unique_ptr<Timer>> diagnosticLatencyTimers) {
-    if (updates.typecheckingPath != TypecheckingPath::Fast) {
+    if (updates->typecheckingPath != TypecheckingPath::Fast) {
         Exception::raise("Tried to typecheck a slow path edit on the fast path.");
     }
-    auto committed = typechecker.typecheck(move(updates), workers, move(diagnosticLatencyTimers));
+    auto committed = typechecker.typecheck(std::move(updates), workers, move(diagnosticLatencyTimers));
     // Fast path edits can't be canceled.
     ENFORCE(committed);
 }
@@ -883,7 +884,7 @@ void LSPTypecheckerDelegate::updateGsFromOptions(const DidChangeConfigurationPar
     typechecker.updateGsFromOptions(options);
 }
 
-LSPFileUpdates LSPTypecheckerDelegate::getNoopUpdate(std::vector<core::FileRef> frefs) const {
+std::unique_ptr<LSPFileUpdates> LSPTypecheckerDelegate::getNoopUpdate(std::vector<core::FileRef> frefs) const {
     return typechecker.getNoopUpdate(frefs);
 }
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -106,7 +106,7 @@ class LSPTypechecker final {
 
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */
-    SlowPathResult runSlowPath(LSPFileUpdates updates, std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
+    SlowPathResult runSlowPath(LSPFileUpdates &updates, std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
                                std::shared_ptr<core::ErrorFlusher> errorFlusher, SlowPathMode mode);
 
     /** Runs incremental typechecking on the provided updates. Returns the final list of files typechecked. */
@@ -139,7 +139,7 @@ public:
      * Typechecks the given input. Returns 'true' if the updates were committed, or 'false' if typechecking was
      * canceled. Distributes work across the given worker pool.
      */
-    bool typecheck(LSPFileUpdates updates, WorkerPool &workers,
+    bool typecheck(std::unique_ptr<LSPFileUpdates> updates, WorkerPool &workers,
                    std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
 
     /**
@@ -207,7 +207,7 @@ public:
      * Get an LSPFileUpdates containing the latest versions of the given files. It's a "no-op" file update because it
      * doesn't actually change anything.
      */
-    LSPFileUpdates getNoopUpdate(std::vector<core::FileRef> frefs) const;
+    std::unique_ptr<LSPFileUpdates> getNoopUpdate(std::vector<core::FileRef> frefs) const;
 };
 
 /**
@@ -241,7 +241,8 @@ public:
 
     void resumeTaskQueue(InitializedTask &task);
 
-    void typecheckOnFastPath(LSPFileUpdates updates, std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
+    void typecheckOnFastPath(std::unique_ptr<LSPFileUpdates> updates,
+                             std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);
     std::vector<std::unique_ptr<core::Error>> retypecheck(std::vector<core::FileRef> frefs) const;
     LSPQueryResult query(const core::lsp::Query &q, const std::vector<core::FileRef> &filesForQuery) const;
     const ast::ParsedFile &getIndexed(core::FileRef fref) const;
@@ -252,7 +253,7 @@ public:
     const core::GlobalState &state() const;
 
     void updateGsFromOptions(const DidChangeConfigurationParams &options) const;
-    LSPFileUpdates getNoopUpdate(std::vector<core::FileRef> frefs) const;
+    std::unique_ptr<LSPFileUpdates> getNoopUpdate(std::vector<core::FileRef> frefs) const;
 };
 } // namespace sorbet::realmain::lsp
 #endif

--- a/main/lsp/notifications/did_change_configuration.cc
+++ b/main/lsp/notifications/did_change_configuration.cc
@@ -26,7 +26,7 @@ void DidChangeConfigurationTask::run(LSPTypecheckerDelegate &tc) {
         openFileRefs.push_back(tc.state().findFileByPath(path));
     }
     auto updates = tc.getNoopUpdate(openFileRefs);
-    updates.epoch = epoch;
+    updates->epoch = epoch;
     tc.typecheckOnFastPath(std::move(updates), {});
 }
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
LSPFileUpdates is a very large type, and we move it around a lot. Instead, let's allocate it in the heap when we know that ownership will be passed around, avoiding using its move constructor.

### Motivation
Being more explicit about ownership of `LSPFileUpdates`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a No behavior should change as a result of this.
