### PR TITLE
Remove duplicate call to GlobalState::setPackagerOptions

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1223,6 +1223,10 @@ void readOptions(Options &opts,
         }
 
         opts.packageRBIGeneration = raw["package-rbi-generation"].as<bool>();
+        if (opts.packageRBIGeneration && !opts.stripePackages) {
+            logger->error("--stripe-packages-hint-message can only be specified in --stripe-packages mode");
+            throw EarlyReturnWithCode(1);
+        }
 
         opts.packageRBIDir = raw["package-rbi-dir"].as<string>();
         if (!opts.packageRBIDir.empty()) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -592,6 +592,7 @@ int realmain(int argc, char *argv[]) {
                 logger->error("Cannot serialize package RBIs in legacy stripe packages mode.");
                 return 1;
             }
+            opts.stripePackages = true;
 
             if (opts.packageRBIDir.empty()) {
                 logger->error("Rbi generation requires --package-rbi-dir to be present");
@@ -632,15 +633,7 @@ int realmain(int argc, char *argv[]) {
             // seconds.
             auto packageFileRefs = pipeline::reserveFiles(*gs, packageFiles);
             auto packages = pipeline::index(*gs, absl::Span<core::FileRef>(packageFileRefs), opts, *workers, nullptr);
-            {
-                core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
-                core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-                gs->setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,
-                                       opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                                       opts.extraPackageFilesDirectorySlashPrefixes,
-                                       opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor,
-                                       opts.packagerLayers, opts.stripePackagesHint);
-            }
+            pipeline::setPackagerOptions(*gs, opts);
 
             packager::Packager::findPackages(*gs, absl::Span<ast::ParsedFile>(packages));
             packager::Packager::setPackageNameOnFiles(*gs, packages);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -588,12 +588,6 @@ int realmain(int argc, char *argv[]) {
 #else
             Timer rbiGenTimer(logger, "rbiGeneration.setup");
 
-            if (opts.stripePackages) {
-                logger->error("Cannot serialize package RBIs in legacy stripe packages mode.");
-                return 1;
-            }
-            opts.stripePackages = true;
-
             if (opts.packageRBIDir.empty()) {
                 logger->error("Rbi generation requires --package-rbi-dir to be present");
                 return 1;

--- a/test/cli/rbi-gen-single/test.sh
+++ b/test/cli/rbi-gen-single/test.sh
@@ -39,6 +39,7 @@ find . -name __package.rb | sort | while read -r package; do
 
   "$sorbet" --silence-dev-message \
     --ignore=__package.rb \
+    --stripe-packages \
     --package-rbi-generation \
     --package-rbi-dir="$rbis" \
     --extra-package-files-directory-prefix-underscore="${test_path}/other/" \

--- a/test/rbi_gen_package_runner.cc
+++ b/test/rbi_gen_package_runner.cc
@@ -271,6 +271,7 @@ int main(int argc, char **argv) {
                       {
                           "--silence-dev-message",
                           "--uniquely-defined-behavior",
+                          "--stripe-packages",
                           "--package-rbi-generation",
                           "--package-rbi-dir",
                           rbiPackageDir,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Trying to consolidate our option parsing in service of two eventual goals:

- Making something like "semantic/typechecking options" which invalidates the
  cache when these options change.
- Ensure that we set the packager options in the right place so that when we
  move package creation into namer, that the single-file hashing logic agrees
  with the rest of the pipeline on whether the packager is enabled.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is only used by package RBI generation, which has exactly one test and
honestly I don't even think it works in its current state. (Separately, I'd
rather just delete this code because I don't see us depending on this code
ever, but that's a separate question).