### PR TITLE
group `ClassType` subtypes together in `TypePtr::Tag`

### DIFF
--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -44,6 +44,9 @@ public:
 
     enum class Tag {
         ClassType = 1,
+        BlamedUntyped,
+        UnresolvedClassType,
+        UnresolvedAppliedType,
         LambdaParam,
         SelfTypeParam,
         AliasType,
@@ -58,9 +61,6 @@ public:
         TupleType,
         AppliedType,
         MetaType,
-        BlamedUntyped,
-        UnresolvedClassType,
-        UnresolvedAppliedType,
     };
 
     // A mapping from type to its corresponding tag.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change makes the assembly for checking `isa_type<ClassType>` somewhat better.  `ClassType` is complex to check because `ClassType` is actually part of a class hierarchy and we have to check for subtypes as well.  Before, we had:

```
# Load the tagged storage
  73872a:       48 8b 06                mov    (%rsi),%rax

# Check for null storage
  73872d:       48 85 c0                test   %rax,%rax
  738730:       0f 84 e6 00 00 00       je     73881c
  738736:       49 89 fe                mov    %rdi,%r14

# Check that the tag is within bounds of `TypePtr::Tag`
  738739:       3c 12                   cmp    $0x12,%al
  73873b:       77 23                   ja     738760

# Multi-way compare by effectively checking (1 << tag) against a bitmask
# of (1 << ClassType) | (1 << BlamedUntyped) | ...
  73873d:       0f b6 c8                movzbl %al,%ecx
  738740:       be 02 00 07 00          mov    $0x70002,%esi
  738745:       0f a3 ce                bt     %ecx,%esi
  738748:       73 16                   jae    738760
```

Which is three branches, one of which involves `bt` which I don't think is especially fast, but it's fast enough for clang to select it over performing several branches.

After this change to group things, we have:

```
# Load the tagged storage
  7386ed:       48 8b 06                mov    (%rsi),%rax
  7386f0:       0f b6 f0                movzbl %al,%esi

# Check for null storage
  7386f3:       48 85 c0                test   %rax,%rax
  7386f6:       74 21                   je     738719

# Check (tag >= ClassType) && (tag <=UnresolvedAppliedType), which can be
# done with a single unsigned comparison after the subtraction.
  7386f8:       0f b6 c8                movzbl %al,%ecx
  7386fb:       ff c9                   dec    %ecx
  7386fd:       83 f9 03                cmp    $0x3,%ecx
  738700:       77 17                   ja     738719
```

Which is two branches, which ought to be marginally faster.  It is also a good bit smaller.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
