### PR TITLE
Allow to `Disable` Sorbet during the `Restarting`/`Initialize` cycle

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history
 
+## 0.3.38
+- Sorbet can be disabled while in `Restarting` / `Initializing` loop.
+- `Copy Symbol to Clipboard` is enabled only for supported `file` and `sorbet` URI schemes.
+
 ## 0.3.26
 - Add option to toggle the auto-complete nudge in `typed: false` files
 

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.37",
+  "version": "0.3.38",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -290,7 +290,14 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
     const activeConfig = this.context.configuration.activeLspConfig;
     const [command, ...args] = activeConfig?.command ?? [];
     if (!command) {
-      const msg = `Missing command-line data to start Sorbet. ConfigId:${this.context.configuration.activeLspConfig?.id}`;
+      let msg: string;
+      if (!activeConfig) {
+        msg = "No active Sorbet configuration.";
+        this.status = ServerStatus.DISABLED;
+      } else {
+        msg = `Missing command-line data to start Sorbet. ConfigId:${activeConfig.id}`;
+      }
+
       this.context.log.error(msg);
       return Promise.reject(new Error(msg));
     }

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -163,7 +163,10 @@ export class SorbetStatusProvider implements Disposable {
    * Return current {@link ServerStatus server status}.
    */
   public get serverStatus(): ServerStatus {
-    return this.activeLanguageClient?.status || ServerStatus.DISABLED;
+    return (
+      this.activeLanguageClient?.status ||
+      (this.isStarting ? ServerStatus.RESTARTING : ServerStatus.DISABLED)
+    );
   }
 
   /**


### PR DESCRIPTION
Allow to `Disable` Sorbet during the `Restarting`/`Initialize` cycle.

-  **Issue**:  the extension enters a `Restarting`/`Initialize` cycle that cannot be stopped  because the "active client"  is only made available to internal code until it is up-and-running (so during initialization state is equivalent to `DISABLED`). 
   -  In scenarios where Sorbet won't be able to start,  e.g. arbitrary `ruby` editor with no associated configuration, not being able to disable Sorbet provides poor UX as UI keeps  changing between states, it logs errors on every, and cannot be stopped.

- **Fix**: `SorbetStatusProvider.serverStatus` should handle the no `activeLanguageClient` scenario better and  report `RESTARTING` instead of `DISABLED` when the initialization process is still active (which enables the `Disable Sorbet` action in the dropdown as expected).
   Additionally, the `LanguageClient`  should report `DISABLED` satus when there is no `active configuration` (a scenario that only became possible now that `Disable Sorbet`, which removes the active configuration, can happen during initialization).

**Future**:  there is still some complexity in the LanguageClient/SorbeStatusProvider initialization logic that has to be improved (some `async` calls are not, intentionally, awaited which makes hard to reason when exactly some events happen).

Updating CHANGELOG and version to ship 0.3.38 with recent changes.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
