### PR TITLE
Upgrade LanguageClient to 8.1.0 (Protocol 3.17.3)

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version history
 
+## 0.3.40
+- Upgrade VS Language Client to [protocol 3.17.3](https://github.com/microsoft/vscode-languageserver-node/blob/main/README.md#3173-protocol-810-json-rpc-810-client-and-810-server)
+
 ## 0.3.39
 - Fix: `Copy Symbol to Clipboard` fails to be enabled in remote devboxes.
 

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -330,7 +330,7 @@
     "async": "^2.6.4",
     "elegant-spinner": "^2.0.0",
     "minimatch": "^3.0.5",
-    "vscode-languageclient": "7.0.0"
+    "vscode-languageclient": "8.1.0"
   },
   "devDependencies": {
     "@types/elegant-spinner": "^1.0.0",

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -43,7 +43,7 @@ export function createClient(
         "Failed to initialize Sorbet language server",
         error instanceof Error ? error : undefined,
       );
-      return true;
+      return false;
     },
     outputChannel: context.logOutputChannel,
     revealOutputChannelOn: context.configuration.revealOutputOnError

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -40,7 +40,7 @@ export function createClient(
     initializationOptions,
     initializationFailedHandler: (error) => {
       context.log.error(
-        "Failed to initialize Sorbet language server",
+        "Failed to initialize Sorbet language server.",
         error instanceof Error ? error : undefined,
       );
       return false;

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -1,52 +1,16 @@
-import { ChildProcess, spawn } from "child_process";
-import { Disposable, Event, EventEmitter, workspace } from "vscode";
-import {
-  CloseAction,
-  ErrorAction,
-  ErrorHandler,
-  GenericNotificationHandler,
-  LanguageClient,
-  RevealOutputChannelOn,
-  ServerCapabilities,
-  ServerOptions,
-} from "vscode-languageclient/node";
-
-import { stopProcess } from "./connections";
-import { SorbetExtensionContext } from "./sorbetExtensionContext";
-import { ServerStatus, RestartReason } from "./types";
+import { ErrorHandler, RevealOutputChannelOn } from "vscode-languageclient";
+import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
 import { backwardsCompatibleTrackUntyped } from "./config";
-import { instrumentLanguageClient } from "./languageClient.metrics";
-
-const VALID_STATE_TRANSITIONS: ReadonlyMap<
-  ServerStatus,
-  ReadonlySet<ServerStatus>
-> = new Map<ServerStatus, Set<ServerStatus>>([
-  [
-    ServerStatus.INITIALIZING,
-    new Set([
-      ServerStatus.ERROR,
-      ServerStatus.RESTARTING,
-      ServerStatus.RUNNING,
-    ]),
-  ],
-  [
-    ServerStatus.RUNNING,
-    new Set([ServerStatus.ERROR, ServerStatus.RESTARTING]),
-  ],
-  // Restarting is a terminal state. The restart occurs by terminating this LanguageClient and creating a new one.
-  [ServerStatus.RESTARTING, new Set()],
-  // Error is a terminal state for this class.
-  [ServerStatus.ERROR, new Set()],
-]);
+import { SorbetExtensionContext } from "./sorbetExtensionContext";
 
 /**
- * Create Sorbet Language Client.
+ * Create Language Client for Sorber Server.
  */
-function createClient(
+export function createClient(
   context: SorbetExtensionContext,
   serverOptions: ServerOptions,
   errorHandler: ErrorHandler,
-) {
+): LanguageClient {
   const initializationOptions = {
     // Opt in to sorbet/showOperation notifications.
     supportsOperationNotifications: true,
@@ -66,15 +30,22 @@ function createClient(
     )}`,
   );
 
-  const client = new LanguageClient("ruby", "Sorbet", serverOptions, {
+  const client = new CustomLanguageClient("ruby", "Sorbet", serverOptions, {
     documentSelector: [
       { language: "ruby", scheme: "file" },
       // Support queries on generated files with sorbet:// URIs that do not exist editor-side.
       { language: "ruby", scheme: "sorbet" },
     ],
-    outputChannel: context.logOutputChannel,
-    initializationOptions,
     errorHandler,
+    initializationOptions,
+    initializationFailedHandler: (error) => {
+      context.log.error(
+        "Failed to initialize Sorbet language server",
+        error instanceof Error ? error : undefined,
+      );
+      return true;
+    },
+    outputChannel: context.logOutputChannel,
     revealOutputChannelOn: context.configuration.revealOutputOnError
       ? RevealOutputChannelOn.Error
       : RevealOutputChannelOn.Never,
@@ -83,278 +54,25 @@ function createClient(
   return client;
 }
 
-export type SorbetServerCapabilities = ServerCapabilities & {
-  sorbetShowSymbolProvider: boolean;
-};
-
-export class SorbetLanguageClient implements Disposable, ErrorHandler {
-  private readonly context: SorbetExtensionContext;
-  private readonly disposables: Disposable[];
-  private readonly languageClient: LanguageClient;
-  private readonly onStatusChangeEmitter: EventEmitter<ServerStatus>;
-  private readonly restart: (reason: RestartReason) => void;
-  private sorbetProcess?: ChildProcess;
-  // Sometimes this is an errno, not a process exit code. This happens when set
-  // via the `.on("error")` handler, instead of the `.on("exit")` handler.
-  private sorbetProcessExitCode?: number;
-  private wrappedLastError?: string;
-  private wrappedStatus: ServerStatus;
-
-  constructor(
-    context: SorbetExtensionContext,
-    restart: (reason: RestartReason) => void,
-  ) {
-    this.context = context;
-    this.onStatusChangeEmitter = new EventEmitter<ServerStatus>();
-    this.restart = restart;
-    this.wrappedStatus = ServerStatus.INITIALIZING;
-
-    this.languageClient = instrumentLanguageClient(
-      createClient(context, () => this.startSorbetProcess(), this),
-      this.context.metrics,
+// This implementation exists for the sole purpose of overriding the `force` flag
+// as the error/closed/init handlers are not used in every case. In particular, if
+// the server fails to start, errors are shown as dialog notification, with errors
+// similar to:
+//
+// - Sorbet client: couldn't create connection to server.
+// - Connection to server got closed. Server will not be restarted.
+//
+// By not forcing a UI component, they are just routed to existing loggers.
+class CustomLanguageClient extends LanguageClient {
+  error(
+    message: string,
+    data?: any,
+    showNotification?: boolean | "force",
+  ): void {
+    super.error(
+      message,
+      data,
+      showNotification === "force" ? true : showNotification,
     );
-    // It's possible for `onReady` to fire after `stop()` is called on the language client. :(
-    this.languageClient.onReady().then(() => {
-      if (this.status !== ServerStatus.ERROR) {
-        // Language client started successfully.
-        this.status = ServerStatus.RUNNING;
-      }
-    });
-
-    this.disposables = [
-      this.languageClient.start(),
-      this.onStatusChangeEmitter,
-    ];
-  }
-
-  /**
-   * Implements the disposable interface so this object can be added to the context's subscriptions
-   * to keep it alive. Stops the language server and Sorbet processes, and removes UI items.
-   */
-  public dispose() {
-    Disposable.from(...this.disposables).dispose();
-    this.disposables.length = 0;
-
-    let stopped = false;
-    /*
-     * stop() only invokes the then() callback after the language server
-     * ACKs the stop request.
-     * Stopping can time out if the language client is repeatedly failing to
-     * start (e.g. if network is down, or path to Sorbet is incorrect), or if
-     * Sorbet never ACKs the stop request.
-     * In the former case (which is the common case), VS code stops retrying
-     * the connection after we call stop(), but never invokes our callback.
-     * Thus, our solution is to wait 5 seconds for a callback, and stop the
-     * process if we haven't heard back.
-     */
-    const stopTimer = setTimeout(() => {
-      stopped = true;
-      this.context.metrics.emitCountMetric("stop.timed_out", 1);
-      if (this.sorbetProcess?.pid) {
-        stopProcess(this.sorbetProcess, this.context.log);
-      }
-      this.sorbetProcess = undefined;
-    }, 5000);
-
-    this.languageClient.stop().then(() => {
-      if (!stopped) {
-        clearTimeout(stopTimer);
-        this.context.metrics.emitCountMetric("stop.success", 1);
-        this.context.log.info("Sorbet has stopped.");
-      }
-    });
-  }
-
-  /**
-   * Sorbet language server {@link SorbetServerCapabilities capabilities}. Only
-   * available if the server has been initialized.
-   */
-  public get capabilities(): SorbetServerCapabilities | undefined {
-    return <SorbetServerCapabilities | undefined>(
-      this.languageClient.initializeResult?.capabilities
-    );
-  }
-
-  /**
-   * Contains error message when {@link status} is {@link ServerStatus.ERROR}.
-   */
-  public get lastError(): string | undefined {
-    return this.wrappedLastError;
-  }
-
-  /**
-   * Resolves when client is ready to serve requests.
-   */
-  public onReady(): Promise<void> {
-    return this.languageClient.onReady();
-  }
-
-  /**
-   * Register a handler for a language server notification. See {@link LanguageClient.onNotification}.
-   */
-  public onNotification(
-    method: string,
-    handler: GenericNotificationHandler,
-  ): Disposable {
-    return this.languageClient.onNotification(method, handler);
-  }
-
-  /**
-   * Event fired on {@link status} changes.
-   */
-  public get onStatusChange(): Event<ServerStatus> {
-    return this.onStatusChangeEmitter.event;
-  }
-
-  /**
-   * Send a request to language server. See {@link LanguageClient.sendRequest}.
-   */
-  public sendRequest<TResponse>(
-    method: string,
-    param: any,
-  ): Promise<TResponse> {
-    return this.languageClient.sendRequest<TResponse>(method, param);
-  }
-
-  /**
-   * Send a notification to language server. See {@link LanguageClient.sendNotification}.
-   */
-  public sendNotification(method: string, param: any): void {
-    this.languageClient.sendNotification(method, param);
-  }
-
-  /**
-   * Language client status.
-   */
-  public get status(): ServerStatus {
-    return this.wrappedStatus;
-  }
-
-  private set status(newStatus: ServerStatus) {
-    if (this.status === newStatus) {
-      return;
-    }
-
-    const set = VALID_STATE_TRANSITIONS.get(this.status);
-    if (!set?.has(newStatus)) {
-      this.context.log.error(
-        `Invalid Sorbet server transition: ${this.status} => ${newStatus}}`,
-      );
-    }
-
-    this.wrappedStatus = newStatus;
-    this.onStatusChangeEmitter.fire(newStatus);
-  }
-
-  /**
-   * Runs a Sorbet process using the current active configuration. Debounced so that it runs Sorbet at most every 3 seconds.
-   */
-  private startSorbetProcess(): Promise<ChildProcess> {
-    this.status = ServerStatus.INITIALIZING;
-    this.context.log.info("Running Sorbet LSP.");
-    const activeConfig = this.context.configuration.activeLspConfig;
-    const [command, ...args] = activeConfig?.command ?? [];
-    if (!command) {
-      let msg: string;
-      if (!activeConfig) {
-        msg = "No active Sorbet configuration.";
-        this.status = ServerStatus.DISABLED;
-      } else {
-        msg = `Missing command-line data to start Sorbet. ConfigId:${activeConfig.id}`;
-      }
-
-      this.context.log.error(msg);
-      return Promise.reject(new Error(msg));
-    }
-
-    this.context.log.debug(` > ${command} ${args.join(" ")}`);
-    this.sorbetProcess = spawn(command, args, {
-      cwd: workspace.rootPath,
-      env: { ...process.env, ...activeConfig?.env },
-    });
-    // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
-    // So, we need to handle both events. ¯\_(ツ)_/¯
-    this.sorbetProcess.on(
-      "exit",
-      (code: number | null, _signal: string | null) => {
-        this.sorbetProcessExitCode = code ?? undefined;
-      },
-    );
-    this.sorbetProcess.on("error", (err?: NodeJS.ErrnoException) => {
-      if (
-        err &&
-        this.status === ServerStatus.INITIALIZING &&
-        err.code === "ENOENT"
-      ) {
-        this.context.metrics.emitCountMetric("error.enoent", 1);
-        // We failed to start the process. The path to Sorbet is likely incorrect.
-        this.wrappedLastError = `Could not start Sorbet with command: '${command} ${args.join(
-          " ",
-        )}'. Encountered error '${
-          err.message
-        }'. Is the path to Sorbet correct?`;
-        this.status = ServerStatus.ERROR;
-      }
-      this.sorbetProcess = undefined;
-      this.sorbetProcessExitCode = err?.errno;
-    });
-    return Promise.resolve(this.sorbetProcess);
-  }
-
-  /** ErrorHandler interface */
-
-  /**
-   * LanguageClient has built-in restart capabilities but if it's broken:
-   * * It drops all `onNotification` subscriptions after restarting, so we'll miss ShowNotification updates.
-   * * It drops all `onReady` subscriptions after restarting, so we won't know when the Sorbet server is running.
-   * * It doesn't reset `onReady` state, so we can't even reset our `onReady` callback.
-   */
-  public error(): ErrorAction {
-    if (this.status !== ServerStatus.ERROR) {
-      this.status = ServerStatus.RESTARTING;
-      this.restart(RestartReason.CRASH_LC_ERROR);
-    }
-    return ErrorAction.Shutdown;
-  }
-
-  /**
-   * Note: If the VPN is disconnected, then Sorbet will repeatedly fail to start.
-   */
-  public closed(): CloseAction {
-    if (this.status !== ServerStatus.ERROR) {
-      let reason: RestartReason;
-      if (this.sorbetProcessExitCode === 11) {
-        // 11 number chosen somewhat arbitrarily. Most important is that this doesn't
-        // clobber the exit code of Sorbet itself (which means Sorbet cannot return 11).
-        //
-        // The only thing that matters is that this value is kept in sync with any
-        // wrapper scripts that people use with Sorbet. If this number has to
-        // change for some reason, we should announce that.
-        reason = RestartReason.WRAPPER_REFUSED_SPAWN;
-      } else if (this.sorbetProcessExitCode === 143) {
-        // 143 = 128 + 15 and 15 is TERM signal
-        reason = RestartReason.FORCIBLY_TERMINATED;
-      } else {
-        reason = RestartReason.CRASH_LC_CLOSED;
-        this.context.log.error("");
-        this.context.log.error(
-          `The Sorbet LSP process crashed exit_code=${this.sorbetProcessExitCode}`,
-        );
-        this.context.log.error("The Node.js backtrace above is not useful.");
-        this.context.log.error(
-          "If there is a C++ backtrace above, that is useful.",
-        );
-        this.context.log.error(
-          "Otherwise, more useful output will be in the --debug-log-file to the Sorbet process",
-        );
-        this.context.log.error("(if provided as a command-line argument).");
-        this.context.log.error("");
-      }
-
-      this.status = ServerStatus.RESTARTING;
-      this.restart(reason);
-    }
-
-    return CloseAction.DoNotRestart;
   }
 }

--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -32,6 +32,7 @@ const VALID_STATE_TRANSITIONS: ReadonlyMap<
     ServerStatus.RUNNING,
     new Set([ServerStatus.ERROR, ServerStatus.RESTARTING]),
   ],
+  [ServerStatus.DISABLED, new Set([ServerStatus.INITIALIZING])],
   // Restarting is a terminal state. The restart occurs by terminating this LanguageClient and creating a new one.
   [ServerStatus.RESTARTING, new Set()],
   // Error is a terminal state for this class.

--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -1,0 +1,310 @@
+import { Disposable, Event, EventEmitter, workspace } from "vscode";
+import {
+  CloseAction,
+  CloseHandlerResult,
+  ErrorAction,
+  ErrorHandler,
+  ErrorHandlerResult,
+  GenericNotificationHandler,
+  LanguageClient,
+  ServerCapabilities,
+} from "vscode-languageclient/node";
+import { ChildProcess, spawn } from "child_process";
+import { stopProcess } from "./connections";
+import { createClient } from "./languageClient";
+import { instrumentLanguageClient } from "./languageClient.metrics";
+import { SorbetExtensionContext } from "./sorbetExtensionContext";
+import { ServerStatus, RestartReason } from "./types";
+
+const VALID_STATE_TRANSITIONS: ReadonlyMap<
+  ServerStatus,
+  ReadonlySet<ServerStatus>
+> = new Map<ServerStatus, Set<ServerStatus>>([
+  [
+    ServerStatus.INITIALIZING,
+    new Set([
+      ServerStatus.ERROR,
+      ServerStatus.RESTARTING,
+      ServerStatus.RUNNING,
+    ]),
+  ],
+  [
+    ServerStatus.RUNNING,
+    new Set([ServerStatus.ERROR, ServerStatus.RESTARTING]),
+  ],
+  // Restarting is a terminal state. The restart occurs by terminating this LanguageClient and creating a new one.
+  [ServerStatus.RESTARTING, new Set()],
+  // Error is a terminal state for this class.
+  [ServerStatus.ERROR, new Set()],
+]);
+
+export type SorbetServerCapabilities = ServerCapabilities & {
+  sorbetShowSymbolProvider: boolean;
+};
+
+export class SorbetLanguageClient implements Disposable, ErrorHandler {
+  private readonly context: SorbetExtensionContext;
+  private readonly languageClient: LanguageClient;
+  private readonly onStatusChangeEmitter: EventEmitter<ServerStatus>;
+  private readonly restart: (reason: RestartReason) => void;
+  private sorbetProcess?: ChildProcess;
+  // Sometimes this is an errno, not a process exit code. This happens when set
+  // via the `.on("error")` handler, instead of the `.on("exit")` handler.
+  private sorbetProcessExitCode?: number;
+  private wrappedLastError?: string;
+  private wrappedStatus: ServerStatus;
+
+  constructor(
+    context: SorbetExtensionContext,
+    restart: (reason: RestartReason) => void,
+  ) {
+    this.context = context;
+    this.languageClient = instrumentLanguageClient(
+      createClient(context, () => this.startSorbetProcess(), this),
+      this.context.metrics,
+    );
+
+    this.onStatusChangeEmitter = new EventEmitter<ServerStatus>();
+    this.restart = restart;
+    this.wrappedStatus = ServerStatus.DISABLED;
+  }
+
+  /**
+   * Implements the disposable interface so this object can be added to the context's subscriptions
+   * to keep it alive. Stops the language server and Sorbet processes, and removes UI items.
+   */
+  public dispose() {
+    this.onStatusChangeEmitter.dispose();
+
+    let stopped = false;
+    /*
+     * stop() only invokes the then() callback after the language server
+     * ACKs the stop request.
+     * Stopping can time out if the language client is repeatedly failing to
+     * start (e.g. if network is down, or path to Sorbet is incorrect), or if
+     * Sorbet never ACKs the stop request.
+     * In the former case (which is the common case), VS code stops retrying
+     * the connection after we call stop(), but never invokes our callback.
+     * Thus, our solution is to wait 5 seconds for a callback, and stop the
+     * process if we haven't heard back.
+     */
+    const stopTimer = setTimeout(() => {
+      stopped = true;
+      this.context.metrics.emitCountMetric("stop.timed_out", 1);
+      if (this.sorbetProcess?.pid) {
+        stopProcess(this.sorbetProcess, this.context.log);
+      }
+      this.sorbetProcess = undefined;
+    }, 5000);
+
+    this.languageClient.stop().then(() => {
+      if (!stopped) {
+        clearTimeout(stopTimer);
+        this.context.metrics.emitCountMetric("stop.success", 1);
+        this.context.log.info("Sorbet has stopped.");
+      }
+    });
+  }
+
+  /**
+   * Sorbet language server {@link SorbetServerCapabilities capabilities}. Only
+   * available when the server has been initialized.
+   */
+  public get capabilities(): SorbetServerCapabilities | undefined {
+    return <SorbetServerCapabilities | undefined>(
+      this.languageClient.initializeResult?.capabilities
+    );
+  }
+
+  /**
+   * Last error message when {@link status} is {@link ServerStatus.ERROR}.
+   */
+  public get lastError(): string | undefined {
+    return this.wrappedLastError;
+  }
+
+  /**
+   * Resolves when client is ready to serve requests.
+   */
+  public async start(): Promise<void> {
+    if (!this.languageClient.needsStart()) {
+      this.context.log.debug("Ignored unnecessary start request");
+      return;
+    }
+
+    await this.languageClient.start();
+  }
+
+  /**
+   * Register a handler for a language server notification. See {@link LanguageClient.onNotification}.
+   */
+  public onNotification(
+    method: string,
+    handler: GenericNotificationHandler,
+  ): Disposable {
+    return this.languageClient.onNotification(method, handler);
+  }
+
+  /**
+   * Event fired on {@link status} changes.
+   */
+  public get onStatusChange(): Event<ServerStatus> {
+    return this.onStatusChangeEmitter.event;
+  }
+
+  /**
+   * Send a request to language server. See {@link LanguageClient.sendRequest}.
+   */
+  public sendRequest<TResponse>(
+    method: string,
+    param: any,
+  ): Promise<TResponse> {
+    return this.languageClient.sendRequest<TResponse>(method, param);
+  }
+
+  /**
+   * Send a notification to language server. See {@link LanguageClient.sendNotification}.
+   */
+  public sendNotification(method: string, param: any): void {
+    this.languageClient.sendNotification(method, param);
+  }
+
+  /**
+   * Language client status.
+   */
+  public get status(): ServerStatus {
+    return this.wrappedStatus;
+  }
+
+  private set status(newStatus: ServerStatus) {
+    if (this.status === newStatus) {
+      return;
+    }
+
+    const set = VALID_STATE_TRANSITIONS.get(this.status);
+    if (!set?.has(newStatus)) {
+      this.context.log.error(
+        `Invalid Sorbet server transition: ${this.status} => ${newStatus}}`,
+      );
+    }
+
+    this.wrappedStatus = newStatus;
+    this.onStatusChangeEmitter.fire(newStatus);
+  }
+
+  /**
+   * Runs a Sorbet process using the current active configuration. Debounced so that it runs Sorbet at most every 3 seconds.
+   */
+  private startSorbetProcess(): Promise<ChildProcess> {
+    this.status = ServerStatus.INITIALIZING;
+    this.context.log.info("Running Sorbet LSP.");
+    const activeConfig = this.context.configuration.activeLspConfig;
+    const [command, ...args] = activeConfig?.command ?? [];
+    if (!command) {
+      let msg: string;
+      if (!activeConfig) {
+        msg = "No active Sorbet configuration.";
+        this.status = ServerStatus.DISABLED;
+      } else {
+        msg = `Missing command-line data to start Sorbet. ConfigId:${activeConfig.id}`;
+      }
+
+      this.context.log.error(msg);
+      return Promise.reject(new Error(msg));
+    }
+
+    this.context.log.debug(` > ${command} ${args.join(" ")}`);
+    this.sorbetProcess = spawn(command, args, {
+      cwd: workspace.rootPath,
+      env: { ...process.env, ...activeConfig?.env },
+    });
+    // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.
+    // So, we need to handle both events. ¯\_(ツ)_/¯
+    this.sorbetProcess.on(
+      "exit",
+      (code: number | null, _signal: string | null) => {
+        this.sorbetProcessExitCode = code ?? undefined;
+      },
+    );
+    this.sorbetProcess.on("error", (err?: NodeJS.ErrnoException) => {
+      if (
+        err &&
+        this.status === ServerStatus.INITIALIZING &&
+        err.code === "ENOENT"
+      ) {
+        this.context.metrics.emitCountMetric("error.enoent", 1);
+        // We failed to start the process. The path to Sorbet is likely incorrect.
+        this.wrappedLastError = `Could not start Sorbet with command: '${command} ${args.join(
+          " ",
+        )}'. Encountered error '${
+          err.message
+        }'. Is the path to Sorbet correct?`;
+        this.status = ServerStatus.ERROR;
+      }
+      this.sorbetProcess = undefined;
+      this.sorbetProcessExitCode = err?.errno;
+    });
+    return Promise.resolve(this.sorbetProcess);
+  }
+
+  /** ErrorHandler interface */
+
+  /**
+   * LanguageClient has built-in restart capabilities but if it's broken:
+   * * It drops all `onNotification` subscriptions after restarting, so we'll miss ShowNotification updates.
+   * * It drops all `onReady` subscriptions after restarting, so we won't know when the Sorbet server is running.
+   * * It doesn't reset `onReady` state, so we can't even reset our `onReady` callback.
+   */
+  public error(): ErrorHandlerResult {
+    if (this.status !== ServerStatus.ERROR) {
+      this.status = ServerStatus.RESTARTING;
+      this.restart(RestartReason.CRASH_LC_ERROR);
+    }
+    return {
+      action: ErrorAction.Shutdown,
+    };
+  }
+
+  /**
+   * Note: If the VPN is disconnected, then Sorbet will repeatedly fail to start.
+   */
+  public closed(): CloseHandlerResult {
+    if (this.status !== ServerStatus.ERROR) {
+      let reason: RestartReason;
+      if (this.sorbetProcessExitCode === 11) {
+        // 11 number chosen somewhat arbitrarily. Most important is that this doesn't
+        // clobber the exit code of Sorbet itself (which means Sorbet cannot return 11).
+        //
+        // The only thing that matters is that this value is kept in sync with any
+        // wrapper scripts that people use with Sorbet. If this number has to
+        // change for some reason, we should announce that.
+        reason = RestartReason.WRAPPER_REFUSED_SPAWN;
+      } else if (this.sorbetProcessExitCode === 143) {
+        // 143 = 128 + 15 and 15 is TERM signal
+        reason = RestartReason.FORCIBLY_TERMINATED;
+      } else {
+        reason = RestartReason.CRASH_LC_CLOSED;
+        this.context.log.error("");
+        this.context.log.error(
+          `The Sorbet LSP process crashed exit_code=${this.sorbetProcessExitCode}`,
+        );
+        this.context.log.error("The Node.js backtrace above is not useful.");
+        this.context.log.error(
+          "If there is a C++ backtrace above, that is useful.",
+        );
+        this.context.log.error(
+          "Otherwise, more useful output will be in the --debug-log-file to the Sorbet process",
+        );
+        this.context.log.error("(if provided as a command-line argument).");
+        this.context.log.error("");
+      }
+
+      this.status = ServerStatus.RESTARTING;
+      this.restart(reason);
+    }
+
+    return {
+      action: CloseAction.DoNotRestart,
+    };
+  }
+}

--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -133,7 +133,9 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
       return;
     }
 
+    this.status = ServerStatus.INITIALIZING;
     await this.languageClient.start();
+    this.status = ServerStatus.RUNNING;
   }
 
   /**
@@ -197,7 +199,6 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
    * Runs a Sorbet process using the current active configuration. Debounced so that it runs Sorbet at most every 3 seconds.
    */
   private startSorbetProcess(): Promise<ChildProcess> {
-    this.status = ServerStatus.INITIALIZING;
     this.context.log.info("Running Sorbet LSP.");
     const activeConfig = this.context.configuration.activeLspConfig;
     const [command, ...args] = activeConfig?.command ?? [];

--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -135,7 +135,12 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
 
     this.status = ServerStatus.INITIALIZING;
     await this.languageClient.start();
-    this.status = ServerStatus.RUNNING;
+
+    // In case of error (missing Sorbet process), the client might have already
+    // transitioned to Error or Restarting so this should not override that.
+    if (this.status === ServerStatus.INITIALIZING) {
+      this.status = ServerStatus.RUNNING;
+    }
   }
 
   /**
@@ -184,8 +189,7 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
       return;
     }
 
-    const set = VALID_STATE_TRANSITIONS.get(this.status);
-    if (!set?.has(newStatus)) {
+    if (!VALID_STATE_TRANSITIONS.get(this.status)?.has(newStatus)) {
       this.context.log.error(
         `Invalid Sorbet server transition: ${this.status} => ${newStatus}}`,
       );

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -1,5 +1,5 @@
 import { Disposable, Event, EventEmitter } from "vscode";
-import { SorbetLanguageClient } from "./languageClient";
+import { SorbetLanguageClient } from "./sorbetLanguageClient";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { RestartReason, ServerStatus, ShowOperationParams } from "./types";
 
@@ -64,7 +64,7 @@ export class SorbetStatusProvider implements Disposable {
       }
     }
 
-    // Hook-up new client for clean-up, if any.
+    // Register new client for clean-up, if any.
     if (value) {
       const i = this.disposables.indexOf(value);
       if (i === -1) {
@@ -204,9 +204,6 @@ export class SorbetStatusProvider implements Disposable {
       this.context,
       (reason: RestartReason) => this.restartSorbet(reason),
     );
-    // Use property-setter to ensure proper setup.
-    this.activeLanguageClient = newClient;
-
     this.disposables.push(
       newClient.onStatusChange((status: ServerStatus) => {
         // Ignore event if this is not the current client (e.g. old client being shut down).
@@ -219,8 +216,10 @@ export class SorbetStatusProvider implements Disposable {
       }),
     );
 
-    // Wait for `ready` before accessing `languageClient`.
-    await newClient.onReady();
+    // Wait for the client to be ready before advertising it as active.
+    await newClient.start();
+    this.activeLanguageClient = newClient;
+
     this.disposables.push(
       newClient.onNotification(
         "sorbet/showOperation",

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -216,9 +216,8 @@ export class SorbetStatusProvider implements Disposable {
       }),
     );
 
-    // Wait for the client to be ready before advertising it as active.
-    await newClient.start();
     this.activeLanguageClient = newClient;
+    await newClient.start();
 
     this.disposables.push(
       newClient.onNotification(

--- a/vscode_extension/src/test/commands/copySymbolToClipboard.test.ts
+++ b/vscode_extension/src/test/commands/copySymbolToClipboard.test.ts
@@ -5,7 +5,7 @@ import * as sinon from "sinon";
 
 import { createLogStub } from "../testUtils";
 import { copySymbolToClipboard } from "../../commands/copySymbolToClipboard";
-import { SorbetLanguageClient } from "../../languageClient";
+import { SorbetLanguageClient } from "../../sorbetLanguageClient";
 import { LogLevel } from "../../log";
 import { SorbetExtensionContext } from "../../sorbetExtensionContext";
 import { SorbetStatusProvider } from "../../sorbetStatusProvider";

--- a/vscode_extension/src/test/languageClient.test.ts
+++ b/vscode_extension/src/test/languageClient.test.ts
@@ -56,6 +56,7 @@ class RecordingMetricsEmitter implements MetricsEmitter {
   }
 }
 
+// Uninitialized client. Call start and awaiton it before use.
 function createLanguageClient(): LanguageClient {
   // The server is implemented in node
   const serverModule = require.resolve("./testLanguageServer");
@@ -88,8 +89,6 @@ function createLanguageClient(): LanguageClient {
     clientOptions,
   );
 
-  // Start the client. This will also launch the server
-  client.start();
   return client;
 }
 
@@ -114,7 +113,8 @@ suite("LanguageClient", () => {
         createLanguageClient(),
         metricsClient,
       );
-      await client.onReady();
+      await client.start();
+
       {
         const successResponse = await client.sendRequest("textDocument/hover", {
           textDocument: {

--- a/vscode_extension/src/test/sorbetContentProvider.test.ts
+++ b/vscode_extension/src/test/sorbetContentProvider.test.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as sinon from "sinon";
 
 import { createLogStub } from "./testUtils";
-import { SorbetLanguageClient } from "../languageClient";
+import { SorbetLanguageClient } from "../sorbetLanguageClient";
 import { LogLevel } from "../log";
 import { SorbetExtensionContext } from "../sorbetExtensionContext";
 import { SorbetContentProvider } from "../sorbetContentProvider";

--- a/vscode_extension/yarn.lock
+++ b/vscode_extension/yarn.lock
@@ -558,6 +558,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
@@ -2061,6 +2068,13 @@ minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatc
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.1.0:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -2689,7 +2703,7 @@ semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.4, semver@^7.3.7:
+semver@^7.2.1, semver@^7.3.7:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
   integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
@@ -3120,14 +3134,19 @@ vscode-jsonrpc@6.0.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
   integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
-vscode-languageclient@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz#b505c22c21ffcf96e167799757fca07a6bad0fb2"
-  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
+vscode-jsonrpc@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz#cb9989c65e219e18533cc38e767611272d274c94"
+  integrity sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==
+
+vscode-languageclient@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz#3e67d5d841481ac66ddbdaa55b4118742f6a9f3f"
+  integrity sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==
   dependencies:
-    minimatch "^3.0.4"
-    semver "^7.3.4"
-    vscode-languageserver-protocol "3.16.0"
+    minimatch "^5.1.0"
+    semver "^7.3.7"
+    vscode-languageserver-protocol "3.17.3"
 
 vscode-languageserver-protocol@3.16.0:
   version "3.16.0"
@@ -3137,10 +3156,23 @@ vscode-languageserver-protocol@3.16.0:
     vscode-jsonrpc "6.0.0"
     vscode-languageserver-types "3.16.0"
 
+vscode-languageserver-protocol@3.17.3:
+  version "3.17.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz#6d0d54da093f0c0ee3060b81612cce0f11060d57"
+  integrity sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==
+  dependencies:
+    vscode-jsonrpc "8.1.0"
+    vscode-languageserver-types "3.17.3"
+
 vscode-languageserver-types@3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
   integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
+
+vscode-languageserver-types@3.17.3:
+  version "3.17.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz#72d05e47b73be93acb84d6e311b5786390f13f64"
+  integrity sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==
 
 vscode-languageserver@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Upgrade LanguageClient to 8.1.0
- 8.1.0 is the latest client version we can upgrade to without further updates (in particular VS Code).
- Updating extension code to use `start` instead of `onReady` is not a trivial as it sounds as state transition graph changed slightly.  More relevant from extension perspective is that error handling has changed in way that more errors bubble up as dialogs which would lead to a bad UX if not dealt with.
  - Internally the client uses a special `force` value when reporting errors that means "force error dialog", and this is not ideal as in many scenarios it erroneously ignores the return values from configured error handlers.
   -  There were and are ongoing issue reports about this: 8.0 allowed errors to bubble up which exposed the issues with `force`, and `8.1.0` fix some, but not all issues ([example](https://github.com/microsoft/vscode-languageserver-node/issues/1608)).
- The `createClient` method now returns a custom `LanguageClient` class that overrides the `error` method , allowing control over the `force` parameter. It simply converts into a `true` boolean value, which allows handlers' result to dictate error handling.
    - Caveat is that not all codepaths have an attached error handler, so there is a chance some random error bubbles up, but so far testing has not shown any condition for that.
- Added an `initializationFailedHandler` to the `LanguageClient` created by `createClient` so connection errors (e.g.  preexisting`Pending response rejected since connection got disposed`) do not surface as notifications.
  -  It is crucial for this handler not to trigger automatic restarting, as we handle restarts ourselves with a timeout. Otherwise, the client library may silently enter a restart loop that consumes excessive CPU resources.
- Due to the `onReady`+`start` change to `start`-only when initializing the extension,  the client now starts in `DISABLED` state now, vs `INITIALIZING`, and the latter state is only entered when `start` is invoked.  This better reflects the state of the client without introducing a new `ServerStatus`, e.g.  "Created".
     - If you want to be pedantic about it, `DISABLED` should be a terminal state but we use it when we stop the extension as well, so effectively `DISABLED` just means "client is not up nor trying to be started".

- Misc:
   - Move `SorbetLanguageClient` to `sorbetLanguageClient.ts` to match class name.
   - `languageClient.ts`, next to `languageClient.metrics.ts`, operates on `LanguageClient`. Conveniently, existing `languageClient.test.ts` matches this, file names and target are in-sync.

**Ship Extension 0.3.40**

**References**
- Previous attempt: Revert "update vscode-languageclient with LSP 3.17 support (#6492)" #6501
- Relevant spec changes:
   - `onReady` removed: [3.17.0](https://github.com/microsoft/vscode-languageserver-node/blob/main/README.md#3170-protocol-800-json-rpc-800-client-and-800-server)
   - Updates to error handling (required but not enough to limit spurious errors from  showing as notifications, unless handled) : [3.17.3](https://github.com/microsoft/vscode-languageserver-node/blob/main/README.md#3173-protocol-810-json-rpc-810-client-and-810-server)

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Based on exploratory work done in https://github.com/sorbet/sorbet/pull/8594 which contains additional API changes not required for the upgrade. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
