### PR TITLE
Add some comments calling out package-specific behavior

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -238,6 +238,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             // NOTE: Using `gs` to access package information here assumes that edits to __package.rb
             // files don't take the fast path. We'll want (or maybe need) to revisit this when we start
             // making edits to `__package.rb` take fast paths.
+            // TODO(jez) This does package-specific behavior without checking `--stripe-packages`!
             if (!(fref.data(*gs).isPackage())) {
                 auto &pkg = gs->packageDB().getPackageForFile(*gs, fref);
                 if (pkg.exists()) {

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -156,6 +156,7 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
                 action->kind = CodeActionKind::Quickfix;
                 auto workspaceEdit = make_unique<WorkspaceEdit>();
                 workspaceEdit->documentChanges = getQuickfixEdits(config, gs, autocorrect.edits);
+                // TODO(jez) This does package-specific behavior without checking `--stripe-packages`!
                 if (absl::c_any_of(autocorrect.edits, [&](auto edit) { return edit.loc.file().isPackage(gs); })) {
                     action->command = make_unique<Command>("Save package files", "sorbet.savePackageFiles");
                 }

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -93,6 +93,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
 
         // If file is untyped, only supports find reference requests from constants and class definitions.
         if (auto constResp = resp->isConstant()) {
+            // TODO(jez) This does package-specific behavior without checking `--stripe-packages`!
             if (fref.data(gs).isPackage()) {
                 // Special handling for package files.
                 //

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -237,6 +237,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
                 for (auto result = fileq->try_pop(idx); !result.done(); result = fileq->try_pop(idx)) {
                     ++n;
                     auto &tree = indexed[idx];
+                    // TODO(jez) This does package-specific behavior without checking `--stripe-packages`!
                     if (tree.file.data(gs).isPackage()) {
                         continue;
                     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2447,6 +2447,7 @@ class ResolveTypeMembersAndFieldsWalk {
         auto resultType = resolveConstantType(ctx, asgn->rhs, /* topCall */ true, /* isFrozen */ false);
         if (data->resultType == nullptr) {
             // Do not attempt to suggest types for aliases that fail to resolve in package files.
+            // TODO(jez) This does package-specific behavior without checking `--stripe-packages`!
             if (resultType == nullptr && !ctx.file.data(ctx).isPackage()) {
                 // Instead of emitting an error now, emit an error in infer that has a proper type suggestion
                 auto rhs = move(job.asgn->rhs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These seem to be the places where we're checking `isPackage` without also having
checked `opts.stripePackages`. Sometimes this is hard to do because it's not in
scope. Specifically, the call sites in resolver do not have access to this
information.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

comment-only