### PR TITLE
Revert "Propagate packager options when copying GlobalState"

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2199,7 +2199,6 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->onlyErrorClasses = this->onlyErrorClasses;
     result->suggestUnsafe = this->suggestUnsafe;
     result->pathPrefix = this->pathPrefix;
-    result->packageDB_ = this->packageDB_.emptyCopyWithOptions();
 
     return result;
 }

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -276,19 +276,11 @@ bool PackageDB::allowRelaxedPackagerChecksFor(MangledName mangledName) const {
 
 PackageDB PackageDB::deepCopy() const {
     ENFORCE(frozen);
-    auto result = this->emptyCopyWithOptions();
-
+    PackageDB result;
     result.packages_.reserve(this->packages_.size());
     for (auto const &[nr, pkgInfo] : this->packages_) {
         result.packages_[nr] = pkgInfo->deepCopy();
     }
-
-    return result;
-}
-
-PackageDB PackageDB::emptyCopyWithOptions() const {
-    ENFORCE(frozen);
-    PackageDB result;
     result.enabled_ = this->enabled_;
     result.extraPackageFilesDirectoryUnderscorePrefixes_ = this->extraPackageFilesDirectoryUnderscorePrefixes_;
     result.extraPackageFilesDirectorySlashDeprecatedPrefixes_ =

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -48,7 +48,6 @@ public:
     absl::Span<const MangledName> packages() const;
 
     PackageDB deepCopy() const;
-    PackageDB emptyCopyWithOptions() const;
 
     UnfreezePackages unfreeze();
 

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -33,8 +33,6 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
     gs.ruby3KeywordArgs = options.ruby3KeywordArgs;
     gs.typedSuper = options.typedSuper;
     gs.suppressPayloadSuperclassRedefinitionFor = options.suppressPayloadSuperclassRedefinitionFor;
-    // We don't have to deal with packager-specific options here, as those will be handled later by
-    // the pipeline code that decides whether to run the packager at all.
 
     // Ensure LSP is enabled.
     options.runLSP = true;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -765,6 +765,7 @@ void setPackagerOptions(core::GlobalState &gs, const options::Options &opts) {
 }
 
 // packager intentionally runs outside of rewriter so that its output does not get cached.
+// TODO(jez) How much of this still needs to be outside of rewriter?
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
@@ -961,9 +962,7 @@ ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, a
 ast::ParsedFilesOrCancelled nameAndResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
                                            const options::Options &opts, WorkerPool &workers,
                                            core::FoundDefHashes *foundHashes) {
-    package(gs, absl::MakeSpan(what), opts, workers);
-
-    auto canceled = name(gs, absl::MakeSpan(what), opts, workers, foundHashes);
+    auto canceled = name(gs, absl::Span<ast::ParsedFile>(what), opts, workers, foundHashes);
     if (canceled) {
         return ast::ParsedFilesOrCancelled::cancel(move(what), workers);
     }


### PR DESCRIPTION
Reverts sorbet/sorbet#8634

This seems to have caused a substantial spike in memory usage.