### PR TITLE
don't take strong refs to `TypePtr`s in `Literal` during tree equality checks

### DIFF
--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -239,8 +239,8 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
         case Tag::Literal: {
             auto *a = reinterpret_cast<const Literal *>(tree);
             auto *b = reinterpret_cast<const Literal *>(other);
-            auto aType = a->value;
-            auto bType = b->value;
+            const auto &aType = a->value;
+            const auto &bType = b->value;
             if (aType.tag() != bType.tag()) {
                 return false;
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's more efficient to avoid extraneous refcounting here, and it will ideally make the assembly more readable.  😅 
### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
