### PR TITLE
Update stale comments

### DIFF
--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -200,7 +200,8 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
   }
 
   /**
-   * Runs a Sorbet process using the current active configuration. Debounced so that it runs Sorbet at most every 3 seconds.
+   * Runs a Sorbet process using the current active configuration. Debounced so that it runs
+   * Sorbet at most every MIN_TIME_BETWEEN_RETRIES_MS.
    */
   private startSorbetProcess(): Promise<ChildProcess> {
     this.context.log.info("Running Sorbet LSP.");
@@ -255,12 +256,6 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
 
   /** ErrorHandler interface */
 
-  /**
-   * LanguageClient has built-in restart capabilities but if it's broken:
-   * * It drops all `onNotification` subscriptions after restarting, so we'll miss ShowNotification updates.
-   * * It drops all `onReady` subscriptions after restarting, so we won't know when the Sorbet server is running.
-   * * It doesn't reset `onReady` state, so we can't even reset our `onReady` callback.
-   */
   public error(): ErrorHandlerResult {
     if (this.status !== ServerStatus.ERROR) {
       this.status = ServerStatus.RESTARTING;
@@ -271,9 +266,6 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
     };
   }
 
-  /**
-   * Note: If the VPN is disconnected, then Sorbet will repeatedly fail to start.
-   */
   public closed(): CloseHandlerResult {
     if (this.status !== ServerStatus.ERROR) {
       let reason: RestartReason;

--- a/vscode_extension/src/test/languageClient.test.ts
+++ b/vscode_extension/src/test/languageClient.test.ts
@@ -56,7 +56,7 @@ class RecordingMetricsEmitter implements MetricsEmitter {
   }
 }
 
-// Uninitialized client. Call start and awaiton it before use.
+// Uninitialized client. Call start and await on it before use.
 function createLanguageClient(): LanguageClient {
   // The server is implemented in node
   const serverModule = require.resolve("./testLanguageServer");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Update stale comments per feedback on  https://github.com/sorbet/sorbet/pull/8606
 - `ErrorHandler`'s `error` and `close` methods have completely out-of-date comments.  Removing them so VSCode shows the comments from the interface definition.
 - Comment mentioning we restart every 3 seconds is incorrect (current value is 7s) , so updating that to reference the constant name that defines the value (`MIN_TIME_BETWEEN_RETRIES_MS`). Not using a `link` because that would create an unnecessary circular dependency (restarts originate from the `SorbetStatusProvider` - a bit convoluted but current state is far simpler that earlier one).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
