### PR TITLE
Fix crash if `__package.rb` file has bad constant

### DIFF
--- a/test/cli/not_stripe_packages/__package.rb
+++ b/test/cli/not_stripe_packages/__package.rb
@@ -1,0 +1,2 @@
+# typed: false
+DoesNotExist

--- a/test/cli/not_stripe_packages/test.out
+++ b/test/cli/not_stripe_packages/test.out
@@ -1,20 +1,11 @@
-Exception::raise() msg="core/packages/PackageDB.cc:113 enforced condition false has failed: Not implemented for NonePackage"
-
-Backtrace:
-sorbet::core::packages::(anonymous namespace)::NonePackage::notImplemented() const (in sorbet) + 264
-sorbet::core::packages::(anonymous namespace)::NonePackage::fullName() const (in sorbet) + 24
-sorbet::core::packages::PackageInfo::getRootSymbolForAutocorrectSearch(sorbet::core::GlobalState const&, sorbet::core::SymbolRef) const (in sorbet) + 100
-sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::constantResolutionFailed(sorbet::core::GlobalState&, sorbet::core::FileRef, sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::ConstantResolutionItem&, sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::ImportStubs const&, int&) (in sorbet) + 4188
-sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::resolveConstants(sorbet::core::GlobalState&, std::__1::vector<sorbet::ast::ParsedFile, std::__1::allocator<sorbet::ast::ParsedFile>>, sorbet::WorkerPool&) (in sorbet) + 5776
-sorbet::resolver::Resolver::run(sorbet::core::GlobalState&, std::__1::vector<sorbet::ast::ParsedFile, std::__1::allocator<sorbet::ast::ParsedFile>>, sorbet::WorkerPool&) (in sorbet) + 96
-sorbet::realmain::pipeline::resolve(sorbet::core::GlobalState&, std::__1::vector<sorbet::ast::ParsedFile, std::__1::allocator<sorbet::ast::ParsedFile>>, sorbet::realmain::options::Options const&, sorbet::WorkerPool&) (in sorbet) + 356
-sorbet::realmain::realmain(int, char**) (in sorbet) + 14256
-main (in sorbet) + 36
-start (in dyld) + 2840
-
-???: Exception resolving (backtrace is above) https://srb.help/1001
-
 test/cli/not_stripe_packages/__package.rb:2: Unable to resolve constant `DoesNotExist` https://srb.help/5002
      2 |DoesNotExist
         ^^^^^^^^^^^^
-Errors: 2
+  Did you mean `SystemExit`? Use `-a` to autocorrect
+    test/cli/not_stripe_packages/__package.rb:2: Replace with `SystemExit`
+     2 |DoesNotExist
+        ^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/errors.rbi#L560: `SystemExit` defined here
+     560 |class SystemExit < Exception
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/not_stripe_packages/test.out
+++ b/test/cli/not_stripe_packages/test.out
@@ -1,0 +1,20 @@
+Exception::raise() msg="core/packages/PackageDB.cc:113 enforced condition false has failed: Not implemented for NonePackage"
+
+Backtrace:
+sorbet::core::packages::(anonymous namespace)::NonePackage::notImplemented() const (in sorbet) + 264
+sorbet::core::packages::(anonymous namespace)::NonePackage::fullName() const (in sorbet) + 24
+sorbet::core::packages::PackageInfo::getRootSymbolForAutocorrectSearch(sorbet::core::GlobalState const&, sorbet::core::SymbolRef) const (in sorbet) + 100
+sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::constantResolutionFailed(sorbet::core::GlobalState&, sorbet::core::FileRef, sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::ConstantResolutionItem&, sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::ImportStubs const&, int&) (in sorbet) + 4188
+sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::resolveConstants(sorbet::core::GlobalState&, std::__1::vector<sorbet::ast::ParsedFile, std::__1::allocator<sorbet::ast::ParsedFile>>, sorbet::WorkerPool&) (in sorbet) + 5776
+sorbet::resolver::Resolver::run(sorbet::core::GlobalState&, std::__1::vector<sorbet::ast::ParsedFile, std::__1::allocator<sorbet::ast::ParsedFile>>, sorbet::WorkerPool&) (in sorbet) + 96
+sorbet::realmain::pipeline::resolve(sorbet::core::GlobalState&, std::__1::vector<sorbet::ast::ParsedFile, std::__1::allocator<sorbet::ast::ParsedFile>>, sorbet::realmain::options::Options const&, sorbet::WorkerPool&) (in sorbet) + 356
+sorbet::realmain::realmain(int, char**) (in sorbet) + 14256
+main (in sorbet) + 36
+start (in dyld) + 2840
+
+???: Exception resolving (backtrace is above) https://srb.help/1001
+
+test/cli/not_stripe_packages/__package.rb:2: Unable to resolve constant `DoesNotExist` https://srb.help/5002
+     2 |DoesNotExist
+        ^^^^^^^^^^^^
+Errors: 2

--- a/test/cli/not_stripe_packages/test.sh
+++ b/test/cli/not_stripe_packages/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# We currently populate core::File::Flags::isPackage only via the filename,
+# regardless of whether the `--stripe-packages` flag has been passed.
+#
+# This makes it easy to have behavior that leaks `--stripe-packages`-specific
+# behavior into the pipeline. Long term, we should figure out how to fix this.
+if main/sorbet --silence-dev-message test/cli/not_stripe_packages/__package.rb 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We would assume that we could find the enclosing package for a `__package.rb`
file.

The annoying thing is that we're doing this regardless of whether the
`--stripe-packages` flag has been passed at the command line.

We will have to figure out a long term strategy to fix this, because I think
there are other places (not just this one) that are doing logic conditional on
whether `--stripe-packages` has been set and assuming that they can use
`isPackage` (or `isPackagedTest`, etc.) as a way to check that the packager has
been enabled.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Commit history shows the crash.