### PR TITLE
Apply "don't import if..." logic to `test_import` to `import` conversions

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -544,7 +544,7 @@ public:
                     if (reasons.size() == 1) {
                         reason = reasons[0];
                     } else if (reasons.size() == 2) {
-                        reason = fmt::format("{} and {}", reasons[0], reasons[1]);
+                        reason = fmt::format("{}, and {}", reasons[0], reasons[1]);
                     } else if (reasons.size() == 3) {
                         reason = fmt::format("{}, {}, and {}", reasons[0], reasons[1], reasons[2]);
                     } else {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -439,47 +439,66 @@ public:
         }
 
         auto importType = this->package.importsPackage(otherPackage);
-        if (!importType.has_value()) {
-            // We failed to import the package that defines the symbol
-            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
-                bool isTestImport = otherFile.data(ctx).isPackagedTest() || ctx.file.data(ctx).isPackagedTest();
-                auto strictDepsLevel = this->package.strictDependenciesLevel();
-                auto importStrictDepsLevel = pkg.strictDependenciesLevel();
-                bool layeringViolation = false;
-                bool strictDependenciesTooLow = false;
-                bool causesCycle = false;
-                if (!isTestImport && db.enforceLayering()) {
-                    layeringViolation =
-                        strictDepsLevel.has_value() &&
-                        strictDepsLevel.value().first != core::packages::StrictDependenciesLevel::False &&
-                        this->package.causesLayeringViolation(db, pkg);
-                    strictDependenciesTooLow =
-                        importStrictDepsLevel.has_value() &&
-                        importStrictDepsLevel.value().first < this->package.minimumStrictDependenciesLevel();
-                    // If there's a path from the imported packaged to this package, then adding the import will close
-                    // the loop and cause a cycle.
-                    // TODO(neil): This could be slow if importsTransitively is called a lot. This could happen if we
-                    // somehow end up in a situation where there's a bunch of uses of constants that resolve but aren't
-                    // imported. I don't think this will happen in practice, but if does, we should cache the result of
-                    // importsTransitively (by pair of {this->package, otherPackage}) to avoid recomputing it.
-                    causesCycle =
-                        strictDepsLevel.has_value() &&
-                        strictDepsLevel.value().first >= core::packages::StrictDependenciesLevel::LayeredDag &&
-                        pkg.importsTransitively(ctx, this->package.mangledName());
-                }
-                if (!causesCycle && !layeringViolation && !strictDependenciesTooLow) {
-                    e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
-                    e.addErrorLine(pkg.declLoc(), "Exported from package here");
-                    if (auto exp = this->package.addImport(ctx, pkg, isTestImport)) {
-                        e.addAutocorrect(std::move(exp.value()));
-                        if (!db.errorHint().empty()) {
-                            e.addErrorNote("{}", db.errorHint());
+        auto wasNotImported = !importType.has_value();
+        auto importedAsTest =
+            importType.has_value() && importType.value() == core::packages::ImportType::Test && !this->insideTestFile;
+        if (wasNotImported || importedAsTest) {
+            auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
+            bool isTestImport = otherFile.data(ctx).isPackagedTest() || ctx.file.data(ctx).isPackagedTest();
+            auto strictDepsLevel = this->package.strictDependenciesLevel();
+            auto importStrictDepsLevel = pkg.strictDependenciesLevel();
+            bool layeringViolation = false;
+            bool strictDependenciesTooLow = false;
+            bool causesCycle = false;
+            if (!isTestImport && db.enforceLayering()) {
+                layeringViolation = strictDepsLevel.has_value() &&
+                                    strictDepsLevel.value().first != core::packages::StrictDependenciesLevel::False &&
+                                    this->package.causesLayeringViolation(db, pkg);
+                strictDependenciesTooLow =
+                    importStrictDepsLevel.has_value() &&
+                    importStrictDepsLevel.value().first < this->package.minimumStrictDependenciesLevel();
+                // If there's a path from the imported packaged to this package, then adding the import will close
+                // the loop and cause a cycle.
+                causesCycle = strictDepsLevel.has_value() &&
+                              strictDepsLevel.value().first >= core::packages::StrictDependenciesLevel::LayeredDag &&
+                              pkg.importsTransitively(ctx, this->package.mangledName());
+            }
+            if (!causesCycle && !layeringViolation && !strictDependenciesTooLow) {
+                if (wasNotImported) {
+                    // We failed to import the package that defines the symbol
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
+                        e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
+                        e.addErrorLine(pkg.declLoc(), "Exported from package here");
+                        if (auto exp = this->package.addImport(ctx, pkg, isTestImport)) {
+                            e.addAutocorrect(std::move(exp.value()));
+                            if (!db.errorHint().empty()) {
+                                e.addErrorNote("{}", db.errorHint());
+                            }
+                        }
+                        if (!ctx.file.data(ctx).isPackaged()) {
+                            e.addErrorNote("A `{}` file is allowed to define constants outside of the package's "
+                                           "namespace,\n    "
+                                           "but must still respect its enclosing package's imports.",
+                                           "# packaged: false");
                         }
                     }
+                } else if (importedAsTest) {
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
+                        e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
+                        auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
+                        if (auto exp = this->package.addImport(ctx, pkg, false)) {
+                            e.addAutocorrect(std::move(exp.value()));
+                        }
+                        e.addErrorLine(pkg.declLoc(), "Defined here");
+                    }
                 } else {
-                    // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
-                    // layering/strict_dependencies issues.
+                    ENFORCE(false);
+                }
+            } else {
+                // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
+                // layering/strict_dependencies issues.
+                // TODO(neil): Maybe we should use a new error code for this case?
+                if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
                     std::vector<std::string> reasons;
                     if (causesCycle) {
                         reasons.emplace_back(core::ErrorColors::format("importing it would put `{}` into a cycle",
@@ -531,29 +550,18 @@ public:
                     } else {
                         ENFORCE(false, "At most three reasons should be present");
                     }
-                    e.setHeader("`{}` resolves but its package is not imported. However, it cannot be automatically "
-                                "imported because {}",
-                                lit.symbol().show(ctx), reason);
+                    if (wasNotImported) {
+                        e.setHeader("`{}` resolves but its package is not imported. However, it cannot be "
+                                    "automatically imported because {}",
+                                    lit.symbol().show(ctx), reason);
+                    } else if (importedAsTest) {
+                        e.setHeader("Used `{}` constant `{}` in non-test file. However, it cannot be automatically "
+                                    "imported because {}",
+                                    "test_import", litSymbol.show(ctx), reason);
+                    } else {
+                        ENFORCE(false);
+                    }
                 }
-
-                if (!ctx.file.data(ctx).isPackaged()) {
-                    e.addErrorNote(
-                        "A `{}` file is allowed to define constants outside of the package's namespace,\n    "
-                        "but must still respect its enclosing package's imports.",
-                        "# packaged: false");
-                }
-            }
-        } else if (*importType == core::packages::ImportType::Test && !this->insideTestFile) {
-            // TODO(neil): we need to do the above "can't import if layering violation/strict_deps violation" check here
-            // too
-            // We used a symbol from a `test_import` in a non-test context
-            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
-                auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
-                if (auto exp = this->package.addImport(ctx, pkg, false)) {
-                    e.addAutocorrect(std::move(exp.value()));
-                }
-                e.addErrorLine(pkg.declLoc(), "Defined here");
             }
         }
     }

--- a/test/cli/package-autocorrect-missing-import/app_cycle_package_test/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/app_cycle_package_test/__package.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar::AppCyclePackageTest < PackageSpec
+  layer 'app'
+  strict_dependencies 'layered'
+
+  import Foo::Bar::AppCyclePackageTest::SubPackage
+  import Foo::MyPackage
+
+  export Foo::Bar::AppCyclePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/app_cycle_package_test/other_class.rb
+++ b/test/cli/package-autocorrect-missing-import/app_cycle_package_test/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::AppCyclePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/app_cycle_package_test/sub_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/app_cycle_package_test/sub_package/__package.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar::AppCyclePackageTest::SubPackage < PackageSpec
+  layer 'app'
+  strict_dependencies 'layered'
+  import Foo::Bar::AppCyclePackageTest
+end

--- a/test/cli/package-autocorrect-missing-import/app_false_cycle_package_test/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/app_false_cycle_package_test/__package.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar::AppFalseCyclePackageTest < PackageSpec
+  layer 'app'
+  strict_dependencies 'false'
+
+  import Foo::Bar::AppFalseCyclePackageTest::SubPackage
+  import Foo::MyPackage
+
+  export Foo::Bar::AppFalseCyclePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/app_false_cycle_package_test/other_class.rb
+++ b/test/cli/package-autocorrect-missing-import/app_false_cycle_package_test/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::AppFalseCyclePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/app_false_cycle_package_test/sub_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/app_false_cycle_package_test/sub_package/__package.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+
+class Foo::Bar::AppFalseCyclePackageTest::SubPackage < PackageSpec
+  layer 'lib'
+  strict_dependencies 'false'
+
+  import Foo::Bar::AppFalseCyclePackageTest
+end

--- a/test/cli/package-autocorrect-missing-import/app_package_test/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/app_package_test/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Foo::Bar::AppPackageTest < PackageSpec
+  layer 'app'
+  strict_dependencies 'layered'
+  export Foo::Bar::AppPackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/app_package_test/other_class.rb
+++ b/test/cli/package-autocorrect-missing-import/app_package_test/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::AppPackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/cycle_package_test/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/cycle_package_test/__package.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar::CyclePackageTest < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+
+  import Foo::Bar::CyclePackageTest::SubPackage
+  import Foo::MyPackage
+
+  export Foo::Bar::CyclePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/cycle_package_test/other_class.rb
+++ b/test/cli/package-autocorrect-missing-import/cycle_package_test/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::CyclePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/cycle_package_test/sub_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/cycle_package_test/sub_package/__package.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+
+class Foo::Bar::CyclePackageTest::SubPackage < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+
+  import Foo::Bar::CyclePackageTest
+end

--- a/test/cli/package-autocorrect-missing-import/false_and_app_package_test/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/false_and_app_package_test/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Foo::Bar::FalseAndAppPackageTest < PackageSpec
+  layer 'app'
+  strict_dependencies 'false'
+  export Foo::Bar::FalseAndAppPackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/false_and_app_package_test/other_class.rb
+++ b/test/cli/package-autocorrect-missing-import/false_and_app_package_test/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::FalseAndAppPackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/false_cycle_package_test/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/false_cycle_package_test/__package.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar::FalseCyclePackageTest < PackageSpec
+  layer 'lib'
+  strict_dependencies 'false'
+
+  import Foo::Bar::FalseCyclePackageTest::SubPackage
+  import Foo::MyPackage
+
+  export Foo::Bar::FalseCyclePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/false_cycle_package_test/other_class.rb
+++ b/test/cli/package-autocorrect-missing-import/false_cycle_package_test/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::FalseCyclePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/false_cycle_package_test/sub_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/false_cycle_package_test/sub_package/__package.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+
+class Foo::Bar::FalseCyclePackageTest::SubPackage < PackageSpec
+  layer 'lib'
+  strict_dependencies 'false'
+
+  import Foo::Bar::FalseCyclePackageTest
+end

--- a/test/cli/package-autocorrect-missing-import/false_package_test/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/false_package_test/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Foo::Bar::FalsePackageTest < PackageSpec
+  layer 'lib'
+  strict_dependencies 'false'
+  export Foo::Bar::FalsePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/false_package_test/other_class.rb
+++ b/test/cli/package-autocorrect-missing-import/false_package_test/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::FalsePackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/other_test/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/other_test/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Foo::Bar::OtherPackageTest < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  export Foo::Bar::OtherPackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/other_test/other_class.rb
+++ b/test/cli/package-autocorrect-missing-import/other_test/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::OtherPackageTest::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -123,15 +123,22 @@ use_app_package/foo.rb:7: `Foo::Bar::AppPackage::OtherClass` resolves but its pa
      4 |  layer 'app'
                 ^^^^^
 
-use_app_package/foo.rb:13: `Foo::Bar::AppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation https://srb.help/3718
-    13 |  Foo::Bar::AppPackage::OtherClass # resolves via root
+use_app_package/foo.rb:8: Used `test_import` constant `Foo::Bar::AppPackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would cause a layering violation https://srb.help/3718
+     8 |      Foo::Bar::AppPackageTest::OtherClass # resolves via root
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    app_package_test/__package.rb:4: Package `Foo::Bar::AppPackageTest` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     4 |  layer 'app'
+                ^^^^^
+
+use_app_package/foo.rb:14: `Foo::Bar::AppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation https://srb.help/3718
+    14 |  Foo::Bar::AppPackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     app_package/__package.rb:4: Package `Foo::Bar::AppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
      4 |  layer 'app'
                 ^^^^^
 
-use_app_package/foo.rb:15: `Test::Foo::Bar::AppPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
-    15 |  Test::Foo::Bar::AppPackage::TestUtil
+use_app_package/foo.rb:16: `Test::Foo::Bar::AppPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    16 |  Test::Foo::Bar::AppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_app_package/foo.test.rb:4: `Test::Foo::Bar::AppPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
@@ -155,7 +162,7 @@ use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage::ImportMeTestOnly` resolves
     use_app_package/__package.rb:7: Inserted `test_import Foo::Bar::AppPackage`
      7 |  strict_dependencies 'layered'
                                        ^
-Errors: 6
+Errors: 7
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -164,6 +171,7 @@ class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered'
   test_import Foo::Bar::AppPackage
+  test_import Foo::Bar::AppPackageTest
 end
 
 --------------------------------------------------------------------------

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -1,23 +1,23 @@
-use_other_package/foo.rb:15: Unable to resolve constant `MyClass` https://srb.help/5002
-    15 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
+use_other_package/foo.rb:16: Unable to resolve constant `MyClass` https://srb.help/5002
+    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
           ^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    use_other_package/foo.rb:15: Replaced with `Class`
-    15 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
+    use_other_package/foo.rb:16: Replaced with `Class`
+    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
           ^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#LCENSORED: `Class` defined here
     NN |class Class < Module
         ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    use_other_package/foo.rb:15: Replaced with `T::Class`
-    15 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
+    use_other_package/foo.rb:16: Replaced with `T::Class`
+    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
           ^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#LCENSORED: `T::Class` defined here
       NN |module T::Class
           ^^^^^^^^^^^^^^^
   Autocorrect: Done
-    use_other_package/foo.rb:15: Replaced with `Digest::Class`
-    15 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
+    use_other_package/foo.rb:16: Replaced with `Digest::Class`
+    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
           ^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/digest.rbi#LCENSORED: `Digest::Class` defined here
       NN |class Digest::Class
@@ -45,8 +45,22 @@ use_other_package/foo.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but it
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
-    14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
+use_other_package/foo.rb:9: Used `test_import` constant `Foo::Bar::OtherPackageTest::OtherClass` in non-test file https://srb.help/3720
+     9 |      Foo::Bar::OtherPackageTest::OtherClass
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    use_other_package/__package.rb:7: Inserted `import Foo::Bar::OtherPackageTest`
+     7 |  strict_dependencies 'layered'
+                                       ^
+    use_other_package/__package.rb:8: Deleted
+     8 |  test_import Foo::Bar::OtherPackageTest
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other_test/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackageTest < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+    15 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Exported from package here
      3 |class Foo::Bar::OtherPackage < PackageSpec
@@ -56,8 +70,8 @@ use_other_package/foo.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but i
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:17: `Test::Foo::Bar::OtherPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
-    17 |  Test::Foo::Bar::OtherPackage::TestUtil
+use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    18 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
@@ -81,7 +95,7 @@ use_other_package/foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` reso
     use_other_package/__package.rb:7: Inserted `test_import Foo::Bar::OtherPackage`
      7 |  strict_dependencies 'layered'
                                        ^
-Errors: 7
+Errors: 8
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -90,6 +104,7 @@ class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered'
   import Foo::Bar::OtherPackage
+
 end
 
 --------------------------------------------------------------------------

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -488,8 +488,18 @@ use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackage::OtherClass` reso
      7 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_cycle_package/foo.rb:13: `Foo::Bar::FalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and its `strict_dependencies` is too low https://srb.help/3718
-    13 |  Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
+use_false_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::FalseCyclePackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and its `strict_dependencies` is too low https://srb.help/3718
+     8 |      Foo::Bar::FalseCyclePackageTest::OtherClass # resolves via root
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+    false_cycle_package_test/__package.rb:7: `Foo::Bar::FalseCyclePackageTest` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     7 |  strict_dependencies 'false'
+                              ^^^^^^^
+
+use_false_cycle_package/foo.rb:14: `Foo::Bar::FalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and its `strict_dependencies` is too low https://srb.help/3718
+    14 |  Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
      7 |  strict_dependencies 'layered_dag'
@@ -498,8 +508,8 @@ use_false_cycle_package/foo.rb:13: `Foo::Bar::FalseCyclePackage::OtherClass` res
      7 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_cycle_package/foo.rb:15: `Test::Foo::Bar::FalseCyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
-    15 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
+use_false_cycle_package/foo.rb:16: `Test::Foo::Bar::FalseCyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    16 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::FalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
@@ -523,7 +533,7 @@ use_false_cycle_package/foo.test.rb:6: `Foo::Bar::FalseCyclePackage::ImportMeTes
     use_false_cycle_package/__package.rb:7: Inserted `test_import Foo::Bar::FalseCyclePackage`
      7 |  strict_dependencies 'layered_dag'
                                            ^
-Errors: 6
+Errors: 7
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -532,6 +542,7 @@ class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
   test_import Foo::Bar::FalseCyclePackage
+  test_import Foo::Bar::FalseCyclePackageTest
 end
 
 --------------------------------------------------------------------------

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -243,7 +243,7 @@ end
 
 --------------------------------------------------------------------------
 
-use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation and its `strict_dependencies` is too low https://srb.help/3718
+use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation, and its `strict_dependencies` is too low https://srb.help/3718
      6 |      Foo::Bar::FalseAndAppPackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_and_app_package/__package.rb:4: Package `Foo::Bar::FalseAndAppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
@@ -253,7 +253,7 @@ use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage::OtherClass` r
      5 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation and its `strict_dependencies` is too low https://srb.help/3718
+use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation, and its `strict_dependencies` is too low https://srb.help/3718
      7 |      Bar::FalseAndAppPackage::OtherClass # resolves via `module Foo`
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_and_app_package/__package.rb:4: Package `Foo::Bar::FalseAndAppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
@@ -263,7 +263,7 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackage::OtherClass` r
      5 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_and_app_package/foo.rb:8: Used `test_import` constant `Foo::Bar::FalseAndAppPackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would cause a layering violation and its `strict_dependencies` is too low https://srb.help/3718
+use_false_and_app_package/foo.rb:8: Used `test_import` constant `Foo::Bar::FalseAndAppPackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would cause a layering violation, and its `strict_dependencies` is too low https://srb.help/3718
      8 |      Foo::Bar::FalseAndAppPackageTest::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_and_app_package_test/__package.rb:4: Package `Foo::Bar::FalseAndAppPackageTest` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
@@ -273,7 +273,7 @@ use_false_and_app_package/foo.rb:8: Used `test_import` constant `Foo::Bar::False
      5 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_and_app_package/foo.rb:14: `Foo::Bar::FalseAndAppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation and its `strict_dependencies` is too low https://srb.help/3718
+use_false_and_app_package/foo.rb:14: `Foo::Bar::FalseAndAppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation, and its `strict_dependencies` is too low https://srb.help/3718
     14 |  Foo::Bar::FalseAndAppPackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_and_app_package/__package.rb:4: Package `Foo::Bar::FalseAndAppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
@@ -389,7 +389,7 @@ end
 
 --------------------------------------------------------------------------
 
-use_app_cycle_package/foo.rb:6: `Foo::Bar::AppCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and importing it would cause a layering violation https://srb.help/3718
+use_app_cycle_package/foo.rb:6: `Foo::Bar::AppCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3718
      6 |      Foo::Bar::AppCyclePackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
@@ -399,7 +399,7 @@ use_app_cycle_package/foo.rb:6: `Foo::Bar::AppCyclePackage::OtherClass` resolves
      6 |  layer 'app'
                 ^^^^^
 
-use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and importing it would cause a layering violation https://srb.help/3718
+use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3718
      7 |      Bar::AppCyclePackage::OtherClass # resolves via `module Foo`
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
@@ -409,7 +409,7 @@ use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackage::OtherClass` resolves
      6 |  layer 'app'
                 ^^^^^
 
-use_app_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::AppCyclePackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and importing it would cause a layering violation https://srb.help/3718
+use_app_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::AppCyclePackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3718
      8 |      Foo::Bar::AppCyclePackageTest::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
@@ -419,7 +419,7 @@ use_app_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::AppCycleP
      6 |  layer 'app'
                 ^^^^^
 
-use_app_cycle_package/foo.rb:14: `Foo::Bar::AppCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and importing it would cause a layering violation https://srb.help/3718
+use_app_cycle_package/foo.rb:14: `Foo::Bar::AppCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3718
     14 |  Foo::Bar::AppCyclePackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
@@ -468,7 +468,7 @@ end
 
 --------------------------------------------------------------------------
 
-use_false_cycle_package/foo.rb:6: `Foo::Bar::FalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and its `strict_dependencies` is too low https://srb.help/3718
+use_false_cycle_package/foo.rb:6: `Foo::Bar::FalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is too low https://srb.help/3718
      6 |      Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
@@ -478,7 +478,7 @@ use_false_cycle_package/foo.rb:6: `Foo::Bar::FalseCyclePackage::OtherClass` reso
      7 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and its `strict_dependencies` is too low https://srb.help/3718
+use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is too low https://srb.help/3718
      7 |      Bar::FalseCyclePackage::OtherClass # resolves via `module Foo`
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
@@ -488,7 +488,7 @@ use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackage::OtherClass` reso
      7 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::FalseCyclePackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and its `strict_dependencies` is too low https://srb.help/3718
+use_false_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::FalseCyclePackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is too low https://srb.help/3718
      8 |      Foo::Bar::FalseCyclePackageTest::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
@@ -498,7 +498,7 @@ use_false_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::FalseCy
      7 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_cycle_package/foo.rb:14: `Foo::Bar::FalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and its `strict_dependencies` is too low https://srb.help/3718
+use_false_cycle_package/foo.rb:14: `Foo::Bar::FalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is too low https://srb.help/3718
     14 |  Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -263,8 +263,18 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackage::OtherClass` r
      5 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_and_app_package/foo.rb:13: `Foo::Bar::FalseAndAppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation and its `strict_dependencies` is too low https://srb.help/3718
-    13 |  Foo::Bar::FalseAndAppPackage::OtherClass # resolves via root
+use_false_and_app_package/foo.rb:8: Used `test_import` constant `Foo::Bar::FalseAndAppPackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would cause a layering violation and its `strict_dependencies` is too low https://srb.help/3718
+     8 |      Foo::Bar::FalseAndAppPackageTest::OtherClass # resolves via root
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    false_and_app_package_test/__package.rb:4: Package `Foo::Bar::FalseAndAppPackageTest` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     4 |  layer 'app'
+                ^^^^^
+    false_and_app_package_test/__package.rb:5: `Foo::Bar::FalseAndAppPackageTest` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     5 |  strict_dependencies 'false'
+                              ^^^^^^^
+
+use_false_and_app_package/foo.rb:14: `Foo::Bar::FalseAndAppPackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would cause a layering violation and its `strict_dependencies` is too low https://srb.help/3718
+    14 |  Foo::Bar::FalseAndAppPackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_and_app_package/__package.rb:4: Package `Foo::Bar::FalseAndAppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
      4 |  layer 'app'
@@ -273,8 +283,8 @@ use_false_and_app_package/foo.rb:13: `Foo::Bar::FalseAndAppPackage::OtherClass` 
      5 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_and_app_package/foo.rb:15: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
-    15 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
+use_false_and_app_package/foo.rb:16: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    16 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_false_and_app_package/foo.test.rb:4: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
@@ -298,7 +308,7 @@ use_false_and_app_package/foo.test.rb:6: `Foo::Bar::FalseAndAppPackage::ImportMe
     use_false_and_app_package/__package.rb:7: Inserted `test_import Foo::Bar::FalseAndAppPackage`
      7 |  strict_dependencies 'layered'
                                        ^
-Errors: 6
+Errors: 7
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -307,6 +317,7 @@ class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered'
   test_import Foo::Bar::FalseAndAppPackage
+  test_import Foo::Bar::FalseAndAppPackageTest
 end
 
 --------------------------------------------------------------------------

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -336,15 +336,22 @@ use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackage::OtherClass` resolves but it
      7 |  strict_dependencies 'layered_dag'
                               ^^^^^^^^^^^^^
 
-use_cycle_package/foo.rb:13: `Foo::Bar::CyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle https://srb.help/3718
-    13 |  Foo::Bar::CyclePackage::OtherClass # resolves via root
+use_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::CyclePackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle https://srb.help/3718
+     8 |      Foo::Bar::CyclePackageTest::OtherClass # resolves via root
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+
+use_cycle_package/foo.rb:14: `Foo::Bar::CyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle https://srb.help/3718
+    14 |  Foo::Bar::CyclePackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
      7 |  strict_dependencies 'layered_dag'
                               ^^^^^^^^^^^^^
 
-use_cycle_package/foo.rb:15: `Test::Foo::Bar::CyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
-    15 |  Test::Foo::Bar::CyclePackage::TestUtil
+use_cycle_package/foo.rb:16: `Test::Foo::Bar::CyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    16 |  Test::Foo::Bar::CyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_cycle_package/foo.test.rb:4: `Test::Foo::Bar::CyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
@@ -368,7 +375,7 @@ use_cycle_package/foo.test.rb:6: `Foo::Bar::CyclePackage::ImportMeTestOnly` reso
     use_cycle_package/__package.rb:7: Inserted `test_import Foo::Bar::CyclePackage`
      7 |  strict_dependencies 'layered_dag'
                                            ^
-Errors: 6
+Errors: 7
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -377,6 +384,7 @@ class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
   test_import Foo::Bar::CyclePackage
+  test_import Foo::Bar::CyclePackageTest
 end
 
 --------------------------------------------------------------------------

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -409,8 +409,18 @@ use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackage::OtherClass` resolves
      6 |  layer 'app'
                 ^^^^^
 
-use_app_cycle_package/foo.rb:13: `Foo::Bar::AppCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and importing it would cause a layering violation https://srb.help/3718
-    13 |  Foo::Bar::AppCyclePackage::OtherClass # resolves via root
+use_app_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::AppCyclePackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and importing it would cause a layering violation https://srb.help/3718
+     8 |      Foo::Bar::AppCyclePackageTest::OtherClass # resolves via root
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+    app_cycle_package_test/__package.rb:6: Package `Foo::Bar::AppCyclePackageTest` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     6 |  layer 'app'
+                ^^^^^
+
+use_app_cycle_package/foo.rb:14: `Foo::Bar::AppCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle and importing it would cause a layering violation https://srb.help/3718
+    14 |  Foo::Bar::AppCyclePackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
      7 |  strict_dependencies 'layered_dag'
@@ -419,8 +429,8 @@ use_app_cycle_package/foo.rb:13: `Foo::Bar::AppCyclePackage::OtherClass` resolve
      6 |  layer 'app'
                 ^^^^^
 
-use_app_cycle_package/foo.rb:15: `Test::Foo::Bar::AppCyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
-    15 |  Test::Foo::Bar::AppCyclePackage::TestUtil
+use_app_cycle_package/foo.rb:16: `Test::Foo::Bar::AppCyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    16 |  Test::Foo::Bar::AppCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_app_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
@@ -444,7 +454,7 @@ use_app_cycle_package/foo.test.rb:6: `Foo::Bar::AppCyclePackage::ImportMeTestOnl
     use_app_cycle_package/__package.rb:7: Inserted `test_import Foo::Bar::AppCyclePackage`
      7 |  strict_dependencies 'layered_dag'
                                            ^
-Errors: 6
+Errors: 7
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -453,6 +463,7 @@ class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
   test_import Foo::Bar::AppCyclePackage
+  test_import Foo::Bar::AppCyclePackageTest
 end
 
 --------------------------------------------------------------------------

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -190,15 +190,22 @@ use_false_package/foo.rb:7: `Foo::Bar::FalsePackage::OtherClass` resolves but it
      5 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_package/foo.rb:13: `Foo::Bar::FalsePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because its `strict_dependencies` is too low https://srb.help/3718
-    13 |  Foo::Bar::FalsePackage::OtherClass # resolves via root
+use_false_package/foo.rb:8: Used `test_import` constant `Foo::Bar::FalsePackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because its `strict_dependencies` is too low https://srb.help/3718
+     8 |      Foo::Bar::FalsePackageTest::OtherClass # resolves via root
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    false_package_test/__package.rb:5: `Foo::Bar::FalsePackageTest` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     5 |  strict_dependencies 'false'
+                              ^^^^^^^
+
+use_false_package/foo.rb:14: `Foo::Bar::FalsePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because its `strict_dependencies` is too low https://srb.help/3718
+    14 |  Foo::Bar::FalsePackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_package/__package.rb:5: `Foo::Bar::FalsePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
      5 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_false_package/foo.rb:15: `Test::Foo::Bar::FalsePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
-    15 |  Test::Foo::Bar::FalsePackage::TestUtil
+use_false_package/foo.rb:16: `Test::Foo::Bar::FalsePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    16 |  Test::Foo::Bar::FalsePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_false_package/foo.test.rb:4: `Test::Foo::Bar::FalsePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
@@ -222,7 +229,7 @@ use_false_package/foo.test.rb:6: `Foo::Bar::FalsePackage::ImportMeTestOnly` reso
     use_false_package/__package.rb:7: Inserted `test_import Foo::Bar::FalsePackage`
      7 |  strict_dependencies 'layered'
                                        ^
-Errors: 6
+Errors: 7
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -231,6 +238,7 @@ class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered'
   test_import Foo::Bar::FalsePackage
+  test_import Foo::Bar::FalsePackageTest
 end
 
 --------------------------------------------------------------------------

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -573,8 +573,21 @@ use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackage::OtherClas
      7 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_app_false_cycle_package/foo.rb:13: `Foo::Bar::AppFalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is too low https://srb.help/3718
-    13 |  Foo::Bar::AppFalseCyclePackage::OtherClass # resolves via root
+use_app_false_cycle_package/foo.rb:8: Used `test_import` constant `Foo::Bar::AppFalseCyclePackageTest::OtherClass` in non-test file. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is too low https://srb.help/3718
+     8 |      Foo::Bar::AppFalseCyclePackageTest::OtherClass # resolves via root
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+    app_false_cycle_package_test/__package.rb:6: Package `Foo::Bar::AppFalseCyclePackageTest` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     6 |  layer 'app'
+                ^^^^^
+    app_false_cycle_package_test/__package.rb:7: `Foo::Bar::AppFalseCyclePackageTest` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     7 |  strict_dependencies 'false'
+                              ^^^^^^^
+
+use_app_false_cycle_package/foo.rb:14: `Foo::Bar::AppFalseCyclePackage::OtherClass` resolves but its package is not imported. However, it cannot be automatically imported because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is too low https://srb.help/3718
+    14 |  Foo::Bar::AppFalseCyclePackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
      7 |  strict_dependencies 'layered_dag'
@@ -586,8 +599,8 @@ use_app_false_cycle_package/foo.rb:13: `Foo::Bar::AppFalseCyclePackage::OtherCla
      7 |  strict_dependencies 'false'
                               ^^^^^^^
 
-use_app_false_cycle_package/foo.rb:15: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
-    15 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
+use_app_false_cycle_package/foo.rb:16: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+    16 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_app_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
@@ -611,7 +624,7 @@ use_app_false_cycle_package/foo.test.rb:6: `Foo::Bar::AppFalseCyclePackage::Impo
     use_app_false_cycle_package/__package.rb:7: Inserted `test_import Foo::Bar::AppFalseCyclePackage`
      7 |  strict_dependencies 'layered_dag'
                                            ^
-Errors: 6
+Errors: 7
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -620,4 +633,5 @@ class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
   test_import Foo::Bar::AppFalseCyclePackage
+  test_import Foo::Bar::AppFalseCyclePackageTest
 end

--- a/test/cli/package-autocorrect-missing-import/test.sh
+++ b/test/cli/package-autocorrect-missing-import/test.sh
@@ -58,7 +58,7 @@ echo
 echo --------------------------------------------------------------------------
 echo
 
-"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 false_cycle_package use_false_cycle_package 2>&1
+"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 false_cycle_package false_cycle_package_test use_false_cycle_package 2>&1
 
 cat use_false_cycle_package/__package.rb
 

--- a/test/cli/package-autocorrect-missing-import/test.sh
+++ b/test/cli/package-autocorrect-missing-import/test.sh
@@ -50,7 +50,7 @@ echo
 echo --------------------------------------------------------------------------
 echo
 
-"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 app_cycle_package use_app_cycle_package 2>&1
+"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 app_cycle_package app_cycle_package_test use_app_cycle_package 2>&1
 
 cat use_app_cycle_package/__package.rb
 

--- a/test/cli/package-autocorrect-missing-import/test.sh
+++ b/test/cli/package-autocorrect-missing-import/test.sh
@@ -10,7 +10,7 @@ for file in $(find . -name '*.rb' | sort); do
 done
 cd "$tmp" || exit 1
 
-"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 other use_other_package 2>&1
+"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 other other_test use_other_package 2>&1
 
 cat use_other_package/__package.rb
 

--- a/test/cli/package-autocorrect-missing-import/test.sh
+++ b/test/cli/package-autocorrect-missing-import/test.sh
@@ -34,7 +34,7 @@ echo
 echo --------------------------------------------------------------------------
 echo
 
-"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 false_and_app_package use_false_and_app_package 2>&1
+"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 false_and_app_package false_and_app_package_test use_false_and_app_package 2>&1
 
 cat use_false_and_app_package/__package.rb
 

--- a/test/cli/package-autocorrect-missing-import/test.sh
+++ b/test/cli/package-autocorrect-missing-import/test.sh
@@ -26,7 +26,7 @@ echo
 echo --------------------------------------------------------------------------
 echo
 
-"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 false_package use_false_package 2>&1
+"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 false_package false_package_test use_false_package 2>&1
 
 cat use_false_package/__package.rb
 

--- a/test/cli/package-autocorrect-missing-import/test.sh
+++ b/test/cli/package-autocorrect-missing-import/test.sh
@@ -42,7 +42,7 @@ echo
 echo --------------------------------------------------------------------------
 echo
 
-"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 cycle_package use_cycle_package 2>&1
+"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 cycle_package cycle_package_test use_cycle_package 2>&1
 
 cat use_cycle_package/__package.rb
 

--- a/test/cli/package-autocorrect-missing-import/test.sh
+++ b/test/cli/package-autocorrect-missing-import/test.sh
@@ -18,7 +18,7 @@ echo
 echo --------------------------------------------------------------------------
 echo
 
-"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 app_package use_app_package 2>&1
+"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 app_package app_package_test use_app_package 2>&1
 
 cat use_app_package/__package.rb
 

--- a/test/cli/package-autocorrect-missing-import/test.sh
+++ b/test/cli/package-autocorrect-missing-import/test.sh
@@ -66,7 +66,7 @@ echo
 echo --------------------------------------------------------------------------
 echo
 
-"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 app_false_cycle_package use_app_false_cycle_package 2>&1
+"$cwd/main/sorbet" -a --censor-for-snapshot-tests --silence-dev-message --stripe-packages --packager-layers=lib,app --max-threads=0 app_false_cycle_package app_false_cycle_package_test use_app_false_cycle_package 2>&1
 
 cat use_app_false_cycle_package/__package.rb
 

--- a/test/cli/package-autocorrect-missing-import/use_app_cycle_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/use_app_cycle_package/__package.rb
@@ -5,4 +5,5 @@
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
+  test_import Foo::Bar::AppCyclePackageTest
 end

--- a/test/cli/package-autocorrect-missing-import/use_app_cycle_package/foo.rb
+++ b/test/cli/package-autocorrect-missing-import/use_app_cycle_package/foo.rb
@@ -5,6 +5,7 @@ module Foo
     class FooClass
       Foo::Bar::AppCyclePackage::OtherClass # resolves via root
       Bar::AppCyclePackage::OtherClass # resolves via `module Foo`
+      Foo::Bar::AppCyclePackageTest::OtherClass # resolves via root
     end
   end
 end

--- a/test/cli/package-autocorrect-missing-import/use_app_false_cycle_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/use_app_false_cycle_package/__package.rb
@@ -5,4 +5,5 @@
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
+  test_import Foo::Bar::AppFalseCyclePackageTest
 end

--- a/test/cli/package-autocorrect-missing-import/use_app_false_cycle_package/foo.rb
+++ b/test/cli/package-autocorrect-missing-import/use_app_false_cycle_package/foo.rb
@@ -5,6 +5,7 @@ module Foo
     class FooClass
       Foo::Bar::AppFalseCyclePackage::OtherClass # resolves via root
       Bar::AppFalseCyclePackage::OtherClass # resolves via `module Foo`
+      Foo::Bar::AppFalseCyclePackageTest::OtherClass # resolves via root
     end
   end
 end

--- a/test/cli/package-autocorrect-missing-import/use_app_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/use_app_package/__package.rb
@@ -5,4 +5,5 @@
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered'
+  test_import Foo::Bar::AppPackageTest
 end

--- a/test/cli/package-autocorrect-missing-import/use_app_package/foo.rb
+++ b/test/cli/package-autocorrect-missing-import/use_app_package/foo.rb
@@ -5,6 +5,7 @@ module Foo
     class FooClass
       Foo::Bar::AppPackage::OtherClass # resolves via root
       Bar::AppPackage::OtherClass # resolves via `module Foo`
+      Foo::Bar::AppPackageTest::OtherClass # resolves via root
     end
   end
 end

--- a/test/cli/package-autocorrect-missing-import/use_cycle_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/use_cycle_package/__package.rb
@@ -5,4 +5,5 @@
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
+  test_import Foo::Bar::CyclePackageTest
 end

--- a/test/cli/package-autocorrect-missing-import/use_cycle_package/foo.rb
+++ b/test/cli/package-autocorrect-missing-import/use_cycle_package/foo.rb
@@ -5,6 +5,7 @@ module Foo
     class FooClass
       Foo::Bar::CyclePackage::OtherClass # resolves via root
       Bar::CyclePackage::OtherClass # resolves via `module Foo`
+      Foo::Bar::CyclePackageTest::OtherClass # resolves via root
     end
   end
 end

--- a/test/cli/package-autocorrect-missing-import/use_false_and_app_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/use_false_and_app_package/__package.rb
@@ -5,4 +5,5 @@
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered'
+  test_import Foo::Bar::FalseAndAppPackageTest
 end

--- a/test/cli/package-autocorrect-missing-import/use_false_and_app_package/foo.rb
+++ b/test/cli/package-autocorrect-missing-import/use_false_and_app_package/foo.rb
@@ -5,6 +5,7 @@ module Foo
     class FooClass
       Foo::Bar::FalseAndAppPackage::OtherClass # resolves via root
       Bar::FalseAndAppPackage::OtherClass # resolves via `module Foo`
+      Foo::Bar::FalseAndAppPackageTest::OtherClass # resolves via root
     end
   end
 end

--- a/test/cli/package-autocorrect-missing-import/use_false_cycle_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/use_false_cycle_package/__package.rb
@@ -5,4 +5,5 @@
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
+  test_import Foo::Bar::FalseCyclePackageTest
 end

--- a/test/cli/package-autocorrect-missing-import/use_false_cycle_package/foo.rb
+++ b/test/cli/package-autocorrect-missing-import/use_false_cycle_package/foo.rb
@@ -5,6 +5,7 @@ module Foo
     class FooClass
       Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
       Bar::FalseCyclePackage::OtherClass # resolves via `module Foo`
+      Foo::Bar::FalseCyclePackageTest::OtherClass # resolves via root
     end
   end
 end

--- a/test/cli/package-autocorrect-missing-import/use_false_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/use_false_package/__package.rb
@@ -5,4 +5,5 @@
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered'
+  test_import Foo::Bar::FalsePackageTest
 end

--- a/test/cli/package-autocorrect-missing-import/use_false_package/foo.rb
+++ b/test/cli/package-autocorrect-missing-import/use_false_package/foo.rb
@@ -5,6 +5,7 @@ module Foo
     class FooClass
       Foo::Bar::FalsePackage::OtherClass # resolves via root
       Bar::FalsePackage::OtherClass # resolves via `module Foo`
+      Foo::Bar::FalsePackageTest::OtherClass # resolves via root
     end
   end
 end

--- a/test/cli/package-autocorrect-missing-import/use_other_package/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/use_other_package/__package.rb
@@ -5,4 +5,5 @@
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered'
+  test_import Foo::Bar::OtherPackageTest
 end

--- a/test/cli/package-autocorrect-missing-import/use_other_package/foo.rb
+++ b/test/cli/package-autocorrect-missing-import/use_other_package/foo.rb
@@ -6,6 +6,7 @@ module Foo
     class FooClass
       Foo::Bar::OtherPackage::OtherClass # resolves via root
       Bar::OtherPackage::OtherClass # resolves via `module Foo`
+      Foo::Bar::OtherPackageTest::OtherClass
     end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

#8469, #8529 and #8647 made it so that we wouldn't suggest an autocorrect to add import if it would cause a layering violation or strict deps violation, but we would still suggest one if it was imported as a `test_import` and it was used in a non test file. This fixes that.

Conceptually, you can think of it as flipping the order of the checks: previously, we'd check if the package wasn't imported, or if it was imported as `test_import`, and then in the case it wasn't imported, we'd check if importing it will cause a layering violation/strict deps error. Now, we check for layering/strict deps first, and then check for if it wasn't imported or was imported as `test_import`.

Easiest to review in split with with `?w=1` and commit-by-commit (all the test commits are basically the same, just checking for a different case in each).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Don't give autocorrects that would lead to another error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
