### PR TITLE
Factor more options helpers

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -674,6 +674,58 @@ RangeAssertion::parseAssertions(const UnorderedMap<string, shared_ptr<core::File
     return assertions;
 }
 
+realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeAssertion>> &assertions) {
+    realmain::options::Options opts;
+
+    opts.noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
+    opts.rbsSignaturesEnabled =
+        BooleanPropertyAssertion::getValue("enable-experimental-rbs-signatures", assertions).value_or(false);
+    opts.requiresAncestorEnabled =
+        BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
+    opts.ruby3KeywordArgs =
+        BooleanPropertyAssertion::getValue("experimental-ruby3-keyword-args", assertions).value_or(false);
+    opts.typedSuper = BooleanPropertyAssertion::getValue("typed-super", assertions).value_or(true);
+    // TODO(jez) Allow allow suppressPayloadSuperclassRedefinitionFor in a testdata test assertion?
+
+    opts.uniquelyDefinedBehavior =
+        BooleanPropertyAssertion::getValue("uniquely-defined-behavior", assertions).value_or(false);
+
+    opts.outOfOrderReferenceChecksEnabled =
+        BooleanPropertyAssertion::getValue("check-out-of-order-constant-references", assertions).value_or(false);
+
+    if (BooleanPropertyAssertion::getValue("enable-suggest-unsafe", assertions).value_or(false)) {
+        opts.suggestUnsafe = "T.unsafe";
+    }
+
+    opts.stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
+    auto extraDirUnderscore =
+        StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);
+    if (extraDirUnderscore.has_value()) {
+        opts.extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDirUnderscore.value());
+    }
+
+    auto extraDirSlashDeprecated =
+        StringPropertyAssertion::getValue("extra-package-files-directory-prefix-slash-deprecated", assertions);
+    if (extraDirSlashDeprecated.has_value()) {
+        opts.extraPackageFilesDirectorySlashDeprecatedPrefixes.emplace_back(extraDirSlashDeprecated.value());
+    }
+
+    auto extraDirSlash = StringPropertyAssertion::getValue("extra-package-files-directory-prefix-slash", assertions);
+    if (extraDirSlash.has_value()) {
+        opts.extraPackageFilesDirectorySlashPrefixes.emplace_back(extraDirSlash.value());
+    }
+
+    auto allowRelaxedPackager = StringPropertyAssertion::getValue("allow-relaxed-packager-checks-for", assertions);
+    if (allowRelaxedPackager.has_value()) {
+        opts.allowRelaxedPackagerChecksFor.emplace_back(allowRelaxedPackager.value());
+    }
+
+    std::vector<std::string> defaultLayers = {};
+    opts.packagerLayers = StringPropertyAssertions::getValues("packager-layers", assertions).value_or(defaultLayers);
+
+    return opts;
+}
+
 unique_ptr<Location> RangeAssertion::getLocation(const LSPConfiguration &config) const {
     auto uri = filePathToUri(config, filename);
     return make_unique<Location>(uri, range->copy());

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -3,6 +3,7 @@
 
 #include "main/lsp/json_types.h"
 #include "main/lsp/wrapper.h"
+#include "main/options/options.h"
 #include "test/helpers/expectations.h"
 #include <regex>
 
@@ -27,6 +28,8 @@ public:
      */
     static std::vector<std::shared_ptr<RangeAssertion>>
     parseAssertions(const UnorderedMap<std::string, std::shared_ptr<core::File>> filesAndContents);
+
+    static realmain::options::Options parseOptions(std::vector<std::shared_ptr<RangeAssertion>> &assertions);
 
     // Creates a Range object for a source line and character range. Matches arbitrary subset of line if only sourceLine
     // is provided.

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -542,58 +542,19 @@ TEST_CASE("LSPTest") {
 
     // Initialize lspWrapper.
     {
-        shared_ptr<realmain::options::Options> opts = make_shared<realmain::options::Options>();
-        opts->noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
-        opts->ruby3KeywordArgs =
-            BooleanPropertyAssertion::getValue("experimental-ruby3-keyword-args", assertions).value_or(false);
-        opts->typedSuper = BooleanPropertyAssertion::getValue("typed-super", assertions).value_or(true);
-        // TODO(jez) Allow suppressPayloadSuperclassRedefinitionFor in a testdata test assertion?
-        opts->uniquelyDefinedBehavior =
-            BooleanPropertyAssertion::getValue("uniquely-defined-behavior", assertions).value_or(false);
-        opts->outOfOrderReferenceChecksEnabled =
-            BooleanPropertyAssertion::getValue("check-out-of-order-constant-references", assertions).value_or(false);
-        opts->rbsSignaturesEnabled =
-            BooleanPropertyAssertion::getValue("enable-experimental-rbs-signatures", assertions).value_or(false);
-        opts->requiresAncestorEnabled =
-            BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
-        opts->lspExtractToVariableEnabled =
+        auto opts = RangeAssertion::parseOptions(assertions);
+
+        opts.lspExtractToVariableEnabled =
             BooleanPropertyAssertion::getValue("enable-experimental-lsp-extract-to-variable", assertions)
                 .value_or(false);
-        opts->stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
-
-        if (opts->stripePackages) {
-            auto extraDirUnderscore =
-                StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);
-            if (extraDirUnderscore.has_value()) {
-                opts->extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDirUnderscore.value());
-            }
-            auto extraDirSlashDeprecated =
-                StringPropertyAssertion::getValue("extra-package-files-directory-prefix-slash-deprecated", assertions);
-            if (extraDirSlashDeprecated.has_value()) {
-                opts->extraPackageFilesDirectorySlashDeprecatedPrefixes.emplace_back(extraDirSlashDeprecated.value());
-            }
-            auto extraDirSlash =
-                StringPropertyAssertion::getValue("extra-package-files-directory-prefix-slash", assertions);
-            if (extraDirSlash.has_value()) {
-                opts->extraPackageFilesDirectorySlashPrefixes.emplace_back(extraDirSlash.value());
-            }
-            auto skipImportVisibility =
-                StringPropertyAssertion::getValue("allow-relaxed-packager-checks-for", assertions);
-            if (skipImportVisibility.has_value()) {
-                opts->allowRelaxedPackagerChecksFor.emplace_back(skipImportVisibility.value());
-            }
-            std::vector<std::string> defaultLayers = {};
-            opts->packagerLayers =
-                StringPropertyAssertions::getValues("packager-layers", assertions).value_or(defaultLayers);
-        }
-        opts->disableWatchman = true;
-        opts->rubyfmtPath = "test/testdata/lsp/rubyfmt-stub/rubyfmt";
+        opts.disableWatchman = true;
+        opts.rubyfmtPath = "test/testdata/lsp/rubyfmt-stub/rubyfmt";
 
         // Set to a number that is reasonable large for tests, but small enough that we can have a test to handle
         // this edge case. If you change this number, `fast_path/{too_many_files,not_enough_files,initialize}` will
         // need to be changed as well.
-        opts->lspMaxFilesOnFastPath = 10;
-        lspWrapper = SingleThreadedLSPWrapper::create("", move(opts));
+        opts.lspMaxFilesOnFastPath = 10;
+        lspWrapper = SingleThreadedLSPWrapper::create("", make_shared<realmain::options::Options>(move(opts)));
         lspWrapper->enableAllExperimentalFeatures();
     }
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -314,17 +314,6 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
     return trees;
 }
 
-void setupPackager(core::GlobalState &gs, realmain::options::Options &opts) {
-    {
-        core::UnfreezeNameTable packageNS(gs);
-        core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
-        gs.setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,
-                              opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                              opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
-                              opts.allowRelaxedPackagerChecksFor, opts.packagerLayers, opts.stripePackagesHint);
-    }
-}
-
 void package(core::GlobalState &gs, unique_ptr<WorkerPool> &workers, absl::Span<ast::ParsedFile> trees,
              ExpectationHandler &handler, vector<shared_ptr<RangeAssertion>> &assertions) {
     if (!gs.packageDB().enabled()) {
@@ -406,7 +395,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     vector<ast::ParsedFile> trees;
     auto filesSpan = absl::Span<core::FileRef>(files);
     if (opts.stripePackages) {
-        setupPackager(*gs, opts);
+        realmain::pipeline::setPackagerOptions(*gs, opts);
 
         auto numPackageFiles = realmain::pipeline::partitionPackageFiles(*gs, filesSpan);
         auto inputPackageFiles = filesSpan.first(numPackageFiles);
@@ -461,7 +450,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             }
 
             // Initialize the package DB
-            setupPackager(*rbiGenGs, opts);
+            realmain::pipeline::setPackagerOptions(*rbiGenGs, opts);
             packager::Packager::findPackages(*rbiGenGs, absl::Span<ast::ParsedFile>(packageTrees));
             packager::Packager::setPackageNameOnFiles(*rbiGenGs, packageTrees);
             packager::Packager::setPackageNameOnFiles(*rbiGenGs, trees);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -184,60 +184,6 @@ public:
     }
 };
 
-realmain::options::Options assertionsToOptions(std::vector<std::shared_ptr<RangeAssertion>> &assertions) {
-    realmain::options::Options opts;
-
-    opts.censorForSnapshotTests = true;
-    opts.noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
-    opts.rbsSignaturesEnabled =
-        BooleanPropertyAssertion::getValue("enable-experimental-rbs-signatures", assertions).value_or(false);
-    opts.requiresAncestorEnabled =
-        BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
-    opts.ruby3KeywordArgs =
-        BooleanPropertyAssertion::getValue("experimental-ruby3-keyword-args", assertions).value_or(false);
-    opts.typedSuper = BooleanPropertyAssertion::getValue("typed-super", assertions).value_or(true);
-    // TODO(jez) Allow allow suppressPayloadSuperclassRedefinitionFor in a testdata test assertion?
-
-    opts.uniquelyDefinedBehavior =
-        BooleanPropertyAssertion::getValue("uniquely-defined-behavior", assertions).value_or(false);
-
-    opts.outOfOrderReferenceChecksEnabled =
-        BooleanPropertyAssertion::getValue("check-out-of-order-constant-references", assertions).value_or(false);
-
-    if (BooleanPropertyAssertion::getValue("enable-suggest-unsafe", assertions).value_or(false)) {
-        opts.suggestUnsafe = "T.unsafe";
-    }
-
-    opts.stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
-    auto extraDirUnderscore =
-        StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);
-    if (extraDirUnderscore.has_value()) {
-        opts.extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDirUnderscore.value());
-    }
-
-    auto extraDirSlashDeprecated =
-        StringPropertyAssertion::getValue("extra-package-files-directory-prefix-slash-deprecated", assertions);
-    if (extraDirSlashDeprecated.has_value()) {
-        opts.extraPackageFilesDirectorySlashDeprecatedPrefixes.emplace_back(extraDirSlashDeprecated.value());
-    }
-
-    auto extraDirSlash = StringPropertyAssertion::getValue("extra-package-files-directory-prefix-slash", assertions);
-    if (extraDirSlash.has_value()) {
-        opts.extraPackageFilesDirectorySlashPrefixes.emplace_back(extraDirSlash.value());
-    }
-
-    auto allowRelaxedPackager = StringPropertyAssertion::getValue("allow-relaxed-packager-checks-for", assertions);
-    if (allowRelaxedPackager.has_value()) {
-        opts.allowRelaxedPackagerChecksFor.emplace_back(allowRelaxedPackager.value());
-    }
-
-    std::vector<std::string> defaultLayers = {};
-    opts.packagerLayers = StringPropertyAssertions::getValues("packager-layers", assertions).value_or(defaultLayers);
-    opts.stripePackagesHint = "PACKAGE_ERROR_HINT";
-
-    return opts;
-}
-
 vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> files, ExpectationHandler &handler,
                               Expectations &test) {
     vector<ast::ParsedFile> trees;
@@ -350,7 +296,9 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
-    auto opts = assertionsToOptions(assertions);
+    auto opts = RangeAssertion::parseOptions(assertions);
+    opts.censorForSnapshotTests = true;
+    opts.stripePackagesHint = "PACKAGE_ERROR_HINT";
 
     auto logger = spdlog::stderr_color_mt("fixtures: " + inputPath);
     auto workers = WorkerPool::create(0, *logger);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -39,6 +39,7 @@
 #include "packager/rbi_gen.h"
 #include "parser/parser.h"
 #include "payload/binary/binary.h"
+#include "payload/payload.h"
 #include "resolver/resolver.h"
 #include "rewriter/rewriter.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
@@ -374,12 +375,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     auto errorQueue = make_shared<core::ErrorQueue>(*logger, *logger, errorCollector);
     auto gs = make_unique<core::GlobalState>(errorQueue);
 
-    if (opts.noStdlib) {
-        gs->initEmpty();
-    } else {
-        core::serialize::Serializer::loadGlobalState(*gs, GLOBAL_STATE_PAYLOAD);
-    }
-
+    unique_ptr<const OwnedKeyValueStore> kvstore = nullptr;
+    payload::createInitialGlobalState(*gs, opts, kvstore);
     realmain::pipeline::setGlobalStateOptions(*gs, opts);
 
     for (auto provider : sorbet::pipeline::semantic_extension::SemanticExtensionProvider::getProviders()) {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -320,8 +320,8 @@ void setupPackager(core::GlobalState &gs, realmain::options::Options &opts) {
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
         gs.setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,
                               opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                              opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor,
-                              opts.packagerLayers, opts.stripePackagesHint);
+                              opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
+                              opts.allowRelaxedPackagerChecksFor, opts.packagerLayers, opts.stripePackagesHint);
     }
 }
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -339,6 +339,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     auto logger = spdlog::stderr_color_mt("fixtures: " + inputPath);
+    auto workers = WorkerPool::create(0, *logger);
     auto errorCollector = make_shared<core::ErrorCollector>();
     auto errorQueue = make_shared<core::ErrorQueue>(*logger, *logger, errorCollector);
     auto gs = make_unique<core::GlobalState>(errorQueue);
@@ -348,7 +349,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     gs->censorForSnapshotTests = true;
-    auto workers = WorkerPool::create(0, gs->tracer());
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -348,6 +348,12 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
 
+    if (BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false)) {
+        gs->initEmpty();
+    } else {
+        core::serialize::Serializer::loadGlobalState(*gs, GLOBAL_STATE_PAYLOAD);
+    }
+
     gs->rbsSignaturesEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-rbs-signatures", assertions).value_or(false);
     gs->requiresAncestorEnabled =
@@ -363,12 +369,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     if (!BooleanPropertyAssertion::getValue("check-out-of-order-constant-references", assertions).value_or(false)) {
         gs->suppressErrorClass(core::errors::Resolver::OutOfOrderConstantAccess.code);
-    }
-
-    if (BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false)) {
-        gs->initEmpty();
-    } else {
-        core::serialize::Serializer::loadGlobalState(*gs, GLOBAL_STATE_PAYLOAD);
     }
 
     if (BooleanPropertyAssertion::getValue("enable-suggest-unsafe", assertions).value_or(false)) {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -344,10 +344,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     auto errorQueue = make_shared<core::ErrorQueue>(*logger, *logger, errorCollector);
     auto gs = make_unique<core::GlobalState>(errorQueue);
 
-    for (auto provider : sorbet::pipeline::semantic_extension::SemanticExtensionProvider::getProviders()) {
-        gs->semanticExtensions.emplace_back(provider->defaultInstance());
-    }
-
     gs->censorForSnapshotTests = true;
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
@@ -377,6 +373,10 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     if (BooleanPropertyAssertion::getValue("enable-suggest-unsafe", assertions).value_or(false)) {
         gs->suggestUnsafe = "T.unsafe";
+    }
+
+    for (auto provider : sorbet::pipeline::semantic_extension::SemanticExtensionProvider::getProviders()) {
+        gs->semanticExtensions.emplace_back(provider->defaultInstance());
     }
 
     unique_ptr<core::GlobalState> emptyGs;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In #8668, I added a `pipeline::setGlobalStateOptions` helper.

This PR uses that to power the option initialization code in both the pipeline
and LSP test runner.

It also factors out a helper to parse options from the various position
assertions that we have at the top of test files, again so that we don't have to
duplicate work in the pipeline and LSP test runners.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests