### PR TITLE
Delete leading whitespace from duplicate imports

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -675,7 +675,13 @@ public:
                 if (auto e = ctx.beginError(it->importLoc, core::errors::Packager::InvalidConfiguration)) {
                     e.setHeader("Duplicate package import `{}`", it->package.show(ctx));
                     e.addErrorLine(ctx.locAt(first->importLoc), "Previous package import found here");
-                    e.replaceWith("Remove import", ctx.locAt(it->importLoc), "");
+                    auto importLoc = ctx.locAt(it->importLoc);
+                    auto [startOfIndent, indentation] = importLoc.findStartOfLine(ctx);
+                    auto replacementLoc = startOfIndent.adjust(ctx, -indentation, 0).join(importLoc);
+                    if (replacementLoc.beginPos() != 0) {
+                        replacementLoc = replacementLoc.adjust(ctx, -1, 0); // Also the preceding newline
+                    }
+                    e.replaceWith("Remove import", replacementLoc, "");
                 }
             }
         }

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -27,4 +27,7 @@ class A < PackageSpec
   export A::REFERENCE # Works; it's a constant.
   export A::AClass
   export A::AModule
+
+  test_import C
+  test_import C # error: Duplicate package import
 end

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -18,7 +18,8 @@ class A < PackageSpec
   # Despite the above, this import should work.
   import B
   # But this one will fail; no duplicate imports allowed.
-  import B # error: Duplicate package import
+  import B
+# ^^^^^^^^ error: Duplicate package import
 
   export 123 # error: Argument to `export` must be a constant
   export "hello" # error: Argument to `export` must be a constant
@@ -29,5 +30,6 @@ class A < PackageSpec
   export A::AModule
 
   test_import C
-  test_import C # error: Duplicate package import
+  test_import C
+# ^^^^^^^^^^^^^ error: Duplicate package import
 end

--- a/test/testdata/packager/invalid_imports_and_exports/c/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/c/__package.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class C < PackageSpec
+end

--- a/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
@@ -19,7 +19,6 @@ class A < PackageSpec
   # Despite the above, this import should work.
   import B
   # But this one will fail; no duplicate imports allowed.
-  
 # ^^^^^^^^ error: Duplicate package import
 
   export 123 # error: Argument to `export` must be a constant
@@ -31,7 +30,6 @@ class A < PackageSpec
   export A::AModule
 
   test_import C
-  
 # ^^^^^^^^^^^^^ error: Duplicate package import
 end
 # ------------------------------

--- a/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
@@ -19,7 +19,8 @@ class A < PackageSpec
   # Despite the above, this import should work.
   import B
   # But this one will fail; no duplicate imports allowed.
-   # error: Duplicate package import
+  
+# ^^^^^^^^ error: Duplicate package import
 
   export 123 # error: Argument to `export` must be a constant
   export "hello" # error: Argument to `export` must be a constant
@@ -30,7 +31,8 @@ class A < PackageSpec
   export A::AModule
 
   test_import C
-   # error: Duplicate package import
+  
+# ^^^^^^^^^^^^^ error: Duplicate package import
 end
 # ------------------------------
 # -- test/testdata/packager/invalid_imports_and_exports/a.rb --

--- a/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
@@ -28,6 +28,9 @@ class A < PackageSpec
   export A::REFERENCE # Works; it's a constant.
   export A::AClass
   export A::AModule
+
+  test_import C
+   # error: Duplicate package import
 end
 # ------------------------------
 # -- test/testdata/packager/invalid_imports_and_exports/a.rb --
@@ -95,5 +98,12 @@ module B
       A::AClass.new
     end
   end
+end
+# ------------------------------
+# -- test/testdata/packager/invalid_imports_and_exports/c/__package.rb --
+# frozen_string_literal: true
+# typed: strict
+
+class C < PackageSpec
 end
 # ------------------------------

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -24,6 +24,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.export(::<root>::<C A>::<C AClass>)
 
     <self>.export(::<root>::<C A>::<C AModule>)
+
+    <self>.test_import(::<PackageSpecRegistry>::<C C>)
+
+    <self>.test_import(::<PackageSpecRegistry>::<C C>)
   end
 end
 # -- test/testdata/packager/invalid_imports_and_exports/b/__package.rb --
@@ -34,6 +38,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.export(::<root>::<C B>::<C BClass>)
 
     <self>.export(::<root>::<C B>::<C BModule>)
+  end
+end
+# -- test/testdata/packager/invalid_imports_and_exports/c/__package.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class ::<PackageSpecRegistry>::<C C><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/invalid_imports_and_exports/a.rb --


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This isn't _amazing_ when there is a trailing comment on the current and
previous line, because they will get combined.

Maybe a better option would be to leave the leading whitespace if the line
would not be empty as a result of removing the import, but even that
wouldn't be perfect, because Stripe's other `__package.rb` parser requires
that comments must be exactly two space indented.

So for now I think this is the easiest-to-implement solution to the problem
of Sorbet autocorrects leaving the file in a malformed state.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

New and existing tests, check the commits.