### PR TITLE
Update `Log` interface to better match VSCode's `LogOutputChannel`

### DIFF
--- a/vscode_extension/src/commands/copySymbolToClipboard.ts
+++ b/vscode_extension/src/commands/copySymbolToClipboard.ts
@@ -16,12 +16,12 @@ export async function copySymbolToClipboard(
   const { activeLanguageClient: client } = context.statusProvider;
 
   if (!client) {
-    context.log.warning("CopySymbol: No active Sorbet LSP.");
+    context.log.warn("CopySymbol: No active Sorbet LSP.");
     return;
   }
 
   if (!client.capabilities?.sorbetShowSymbolProvider) {
-    context.log.warning(
+    context.log.warn(
       "CopySymbol: Sorbet LSP does not support 'showSymbol' capability.",
     );
     return;
@@ -41,7 +41,7 @@ export async function copySymbolToClipboard(
   }
 
   if (client.status !== ServerStatus.RUNNING) {
-    context.log.warning("CopySymbol: Sorbet LSP is not ready.");
+    context.log.warn("CopySymbol: Sorbet LSP is not ready.");
     return;
   }
 

--- a/vscode_extension/src/commands/savePackageFiles.ts
+++ b/vscode_extension/src/commands/savePackageFiles.ts
@@ -16,13 +16,13 @@ export async function savePackageFiles(
       document.isDirty && basename(document.fileName) === "__package.rb",
   );
   if (!packageDocuments.length) {
-    context.log.trace("savePackageFiles: nothing to save");
+    context.log.trace("SavePackageFiles: nothing to save");
     return true;
   }
 
   const allSaved = await Promise.all(
     packageDocuments.map((document) => {
-      context.log.trace(`savePackageFiles: saving ${document.fileName}`);
+      context.log.trace("SavePackageFiles: Saving file", document.fileName);
       return document.save();
     }),
   );

--- a/vscode_extension/src/commands/setLogLevel.ts
+++ b/vscode_extension/src/commands/setLogLevel.ts
@@ -15,11 +15,11 @@ export async function setLogLevel(
   context: SorbetExtensionContext,
   level?: LogLevel,
 ): Promise<void> {
-  const newLevel = level ?? (await getLogLevel(context.log.level));
+  const newLevel = level ?? (await getLogLevel(context.log.logLevel));
   if (newLevel === undefined) {
     return; // User canceled
   }
-  context.log.level = newLevel;
+  context.log.logLevel = newLevel;
 }
 
 async function getLogLevel(

--- a/vscode_extension/src/commands/toggleTypedFalseCompletionNudges.ts
+++ b/vscode_extension/src/commands/toggleTypedFalseCompletionNudges.ts
@@ -12,7 +12,8 @@ export async function toggleTypedFalseCompletionNudges(
   const targetState = !context.configuration.typedFalseCompletionNudges;
   await context.configuration.setTypedFalseCompletionNudges(targetState);
   context.log.info(
-    `Untyped file auto-complete nudge: ${targetState ? "enabled" : "disabled"}`,
+    "Untyped file auto-complete nudge",
+    targetState ? "enabled" : "disabled",
   );
 
   await context.statusProvider.restartSorbet(RestartReason.CONFIG_CHANGE);

--- a/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
+++ b/vscode_extension/src/commands/toggleUntypedCodeHighlighting.ts
@@ -27,7 +27,7 @@ function toggle(log: Log, configuration: SorbetExtensionConfig): TrackUntyped {
       return "nowhere";
     default:
       const exhaustiveCheck: never = configuration.highlightUntyped;
-      log.warning(`Got unexpected state: ${exhaustiveCheck}`);
+      log.warn("Got unexpected state", exhaustiveCheck);
       return "nowhere";
   }
 }
@@ -41,7 +41,7 @@ async function cycleStates(
   context.configuration.oldHighlightUntyped = oldHighlightUntyped;
 
   await context.configuration.setHighlightUntyped(targetState);
-  context.log.info(`${forCommand}: Untyped code highlighting: ${targetState}`);
+  context.log.info(forCommand, "Untyped code highlighting", targetState);
 }
 
 /**

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -63,7 +63,7 @@ export function backwardsCompatibleTrackUntyped(
       return trackWhere;
     default:
       const exhaustiveCheck: never = trackWhere;
-      log.warning(`Got unexpected state: ${exhaustiveCheck}`);
+      log.warn("Got unexpected state", exhaustiveCheck);
       return false;
   }
 }

--- a/vscode_extension/src/connections.ts
+++ b/vscode_extension/src/connections.ts
@@ -7,7 +7,7 @@ import { Log } from "./log";
 export async function stopProcess(p: ChildProcess, log: Log): Promise<void> {
   return new Promise<void>((res) => {
     let hasExited = false;
-    log.debug(`Stopping process ${p.pid}`);
+    log.debug("Stopping process", p.pid);
     function onExit() {
       if (!hasExited) {
         hasExited = true;

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -21,7 +21,7 @@ import { ServerStatus, RestartReason } from "./types";
  */
 export function activate(context: ExtensionContext) {
   const sorbetExtensionContext = new SorbetExtensionContext(context);
-  sorbetExtensionContext.log.level = getLogLevelFromEnvironment();
+  sorbetExtensionContext.log.logLevel = getLogLevelFromEnvironment();
 
   context.subscriptions.push(
     sorbetExtensionContext,

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -25,9 +25,8 @@ export function createClient(
   };
 
   context.log.debug(
-    `Initializing with initializationOptions=${JSON.stringify(
-      initializationOptions,
-    )}`,
+    "Initializing with initializationOptions",
+    ...Object.entries(initializationOptions).map(([k, v]) => `${k}:${v}`),
   );
 
   const client = new CustomLanguageClient("ruby", "Sorbet", serverOptions, {

--- a/vscode_extension/src/log.ts
+++ b/vscode_extension/src/log.ts
@@ -57,44 +57,50 @@ export interface Log {
   /**
    * Appends a new debug message to the log.
    * @param message Log message.
+   * @param args Additional values to log.
    */
-  debug(message: string): void;
+  debug(message: string, ...args: any[]): void;
 
   /**
    * Appends a new error message to the log.
    * @param message Log message.
    * @param error Error.
+   * @param args Additional values to log.
    */
-  error(message: string, error?: Error): void;
+  error(message: string, error: Error, ...args: any[]): void;
 
   /**
    * Appends a new error message to the log.
    * @param errorOrMessage Error or log message.
+   * @param args Additional values to log.
    */
-  error(errorOrMessage: string | Error): void;
+  error(errorOrMessage: string | Error, ...args: any[]): void;
 
   /**
    * Appends a new information message to the log.
    * @param message Log message.
+   * @param args Additional values to log.
    */
-  info(message: string): void;
+  info(message: string, ...args: any[]): void;
 
   /**
    * Log level.
    */
-  level: LogLevel;
+  logLevel: LogLevel;
 
   /**
    * Appends a new trace message to the log.
    * @param message Log message.
+   * @param args Additional values to log.
    */
-  trace(message: string): void;
+  trace(message: string, ...args: any[]): void;
 
   /**
    * Appends a new warning message to the log.
    * @param message Log message.
+   * @param args Additional values to log.
    */
-  warning(message: string): void;
+  warn(message: string, ...args: any[]): void;
 }
 
 /**
@@ -112,18 +118,24 @@ export class OutputChannelLog implements Log, Disposable {
     this.outputChannel = window.createOutputChannel(name);
   }
 
-  private appendLine(level: string, message: string): void {
-    const formattedMessage = `${new Date().toISOString()} [${level.toLowerCase()}] ${message}`.trim();
+  private appendLine(level: string, message: string, args: any[]): void {
+    const formattedMessage = [
+      new Date().toISOString(),
+      `[${level.toLowerCase()}]`,
+      message,
+      ...args,
+    ].join(" ");
     this.outputChannel.appendLine(formattedMessage);
   }
 
   /**
    * Appends a new debug message to the log.
    * @param message Log message.
+   * @param args Additional values to log.
    */
-  public debug(message: string): void {
-    if (this.level <= LogLevel.Debug) {
-      this.appendLine("Debug", message);
+  public debug(message: string, ...args: any[]): void {
+    if (this.logLevel <= LogLevel.Debug) {
+      this.appendLine("Debug", message, args);
     }
   }
 
@@ -138,19 +150,27 @@ export class OutputChannelLog implements Log, Disposable {
    * Appends a new error message to the log.
    * @param errorOrMessage Error or log message.
    * @param error Error (only used when `errorOrMessage` is not a `string`).
+   * @param args Additional values to log.
    */
-  public error(errorOrMessage: string | Error, error?: Error): void {
-    if (this.level <= LogLevel.Error) {
+  public error(
+    errorOrMessage: string | Error,
+    error?: Error,
+    ...args: any[]
+  ): void {
+    if (this.logLevel <= LogLevel.Error) {
       let message: string;
       if (typeof errorOrMessage === "string") {
         message = errorOrMessage;
-        if (error) {
-          message += ` Error: ${err2Str(error)}`;
+        if (typeof error === "string") {
+          args.unshift(error);
+        } else if (error) {
+          args.unshift(err2Str(error));
+          args.unshift("Error:");
         }
       } else {
         message = err2Str(errorOrMessage);
       }
-      this.appendLine("Error", message);
+      this.appendLine("Error", message, args);
     }
 
     function err2Str(err: Error) {
@@ -161,21 +181,22 @@ export class OutputChannelLog implements Log, Disposable {
   /**
    * Appends a new information message to the log.
    * @param message Log message.
+   * @param args Additional values to log.
    */
-  public info(message: string): void {
-    if (this.level <= LogLevel.Info) {
-      this.appendLine("Info", message);
+  public info(message: string, ...args: any[]): void {
+    if (this.logLevel <= LogLevel.Info) {
+      this.appendLine("Info", message, args);
     }
   }
 
   /**
    * Log level.
    */
-  public get level(): LogLevel {
+  public get logLevel(): LogLevel {
     return this.wrappedLevel;
   }
 
-  public set level(level: LogLevel) {
+  public set logLevel(level: LogLevel) {
     if (this.wrappedLevel !== level) {
       this.wrappedLevel = level;
       this.outputChannel.appendLine(`Log level changed to: ${LogLevel[level]}`);
@@ -185,20 +206,22 @@ export class OutputChannelLog implements Log, Disposable {
   /**
    * Appends a new trace message to the log.
    * @param message Log message.
+   * @param args Additional values to log.
    */
-  public trace(message: string): void {
-    if (this.level <= LogLevel.Trace) {
-      this.appendLine("Trace", message);
+  public trace(message: string, ...args: any[]): void {
+    if (this.logLevel <= LogLevel.Trace) {
+      this.appendLine("Trace", message, args);
     }
   }
 
   /**
    * Appends a new warning message to the log.
    * @param message Log message.
+   * @param args Additional values to log.
    */
-  public warning(message: string): void {
-    if (this.level <= LogLevel.Warning) {
-      this.appendLine("Warning", message);
+  public warn(message: string, ...args: any[]): void {
+    if (this.logLevel <= LogLevel.Warning) {
+      this.appendLine("Warning", message, args);
     }
   }
 }

--- a/vscode_extension/src/metricsClient.ts
+++ b/vscode_extension/src/metricsClient.ts
@@ -116,7 +116,8 @@ export class MetricsClient {
           : (<any>reason).message;
 
       this.context.log.error(
-        `Metrics-gathering disabled (error): ${adjustedReason}`,
+        "Metrics-gathering disabled (error)",
+        adjustedReason,
       );
     }
     return sorbetMetricsApi;

--- a/vscode_extension/src/sorbetContentProvider.ts
+++ b/vscode_extension/src/sorbetContentProvider.ts
@@ -27,7 +27,7 @@ export class SorbetContentProvider implements TextDocumentContentProvider {
     let content: string;
     const { activeLanguageClient: client } = this.context.statusProvider;
     if (client) {
-      this.context.log.info(`Retrieving file contents. URI:${uri}`);
+      this.context.log.info("Retrieving file contents", uri);
       const response = await client.sendRequest<TextDocumentItem>(
         "sorbet/readFile",
         {
@@ -37,7 +37,8 @@ export class SorbetContentProvider implements TextDocumentContentProvider {
       content = response.text;
     } else {
       this.context.log.info(
-        `Cannot retrieve file contents, no active Sorbet client. URI:${uri}`,
+        "Cannot retrieve file contents, no active Sorbet client",
+        uri,
       );
       content = "";
     }

--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -220,7 +220,7 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
       return Promise.reject(new Error(msg));
     }
 
-    this.context.log.debug(` > ${command} ${args.join(" ")}`);
+    this.context.log.debug(">", command, ...args);
     this.sorbetProcess = spawn(command, args, {
       cwd: workspace.rootPath,
       env: { ...process.env, ...activeConfig?.env },
@@ -282,19 +282,16 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
         reason = RestartReason.FORCIBLY_TERMINATED;
       } else {
         reason = RestartReason.CRASH_LC_CLOSED;
-        this.context.log.error("");
         this.context.log.error(
-          `The Sorbet LSP process crashed exit_code=${this.sorbetProcessExitCode}`,
+          "The Sorbet LSP process crashed exit_code",
+          this.sorbetProcessExitCode,
         );
-        this.context.log.error("The Node.js backtrace above is not useful.");
         this.context.log.error(
+          "The Node.js backtrace above is not useful.",
           "If there is a C++ backtrace above, that is useful.",
-        );
-        this.context.log.error(
           "Otherwise, more useful output will be in the --debug-log-file to the Sorbet process",
+          "(if provided as a command-line argument).",
         );
-        this.context.log.error("(if provided as a command-line argument).");
-        this.context.log.error("");
       }
 
       this.status = ServerStatus.RESTARTING;

--- a/vscode_extension/src/sorbetStatusBarEntry.ts
+++ b/vscode_extension/src/sorbetStatusBarEntry.ts
@@ -108,7 +108,7 @@ export class SorbetStatusBarEntry implements Disposable {
           tooltip = "The Sorbet server is currently running.";
           break;
         default:
-          this.context.log.error(`Invalid ServerStatus: ${this.serverStatus}`);
+          this.context.log.error("Invalid ServerStatus", this.serverStatus);
           text = "";
           tooltip = "";
           break;

--- a/vscode_extension/src/test/commands/setLogLevel.test.ts
+++ b/vscode_extension/src/test/commands/setLogLevel.test.ts
@@ -32,9 +32,9 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     const context = <SorbetExtensionContext>{
       log: createLogStub(LogLevel.Info),
     };
-    assert.ok(context.log.level !== expectedLogLevel);
+    assert.ok(context.log.logLevel !== expectedLogLevel);
     await assert.doesNotReject(setLogLevel(context));
-    assert.strictEqual(context.log.level, expectedLogLevel);
+    assert.strictEqual(context.log.logLevel, expectedLogLevel);
 
     sinon.assert.calledWithExactly(
       showQuickPickSingleStub,
@@ -84,7 +84,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     const context = <SorbetExtensionContext>{ log };
 
     await assert.doesNotReject(setLogLevel(context, expectedLogLevel));
-    assert.strictEqual(log.level, expectedLogLevel);
+    assert.strictEqual(log.logLevel, expectedLogLevel);
 
     sinon.assert.notCalled(showQuickPickSingleStub);
   });

--- a/vscode_extension/src/test/log.test.ts
+++ b/vscode_extension/src/test/log.test.ts
@@ -107,10 +107,10 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     testRestorables.push(createOutputChannelStub);
 
     const log = new OutputChannelLog("Test", LogLevel.Info);
-    assert.strictEqual(log.level, LogLevel.Info, "Expected default state");
+    assert.strictEqual(log.logLevel, LogLevel.Info, "Expected default state");
 
-    log.level = expectedLogLevel;
-    assert.strictEqual(log.level, expectedLogLevel, "Expected new state");
+    log.logLevel = expectedLogLevel;
+    assert.strictEqual(log.logLevel, expectedLogLevel, "Expected new state");
 
     sinon.assert.calledOnce(createOutputChannelStub);
   });
@@ -133,7 +133,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     assert.strictEqual(1, callCount);
     log.info(logMessage);
     assert.strictEqual(2, callCount);
-    log.warning(logMessage);
+    log.warn(logMessage);
     assert.strictEqual(3, callCount);
     log.debug(logMessage);
     assert.strictEqual(4, callCount);

--- a/vscode_extension/src/test/testUtils.ts
+++ b/vscode_extension/src/test/testUtils.ts
@@ -6,11 +6,11 @@ import { Log, LogLevel } from "../log";
  */
 export function createLogStub(level = LogLevel.Critical): Log {
   return {
-    debug: (_message: string) => {},
-    error: (_messageOrError: string | Error) => {},
-    info: (_message: string) => {},
-    trace: (_message: string) => {},
-    warning: (_message: string) => {},
-    level,
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    trace: () => {},
+    warn: () => {},
+    logLevel: level,
   };
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Update Sorbet Extension's `Log` interface  to better match VSCode's `LogOutputChannel`. The latter interface was introduced in VSCode in [1.74](https://code.visualstudio.com/updates/v1_74#_log-output-channel) to represent an output channel used for logging, but since the extension still targets an ancient 1.65, it cannot be used yet.
- The interface allows to pass several additional `args` to log messages, which has the minor benefit of not needing to format a message string (that might be discarded).

**Reviewers**: PRs is structured as two commits: one for the API change and one updating all call sites to benefit from `args` (and some consistency tweaks).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This change prepares the extension to migrate to the logging API in the future (not plans to update target VSCode right now, this is just to get this out the way, and be able to use the log API in a modern way). Moving to a more recent version would get syntax coloring on logs, remove the custom logger implementation and benefit from VSCode's features around logging.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
