### PR TITLE
Cancelable indexer

### DIFF
--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -170,8 +170,8 @@ void Hashing::computeFileHashes(absl::Span<const shared_ptr<core::File>> files, 
 ast::ParsedFilesOrCancelled
 Hashing::indexAndComputeFileHashes(core::GlobalState &gs, const realmain::options::Options &opts,
                                    spdlog::logger &logger, absl::Span<const core::FileRef> files, WorkerPool &workers,
-                                   const unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    auto indexed = realmain::pipeline::index(gs, files, opts, workers, kvstore);
+                                   const unique_ptr<const OwnedKeyValueStore> &kvstore, bool cancelable) {
+    auto indexed = realmain::pipeline::index(gs, files, opts, workers, kvstore, cancelable);
     if (!indexed.hasResult()) {
         return indexed;
     }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -167,12 +167,16 @@ void Hashing::computeFileHashes(absl::Span<const shared_ptr<core::File>> files, 
     }
 }
 
-vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(core::GlobalState &gs,
-                                                           const realmain::options::Options &opts,
-                                                           spdlog::logger &logger,
-                                                           absl::Span<const core::FileRef> files, WorkerPool &workers,
-                                                           const unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    auto asts = realmain::pipeline::index(gs, files, opts, workers, kvstore);
+ast::ParsedFilesOrCancelled
+Hashing::indexAndComputeFileHashes(core::GlobalState &gs, const realmain::options::Options &opts,
+                                   spdlog::logger &logger, absl::Span<const core::FileRef> files, WorkerPool &workers,
+                                   const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+    auto indexed = realmain::pipeline::index(gs, files, opts, workers, kvstore);
+    if (!indexed.hasResult()) {
+        return indexed;
+    }
+
+    auto asts = std::move(indexed.result());
     ENFORCE_NO_TIMER(asts.size() == files.size());
 
     // Below, we rewrite ASTs to an empty GlobalState and use them for hashing.

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -52,7 +52,7 @@ public:
     static ast::ParsedFilesOrCancelled
     indexAndComputeFileHashes(core::GlobalState &gs, const realmain::options::Options &opts, spdlog::logger &logger,
                               absl::Span<const core::FileRef> files, WorkerPool &workers,
-                              const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
+                              const std::unique_ptr<const OwnedKeyValueStore> &kvstore, bool cancelable = false);
 };
 } // namespace sorbet::hashing
 

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -1,7 +1,6 @@
 #ifndef RUBY_TYPER_HASHING_HASHING_H
 #define RUBY_TYPER_HASHING_HASHING_H
 
-#include "ast/Trees.h"
 #include "common/common.h"
 #include "common/concurrency/WorkerPool.h"
 #include "core/Files.h"
@@ -11,7 +10,7 @@ class OwnedKeyValueStore;
 }
 
 namespace sorbet::ast {
-struct ParsedFile;
+class ParsedFilesOrCancelled;
 }
 
 namespace sorbet::realmain::options {

--- a/hashing/hashing.h
+++ b/hashing/hashing.h
@@ -1,6 +1,7 @@
 #ifndef RUBY_TYPER_HASHING_HASHING_H
 #define RUBY_TYPER_HASHING_HASHING_H
 
+#include "ast/Trees.h"
 #include "common/common.h"
 #include "common/concurrency/WorkerPool.h"
 #include "core/Files.h"
@@ -48,7 +49,7 @@ public:
      *
      * Note: ASTs are returned in `FileRef` order (not input order).
      */
-    static std::vector<ast::ParsedFile>
+    static ast::ParsedFilesOrCancelled
     indexAndComputeFileHashes(core::GlobalState &gs, const realmain::options::Options &opts, spdlog::logger &logger,
                               absl::Span<const core::FileRef> files, WorkerPool &workers,
                               const std::unique_ptr<const OwnedKeyValueStore> &kvstore);

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -337,8 +337,9 @@ std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams
             initialGS->errorQueue->logger, initialGS->errorQueue->tracer, make_shared<core::NullFlusher>());
         auto trees = hashing::Hashing::indexAndComputeFileHashes(*initialGS, config->opts, *config->logger,
                                                                  absl::Span<core::FileRef>(frefs), workers, kvstore);
-        update.updatedFileIndexes.resize(trees.size());
-        for (auto &ast : trees) {
+        ENFORCE(trees.hasResult(), "The indexer thread doesn't support cancellation");
+        update.updatedFileIndexes.resize(trees.result().size());
+        for (auto &ast : trees.result()) {
             const int i = fileToPos[ast.file];
             update.updatedFileIndexes[i] = move(ast);
         }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -416,9 +416,10 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                     auto asts = hashing::Hashing::indexAndComputeFileHashes(*finalGS, config->opts, *config->logger,
                                                                             absl::Span<core::FileRef>(inputFiles),
                                                                             workers, ownedKvstore);
+                    ENFORCE(asts.hasResult(), "LSP initialization does not support cancellation");
                     // asts are in fref order, but we (currently) don't index and compute file hashes for payload files,
                     // so vector index != FileRef ID. Fix that by slotting them into `indexed`.
-                    for (auto &ast : asts) {
+                    for (auto &ast : asts.result()) {
                         int id = ast.file.id();
                         ENFORCE_NO_TIMER(id < this->indexed.size());
                         this->indexed[id] = std::move(ast);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -672,6 +672,7 @@ ast::ParsedFilesOrCancelled index(core::GlobalState &gs, absl::Span<const core::
             return ast::ParsedFilesOrCancelled::cancel(std::move(parsed), workers);
         }
 
+        // TODO(jez) Do we want this fast_sort here? Is it redundant?
         fast_sort(parsed, [](ast::ParsedFile const &a, ast::ParsedFile const &b) { return a.file < b.file; });
         ENFORCE(files.size() == parsed.size());
         return parsed;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -478,6 +478,12 @@ ast::ExpressionPtr readFileWithStrictnessOverrides(core::GlobalState &gs, core::
 struct IndexResult {
     unique_ptr<core::GlobalState> gs;
     vector<ast::ParsedFile> trees;
+
+    // The number of trees that were processed by the thread that produced this result. This can be greater than
+    // `trees.size()` when cancelation happens, as we skip trees to save time at that point. This value must be used in
+    // place of `trees.size()` anywhere that we're accounting for the number of trees processed by indexing, otherwise
+    // we risk starving the main thread which expects to read one result for every tree processed.
+    int numTreesProcessed = 0;
 };
 
 struct IndexThreadResultPack {
@@ -493,10 +499,14 @@ struct IndexSubstitutionJob {
     std::optional<core::NameSubstitution> subst;
     vector<ast::ParsedFile> trees;
 
+    // Please see the comment on `IndexResult::numTreesProcessed` for a more thorough description about why this might
+    // be greater than `trees.size()`.
+    int numTreesProcessed = 0;
+
     IndexSubstitutionJob() {}
 
     IndexSubstitutionJob(core::GlobalState &to, IndexResult res)
-        : threadGs{std::move(res.gs)}, subst{}, trees{std::move(res.trees)} {
+        : threadGs{std::move(res.gs)}, subst{}, trees{std::move(res.trees)}, numTreesProcessed{res.numTreesProcessed} {
         to.mergeFileTable(*this->threadGs);
         if (absl::c_any_of(this->trees, [](auto &parsed) { return !parsed.cached(); })) {
             this->subst.emplace(*this->threadGs, to);
@@ -509,8 +519,8 @@ struct IndexSubstitutionJob {
 
 ast::ParsedFilesOrCancelled mergeIndexResults(core::GlobalState &cgs, const options::Options &opts,
                                               shared_ptr<BlockingBoundedQueue<IndexThreadResultPack>> input,
-                                              WorkerPool &workers,
-                                              const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+                                              WorkerPool &workers, const unique_ptr<const OwnedKeyValueStore> &kvstore,
+                                              bool cancelable) {
     ProgressIndicator progress(opts.showProgress, "Indexing", input->bound);
 
     auto batchq = make_shared<ConcurrentBoundedQueue<IndexSubstitutionJob>>(input->bound);
@@ -524,7 +534,7 @@ ast::ParsedFilesOrCancelled mergeIndexResults(core::GlobalState &cgs, const opti
              !result.done(); result = input->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), cgs.tracer())) {
             if (result.gotItem()) {
                 counterConsume(move(threadResult.counters));
-                auto numTrees = threadResult.res.trees.size();
+                auto numTrees = threadResult.res.numTreesProcessed;
                 batchq->push(IndexSubstitutionJob{cgs, std::move(threadResult.res)}, numTrees);
                 totalNumTrees += numTrees;
             }
@@ -535,11 +545,21 @@ ast::ParsedFilesOrCancelled mergeIndexResults(core::GlobalState &cgs, const opti
         Timer timeit(cgs.tracer(), "substituteTrees");
         auto resultq = make_shared<BlockingBoundedQueue<vector<ast::ParsedFile>>>(batchq->bound);
 
-        workers.multiplexJob("substituteTrees", [&cgs, batchq, resultq]() {
+        workers.multiplexJob("substituteTrees", [&cgs, batchq, resultq, cancelable]() {
             Timer timeit(cgs.tracer(), "substituteTreesWorker");
             IndexSubstitutionJob job;
+            int numTreesProcessed = 0;
+            std::vector<ast::ParsedFile> trees;
             for (auto result = batchq->try_pop(job); !result.done(); result = batchq->try_pop(job)) {
                 if (result.gotItem()) {
+                    // Unconditionally update the total to avoid starving the consumer thread
+                    numTreesProcessed += job.numTreesProcessed;
+
+                    // If the slow path has been cancelled, skip substitution to handle the tree dropping in once place.
+                    if (cancelable && cgs.epochManager->wasTypecheckingCanceled()) {
+                        continue;
+                    }
+
                     if (job.subst.has_value()) {
                         for (auto &tree : job.trees) {
                             if (!tree.cached()) {
@@ -548,10 +568,13 @@ ast::ParsedFilesOrCancelled mergeIndexResults(core::GlobalState &cgs, const opti
                             }
                         }
                     }
-                    auto numSubstitutedTrees = job.trees.size();
-                    resultq->push(std::move(job.trees), numSubstitutedTrees);
+
+                    trees.insert(trees.end(), std::make_move_iterator(job.trees.begin()),
+                                 std::make_move_iterator(job.trees.end()));
                 }
             }
+
+            resultq->push(std::move(trees), numTreesProcessed);
         });
 
         ret.reserve(totalNumTrees);
@@ -565,12 +588,16 @@ ast::ParsedFilesOrCancelled mergeIndexResults(core::GlobalState &cgs, const opti
         }
     }
 
+    if (cancelable && cgs.epochManager->wasTypecheckingCanceled()) {
+        return ast::ParsedFilesOrCancelled::cancel(std::move(ret), workers);
+    }
+
     return ret;
 }
 
 ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::Span<const core::FileRef> files,
                                                const options::Options &opts, WorkerPool &workers,
-                                               const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+                                               const unique_ptr<const OwnedKeyValueStore> &kvstore, bool cancelable) {
     auto resultq = make_shared<BlockingBoundedQueue<IndexThreadResultPack>>(files.size());
     auto fileq = make_shared<ConcurrentBoundedQueue<core::FileRef>>(files.size());
     for (auto file : files) {
@@ -579,12 +606,13 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
 
     std::shared_ptr<const core::GlobalState> emptyGs = baseGs.copyForIndex();
 
-    workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, resultq, &kvstore]() {
+    workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, resultq, &kvstore, cancelable]() {
         Timer timeit(emptyGs->tracer(), "indexSuppliedFilesWorker");
 
         // clone the empty global state to avoid manually re-entering everything, and copy the base filetable so that
         // file sources are available.
         unique_ptr<core::GlobalState> localGs = emptyGs->deepCopy();
+        auto &epochManager = *localGs->epochManager;
 
         IndexThreadResultPack threadResult;
 
@@ -592,6 +620,14 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
             core::FileRef job;
             for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
                 if (result.gotItem()) {
+                    // Increment the count even if we're cancelled to ensure that we indicate downstream that all inputs
+                    // have been processed.
+                    threadResult.res.numTreesProcessed++;
+
+                    // Drain the queue if the slow path gets canceled.
+                    if (cancelable && epochManager.wasTypecheckingCanceled()) {
+                        continue;
+                    }
                     core::FileRef file = job;
                     auto cachedTree = readFileWithStrictnessOverrides(*localGs, file, opts, kvstore);
                     auto parsedFile = indexOne(opts, *localGs, file, move(cachedTree));
@@ -600,20 +636,19 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
             }
         }
 
-        if (!threadResult.res.trees.empty()) {
+        if (threadResult.res.numTreesProcessed > 0) {
             threadResult.counters = getAndClearThreadCounters();
             threadResult.res.gs = move(localGs);
-            auto computedTreesCount = threadResult.res.trees.size();
-            resultq->push(move(threadResult), computedTreesCount);
+            resultq->push(move(threadResult), threadResult.res.numTreesProcessed);
         }
     });
 
-    return mergeIndexResults(baseGs, opts, resultq, workers, kvstore);
+    return mergeIndexResults(baseGs, opts, resultq, workers, kvstore, cancelable);
 }
 
 ast::ParsedFilesOrCancelled index(core::GlobalState &gs, absl::Span<const core::FileRef> files,
                                   const options::Options &opts, WorkerPool &workers,
-                                  const unique_ptr<const OwnedKeyValueStore> &kvstore) {
+                                  const unique_ptr<const OwnedKeyValueStore> &kvstore, bool cancelable) {
     Timer timeit(gs.tracer(), "index");
     vector<ast::ParsedFile> empty;
 
@@ -632,11 +667,16 @@ ast::ParsedFilesOrCancelled index(core::GlobalState &gs, absl::Span<const core::
             auto parsedFile = indexOne(opts, gs, file, move(tree));
             parsed.emplace_back(move(parsedFile));
         }
+
+        if (cancelable && gs.epochManager->wasTypecheckingCanceled()) {
+            return ast::ParsedFilesOrCancelled::cancel(std::move(parsed), workers);
+        }
+
         fast_sort(parsed, [](ast::ParsedFile const &a, ast::ParsedFile const &b) { return a.file < b.file; });
         ENFORCE(files.size() == parsed.size());
         return parsed;
     } else {
-        auto ret = indexSuppliedFiles(gs, files, opts, workers, kvstore);
+        auto ret = indexSuppliedFiles(gs, files, opts, workers, kvstore, cancelable);
         if (ret.hasResult()) {
             // TODO(jez) Do we want this fast_sort here? Is it redundant?
             fast_sort(ret.result(), [](ast::ParsedFile const &a, ast::ParsedFile const &b) { return a.file < b.file; });

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -22,9 +22,9 @@ ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &g
 
 std::vector<core::FileRef> reserveFiles(core::GlobalState &gs, const std::vector<std::string> &files);
 
-std::vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<const core::FileRef> files,
-                                   const options::Options &opts, WorkerPool &workers,
-                                   const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
+ast::ParsedFilesOrCancelled index(core::GlobalState &gs, absl::Span<const core::FileRef> files,
+                                  const options::Options &opts, WorkerPool &workers,
+                                  const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
 
 size_t partitionPackageFiles(const core::GlobalState &gs, absl::Span<core::FileRef> files);
 void unpartitionPackageFiles(std::vector<ast::ParsedFile> &packageFiles,

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -24,7 +24,7 @@ std::vector<core::FileRef> reserveFiles(core::GlobalState &gs, const std::vector
 
 ast::ParsedFilesOrCancelled index(core::GlobalState &gs, absl::Span<const core::FileRef> files,
                                   const options::Options &opts, WorkerPool &workers,
-                                  const std::unique_ptr<const OwnedKeyValueStore> &kvstore);
+                                  const std::unique_ptr<const OwnedKeyValueStore> &kvstore, bool cancelable = false);
 
 size_t partitionPackageFiles(const core::GlobalState &gs, absl::Span<core::FileRef> files);
 void unpartitionPackageFiles(std::vector<ast::ParsedFile> &packageFiles,

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -631,8 +631,9 @@ int realmain(int argc, char *argv[]) {
             // only the package files that we know we need to load, it would cut down command-line rbi generation by
             // seconds.
             auto packageFileRefs = pipeline::reserveFiles(*gs, packageFiles);
-            auto packages = pipeline::index(*gs, absl::Span<core::FileRef>(packageFileRefs), opts, *workers, nullptr);
-            ENFORCE(packages.hasResult(), "There's no cancellation in batch mode");
+            auto packagesResult = pipeline::index(*gs, absl::Span<core::FileRef>(packageFileRefs), opts, *workers, nullptr);
+            ENFORCE(packagesResult.hasResult(), "There's no cancellation in batch mode");
+            auto packages = std::move(packagesResult.result());
             {
                 core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
                 core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
@@ -643,8 +644,8 @@ int realmain(int argc, char *argv[]) {
                                        opts.packagerLayers, opts.stripePackagesHint);
             }
 
-            packager::Packager::findPackages(*gs, absl::MakeSpan(packages.result()));
-            packager::Packager::setPackageNameOnFiles(*gs, absl::MakeSpan(packages.result()));
+            packager::Packager::findPackages(*gs, absl::MakeSpan(packages));
+            packager::Packager::setPackageNameOnFiles(*gs, absl::MakeSpan(packages));
             packager::Packager::setPackageNameOnFiles(*gs, inputFiles);
 
             if (!opts.singlePackage.empty()) {
@@ -718,28 +719,28 @@ int realmain(int argc, char *argv[]) {
                 ENFORCE(!canceled, "There's no cancellation in batch mode");
             }
 
-            auto nonPackageIndexed =
+            auto nonPackageIndexedResult =
                 (!opts.storeState.empty() || opts.forceHashing)
                     // Calculate file hashes alongside indexing when --store-state is specified for LSP mode
                     ? hashing::Hashing::indexAndComputeFileHashes(*gs, opts, *logger, inputFilesSpan, *workers, kvstore)
                     : pipeline::index(*gs, inputFilesSpan, opts, *workers, kvstore);
-            ENFORCE(nonPackageIndexed.hasResult(), "There's no cancellation in batch mode");
+            ENFORCE(nonPackageIndexedResult.hasResult(), "There's no cancellation in batch mode");
+            auto nonPackageIndexed = std::move(nonPackageIndexedResult.result());
 
             // Cache these before any pipeline::package rewrites, so that the cache is still usable
             // regardless of whether `--stripe-packages` was passed.
             cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers,
-                                                 nonPackageIndexed.result());
+                                                 nonPackageIndexed);
 
             // Now validate all the other files (the packageDB shouldn't change)
-            pipeline::validatePackagedFiles(*gs, absl::MakeSpan(nonPackageIndexed.result()), opts, *workers);
+            pipeline::validatePackagedFiles(*gs, absl::MakeSpan(nonPackageIndexed), opts, *workers);
 
             // Only need to compute hashes when running to compute a FileHash
             auto foundHashes = nullptr;
-            auto canceled =
-                pipeline::name(*gs, absl::MakeSpan(nonPackageIndexed.result()), opts, *workers, foundHashes);
+            auto canceled = pipeline::name(*gs, absl::MakeSpan(nonPackageIndexed), opts, *workers, foundHashes);
             ENFORCE(!canceled, "There's no cancellation in batch mode");
 
-            pipeline::unpartitionPackageFiles(indexed, move(nonPackageIndexed.result()));
+            pipeline::unpartitionPackageFiles(indexed, move(nonPackageIndexed));
             // TODO(jez) At this point, it's not correct to call it `indexed` anymore: we've run namer too
 
             if (gs->hadCriticalError()) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -631,7 +631,8 @@ int realmain(int argc, char *argv[]) {
             // only the package files that we know we need to load, it would cut down command-line rbi generation by
             // seconds.
             auto packageFileRefs = pipeline::reserveFiles(*gs, packageFiles);
-            auto packagesResult = pipeline::index(*gs, absl::Span<core::FileRef>(packageFileRefs), opts, *workers, nullptr);
+            auto packagesResult =
+                pipeline::index(*gs, absl::Span<core::FileRef>(packageFileRefs), opts, *workers, nullptr);
             ENFORCE(packagesResult.hasResult(), "There's no cancellation in batch mode");
             auto packages = std::move(packagesResult.result());
             {

--- a/payload/text/populate.cc
+++ b/payload/text/populate.cc
@@ -23,6 +23,7 @@ void populateRBIsInto(core::GlobalState &gs) {
     unique_ptr<const OwnedKeyValueStore> kvstore;
     auto workers = WorkerPool::create(emptyOpts.threads, gs.tracer());
     auto indexed = realmain::pipeline::index(gs, absl::Span<core::FileRef>(payloadFiles), emptyOpts, *workers, kvstore);
+    ENFORCE(indexed.hasResult(), "Cancelation is not supported during payload generation");
 
     // We don't run the payload with any packager options, so we can skip pipeline::package()
 
@@ -32,7 +33,7 @@ void populateRBIsInto(core::GlobalState &gs) {
     // '[0].to_set' will typecheck (using text-based payload) but never calculate hashes for the
     // payload files (because neither `--lsp` nor `--store-state` was passed).
     auto foundMethodHashes = nullptr;
-    realmain::pipeline::nameAndResolve(gs, move(indexed), emptyOpts, *workers, foundMethodHashes);
+    realmain::pipeline::nameAndResolve(gs, move(indexed.result()), emptyOpts, *workers, foundMethodHashes);
     // ^ result is thrown away
     gs.ensureCleanStrings = false;
 }

--- a/test/BUILD
+++ b/test/BUILD
@@ -188,6 +188,27 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "cancelable-indexer-test",
+    size = "small",
+    srcs = ["cancelable-indexer-test.cc"],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//tools:__pkg__"],
+    deps = [
+        "//ast",
+        "//common",
+        "//core",
+        "//main/options",
+        "//main/pipeline",
+        "//payload",
+        "@doctest//doctest",
+        "@doctest//doctest:main",
+    ],
+)
+
 # Passes with --config=dbg but I'm not smart enough to figure out how to make it
 # only run when in that config
 # sh_test(

--- a/test/cancelable-indexer-test.cc
+++ b/test/cancelable-indexer-test.cc
@@ -1,0 +1,106 @@
+#include "doctest/doctest.h"
+// has to go first as it violates our requirements
+
+#include "ast/ast.h"
+#include "common/common.h"
+#include "core/Error.h"
+#include "core/ErrorCollector.h"
+#include "core/ErrorQueue.h"
+#include "core/GlobalState.h"
+#include "core/Unfreeze.h"
+#include "core/lsp/TypecheckEpochManager.h"
+#include "main/options/options.h"
+#include "main/pipeline/pipeline.h"
+#include "payload/payload.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/spdlog.h"
+
+namespace sorbet {
+
+namespace {
+auto logger = spdlog::stderr_color_mt("error-check-test");
+auto errorCollector = std::make_shared<sorbet::core::ErrorCollector>();
+auto errorQueue = std::make_shared<sorbet::core::ErrorQueue>(*logger, *logger, errorCollector);
+} // namespace
+
+// Tests cancellation when there aren't enough files to trigger parallelism
+TEST_CASE("CanceledWithFewFiles") {
+    std::vector<std::pair<std::string, std::string>> sources{
+        {"foo.rb", "# typed: true\n"
+                   "class Foo\n"
+                   "end"},
+
+        {"bar.rb", "# typed: true\n"
+                   "class Bar\n"
+                   "end"},
+    };
+
+    auto kvstore = nullptr;
+    realmain::options::Options opts;
+    sorbet::core::GlobalState gs(errorQueue);
+    payload::createInitialGlobalState(gs, opts, kvstore);
+
+    std::vector<core::FileRef> files;
+    {
+        core::UnfreezeFileTable fileTableAccess(gs);
+        for (auto &[path, source] : sources) {
+            files.emplace_back(gs.enterFile(path, source));
+        }
+    }
+
+    gs.epochManager->startCommitEpoch(1);
+    REQUIRE(gs.epochManager->tryCancelSlowPath(2));
+
+    auto workers = WorkerPool::create(0, *logger);
+    auto cancelable = true;
+    auto result = realmain::pipeline::index(gs, absl::MakeSpan(files), opts, *workers, kvstore, cancelable);
+
+    // As the slow path was already canceled, indexing will be canceled immediately.
+    REQUIRE(!result.hasResult());
+}
+
+// Tests cancelation when there are more than two files, triggering the parallel indexer.
+TEST_CASE("CanceledWithMoreFiles") {
+    std::vector<std::pair<std::string, std::string>> sources{
+        {"foo.rb", "# typed: true\n"
+                   "class Foo\n"
+                   "end"},
+
+        {"bar.rb", "# typed: true\n"
+                   "class Bar\n"
+                   "end"},
+
+        {"baz.rb", "# typed: true\n"
+                   "class Baz\n"
+                   "end"},
+
+        {"bot.rb", "# typed: true\n"
+                   "class Bot\n"
+                   "end"},
+    };
+
+    auto kvstore = nullptr;
+    realmain::options::Options opts;
+    sorbet::core::GlobalState gs(errorQueue);
+    payload::createInitialGlobalState(gs, opts, kvstore);
+
+    std::vector<core::FileRef> files;
+    {
+        core::UnfreezeFileTable fileTableAccess(gs);
+        for (auto &[path, source] : sources) {
+            files.emplace_back(gs.enterFile(path, source));
+        }
+    }
+
+    gs.epochManager->startCommitEpoch(1);
+    REQUIRE(gs.epochManager->tryCancelSlowPath(2));
+
+    auto workers = WorkerPool::create(0, *logger);
+    auto cancelable = true;
+    auto result = realmain::pipeline::index(gs, absl::MakeSpan(files), opts, *workers, kvstore, cancelable);
+
+    // As the slow path was already canceled, indexing will be canceled immediately.
+    REQUIRE(!result.hasResult());
+}
+
+} // namespace sorbet

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -60,7 +60,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     unique_ptr<core::GlobalState> gs;
     { gs = commonGs->deepCopy(true); }
     string inputData((const char *)data, size);
-    vector<ast::ParsedFile> indexed;
     vector<core::FileRef> inputFiles;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
@@ -69,10 +68,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         file.data(*gs).strictLevel = core::StrictLevel::True;
     }
 
-    indexed = realmain::pipeline::index(*gs, absl::Span<core::FileRef>(inputFiles), *opts, *workers, kvstore);
+    auto indexed = realmain::pipeline::index(*gs, absl::MakeSpan(inputFiles), *opts, *workers, kvstore);
+    ENFORCE(indexed.hasResult(), "Cancellation is not supported with fuzzing");
     // We don't run this fuzzer with any packager options, so we can skip pipeline::package()
     auto foundHashes = nullptr;
-    indexed = move(realmain::pipeline::nameAndResolve(*gs, move(indexed), *opts, *workers, foundHashes).result());
-    realmain::pipeline::typecheck(*gs, move(indexed), *opts, *workers);
+    indexed =
+        move(realmain::pipeline::nameAndResolve(*gs, move(indexed.result()), *opts, *workers, foundHashes).result());
+    realmain::pipeline::typecheck(*gs, move(indexed.result()), *opts, *workers);
     return 0;
 }

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -322,7 +322,10 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "ReindexingUsesTheCache") {
 
     // We should be able to reindex the file multiple times, getting a cache hit for each one.
     for (auto i = 0; i < 2; ++i) {
-        auto asts = realmain::pipeline::index(*gs, absl::MakeSpan(frefs), *opts, *workers, kvstore);
+        auto result = realmain::pipeline::index(*gs, absl::MakeSpan(frefs), *opts, *workers, kvstore);
+        REQUIRE(result.hasResult());
+
+        auto &asts = result.result();
         REQUIRE_EQ(asts.size(), 1);
         REQUIRE(asts.front().cached());
     }

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -107,6 +107,7 @@ compilation_database(
         "//sorbet_version:sorbet_version",
         "//test:backtrace-test-error",
         "//test:backtrace-test-raise",
+        "//test:cancelable-indexer-test",
         "//test:error-check-test",
         "//test:hello-test",
         "//test:lsp_test_runner",


### PR DESCRIPTION
Plumb cancelation support through the `pipeline::index` pass, in anticipation of supporting reindexing in the slow path in LSP. This is implemented in roughly the same way as cancellation for typechecking, adding a boolean parameter that we consult before checking for a cancelation, allowing batch mode to fully disable cancelation. Additionally, cancelation is disabled by default, so all existing callsites keep the same behavior.

I would recommend reviewing by commit. The first commit changes the return type of the `index` pass from `std::vector<ast::ParsedFile>` to `ast::ParsedFilesOrCancelled`, and the second updates the `index` pass to actually support cancelation.

### Motivation
Supporting cancelation during indexing, so that we can begin reindexing during the slow path in LSP.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See the included `test/cancelable-indexer-test.cc` test. This only tests the path where the cancelation signal is given before calling `pipeline::index`, as I couldn't figure out how to start some work and then trigger the cancelation signal without adding some pretty invasive testing hooks to the indexer. Once we're making use of the cancelable indexer in the slow path, I think we'll have better options for testing that case.