### PR TITLE
Stopping hidden classes and TypeMembers in T.proc from revealing themselves.

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1286,9 +1286,21 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                                 break;
                             }
                         }
-                        auto message = ErrorColors::format("`{}` is not {} `{}` for {} type member `{}`", a1i.show(gs),
-                                                           joiningText, a2j.show(gs), variance, idxTypeMember.show(gs));
-                        subCollector.message = message;
+                        // For proc types, make type member references more user-friendly
+                        if (a2->klass.data(gs)->name.show(gs).compare("Proc1") == 0) {
+                            auto message = ErrorColors::format("`{}` is not {} `{}`", a1i.show(gs), joiningText, a2j.show(gs));
+                            if (variance == "covariant") {
+                                subCollector.message = fmt::format("{} for return type of Proc1", message);
+                            } else if (variance == "contravariant") {
+                                subCollector.message = fmt::format("{} for Arg0 of Proc1", message);
+                            } else {
+                                subCollector.message = message;
+                            }
+                        } else {
+                            auto message = ErrorColors::format("`{}` is not {} `{}` for {} type member `{}`", a1i.show(gs),
+                                                            joiningText, a2j.show(gs), variance, idxTypeMember.show(gs));
+                            subCollector.message = message;
+                        }
                         errorDetailsCollector.addErrorDetails(std::move(subCollector));
                     }
                 } else {
@@ -1439,7 +1451,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     // backwards compatibility, but maybe we should do this under the `constr`
                     // that's in scope.
                     result = Types::equivUnderConstraint(gs, TypeConstraint::EmptyFrozenConstraint, m1.wrapped,
-                                                         m2->wrapped, errorDetailsCollector);
+                                                       m2->wrapped, errorDetailsCollector);
                 });
             return result;
             // both are proxy

--- a/test/testdata/infer/proc_type_messages.rb
+++ b/test/testdata/infer/proc_type_messages.rb
@@ -8,6 +8,14 @@ class ProcTypeErrorTest
   def foo(x)
   end
 
+  sig {params(x: T.proc.params(x: T::Array[Integer]).returns(T::Array[String])).void}
+  def array_proc(x)
+  end
+
+  sig {params(x: T.proc.params(x: T::Hash[String, Integer]).returns(T::Hash[Integer, String])).void}
+  def hash_proc(x)
+  end
+
   sig {void}
   def test_proc_type_error
     x = T.cast(nil, T.proc.params(x: String).returns(Integer))
@@ -16,6 +24,26 @@ class ProcTypeErrorTest
 #       Detailed explanation:
 #         Integer is not a subtype of String for return type of Proc1
 #         String is not a supertype of Integer for Arg0 of Proc1
+  end
+
+  sig {void}
+  def test_array_proc_error
+    x = T.cast(nil, T.proc.params(x: T::Array[String]).returns(T::Array[Integer]))
+    array_proc(x)
+#              ^ error: Expected `T.proc.params(arg0: T::Array[Integer]).returns(T::Array[String])` but found `T.proc.params(arg0: T::Array[String]).returns(T::Array[Integer])` for argument `x`
+#              Detailed explanation:
+#                T::Array[Integer] is not a subtype of T::Array[String] for return type of Proc1
+#                T::Array[String] is not a supertype of T::Array[Integer] for Arg0 of Proc1
+  end
+
+  sig {void}
+  def test_hash_proc_error
+    x = T.cast(nil, T.proc.params(x: T::Hash[Integer, String]).returns(T::Hash[String, Integer]))
+    hash_proc(x)
+#             ^ error: Expected `T.proc.params(arg0: T::Hash[String, Integer]).returns(T::Hash[Integer, String])` but found `T.proc.params(arg0: T::Hash[Integer, String]).returns(T::Hash[String, Integer])` for argument `x`
+#             Detailed explanation:
+#               T::Hash[String, Integer] is not a subtype of T::Hash[Integer, String] for return type of Proc1
+#               T::Hash[Integer, String] is not a supertype of T::Hash[String, Integer] for Arg0 of Proc1
   end
 
 end

--- a/test/testdata/infer/proc_type_messages.rb
+++ b/test/testdata/infer/proc_type_messages.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+class ProcTypeErrorTest
+
+  extend T::Sig
+
+  sig {params(x: T.proc.params(x: Integer).returns(String)).void}
+  def foo(x)
+  end
+
+  sig {void}
+  def test_proc_type_error
+    x = T.cast(nil, T.proc.params(x: String).returns(Integer))
+    foo(x)
+#       ^ error: Expected `T.proc.params(arg0: Integer).returns(String)` but found `T.proc.params(arg0: String).returns(Integer)` for argument `x`
+#       Detailed explanation:
+#         Integer is not a subtype of String for return type of Proc1
+#         String is not a supertype of Integer for Arg0 of Proc1
+  end
+
+end

--- a/test/testdata/infer/proc_type_messages.rb.autocorrects.exp
+++ b/test/testdata/infer/proc_type_messages.rb.autocorrects.exp
@@ -1,0 +1,23 @@
+# -- test/testdata/infer/proc_type_messages.rb --
+# typed: true
+
+class ProcTypeErrorTest
+
+  extend T::Sig
+
+  sig {params(x: T.proc.params(x: Integer).returns(String)).void}
+  def foo(x)
+  end
+
+  sig {void}
+  def test_proc_type_error
+    x = T.cast(nil, T.proc.params(x: String).returns(Integer))
+    foo(x)
+#       ^ error: Expected `T.proc.params(arg0: Integer).returns(String)` but found `T.proc.params(arg0: String).returns(Integer)` for argument `x`
+#       Detailed explanation:
+#         Integer is not a subtype of String for return type of Proc1
+#         String is not a supertype of Integer for Arg0 of Proc1
+  end
+
+end
+# ------------------------------

--- a/test/testdata/infer/proc_type_messages.rb.autocorrects.exp
+++ b/test/testdata/infer/proc_type_messages.rb.autocorrects.exp
@@ -9,6 +9,14 @@ class ProcTypeErrorTest
   def foo(x)
   end
 
+  sig {params(x: T.proc.params(x: T::Array[Integer]).returns(T::Array[String])).void}
+  def array_proc(x)
+  end
+
+  sig {params(x: T.proc.params(x: T::Hash[String, Integer]).returns(T::Hash[Integer, String])).void}
+  def hash_proc(x)
+  end
+
   sig {void}
   def test_proc_type_error
     x = T.cast(nil, T.proc.params(x: String).returns(Integer))
@@ -17,6 +25,26 @@ class ProcTypeErrorTest
 #       Detailed explanation:
 #         Integer is not a subtype of String for return type of Proc1
 #         String is not a supertype of Integer for Arg0 of Proc1
+  end
+
+  sig {void}
+  def test_array_proc_error
+    x = T.cast(nil, T.proc.params(x: T::Array[String]).returns(T::Array[Integer]))
+    array_proc(x)
+#              ^ error: Expected `T.proc.params(arg0: T::Array[Integer]).returns(T::Array[String])` but found `T.proc.params(arg0: T::Array[String]).returns(T::Array[Integer])` for argument `x`
+#              Detailed explanation:
+#                T::Array[Integer] is not a subtype of T::Array[String] for return type of Proc1
+#                T::Array[String] is not a supertype of T::Array[Integer] for Arg0 of Proc1
+  end
+
+  sig {void}
+  def test_hash_proc_error
+    x = T.cast(nil, T.proc.params(x: T::Hash[Integer, String]).returns(T::Hash[String, Integer]))
+    hash_proc(x)
+#             ^ error: Expected `T.proc.params(arg0: T::Hash[String, Integer]).returns(T::Hash[Integer, String])` but found `T.proc.params(arg0: T::Hash[Integer, String]).returns(T::Hash[String, Integer])` for argument `x`
+#             Detailed explanation:
+#               T::Hash[String, Integer] is not a subtype of T::Hash[Integer, String] for return type of Proc1
+#               T::Hash[Integer, String] is not a supertype of T::Hash[String, Integer] for Arg0 of Proc1
   end
 
 end


### PR DESCRIPTION

### Motivation
Fixes #8492 and is an improvement from the previous PR #8526 

When proc types are part of the error, we now ensure we do not display any hidden classes or Typemembers, instead, we output a more user-friendly message based on variance. 

### Test plan

The test plan includes the examples from the original issue to verify the change went through and to ensure no hidden classes or type members from T.proc are displayed. Testing is also verified for Hash and Array's

See included automated tests.
