### PR TITLE
Factor all the code to `runAutogen`

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -203,8 +203,8 @@ void addInlineInput(const string &input, const string &filename, vector<core::Fi
 
 #ifdef SORBET_REALMAIN_MIN
 
-void runAutogen(const core::GlobalState &gs, options::Options &opts, const autogen::AutogenConfig &autogenCfg,
-                WorkerPool &workers, vector<ast::ParsedFile> &indexed) {
+void runAutogen(const core::GlobalState &gs, options::Options &opts, WorkerPool &workers,
+                vector<ast::ParsedFile> &indexed) {
     Exception::raise("Autogen is disabled in sorbet-orig for faster builds");
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes it easier to follow the main pipeline (index, name, resolve,
typecheck) without having to have the code for autogen spliced into the
middle (taking up screen real-estate).

It comes at the expense of having two definitions of `runAutogen`, one
which raises, but I think that's fine.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.