### PR TITLE
Consistent variable names in calls.cc

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1081,7 +1081,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     if (kwSplatType.isUntyped()) {
                         // Allow an untyped arg to satisfy all kwargs
                         --aend;
-                        kwargs = Types::untypedUntracked();
+                        kwargs = kwSplatType;
                     } else if (kwSplatType.derivesFrom(gs, Symbols::Hash())) {
                         // This will be an error if the kwsplat hash ends up being used to supply keyword arguments,
                         // however it may also be consumed as a positional arg. Defer raising an error until we're


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Commit summary
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- **hasKwargs → hasKwparams** (b2a8bd8c9)

  args are at the call site, params are at the definition site. This
  method plays fast-and-loose with that convention, especially because the
  list of a method's parameters are stored on a field called
  `arguments` on the symbol. But we already use `ait` and `pit` for the
  argument and parameter iterator in this method, and this code is hard
  enough to read as it is.

  Eventually, we should even change `core::Method::arguments` to be called
  `parameters` and `ArgInfo` to `ParameterInfo` but that's a refactor for
  another day.

- **Use kwSplatType to forward untyped blame** (ae36e1db3)

  The blame for `kwargs` should be the same as whatever the `kwSplatType`
  was.

- **spec -> param** (b4bd0ea2b)


- **kwSplatType -> kwSplatArgType** (bd5263e12)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests