### PR TITLE
Fix update_testdata_exp.sh for RBS signatures

### DIFF
--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -116,6 +116,11 @@ for this_src in "${rb_src[@]}" DUMMY; do
       needs_requires_ancestor=true
     fi
 
+    needs_experimental_rbs_signatures=false
+    if grep -q '^# enable-experimental-rbs-signatures: true' "${srcs[@]}"; then
+      needs_experimental_rbs_signatures=true
+    fi
+
     if grep -q '^# typed-super: false' "${srcs[@]}"; then
       needs_typed_super_false=true
     else
@@ -176,6 +181,9 @@ for this_src in "${rb_src[@]}" DUMMY; do
         args=("--enable-experimental-requires-ancestor")
       else
         args=()
+      fi
+      if $needs_experimental_rbs_signatures; then
+        args+=("--enable-experimental-rbs-signatures")
       fi
       if $needs_typed_super_false; then
         args+=("--typed-super=false")


### PR DESCRIPTION
cc @Morriar


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It was not possible to regenerate all the exp files on master.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Ran this manually:

```
sbg && tools/scripts/update_testdata_exp.sh --no-build test/testdata/rewriter/rbs_signatures_sigs.rb test/testdata/rewriter/rbs_signatures_types.rb test/testdata/rewriter/rbs_signatures_attrs.rb
```

where `sbg` is `bazel build //main:sorbet --config=dbg`