### PR TITLE
Remove a redundant `readFile`

### DIFF
--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -32,9 +32,7 @@ UnorderedMap<FileRef, string> AutocorrectSuggestion::apply(const GlobalState &gs
     for (auto &autocorrect : autocorrects) {
         for (auto &edit : autocorrect.edits) {
             auto file = edit.loc.file();
-            if (!sources.count(file)) {
-                sources[file] = fs.readFile(string(file.data(gs).path()));
-            }
+            sources.emplace(file, file.data(gs).source());
         }
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The `core::File` objects already have the whole source in
memory--there's no need to go read the file from disk again.

I tried to trace the history of this, and it looks like we've been
reading the file from disk as far back as the autocorrect option
existed, see cb6bc7afcc521ed347f9bf94016be84fbdadf503.

Stripe employees can see the original PR review here:

<http://go/si/sorbet/pull/1257>

There's no discussion of the `FileOps::read` call that was added in that
PR. Also, the `core::File` object for sure had the `string source_`
field at that point already.

The only argument I can think in favor of making autocorrects work this
way (read the file again) is that maybe between when Sorbet started and
when Sorbet decided to flush an autocorrect, the file had been modified
on disk, possibly in a way that was benign for the sake of the
autocorrect? E.g. maybe you added content at the end of a file: the
autocorrect's offset still applies cleanly, and by re-reading the file
you don't accidentally clobber an edit that's been made.

That behavior is possibly worth preserving? But I wanted to open a PR to
at least have the discussion.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.