### PR TITLE
Allow making testdata packager autocorrects tests

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -706,7 +706,11 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             *gs, "autocorrects",
             [&]() {
                 fmt::memory_buffer buf;
-                for (const auto &file : files) {
+                auto sortedFiles = files; // copy
+                fast_sort(sortedFiles, [&](const auto &lhs, const auto &rhs) -> bool {
+                    return lhs.data(*gs).path() < rhs.data(*gs).path();
+                });
+                for (const auto &file : sortedFiles) {
                     string editedSource;
                     if (toWrite.contains(file)) {
                         editedSource = toWrite[file];

--- a/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
@@ -1,0 +1,99 @@
+# -- test/testdata/packager/invalid_imports_and_exports/__package.rb --
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class A < PackageSpec
+  import 123
+       # ^^^ error: Argument to `import` must be a constant
+       # ^^^ error: Expected `T.class_of(Sorbet::Private::Static::PackageSpec)`
+  import "hello"
+       # ^^^^^^^ error: Argument to `import` must be a constant
+       # ^^^^^^^ error: Expected `T.class_of(Sorbet::Private::Static::PackageSpec)`
+  import method
+       # ^^^^^^ error: Argument to `import` must be a constant
+       # ^^^^^^ error: Expected `T.class_of(Sorbet::Private::Static::PackageSpec)`
+       #       ^ error: Not enough arguments
+  import REFERENCE
+       # ^^^^^^^^^ error: Unable to resolve constant `REFERENCE`
+  # Despite the above, this import should work.
+  import B
+  # But this one will fail; no duplicate imports allowed.
+   # error: Duplicate package import
+
+  export 123 # error: Argument to `export` must be a constant
+  export "hello" # error: Argument to `export` must be a constant
+  export method # error: Argument to `export` must be a constant
+       #       ^ error: Not enough arguments
+  export A::REFERENCE # Works; it's a constant.
+  export A::AClass
+  export A::AModule
+end
+# ------------------------------
+# -- test/testdata/packager/invalid_imports_and_exports/a.rb --
+# frozen_string_literal: true
+# typed: strict
+
+module A
+  REFERENCE = ASecondClass
+
+  class ASecondClass
+
+  end
+
+  class AClass
+    extend T::Sig
+
+    sig {returns(AClass)}
+    def get_a
+      B::BModule.get_a
+    end
+  end
+
+
+  module AModule
+    extend T::Sig
+
+    sig {returns(Integer)}
+    def self.one
+      1
+    end
+  end
+end
+# ------------------------------
+# -- test/testdata/packager/invalid_imports_and_exports/b/__package.rb --
+# frozen_string_literal: true
+# typed: strict
+
+# Despite A having invalid imports, B should still typecheck fine.
+
+class B < PackageSpec
+  import A
+  export B::BClass
+  export B::BModule
+end
+# ------------------------------
+# -- test/testdata/packager/invalid_imports_and_exports/b/b.rb --
+# frozen_string_literal: true
+# typed: strict
+
+module B
+  class BClass
+    extend T::Sig
+
+    sig {returns(Integer)}
+    def get_one
+      A::AModule.one
+    end
+  end
+
+  module BModule
+    extend T::Sig
+
+    sig {returns(A::AClass)}
+    def self.get_a
+      A::AClass.new
+    end
+  end
+end
+# ------------------------------

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -111,6 +111,11 @@ for this_src in "${rb_src[@]}" DUMMY; do
   fi
 
   if [ -n "$basename" ]; then
+    needs_stripe_packages=false
+    if grep -q '^# enable-packager: true' "${srcs[@]}"; then
+      needs_stripe_packages=true
+    fi
+
     needs_requires_ancestor=false
     if grep -q '^# enable-experimental-requires-ancestor: true' "${srcs[@]}"; then
       needs_requires_ancestor=true
@@ -191,8 +196,10 @@ for this_src in "${rb_src[@]}" DUMMY; do
         args=("--stop-after=namer")
       elif [ "$pass" = "minimized-rbi" ]; then
         args=("--minimize-to-rbi=$basename.minimize.rbi")
-      elif [ "$pass" = "package-tree" ]; then
-        args=("--stripe-packages")
+      fi
+
+      if $needs_stripe_packages; then
+        args+=("--stripe-packages")
 
         extra_underscore_prefixes=()
         while IFS='' read -r prefix; do
@@ -224,6 +231,7 @@ for this_src in "${rb_src[@]}" DUMMY; do
           done
         fi
       fi
+
       case "$pass" in
         document-symbols)
           # See above for why this case is weird.
@@ -239,7 +247,7 @@ for this_src in "${rb_src[@]}" DUMMY; do
           ;;
         autocorrects)
           echo tools/scripts/print_autocorrects_exp.sh \
-            "${srcs[@]}" \
+            "${args[@]}" "${srcs[@]}" \
             \> "$candidate" \
             2\> /dev/null \
             >>"$COMMAND_FILE"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I tried to write a test to fix a bug and it didn't work, so I figured I'd make
this possible.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

There are only a few autocorrects.exp tests that have multiple files:

```
❯ rg -c '# -- ' **/*.autocorrects.exp | awk -F : '{ print $2 " " $1}' | sort | rg '^[^1]'
2 test/testdata/infer/multi_file_autocorrect.autocorrects.exp
3 test/testdata/definition_validator/subclass_t_struct_multi_file.autocorrects.exp
4 test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
```

I manually verified that the other two tests have their files in sorted order. I
think that this was only a problem for me because this test is a whole folder,
and it depends on the order that the directories are recursed into?

In any case I think sorting is good.

**Also**: I manually verified that the `*.autocorrects.exp` does not have the
`import` line for the line that says "Duplicate package import" anymore, which
is what we expect.

**Also**: I ran a whole `update_testdata_exp.sh` run and nothing changed (except for a bug with RBS, fix incoming).