### PR TITLE
remove `TimeoutError` alias from the `timeout` gem

### DIFF
--- a/rbi/stdlib/timeout.rbi
+++ b/rbi/stdlib/timeout.rbi
@@ -103,8 +103,3 @@ class Timeout::Error < RuntimeError
   sig {returns(::T.untyped)}
   def thread(); end
 end
-
-# Raised by
-# [`Timeout.timeout`](https://docs.ruby-lang.org/en/2.7.0/Timeout.html#method-c-timeout)
-# when the block times out.
-TimeoutError = Timeout::Error


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This alias was removed four years ago:

https://github.com/ruby/timeout/pull/2

and newer versions of the gem have a significantly more efficient implementation strategy, so we should be using that instead.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
