### PR TITLE
Update `Copy Symbol to Clipboard` enablement

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -66,7 +66,7 @@
         "command": "sorbet.copySymbolToClipboard",
         "title": "Copy Symbol to Clipboard",
         "category": "Sorbet",
-        "enablement": "editorLangId == ruby && !editorHasSelection"
+        "enablement": "editorLangId == ruby && (resourceScheme == file || resourceScheme == sorbet) && !editorHasSelection"
       },
       {
         "command": "sorbet.disable",


### PR DESCRIPTION
Update `Copy Symbol to Clipboard` enablement rules to limit to `file` and `sorbet` schemes, matching `LanguageClient` initialization.
- This fixes the command failing silently when looking at editors with special schemes (e.g. `git` used when comparing stashed contents).

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
