### PR TITLE
Allow preemption during initialization

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -84,24 +84,12 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
     // TODO(jvilk): Make it preemptible.
     {
         const bool isIncremental = false;
-        ErrorEpoch epoch(*errorReporter, updates.epoch, isIncremental, {});
+        ErrorEpoch epoch(*errorReporter, 0, isIncremental, {});
         auto errorFlusher = make_shared<ErrorFlusherLSP>(updates.epoch, errorReporter);
-        auto result = runSlowPath(updates, std::move(kvstore), workers, errorFlusher, SlowPathMode::Init);
+        auto committed = runSlowPath(updates, std::move(kvstore), workers, errorFlusher, SlowPathMode::Init, &queue);
+        ENFORCE(committed);
         epoch.committed = true;
-        ENFORCE(std::holds_alternative<std::unique_ptr<core::GlobalState>>(result));
-        initialGS = std::move(std::get<std::unique_ptr<core::GlobalState>>(result));
     }
-
-    // Unblock the indexer now that its state is fully initialized.
-    {
-        absl::MutexLock lck{queue.getMutex()};
-
-        // ensure that the next task we process initializes the indexer
-        auto initTask = std::make_unique<IndexerInitializationTask>(*config, std::move(initialGS));
-        queue.tasks().push_front(std::move(initTask));
-    }
-
-    config->logger->error("Resuming");
 }
 
 bool LSPTypechecker::typecheck(std::unique_ptr<LSPFileUpdates> updates, WorkerPool &workers,
@@ -151,9 +139,8 @@ bool LSPTypechecker::typecheck(std::unique_ptr<LSPFileUpdates> updates, WorkerPo
             commitFileUpdates(*updates, /* cancelable */ false);
             prodCategoryCounterInc("lsp.updates", "fastpath");
         } else {
-            auto result = runSlowPath(*updates, nullptr, workers, errorFlusher, SlowPathMode::Cancelable);
-            ENFORCE(std::holds_alternative<bool>(result));
-            committed = std::get<bool>(result);
+            auto queue = nullptr;
+            committed = runSlowPath(*updates, nullptr, workers, errorFlusher, SlowPathMode::Cancelable, queue);
         }
         epoch.committed = committed;
     }
@@ -368,15 +355,11 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
     return epochManager.wasTypecheckingCanceled();
 }
 
-LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updates,
-                                                           std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
-                                                           shared_ptr<core::ErrorFlusher> errorFlusher,
-                                                           LSPTypechecker::SlowPathMode mode) {
+bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
+                                 shared_ptr<core::ErrorFlusher> errorFlusher, LSPTypechecker::SlowPathMode mode,
+                                 TaskQueue *queue) {
     ENFORCE(this_thread::get_id() == typecheckerThreadId,
             "runSlowPath can only be called from the typechecker thread.");
-
-    // This is populated when running in `SlowPathMode::Init`.
-    std::unique_ptr<core::GlobalState> indexedState;
 
     bool cancelable = mode == SlowPathMode::Cancelable;
 
@@ -407,6 +390,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
         switch (mode) {
             case SlowPathMode::Init: {
                 ENFORCE(!this->initialized);
+                ENFORCE(queue != nullptr);
                 Timer timeit(config->logger, "initial_index");
 
                 ShowOperation op(*config, ShowOperation::Kind::Indexing);
@@ -439,11 +423,22 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                 ENFORCE_NO_TIMER(indexed.size() == finalGS->filesUsed());
 
                 // At this point finalGS has a name table that's initialized enough for the indexer thread, so we make a
-                // copy to pass back over.
-                indexedState = finalGS->deepCopy();
+                // copy and pass it back over. This unblocks the indexer, and will allow it to preempt typechecking
+                // later on in the initialization phase.
+                auto indexedState = finalGS->deepCopy();
                 indexedState->errorQueue = std::move(savedErrorQueue);
 
                 this->initialized = true;
+
+                {
+                    absl::MutexLock lck{queue->getMutex()};
+                    queue->tasks().push_front(
+                        std::make_unique<IndexerInitializationTask>(*this->config, std::move(indexedState)));
+                    ENFORCE(queue->isPaused());
+                    queue->resume();
+                }
+
+                this->config->logger->error("Resuming");
 
                 break;
             }
@@ -532,12 +527,11 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
 
         // Inform the fast path that this global state is OK for typechecking as resolution has completed.
         gs->lspTypecheckCount++;
-        // TODO(jvilk): Remove conditional once initial typecheck is preemptible.
-        if (cancelable) {
-            // Inform users that Sorbet should be responsive now.
-            // Explicitly end previous operation before beginning next operation.
-            slowPathOp.emplace(*config, ShowOperation::Kind::SlowPathNonBlocking);
-        }
+
+        // Inform users that Sorbet should be responsive now.
+        // Explicitly end previous operation before beginning next operation.
+        slowPathOp.emplace(*config, ShowOperation::Kind::SlowPathNonBlocking);
+
         // Report how long the slow path blocks preemption.
         timeit.clone("slow_path.blocking_time");
 
@@ -592,15 +586,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
         logger->debug("[Typechecker] Typecheck run for epoch {} was canceled.", updates.epoch);
     }
 
-    switch (mode) {
-        case SlowPathMode::Init:
-            ENFORCE(committed);
-            ENFORCE(indexedState != nullptr);
-            return indexedState;
-        case SlowPathMode::Cancelable:
-            ENFORCE(indexedState == nullptr);
-            return committed;
-    }
+    return committed;
 }
 
 void LSPTypechecker::commitFileUpdates(LSPFileUpdates &updates, bool couldBeCanceled) {
@@ -838,12 +824,6 @@ LSPTypecheckerDelegate::LSPTypecheckerDelegate(TaskQueue &queue, WorkerPool &wor
 void LSPTypecheckerDelegate::initialize(InitializedTask &task, std::unique_ptr<core::GlobalState> gs,
                                         std::unique_ptr<KeyValueStore> kvstore, const LSPConfiguration &currentConfig) {
     return typechecker.initialize(this->queue, std::move(gs), std::move(kvstore), this->workers, currentConfig);
-}
-
-void LSPTypecheckerDelegate::resumeTaskQueue(InitializedTask &task) {
-    absl::MutexLock lck{this->queue.getMutex()};
-    ENFORCE(this->queue.isPaused());
-    this->queue.resume();
 }
 
 void LSPTypecheckerDelegate::typecheckOnFastPath(std::unique_ptr<LSPFileUpdates> updates,

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -92,22 +92,10 @@ class LSPTypechecker final {
         Cancelable,
     };
 
-    /**
-     * The result of a slow path operation depends on the mode that it was run in:
-     * - Init indicates that the LSPTypechecker is being initialized by the indexer. One implication of this is that the
-     *   slow path operation will not be cancelable, meaning that the result will always be committed. As we know that
-     *   the result will be committed, and the indexer needs a copy of the GlobalState to be taken after indexing, we
-     *   return that copy as the result of the slow path.
-     * - Cancelable indicates that the slow path may be canceled before it completes. As this mode does not require a
-     *   copy of the typechecker's GlobalState to be returned, and the slow path operation may be canceled, we return a
-     *   boolean indicating whether or not the result of the slow path was committed.
-     */
-    using SlowPathResult = std::variant<std::unique_ptr<core::GlobalState>, bool>;
-
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */
-    SlowPathResult runSlowPath(LSPFileUpdates &updates, std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
-                               std::shared_ptr<core::ErrorFlusher> errorFlusher, SlowPathMode mode);
+    bool runSlowPath(LSPFileUpdates &updates, std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
+                     std::shared_ptr<core::ErrorFlusher> errorFlusher, SlowPathMode mode, TaskQueue *queue);
 
     /** Runs incremental typechecking on the provided updates. Returns the final list of files typechecked. */
     std::vector<core::FileRef> runFastPath(LSPFileUpdates &updates, WorkerPool &workers,
@@ -233,8 +221,6 @@ public:
 
     void initialize(InitializedTask &task, std::unique_ptr<core::GlobalState> gs,
                     std::unique_ptr<KeyValueStore> kvstore, const LSPConfiguration &currentConfig);
-
-    void resumeTaskQueue(InitializedTask &task);
 
     void typecheckOnFastPath(std::unique_ptr<LSPFileUpdates> updates,
                              std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers);

--- a/main/lsp/notifications/initialized.cc
+++ b/main/lsp/notifications/initialized.cc
@@ -25,7 +25,6 @@ void InitializedTask::index(LSPIndexer &indexer) {
 void InitializedTask::run(LSPTypecheckerDelegate &typechecker) {
     ENFORCE(this->gs != nullptr);
     typechecker.initialize(*this, std::move(this->gs), std::move(this->kvstore), config);
-    typechecker.resumeTaskQueue(*this);
 }
 
 bool InitializedTask::needsMultithreading(const LSPIndexer &indexer) const {


### PR DESCRIPTION
**WIP**

Return the indexer's copy of the initial `GlobalState` right after indexing is done.

- [ ] The initialized task blocks until the first slow path completes, how can we avoid this?

### Motivation
The initial typecheck shouldn't block preemption.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
