### PR TITLE
comment out some slow counter gathering

### DIFF
--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -87,7 +87,8 @@ optional<ErrorSection> TypeAndOrigins::explainGot(const GlobalState &gs, Loc ori
 TypeAndOrigins::TypeAndOrigins(TypePtr type, Loc origin) : type(std::move(type)), origins(1, origin) {}
 
 TypeAndOrigins::~TypeAndOrigins() noexcept {
-    histogramInc("TypeAndOrigins.origins.size", origins.size());
+    // This counting turns out to be rather slow for tests.
+    // histogramInc("TypeAndOrigins.origins.size", origins.size());
 }
 
 } // namespace sorbet::core

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -346,10 +346,12 @@ void TestedKnowledge::removeReferencesToVar(cfg::LocalRef var) {
 }
 
 void TestedKnowledge::emitKnowledgeSizeMetric() const {
-    histogramInc("infer.knowledge.truthy.yes.size", _truthy->yesTypeTests.size());
-    histogramInc("infer.knowledge.truthy.no.size", _truthy->noTypeTests.size());
-    histogramInc("infer.knowledge.falsy.yes.size", _falsy->yesTypeTests.size());
-    histogramInc("infer.knowledge.falsy.no.size", _falsy->noTypeTests.size());
+    // Counting these turns out to be rather slow for tests; if you're curious to
+    // see the numbers, you can uncomment these and recompile.
+    // histogramInc("infer.knowledge.truthy.yes.size", _truthy->yesTypeTests.size());
+    // histogramInc("infer.knowledge.truthy.no.size", _truthy->noTypeTests.size());
+    // histogramInc("infer.knowledge.falsy.yes.size", _falsy->yesTypeTests.size());
+    // histogramInc("infer.knowledge.falsy.no.size", _falsy->noTypeTests.size());
 }
 
 void TestedKnowledge::sanityCheck() const {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Continuing on from #8544 , these histograms were showing up as expensive in callgrind profiles for a more-or-less representative slow LSP test (test/testdata/lsp/prop_support.rb).  I don't think anybody is really looking at these.

The last time I ran a debug build with counters on Stripe's codebase, in literally 99% of the cases the `infer.knowledge.*` ones are 0.  The `TypeAndOrigins.origins.size` one is ~1/3 0, ~2/3 1, and a small percentage of >= 2.

`prop_support.rb` executed ~15% fewer instructions according to callgrind, which is admittedly an imperfect measure, but it seems to roughly correlate with real-world speed.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Faster debug builds.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.