### PR TITLE
Don't skip the cache if files are already present in the file table

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -406,48 +406,64 @@ void incrementStrictLevelCounter(core::StrictLevel level) {
 ast::ExpressionPtr readFileWithStrictnessOverrides(core::GlobalState &gs, core::FileRef file,
                                                    const options::Options &opts,
                                                    const unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    ast::ExpressionPtr ast;
-    if (file.dataAllowingUnsafe(gs).sourceType != core::File::Type::NotYetRead) {
-        return ast;
-    }
-    string fileName{file.dataAllowingUnsafe(gs).path()};
-    Timer timeit(gs.tracer(), "readFileWithStrictnessOverrides", {{"file", fileName}});
-    string src;
-    bool fileFound = true;
-    try {
-        src = opts.fs->readFile(fileName);
-    } catch (FileNotFoundException e) {
-        // continue with an empty source, because the
-        // assertion below requires every input file to map
-        // to one output tree
-        fileFound = false;
-    }
-    prodCounterAdd("types.input.bytes", src.size());
-    prodCounterInc("types.input.files");
-    if (core::File::isRBIPath(fileName)) {
-        counterAdd("types.input.rbi.bytes", src.size());
-        counterInc("types.input.rbi.files");
-    }
+    switch (file.dataAllowingUnsafe(gs).sourceType) {
+        case core::File::Type::NotYetRead: {
+            string fileName{file.dataAllowingUnsafe(gs).path()};
+            Timer timeit(gs.tracer(), "readFileWithStrictnessOverrides", {{"file", fileName}});
+            string src;
+            bool fileFound = true;
+            try {
+                src = opts.fs->readFile(fileName);
+            } catch (FileNotFoundException e) {
+                // continue with an empty source, because the
+                // assertion below requires every input file to map
+                // to one output tree
+                fileFound = false;
+            }
+            prodCounterAdd("types.input.bytes", src.size());
+            prodCounterInc("types.input.files");
+            if (core::File::isRBIPath(fileName)) {
+                counterAdd("types.input.rbi.bytes", src.size());
+                counterInc("types.input.rbi.files");
+            }
 
-    {
-        core::UnfreezeFileTable unfreezeFiles(gs);
-        auto fileObj = make_shared<core::File>(move(fileName), move(src), core::File::Type::Normal);
-        // Returns nullptr if tree is not in cache.
-        ast = fetchTreeFromCache(gs, file, *fileObj, kvstore);
+            {
+                core::UnfreezeFileTable unfreezeFiles(gs);
+                auto fileObj = make_shared<core::File>(move(fileName), move(src), core::File::Type::Normal);
 
-        auto entered = gs.enterNewFileAt(move(fileObj), file);
-        ENFORCE(entered == file);
-    }
-    if (enable_counters) {
-        counterAdd("types.input.lines", file.data(gs).lineCount());
+                auto entered = gs.enterNewFileAt(move(fileObj), file);
+                ENFORCE(entered == file);
+            }
+
+            if constexpr (enable_counters) {
+                counterAdd("types.input.lines", file.data(gs).lineCount());
+            }
+
+            if (!fileFound) {
+                if (auto e = gs.beginError(sorbet::core::Loc::none(file), core::errors::Internal::FileNotFound)) {
+                    e.setHeader("File Not Found");
+                }
+            }
+
+            break;
+        }
+        case core::File::Type::Normal: {
+            // If we load successfully from the cache then there weren't any indexing errors, and otherwise we'll set
+            // this flag during indexing if necessary.
+            file.data(gs).setHasIndexErrors(false);
+
+            break;
+        }
+        case core::File::Type::PayloadGeneration:
+        case core::File::Type::Payload:
+        case core::File::Type::TombStone:
+            return nullptr;
     }
 
     auto &fileData = file.data(gs);
-    if (!fileFound) {
-        if (auto e = gs.beginError(sorbet::core::Loc::none(file), core::errors::Internal::FileNotFound)) {
-            e.setHeader("File Not Found");
-        }
-    }
+
+    // Returns nullptr if tree is not in cache.
+    auto ast = fetchTreeFromCache(gs, file, fileData, kvstore);
 
     if (!opts.storeState.empty()) {
         fileData.sourceType = core::File::Type::PayloadGeneration;

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -266,7 +266,8 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "ReindexingUsesTheCache") {
     auto filePath = fmt::format("{}/{}", rootPath, relativeFilepath);
     // This file has an error to indirectly assert that LSP is actually typechecking the file during initialization.
     auto fileContents = "# typed: true\n"
-                        "class Foo extend T::Sig\n"
+                        "class Foo\n"
+                        "  extend T::Sig\n"
                         "  sig {returns(Integer)}\n"
                         "  def bar\n"
                         "    'hello'\n"

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -283,7 +283,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "ReindexingUsesTheCache") {
         lspWrapper->opts->inputFileNames.push_back(filePath);
         assertErrorDiagnostics(
             initializeLSP(),
-            {{relativeFilepath, 4, "Expected `Integer` but found `String(\"hello\")` for method result type"}});
+            {{relativeFilepath, 5, "Expected `Integer` but found `String(\"hello\")` for method result type"}});
     }
 
     // LSP should have written cache to disk with file hashes from initialization.

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -289,7 +289,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "ReindexingUsesTheCache") {
     // It should not include data from file updates made during the editor session.
     auto opts = lspWrapper->opts;
 
-    // Release cache lock.
+    // Release cache lock by dropping the entire LSP wrapper which holds onto a kvstore.
     lspWrapper = nullptr;
 
     auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -6,6 +6,7 @@
 #include "common/common.h"
 #include "common/kvstore/KeyValueStore.h"
 #include "core/ErrorQueue.h"
+#include "core/Unfreeze.h"
 #include "core/serialize/serialize.h"
 #include "main/cache/cache.h"
 #include "main/pipeline/pipeline.h"
@@ -258,4 +259,72 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPDoesNotUseCacheIfModified") {
         }
     }
 }
+
+TEST_CASE_FIXTURE(CacheProtocolTest, "ReindexingUsesTheCache") {
+    // Write a file to disk.
+    auto relativeFilepath = "test.rb";
+    auto filePath = fmt::format("{}/{}", rootPath, relativeFilepath);
+    // This file has an error to indirectly assert that LSP is actually typechecking the file during initialization.
+    auto fileContents = "# typed: true\n"
+                        "class Foo extend T::Sig\n"
+                        "  sig {returns(Integer)}\n"
+                        "  def bar\n"
+                        "    'hello'\n"
+                        "  end\n"
+                        "end\n";
+    auto key = core::serialize::Serializer::fileKey(
+        core::File(string(filePath), string(fileContents), core::File::Type::Normal, 0));
+
+    // LSP should write a cache to disk corresponding to initialization state.
+    {
+        writeFilesToFS({{relativeFilepath, fileContents}});
+
+        lspWrapper->opts->inputFileNames.push_back(filePath);
+        assertErrorDiagnostics(
+            initializeLSP(),
+            {{relativeFilepath, 4, "Expected `Integer` but found `String(\"hello\")` for method result type"}});
+    }
+
+    // LSP should have written cache to disk with file hashes from initialization.
+    // It should not include data from file updates made during the editor session.
+    auto opts = lspWrapper->opts;
+
+    // Release cache lock.
+    lspWrapper = nullptr;
+
+    auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+    auto logger = std::make_shared<spdlog::logger>("null", sink);
+    unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(logger, *opts);
+
+    // The key should exist in the kvstore
+    auto contents = kvstore->read(key);
+    REQUIRE_NE(contents.data, nullptr);
+
+    auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*logger, *logger));
+    payload::createInitialGlobalState(*gs, *opts, kvstore);
+
+    // If caching fails, gs gets modified during payload creation.
+    CHECK_FALSE(gs->wasModified());
+
+    core::FileRef fref;
+    {
+        core::UnfreezeFileTable fileTableAccess(*gs);
+        fref = gs->enterFile(filePath, fileContents);
+    }
+
+    // The file should now be present in the file table with its contents loaded, meaning that its type is `Normal`
+    REQUIRE(fref.exists());
+    REQUIRE_EQ(fref.data(*gs).sourceType, core::File::Type::Normal);
+
+    auto workers = WorkerPool::create(0, *logger);
+    std::vector<core::FileRef> frefs{fref};
+
+    // We should be able to reindex the file multiple times, getting a cache hit for each one.
+    for (auto i = 0; i < 2; ++i) {
+        auto asts = realmain::pipeline::index(*gs, absl::MakeSpan(frefs), *opts, *workers, kvstore);
+        REQUIRE_EQ(asts.size(), 1);
+        REQUIRE(asts.front().cached());
+    }
+}
+
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
This PR switches to processing files in the `Normal` state as well as the `NotYetRead` state in `readFileWithStrictnessOverrides`. This permits using the cache when reindexing with a long-lived file table. The new cache protocol test case added will fail when run on master, as calling `pipeline::index` multiple times on files that have entries in the cache will not return cached files after the first index.

I considered adding a flag on `File` to track if the file was missing the first time it was read, but decided against adding it in this PR. The only action we could take based on that flag would be to re-raise the `File Not Found` error for every subsequent slow path, and I'm not sure that's valuable right now.

### Motivation

The `readFileWithStrictnessOverrides` function (who is responsible for reading from the cache) currently exits early if it's given a `FileRef` whose `File` value has a `sourceType` of anything other than `NotYetRead`. This is fine for now, but with the potential switch to reindexing on the slow path, this behavior means that we'll never read a tree from the cache after initialization. This is bad for performance, as all slow paths will force a reindex of every file instead of quickly loading their trees out of the cache.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included cache protocol test.
