### PR TITLE
Fix compilation of fuzz targets

### DIFF
--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -32,7 +32,7 @@ unique_ptr<core::GlobalState> buildInitialGlobalState() {
 
     logger->trace("Doing on-start initialization");
 
-    payload::createInitialGlobalState(gs, *opts, kvstore);
+    payload::createInitialGlobalState(*gs, *opts, kvstore);
     return gs;
 }
 
@@ -72,7 +72,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     indexed = realmain::pipeline::index(*gs, absl::Span<core::FileRef>(inputFiles), *opts, *workers, kvstore);
     // We don't run this fuzzer with any packager options, so we can skip pipeline::package()
     auto foundHashes = nullptr;
-    indexed = move(realmain::pipeline::nameAndResolve(gs, move(indexed), *opts, *workers, foundHashes).result());
+    indexed = move(realmain::pipeline::nameAndResolve(*gs, move(indexed), *opts, *workers, foundHashes).result());
     realmain::pipeline::typecheck(*gs, move(indexed), *opts, *workers);
     return 0;
 }


### PR DESCRIPTION
I missed updating this target in #8579 because we don't build it in CI.

### Motivation
Fixing the build of `//test/fuzz`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
