### PR TITLE
Ensure `scripts/` are not added to .vsix

### DIFF
--- a/vscode_extension/.vscodeignore
+++ b/vscode_extension/.vscodeignore
@@ -1,8 +1,10 @@
 .vscode/**
 .vscode-test/**
-out/test/**
-src/**
 out/**/*.map
+out/scripts/**
+out/test/**
+scripts/**
+src/**
 .gitignore
 tsconfig.json
 xvfb.out


### PR DESCRIPTION
Ensure `scripts/` folders are not added to extension's .vsix package:
- These folders appeared in the .vsix when building locally.
- Only scripts being added are `runTests*` which are not valuable since `out/test/**` is already ignored.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
