### PR TITLE
Track cached trees in a separate vector, instead of using a flag

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -275,30 +275,10 @@ struct ParsedFile {
     ExpressionPtr tree;
     core::FileRef file;
 
-    struct Flags {
-        // if 'true' file is completely cached in kvstore
-        bool cached : 1;
-
-        Flags() : cached{false} {}
-    };
-
-    Flags flags;
-
-    ParsedFile() = default;
-    ParsedFile(ast::ExpressionPtr tree, core::FileRef file) : tree{std::move(tree)}, file{file}, flags{} {}
-
     void swap(ParsedFile &other) noexcept {
         using std::swap;
         this->tree.swap(other.tree);
         swap(this->file, other.file);
-    }
-
-    bool cached() const {
-        return this->flags.cached;
-    }
-
-    void setCached(bool cached) {
-        this->flags.cached = cached;
     }
 };
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -115,7 +115,7 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::
                     }
 
                     auto &file = job->file.data(gs);
-                    if (!job->cached() && !file.hasIndexErrors()) {
+                    if (!file.hasIndexErrors()) {
                         threadResult.emplace_back(core::serialize::Serializer::fileKey(file),
                                                   core::serialize::Serializer::storeTree(file, *job));
                         // Stream out compressed files so that writes happen in parallel with processing.


### PR DESCRIPTION
Instead of tracking whether a tree was loaded from the cache with flag, store cached trees in a different vector. This is useful because the only pass that needs to know if the tree came from the cache is the indexer, every pass after that has no use for the cached flag.

### Motivation
Simplifying a bit to avoid tracking unnecessary information.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a This shouldn't affect behavior.
