### PR TITLE
Populate `opts.cacheDir` before we read it

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -915,6 +915,8 @@ void readOptions(Options &opts,
         opts.inputFileNames.erase(unique(opts.inputFileNames.begin(), opts.inputFileNames.end()),
                                   opts.inputFileNames.end());
 
+        opts.cacheDir = raw["cache-dir"].as<string>();
+
         opts.rbsSignaturesEnabled = raw["enable-experimental-rbs-signatures"].as<bool>();
         if (opts.rbsSignaturesEnabled && !opts.cacheDir.empty()) {
             logger->error("--enable-experimental-rbs-signatures is incompatible with --cache-dir. Ignoring cache");
@@ -958,7 +960,6 @@ void readOptions(Options &opts,
 
         opts.lspErrorCap = raw["lsp-error-cap"].as<int>();
 
-        opts.cacheDir = raw["cache-dir"].as<string>();
         opts.maxCacheSizeBytes = raw["max-cache-size-bytes"].as<size_t>();
         if (!extractPrinters(raw, opts, logger)) {
             throw EarlyReturnWithCode(1);

--- a/test/cli/rbs-cache-dir/test.out
+++ b/test/cli/rbs-cache-dir/test.out
@@ -1,3 +1,4 @@
+--enable-experimental-rbs-signatures is incompatible with --cache-dir. Ignoring cache
 No errors! Great job.
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
@@ -16,10 +17,6 @@ end
 No errors! Great job.
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.returns(<emptyTree>::<C Integer>)
-    end
-
     def foo<<todo method>>(&<blk>)
       0
     end

--- a/test/cli/rbs-cache-dir/test.out
+++ b/test/cli/rbs-cache-dir/test.out
@@ -1,0 +1,29 @@
+No errors! Great job.
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<<todo method>>(&<blk>)
+      0
+    end
+
+    <runtime method definition of foo>
+  end
+end
+--------------------------------------------------------------------------
+No errors! Great job.
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<<todo method>>(&<blk>)
+      0
+    end
+
+    <runtime method definition of foo>
+  end
+end

--- a/test/cli/rbs-cache-dir/test.rb
+++ b/test/cli/rbs-cache-dir/test.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+class A
+  #: () -> Integer
+  def foo = 0
+end

--- a/test/cli/rbs-cache-dir/test.sh
+++ b/test/cli/rbs-cache-dir/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+trap 'rm -rf ./my-cache-dir' EXIT
+
+
+main/sorbet \
+  --silence-dev-message \
+  --print=index-tree \
+  --cache-dir=my-cache-dir \
+  --enable-experimental-rbs-signatures \
+  test/cli/rbs-cache-dir/test.rb 2>&1
+
+echo --------------------------------------------------------------------------
+
+main/sorbet \
+  --silence-dev-message \
+  --print=index-tree \
+  --cache-dir=my-cache-dir \
+  test/cli/rbs-cache-dir/test.rb 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was a problem with #8470 that managed to slip through.

The code checks whether `opts.cacheDir` is set before setting it.

cc @Morriar

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] CLI test