### PR TITLE
call functions on `ConstantLit` fewer times in CFG construction

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -451,25 +451,24 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 auto aliasName = cctx.newTemporary(core::Names::cfgAlias());
                 auto loc = a.loc();
 
-                if (a.symbol() == core::Symbols::StubModule()) {
+                if (auto sym = a.symbol(); sym == core::Symbols::StubModule()) {
                     current->exprs.emplace_back(aliasName, loc, make_insn<Alias>(core::Symbols::untyped()));
                 } else {
-                    current->exprs.emplace_back(aliasName, loc, make_insn<Alias>(a.symbol()));
+                    current->exprs.emplace_back(aliasName, loc, make_insn<Alias>(sym));
                 }
 
                 synthesizeExpr(current, cctx.target, loc, make_insn<Ident>(aliasName));
 
-                if (a.original()) {
-                    auto &orig = *a.original();
+                if (auto *orig = a.original()) {
                     // Empirically, these are the only two cases we've needed so far to service the
                     // LSP requests we want (hover and completion), but that doesn't mean these are
                     // the **only** we'll ever want.
-                    if (ast::isa_tree<ast::ConstantLit>(orig.scope)) {
+                    if (ast::isa_tree<ast::ConstantLit>(orig->scope)) {
                         LocalRef deadSym = cctx.newTemporary(core::Names::keepForIde());
-                        current = walk(cctx.withTarget(deadSym), orig.scope, current);
-                    } else if (ast::isa_tree<ast::Send>(orig.scope)) {
+                        current = walk(cctx.withTarget(deadSym), orig->scope, current);
+                    } else if (ast::isa_tree<ast::Send>(orig->scope)) {
                         LocalRef deadSym = cctx.newTemporary(core::Names::keepForIde());
-                        current = walk(cctx.withTarget(deadSym), orig.scope, current);
+                        current = walk(cctx.withTarget(deadSym), orig->scope, current);
                     }
                 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These functions on `ConstantLit` are not especially cheap, so we might as well manually dedup them.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
