### PR TITLE
Clean-up LanguageClient: extract `shimLanguageClient`

### DIFF
--- a/vscode_extension/src/languageClient.metrics.ts
+++ b/vscode_extension/src/languageClient.metrics.ts
@@ -1,5 +1,5 @@
 import { LanguageClient } from "vscode-languageclient/node";
-import { MetricClient } from "./metricsClient";
+import { MetricsClient } from "./metricsClient";
 
 /**
  * Shims the language client object so that all requests sent get timed.
@@ -7,7 +7,7 @@ import { MetricClient } from "./metricsClient";
  */
 export function instrumentLanguageClient(
   client: LanguageClient,
-  metrics: MetricClient,
+  metrics: MetricsClient,
 ): LanguageClient {
   const originalSendRequest = client.sendRequest;
 

--- a/vscode_extension/src/languageClient.metrics.ts
+++ b/vscode_extension/src/languageClient.metrics.ts
@@ -1,0 +1,36 @@
+import { LanguageClient } from "vscode-languageclient/node";
+import { MetricClient } from "./metricsClient";
+
+/**
+ * Shims the language client object so that all requests sent get timed.
+ * @returns The instrumented language client.
+ */
+export function instrumentLanguageClient(
+  client: LanguageClient,
+  metrics: MetricClient,
+): LanguageClient {
+  const originalSendRequest = client.sendRequest;
+
+  client.sendRequest = (method: any, ...args: any[]) => {
+    const now = new Date();
+
+    const requestName = typeof method === "string" ? method : method.method;
+    // Replace some special characters with underscores.
+    const sanitizedRequestName = requestName.replace(/[/$]/g, "_");
+    args.unshift(method);
+
+    const response = originalSendRequest.apply(client, args as any);
+    const metricName = `latency.${sanitizedRequestName}_ms`;
+    response.then(
+      () =>
+        // This is request succeeded. If the request is canceled, the promise is rejected.
+        metrics.emitTimingMetric(metricName, now, { success: "true" }),
+      () =>
+        // This request failed or was canceled.
+        metrics.emitTimingMetric(metricName, now, { success: "false" }),
+    );
+    return response;
+  };
+
+  return client;
+}

--- a/vscode_extension/src/metricsClient.ts
+++ b/vscode_extension/src/metricsClient.ts
@@ -56,7 +56,7 @@ export class NoOpApi implements Api {
   static INSTANCE = new NoOpApi();
 }
 
-export class MetricClient {
+export class MetricsClient {
   private apiPromise: Promise<Api | undefined>;
   private readonly context: SorbetExtensionContext;
   private readonly sorbetExtensionVersion: string;

--- a/vscode_extension/src/sorbetExtensionContext.ts
+++ b/vscode_extension/src/sorbetExtensionContext.ts
@@ -1,14 +1,14 @@
 import { Disposable, ExtensionContext, OutputChannel } from "vscode";
 import { DefaultSorbetWorkspaceContext, SorbetExtensionConfig } from "./config";
 import { Log, OutputChannelLog } from "./log";
-import { MetricClient } from "./metricsClient";
+import { MetricsClient } from "./metricsClient";
 import { SorbetStatusProvider } from "./sorbetStatusProvider";
 
 export class SorbetExtensionContext implements Disposable {
   public readonly configuration: SorbetExtensionConfig;
   private readonly disposable: Disposable;
   public readonly extensionContext: ExtensionContext;
-  public readonly metrics: MetricClient;
+  public readonly metrics: MetricsClient;
   public readonly statusProvider: SorbetStatusProvider;
   private readonly wrappedLog: OutputChannelLog;
 
@@ -17,7 +17,7 @@ export class SorbetExtensionContext implements Disposable {
     this.configuration = new SorbetExtensionConfig(sorbetWorkspaceContext);
     this.extensionContext = context;
     this.wrappedLog = new OutputChannelLog("Sorbet");
-    this.metrics = new MetricClient(this);
+    this.metrics = new MetricsClient(this);
     this.statusProvider = new SorbetStatusProvider(this);
 
     this.disposable = Disposable.from(

--- a/vscode_extension/src/test/languageClient.test.ts
+++ b/vscode_extension/src/test/languageClient.test.ts
@@ -8,7 +8,7 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { TestLanguageServerSpecialURIs } from "./testLanguageServerSpecialURIs";
 import { instrumentLanguageClient } from "../languageClient.metrics";
-import { MetricClient, MetricsEmitter, Tags } from "../metricsClient";
+import { MetricsClient, MetricsEmitter, Tags } from "../metricsClient";
 
 const enum MetricType {
   Increment,
@@ -94,15 +94,16 @@ function createLanguageClient(): LanguageClient {
 }
 
 suite("LanguageClient", () => {
-  let metricsEmitter: RecordingMetricsEmitter;
-  let metricsClient: sinon.SinonStubbedInstance<MetricClient> & MetricClient;
-
   suite("Metrics", () => {
+    let metricsEmitter: RecordingMetricsEmitter;
+    let metricsClient: sinon.SinonStubbedInstance<MetricsClient> &
+      MetricsClient;
+
     suiteSetup(() => {
       metricsEmitter = new RecordingMetricsEmitter();
       metricsClient = sinon.createStubInstance(
-        MetricClient,
-      ) as sinon.SinonStubbedInstance<MetricClient> & MetricClient;
+        MetricsClient,
+      ) as sinon.SinonStubbedInstance<MetricsClient> & MetricsClient;
       metricsClient.emitTimingMetric.callsFake((name, value, tags) => {
         return metricsEmitter.timing(name, value, tags);
       });

--- a/vscode_extension/src/test/metricsClient.test.ts
+++ b/vscode_extension/src/test/metricsClient.test.ts
@@ -4,7 +4,7 @@ import * as sinon from "sinon";
 import { createLogStub } from "./testUtils";
 import {
   METRIC_PREFIX,
-  MetricClient,
+  MetricsClient,
   NoOpApi,
   NoOpMetricsEmitter,
 } from "../metricsClient";
@@ -28,7 +28,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
 
     const incrementStub = sinon.stub(NoOpMetricsEmitter.prototype, "increment");
     testRestorables.push(incrementStub);
-    const client = new MetricClient(
+    const client = new MetricsClient(
       <SorbetExtensionContext>{
         configuration: {
           activeLspConfig: undefined,
@@ -60,7 +60,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
 
     const timingStub = sinon.stub(NoOpMetricsEmitter.prototype, "timing");
     testRestorables.push(timingStub);
-    const client = new MetricClient(
+    const client = new MetricsClient(
       <SorbetExtensionContext>{
         configuration: {
           activeLspConfig: undefined,


### PR DESCRIPTION
Clean-up `LanguageClient` class so it is easier to work on it: extract `shimLanguageClient` as `instrumentLanguageClient`.

Fix `MetricClient` vs `MetricsClient` name.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
