### PR TITLE
Move `PackageSpec` off of `::<root>`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -604,7 +604,7 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(klass == Symbols::PackageSpecRegistry());
 
     // PackageSpec is a class that can be subclassed.
-    klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpec());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), Names::Constants::PackageSpec());
     klass.data(*this)->setIsModule(false);
     ENFORCE_NO_TIMER(klass == Symbols::PackageSpec());
 

--- a/rbi/sorbet/packages.rbi
+++ b/rbi/sorbet/packages.rbi
@@ -1,0 +1,2 @@
+# typed: __STDLIB_INTERNAL
+class Sorbet::Private::Static::PackageSpec; end

--- a/test/cli/packager-layers/test.out
+++ b/test/cli/packager-layers/test.out
@@ -9,7 +9,9 @@ __package.rb:3: Unable to resolve constant `PackageSpec` https://srb.help/5002
     __package.rb:3: Replace with `Sorbet::Private::Static::PackageSpec`
      3 |class Project::Root < PackageSpec
                               ^^^^^^^^^^^
-    ???: `Sorbet::Private::Static::PackageSpec` defined here
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/packages.rbi#L2: `Sorbet::Private::Static::PackageSpec` defined here
+     2 |class Sorbet::Private::Static::PackageSpec; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 __package.rb:4: Method `strict_dependencies` does not exist on `T.class_of(Project::Root)` https://srb.help/7003
      4 |  strict_dependencies 'false'

--- a/test/cli/packager-layers/test.out
+++ b/test/cli/packager-layers/test.out
@@ -2,7 +2,23 @@ __package.rb:5: Argument to `layer` must be one of: `library` or `application` h
      5 |  layer 'fake'
                 ^^^^^^
 Errors: 1
-No errors! Great job.
+__package.rb:3: Unable to resolve constant `PackageSpec` https://srb.help/5002
+     3 |class Project::Root < PackageSpec
+                              ^^^^^^^^^^^
+  Did you mean `Sorbet::Private::Static::PackageSpec`? Use `-a` to autocorrect
+    __package.rb:3: Replace with `Sorbet::Private::Static::PackageSpec`
+     3 |class Project::Root < PackageSpec
+                              ^^^^^^^^^^^
+    ???: `Sorbet::Private::Static::PackageSpec` defined here
+
+__package.rb:4: Method `strict_dependencies` does not exist on `T.class_of(Project::Root)` https://srb.help/7003
+     4 |  strict_dependencies 'false'
+          ^^^^^^^^^^^^^^^^^^^
+
+__package.rb:5: Method `layer` does not exist on `T.class_of(Project::Root)` https://srb.help/7003
+     5 |  layer 'fake'
+          ^^^^^
+Errors: 3
 __package.rb:5: Argument to `layer` must be one of: `a`, `b`, or `c` https://srb.help/3725
      5 |  layer 'fake'
                 ^^^^^^

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/deeply_nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
 
     <self>.export(::<root>::<C Package>::<C PackageClass>)
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>)
 
     <self>.export(::<root>::<C Package>::<C Subpackage>::<C SubpackageClass>)

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -1,11 +1,11 @@
 # -- test/testdata/packager/export_for_test/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPkg><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C RootPkg><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/export_for_test/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Opus>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar>)
 
     <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Util>)
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/foo/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
 
     <self>.export(::<root>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/test_imported/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C TestImported><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Opus>::<C TestImported><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Opus>::<C TestImported>::<C TIClass>)
 
     <self>.export(::<root>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Util><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Opus>::<C Util><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Opus>::<C Util>::<C UtilClass>)
 
     <self>.export(::<root>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/export_imported/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C B>)
 
     <self>.export(::<root>::<C B>::<C BClass>)
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_imported/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C B>::<C BClass>)
   end
 end

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/extra_package_paths/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
 
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package>)
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/baz/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C C>)
 
     <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C E>)
@@ -18,7 +18,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Project>::<C Foo>::<C B>)
 
     <self>.export(::<root>::<C Project>::<C Foo>::<C D>)
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo_bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C FooBar><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C FooBar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Project>::<C FooBar>::<C Z>)
   end
 end

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -1,12 +1,12 @@
 # -- test/testdata/packager/import_subpackage/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Root><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Root><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Root>::<C B>)
   end
 end
 # -- test/testdata/packager/import_subpackage/a/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Root>::<C B><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Root>::<C B><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Root>::<C B>::<C Foo>)
   end
 end

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -5,13 +5,13 @@
 class A < PackageSpec
   import 123
        # ^^^ error: Argument to `import` must be a constant
-       # ^^^ error: Expected `T.class_of(PackageSpec)`
+       # ^^^ error: Expected `T.class_of(Sorbet::Private::Static::PackageSpec)`
   import "hello"
        # ^^^^^^^ error: Argument to `import` must be a constant
-       # ^^^^^^^ error: Expected `T.class_of(PackageSpec)`
+       # ^^^^^^^ error: Expected `T.class_of(Sorbet::Private::Static::PackageSpec)`
   import method
        # ^^^^^^ error: Argument to `import` must be a constant
-       # ^^^^^^ error: Expected `T.class_of(PackageSpec)`
+       # ^^^^^^ error: Expected `T.class_of(Sorbet::Private::Static::PackageSpec)`
        #       ^ error: Not enough arguments
   import REFERENCE
        # ^^^^^^^^^ error: Unable to resolve constant `REFERENCE`

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/invalid_imports_and_exports/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(123)
 
     <self>.import("hello")
@@ -28,7 +28,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/invalid_imports_and_exports/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C A>)
 
     <self>.export(::<root>::<C B>::<C BClass>)

--- a/test/testdata/packager/invalid_package_control_flow/__package.rb
+++ b/test/testdata/packager/invalid_package_control_flow/__package.rb
@@ -4,6 +4,7 @@
 
 # Constant definitions/assignments are not OK
 SomeConstant = PackageSpec # error: Invalid expression in package: `Assign`
+#              ^^^^^^^^^^^ error: Unable to resolve constant `PackageSpec`
 
 class MyPackage < PackageSpec
   extend T::Helpers # error: Invalid expression in package: `extend` is not allowed

--- a/test/testdata/packager/invalid_package_control_flow/package_spec_additions.rb
+++ b/test/testdata/packager/invalid_package_control_flow/package_spec_additions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # typed: true
 
-class ::PackageSpec
+class ::Sorbet::Private::Static::PackageSpec
   extend T::Sig
 
   # Define the things referenced in __package.rb

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -2,7 +2,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C SomeConstant> = <emptyTree>::<C PackageSpec>
 
-  class ::<PackageSpecRegistry>::<C MyPackage><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C MyPackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end
@@ -48,7 +48,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/invalid_package_control_flow/package_spec_additions.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<root>::<C PackageSpec><<C <todo sym>>> < (::<todo sym>)
+  class ::<root>::<C Sorbet>::<C Private>::<C Static>::<C PackageSpec><<C <todo sym>>> < (::<todo sym>)
     def self.some_method<<todo method>>(x, &<blk>)
       <emptyTree>
     end

--- a/test/testdata/packager/layer/too_few_args/__package.rb
+++ b/test/testdata/packager/layer/too_few_args/__package.rb
@@ -5,5 +5,5 @@
 
 class TooFewArgs < PackageSpec
   strict_dependencies 'false'
-  layer # error: Not enough arguments provided for method `PackageSpec.layer`. Expected: `1`, got: `0`
+  layer # error: Not enough arguments provided for method `Sorbet::Private::Static::PackageSpec.layer`. Expected: `1`, got: `0`
 end

--- a/test/testdata/packager/layer/too_many_args/__package.rb
+++ b/test/testdata/packager/layer/too_many_args/__package.rb
@@ -5,5 +5,5 @@
 
 class TooManyArgs < PackageSpec
   strict_dependencies 'false'
-  layer 'a', 'b' # error: Too many arguments provided for method `PackageSpec.layer`. Expected: `1`, got: `2`
+  layer 'a', 'b' # error: Too many arguments provided for method `Sorbet::Private::Static::PackageSpec.layer`. Expected: `1`, got: `2`
 end

--- a/test/testdata/packager/multiple_packages_in_file/__package.rb
+++ b/test/testdata/packager/multiple_packages_in_file/__package.rb
@@ -6,3 +6,4 @@ class MyPackage < PackageSpec
 end
 
 class SecondPackage < PackageSpec; end # error: Package files can only declare one package
+#                     ^^^^^^^^^^^ error: Unable to resolve constant `PackageSpec`

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -1,12 +1,12 @@
 # -- test/testdata/packager/nested_inner_namespaces/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPackage><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C RootPackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C RootPackage>::<C Foo>)
   end
 end
 # -- test/testdata/packager/nested_inner_namespaces/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPackage>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C RootPackage>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C RootPackage>::<C Foo>::<C Constant>)
 
     <self>.export(::<root>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
 
     <self>.export(::<root>::<C Package>::<C PackageClass>)
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/nested_packages/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>)
 
     <self>.export(::<root>::<C Package>::<C Subpackage>::<C SubpackageClass>)

--- a/test/testdata/packager/packagespec_methods/__package.rb
+++ b/test/testdata/packager/packagespec_methods/__package.rb
@@ -1,4 +1,5 @@
 # typed: strict
+# enable-packager: true
 
 class MyPkg < PackageSpec
   custom_method 'abc'

--- a/test/testdata/packager/packagespec_methods/__package.rb
+++ b/test/testdata/packager/packagespec_methods/__package.rb
@@ -3,7 +3,7 @@
 class MyPkg < PackageSpec
   custom_method 'abc'
   custom_method 'abc', 'too_many_args'
-  #                    ^^^^^^^^^^^^^^^ error: Too many arguments provided for method `PackageSpec.custom_method`. Expected: `1`, got: `2`
+  #                    ^^^^^^^^^^^^^^^ error: Too many arguments provided for method `Sorbet::Private::Static::PackageSpec.custom_method`. Expected: `1`, got: `2`
 
   bad_method 'def'
 # ^^^^^^^^^^ error: Method `bad_method` does not exist on `T.class_of(MyPkg)`

--- a/test/testdata/packager/packagespec_methods/packagespec.rbi
+++ b/test/testdata/packager/packagespec_methods/packagespec.rbi
@@ -1,6 +1,6 @@
 # typed: strict
 
-class ::PackageSpec
+class ::Sorbet::Private::Static::PackageSpec
   sig {params(x: String).void}
   def self.custom_method(x); end
 end

--- a/test/testdata/packager/shared_prefix/pass.package-tree.exp
+++ b/test/testdata/packager/shared_prefix/pass.package-tree.exp
@@ -1,18 +1,18 @@
 # -- test/testdata/packager/shared_prefix/bar/that/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C That><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C That><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Project>::<C Bar>::<C That>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/this/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C This><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C This><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Project>::<C Bar>::<C This>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/that/that.rb --

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/simple_package/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
 
     <self>.export(::<root>::<C Project>::<C Bar>::<C Bar>)
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Bar>)
 
     <self>.export(::<root>::<C Project>::<C Foo>::<C Foo>)

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/simple_test_import/main_lib/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C MainLib><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C MainLib><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Util>)
 
     <self>.test_import(::<PackageSpecRegistry>::<C Project>::<C TestOnly>)
@@ -10,13 +10,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_test_import/test_only/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C TestOnly><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C TestOnly><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Project>::<C TestOnly>::<C SomeHelper>)
   end
 end
 # -- test/testdata/packager/simple_test_import/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Util><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C Project>::<C Util><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C Project>::<C Util>::<C MyUtil>)
 
     <self>.export(::<root>::<C Test>::<C Project>::<C Util>::<C UtilHelper>)

--- a/test/testdata/packager/strict_dependencies/too_few_args/__package.rb
+++ b/test/testdata/packager/strict_dependencies/too_few_args/__package.rb
@@ -4,6 +4,6 @@
 # packager-layers: a
 
 class TooFewArgs < PackageSpec
-  strict_dependencies # error: Not enough arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `0`
+  strict_dependencies # error: Not enough arguments provided for method `Sorbet::Private::Static::PackageSpec.strict_dependencies`. Expected: `1`, got: `0`
   layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
+++ b/test/testdata/packager/strict_dependencies/too_many_args/__package.rb
@@ -4,6 +4,6 @@
 # packager-layers: a
 
 class TooManyArgs < PackageSpec
-  strict_dependencies 'false', 'true' # error: Too many arguments provided for method `PackageSpec.strict_dependencies`. Expected: `1`, got: `2`
+  strict_dependencies 'false', 'true' # error: Too many arguments provided for method `Sorbet::Private::Static::PackageSpec.strict_dependencies`. Expected: `1`, got: `2`
   layer 'a'
 end

--- a/test/testdata/packager/unimported_namespace/pass.package-tree.exp
+++ b/test/testdata/packager/unimported_namespace/pass.package-tree.exp
@@ -1,18 +1,18 @@
 # -- test/testdata/packager/unimported_namespace/aaa/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C AAA><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C AAA><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(::<root>::<C AAA>::<C AClass>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/bbb/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C BBB><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C BBB><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C AAA>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/ccc/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C CCC><<C <todo sym>>> < (::PackageSpec)
+  class ::<PackageSpecRegistry>::<C CCC><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/unimported_namespace/aaa/a_class.rb --

--- a/test/testdata/resolver/package_spec.rb
+++ b/test/testdata/resolver/package_spec.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-PackageSpec
+PackageSpec # error: Unable to resolve constant `PackageSpec`

--- a/test/testdata/resolver/package_spec.rb
+++ b/test/testdata/resolver/package_spec.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+PackageSpec


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

People could technically be defining their own constants with this name. We
can pretend that

    class A < PackageSpec

actually means

    class A < ::Sorbet::Private::Static::PackageSpec

in `__package.rb` files if the `--stripe-packages` flag is set to avoid
this fact leaking into people's programs.

This will involve breaking changes at Stripe, because we use an RBI file to
declare extra methods on the `PackageSpec` class. It will be easiest to make
those changes in lock step.

The reason why I've chosen to use `::Sorbet::Private::Static::PackageSpec`
instead of `::<PackageSpec>` is so that Stripe can continue using such an RBI
file.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.