### PR TITLE
Remove the warning about mimalloc's MI_INSTALL_TOPLEVEL option

### DIFF
--- a/third_party/mimalloc.BUILD
+++ b/third_party/mimalloc.BUILD
@@ -6,14 +6,6 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-# The MI_INSTALL_TOPLEVEL CMake flag is deprecated
-# https://github.com/microsoft/mimalloc/blob/4e50d6714d471b72b2285e25a3df6c92db944593/CMakeLists.txt#L33
-# this could break at any point. The current default
-# behavior is to append the mimalloc version. Eg:
-# out_static_libs = ["mimalloc-2.1/libmimalloc.a"]
-# If this flag breaks in the future, you may want to
-# either hard-code the version or be more clever.
-# find the static library in bazel-out to debug
 cmake(
     name = "mimalloc_lib",
     cache_entries = {


### PR DESCRIPTION
The `MI_INSTALL_TOPLEVEL` config option was [un-deprecated in 2023](https://github.com/microsoft/mimalloc/issues/737), so we can remove our warning about it potentially disappearing in the future.

### Motivation
Cleaning up comments.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a Comments only.
