### PR TITLE
add `isRootScopedSyntacticConstant` helper

### DIFF
--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -5,6 +5,7 @@
 #include "core/Names.h"
 #include "core/core.h"
 #include "rewriter/rewriter.h"
+#include "rewriter/util/Util.h"
 
 using namespace std;
 
@@ -40,13 +41,11 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
         return empty;
     }
 
-    auto recv = ast::cast_tree<ast::UnresolvedConstantLit>(send->recv);
-    if (recv == nullptr) {
+    if (!ASTUtil::isRootScopedSyntacticConstant(send->recv, {core::Names::Constants::Class()})) {
         return empty;
     }
 
-    if (!ast::isa_tree<ast::EmptyTree>(recv->scope) || recv->cnst != core::Names::Constants::Class() ||
-        send->fun != core::Names::new_()) {
+    if (send->fun != core::Names::new_()) {
         return empty;
     }
 
@@ -98,13 +97,11 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
 }
 
 bool ClassNew::run(core::MutableContext ctx, ast::Send *send) {
-    auto recv = ast::cast_tree<ast::UnresolvedConstantLit>(send->recv);
-    if (recv == nullptr) {
+    if (!ASTUtil::isRootScopedSyntacticConstant(send->recv, {core::Names::Constants::Class()})) {
         return false;
     }
 
-    if (!ast::isa_tree<ast::EmptyTree>(recv->scope) || recv->cnst != core::Names::Constants::Class() ||
-        send->fun != core::Names::new_()) {
+    if (send->fun != core::Names::new_()) {
         return false;
     }
 

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -5,6 +5,7 @@
 #include "core/Names.h"
 #include "core/core.h"
 #include "rewriter/rewriter.h"
+#include "rewriter/util/Util.h"
 
 using namespace std;
 
@@ -14,21 +15,12 @@ bool isCommand(const ast::ClassDef *klass) {
     if (klass->kind != ast::ClassDef::Kind::Class || klass->ancestors.empty()) {
         return false;
     }
-    auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(klass->ancestors.front());
-    if (cnst == nullptr) {
-        return false;
-    }
-    if (cnst->cnst != core::Names::Constants::Command()) {
-        return false;
-    }
-    auto scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope);
-    if (scope == nullptr) {
-        return false;
-    }
-    if (scope->cnst != core::Names::Constants::Opus()) {
-        return false;
-    }
-    return ast::MK::isRootScope(scope->scope);
+
+    static constexpr core::NameRef opusCommand[] = {
+        core::Names::Constants::Opus(),
+        core::Names::Constants::Command(),
+    };
+    return ASTUtil::isRootScopedSyntacticConstant(klass->ancestors.front(), opusCommand);
 }
 
 void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -60,13 +60,11 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
         return empty;
     }
 
-    auto recv = ast::cast_tree<ast::UnresolvedConstantLit>(send->recv);
-    if (recv == nullptr) {
+    if (!ASTUtil::isRootScopedSyntacticConstant(send->recv, {core::Names::Constants::Data()})) {
         return empty;
     }
 
-    if (!ast::MK::isRootScope(recv->scope) || recv->cnst != core::Names::Constants::Data() ||
-        send->fun != core::Names::define() || send->hasKwArgs() || send->hasKwSplat()) {
+    if (send->fun != core::Names::define() || send->hasKwArgs() || send->hasKwSplat()) {
         return empty;
     }
 

--- a/rewriter/Rails.cc
+++ b/rewriter/Rails.cc
@@ -6,6 +6,7 @@
 #include "core/core.h"
 #include "core/errors/rewriter.h"
 #include "rewriter/rewriter.h"
+#include "rewriter/util/Util.h"
 
 using namespace std;
 
@@ -22,18 +23,13 @@ void Rails::run(core::MutableContext ctx, ast::ClassDef *cdef) {
     if (send->fun != core::Names::squareBrackets()) {
         return;
     }
-    auto name = ast::cast_tree<ast::UnresolvedConstantLit>(send->recv);
-    if (!name) {
-        return;
-    }
-    if (name->cnst != core::Names::Constants::Migration()) {
-        return;
-    }
-    auto name2 = ast::cast_tree<ast::UnresolvedConstantLit>(name->scope);
-    if (!name2) {
-        return;
-    }
-    if (name2->cnst != core::Names::Constants::ActiveRecord()) {
+
+    static constexpr core::NameRef activeRecordMigration[] = {
+        core::Names::Constants::ActiveRecord(),
+        core::Names::Constants::Migration(),
+    };
+
+    if (!ASTUtil::isRootScopedSyntacticConstant(send->recv, activeRecordMigration)) {
         return;
     }
     if (send->numPosArgs() != 1 && !send->hasKwArgs()) {

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -1,6 +1,7 @@
 #include "rewriter/SigRewriter.h"
 #include "ast/Helpers.h"
 #include "ast/treemap/treemap.h"
+#include "rewriter/util/Util.h"
 
 using namespace std;
 namespace sorbet::rewriter {
@@ -11,16 +12,12 @@ bool isTSigWithoutRuntime(ast::ExpressionPtr &expr) {
     if (auto cnst = ast::cast_tree<ast::ConstantLit>(expr)) {
         return cnst->symbol() == core::Symbols::T_Sig_WithoutRuntime();
     } else {
-        auto withoutRuntime = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
-        if (withoutRuntime == nullptr || withoutRuntime->cnst != core::Names::Constants::WithoutRuntime()) {
-            return false;
-        }
-        auto sig = ast::cast_tree<ast::UnresolvedConstantLit>(withoutRuntime->scope);
-        if (sig == nullptr || sig->cnst != core::Names::Constants::Sig()) {
-            return false;
-        }
-        auto t = ast::cast_tree<ast::UnresolvedConstantLit>(sig->scope);
-        return t != nullptr && t->cnst == core::Names::Constants::T() && ast::MK::isRootScope(t->scope);
+        static constexpr core::NameRef tSigWithoutRuntime[] = {
+            core::Names::Constants::T(),
+            core::Names::Constants::Sig(),
+            core::Names::Constants::WithoutRuntime(),
+        };
+        return ASTUtil::isRootScopedSyntacticConstant(expr, tSigWithoutRuntime);
     }
 }
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -67,13 +67,11 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
         return empty;
     }
 
-    auto recv = ast::cast_tree<ast::UnresolvedConstantLit>(send->recv);
-    if (recv == nullptr) {
+    if (!ASTUtil::isRootScopedSyntacticConstant(send->recv, {core::Names::Constants::Struct()})) {
         return empty;
     }
 
-    if (!ast::MK::isRootScope(recv->scope) || recv->cnst != core::Symbols::Struct().data(ctx)->name ||
-        send->fun != core::Names::new_() || (!send->hasPosArgs() && !send->hasKwArgs())) {
+    if (send->fun != core::Names::new_() || (!send->hasPosArgs() && !send->hasKwArgs())) {
         return empty;
     }
 

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -6,6 +6,7 @@
 #include "core/core.h"
 #include "core/errors/rewriter.h"
 #include "rewriter/rewriter.h"
+#include "rewriter/util/Util.h"
 
 using namespace std;
 
@@ -23,21 +24,11 @@ bool isTEnum(core::MutableContext ctx, ast::ClassDef *klass) {
     if (klass->kind != ast::ClassDef::Kind::Class || klass->ancestors.empty()) {
         return false;
     }
-    auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(klass->ancestors.front());
-    if (cnst == nullptr) {
-        return false;
-    }
-    if (cnst->cnst != core::Names::Constants::Enum()) {
-        return false;
-    }
-    auto scope = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope);
-    if (scope == nullptr) {
-        return false;
-    }
-    if (scope->cnst != core::Names::Constants::T()) {
-        return false;
-    }
-    return ast::MK::isRootScope(scope->scope);
+    static constexpr core::NameRef tEnum[] = {
+        core::Names::Constants::T(),
+        core::Names::Constants::Enum(),
+    };
+    return ASTUtil::isRootScopedSyntacticConstant(klass->ancestors.front(), tEnum);
 }
 
 ast::Send *asEnumsDo(ast::ExpressionPtr &stat) {

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -399,4 +399,21 @@ pair<core::NameRef, core::LocOffsets> ASTUtil::getAttrName(core::MutableContext 
     return make_pair(res, loc);
 }
 
+bool ASTUtil::isRootScopedSyntacticConstant(const ast::ExpressionPtr &expr,
+                                            absl::Span<const core::NameRef> constantName) {
+    auto *p = &expr;
+
+    for (auto it = constantName.rbegin(), end = constantName.rend(); it != end; ++it) {
+        auto ucl = ast::cast_tree<ast::UnresolvedConstantLit>(*p);
+
+        if (ucl == nullptr || ucl->cnst != *it) {
+            return false;
+        }
+
+        p = &ucl->scope;
+    }
+
+    return ast::MK::isRootScope(*p);
+}
+
 } // namespace sorbet::rewriter

--- a/rewriter/util/Util.h
+++ b/rewriter/util/Util.h
@@ -39,6 +39,9 @@ public:
     static std::pair<core::NameRef, core::LocOffsets> getAttrName(core::MutableContext ctx, core::NameRef attrFun,
                                                                   const ast::ExpressionPtr &name);
 
+    static bool isRootScopedSyntacticConstant(const ast::ExpressionPtr &expr,
+                                              absl::Span<const core::NameRef> constantName);
+
     ASTUtil() = delete;
 };
 } // namespace sorbet::rewriter

--- a/rewriter/util/Util.h
+++ b/rewriter/util/Util.h
@@ -39,6 +39,12 @@ public:
     static std::pair<core::NameRef, core::LocOffsets> getAttrName(core::MutableContext ctx, core::NameRef attrFun,
                                                                   const ast::ExpressionPtr &name);
 
+    // Test if `expr` is a chain of `UnresolvedConstantLit` trees with names equal to `constantName`.
+    //
+    // 1. Opus::Command as `expr` would match {Constants::Opus(), Constants::Command()}
+    // 2. ::Opus::Command as `expr` would match {Constants::Opus(), Constants::Command()}
+    // 3. Opus::Command::DoThing as `expr` would not match {Constants::Opus(), Constants::Command()}
+    // 4. Prelude::Opus::Command as `expr` would not match {Constants::Opus(), Constants::Command()}
     static bool isRootScopedSyntacticConstant(const ast::ExpressionPtr &expr,
                                               absl::Span<const core::NameRef> constantName);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I don't have super-strong opinions about this landing, but I think it does make things a little clearer.

I did not modify the Rails rewriters, as they don't check for root-scoped constants...but they probably should?

The formatting here leaves something to be desired, but such is the way with automatic formatters.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
