### PR TITLE
Convert unique_ptr reference arguments to regular references

### DIFF
--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -41,10 +41,10 @@ bool isEmptyParseResult(const core::GlobalState &gs, const ast::ExpressionPtr &t
     return classDef->rhs.empty();
 }
 
-unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_ptr<core::GlobalState> &lgs,
+unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, core::GlobalState &lgs,
                                                  core::UsageHash usageHash, ast::ParsedFile file) {
-    if (file.file.data(*lgs).hasIndexErrors()) {
-        if (isEmptyParseResult(*lgs, file.tree)) {
+    if (file.file.data(lgs).hasIndexErrors()) {
+        if (isEmptyParseResult(lgs, file.tree)) {
             rapidjson::StringBuffer result;
             rapidjson::Writer<rapidjson::StringBuffer> writer(result);
 
@@ -55,11 +55,11 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
                 writer.Bool(true);
 
                 writer.String("file_path");
-                auto path = file.file.data(*lgs).path();
+                auto path = file.file.data(lgs).path();
                 writer.String(path.data(), path.size());
 
                 writer.String("contents");
-                auto source = file.file.data(*lgs).source();
+                auto source = file.file.data(lgs).source();
                 writer.String(source.data(), source.size());
 
                 writer.EndObject();
@@ -78,11 +78,11 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
 
     // We run computeFileHashForAST with the empty set of options which means we can skip calling pipeline::package()
 
-    auto workers = WorkerPool::create(0, lgs->tracer());
+    auto workers = WorkerPool::create(0, lgs.tracer());
     core::FoundDefHashes foundHashes; // out parameter
-    realmain::pipeline::nameAndResolve(*lgs, move(single), opts(), *workers, &foundHashes);
+    realmain::pipeline::nameAndResolve(lgs, move(single), opts(), *workers, &foundHashes);
 
-    return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash), move(foundHashes));
+    return make_unique<core::FileHash>(move(*lgs.hash()), move(usageHash), move(foundHashes));
 }
 
 // Note: lgs is an outparameter.
@@ -115,7 +115,7 @@ unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat
     core::LazyNameSubstitution subst(*lgs, *lgs);
     core::MutableContext ctx(*lgs, core::Symbols::root(), fref);
     ast = ast::Substitute::run(ctx, subst, move(ast));
-    return computeFileHashForAST(logger, lgs, subst.getAllNames(), move(ast));
+    return computeFileHashForAST(logger, *lgs, subst.getAllNames(), move(ast));
 }
 }; // namespace
 
@@ -210,7 +210,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(core::GlobalState &gs
                     auto [rewrittenAST, usageHash] = rewriteAST(sharedGs, *lgs, newFref, ast);
 
                     threadResult.emplace_back(ast.file,
-                                              computeFileHashForAST(logger, lgs, move(usageHash), move(rewrittenAST)));
+                                              computeFileHashForAST(logger, *lgs, move(usageHash), move(rewrittenAST)));
                 }
             }
         }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -80,7 +80,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
 
     auto workers = WorkerPool::create(0, lgs->tracer());
     core::FoundDefHashes foundHashes; // out parameter
-    realmain::pipeline::nameAndResolve(lgs, move(single), opts(), *workers, &foundHashes);
+    realmain::pipeline::nameAndResolve(*lgs, move(single), opts(), *workers, &foundHashes);
 
     return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash), move(foundHashes));
 }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -417,7 +417,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                 {
                     Timer timeit(config->logger, "reIndexFromFileSystem");
 
-                    auto inputFiles = pipeline::reserveFiles(finalGS, config->opts.inputFileNames);
+                    auto inputFiles = pipeline::reserveFiles(*finalGS, config->opts.inputFileNames);
                     this->indexed.clear();
                     this->indexed.resize(finalGS->filesUsed());
 
@@ -515,7 +515,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
             return;
         }
 
-        auto maybeResolved = pipeline::resolve(gs, move(indexedCopies), config->opts, workers);
+        auto maybeResolved = pipeline::resolve(*gs, move(indexedCopies), config->opts, workers);
         if (!maybeResolved.hasResult()) {
             return;
         }

--- a/main/lsp/test/error_reporter_test.cc
+++ b/main/lsp/test/error_reporter_test.cc
@@ -47,7 +47,7 @@ unique_ptr<core::GlobalState> makeGS() {
     auto gs = make_unique<core::GlobalState>(
         (make_shared<core::ErrorQueue>(*logger, *logger, make_shared<core::NullFlusher>())));
     unique_ptr<const OwnedKeyValueStore> kvstore;
-    payload::createInitialGlobalState(gs, nullOpts, kvstore);
+    payload::createInitialGlobalState(*gs, nullOpts, kvstore);
     return gs;
 }
 

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -62,7 +62,7 @@ unique_ptr<core::GlobalState> makeGS(shared_ptr<core::ErrorFlusher> errorFlusher
     auto gs =
         make_unique<core::GlobalState>((make_shared<core::ErrorQueue>(*typeErrorsConsole, *logger, errorFlusher)));
     unique_ptr<const OwnedKeyValueStore> kvstore;
-    payload::createInitialGlobalState(gs, opts, kvstore);
+    payload::createInitialGlobalState(*gs, opts, kvstore);
     return gs;
 }
 

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -54,7 +54,7 @@ createGlobalStateAndOtherObjects(string_view rootPath, options::Options &options
     auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*typeErrorsConsoleOut, *loggerOut));
 
     unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(loggerOut, options);
-    payload::createInitialGlobalState(gs, options, kvstore);
+    payload::createInitialGlobalState(*gs, options, kvstore);
     setRequiredLSPOptions(*gs, options);
     return make_pair(move(gs), OwnedKeyValueStore::abort(move(kvstore)));
 }

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -409,7 +409,7 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
             "--minimize-to-rbi will yield empty file because {} was already processed by the main pipeline",
             minimizeRBI);
 
-    auto rbiInputFiles = pipeline::reserveFiles(rbiGS, {minimizeRBI});
+    auto rbiInputFiles = pipeline::reserveFiles(*rbiGS, {minimizeRBI});
 
     // I'm ignoring everything relating to caching here, because missing methods is likely
     // to run on a new _unknown.rbi file every time and I didn't want to think about it.
@@ -426,7 +426,7 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
     auto canceled = pipeline::name(*rbiGS, absl::Span<ast::ParsedFile>(rbiIndexed), opts, workers, foundHashes);
     ENFORCE(!canceled, "Can only cancel in LSP mode");
 
-    rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers).result());
+    rbiIndexed = move(pipeline::resolve(*rbiGS, move(rbiIndexed), opts, workers).result());
     if (rbiGS->hadCriticalError()) {
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }

--- a/main/minimize/minimize.h
+++ b/main/minimize/minimize.h
@@ -9,9 +9,8 @@ namespace sorbet::realmain {
 
 class Minimize final {
 public:
-    static void indexAndResolveForMinimize(std::unique_ptr<core::GlobalState> &sourceGS,
-                                           std::unique_ptr<core::GlobalState> &rbiGS, options::Options &opts,
-                                           WorkerPool &workers, std::string minimizeRBI);
+    static void indexAndResolveForMinimize(core::GlobalState &sourceGS, core::GlobalState &rbiGS,
+                                           options::Options &opts, WorkerPool &workers, std::string minimizeRBI);
     static void writeDiff(const core::GlobalState &sourceGS, const core::GlobalState &rbiGS,
                           options::PrinterConfig &outfile);
 };

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -307,15 +307,15 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
     return what;
 }
 
-vector<core::FileRef> reserveFiles(unique_ptr<core::GlobalState> &gs, const vector<string> &files) {
-    Timer timeit(gs->tracer(), "reserveFiles");
+vector<core::FileRef> reserveFiles(core::GlobalState &gs, const vector<string> &files) {
+    Timer timeit(gs.tracer(), "reserveFiles");
     vector<core::FileRef> ret;
     ret.reserve(files.size());
-    core::UnfreezeFileTable unfreezeFiles(*gs);
+    core::UnfreezeFileTable unfreezeFiles(gs);
     for (auto &f : files) {
-        auto fileRef = gs->findFileByPath(f);
+        auto fileRef = gs.findFileByPath(f);
         if (!fileRef.exists()) {
-            fileRef = gs->reserveFileRef(f);
+            fileRef = gs.reserveFileRef(f);
         }
         ret.emplace_back(move(fileRef));
     }
@@ -892,10 +892,10 @@ ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, a
     return what;
 }
 
-ast::ParsedFilesOrCancelled nameAndResolve(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
+ast::ParsedFilesOrCancelled nameAndResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
                                            const options::Options &opts, WorkerPool &workers,
                                            core::FoundDefHashes *foundHashes) {
-    auto canceled = name(*gs, absl::Span<ast::ParsedFile>(what), opts, workers, foundHashes);
+    auto canceled = name(gs, absl::Span<ast::ParsedFile>(what), opts, workers, foundHashes);
     if (canceled) {
         return ast::ParsedFilesOrCancelled::cancel(move(what), workers);
     }
@@ -903,16 +903,16 @@ ast::ParsedFilesOrCancelled nameAndResolve(unique_ptr<core::GlobalState> &gs, ve
     return resolve(gs, move(what), opts, workers);
 }
 
-ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers) {
+ast::ParsedFilesOrCancelled resolve(core::GlobalState &gs, vector<ast::ParsedFile> what, const options::Options &opts,
+                                    WorkerPool &workers) {
     try {
         if (opts.stopAfterPhase != options::Phase::NAMER) {
             ProgressIndicator namingProgress(opts.showProgress, "Resolving", 1);
             {
-                Timer timeit(gs->tracer(), "resolving");
-                core::UnfreezeNameTable nameTableAccess(*gs);     // Resolver::defineAttr
-                core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters stubs
-                auto maybeResult = resolver::Resolver::run(*gs, move(what), workers);
+                Timer timeit(gs.tracer(), "resolving");
+                core::UnfreezeNameTable nameTableAccess(gs);     // Resolver::defineAttr
+                core::UnfreezeSymbolTable symbolTableAccess(gs); // enters stubs
+                auto maybeResult = resolver::Resolver::run(gs, move(what), workers);
                 if (!maybeResult.hasResult()) {
                     return maybeResult;
                 }
@@ -921,39 +921,39 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
 
 #ifndef SORBET_REALMAIN_MIN
             if (opts.stripePackages) {
-                Timer timeit(gs->tracer(), "visibility_checker");
-                what = packager::VisibilityChecker::run(*gs, workers, std::move(what));
+                Timer timeit(gs.tracer(), "visibility_checker");
+                what = packager::VisibilityChecker::run(gs, workers, std::move(what));
             }
 #endif
 
             if (opts.stressIncrementalResolver) {
-                auto symbolsBefore = gs->symbolsUsedTotal();
+                auto symbolsBefore = gs.symbolsUsedTotal();
                 for (auto &f : what) {
                     // Shift contents of file past current file's EOF, re-run incrementalResolve, assert that no
                     // locations appear before file's old EOF.
-                    const int prohibitedLines = f.file.data(*gs).source().size();
-                    auto newSource = fmt::format("{}\n{}", string(prohibitedLines, '\n'), f.file.data(*gs).source());
-                    auto newFile = make_shared<core::File>(string(f.file.data(*gs).path()), move(newSource),
-                                                           f.file.data(*gs).sourceType);
-                    gs->replaceFile(f.file, move(newFile));
-                    f.file.data(*gs).strictLevel = decideStrictLevel(*gs, f.file, opts);
-                    auto reIndexed = indexOne(opts, *gs, f.file);
+                    const int prohibitedLines = f.file.data(gs).source().size();
+                    auto newSource = fmt::format("{}\n{}", string(prohibitedLines, '\n'), f.file.data(gs).source());
+                    auto newFile = make_shared<core::File>(string(f.file.data(gs).path()), move(newSource),
+                                                           f.file.data(gs).sourceType);
+                    gs.replaceFile(f.file, move(newFile));
+                    f.file.data(gs).strictLevel = decideStrictLevel(gs, f.file, opts);
+                    auto reIndexed = indexOne(opts, gs, f.file);
                     vector<ast::ParsedFile> toBeReResolved;
                     toBeReResolved.emplace_back(move(reIndexed));
                     // We don't compute file hashes when running for incrementalResolve.
                     auto foundHashesForFiles = nullopt;
                     auto reresolved =
-                        pipeline::incrementalResolve(*gs, move(toBeReResolved), foundHashesForFiles, opts, workers);
+                        pipeline::incrementalResolve(gs, move(toBeReResolved), foundHashesForFiles, opts, workers);
                     ENFORCE(reresolved.size() == 1);
-                    f = checkNoDefinitionsInsideProhibitedLines(*gs, move(reresolved[0]), 0, prohibitedLines);
+                    f = checkNoDefinitionsInsideProhibitedLines(gs, move(reresolved[0]), 0, prohibitedLines);
                 }
-                ENFORCE(symbolsBefore == gs->symbolsUsedTotal(),
+                ENFORCE(symbolsBefore == gs.symbolsUsedTotal(),
                         "Stressing the incremental resolver should not add any new symbols");
             }
         }
     } catch (SorbetException &) {
         Exception::failInFuzzer();
-        if (auto e = gs->beginError(sorbet::core::Loc::none(), core::errors::Internal::InternalError)) {
+        if (auto e = gs.beginError(sorbet::core::Loc::none(), core::errors::Internal::InternalError)) {
             e.setHeader("Exception resolving (backtrace is above)");
         }
     }
@@ -961,24 +961,24 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
     if (opts.print.ResolveTree.enabled || opts.print.ResolveTreeRaw.enabled) {
         for (auto &resolved : what) {
             if (opts.print.ResolveTree.enabled) {
-                opts.print.ResolveTree.fmt("{}\n", resolved.tree.toString(*gs));
+                opts.print.ResolveTree.fmt("{}\n", resolved.tree.toString(gs));
             }
             if (opts.print.ResolveTreeRaw.enabled) {
-                opts.print.ResolveTreeRaw.fmt("{}\n", resolved.tree.showRaw(*gs));
+                opts.print.ResolveTreeRaw.fmt("{}\n", resolved.tree.showRaw(gs));
             }
         }
     }
 
     if (opts.print.SymbolTable.enabled) {
-        opts.print.SymbolTable.fmt("{}\n", gs->toString());
+        opts.print.SymbolTable.fmt("{}\n", gs.toString());
     }
     if (opts.print.SymbolTableRaw.enabled) {
-        opts.print.SymbolTableRaw.fmt("{}\n", gs->showRaw());
+        opts.print.SymbolTableRaw.fmt("{}\n", gs.showRaw());
     }
 
 #ifndef SORBET_REALMAIN_MIN
     if (opts.print.SymbolTableJson.enabled) {
-        auto root = core::Proto::toProto(*gs, core::Symbols::root(), false);
+        auto root = core::Proto::toProto(gs, core::Symbols::root(), false);
         if (opts.print.SymbolTableJson.outputPath.empty()) {
             core::Proto::toJSON(root, cout);
         } else {
@@ -988,7 +988,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
         }
     }
     if (opts.print.SymbolTableProto.enabled) {
-        auto root = core::Proto::toProto(*gs, core::Symbols::root(), false);
+        auto root = core::Proto::toProto(gs, core::Symbols::root(), false);
         if (opts.print.SymbolTableProto.outputPath.empty()) {
             root.SerializeToOstream(&cout);
         } else {
@@ -998,7 +998,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
         }
     }
     if (opts.print.SymbolTableMessagePack.enabled) {
-        auto root = core::Proto::toProto(*gs, core::Symbols::root(), false);
+        auto root = core::Proto::toProto(gs, core::Symbols::root(), false);
         stringstream buf;
         core::Proto::toJSON(root, buf);
         auto str = buf.str();
@@ -1016,7 +1016,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
         }
     }
     if (opts.print.SymbolTableFullJson.enabled) {
-        auto root = core::Proto::toProto(*gs, core::Symbols::root(), true);
+        auto root = core::Proto::toProto(gs, core::Symbols::root(), true);
         if (opts.print.SymbolTableJson.outputPath.empty()) {
             core::Proto::toJSON(root, cout);
         } else {
@@ -1026,7 +1026,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
         }
     }
     if (opts.print.SymbolTableFullProto.enabled) {
-        auto root = core::Proto::toProto(*gs, core::Symbols::root(), true);
+        auto root = core::Proto::toProto(gs, core::Symbols::root(), true);
         if (opts.print.SymbolTableFullProto.outputPath.empty()) {
             root.SerializeToOstream(&cout);
         } else {
@@ -1036,7 +1036,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
         }
     }
     if (opts.print.SymbolTableFullMessagePack.enabled) {
-        auto root = core::Proto::toProto(*gs, core::Symbols::root(), true);
+        auto root = core::Proto::toProto(gs, core::Symbols::root(), true);
         stringstream buf;
         core::Proto::toJSON(root, buf);
         auto str = buf.str();
@@ -1055,14 +1055,14 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
     }
 #endif
     if (opts.print.SymbolTableFull.enabled) {
-        opts.print.SymbolTableFull.fmt("{}\n", gs->toStringFull());
+        opts.print.SymbolTableFull.fmt("{}\n", gs.toStringFull());
     }
     if (opts.print.SymbolTableFullRaw.enabled) {
-        opts.print.SymbolTableFullRaw.fmt("{}\n", gs->showRawFull());
+        opts.print.SymbolTableFullRaw.fmt("{}\n", gs.showRawFull());
     }
 
     if (opts.print.MissingConstants.enabled) {
-        what = printMissingConstants(*gs, opts, move(what));
+        what = printMissingConstants(gs, opts, move(what));
     }
 
     return ast::ParsedFilesOrCancelled(move(what));
@@ -1203,14 +1203,14 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const 
     }
 }
 
-void printFileTable(unique_ptr<core::GlobalState> &gs, const options::Options &opts,
+void printFileTable(core::GlobalState &gs, const options::Options &opts,
                     const UnorderedMap<long, long> &untypedUsages) {
 #ifndef SORBET_REALMAIN_MIN
     if (opts.print.FileTableProto.enabled || opts.print.FileTableFullProto.enabled) {
         if (opts.print.FileTableProto.enabled && opts.print.FileTableFullProto.enabled) {
             Exception::raise("file-table-proto and file-table-full-proto are mutually exclusive print options");
         }
-        auto files = core::Proto::filesToProto(*gs, untypedUsages, opts.print.FileTableFullProto.enabled);
+        auto files = core::Proto::filesToProto(gs, untypedUsages, opts.print.FileTableFullProto.enabled);
         if (opts.print.FileTableProto.outputPath.empty()) {
             files.SerializeToOstream(&cout);
         } else {
@@ -1223,7 +1223,7 @@ void printFileTable(unique_ptr<core::GlobalState> &gs, const options::Options &o
         if (opts.print.FileTableJson.enabled && opts.print.FileTableFullJson.enabled) {
             Exception::raise("file-table-json and file-table-full-json are mutually exclusive print options");
         }
-        auto files = core::Proto::filesToProto(*gs, untypedUsages, opts.print.FileTableFullJson.enabled);
+        auto files = core::Proto::filesToProto(gs, untypedUsages, opts.print.FileTableFullJson.enabled);
         if (opts.print.FileTableJson.outputPath.empty()) {
             core::Proto::toJSON(files, cout);
         } else {
@@ -1236,7 +1236,7 @@ void printFileTable(unique_ptr<core::GlobalState> &gs, const options::Options &o
         if (opts.print.FileTableMessagePack.enabled && opts.print.FileTableFullMessagePack.enabled) {
             Exception::raise("file-table-msgpack and file-table-full-msgpack are mutually exclusive print options");
         }
-        auto files = core::Proto::filesToProto(*gs, untypedUsages, opts.print.FileTableFullMessagePack.enabled);
+        auto files = core::Proto::filesToProto(gs, untypedUsages, opts.print.FileTableFullMessagePack.enabled);
         stringstream buf;
         core::Proto::toJSON(files, buf);
         auto str = buf.str();

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -20,7 +20,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
 ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &gs, core::FileRef file,
                               bool preserveConcreteSyntax);
 
-std::vector<core::FileRef> reserveFiles(std::unique_ptr<core::GlobalState> &gs, const std::vector<std::string> &files);
+std::vector<core::FileRef> reserveFiles(core::GlobalState &gs, const std::vector<std::string> &files);
 
 std::vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<const core::FileRef> files,
                                    const options::Options &opts, WorkerPool &workers,
@@ -34,7 +34,7 @@ void setPackagerOptions(core::GlobalState &gs, const options::Options &opts);
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers);
 
-ast::ParsedFilesOrCancelled nameAndResolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
+ast::ParsedFilesOrCancelled nameAndResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                            const options::Options &opts, WorkerPool &workers,
                                            core::FoundDefHashes *foundHashes);
 
@@ -52,7 +52,7 @@ incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
 [[nodiscard]] bool name(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
                         WorkerPool &workers, core::FoundDefHashes *foundHashes);
 
-ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
+ast::ParsedFilesOrCancelled resolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                     const options::Options &opts, WorkerPool &workers);
 
 std::vector<ast::ParsedFile> autogenWriteCacheFile(const core::GlobalState &gs, const std::string &cachePath,
@@ -66,8 +66,7 @@ void typecheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> what, c
                std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
                bool presorted = false, bool intentionallyLeakASTs = false);
 
-void printFileTable(std::unique_ptr<core::GlobalState> &gs, const options::Options &opts,
-                    const UnorderedMap<long, long> &untypedUsages);
+void printFileTable(core::GlobalState &gs, const options::Options &opts, const UnorderedMap<long, long> &untypedUsages);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -794,7 +794,7 @@ int realmain(int argc, char *argv[]) {
             // project is a single RBI file.
             optsForMinimize.stripePackages = false;
 
-            Minimize::indexAndResolveForMinimize(gs, gsForMinimize, optsForMinimize, *workers, opts.minimizeRBI);
+            Minimize::indexAndResolveForMinimize(*gs, *gsForMinimize, optsForMinimize, *workers, opts.minimizeRBI);
             Minimize::writeDiff(*gs, *gsForMinimize, opts.print.MinimizeRBI);
 #endif
         }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -578,7 +578,7 @@ int realmain(int argc, char *argv[]) {
             hashing::Hashing::computeFileHashes(gs->getFiles(), *logger, *workers, opts);
         }
 
-        inputFiles = pipeline::reserveFiles(gs, opts.inputFileNames);
+        inputFiles = pipeline::reserveFiles(*gs, opts.inputFileNames);
 
         if (opts.packageRBIGeneration) {
 #ifdef SORBET_REALMAIN_MIN
@@ -629,7 +629,7 @@ int realmain(int argc, char *argv[]) {
             // Indexing package files is by far the most expensive part of rbi generation. If we could instead select
             // only the package files that we know we need to load, it would cut down command-line rbi generation by
             // seconds.
-            auto packageFileRefs = pipeline::reserveFiles(gs, packageFiles);
+            auto packageFileRefs = pipeline::reserveFiles(*gs, packageFiles);
             auto packages = pipeline::index(*gs, absl::Span<core::FileRef>(packageFileRefs), opts, *workers, nullptr);
             {
                 core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
@@ -759,7 +759,7 @@ int realmain(int argc, char *argv[]) {
             runAutogen(*gs, opts, autogenCfg, *workers, indexed);
 #endif
         } else {
-            indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers).result());
+            indexed = move(pipeline::resolve(*gs, move(indexed), opts, *workers).result());
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
@@ -776,7 +776,7 @@ int realmain(int argc, char *argv[]) {
 
         // getAndClearHistogram ensures that we don't accidentally submit a high-cardinality histogram to statsd
         auto untypedUsages = getAndClearHistogram("untyped.usages");
-        pipeline::printFileTable(gs, opts, untypedUsages);
+        pipeline::printFileTable(*gs, opts, untypedUsages);
 
         if (!opts.minimizeRBI.empty()) {
 #ifdef SORBET_REALMAIN_MIN

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -443,7 +443,7 @@ int realmain(int argc, char *argv[]) {
 
     logger->trace("building initial global state");
     unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(logger, opts);
-    payload::createInitialGlobalState(gs, opts, kvstore);
+    payload::createInitialGlobalState(*gs, opts, kvstore);
     if (opts.silenceErrors) {
         gs->silenceErrors = true;
     }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -159,10 +159,10 @@ string levelToSigil(core::StrictLevel level) {
     }
 }
 
-core::Loc findTyped(unique_ptr<core::GlobalState> &gs, core::FileRef file) {
-    auto source = file.data(*gs).source();
+core::Loc findTyped(core::GlobalState &gs, core::FileRef file) {
+    auto source = file.data(gs).source();
 
-    if (file.data(*gs).originalSigil == core::StrictLevel::None) {
+    if (file.data(gs).originalSigil == core::StrictLevel::None) {
         if (source.length() >= 2 && source[0] == '#' && source[1] == '!') {
             int newline = source.find("\n", 0);
             return core::Loc(file, newline + 1, newline + 1);
@@ -827,7 +827,7 @@ int realmain(int argc, char *argv[]) {
                     // marked strict.
                     continue;
                 }
-                auto loc = findTyped(gs, file);
+                auto loc = findTyped(*gs, file);
                 if (auto e = gs->beginError(loc, core::errors::Infer::SuggestTyped)) {
                     auto sigil = levelToSigil(minErrorLevel);
                     e.setHeader("You could add `# typed: {}`", sigil);

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -8,69 +8,69 @@ using namespace std;
 
 namespace sorbet::payload {
 
-void createInitialGlobalState(unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
+void createInitialGlobalState(core::GlobalState &gs, const realmain::options::Options &options,
                               const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     if (options.noStdlib) {
         ENFORCE(kvstore == nullptr, "--no-stdlib and --cache-dir are incompatible");
-        gs->initEmpty();
+        gs.initEmpty();
         return;
     }
 
     if (GLOBAL_STATE_PAYLOAD == nullptr) {
-        Timer timeit(gs->tracer(), "read_global_state.source");
+        Timer timeit(gs.tracer(), "read_global_state.source");
         sorbet::rbi::populateRBIsInto(gs);
     } else {
-        Timer timeit(gs->tracer(), "read_global_state.binary");
-        core::serialize::Serializer::loadGlobalState(*gs, GLOBAL_STATE_PAYLOAD);
+        Timer timeit(gs.tracer(), "read_global_state.binary");
+        core::serialize::Serializer::loadGlobalState(gs, GLOBAL_STATE_PAYLOAD);
     }
-    ENFORCE(gs->utf8NamesUsed() < core::GlobalState::PAYLOAD_MAX_UTF8_NAME_COUNT,
+    ENFORCE(gs.utf8NamesUsed() < core::GlobalState::PAYLOAD_MAX_UTF8_NAME_COUNT,
             "Payload defined `{}` UTF8 names, which is greater than the expected maximum of `{}`. Consider updating "
             "`PAYLOAD_MAX_UTF8_NAME_COUNT` in `GlobalState`.",
-            gs->utf8NamesUsed(), core::GlobalState::PAYLOAD_MAX_UTF8_NAME_COUNT);
+            gs.utf8NamesUsed(), core::GlobalState::PAYLOAD_MAX_UTF8_NAME_COUNT);
     ENFORCE(
-        gs->constantNamesUsed() < core::GlobalState::PAYLOAD_MAX_CONSTANT_NAME_COUNT,
+        gs.constantNamesUsed() < core::GlobalState::PAYLOAD_MAX_CONSTANT_NAME_COUNT,
         "Payload defined `{}` Constant names, which is greater than the expected maximum of `{}`. Consider updating "
         "`PAYLOAD_MAX_CONSTANT_NAME_COUNT` in `GlobalState`.",
-        gs->constantNamesUsed(), core::GlobalState::PAYLOAD_MAX_CONSTANT_NAME_COUNT);
-    ENFORCE(gs->uniqueNamesUsed() < core::GlobalState::PAYLOAD_MAX_UNIQUE_NAME_COUNT,
+        gs.constantNamesUsed(), core::GlobalState::PAYLOAD_MAX_CONSTANT_NAME_COUNT);
+    ENFORCE(gs.uniqueNamesUsed() < core::GlobalState::PAYLOAD_MAX_UNIQUE_NAME_COUNT,
             "Payload defined `{}` Unique names, which is greater than the expected maximum of `{}`. Consider updating "
             "`PAYLOAD_MAX_UNIQUE_NAME_COUNT` in `GlobalState`.",
-            gs->uniqueNamesUsed(), core::GlobalState::PAYLOAD_MAX_UNIQUE_NAME_COUNT);
-    ENFORCE(gs->fieldsUsed() < core::GlobalState::PAYLOAD_MAX_FIELD_COUNT,
+            gs.uniqueNamesUsed(), core::GlobalState::PAYLOAD_MAX_UNIQUE_NAME_COUNT);
+    ENFORCE(gs.fieldsUsed() < core::GlobalState::PAYLOAD_MAX_FIELD_COUNT,
             "Payload defined `{}` fields, which is greater than the expected maximum of `{}`. Consider updating "
             "`PAYLOAD_MAX_FIELD_COUNT` in `GlobalState`.",
-            gs->fieldsUsed(), core::GlobalState::PAYLOAD_MAX_FIELD_COUNT);
-    ENFORCE(gs->methodsUsed() < core::GlobalState::PAYLOAD_MAX_METHOD_COUNT,
+            gs.fieldsUsed(), core::GlobalState::PAYLOAD_MAX_FIELD_COUNT);
+    ENFORCE(gs.methodsUsed() < core::GlobalState::PAYLOAD_MAX_METHOD_COUNT,
             "Payload defined `{}` methods, which is greater than the expected maximum of `{}`. Consider updating "
             "`PAYLOAD_MAX_METHOD_COUNT` in `GlobalState`.",
-            gs->methodsUsed(), core::GlobalState::PAYLOAD_MAX_METHOD_COUNT);
-    ENFORCE(gs->classAndModulesUsed() < core::GlobalState::PAYLOAD_MAX_CLASS_AND_MODULE_COUNT,
+            gs.methodsUsed(), core::GlobalState::PAYLOAD_MAX_METHOD_COUNT);
+    ENFORCE(gs.classAndModulesUsed() < core::GlobalState::PAYLOAD_MAX_CLASS_AND_MODULE_COUNT,
             "Payload defined `{}` classes and modules, which is greater than the expected maximum of `{}`. Consider "
             "updating `PAYLOAD_MAX_CLASS_AND_MODULE_COUNT` in `GlobalState`.",
-            gs->classAndModulesUsed(), core::GlobalState::PAYLOAD_MAX_CLASS_AND_MODULE_COUNT);
-    ENFORCE(gs->typeMembersUsed() < core::GlobalState::PAYLOAD_MAX_TYPE_MEMBER_COUNT,
+            gs.classAndModulesUsed(), core::GlobalState::PAYLOAD_MAX_CLASS_AND_MODULE_COUNT);
+    ENFORCE(gs.typeMembersUsed() < core::GlobalState::PAYLOAD_MAX_TYPE_MEMBER_COUNT,
             "Payload defined `{}` type members, which is greater than the expected maximum of `{}`. Consider updating "
             "`PAYLOAD_MAX_TYPE_MEMBER_COUNT` in `GlobalState`.",
-            gs->typeMembersUsed(), core::GlobalState::PAYLOAD_MAX_TYPE_MEMBER_COUNT);
+            gs.typeMembersUsed(), core::GlobalState::PAYLOAD_MAX_TYPE_MEMBER_COUNT);
     ENFORCE(
-        gs->typeArgumentsUsed() < core::GlobalState::PAYLOAD_MAX_TYPE_ARGUMENT_COUNT,
+        gs.typeArgumentsUsed() < core::GlobalState::PAYLOAD_MAX_TYPE_ARGUMENT_COUNT,
         "Payload defined `{}` type arguments, which is greater than the expected maximum of `{}`. Consider updating "
         "`PAYLOAD_MAX_TYPE_ARGUMENT_COUNT` in `GlobalState`.",
-        gs->typeArgumentsUsed(), core::GlobalState::PAYLOAD_MAX_TYPE_ARGUMENT_COUNT);
+        gs.typeArgumentsUsed(), core::GlobalState::PAYLOAD_MAX_TYPE_ARGUMENT_COUNT);
 
     // We can use the kvstore to read in the cached name table. We read this in after the payload has been initialized,
     // as the cached name table will extend the payload's existing table when the sorbet versions match.
     if (kvstore) {
         auto maybeGsBytes = kvstore->read(core::serialize::Serializer::NAME_TABLE_KEY);
         if (maybeGsBytes.data != nullptr) {
-            Timer timeit(gs->tracer(), "read_name_table.kvstore");
-            core::serialize::Serializer::loadAndOverwriteNameTable(*gs, maybeGsBytes.data);
+            Timer timeit(gs.tracer(), "read_name_table.kvstore");
+            core::serialize::Serializer::loadAndOverwriteNameTable(gs, maybeGsBytes.data);
             if constexpr (debug_mode) {
-                for (unsigned int i = 1; i < gs->filesUsed(); i++) {
+                for (unsigned int i = 1; i < gs.filesUsed(); i++) {
                     core::FileRef fref(i);
 
                     // We should only see payload files at this point.
-                    ENFORCE(fref.dataAllowingUnsafe(*gs).sourceType != core::File::Type::Normal);
+                    ENFORCE(fref.dataAllowingUnsafe(gs).sourceType != core::File::Type::Normal);
                 }
             }
         }

--- a/payload/payload.h
+++ b/payload/payload.h
@@ -7,7 +7,7 @@
 
 namespace sorbet::payload {
 
-void createInitialGlobalState(std::unique_ptr<core::GlobalState> &gs, const realmain::options::Options &options,
+void createInitialGlobalState(core::GlobalState &gs, const realmain::options::Options &options,
                               const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 
 } // namespace sorbet::payload

--- a/payload/text/nopopulate.cc
+++ b/payload/text/nopopulate.cc
@@ -2,7 +2,7 @@
 using namespace std;
 
 namespace sorbet::rbi {
-void populateRBIsInto(unique_ptr<core::GlobalState> &gs) {
+void populateRBIsInto(core::GlobalState &gs) {
     Exception::raise("Should never call populateRBIsInto with nopopulate.cc");
 }
 

--- a/payload/text/populate.cc
+++ b/payload/text/populate.cc
@@ -33,7 +33,7 @@ void populateRBIsInto(unique_ptr<core::GlobalState> &gs) {
     // '[0].to_set' will typecheck (using text-based payload) but never calculate hashes for the
     // payload files (because neither `--lsp` nor `--store-state` was passed).
     auto foundMethodHashes = nullptr;
-    realmain::pipeline::nameAndResolve(gs, move(indexed), emptyOpts, *workers, foundMethodHashes);
+    realmain::pipeline::nameAndResolve(*gs, move(indexed), emptyOpts, *workers, foundMethodHashes);
     // ^ result is thrown away
     gs->ensureCleanStrings = false;
 }

--- a/payload/text/text.h
+++ b/payload/text/text.h
@@ -4,5 +4,5 @@
 
 namespace sorbet::rbi {
 std::vector<std::pair<std::string_view, std::string_view>> all();
-void populateRBIsInto(std::unique_ptr<core::GlobalState> &gs);
+void populateRBIsInto(core::GlobalState &gs);
 } // namespace sorbet::rbi

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -90,7 +90,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         REQUIRE_NE(contents.data, nullptr);
 
         auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*logger, *logger));
-        payload::createInitialGlobalState(gs, *opts, kvstore);
+        payload::createInitialGlobalState(*gs, *opts, kvstore);
 
         // If caching fails, gs gets modified during payload creation.
         CHECK_FALSE(gs->wasModified());
@@ -145,7 +145,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         REQUIRE_NE(updatedFileData.data, nullptr);
 
         auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*logger, *logger));
-        payload::createInitialGlobalState(gs, *opts, kvstore);
+        payload::createInitialGlobalState(*gs, *opts, kvstore);
 
         core::File file{string(filePath), string(updatedFileContents), core::File::Type::Normal};
         auto cachedFile = core::serialize::Serializer::loadTree(*gs, file, updatedFileData.data);
@@ -192,7 +192,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPDoesNotUseCacheIfModified") {
         REQUIRE_NE(contents.data, nullptr);
 
         auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*nullLogger, *nullLogger));
-        payload::createInitialGlobalState(gs, *opts, kvstore);
+        payload::createInitialGlobalState(*gs, *opts, kvstore);
 
         // If caching fails, gs gets modified during payload creation.
         CHECK_FALSE(gs->wasModified());

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -564,7 +564,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         auto gsForMinimize = emptyGs->deepCopy();
         auto opts = realmain::options::Options{};
         auto minimizeRBI = test.folder + test.minimizeRBI;
-        realmain::Minimize::indexAndResolveForMinimize(gs, gsForMinimize, opts, *workers, minimizeRBI);
+        realmain::Minimize::indexAndResolveForMinimize(*gs, *gsForMinimize, opts, *workers, minimizeRBI);
         auto printerConfig = realmain::options::PrinterConfig{};
         printerConfig.enabled = true;
         printerConfig.outputPath = "/dev/null"; // tricks PrinterConfig::print into buffering


### PR DESCRIPTION
There are a few places where we take `std::unique_ptr<core::GlobalState> &` arguments to functions that never change the ownership of the unique pointer. This causes unnecessary pointer indirection when working directly with the `core::GlobalState` value in that function, when a regular reference would work fine.

Instead, let's change these to `core::GlobalState &` arguments, to avoid the extra indirection of a `std::unique_ptr`.

### Motivation
Simplifying apis, and avoiding the small runtime cost of the extra indirection.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a Should not affect correctness
