### PR TITLE
Split __package.rb and packaged file processing into two separate steps

### DIFF
--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -34,6 +34,12 @@ void setPackagerOptions(core::GlobalState &gs, const options::Options &opts);
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers);
 
+void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
+                    WorkerPool &workers);
+
+void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
+                           WorkerPool &workers);
+
 ast::ParsedFilesOrCancelled nameAndResolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
                                            const options::Options &opts, WorkerPool &workers,
                                            core::FoundDefHashes *foundHashes);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -703,9 +703,9 @@ int realmain(int argc, char *argv[]) {
                     *gs, cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs,
                                                               *workers, indexed));
 
-                // First run: only the __package.rb files. This populates the packageDB
+                // Populate the packageDB by processing only the __package.rb files.
                 pipeline::setPackagerOptions(*gs, opts);
-                pipeline::package(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers);
+                pipeline::buildPackageDB(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers);
                 // Only need to compute hashes when running to compute a FileHash
                 auto foundHashes = nullptr;
                 auto canceled = pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers, foundHashes);
@@ -723,8 +723,8 @@ int realmain(int argc, char *argv[]) {
             cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers,
                                                  nonPackageIndexed);
 
-            // Second run: all the other files (the packageDB shouldn't change)
-            pipeline::package(*gs, absl::Span<ast::ParsedFile>(nonPackageIndexed), opts, *workers);
+            // Now validate all the other files (the packageDB shouldn't change)
+            pipeline::validatePackagedFiles(*gs, absl::Span<ast::ParsedFile>(nonPackageIndexed), opts, *workers);
 
             // Only need to compute hashes when running to compute a FileHash
             auto foundHashes = nullptr;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2074,13 +2074,39 @@ void Packager::setPackageNameOnFiles(core::GlobalState &gs, absl::Span<const cor
     }
 }
 
-void Packager::run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files) {
+namespace {
+
+enum class PackagerMode {
+    PackagesOnly,
+    PackagedFilesOnly,
+    AllFiles,
+};
+
+template <PackagerMode Mode>
+void packageRunCore(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files) {
     ENFORCE(!gs.runningUnderAutogen, "Packager pass does not run in autogen");
 
     Timer timeit(gs.tracer(), "packager");
 
-    findPackages(gs, files);
-    setPackageNameOnFiles(gs, files);
+    switch (Mode) {
+        case PackagerMode::PackagesOnly:
+            timeit.setTag("mode", "packages_only");
+            break;
+        case PackagerMode::PackagedFilesOnly:
+            timeit.setTag("mode", "packaged_files_only");
+            break;
+        case PackagerMode::AllFiles:
+            break;
+    }
+
+    constexpr bool buildPackageDB = Mode == PackagerMode::PackagesOnly || Mode == PackagerMode::AllFiles;
+    constexpr bool validatePackagedFiles = Mode == PackagerMode::PackagedFilesOnly || Mode == PackagerMode::AllFiles;
+
+    if constexpr (buildPackageDB) {
+        Packager::findPackages(gs, files);
+    }
+
+    Packager::setPackageNameOnFiles(gs, files);
 
     {
         Timer timeit(gs.tracer(), "packager.rewritePackagesAndFiles");
@@ -2092,8 +2118,10 @@ void Packager::run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::P
             taskq->push(i, 1);
         }
 
-        if (gs.packageDB().enforceLayering()) {
-            computeSCCs(gs);
+        if constexpr (buildPackageDB) {
+            if (gs.packageDB().enforceLayering()) {
+                computeSCCs(gs);
+            }
         }
 
         workers.multiplexJob("rewritePackagesAndFiles", [&gs, &files, &barrier, taskq]() {
@@ -2106,8 +2134,10 @@ void Packager::run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::P
                     core::Context ctx(gs, core::Symbols::root(), job.file);
 
                     if (file.isPackage()) {
+                        ENFORCE(buildPackageDB);
                         validatePackage(ctx);
                     } else {
+                        ENFORCE(validatePackagedFiles);
                         validatePackagedFile(ctx, job.tree);
                     }
                 }
@@ -2118,6 +2148,11 @@ void Packager::run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::P
 
         barrier.Wait();
     }
+}
+} // namespace
+
+void Packager::run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files) {
+    packageRunCore<PackagerMode::AllFiles>(gs, workers, files);
 }
 
 vector<ast::ParsedFile> Packager::runIncremental(const core::GlobalState &gs, vector<ast::ParsedFile> files,
@@ -2161,97 +2196,11 @@ vector<ast::ParsedFile> Packager::runIncremental(const core::GlobalState &gs, ve
 }
 
 void Packager::buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files) {
-    ENFORCE(!gs.runningUnderAutogen, "Packager pass does not run in autogen");
-
-    Timer timeit(gs.tracer(), "packager");
-    timeit.setTag("mode", "buildPackageDB");
-
-    findPackages(gs, files);
-    setPackageNameOnFiles(gs, files);
-
-    {
-        Timer timeit(gs.tracer(), "packager.buildPackageDB");
-
-        auto taskq = std::make_shared<ConcurrentBoundedQueue<size_t>>(files.size());
-        absl::BlockingCounter barrier(max(workers.size(), 1));
-
-        for (size_t i = 0; i < files.size(); ++i) {
-            taskq->push(i, 1);
-        }
-
-        if (gs.packageDB().enforceLayering()) {
-            computeSCCs(gs);
-        }
-
-        workers.multiplexJob("rewritePackagesAndFiles", [&gs, &files, &barrier, taskq]() {
-            Timer timeit(gs.tracer(), "packager.rewritePackagesAndFilesWorker");
-            size_t idx;
-            for (auto result = taskq->try_pop(idx); !result.done(); result = taskq->try_pop(idx)) {
-                ast::ParsedFile &job = files[idx];
-                if (result.gotItem()) {
-                    auto &file = job.file.data(gs);
-                    core::Context ctx(gs, core::Symbols::root(), job.file);
-
-                    ENFORCE(file.isPackage());
-                    // Defensive
-                    if (!file.isPackage()) {
-                        fatalLogger->error("Non-packaged file given to buildPackageDB: {}", file.path());
-                        continue;
-                    }
-                    validatePackage(ctx);
-                }
-            }
-
-            barrier.DecrementCount();
-        });
-
-        barrier.Wait();
-    }
+    packageRunCore<PackagerMode::PackagesOnly>(gs, workers, files);
 }
 
 void Packager::validatePackagedFiles(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files) {
-    ENFORCE(!gs.runningUnderAutogen, "Packager pass does not run in autogen");
-
-    Timer timeit(gs.tracer(), "packager");
-    timeit.setTag("mode", "validatePackagedFile");
-
-    setPackageNameOnFiles(gs, files);
-
-    {
-        Timer timeit(gs.tracer(), "packager.validatePackagedFiles");
-
-        auto taskq = std::make_shared<ConcurrentBoundedQueue<size_t>>(files.size());
-        absl::BlockingCounter barrier(max(workers.size(), 1));
-
-        for (size_t i = 0; i < files.size(); ++i) {
-            taskq->push(i, 1);
-        }
-
-        workers.multiplexJob("rewritePackagesAndFiles", [&gs, &files, &barrier, taskq]() {
-            Timer timeit(gs.tracer(), "packager.rewritePackagesAndFilesWorker");
-            size_t idx;
-            for (auto result = taskq->try_pop(idx); !result.done(); result = taskq->try_pop(idx)) {
-                ast::ParsedFile &job = files[idx];
-                if (result.gotItem()) {
-                    auto &file = job.file.data(gs);
-                    core::Context ctx(gs, core::Symbols::root(), job.file);
-
-                    ENFORCE(!file.isPackage());
-                    // Defensive
-                    if (file.isPackage()) {
-                        fatalLogger->error("__package.rb file given to validatePackagedFiles: {}", file.path());
-                        continue;
-                    }
-
-                    validatePackagedFile(ctx, job.tree);
-                }
-            }
-
-            barrier.DecrementCount();
-        });
-
-        barrier.Wait();
-    }
+    packageRunCore<PackagerMode::PackagedFilesOnly>(gs, workers, files);
 }
 
 namespace {

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -42,11 +42,18 @@ class Packager final {
 public:
     static void findPackages(core::GlobalState &gs, absl::Span<ast::ParsedFile> files);
 
+    // Build the packageDB, and validate packaged files at the same time.
     static void run(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
     static std::vector<ast::ParsedFile> runIncremental(const core::GlobalState &gs, std::vector<ast::ParsedFile> files,
                                                        WorkerPool &workers);
+
+    // Build the packageDB only. This requires that the `files` span only contains `__package.rb` files.
+    static void buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);
+
+    // Validate packaged files. This requires that hte `files` span does not contain any `__package.rb` files.
+    static void validatePackagedFiles(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);
 
     static void dumpPackageInfo(const core::GlobalState &gs, std::string output);
 


### PR DESCRIPTION
In batch mode we run the packager pass twice: once over the `__package.rb` files that define all packages in the workspace, and then over everything else. As we partition the files befhorehand into `__package.rb` files and everything else, we're duplicating logic that depends on either to have one interface to the packager pass.

Instead, let's split out two functions that are specialized to the behavior of each phase: `buildPackageDB` and `validatePackagedFiles`. There's still quite a bit of overlap between these two functions, but making assumptions about the kind of files they process does mean that we can avoid running operations that build the package database twice.

This change cuts out about `10%` of the runtime of the second packager pass on Stripe's codebase, and has no effect on the first.

The original interface `pipeline::package` is left in place, as there's currently not a great way to handle the split of `__package.rb` and source files in LSP.

### Motivation
Reducing the amount of work done in the packager.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a Performance only change
