### PR TITLE
Move the cached flag to ast::ParsedFile

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -275,10 +275,30 @@ struct ParsedFile {
     ExpressionPtr tree;
     core::FileRef file;
 
+    struct Flags {
+        // if 'true' file is completely cached in kvstore
+        bool cached : 1;
+
+        Flags() : cached{false} {}
+    };
+
+    Flags flags;
+
+    ParsedFile() = default;
+    ParsedFile(ast::ExpressionPtr tree, core::FileRef file) : tree{std::move(tree)}, file{file}, flags{} {}
+
     void swap(ParsedFile &other) noexcept {
         using std::swap;
         this->tree.swap(other.tree);
         swap(this->file, other.file);
+    }
+
+    bool cached() const {
+        return this->flags.cached;
+    }
+
+    void setCached(bool cached) {
+        this->flags.cached = cached;
     }
 };
 

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -107,7 +107,7 @@ bool File::isPackagePath(string_view path) {
 }
 
 File::Flags::Flags(string_view path)
-    : cached(false), hasIndexErrors(false), isPackagedTest(isTestPath(path)), isPackageRBI(isPackageRBIPath(path)),
+    : hasIndexErrors(false), isPackagedTest(isTestPath(path)), isPackageRBI(isPackageRBIPath(path)),
       isPackage(isPackagePath(path)), isOpenInClient(false) {}
 
 File::File(string &&path_, string &&source_, Type sourceType, uint32_t epoch)
@@ -129,7 +129,6 @@ void File::setFileHash(unique_ptr<const FileHash> hash) {
     // If hash_ != nullptr, then the contents of hash_ and hash should be identical.
     // Avoid needlessly invalidating references to *hash_.
     if (hash_ == nullptr) {
-        flags.cached = false;
         hash_ = move(hash);
     }
 }
@@ -282,14 +281,6 @@ bool File::hasIndexErrors() const {
 
 void File::setHasIndexErrors(bool value) {
     flags.hasIndexErrors = value;
-}
-
-bool File::cached() const {
-    return flags.cached;
-}
-
-void File::setCached(bool value) {
-    flags.cached = value;
 }
 
 bool File::isPackaged() const {

--- a/core/Files.h
+++ b/core/Files.h
@@ -65,9 +65,6 @@ public:
     bool hasIndexErrors() const;
     void setHasIndexErrors(bool value);
 
-    bool cached() const;
-    void setCached(bool value);
-
     // Returns whether or not this file is considered to be packaged.
     bool isPackaged() const;
 
@@ -91,8 +88,6 @@ public:
 
 private:
     struct Flags {
-        // if 'true' file is completely cached in kvstore
-        bool cached : 1;
         // some reasonable invariants don't hold for invalid files
         bool hasIndexErrors : 1;
         // only relevant in --stripe-packages mode: is the file a `.test.rb` file?

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1152,8 +1152,6 @@ ast::ExpressionPtr Serializer::loadTree(const core::GlobalState &gs, core::File 
         return nullptr;
     }
     file.setFileHash(SerializerImpl::unpickleFileHash(p));
-    // cached must be set _after_ setting the file hash, as setFileHash unsets the cached flag
-    file.setCached(true);
     return SerializerImpl::unpickleExpr(p, gs);
 }
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -115,7 +115,7 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::
                     }
 
                     auto &file = job->file.data(gs);
-                    if (!file.cached() && !file.hasIndexErrors()) {
+                    if (!job->cached() && !file.hasIndexErrors()) {
                         threadResult.emplace_back(core::serialize::Serializer::fileKey(file),
                                                   core::serialize::Serializer::storeTree(file, *job));
                         // Stream out compressed files so that writes happen in parallel with processing.

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -97,9 +97,8 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
 
         core::File file{string(filePath), string(fileContents), core::File::Type::Normal};
         auto tree = core::serialize::Serializer::loadTree(*gs, file, contents.data);
-        CHECK(file.cached());
-        CHECK_NE(file.getFileHash(), nullptr);
         CHECK_NE(tree, nullptr);
+        CHECK_NE(file.getFileHash(), nullptr);
 
         // Loading should fail if file is too small
         core::File smallFile{"", "", core::File::Type::Normal};
@@ -149,9 +148,8 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
 
         core::File file{string(filePath), string(updatedFileContents), core::File::Type::Normal};
         auto cachedFile = core::serialize::Serializer::loadTree(*gs, file, updatedFileData.data);
-        CHECK(file.cached());
-        CHECK_NE(file.getFileHash(), nullptr);
         CHECK_NE(cachedFile, nullptr);
+        CHECK_NE(file.getFileHash(), nullptr);
     }
 }
 
@@ -199,9 +197,8 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPDoesNotUseCacheIfModified") {
 
         core::File file{string(filePath), string(fileContents), core::File::Type::Normal};
         auto tree = core::serialize::Serializer::loadTree(*gs, file, contents.data);
-        CHECK(file.cached());
-        CHECK_NE(file.getFileHash(), nullptr);
         CHECK_NE(tree, nullptr);
+        CHECK_NE(file.getFileHash(), nullptr);
     }
 
     // LSP should read from disk when the cache gets updated by a different process mid-process.


### PR DESCRIPTION
Whether or not the tree for a `ParsedFile` was loaded from the cache is not really a property of the `File` object that holds the source, but of the state of the cache when the file was loaded. This PR reflects that fact by moving the `cached` flag out of the `File` object, and into a new `Flags` struct held on `ast::ParsedFile`. This change doesn't affect the size of `ast::ParsedFile`, as we have a free 4 bytes to work with.

It would be nice to move the `hasIndexErrors` flag out of the `File` object as well, as we use that to control whether or not we write the cache, but I wasn't really sure how to get that to propagate back to the `ParsedFile` without increasing the size of `Context`.

### Motivation
Working towards allowing files to be loaded out of the cache multiple times, without swapping out the underlying `File` object in the file table.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a This shouldn't affect behavior, as it's just moving a flag around.
