### PR TITLE
Propagate packager options when copying GlobalState

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2199,6 +2199,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->onlyErrorClasses = this->onlyErrorClasses;
     result->suggestUnsafe = this->suggestUnsafe;
     result->pathPrefix = this->pathPrefix;
+    result->packageDB_ = this->packageDB_.emptyCopyWithOptions();
 
     return result;
 }

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -275,11 +275,19 @@ bool PackageDB::allowRelaxedPackagerChecksFor(MangledName mangledName) const {
 
 PackageDB PackageDB::deepCopy() const {
     ENFORCE(frozen);
-    PackageDB result;
+    auto result = this->emptyCopyWithOptions();
+
     result.packages_.reserve(this->packages_.size());
     for (auto const &[nr, pkgInfo] : this->packages_) {
         result.packages_[nr] = pkgInfo->deepCopy();
     }
+
+    return result;
+}
+
+PackageDB PackageDB::emptyCopyWithOptions() const {
+    ENFORCE(frozen);
+    PackageDB result;
     result.enabled_ = this->enabled_;
     result.extraPackageFilesDirectoryUnderscorePrefixes_ = this->extraPackageFilesDirectoryUnderscorePrefixes_;
     result.extraPackageFilesDirectorySlashDeprecatedPrefixes_ =

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -48,6 +48,7 @@ public:
     absl::Span<const MangledName> packages() const;
 
     PackageDB deepCopy() const;
+    PackageDB emptyCopyWithOptions() const;
 
     UnfreezePackages unfreeze();
 

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -33,6 +33,8 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
     gs.ruby3KeywordArgs = options.ruby3KeywordArgs;
     gs.typedSuper = options.typedSuper;
     gs.suppressPayloadSuperclassRedefinitionFor = options.suppressPayloadSuperclassRedefinitionFor;
+    // We don't have to deal with packager-specific options here, as those will be handled later by
+    // the pipeline code that decides whether to run the packager at all.
 
     // Ensure LSP is enabled.
     options.runLSP = true;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -944,9 +944,9 @@ ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, a
 ast::ParsedFilesOrCancelled nameAndResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
                                            const options::Options &opts, WorkerPool &workers,
                                            core::FoundDefHashes *foundHashes) {
-    package(gs, absl::Span<ast::ParsedFile>(what), opts, workers);
+    package(gs, absl::MakeSpan(what), opts, workers);
 
-    auto canceled = name(gs, absl::Span<ast::ParsedFile>(what), opts, workers, foundHashes);
+    auto canceled = name(gs, absl::MakeSpan(what), opts, workers, foundHashes);
     if (canceled) {
         return ast::ParsedFilesOrCancelled::cancel(move(what), workers);
     }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -748,7 +748,6 @@ void setPackagerOptions(core::GlobalState &gs, const options::Options &opts) {
 }
 
 // packager intentionally runs outside of rewriter so that its output does not get cached.
-// TODO(jez) How much of this still needs to be outside of rewriter?
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
@@ -945,6 +944,8 @@ ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, a
 ast::ParsedFilesOrCancelled nameAndResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
                                            const options::Options &opts, WorkerPool &workers,
                                            core::FoundDefHashes *foundHashes) {
+    package(gs, absl::Span<ast::ParsedFile>(what), opts, workers);
+
     auto canceled = name(gs, absl::Span<ast::ParsedFile>(what), opts, workers, foundHashes);
     if (canceled) {
         return ast::ParsedFilesOrCancelled::cancel(move(what), workers);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The core problem here is that when we would hash a file in isolation (in
hashing.cc), we would not also run packager on the file: we would only
run `indexOne` and `nameAndResolve`.

At this point, there are only three usages of `nameAndResolve`:

1.  The call from `populate.cc`, where we make the binary payload.
2.  The call from `fuzz_dash_e` where we attempt to recreate Sorbet's
    pipeline with as little overhead as possible for the sake of
    fuzzing. Probably completely broken at this point, because it's not
    used.
3.  The call from `hashing.cc`.

We don't currently read any of the options out of `packageDB` in either
namer or resolver, but we are going to start doing that as we move more
of the packager out of `packager.cc` and into Sorbet's core pipeline. In
that case, it's important that the `enabled_` boolean on the `packageDB`
be accurate.

### Alternatives considered

I initially started building a feature which would add a `bool stripePackages;`
to `GlobalState.h`. My guiding light when adding such features is always to look
at where the other "semantic" booleans in `GlobalState` are, like
`ruby3Keywords`, `typedSuper`, `requiresAncestorEnabled`, etc.

These are semantic in that they change the meaning of type checking a codebase,
and need to be copied even when we would otherwise want an "empty" GlobalState,
like we do when we want to index or hash a file in isolation.

This `packageDB_.enabled_` boolean is also semantic in the same sense, and so I
tracked down all the places where we were setting `ruby3KeywordArgs` but not
initializing the packager.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This boolean is currently only used in one place: the `toProto` logic
when serializing the file table, so the fact that it didn't do the right
thing was not really load bearing yet, and thus cannot be tested.