### PR TITLE
Eagerly restore the UndoState when the slow path is cancelled

### DIFF
--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -24,6 +24,9 @@ void UndoState::recordEvictedState(ast::ParsedFile evictedIndexTree) {
 
 void UndoState::restore(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> &indexed,
                         UnorderedMap<int, ast::ParsedFile> &indexedFinalGS) {
+    // We should never apply this twice, as that would end up dropping the other GlobalState
+    ENFORCE(this->evictedGs != nullptr);
+
     // Replace evicted index trees.
     for (auto &entry : evictedIndexed) {
         indexed[entry.first] = move(entry.second);


### PR DESCRIPTION
Currently we wait for the next fast path edit to restore the typechecker's saved state when a slow path is cancelled. This means any cached trees that differed from the previous indexed set, and the previous `GlobalState` will hang around arbitrarily long. There's no reason to keep this state around longer than necessary though, as the only piece of the `UndoState` that we need on the next fast path operation is the previous epoch.

This PR eagerly restores the state at the end of the slow path when the operation didn't commit successfully, but leaves the `UndoState` around for the next fast path operation so that the epoch is still available.

### Motivation
Avoiding holding on to memory past the end of a cancelled slow path.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a This shouldn't affect behavior, only memory usage.
