### PR TITLE
Improve resiliency of call stack parsing for sealed modules

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/sealed.rb
+++ b/gems/sorbet-runtime/lib/types/private/sealed.rb
@@ -22,14 +22,14 @@ module T::Private::Sealed
   module NoIncludeExtend
     def included(child)
       super
-      caller_loc = T::Private::CallerUtils.find_caller {|loc| !loc.to_s.match(/in `included'$/)}
+      caller_loc = T::Private::CallerUtils.find_caller {|loc| loc.base_label != 'included'}
       T::Private::Sealed.validate_inheritance(caller_loc, self, child, 'included')
       @sorbet_sealed_module_all_subclasses << child
     end
 
     def extended(child)
       super
-      caller_loc = T::Private::CallerUtils.find_caller {|loc| !loc.to_s.match(/in `extended'$/)}
+      caller_loc = T::Private::CallerUtils.find_caller {|loc| loc.base_label != 'extended'}
       T::Private::Sealed.validate_inheritance(caller_loc, self, child, 'extended')
       @sorbet_sealed_module_all_subclasses << child
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Extend the work in https://github.com/sorbet/sorbet/commit/685f197c09c6a62803badad6857604b0c87989e4#diff-92b2f23eee3b9e85b4f240f38d3152181b137424f3bfff674eab2de6476e022b to cover sealed modules.

This is necessary because the content of `Thread.each_caller_location` has changed and no longer uses backticks. Instead of switching to `'` replace with `base_label` which is more robust


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Resolves a breaking 3.4 compatibility issue within Stripe


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
I've tested this within Stripe and sealed modules now work correctly

See included automated tests.
