### PR TITLE
Add RBS comments for `T.let` assertions

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2082,6 +2082,7 @@ void GlobalState::copyOptions(const core::GlobalState &other) {
     this->censorForSnapshotTests = other.censorForSnapshotTests;
     this->sleepInSlowPathSeconds = other.sleepInSlowPathSeconds;
     this->rbsSignaturesEnabled = other.rbsSignaturesEnabled;
+    this->rbsAssertionsEnabled = other.rbsAssertionsEnabled;
     this->requiresAncestorEnabled = other.requiresAncestorEnabled;
     this->ruby3KeywordArgs = other.ruby3KeywordArgs;
     this->typedSuper = other.typedSuper;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -325,6 +325,7 @@ public:
     std::vector<std::unique_ptr<pipeline::semantic_extension::SemanticExtension>> semanticExtensions;
 
     bool rbsSignaturesEnabled = false;
+    bool rbsAssertionsEnabled = false;
     bool requiresAncestorEnabled = false;
 
     bool shouldReportErrorOn(FileRef file, ErrorClass what) const;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -452,6 +452,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                  cxxopts::value<bool>());
     options.add_options(section)("enable-experimental-rbs-signatures",
                                  "Enable experimental support for RBS signatures as inline comments");
+    options.add_options(section)("enable-experimental-rbs-assertions",
+                                 "Enable experimental support for RBS assertions as inline comments");
     options.add_options(section)("enable-experimental-requires-ancestor",
                                  "Enable experimental `requires_ancestor` annotation");
     options.add_options(section)("uniquely-defined-behavior",
@@ -920,6 +922,12 @@ void readOptions(Options &opts,
         opts.rbsSignaturesEnabled = raw["enable-experimental-rbs-signatures"].as<bool>();
         if (opts.rbsSignaturesEnabled && !opts.cacheDir.empty()) {
             logger->error("--enable-experimental-rbs-signatures is incompatible with --cache-dir. Ignoring cache");
+            opts.cacheDir = "";
+        }
+
+        opts.rbsAssertionsEnabled = raw["enable-experimental-rbs-assertions"].as<bool>();
+        if (opts.rbsAssertionsEnabled && !opts.cacheDir.empty()) {
+            logger->error("--enable-experimental-rbs-assertions is incompatible with --cache-dir. Ignoring cache");
             opts.cacheDir = "";
         }
 

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -255,6 +255,9 @@ struct Options {
     // Enable experimental support for RBS signatures
     bool rbsSignaturesEnabled = false;
 
+    // Enable experimental support for RBS assertions such as `T.let`
+    bool rbsAssertionsEnabled = false;
+
     // Experimental feature `requires_ancestor`
     bool requiresAncestorEnabled = false;
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -53,6 +53,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
     gs.errorUrlBase = opts.errorUrlBase;
 
     gs.rbsSignaturesEnabled = opts.rbsSignaturesEnabled;
+    gs.rbsAssertionsEnabled = opts.rbsAssertionsEnabled;
     gs.requiresAncestorEnabled = opts.requiresAncestorEnabled;
 
     if (opts.silenceErrors) {

--- a/rbs/TypeTranslator.cc
+++ b/rbs/TypeTranslator.cc
@@ -67,9 +67,13 @@ ast::ExpressionPtr typeNameType(core::MutableContext ctx,
             } else if (nameConstant == core::Names::Constants::Range()) {
                 return ast::MK::T_Range(loc);
             }
-        } else if (hasTypeParam(ctx, typeParams, nameConstant)) {
-            return ast::MK::Send1(loc, ast::MK::T(loc), core::Names::typeParameter(), loc,
-                                  ast::MK::Symbol(loc, nameConstant));
+        } else {
+            // The type may refer to a type parameter, so we need to check if it exists as a NameKind::UTF8
+            auto nameUTF8 = ctx.state.enterNameUTF8(nameStr);
+            if (hasTypeParam(ctx, typeParams, nameUTF8)) {
+                return ast::MK::Send1(loc, ast::MK::T(loc), core::Names::typeParameter(), loc,
+                                      ast::MK::Symbol(loc, nameUTF8));
+            }
         }
     } else if (pathNames.size() == 2 && isGeneric) {
         if (pathNames[0] == core::Names::Constants::Enumerator()) {

--- a/rbs/TypeTranslator.cc
+++ b/rbs/TypeTranslator.cc
@@ -47,7 +47,8 @@ ast::ExpressionPtr typeNameType(core::MutableContext ctx,
 
     rbs_constant_t *name = rbs_constant_pool_id_to_constant(fake_constant_pool, typeName->name->constant_id);
     string_view nameStr(name->start, name->length);
-    auto nameConstant = ctx.state.enterNameConstant(nameStr);
+    auto nameUTF8 = ctx.state.enterNameUTF8(nameStr);
+    auto nameConstant = ctx.state.enterNameConstant(nameUTF8);
     pathNames.emplace_back(nameConstant);
 
     if (pathNames.size() == 1) {
@@ -69,7 +70,6 @@ ast::ExpressionPtr typeNameType(core::MutableContext ctx,
             }
         } else {
             // The type may refer to a type parameter, so we need to check if it exists as a NameKind::UTF8
-            auto nameUTF8 = ctx.state.enterNameUTF8(nameStr);
             if (hasTypeParam(ctx, typeParams, nameUTF8)) {
                 return ast::MK::Send1(loc, ast::MK::T(loc), core::Names::typeParameter(), loc,
                                       ast::MK::Symbol(loc, nameUTF8));

--- a/rewriter/RBSAssertions.cc
+++ b/rewriter/RBSAssertions.cc
@@ -1,0 +1,509 @@
+#include "rewriter/RBSAssertions.h"
+
+#include "absl/strings/str_split.h"
+#include "ast/Helpers.h"
+#include "ast/treemap/treemap.h"
+#include "core/Context.h"
+#include "core/Names.h"
+#include "core/core.h"
+#include "core/errors/rewriter.h"
+#include "rbs/RBSParser.h"
+#include "rbs/TypeTranslator.h"
+#include "rewriter/util/Util.h"
+#include <regex>
+
+using namespace std;
+using namespace sorbet;
+
+namespace {
+
+/**
+ * Check if the given expression is a desugared identifier
+ */
+bool isDesugarIdent(core::MutableContext ctx, const ast::ExpressionPtr &expr) {
+    auto ident = ast::cast_tree<ast::UnresolvedIdent>(expr);
+    return ident && ident->kind == ast::UnresolvedIdent::Kind::Local &&
+           (ident->name.isUniqueNameOf(ctx, core::Names::andAnd()) ||
+            ident->name.isUniqueNameOf(ctx, core::Names::assignTemp()) ||
+            ident->name.isUniqueNameOf(ctx, core::Names::destructureArg()) ||
+            ident->name.isUniqueNameOf(ctx, core::Names::forTemp()) ||
+            ident->name.isUniqueNameOf(ctx, core::Names::hashTemp()) ||
+            ident->name.isUniqueNameOf(ctx, core::Names::orOr()) ||
+            ident->name.isUniqueNameOf(ctx, core::Names::rescueTemp()) ||
+            ident->name.isUniqueNameOf(ctx, core::Names::statTemp()));
+}
+
+/**
+ * Check if the given expression is a send on a desugared identifier receiver
+ */
+bool isDesugarSend(core::MutableContext ctx, const ast::ExpressionPtr &expr) {
+    auto send = ast::cast_tree<ast::Send>(expr);
+    while (send) {
+        if (isDesugarIdent(ctx, send->recv)) {
+            return true;
+        }
+
+        send = ast::cast_tree<ast::Send>(send->recv);
+    }
+
+    return false;
+}
+
+class RBSAssertionsWalker final {
+private:
+    const vector<pair<core::LocOffsets, core::NameRef>> &typeParams;
+
+    /**
+     * Check if the given range contains a heredoc marker `<<-` or `<<~`
+     */
+    bool hasHeredocMarker(core::MutableContext ctx, const uint32_t fromPos, const uint32_t toPos) {
+        string source(ctx.file.data(ctx).source().substr(fromPos, toPos - fromPos));
+        regex heredoc_pattern("(\\s+=\\s<<-|~)");
+        smatch matches;
+        return regex_search(source, matches, heredoc_pattern);
+    }
+
+    /**
+     * Check if the given send is a magic string interpolation
+     */
+    bool isMagicString(const ast::Send &send) {
+        auto recv = ast::cast_tree<ast::ConstantLit>(send.recv);
+        if (!recv) {
+            return false;
+        }
+
+        if (recv->symbol() != core::Symbols::Magic()) {
+            return false;
+        }
+
+        if (send.fun != core::Names::stringInterpolate()) {
+            return false;
+        }
+
+        if (send.numPosArgs() < 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the given expression is a heredoc
+     */
+    bool isHeredoc(core::MutableContext ctx, core::LocOffsets assignLoc, const ast::ExpressionPtr &expr) {
+        auto result = false;
+
+        typecase(
+            expr,
+            [&](const ast::Literal &lit) {
+                if (lit.isString()) {
+                    // For some reason, heredoc strings are parser differently if they contain a single line or more.
+                    //
+                    // Single line heredocs do not contain the `<<-` or `<<~` markers inside their location.
+                    //
+                    // For example, this heredoc:
+                    //
+                    //     <<~MSG
+                    //       foo
+                    //     MSG
+
+                    // has the `<<-` or `<<~` markers **outside** its location.
+                    //
+                    // While this heredoc:
+                    //
+                    //     <<~MSG
+                    //       foo
+                    //     MSG
+                    //
+                    // has the `<<-` or `<<~` markers **inside** its location.
+
+                    auto lineStart = core::Loc::offset2Pos(ctx.file.data(ctx), lit.loc.beginLoc).line;
+                    auto lineEnd = core::Loc::offset2Pos(ctx.file.data(ctx), lit.loc.endLoc).line;
+
+                    if (lineEnd - lineStart <= 1) {
+                        // Single line heredoc, we look for the heredoc marker outside, ie. between the assign `=` sign
+                        // and the begining of the string.
+                        if (hasHeredocMarker(ctx, assignLoc.endPos(), lit.loc.beginPos())) {
+                            result = true;
+                        }
+                    } else {
+                        // Multi-line heredoc, we look for the heredoc marker inside the string itself.
+                        if (hasHeredocMarker(ctx, lit.loc.beginPos(), lit.loc.endPos())) {
+                            result = true;
+                        }
+                    }
+                }
+            },
+            [&](const ast::Send &send) {
+                if (isMagicString(send)) {
+                    result = hasHeredocMarker(ctx, assignLoc.endPos(), send.getPosArg(0).loc().beginPos());
+                } else {
+                    result = isHeredoc(ctx, assignLoc, send.recv);
+                }
+            },
+            [&](const ast::ExpressionPtr &expr) { result = false; });
+
+        return result;
+    }
+
+    /**
+     * Find the RBS comment for the given assign
+     */
+    optional<rbs::Comment> findRBSComments(core::MutableContext ctx, ast::Assign *assign) {
+        auto source = ctx.file.data(ctx).source();
+
+        // We want to find the comment right after the end of the assign
+        auto startingLoc = assign->loc.endPos();
+
+        // On heredocs, adding the comment at the end of the assign won't work because this is invalid Ruby syntax:
+        // ```
+        // <<~MSG
+        //   foo
+        // MSG #: String
+        // ```
+        // We add a special case for heredocs to allow adding the comment at the end of the assign:
+        // ```
+        // <<~MSG #: String
+        //   foo
+        // MSG
+        // ```
+        if (isHeredoc(ctx, assign->lhs.loc(), assign->rhs)) {
+            startingLoc = assign->loc.beginPos();
+        }
+
+        // Get the position of the end of the line from the startingLoc
+        auto endOfLine = source.find('\n', startingLoc);
+        if (endOfLine == string::npos) {
+            return nullopt;
+        }
+
+        // Check between the startingLoc and the end of the line for a `#: ...` comment
+        auto comment = source.substr(startingLoc, endOfLine - startingLoc);
+
+        // Find the position of the `#:` in the comment
+        auto commentStart = comment.find("#:");
+        if (commentStart == string::npos) {
+            return nullopt;
+        }
+
+        // Adjust the location to be the correct position depending on the number of spaces after the `#:`
+        auto offset = 0;
+        for (auto i = startingLoc + commentStart + 2; i < endOfLine; i++) {
+            if (source[i] == ' ') {
+                offset++;
+            } else {
+                break;
+            }
+        }
+
+        return rbs::Comment{
+            core::LocOffsets{startingLoc + (uint32_t)commentStart + offset, static_cast<uint32_t>(endOfLine)},
+            absl::StripAsciiWhitespace(comment.substr(commentStart + 2))};
+    }
+
+    /**
+     * Get the RBS type from the given assign
+     */
+    ast::ExpressionPtr getRBSAssertionType(core::MutableContext ctx, ast::Assign *assign) {
+        auto assertion = findRBSComments(ctx, assign);
+
+        if (!assertion) {
+            return nullptr;
+        }
+
+        auto result = rbs::RBSParser::parseType(ctx, *assertion);
+        if (result.second) {
+            if (auto e = ctx.beginError(result.second->loc, core::errors::Rewriter::RBSSyntaxError)) {
+                e.setHeader("Failed to parse RBS type ({})", result.second->message);
+            }
+            return nullptr;
+        }
+
+        auto rbsType = move(result.first.value());
+        return rbs::TypeTranslator::toExpressionPtr(ctx, typeParams, rbsType.node.get(), assertion->loc);
+    }
+
+    /**
+     * Transform the given assign into an `Assign` with a `Let` if it has an RBS comment
+     */
+    ast::ExpressionPtr transformAssign(core::MutableContext ctx, ast::Assign *assign) {
+        if (auto type = getRBSAssertionType(ctx, assign)) {
+            auto rhs = ast::MK::Let(type.loc(), move(assign->rhs), move(type));
+            return ast::make_expression<ast::Assign>(assign->loc, move(assign->lhs), move(rhs));
+        }
+
+        return nullptr;
+    }
+
+public:
+    RBSAssertionsWalker(const vector<pair<core::LocOffsets, core::NameRef>> &typeParams) : typeParams(typeParams) {}
+
+    void postTransformAssign(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+        auto assign = ast::cast_tree<ast::Assign>(tree);
+
+        // Desugar added a bunch of magic variables, we don't want to add assertions from RBS to them
+        if (isDesugarIdent(ctx, assign->lhs)) {
+            return;
+        }
+
+        // It's hard to distinguish between a desugared expression and a normal one,
+        // sometimes we also have to check if the rhs is a send on a expression added by the desugarer.
+        if (isDesugarSend(ctx, assign->rhs)) {
+            return;
+        }
+
+        if (auto expr = transformAssign(ctx, assign)) {
+            tree = move(expr);
+        }
+    }
+
+    /*
+     * We need to handle expressions such as `@x ||= 42 #: Integer?` into the proper `T.let`.
+     *
+     * `||=` assigns are already desugared into an else if such as:
+     *
+     *     if @x
+     *       @x
+     *     else
+     *       @x = 42
+     *     end
+     *
+     * Also in desugar, there is a special case for `@x ||= T.let(42, T.nilable(Integer))` to return a
+     * non-nilable value:
+     *
+     *     if @x
+     *       @x
+     *     else
+     *       @x = T.let(@x, T.nilable(Integer))
+     *       <tmp> = 42
+     *       @x = <tmp>
+     *     end
+     *
+     * Since with RBS comments we introduce the `T.let` after the desugar we need to manually emulate this
+     * behavior and transform the `else` branch accordingly.
+     *
+     * Will apply the transformation if and only if:
+     *
+     *  1. The condition is an `UnresolvedIdent` and it's an instance variable
+     *  2. The `then` branch returns the same instance variable
+     *  3. The `else` branch is an `Assign` to the same instance variable using a `T.let` of a nilable type
+     */
+    void postTransformIf(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+        auto iff = ast::cast_tree<ast::If>(tree);
+
+        // Is the condition an `UnresolvedIdent` and it's an instance variable?
+        auto condIdent = ast::cast_tree<ast::UnresolvedIdent>(iff->cond);
+        if (!condIdent || condIdent->kind != ast::UnresolvedIdent::Kind::Instance) {
+            return;
+        }
+
+        // Is the `then` branch an `UnresolvedIdent` and it's the same instance variable?
+        auto name = condIdent->name;
+        auto thenIdent = ast::cast_tree<ast::UnresolvedIdent>(iff->thenp);
+        if (!thenIdent || thenIdent->name != name) {
+            return;
+        }
+
+        // Is the `else` branch an `Assign` to the same instance variable using a `T.let` of a nilable type?
+        auto elseAssign = ast::cast_tree<ast::Assign>(iff->elsep);
+        if (!elseAssign) {
+            return;
+        }
+        auto elseAssignLhs = ast::cast_tree<ast::UnresolvedIdent>(elseAssign->lhs);
+        if (!elseAssignLhs || elseAssignLhs->name != name) {
+            return;
+        }
+        auto elseAssignCast = ast::cast_tree<ast::Cast>(elseAssign->rhs);
+        if (!elseAssignCast) {
+            return;
+        }
+        if (!ast::MK::isTNilable(elseAssignCast->typeExpr)) {
+            return;
+        }
+
+        // We have a else branch that looks like this:
+        //
+        //     @x = T.let(42, T.nilable(Integer))
+        //
+        // We need to transform it into:
+        //
+        //     @x = T.let(@x, T.nilable(Integer))
+        //     <tmp> = 42
+        //     @x = <tmp>
+
+        auto stats = ast::InsSeq::STATS_store();
+        stats.reserve(3);
+
+        auto let = ast::MK::Let(elseAssignCast->loc, ast::MK::cpRef(elseAssign->lhs), move(elseAssignCast->typeExpr));
+        auto newLet = ast::make_expression<ast::Assign>(elseAssign->loc, ast::MK::cpRef(elseAssign->lhs), move(let));
+        stats.push_back(move(newLet));
+
+        auto tempLocal = ast::MK::Local(elseAssignCast->loc, core::Names::statTemp());
+        auto newTemp = ast::MK::Assign(elseAssignCast->loc, ast::MK::cpRef(tempLocal), move(elseAssignCast->arg));
+        stats.push_back(move(newTemp));
+
+        auto expr = ast::make_expression<ast::Assign>(elseAssign->loc, move(elseAssign->lhs), move(tempLocal));
+
+        iff->elsep = ast::make_expression<ast::InsSeq>(iff->elsep.loc(), move(stats), move(expr));
+
+        tree = ast::make_expression<ast::If>(iff->loc, move(iff->cond), move(iff->thenp), move(iff->elsep));
+    }
+
+    /*
+     * Splat expression such as:
+     *
+     *     x, y = value #: [Integer, String]
+     *
+     * are desugared using a Magic.expand-splat call:
+     *
+     *     <assignTemp>$1 = value
+     *     <assignTemp>$2 = ::<Magic>.<expand-splat>(<assignTemp>$1 ...)
+     *     x = <assignTemp>$2[0]
+     *     y = <assignTemp>$2[1]
+     *     <assignTemp>$1
+     *
+     * We need to transform this into:
+     *
+     *     <assignTemp>$1 = T.let(value, [Integer, String])
+     *     <assignTemp>$2 = ::<Magic>.<expand-splat>(<assignTemp>$1 ...)
+     *     x = <assignTemp>$2[0]
+     *     y = <assignTemp>$2[1]
+     *     <assignTemp>$1
+     */
+    void postTransformInsSeq(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+        // Are we in an ins seq?
+        auto insSeq = ast::cast_tree<ast::InsSeq>(tree);
+        if (!insSeq) {
+            return;
+        }
+
+        // Do we have at least 2 stats?
+        // So we have the `<assignTemp>$1 = T.let...` and `<assignTemp>$2 = <Magic>.expand-splat(...)`
+        if (insSeq->stats.size() < 2) {
+            return;
+        }
+
+        // Is the first stat an assign to a desugared identifier?
+        auto assignTemp1 = ast::cast_tree<ast::Assign>(insSeq->stats[0]);
+        if (!assignTemp1 || !isDesugarIdent(ctx, assignTemp1->lhs)) {
+            return;
+        }
+
+        // Is the second stat also an assign to a desugared identifier?
+        auto assignTemp2 = ast::cast_tree<ast::Assign>(insSeq->stats[1]);
+        if (!assignTemp2 || !isDesugarIdent(ctx, assignTemp2->lhs)) {
+            return;
+        }
+
+        // Is the rhs of the second stat a call to `<Magic>.<expand-splat>`?
+        auto expandSplat = ast::cast_tree<ast::Send>(assignTemp2->rhs);
+        if (!expandSplat || expandSplat->fun != core::Names::expandSplat()) {
+            return;
+        }
+
+        // Is the receiver of the send the `<Magic>` constant?
+        auto recv = ast::cast_tree<ast::ConstantLit>(expandSplat->recv);
+        if (!recv || recv->symbol() != core::Symbols::Magic()) {
+            return;
+        }
+
+        // Transform the first assign into an `Assign` with a `Let` if it has an RBS comment
+        if (auto newAssign = transformAssign(ctx, assignTemp1)) {
+            insSeq->stats[0] = move(newAssign);
+        }
+
+        return;
+    }
+};
+
+/**
+ * Parse the type parameters from the previous statement
+ *
+ * Given a case like this one:
+ *
+ *     #: [X] (X) -> void
+ *     def foo(x)
+ *       y = nil #: X?
+ *     end
+ *
+ * We need to be aware of the type parameter `X` so we can use it to resolve the type of `y`.
+ */
+vector<pair<core::LocOffsets, core::NameRef>> parseTypeParams(core::MutableContext ctx, ast::ExpressionPtr *prevStat) {
+    vector<pair<core::LocOffsets, core::NameRef>> typeParams;
+
+    // Do we have a previous statement?
+    if (!prevStat) {
+        return typeParams;
+    }
+
+    // Is the previous statement a sig call?
+    auto *sig = rewriter::ASTUtil::castSig(*prevStat);
+    if (sig == nullptr) {
+        return typeParams;
+    }
+
+    // Make sure the sig has a block
+    auto *block = sig->block();
+    if (block == nullptr) {
+        return typeParams;
+    }
+
+    // Does the sig contain a `type_parameters()` invocation?
+    auto send = ast::cast_tree<ast::Send>(block->body);
+    while (send && send->fun != core::Names::typeParameters()) {
+        send = ast::cast_tree<ast::Send>(send->recv);
+    }
+    if (send == nullptr) {
+        return typeParams;
+    }
+
+    // Collect the type parameters
+    for (auto &arg : send->posArgs()) {
+        auto sym = ast::cast_tree<ast::Literal>(arg);
+        if (sym == nullptr) {
+            continue;
+        }
+
+        if (!sym->isSymbol()) {
+            continue;
+        }
+
+        typeParams.emplace_back(arg.loc(), sym->asName());
+    }
+
+    return typeParams;
+}
+
+} // namespace
+
+namespace sorbet::rewriter {
+void RBSAssertions::run(core::MutableContext ctx, ast::ClassDef *classDef) {
+    ast::ExpressionPtr *prevStat = nullptr;
+
+    for (auto &stat : classDef->rhs) {
+        typecase(
+            stat,
+            [&](ast::ClassDef &cdef) {
+                // no-op to avoid visiting the same class defs twice
+            },
+            [&](ast::MethodDef &mdef) {
+                // When visiting a method definition, we need to parse the type parameters from the previous
+                // statement
+                auto typeParams = parseTypeParams(ctx, prevStat);
+                RBSAssertionsWalker walker(typeParams);
+                ast::TreeWalk::apply(ctx, walker, stat);
+            },
+            [&](ast::ExpressionPtr &e) {
+                // For bare statements, we don't have any type parameters
+                vector<pair<core::LocOffsets, core::NameRef>> typeParams = {};
+                RBSAssertionsWalker walker(typeParams);
+                ast::TreeWalk::apply(ctx, walker, stat);
+            });
+
+        prevStat = &stat;
+    }
+}
+
+} // namespace sorbet::rewriter
+
+// TODO: fix heredoc location

--- a/rewriter/RBSAssertions.cc
+++ b/rewriter/RBSAssertions.cc
@@ -231,7 +231,7 @@ private:
     ast::ExpressionPtr transformAssign(core::MutableContext ctx, ast::Assign *assign) {
         if (auto type = getRBSAssertionType(ctx, assign)) {
             auto rhs = ast::MK::Let(type.loc(), move(assign->rhs), move(type));
-            return ast::make_expression<ast::Assign>(assign->loc, move(assign->lhs), move(rhs));
+            return ast::MK::Assign(assign->loc, move(assign->lhs), move(rhs));
         }
 
         return nullptr;
@@ -337,18 +337,18 @@ public:
         stats.reserve(3);
 
         auto let = ast::MK::Let(elseAssignCast->loc, ast::MK::cpRef(elseAssign->lhs), move(elseAssignCast->typeExpr));
-        auto newLet = ast::make_expression<ast::Assign>(elseAssign->loc, ast::MK::cpRef(elseAssign->lhs), move(let));
+        auto newLet = ast::MK::Assign(elseAssign->loc, ast::MK::cpRef(elseAssign->lhs), move(let));
         stats.push_back(move(newLet));
 
         auto tempLocal = ast::MK::Local(elseAssignCast->loc, core::Names::statTemp());
         auto newTemp = ast::MK::Assign(elseAssignCast->loc, ast::MK::cpRef(tempLocal), move(elseAssignCast->arg));
         stats.push_back(move(newTemp));
 
-        auto expr = ast::make_expression<ast::Assign>(elseAssign->loc, move(elseAssign->lhs), move(tempLocal));
+        auto expr = ast::MK::Assign(elseAssign->loc, move(elseAssign->lhs), move(tempLocal));
 
-        iff->elsep = ast::make_expression<ast::InsSeq>(iff->elsep.loc(), move(stats), move(expr));
+        iff->elsep = ast::MK::InsSeq(iff->elsep.loc(), move(stats), move(expr));
 
-        tree = ast::make_expression<ast::If>(iff->loc, move(iff->cond), move(iff->thenp), move(iff->elsep));
+        tree = ast::MK::If(iff->loc, move(iff->cond), move(iff->thenp), move(iff->elsep));
     }
 
     /*

--- a/rewriter/RBSAssertions.cc
+++ b/rewriter/RBSAssertions.cc
@@ -430,7 +430,8 @@ public:
  *
  * We need to be aware of the type parameter `X` so we can use it to resolve the type of `y`.
  */
-vector<pair<core::LocOffsets, core::NameRef>> parseTypeParams(core::MutableContext ctx, ast::ExpressionPtr *prevStat) {
+vector<pair<core::LocOffsets, core::NameRef>> parseTypeParams(core::MutableContext ctx,
+                                                              const ast::ExpressionPtr *prevStat) {
     vector<pair<core::LocOffsets, core::NameRef>> typeParams;
 
     // Do we have a previous statement?

--- a/rewriter/RBSAssertions.cc
+++ b/rewriter/RBSAssertions.cc
@@ -15,6 +15,8 @@
 using namespace std;
 using namespace sorbet;
 
+namespace sorbet::rewriter {
+
 namespace {
 
 /**
@@ -476,7 +478,6 @@ vector<pair<core::LocOffsets, core::NameRef>> parseTypeParams(core::MutableConte
 
 } // namespace
 
-namespace sorbet::rewriter {
 void RBSAssertions::run(core::MutableContext ctx, ast::ClassDef *classDef) {
     ast::ExpressionPtr *prevStat = nullptr;
 

--- a/rewriter/RBSAssertions.cc
+++ b/rewriter/RBSAssertions.cc
@@ -24,15 +24,8 @@ namespace {
  */
 bool isDesugarIdent(core::MutableContext ctx, const ast::ExpressionPtr &expr) {
     auto ident = ast::cast_tree<ast::UnresolvedIdent>(expr);
-    return ident && ident->kind == ast::UnresolvedIdent::Kind::Local &&
-           (ident->name.isUniqueNameOf(ctx, core::Names::andAnd()) ||
-            ident->name.isUniqueNameOf(ctx, core::Names::assignTemp()) ||
-            ident->name.isUniqueNameOf(ctx, core::Names::destructureArg()) ||
-            ident->name.isUniqueNameOf(ctx, core::Names::forTemp()) ||
-            ident->name.isUniqueNameOf(ctx, core::Names::hashTemp()) ||
-            ident->name.isUniqueNameOf(ctx, core::Names::orOr()) ||
-            ident->name.isUniqueNameOf(ctx, core::Names::rescueTemp()) ||
-            ident->name.isUniqueNameOf(ctx, core::Names::statTemp()));
+    return ident && ident->name.kind() == core::NameKind::UNIQUE &&
+           ident->name.dataUnique(ctx.state)->uniqueNameKind == core::UniqueNameKind::Desugar;
 }
 
 /**

--- a/rewriter/RBSAssertions.h
+++ b/rewriter/RBSAssertions.h
@@ -1,0 +1,25 @@
+#ifndef SORBET_REWRITER_RBS_ASSERTIONS_H
+#define SORBET_REWRITER_RBS_ASSERTIONS_H
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * This class rewrites RBS type assertions into Sorbet `T.let` calls.
+ *
+ * So this:
+ *
+ *     x = foo #: Integer
+ *
+ * Will be rewritten to:
+ *
+ *     x = T.let(foo, Integer)
+ */
+class RBSAssertions final {
+public:
+    static void run(core::MutableContext ctx, ast::ClassDef *classDef);
+};
+
+} // namespace sorbet::rewriter
+
+#endif

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -23,6 +23,7 @@
 #include "rewriter/ModuleFunction.h"
 #include "rewriter/Private.h"
 #include "rewriter/Prop.h"
+#include "rewriter/RBSAssertions.h"
 #include "rewriter/RBSSignatures.h"
 #include "rewriter/Rails.h"
 #include "rewriter/SigRewriter.h"
@@ -44,6 +45,10 @@ public:
         auto classDef = ast::cast_tree<ast::ClassDef>(tree);
 
         auto isClass = classDef->kind == ast::ClassDef::Kind::Class;
+
+        if (ctx.state.rbsAssertionsEnabled) {
+            RBSAssertions::run(ctx, classDef);
+        }
 
         Command::run(ctx, classDef);
         Rails::run(ctx, classDef);

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -255,6 +255,7 @@ const UnorderedMap<
         {"check-out-of-order-constant-references", BooleanPropertyAssertion::make},
         {"enable-packager", BooleanPropertyAssertion::make},
         {"enable-experimental-rbs-signatures", BooleanPropertyAssertion::make},
+        {"enable-experimental-rbs-assertions", BooleanPropertyAssertion::make},
         {"enable-experimental-requires-ancestor", BooleanPropertyAssertion::make},
         {"experimental-ruby3-keyword-args", BooleanPropertyAssertion::make},
         {"typed-super", BooleanPropertyAssertion::make},
@@ -680,6 +681,8 @@ realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeA
     opts.noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
     opts.rbsSignaturesEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-rbs-signatures", assertions).value_or(false);
+    opts.rbsAssertionsEnabled =
+        BooleanPropertyAssertion::getValue("enable-experimental-rbs-assertions", assertions).value_or(false);
     opts.requiresAncestorEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
     opts.ruby3KeywordArgs =

--- a/test/testdata/lsp/hover_rbs_assertions_let.rb
+++ b/test/testdata/lsp/hover_rbs_assertions_let.rb
@@ -1,0 +1,27 @@
+# typed: true
+# enable-experimental-rbs-signatures: true
+# enable-experimental-rbs-assertions: true
+
+  x = 42 #: Integer
+# ^ hover: Integer
+#        ^ hover: null
+#         ^ hover: null
+#          ^ hover: null
+#           ^ hover: T.class_of(Integer)
+#            ^ hover: T.class_of(Integer)
+#             ^ hover: T.class_of(Integer)
+#              ^ hover: T.class_of(Integer)
+#               ^ hover: T.class_of(Integer)
+#                ^ hover: T.class_of(Integer)
+#                 ^ hover: T.class_of(Integer)
+
+class Foo
+  def foo
+    @x ||= 42 #: Integer?
+  end
+
+  def bar
+    puts @x
+       # ^ hover: T.nilable(Integer)
+  end
+end

--- a/test/testdata/rewriter/rbs_assertions_let.rb
+++ b/test/testdata/rewriter/rbs_assertions_let.rb
@@ -52,6 +52,10 @@ T.reveal_type(h) # error: Revealed type: `T::Array[String]`
 i = "#: Integer" #: String
 T.reveal_type(i) # error: Revealed type: `String`
 
+j = 42 #: Integer
+j += 42 #: String # error: Argument does not have asserted type `String`
+T.reveal_type(j) # error: Revealed type: `String`
+
 # constants
 
 A = ARGV.first #: String

--- a/test/testdata/rewriter/rbs_assertions_let.rb
+++ b/test/testdata/rewriter/rbs_assertions_let.rb
@@ -1,0 +1,183 @@
+# typed: strict
+# enable-experimental-rbs-signatures: true
+# enable-experimental-rbs-assertions: true
+
+# errors
+
+e1 = ARGV #: Integer
+          #  ^^^^^^^ error: Argument does not have asserted type `Integer`
+
+e2 = ARGV #:Integer
+          # ^^^^^^^ error: Argument does not have asserted type `Integer`
+
+e3 = ARGV #: Int
+          #  ^^^ error: Unable to resolve constant `Int`
+
+e4 = ARGV #: -
+          #  ^ error: Failed to parse RBS type (unexpected token for simple type)
+
+e5 = ARGV #:
+          # ^ error: Failed to parse RBS type (unexpected token for simple type)
+
+e6 = ARGV #: Integer # error: Argument does not have asserted type `Integer`
+
+# local variables
+
+a = ARGV.first #: String
+T.reveal_type(a) # error: Revealed type: `String`
+
+b = nil #: Integer?
+T.reveal_type(b) # error: Revealed type: `T.nilable(Integer)`
+
+c =
+    nil #: Integer?
+T.reveal_type(c) # error: Revealed type: `T.nilable(Integer)`
+
+d = ARGV
+      .first
+      .strip #: String
+T.reveal_type(d) # error: Revealed type: `String`
+
+e ||= "foo" #: String?
+T.reveal_type(e) # error: Revealed type: `T.nilable(String)`
+
+f = "" #: String?
+f &&= "foo" #: Integer # error: Argument does not have asserted type `Integer`
+T.reveal_type(f) # error: Revealed type: `T.nilable(Integer)`
+
+g, *h = ARGV #: Array[String]
+T.reveal_type(g) # error: Revealed type: `T.nilable(String)`
+T.reveal_type(h) # error: Revealed type: `T::Array[String]`
+
+i = "#: Integer" #: String
+T.reveal_type(i) # error: Revealed type: `String`
+
+# constants
+
+A = ARGV.first #: String
+T.reveal_type(A) # error: Revealed type: `String`
+
+B = T.must("foo"[0]) #: String
+T.reveal_type(B) # error: Revealed type: `String`
+
+# instance variables
+
+@a = ARGV.first #: String
+T.reveal_type(@a) # error: Revealed type: `String`
+
+@b = ARGV.first || [] #: Array[String]
+T.reveal_type(@b) # error: Revealed type: `T::Array[String]`
+
+@c = ARGV.first&.strip #: String?
+T.reveal_type(@c) # error: Revealed type: `T.nilable(String)`
+
+# class variables
+
+@@a = 1 #: Integer
+T.reveal_type(@@a) # error: Revealed type: `Integer`
+
+# global variables
+
+$a = ARGV.first #: String
+T.reveal_type($a) # error: Revealed type: `String`
+
+# accessors
+
+class LetAccessor
+  #: Integer
+  attr_accessor :x
+
+  #: (untyped) -> void
+  def initialize(something)
+    @x = something.num #: Integer
+    T.reveal_type(@x) # error: Revealed type: `Integer`
+    T.reveal_type(x) # error: Revealed type: `Integer`
+  end
+end
+
+class DesugaredLetNilable
+  #: -> Integer
+  def foo
+    @x ||= 42 #: Integer?
+    T.reveal_type(@x) # error: Revealed type: `Integer`
+  end
+
+  #: -> void
+  def bar
+    @y ||= nil #: Integer?
+    @y ||= 42
+    T.reveal_type(@y) # error: Revealed type: `Integer`
+  end
+
+  #: -> void
+  def baz
+    T.reveal_type(@x) # error: Revealed type: `T.nilable(Integer)`
+    T.reveal_type(@y) # error: Revealed type: `T.nilable(Integer)`
+  end
+end
+
+# type parameters
+
+class TypeParams
+  #: [A, B, C] (A, B?, C) -> void
+  def foo(a, b, c)
+    x = a #: A
+    T.reveal_type(x) # error: Revealed type: `T.type_parameter(:A) (of TypeParams#foo)`
+
+    y = [] #: Array[B]
+    T.reveal_type(y) # error: Revealed type: `T::Array[T.type_parameter(:B) (of TypeParams#foo)]`
+
+    z = nil #: C?
+    T.reveal_type(z) # error: Revealed type: `T.nilable(T.type_parameter(:C) (of TypeParams#foo))`
+  end
+end
+
+# heredocs
+
+# Make sure we don't parse parts of heredocs as RBS assertions
+HEREDOC_ERROR = <<~MSG.strip # error: Constants must have type annotations with `T.let` when specifying `# typed: strict
+  #: Integer
+MSG
+
+# Make sure we don't parse parts of strings as RBS assertions
+HEREDOC_STRING = "<<~ #: Integer".strip # error: Constants must have type annotations with `T.let` when specifying `# typed: strict
+
+HEREDOC1 = <<~MSG #: String?
+  foo
+MSG
+T.reveal_type(HEREDOC1) # error: Revealed type: `T.nilable(String)`
+
+HEREDOC2 = <<~MSG.strip.strip #: String?
+  #{42}
+MSG
+T.reveal_type(HEREDOC2) # error: Revealed type: `T.nilable(String)`
+
+HEREDOC3 = String(<<~MSG.strip) #: String?
+  foo
+MSG
+T.reveal_type(HEREDOC3) # error: Revealed type: `T.nilable(String)`
+
+HEREDOC4 = <<~MSG #: String?
+  foo
+  bar
+  baz
+MSG
+T.reveal_type(HEREDOC4) # error: Revealed type: `T.nilable(String)`
+
+# avoid desugar magics
+
+class Foo
+  #: (untyped) -> void
+  def initialize(x)
+    @x = x
+  end
+end
+
+#: -> Hash[Symbol, untyped]
+def foo_params
+  {}
+end
+
+foo = Foo.new({
+  **foo_params,
+}) #: Foo?

--- a/test/testdata/rewriter/rbs_assertions_let.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rbs_assertions_let.rb.rewrite-tree.exp
@@ -1,0 +1,275 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+    <self>.returns(<emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, ::T.untyped()))
+  end
+
+  def foo_params<<todo method>>(&<blk>)
+    {}
+  end
+
+  e1 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, <emptyTree>::<C Integer>)
+
+  e2 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, <emptyTree>::<C Integer>)
+
+  e3 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, <emptyTree>::<C Int>)
+
+  e4 = <emptyTree>::<C ARGV>
+
+  e5 = <emptyTree>::<C ARGV>
+
+  e6 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, <emptyTree>::<C Integer>)
+
+  a = <cast:let>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C String>)
+
+  <emptyTree>::<C T>.reveal_type(a)
+
+  b = <cast:let>(nil, <todo sym>, ::T.nilable(<emptyTree>::<C Integer>))
+
+  <emptyTree>::<C T>.reveal_type(b)
+
+  c = <cast:let>(nil, <todo sym>, ::T.nilable(<emptyTree>::<C Integer>))
+
+  <emptyTree>::<C T>.reveal_type(c)
+
+  d = <cast:let>(<emptyTree>::<C ARGV>.first().strip(), <todo sym>, <emptyTree>::<C String>)
+
+  <emptyTree>::<C T>.reveal_type(d)
+
+  if e
+    e
+  else
+    e = <cast:let>("foo", <todo sym>, ::T.nilable(<emptyTree>::<C String>))
+  end
+
+  <emptyTree>::<C T>.reveal_type(e)
+
+  f = <cast:let>("", <todo sym>, ::T.nilable(<emptyTree>::<C String>))
+
+  if f
+    f = <cast:let>("foo", <todo sym>, <emptyTree>::<C Integer>)
+  else
+    f
+  end
+
+  <emptyTree>::<C T>.reveal_type(f)
+
+  begin
+    <assignTemp>$2 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+    <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 1, 0)
+    g = <assignTemp>$3.[](0)
+    h = <assignTemp>$3.to_ary()
+    <assignTemp>$2
+  end
+
+  <emptyTree>::<C T>.reveal_type(g)
+
+  <emptyTree>::<C T>.reveal_type(h)
+
+  i = <cast:let>("#: Integer", <todo sym>, <emptyTree>::<C String>)
+
+  <emptyTree>::<C T>.reveal_type(i)
+
+  j = <cast:let>(42, <todo sym>, <emptyTree>::<C Integer>)
+
+  j = <cast:let>(j.+(42), <todo sym>, <emptyTree>::<C String>)
+
+  <emptyTree>::<C T>.reveal_type(j)
+
+  <emptyTree>::<C A> = <cast:let>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C String>)
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C A>)
+
+  <emptyTree>::<C B> = <cast:let>(<emptyTree>::<C T>.must("foo".[](0)), <todo sym>, <emptyTree>::<C String>)
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C B>)
+
+  @a = <cast:let>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C String>)
+
+  <emptyTree>::<C T>.reveal_type(@a)
+
+  @b = <cast:let>(begin
+    ||$4 = <emptyTree>::<C ARGV>.first()
+    if ||$4
+      ||$4
+    else
+      []
+    end
+  end, <todo sym>, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(@b)
+
+  @c = <cast:let>(begin
+    <assignTemp>$5 = <emptyTree>::<C ARGV>.first()
+    if ::NilClass.===(<assignTemp>$5)
+      ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$5)
+    else
+      <assignTemp>$5.strip()
+    end
+  end, <todo sym>, ::T.nilable(<emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(@c)
+
+  @@a = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
+
+  <emptyTree>::<C T>.reveal_type(@@a)
+
+  $a = <cast:let>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C String>)
+
+  <emptyTree>::<C T>.reveal_type($a)
+
+  class <emptyTree>::<C LetAccessor><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def x<<todo method>>(&<blk>)
+      @x
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:x, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
+    end
+
+    def x=<<todo method>>(x, &<blk>)
+      @x = x
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:something, ::T.untyped()).void()
+    end
+
+    def initialize<<todo method>>(something, &<blk>)
+      begin
+        @x = <cast:let>(something.num(), <todo sym>, <emptyTree>::<C Integer>)
+        <emptyTree>::<C T>.reveal_type(@x)
+        <emptyTree>::<C T>.reveal_type(<self>.x())
+      end
+    end
+
+    <runtime method definition of x>
+
+    <runtime method definition of x=>
+
+    <runtime method definition of initialize>
+  end
+
+  class <emptyTree>::<C DesugaredLetNilable><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<<todo method>>(&<blk>)
+      begin
+        if @x
+          @x
+        else
+          begin
+            @x = <cast:let>(@x, <todo sym>, ::T.nilable(<emptyTree>::<C Integer>))
+            <statTemp> = 42
+            @x = <statTemp>
+          end
+        end
+        <emptyTree>::<C T>.reveal_type(@x)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def bar<<todo method>>(&<blk>)
+      begin
+        if @y
+          @y
+        else
+          begin
+            @y = <cast:let>(@y, <todo sym>, ::T.nilable(<emptyTree>::<C Integer>))
+            <statTemp> = nil
+            @y = <statTemp>
+          end
+        end
+        if @y
+          @y
+        else
+          @y = 42
+        end
+        <emptyTree>::<C T>.reveal_type(@y)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def baz<<todo method>>(&<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(@x)
+        <emptyTree>::<C T>.reveal_type(@y)
+      end
+    end
+
+    <runtime method definition of foo>
+
+    <runtime method definition of bar>
+
+    <runtime method definition of baz>
+  end
+
+  class <emptyTree>::<C TypeParams><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.type_parameters(:A, :B, :C).params(:a, ::T.type_parameter(:A), :b, ::T.nilable(::T.type_parameter(:B)), :c, ::T.type_parameter(:C)).void()
+    end
+
+    def foo<<todo method>>(a, b, c, &<blk>)
+      begin
+        x = <cast:let>(a, <todo sym>, ::T.type_parameter(:A))
+        <emptyTree>::<C T>.reveal_type(x)
+        y = <cast:let>([], <todo sym>, <emptyTree>::<C T>::<C Array>.[](::T.type_parameter(:B)))
+        <emptyTree>::<C T>.reveal_type(y)
+        z = <cast:let>(nil, <todo sym>, ::T.nilable(::T.type_parameter(:C)))
+        <emptyTree>::<C T>.reveal_type(z)
+      end
+    end
+
+    <runtime method definition of foo>
+  end
+
+  <emptyTree>::<C HEREDOC_ERROR> = "#: Integer\n".strip()
+
+  <emptyTree>::<C HEREDOC_STRING> = "<<~ #: Integer".strip()
+
+  <emptyTree>::<C HEREDOC1> = <cast:let>("foo\n", <todo sym>, ::T.nilable(<emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C HEREDOC1>)
+
+  <emptyTree>::<C HEREDOC2> = <cast:let>(::<Magic>.<string-interpolate>(42, "\n").strip().strip(), <todo sym>, ::T.nilable(<emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C HEREDOC2>)
+
+  <emptyTree>::<C HEREDOC3> = <cast:let>(<self>.String("foo\n".strip()), <todo sym>, ::T.nilable(<emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C HEREDOC3>)
+
+  <emptyTree>::<C HEREDOC4> = <cast:let>("foo\nbar\nbaz\n", <todo sym>, ::T.nilable(<emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C HEREDOC4>)
+
+  class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:x, ::T.untyped()).void()
+    end
+
+    def initialize<<todo method>>(x, &<blk>)
+      @x = <cast:let>(x, <todo sym>, ::T.untyped())
+    end
+
+    <runtime method definition of initialize>
+  end
+
+  <runtime method definition of foo_params>
+
+  foo = <cast:let>(<emptyTree>::<C Foo>.new(begin
+      <hashTemp>$6 = ::<Magic>.<to-hash-dup>(<self>.foo_params())
+      <hashTemp>$6
+    end), <todo sym>, ::T.nilable(<emptyTree>::<C Foo>))
+end

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -126,6 +126,11 @@ for this_src in "${rb_src[@]}" DUMMY; do
       needs_experimental_rbs_signatures=true
     fi
 
+    needs_experimental_rbs_assertions=false
+    if grep -q '^# enable-experimental-rbs-assertions: true' "${srcs[@]}"; then
+      needs_experimental_rbs_assertions=true
+    fi
+
     if grep -q '^# typed-super: false' "${srcs[@]}"; then
       needs_typed_super_false=true
     else
@@ -189,6 +194,9 @@ for this_src in "${rb_src[@]}" DUMMY; do
       fi
       if $needs_experimental_rbs_signatures; then
         args+=("--enable-experimental-rbs-signatures")
+      fi
+      if $needs_experimental_rbs_assertions; then
+        args+=("--enable-experimental-rbs-assertions")
       fi
       if $needs_typed_super_false; then
         args+=("--typed-super=false")

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -151,6 +151,9 @@ Usage:
       --enable-experimental-rbs-signatures
                                 Enable experimental support for RBS signatures as inline
                                 comments
+      --enable-experimental-rbs-assertions
+                                Enable experimental support for RBS assertions as inline
+                                comments
       --enable-experimental-requires-ancestor
                                 Enable experimental `requires_ancestor` annotation
       --uniquely-defined-behavior

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -37,7 +37,7 @@ def foo(x)
 end
 ```
 
-### Caveats
+## Caveats
 
 > Support for this feature is experimental, and we actively discourage depending
 > on it for anything other than to offer feedback to the Sorbet developers.
@@ -45,7 +45,7 @@ end
 There are numerous shortcomings of the comment-based syntax versus `sig` syntax.
 By contrast, the near-sole upside is that the syntax is terser.
 
-#### The comment-based syntax is second class
+### The comment-based syntax is second class
 
 The comment-based syntax uses [RBS syntax](https://github.com/ruby/rbs). RBS is
 an alternative annotation syntax for Ruby. The headline features of RBS:
@@ -60,7 +60,7 @@ an alternative annotation syntax for Ruby. The headline features of RBS:
 However, there are a number of problems which mean that RBS syntax has a
 second-class position in Sorbet:
 
-##### RBS syntax does not match the semantics of Sorbet
+### RBS syntax does not match the semantics of Sorbet
 
 Sorbet's type annotation syntax evolved differently from the evolution of RBS
 syntax. Unfortunately, this difference is not syntax-deep: it affects the
@@ -95,7 +95,7 @@ possible to embed Sorbet-only syntax within the context of an RBS signature.
 While it is possible for RBS comment signatures to coexist with Sorbet `sig`
 signatures, needing to flip between them adds development friction.
 
-##### Sorbet has minimal influence over the evolution of RBS syntax
+### Sorbet has minimal influence over the evolution of RBS syntax
 
 Sorbet continues to evolve its type syntax. For example, `T.anything`,
 `T::Class`, and `has_attached_class!` are additions to Sorbet which arrived 6
@@ -137,7 +137,7 @@ There are a lot of features that come for free by reusing Ruby syntax:
 In fairness, these are technical, implementation considerations, and thus could
 hope to improve one day. But they remain problems today.
 
-#### Performance is worse
+### Performance is worse
 
 The chosen implementation for RBS annotations in comments is:
 
@@ -211,7 +211,7 @@ alongside the existing Sorbet syntax. In the mean time, users will need to
 mentally translate from Sorbet syntax to RBS syntax on their own, including
 understanding the cases where there is no suitable RBS replacement.
 
-### Quick reference
+## Quick reference
 
 Most RBS features can be used and will be translated to equivalent Sorbet syntax
 during type checking:
@@ -234,7 +234,7 @@ during type checking:
 | [Shape type]           | `{ a: Foo, b: Bar }`                     | [`{ a: Foo, b: Bar }`](shapes.md)                       |
 | [Proc type]            | `^(Foo) -> Bar`                          | [`T.proc.params(arg: Foo).returns(Bar)`](procs.md)      |
 
-### Attribute accessor types
+## Attribute accessor types
 
 Attribute accessors can be annotated with RBS types:
 
@@ -249,7 +249,7 @@ attr_writer :bar
 attr_accessor :baz
 ```
 
-### Annotations
+## Annotations
 
 While RBS does not support the same modifiers as Sorbet, it is possible to
 specify them using `@` annotation comments.
@@ -290,7 +290,7 @@ Note: these annotations like `@abstract` use normal comments, like `# @abstract`
 (not the special `#:` comment). This makes it possible to reuse any existing
 YARD or RDoc annotations.
 
-### Special behaviors
+## Special behaviors
 
 The `#:` comment must come **immediately** before the following method
 definition. If there is a blank line between the comment and method definition,
@@ -312,9 +312,9 @@ equivalent:
 Note that non-generic types are not translated, so `Array` without a type
 argument stays `Array`.
 
-### Unsupported features
+## Unsupported features
 
-#### Class types
+### Class types
 
 The `class` type in RBS is context sensitive (depends on the class where it is
 used) and Sorbet does not support this feature yet. Instead, use the equivalent
@@ -327,7 +327,7 @@ class Foo
 end
 ```
 
-#### Interface types
+### Interface types
 
 Interface types are not supported, use the equivalent Sorbet syntax instead:
 
@@ -342,7 +342,7 @@ end
 def takes_foo(x); end
 ```
 
-#### Alias types
+### Alias types
 
 Alias types are not supported, use the equivalent Sorbet syntax instead:
 
@@ -353,7 +353,7 @@ sig { params(x: Bool).void }
 def foo(x); end
 ```
 
-#### Literal types
+### Literal types
 
 Sorbet does not support RBS's concept of "literal types". The next best thing is
 to use the literal's underlying type instead:


### PR DESCRIPTION
### Motivation

Introduce inline RBS comments to replace `T.let`:

```rb
x = foo #: String
```

is equivalent to:

```rb
x = T.let(foo, String)
```

This is done through a new `RBS Assertions` rewriter. Most of the complexity is handling cases we desugared in the previous pipeline step. I documented each of them in the rewriter itself.

See website documentation for details:

<img width="655" alt="image" src="https://github.com/user-attachments/assets/5ad410d3-2463-4a2b-bf9a-3f140f2b413e" />

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
