### PR TITLE
Fix: `Copy Symbol to Clipboard` fails to be enabled in remote devboxes

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version history
 
+## 0.3.39
+- Fix: `Copy Symbol to Clipboard` fails to be enabled in remote devboxes.
+
 ## 0.3.38
 - Sorbet can be disabled while in `Restarting` / `Initializing` loop.
 - `Copy Symbol to Clipboard` is enabled only for supported `file` and `sorbet` URI schemes.

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {
@@ -66,7 +66,7 @@
         "command": "sorbet.copySymbolToClipboard",
         "title": "Copy Symbol to Clipboard",
         "category": "Sorbet",
-        "enablement": "editorLangId == ruby && (resourceScheme == file || resourceScheme == sorbet) && !editorHasSelection"
+        "enablement": "editorLangId == ruby && !editorHasSelection && (resourceScheme == file || resourceScheme == sorbet || resourceScheme == vscode-remote)"
       },
       {
         "command": "sorbet.disable",


### PR DESCRIPTION
Fix: `Copy Symbol to Clipboard` fails to be enabled in remote devboxes because VS Code somewhat inconsistently (although understandably in retrospect) reports `vscode-remote` as `resourceScheme` for files whereas the extension APIs return `file` or `sorbet`.

Ship 0.3.39

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Caused by
- https://github.com/sorbet/sorbet/pull/8583

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
