### PR TITLE
Build support to allow open enums (for codeAction kind)

### DIFF
--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -44,6 +44,11 @@ shared_ptr<JSONType> makeVariant(vector<shared_ptr<JSONType>> variants) {
     return make_shared<JSONBasicVariantType>(variants);
 }
 
+shared_ptr<JSONType> makeOpenVariant(vector<shared_ptr<JSONType>> variants) {
+    auto allowFallThrough = true;
+    return make_shared<JSONBasicVariantType>(variants, allowFallThrough);
+}
+
 shared_ptr<JSONType>
 makeDiscriminatedUnion(shared_ptr<FieldDef> fieldDef,
                        const vector<pair<const string, shared_ptr<JSONType>>> variantsByDiscriminant) {
@@ -1050,12 +1055,13 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                         },
                                         classTypes);
 
-    auto CodeActionContext = makeObject("CodeActionContext",
-                                        {
-                                            makeField("diagnostics", makeArray(Diagnostic)),
-                                            makeField("only", makeOptional(makeArray(CodeActionKind))),
-                                        },
-                                        classTypes);
+    auto CodeActionContext =
+        makeObject("CodeActionContext",
+                   {
+                       makeField("diagnostics", makeArray(Diagnostic)),
+                       makeField("only", makeOptional(makeArray(makeOpenVariant({CodeActionKind, JSONString})))),
+                   },
+                   classTypes);
 
     auto CodeActionParams = makeObject("CodeActionParams",
                                        {

--- a/test/lsp/unknown-code-action-kind/unknown-code-action-kind.rec
+++ b/test/lsp/unknown-code-action-kind/unknown-code-action-kind.rec
@@ -5,5 +5,5 @@ Read: {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":
 Write: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"inmemory://model/default.rb","diagnostics":[{"range":{"start":{"line":1,"character":0},"end":{"line":1,"character":3}},"severity":1,"code":7003,"codeDescription":{"href":"https://srb.help/7003"},"message":"Method `foo` does not exist on `T.class_of(<root>)`","relatedInformation":[]}]}}
 Read: {"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"inmemory://model/default.rb","version":2},"contentChanges":[{"text":"# typed: true\nputs\n"}]}}
 Write: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"inmemory://model/default.rb","diagnostics":[]}}
-Read: {"jsonrpc":"2.0","id":68,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"inmemory://model/default.rb"},"range":{"start":{"line":0,"character":0},"end":{"line":2,"character":0}},"context":{"diagnostics":[],"only":["source.fixAll"]}}}
-Write: {"jsonrpc":"2.0","id":68,"requestMethod":"textDocument/codeAction","result":[]}
+Read: {"jsonrpc":"2.0","id":1,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"inmemory://model/default.rb"},"range":{"start":{"line":0,"character":0},"end":{"line":2,"character":0}},"context":{"diagnostics":[],"only":["source.fixAll"]}}}
+Write: {"jsonrpc":"2.0","id":1,"requestMethod":"textDocument/codeAction","result":[]}

--- a/test/lsp/unknown-code-action-kind/unknown-code-action-kind.rec
+++ b/test/lsp/unknown-code-action-kind/unknown-code-action-kind.rec
@@ -8,4 +8,4 @@ Write: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"ur
 Read: {"jsonrpc":"2.0","id":1,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"inmemory://model/default.rb"},"range":{"start":{"line":0,"character":0},"end":{"line":2,"character":0}},"context":{"diagnostics":[],"only":["source.fixAll"]}}}
 Write: {"jsonrpc":"2.0","id":1,"requestMethod":"textDocument/codeAction","result":[]}
 Read: {"jsonrpc":"2.0","id":2,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"inmemory://model/default.rb"},"range":{"start":{"line":0,"character":0},"end":{"line":2,"character":0}},"context":{"diagnostics":[],"only":["no one knows"]}}}
-Write: {"jsonrpc":"2.0","id":2,"requestMethod":"sorbet/error","error":{"code":-32602,"message":"Unable to deserialize LSP request: Error deserializing JSON message: Invalid value for enum type `CodeActionKind`: no one knows"}}
+Write: {"jsonrpc":"2.0","id":2,"requestMethod":"textDocument/codeAction","result":[]}

--- a/test/lsp/unknown-code-action-kind/unknown-code-action-kind.rec
+++ b/test/lsp/unknown-code-action-kind/unknown-code-action-kind.rec
@@ -7,3 +7,5 @@ Read: {"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument
 Write: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"inmemory://model/default.rb","diagnostics":[]}}
 Read: {"jsonrpc":"2.0","id":1,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"inmemory://model/default.rb"},"range":{"start":{"line":0,"character":0},"end":{"line":2,"character":0}},"context":{"diagnostics":[],"only":["source.fixAll"]}}}
 Write: {"jsonrpc":"2.0","id":1,"requestMethod":"textDocument/codeAction","result":[]}
+Read: {"jsonrpc":"2.0","id":2,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"inmemory://model/default.rb"},"range":{"start":{"line":0,"character":0},"end":{"line":2,"character":0}},"context":{"diagnostics":[],"only":["no one knows"]}}}
+Write: {"jsonrpc":"2.0","id":2,"requestMethod":"sorbet/error","error":{"code":-32602,"message":"Unable to deserialize LSP request: Error deserializing JSON message: Invalid value for enum type `CodeActionKind`: no one knows"}}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The code action kind is allowed to be an open enum: anyone is allowed to send us
whatever they want. Previously, if someone sent us a value we didn't understand,
we would crash. Now, we can handle it gracefully.

As it happens, no one is using this `CodeActionContext::only` property, so we
don't actually have to change any downstream code (to teach it how to see
through the fact that it's now backed by a `std::variant`).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.