### PR TITLE
Prevent creating files larger than 2^31 bytes

### DIFF
--- a/core/Loc.h
+++ b/core/Loc.h
@@ -73,12 +73,13 @@ public:
     }
 
     inline Loc(FileRef file, uint32_t begin, uint32_t end) : storage{{begin, end}, file} {
-        ENFORCE_NO_TIMER(begin <= INVALID_POS_LOC);
-        ENFORCE_NO_TIMER(end <= INVALID_POS_LOC);
+        ENFORCE_NO_TIMER(storage.offsets.exists());
         ENFORCE_NO_TIMER(begin <= end);
     }
 
-    inline Loc(FileRef file, LocOffsets offsets) : Loc(file, offsets.beginPos(), offsets.endPos()){};
+    inline Loc(FileRef file, LocOffsets offsets) : storage{offsets, file} {
+        ENFORCE_NO_TIMER(offsets.beginPos() <= offsets.endPos());
+    }
 
     Loc() : Loc(0, LocOffsets::none()){};
 

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -74,12 +74,9 @@ public:
 
     inline Loc(FileRef file, uint32_t begin, uint32_t end) : storage{{begin, end}, file} {
         ENFORCE_NO_TIMER(storage.offsets.exists());
-        ENFORCE_NO_TIMER(begin <= end);
     }
 
-    inline Loc(FileRef file, LocOffsets offsets) : storage{offsets, file} {
-        ENFORCE_NO_TIMER(offsets.beginPos() <= offsets.endPos());
-    }
+    inline Loc(FileRef file, LocOffsets offsets) : storage{offsets, file} {}
 
     Loc() : Loc(0, LocOffsets::none()){};
 

--- a/core/LocOffsets.h
+++ b/core/LocOffsets.h
@@ -27,6 +27,13 @@ struct LocOffsets {
         ENFORCE_NO_TIMER(exists());
         return beginLoc == endLoc;
     }
+
+    LocOffsets() : beginLoc(INVALID_POS_LOC), endLoc(INVALID_POS_LOC) {}
+
+    LocOffsets(uint32_t beginLoc, uint32_t endLoc) : beginLoc(beginLoc), endLoc(endLoc) {
+        ENFORCE_NO_TIMER(beginLoc <= endLoc);
+    }
+
     static LocOffsets none() {
         return LocOffsets{INVALID_POS_LOC, INVALID_POS_LOC};
     }

--- a/core/LocOffsets.h
+++ b/core/LocOffsets.h
@@ -28,9 +28,9 @@ struct LocOffsets {
         return beginLoc == endLoc;
     }
 
-    LocOffsets() : beginLoc(INVALID_POS_LOC), endLoc(INVALID_POS_LOC) {}
+    LocOffsets() : beginLoc{INVALID_POS_LOC}, endLoc{INVALID_POS_LOC} {}
 
-    LocOffsets(uint32_t beginLoc, uint32_t endLoc) : beginLoc(beginLoc), endLoc(endLoc) {
+    LocOffsets(uint32_t beginLoc, uint32_t endLoc) : beginLoc{beginLoc}, endLoc{endLoc} {
         ENFORCE_NO_TIMER(beginLoc <= endLoc);
     }
 

--- a/core/LocOffsets.h
+++ b/core/LocOffsets.h
@@ -9,7 +9,7 @@ class GlobalState;
 class Context;
 class MutableContext;
 
-constexpr int INVALID_POS_LOC = 0xfffffff;
+constexpr uint32_t INVALID_POS_LOC = UINT32_MAX;
 struct LocOffsets {
     uint32_t beginLoc = INVALID_POS_LOC;
     uint32_t endLoc = INVALID_POS_LOC;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

... also shuffles around some of the ENFORCE logic in Files.cc and Loc{,Offsets}

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I got down a rabbit hole trying to fix a bug with leading spaces in a packager autocorrect last week, and now I'm unwinding the stack.

The stack looked something like

- I want to fix the start-of-line leading whitespace in the autocorrect
  - I want to factor a helper for finding the start of line
    - The `lineBreaks` vector uses `int` instead of `uint32_t` like the rest of the LocOffsets code?
      - Wait, `INVALID_POS_LOC` uses `int` instead of `uint32_t` like the rest of `LocOffsets` code?
        - Wait, we don't actually check whether files have fewer than `2 ^ 32` bytes? Do we really not have a ~4 GB generated file in Stripe's codebase somewhere? Turns out we don't
          - Should we check this assumption all the time? Maybe it adds an unnecessary branch in a hot codepath and we should just let things fail, because we can't recover from it anyways?
      - Should we factor a helper type alias for the type of a position, so that we can use that everywhere?


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested on Stripe's codebase, and wrote some static assertions.