### PR TITLE
Factor out a copyOptions method on GlobalState

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2074,25 +2074,36 @@ bool GlobalState::unfreezeSymbolTable() {
     return old;
 }
 
+void GlobalState::copyOptions(const core::GlobalState &other) {
+    this->silenceErrors = other.silenceErrors;
+    this->autocorrect = other.autocorrect;
+    this->didYouMean = other.didYouMean;
+    this->ensureCleanStrings = other.ensureCleanStrings;
+    this->runningUnderAutogen = other.runningUnderAutogen;
+    this->censorForSnapshotTests = other.censorForSnapshotTests;
+    this->sleepInSlowPathSeconds = other.sleepInSlowPathSeconds;
+    this->rbsSignaturesEnabled = other.rbsSignaturesEnabled;
+    this->requiresAncestorEnabled = other.requiresAncestorEnabled;
+    this->ruby3KeywordArgs = other.ruby3KeywordArgs;
+    this->typedSuper = other.typedSuper;
+    this->suppressPayloadSuperclassRedefinitionFor = other.suppressPayloadSuperclassRedefinitionFor;
+    this->trackUntyped = other.trackUntyped;
+    this->printingFileTable = other.printingFileTable;
+    this->errorUrlBase = other.errorUrlBase;
+    this->includeErrorSections = other.includeErrorSections;
+    this->ignoredForSuggestTypedErrorClasses = other.ignoredForSuggestTypedErrorClasses;
+    this->suppressedErrorClasses = other.suppressedErrorClasses;
+    this->onlyErrorClasses = other.onlyErrorClasses;
+    this->suggestUnsafe = other.suggestUnsafe;
+    this->pathPrefix = other.pathPrefix;
+}
+
 unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     Timer timeit(tracer(), "GlobalState::deepCopy", this->creation);
     this->sanityCheck();
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
-    result->silenceErrors = this->silenceErrors;
-    result->autocorrect = this->autocorrect;
-    result->didYouMean = this->didYouMean;
-    result->ensureCleanStrings = this->ensureCleanStrings;
-    result->runningUnderAutogen = this->runningUnderAutogen;
-    result->censorForSnapshotTests = this->censorForSnapshotTests;
-    result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
-    result->rbsSignaturesEnabled = this->rbsSignaturesEnabled;
-    result->requiresAncestorEnabled = this->requiresAncestorEnabled;
-    result->ruby3KeywordArgs = this->ruby3KeywordArgs;
-    result->typedSuper = this->typedSuper;
-    result->suppressPayloadSuperclassRedefinitionFor = this->suppressPayloadSuperclassRedefinitionFor;
-    result->trackUntyped = this->trackUntyped;
-    result->printingFileTable = this->printingFileTable;
+    result->copyOptions(*this);
 
     if (keepId) {
         result->globalStateId = this->globalStateId;
@@ -2107,12 +2118,6 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->lspQuery = this->lspQuery;
     result->kvstoreUuid = this->kvstoreUuid;
     result->lspTypecheckCount = this->lspTypecheckCount;
-    result->errorUrlBase = this->errorUrlBase;
-    result->includeErrorSections = this->includeErrorSections;
-    result->ignoredForSuggestTypedErrorClasses = this->ignoredForSuggestTypedErrorClasses;
-    result->suppressedErrorClasses = this->suppressedErrorClasses;
-    result->onlyErrorClasses = this->onlyErrorClasses;
-    result->suggestUnsafe = this->suggestUnsafe;
     result->utf8Names.reserve(this->utf8Names.capacity());
     result->constantNames.reserve(this->constantNames.capacity());
     result->uniqueNames.reserve(this->uniqueNames.capacity());
@@ -2159,7 +2164,6 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     for (auto &sym : this->typeMembers) {
         result->typeMembers.emplace_back(sym.deepCopy(*result));
     }
-    result->pathPrefix = this->pathPrefix;
     for (auto &semanticExtension : this->semanticExtensions) {
         result->semanticExtensions.emplace_back(semanticExtension->deepCopy(*this, *result));
     }
@@ -2176,29 +2180,12 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     result->initEmpty();
+    result->copyOptions(*this);
 
-    // Options that might be used during indexing are manually copied over here
+    // Additional options that might be used during indexing are manually copied over here
     result->files = this->files;
     result->fileRefByPath = this->fileRefByPath;
-    result->silenceErrors = this->silenceErrors;
-    result->autocorrect = this->autocorrect;
-    result->didYouMean = this->didYouMean;
-    result->ensureCleanStrings = this->ensureCleanStrings;
-    result->runningUnderAutogen = this->runningUnderAutogen;
-    result->censorForSnapshotTests = this->censorForSnapshotTests;
-    result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
-    result->rbsSignaturesEnabled = this->rbsSignaturesEnabled;
-    result->requiresAncestorEnabled = this->requiresAncestorEnabled;
-    result->ruby3KeywordArgs = this->ruby3KeywordArgs;
-    result->typedSuper = this->typedSuper;
-    result->suppressPayloadSuperclassRedefinitionFor = this->suppressPayloadSuperclassRedefinitionFor;
-    result->trackUntyped = this->trackUntyped;
     result->kvstoreUuid = this->kvstoreUuid;
-    result->errorUrlBase = this->errorUrlBase;
-    result->suppressedErrorClasses = this->suppressedErrorClasses;
-    result->onlyErrorClasses = this->onlyErrorClasses;
-    result->suggestUnsafe = this->suggestUnsafe;
-    result->pathPrefix = this->pathPrefix;
 
     return result;
 }

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -373,6 +373,10 @@ private:
     bool symbolTableFrozen = true;
     bool fileTableFrozen = true;
 
+    // Copy options over from another GlobalState. Private, as it's only meant to be used as a helper to implement other
+    // copying strategies.
+    void copyOptions(const GlobalState &other);
+
     void expandNames(uint32_t utf8NameSize, uint32_t constantNameSize, uint32_t uniqueNameSize);
     void moveNames(Bucket *from, Bucket *to, unsigned int szFrom, unsigned int szTo);
 


### PR DESCRIPTION
Adds the private `GlobalState::copyOptions` method to ensure that `copyForIndex`
and `deepCopy` stay in sync on important options.

### Motivation
Refactoring to make it easier to add a new copy method in #8589.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a Refactoring only
