### PR TITLE
Remove some more unique_ptr references

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -88,7 +88,7 @@ ExpressionPtr numparamTree(DesugarContext dctx, int num, parser::NodeVec *decls)
 ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what);
 
 pair<MethodDef::ARGS_store, InsSeq::STATS_store> desugarArgs(DesugarContext dctx, core::LocOffsets loc,
-                                                             unique_ptr<parser::Node> argnode) {
+                                                             unique_ptr<parser::Node> &argnode) {
     MethodDef::ARGS_store args;
     InsSeq::STATS_store destructures;
 
@@ -135,7 +135,7 @@ pair<MethodDef::ARGS_store, InsSeq::STATS_store> desugarArgs(DesugarContext dctx
     return make_pair(std::move(args), std::move(destructures));
 }
 
-ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> bodynode,
+ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &bodynode,
                           InsSeq::STATS_store destructures) {
     auto body = node2TreeImpl(dctx, std::move(bodynode));
     if (!destructures.empty()) {
@@ -172,8 +172,8 @@ void checkBlockRestArg(DesugarContext dctx, const MethodDef::ARGS_store &args) {
 }
 
 ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocOffsets blockLoc,
-                           unique_ptr<parser::Node> blockSend, unique_ptr<parser::Node> blockArgs,
-                           unique_ptr<parser::Node> blockBody) {
+                           unique_ptr<parser::Node> &blockSend, unique_ptr<parser::Node> &blockArgs,
+                           unique_ptr<parser::Node> &blockBody) {
     blockSend->loc = loc;
     auto recv = node2TreeImpl(dctx, std::move(blockSend));
     Send *send;
@@ -196,14 +196,14 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
         send = cast_tree<Send>(iff->elsep);
         ENFORCE(send != nullptr, "DesugarBlock: failed to find Send");
     }
-    auto [args, destructures] = desugarArgs(dctx, loc, std::move(blockArgs));
+    auto [args, destructures] = desugarArgs(dctx, loc, blockArgs);
 
     checkBlockRestArg(dctx, args);
 
     auto inBlock = true;
     DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
                          dctx.enclosingMethodName, inBlock, dctx.inModule, dctx.preserveConcreteSyntax);
-    auto desugaredBody = desugarBody(dctx1, loc, std::move(blockBody), std::move(destructures));
+    auto desugaredBody = desugarBody(dctx1, loc, blockBody, std::move(destructures));
 
     // TODO the send->block's loc is too big and includes the whole send
     send->setBlock(MK::Block(loc, std::move(desugaredBody), std::move(args)));
@@ -361,13 +361,13 @@ ExpressionPtr validateRBIBody(DesugarContext dctx, ExpressionPtr body) {
 }
 
 ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                          unique_ptr<parser::Node> argnode, unique_ptr<parser::Node> body, bool isSelf) {
+                          unique_ptr<parser::Node> &argnode, unique_ptr<parser::Node> &body, bool isSelf) {
     // Reset uniqueCounter within this scope (to keep numbers small)
     uint32_t uniqueCounter = 1;
     auto inModule = dctx.inModule && !isSelf;
     DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockArg, declLoc, name, dctx.inAnyBlock, inModule,
                          dctx.preserveConcreteSyntax);
-    auto [args, destructures] = desugarArgs(dctx1, loc, std::move(argnode));
+    auto [args, destructures] = desugarArgs(dctx1, loc, argnode);
 
     if (args.empty() || !isa_tree<BlockArg>(args.back())) {
         auto blkLoc = core::LocOffsets::none();
@@ -380,7 +380,7 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
 
     DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockArg, declLoc, name, dctx.inAnyBlock, inModule,
                          dctx.preserveConcreteSyntax);
-    ExpressionPtr desugaredBody = desugarBody(dctx2, loc, std::move(body), std::move(destructures));
+    ExpressionPtr desugaredBody = desugarBody(dctx2, loc, body, std::move(destructures));
     desugaredBody = validateRBIBody(dctx2, move(desugaredBody));
 
     auto mdef = MK::Method(loc, declLoc, name, std::move(args), std::move(desugaredBody));
@@ -500,47 +500,47 @@ ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlh
 }
 
 // Map all MatchVars used in `pattern` to local variables initialized from magic calls
-void desugarPatternMatchingVars(InsSeq::STATS_store &vars, DesugarContext dctx, parser::Node *node) {
-    if (auto var = parser::cast_node<parser::MatchVar>(node)) {
+void desugarPatternMatchingVars(InsSeq::STATS_store &vars, DesugarContext dctx, unique_ptr<parser::Node> &node) {
+    if (auto var = parser::cast_node<parser::MatchVar>(node.get())) {
         auto loc = var->loc;
         auto val = MK::RaiseUnimplemented(loc);
         vars.emplace_back(MK::Assign(loc, var->name, std::move(val)));
-    } else if (auto rest = parser::cast_node<parser::MatchRest>(node)) {
-        desugarPatternMatchingVars(vars, dctx, rest->var.get());
-    } else if (auto pair = parser::cast_node<parser::Pair>(node)) {
-        desugarPatternMatchingVars(vars, dctx, pair->value.get());
-    } else if (auto as_pattern = parser::cast_node<parser::MatchAs>(node)) {
+    } else if (auto rest = parser::cast_node<parser::MatchRest>(node.get())) {
+        desugarPatternMatchingVars(vars, dctx, rest->var);
+    } else if (auto pair = parser::cast_node<parser::Pair>(node.get())) {
+        desugarPatternMatchingVars(vars, dctx, pair->value);
+    } else if (auto as_pattern = parser::cast_node<parser::MatchAs>(node.get())) {
         auto loc = as_pattern->as->loc;
         auto name = parser::cast_node<parser::MatchVar>(as_pattern->as.get())->name;
         auto val = MK::RaiseUnimplemented(loc);
         vars.emplace_back(MK::Assign(loc, name, std::move(val)));
-        desugarPatternMatchingVars(vars, dctx, as_pattern->value.get());
-    } else if (auto array_pattern = parser::cast_node<parser::ArrayPattern>(node)) {
+        desugarPatternMatchingVars(vars, dctx, as_pattern->value);
+    } else if (auto array_pattern = parser::cast_node<parser::ArrayPattern>(node.get())) {
         for (auto &elt : array_pattern->elts) {
-            desugarPatternMatchingVars(vars, dctx, elt.get());
+            desugarPatternMatchingVars(vars, dctx, elt);
         }
-    } else if (auto array_pattern = parser::cast_node<parser::ArrayPatternWithTail>(node)) {
+    } else if (auto array_pattern = parser::cast_node<parser::ArrayPatternWithTail>(node.get())) {
         for (auto &elt : array_pattern->elts) {
-            desugarPatternMatchingVars(vars, dctx, elt.get());
+            desugarPatternMatchingVars(vars, dctx, elt);
         }
-    } else if (auto hash_pattern = parser::cast_node<parser::HashPattern>(node)) {
+    } else if (auto hash_pattern = parser::cast_node<parser::HashPattern>(node.get())) {
         for (auto &elt : hash_pattern->pairs) {
-            desugarPatternMatchingVars(vars, dctx, elt.get());
+            desugarPatternMatchingVars(vars, dctx, elt);
         }
-    } else if (auto alt_pattern = parser::cast_node<parser::MatchAlt>(node)) {
-        desugarPatternMatchingVars(vars, dctx, alt_pattern->left.get());
-        desugarPatternMatchingVars(vars, dctx, alt_pattern->right.get());
+    } else if (auto alt_pattern = parser::cast_node<parser::MatchAlt>(node.get())) {
+        desugarPatternMatchingVars(vars, dctx, alt_pattern->left);
+        desugarPatternMatchingVars(vars, dctx, alt_pattern->right);
     }
 }
 
 // Desugar `in` and `=>` oneline pattern matching
-ExpressionPtr desugarOnelinePattern(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> match) {
+ExpressionPtr desugarOnelinePattern(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &match) {
     auto matchExpr = MK::RaiseUnimplemented(loc);
     auto bodyExpr = MK::RaiseUnimplemented(loc);
     auto elseExpr = MK::EmptyTree();
 
     InsSeq::STATS_store vars;
-    desugarPatternMatchingVars(vars, dctx, match.get());
+    desugarPatternMatchingVars(vars, dctx, match);
     if (!vars.empty()) {
         bodyExpr = MK::InsSeq(match->loc, std::move(vars), std::move(bodyExpr));
     }
@@ -1162,8 +1162,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 }
             },
             [&](parser::Block *block) {
-                result = desugarBlock(dctx, loc, block->loc, std::move(block->send), std::move(block->args),
-                                      std::move(block->body));
+                result = desugarBlock(dctx, loc, block->loc, block->send, block->args, block->body);
             },
             [&](parser::Begin *begin) { result = desugarBegin(dctx, loc, begin->stmts); },
             [&](parser::Assign *asgn) {
@@ -1641,8 +1640,9 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::DefMethod *method) {
                 bool isSelf = false;
-                result = buildMethod(dctx, method->loc, method->declLoc, method->name, std::move(method->args),
-                                     std::move(method->body), isSelf);
+                ExpressionPtr res =
+                    buildMethod(dctx, method->loc, method->declLoc, method->name, method->args, method->body, isSelf);
+                result = std::move(res);
             },
             [&](parser::DefS *method) {
                 auto *self = parser::cast_node<parser::Self>(method->singleton.get());
@@ -1657,8 +1657,9 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     }
                 }
                 bool isSelf = true;
-                result = buildMethod(dctx, method->loc, method->declLoc, method->name, std::move(method->args),
-                                     std::move(method->body), isSelf);
+                ExpressionPtr res =
+                    buildMethod(dctx, method->loc, method->declLoc, method->name, method->args, method->body, isSelf);
+                result = std::move(res);
             },
             [&](parser::SClass *sclass) {
                 // This will be a nested ClassDef which we leave in the tree
@@ -1688,8 +1689,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             [&](parser::NumBlock *block) {
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
                                      dctx.enclosingMethodName, true, dctx.inModule, dctx.preserveConcreteSyntax);
-                result = desugarBlock(dctx1, loc, block->loc, std::move(block->send), std::move(block->args),
-                                      std::move(block->body));
+                result = desugarBlock(dctx1, loc, block->loc, block->send, block->args, block->body);
             },
             [&](parser::While *wl) {
                 auto cond = node2TreeImpl(dctx, std::move(wl->cond));
@@ -2405,7 +2405,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
 
                     // Desugar match variables found inside the pattern
                     InsSeq::STATS_store vars;
-                    desugarPatternMatchingVars(vars, dctx, pattern.get());
+                    desugarPatternMatchingVars(vars, dctx, pattern);
                     if (!vars.empty()) {
                         body = MK::InsSeq(pattern->loc, std::move(vars), std::move(body));
                     }
@@ -2444,10 +2444,12 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = MK::Send0(loc, std::move(recv), core::Names::getEncoding(), locZeroLen);
             },
             [&](parser::MatchPattern *pattern) {
-                result = desugarOnelinePattern(dctx, pattern->loc, std::move(pattern->rhs));
+                auto res = desugarOnelinePattern(dctx, pattern->loc, pattern->rhs);
+                result = std::move(res);
             },
             [&](parser::MatchPatternP *pattern) {
-                result = desugarOnelinePattern(dctx, pattern->loc, std::move(pattern->rhs));
+                auto res = desugarOnelinePattern(dctx, pattern->loc, pattern->rhs);
+                result = std::move(res);
             },
             [&](parser::EmptyElse *else_) { result = MK::EmptyTree(); },
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -88,7 +88,7 @@ ExpressionPtr numparamTree(DesugarContext dctx, int num, parser::NodeVec *decls)
 ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what);
 
 pair<MethodDef::ARGS_store, InsSeq::STATS_store> desugarArgs(DesugarContext dctx, core::LocOffsets loc,
-                                                             unique_ptr<parser::Node> &argnode) {
+                                                             unique_ptr<parser::Node> argnode) {
     MethodDef::ARGS_store args;
     InsSeq::STATS_store destructures;
 
@@ -135,7 +135,7 @@ pair<MethodDef::ARGS_store, InsSeq::STATS_store> desugarArgs(DesugarContext dctx
     return make_pair(std::move(args), std::move(destructures));
 }
 
-ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &bodynode,
+ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> bodynode,
                           InsSeq::STATS_store destructures) {
     auto body = node2TreeImpl(dctx, std::move(bodynode));
     if (!destructures.empty()) {
@@ -172,8 +172,8 @@ void checkBlockRestArg(DesugarContext dctx, const MethodDef::ARGS_store &args) {
 }
 
 ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocOffsets blockLoc,
-                           unique_ptr<parser::Node> &blockSend, unique_ptr<parser::Node> &blockArgs,
-                           unique_ptr<parser::Node> &blockBody) {
+                           unique_ptr<parser::Node> blockSend, unique_ptr<parser::Node> blockArgs,
+                           unique_ptr<parser::Node> blockBody) {
     blockSend->loc = loc;
     auto recv = node2TreeImpl(dctx, std::move(blockSend));
     Send *send;
@@ -196,14 +196,14 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
         send = cast_tree<Send>(iff->elsep);
         ENFORCE(send != nullptr, "DesugarBlock: failed to find Send");
     }
-    auto [args, destructures] = desugarArgs(dctx, loc, blockArgs);
+    auto [args, destructures] = desugarArgs(dctx, loc, std::move(blockArgs));
 
     checkBlockRestArg(dctx, args);
 
     auto inBlock = true;
     DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
                          dctx.enclosingMethodName, inBlock, dctx.inModule, dctx.preserveConcreteSyntax);
-    auto desugaredBody = desugarBody(dctx1, loc, blockBody, std::move(destructures));
+    auto desugaredBody = desugarBody(dctx1, loc, std::move(blockBody), std::move(destructures));
 
     // TODO the send->block's loc is too big and includes the whole send
     send->setBlock(MK::Block(loc, std::move(desugaredBody), std::move(args)));
@@ -361,13 +361,13 @@ ExpressionPtr validateRBIBody(DesugarContext dctx, ExpressionPtr body) {
 }
 
 ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                          unique_ptr<parser::Node> &argnode, unique_ptr<parser::Node> &body, bool isSelf) {
+                          unique_ptr<parser::Node> argnode, unique_ptr<parser::Node> body, bool isSelf) {
     // Reset uniqueCounter within this scope (to keep numbers small)
     uint32_t uniqueCounter = 1;
     auto inModule = dctx.inModule && !isSelf;
     DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockArg, declLoc, name, dctx.inAnyBlock, inModule,
                          dctx.preserveConcreteSyntax);
-    auto [args, destructures] = desugarArgs(dctx1, loc, argnode);
+    auto [args, destructures] = desugarArgs(dctx1, loc, std::move(argnode));
 
     if (args.empty() || !isa_tree<BlockArg>(args.back())) {
         auto blkLoc = core::LocOffsets::none();
@@ -380,7 +380,7 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
 
     DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockArg, declLoc, name, dctx.inAnyBlock, inModule,
                          dctx.preserveConcreteSyntax);
-    ExpressionPtr desugaredBody = desugarBody(dctx2, loc, body, std::move(destructures));
+    ExpressionPtr desugaredBody = desugarBody(dctx2, loc, std::move(body), std::move(destructures));
     desugaredBody = validateRBIBody(dctx2, move(desugaredBody));
 
     auto mdef = MK::Method(loc, declLoc, name, std::move(args), std::move(desugaredBody));
@@ -500,47 +500,47 @@ ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlh
 }
 
 // Map all MatchVars used in `pattern` to local variables initialized from magic calls
-void desugarPatternMatchingVars(InsSeq::STATS_store &vars, DesugarContext dctx, unique_ptr<parser::Node> &node) {
-    if (auto var = parser::cast_node<parser::MatchVar>(node.get())) {
+void desugarPatternMatchingVars(InsSeq::STATS_store &vars, DesugarContext dctx, parser::Node *node) {
+    if (auto var = parser::cast_node<parser::MatchVar>(node)) {
         auto loc = var->loc;
         auto val = MK::RaiseUnimplemented(loc);
         vars.emplace_back(MK::Assign(loc, var->name, std::move(val)));
-    } else if (auto rest = parser::cast_node<parser::MatchRest>(node.get())) {
-        desugarPatternMatchingVars(vars, dctx, rest->var);
-    } else if (auto pair = parser::cast_node<parser::Pair>(node.get())) {
-        desugarPatternMatchingVars(vars, dctx, pair->value);
-    } else if (auto as_pattern = parser::cast_node<parser::MatchAs>(node.get())) {
+    } else if (auto rest = parser::cast_node<parser::MatchRest>(node)) {
+        desugarPatternMatchingVars(vars, dctx, rest->var.get());
+    } else if (auto pair = parser::cast_node<parser::Pair>(node)) {
+        desugarPatternMatchingVars(vars, dctx, pair->value.get());
+    } else if (auto as_pattern = parser::cast_node<parser::MatchAs>(node)) {
         auto loc = as_pattern->as->loc;
         auto name = parser::cast_node<parser::MatchVar>(as_pattern->as.get())->name;
         auto val = MK::RaiseUnimplemented(loc);
         vars.emplace_back(MK::Assign(loc, name, std::move(val)));
-        desugarPatternMatchingVars(vars, dctx, as_pattern->value);
-    } else if (auto array_pattern = parser::cast_node<parser::ArrayPattern>(node.get())) {
+        desugarPatternMatchingVars(vars, dctx, as_pattern->value.get());
+    } else if (auto array_pattern = parser::cast_node<parser::ArrayPattern>(node)) {
         for (auto &elt : array_pattern->elts) {
-            desugarPatternMatchingVars(vars, dctx, elt);
+            desugarPatternMatchingVars(vars, dctx, elt.get());
         }
-    } else if (auto array_pattern = parser::cast_node<parser::ArrayPatternWithTail>(node.get())) {
+    } else if (auto array_pattern = parser::cast_node<parser::ArrayPatternWithTail>(node)) {
         for (auto &elt : array_pattern->elts) {
-            desugarPatternMatchingVars(vars, dctx, elt);
+            desugarPatternMatchingVars(vars, dctx, elt.get());
         }
-    } else if (auto hash_pattern = parser::cast_node<parser::HashPattern>(node.get())) {
+    } else if (auto hash_pattern = parser::cast_node<parser::HashPattern>(node)) {
         for (auto &elt : hash_pattern->pairs) {
-            desugarPatternMatchingVars(vars, dctx, elt);
+            desugarPatternMatchingVars(vars, dctx, elt.get());
         }
-    } else if (auto alt_pattern = parser::cast_node<parser::MatchAlt>(node.get())) {
-        desugarPatternMatchingVars(vars, dctx, alt_pattern->left);
-        desugarPatternMatchingVars(vars, dctx, alt_pattern->right);
+    } else if (auto alt_pattern = parser::cast_node<parser::MatchAlt>(node)) {
+        desugarPatternMatchingVars(vars, dctx, alt_pattern->left.get());
+        desugarPatternMatchingVars(vars, dctx, alt_pattern->right.get());
     }
 }
 
 // Desugar `in` and `=>` oneline pattern matching
-ExpressionPtr desugarOnelinePattern(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &match) {
+ExpressionPtr desugarOnelinePattern(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> match) {
     auto matchExpr = MK::RaiseUnimplemented(loc);
     auto bodyExpr = MK::RaiseUnimplemented(loc);
     auto elseExpr = MK::EmptyTree();
 
     InsSeq::STATS_store vars;
-    desugarPatternMatchingVars(vars, dctx, match);
+    desugarPatternMatchingVars(vars, dctx, match.get());
     if (!vars.empty()) {
         bodyExpr = MK::InsSeq(match->loc, std::move(vars), std::move(bodyExpr));
     }
@@ -1162,7 +1162,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 }
             },
             [&](parser::Block *block) {
-                result = desugarBlock(dctx, loc, block->loc, block->send, block->args, block->body);
+                result = desugarBlock(dctx, loc, block->loc, std::move(block->send), std::move(block->args),
+                                      std::move(block->body));
             },
             [&](parser::Begin *begin) { result = desugarBegin(dctx, loc, begin->stmts); },
             [&](parser::Assign *asgn) {
@@ -1640,9 +1641,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             },
             [&](parser::DefMethod *method) {
                 bool isSelf = false;
-                ExpressionPtr res =
-                    buildMethod(dctx, method->loc, method->declLoc, method->name, method->args, method->body, isSelf);
-                result = std::move(res);
+                result = buildMethod(dctx, method->loc, method->declLoc, method->name, std::move(method->args),
+                                     std::move(method->body), isSelf);
             },
             [&](parser::DefS *method) {
                 auto *self = parser::cast_node<parser::Self>(method->singleton.get());
@@ -1657,9 +1657,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     }
                 }
                 bool isSelf = true;
-                ExpressionPtr res =
-                    buildMethod(dctx, method->loc, method->declLoc, method->name, method->args, method->body, isSelf);
-                result = std::move(res);
+                result = buildMethod(dctx, method->loc, method->declLoc, method->name, std::move(method->args),
+                                     std::move(method->body), isSelf);
             },
             [&](parser::SClass *sclass) {
                 // This will be a nested ClassDef which we leave in the tree
@@ -1689,7 +1688,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             [&](parser::NumBlock *block) {
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
                                      dctx.enclosingMethodName, true, dctx.inModule, dctx.preserveConcreteSyntax);
-                result = desugarBlock(dctx1, loc, block->loc, block->send, block->args, block->body);
+                result = desugarBlock(dctx1, loc, block->loc, std::move(block->send), std::move(block->args),
+                                      std::move(block->body));
             },
             [&](parser::While *wl) {
                 auto cond = node2TreeImpl(dctx, std::move(wl->cond));
@@ -2405,7 +2405,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
 
                     // Desugar match variables found inside the pattern
                     InsSeq::STATS_store vars;
-                    desugarPatternMatchingVars(vars, dctx, pattern);
+                    desugarPatternMatchingVars(vars, dctx, pattern.get());
                     if (!vars.empty()) {
                         body = MK::InsSeq(pattern->loc, std::move(vars), std::move(body));
                     }
@@ -2444,12 +2444,10 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = MK::Send0(loc, std::move(recv), core::Names::getEncoding(), locZeroLen);
             },
             [&](parser::MatchPattern *pattern) {
-                auto res = desugarOnelinePattern(dctx, pattern->loc, pattern->rhs);
-                result = std::move(res);
+                result = desugarOnelinePattern(dctx, pattern->loc, std::move(pattern->rhs));
             },
             [&](parser::MatchPatternP *pattern) {
-                auto res = desugarOnelinePattern(dctx, pattern->loc, pattern->rhs);
-                result = std::move(res);
+                result = desugarOnelinePattern(dctx, pattern->loc, std::move(pattern->rhs));
             },
             [&](parser::EmptyElse *else_) { result = MK::EmptyTree(); },
 

--- a/infer/SigSuggestion.h
+++ b/infer/SigSuggestion.h
@@ -6,7 +6,7 @@
 namespace sorbet::infer {
 class SigSuggestion final {
 public:
-    static std::optional<core::AutocorrectSuggestion> maybeSuggestSig(core::Context ctx, std::unique_ptr<cfg::CFG> &cfg,
+    static std::optional<core::AutocorrectSuggestion> maybeSuggestSig(core::Context ctx, cfg::CFG &cfg,
                                                                       const core::TypePtr &methodReturnType,
                                                                       core::TypeConstraint &constr);
 };

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -78,9 +78,9 @@ struct KnowledgeFact {
     std::string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
 };
 
-KnowledgeFilter::KnowledgeFilter(core::Context ctx, unique_ptr<cfg::CFG> &cfg) {
-    used_vars.resize(cfg->numLocalVariables());
-    for (auto &bb : cfg->basicBlocks) {
+KnowledgeFilter::KnowledgeFilter(core::Context ctx, cfg::CFG &cfg) {
+    used_vars.resize(cfg.numLocalVariables());
+    for (auto &bb : cfg.basicBlocks) {
         ENFORCE(bb->bexit.cond.variable.exists());
         if (bb->bexit.cond.variable != cfg::LocalRef::unconditional() &&
             bb->bexit.cond.variable != cfg::LocalRef::blockCall()) {
@@ -90,7 +90,7 @@ KnowledgeFilter::KnowledgeFilter(core::Context ctx, unique_ptr<cfg::CFG> &cfg) {
     bool changed = true;
     while (changed) {
         changed = false;
-        for (auto &bb : cfg->forwardsTopoSort) {
+        for (auto &bb : cfg.forwardsTopoSort) {
             for (auto &bind : bb->exprs) {
                 if (auto id = cfg::cast_instruction<cfg::Ident>(bind.value)) {
                     if (isNeeded(bind.bind.variable) && !isNeeded(id->what)) {

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -46,7 +46,7 @@ class KnowledgeFilter {
     std::vector<bool> used_vars;
 
 public:
-    KnowledgeFilter(core::Context ctx, std::unique_ptr<cfg::CFG> &cfg);
+    KnowledgeFilter(core::Context ctx, cfg::CFG &cfg);
 
     KnowledgeFilter(KnowledgeFilter &) = delete;
     KnowledgeFilter(KnowledgeFilter &&) = delete;

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -113,7 +113,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
     }
     vector<bool> visited;
     visited.resize(cfg->maxBasicBlockId);
-    KnowledgeFilter knowledgeFilter(ctx, cfg);
+    KnowledgeFilter knowledgeFilter(ctx, *cfg);
     for (auto it = cfg->forwardsTopoSort.rbegin(); it != cfg->forwardsTopoSort.rend(); ++it) {
         cfg::BasicBlock *bb = *it;
         if (bb == cfg->deadBlock()) {

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -396,7 +396,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
     if (missingReturnType && guessTypes) {
         if (auto e = ctx.state.beginError(cfg->symbol.data(ctx)->loc(), core::errors::Infer::UntypedMethod)) {
             e.setHeader("The method `{}` does not have a `{}`", cfg->symbol.data(ctx)->name.show(ctx), "sig");
-            auto maybeAutocorrect = SigSuggestion::maybeSuggestSig(ctx, cfg, methodReturnType, *constr);
+            auto maybeAutocorrect = SigSuggestion::maybeSuggestSig(ctx, *cfg, methodReturnType, *constr);
             if (maybeAutocorrect.has_value()) {
                 e.addAutocorrect(move(maybeAutocorrect.value()));
             } else if (cfg->symbol.data(ctx)->owner.data(ctx)->derivesFrom(ctx, core::Symbols::Struct())) {
@@ -406,7 +406,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             }
         } else if (ctx.state.lspQuery.matchesSuggestSig(cfg->symbol)) {
             // Force maybeSuggestSig to run just to respond to the query (discard the result)
-            SigSuggestion::maybeSuggestSig(ctx, cfg, methodReturnType, *constr);
+            SigSuggestion::maybeSuggestSig(ctx, *cfg, methodReturnType, *constr);
         }
     }
 


### PR DESCRIPTION

### Motivation
Remove some more unique_ptr references in favor of using a regular reference, or explicitly transferring ownership. Passing a unique_ptr reference is more like passing a pointer to a pointer, and that indirection isn't helping us. Instead, let's make a decision and accept the unique_ptr by value, or take a reference to the thing it points to.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a Shouldn't change behavior, just cleaning up memory lifetimes.
