### PR TITLE
Fix rewriting of attribute writer with RBS signatures

### DIFF
--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -16,11 +16,20 @@ namespace {
 // either with no scope or with the root scope (i.e. `::T`). this might not actually refer to the `T` that we define for
 // users, but we don't know that information in the Rewriter passes.
 bool isT(const ast::ExpressionPtr &expr) {
-    auto t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
-    if (t == nullptr || t->cnst != core::Names::Constants::T()) {
-        return false;
-    }
-    return ast::MK::isRootScope(t->scope);
+    auto res = false;
+
+    typecase(
+        expr,
+        [&](const ast::UnresolvedConstantLit &constLit) {
+            // When the `T` was written by the user, we get an UnresolvedConstantLit.
+            res = constLit.cnst == core::Names::Constants::T() && ast::MK::isRootScope(constLit.scope);
+        },
+        [&](const ast::ConstantLit &constLit) {
+            // When the `T` was inserted by `ast::MK::T()`, we get a ConstantLit.
+            res = constLit.symbol() == core::Symbols::T();
+        });
+
+    return res;
 }
 
 bool isTNilableOrUntyped(const ast::ExpressionPtr &expr) {

--- a/test/testdata/rewriter/rbs_signatures_attrs.rb
+++ b/test/testdata/rewriter/rbs_signatures_attrs.rb
@@ -46,3 +46,15 @@ T.reveal_type(x.foo) # error: Revealed type: `Integer`
 T.reveal_type(x.bar) # error: Revealed type: `T.nilable(Integer)`
 T.reveal_type(x.baz) # error: Revealed type: `T.nilable(Integer)`
 x.qux = "" # error: Assigning a value to `qux` that does not match expected type `T.nilable(Integer)`
+
+class AttrRewriter
+  extend T::Sig
+
+  #: Integer?
+  attr_accessor :a
+
+  #: -> void
+  def initialize
+    T.reveal_type(@a) # error: Revealed type: `T.nilable(Integer)`
+  end
+end

--- a/test/testdata/rewriter/rbs_signatures_attrs.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rbs_signatures_attrs.rb.rewrite-tree.exp
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar=<<todo method>>(bar, &<blk>)
-      @bar = bar
+      @bar = <cast:let>(bar, <todo sym>, ::T.nilable(<emptyTree>::<C Integer>))
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def baz=<<todo method>>(baz, &<blk>)
-      @baz = baz
+      @baz = <cast:let>(baz, <todo sym>, ::T.nilable(<emptyTree>::<C Integer>))
     end
 
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def qux=<<todo method>>(qux, &<blk>)
-      @qux = qux
+      @qux = <cast:let>(qux, <todo sym>, ::T.nilable(<emptyTree>::<C Integer>))
     end
 
     def quux1=<<todo method>>(quux1, &<blk>)
@@ -112,4 +112,38 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(x.baz())
 
   x.qux=("")
+
+  class <emptyTree>::<C AttrRewriter><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(::T.nilable(<emptyTree>::<C Integer>))
+    end
+
+    def a<<todo method>>(&<blk>)
+      @a
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:a, ::T.nilable(<emptyTree>::<C Integer>)).returns(::T.nilable(<emptyTree>::<C Integer>))
+    end
+
+    def a=<<todo method>>(a, &<blk>)
+      @a = <cast:let>(a, <todo sym>, ::T.nilable(<emptyTree>::<C Integer>))
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def initialize<<todo method>>(&<blk>)
+      <emptyTree>::<C T>.reveal_type(@a)
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of a>
+
+    <runtime method definition of a=>
+
+    <runtime method definition of initialize>
+  end
 end


### PR DESCRIPTION
### Motivation

We currently have a rewriter for `attr_writer` that will automatically insert a `T.let` on nilable instance variables so this:

```rb
class Foo
  sig { returns(T.nilable(Integer))
  attr_accessor :foo
end
```

Is rewritten into:

```rb
class Foo
  sig { returns(T.nilable(Integer))
  def foo
    @foo
  end

  sig { params(foo: T.nilable(Integer)).returns(T.nilable(Integer))
  def foo=(foo)
    @foo = T.let(foo, T.nilable(Integer))
  end
end
```

The rewriter inserts the `T.let` if the parameter is marked `nilable` in the signature by calling `isT` which checks if `nilable` is called on `::T`. Though the check is limited to unresolved constant literals.

In the case of a RBS signature, the `T.nilable` is inserted using a resolved constant lit and this check fails.

This PR changes `AttrReader::isT` so it accepts both a `UnresolvedConstantLit` and a `ConstantLit`.

### Test plan

See included automated tests.
