### PR TITLE
No need to check runningUnderAutogen in resolver

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -497,8 +497,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     // Detect if we would have reported an error
                     // Only do this transformation if we're sure that it would produce an error, so
                     // that we don't pay the performance cost of inflating the CFG needlessly.
-                    auto shouldReportErrorOn = cctx.ctx.state.shouldReportErrorOn(
-                        cctx.ctx.locAt(a.loc), core::errors::CFG::UndeclaredVariable);
+                    auto shouldReportErrorOn =
+                        cctx.ctx.state.shouldReportErrorOn(cctx.ctx.file, core::errors::CFG::UndeclaredVariable);
                     if (foundError && shouldReportErrorOn) {
                         auto zeroLoc = a.loc.copyWithZeroLength();
                         auto magic = ast::MK::Constant(zeroLoc, core::Symbols::Magic());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2250,7 +2250,7 @@ ErrorBuilder GlobalState::beginError(Loc loc, ErrorClass what) const {
     if (what == errors::Internal::InternalError) {
         Exception::failInFuzzer();
     }
-    return ErrorBuilder(*this, shouldReportErrorOn(loc, what), loc, what);
+    return ErrorBuilder(*this, shouldReportErrorOn(loc.file(), what), loc, what);
 }
 
 ErrorBuilder GlobalState::beginIndexerError(Loc loc, ErrorClass what) {
@@ -2274,7 +2274,7 @@ void GlobalState::onlyShowErrorClass(int code) {
     onlyErrorClasses.insert(code);
 }
 
-bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
+bool GlobalState::shouldReportErrorOn(FileRef file, ErrorClass what) const {
     if (what.minLevel == StrictLevel::Internal) {
         return true;
     }
@@ -2294,8 +2294,8 @@ bool GlobalState::shouldReportErrorOn(Loc loc, ErrorClass what) const {
     }
 
     StrictLevel level = StrictLevel::Strong;
-    if (loc.file().exists()) {
-        level = loc.file().data(*this).strictLevel;
+    if (file.exists()) {
+        level = file.data(*this).strictLevel;
     }
     if (level >= StrictLevel::Max) {
         // Custom rules

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -327,7 +327,7 @@ public:
     bool rbsSignaturesEnabled = false;
     bool requiresAncestorEnabled = false;
 
-    bool shouldReportErrorOn(Loc loc, ErrorClass what) const;
+    bool shouldReportErrorOn(FileRef file, ErrorClass what) const;
 
 private:
     struct DeepCloneHistoryEntry {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -525,6 +525,7 @@ int realmain(int argc, char *argv[]) {
         gs->suppressErrorClass(core::errors::Namer::ConstantKindRedefinition.code);
         gs->suppressErrorClass(core::errors::Resolver::StubConstant.code);
         gs->suppressErrorClass(core::errors::Resolver::RecursiveTypeAlias.code);
+        gs->suppressErrorClass(core::errors::Resolver::AmbiguousDefinitionError.code);
     }
 
     logger->trace("done building initial global state");

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1470,8 +1470,8 @@ public:
 
     const bool checkAmbiguousDefinition(core::Context ctx, core::SymbolRef curSym,
                                         const shared_ptr<Nesting> &curNesting) {
-        if (ctx.state.runningUnderAutogen) {
-            // no need to check in autogen
+        if (!ctx.state.shouldReportErrorOn(ctx.file, core::errors::Resolver::AmbiguousDefinitionError)) {
+            // no need to check if suppressed
             return false;
         }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After this, the only references to `runningUnderAutogen` are in:

1.  GlobalState copying code
1.  the pipeline test runner
1.  realmain, which sets up the autogen run
1.  a packager ENFORCE (saying that we don't run packager in autogen)
1.  decideStrictLevel, which might not actually be load bearing,
    but which treats all autogen files as `# typed: false`
1.  various rewriters, so we skip them in autogen

The first four are completely benign. The fifth could technically be a read from
`options::Options` instead of `GlobalState`. The last, rewriters, are super load
bearing and basically the only reason why we have to have this in `GlobalState`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests