### PR TITLE
Move setPackagerOptions into setGlobalStateOptions

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -282,18 +282,26 @@ bool PackageDB::allowRelaxedPackagerChecksFor(MangledName mangledName) const {
 PackageDB PackageDB::deepCopy() const {
     ENFORCE(frozen);
     PackageDB result;
+
+    // --- data ---
     result.packages_.reserve(this->packages_.size());
     for (auto const &[nr, pkgInfo] : this->packages_) {
         result.packages_[nr] = pkgInfo->deepCopy();
     }
+    result.packagesByPathPrefix = this->packagesByPathPrefix;
+    result.mangledNames = this->mangledNames;
+
+    // --- options ---
     result.enabled_ = this->enabled_;
     result.extraPackageFilesDirectoryUnderscorePrefixes_ = this->extraPackageFilesDirectoryUnderscorePrefixes_;
     result.extraPackageFilesDirectorySlashDeprecatedPrefixes_ =
         this->extraPackageFilesDirectorySlashDeprecatedPrefixes_;
     result.extraPackageFilesDirectorySlashPrefixes_ = this->extraPackageFilesDirectorySlashPrefixes_;
-    result.packagesByPathPrefix = this->packagesByPathPrefix;
-    result.mangledNames = this->mangledNames;
+    result.skipRBIExportEnforcementDirs_ = this->skipRBIExportEnforcementDirs_;
+    result.layers_ = this->layers_;
+    result.allowRelaxedPackagerChecksFor_ = this->allowRelaxedPackagerChecksFor_;
     result.errorHint_ = this->errorHint_;
+
     return result;
 }
 

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -289,6 +289,8 @@ PackageDB PackageDB::deepCopy() const {
         result.packages_[nr] = pkgInfo->deepCopy();
     }
     result.packagesByPathPrefix = this->packagesByPathPrefix;
+    // This assumes that the GlobalState this PackageDB is getting copied into also has these
+    // interned mangledName NameRefs at the same IDs as the current PackageDB.
     result.mangledNames = this->mangledNames;
 
     // --- options ---
@@ -298,6 +300,8 @@ PackageDB PackageDB::deepCopy() const {
         this->extraPackageFilesDirectorySlashDeprecatedPrefixes_;
     result.extraPackageFilesDirectorySlashPrefixes_ = this->extraPackageFilesDirectorySlashPrefixes_;
     result.skipRBIExportEnforcementDirs_ = this->skipRBIExportEnforcementDirs_;
+    // This assumes that the GlobalState this PackageDB is getting copied into also has these
+    // interned layer NameRefs at the same IDs as the current PackageDB.
     result.layers_ = this->layers_;
     result.allowRelaxedPackagerChecksFor_ = this->allowRelaxedPackagerChecksFor_;
     result.errorHint_ = this->errorHint_;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -511,7 +511,6 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
             }
         }
 
-        pipeline::setPackagerOptions(*gs, config->opts);
         // TODO(jez) Splitting this like how the pipeline intersperses this with indexing is going
         // to take more work. Punting for now.
         pipeline::package(*gs, absl::Span<ast::ParsedFile>(indexedCopies), config->opts, workers);

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -420,7 +420,7 @@ void Minimize::indexAndResolveForMinimize(core::GlobalState &sourceGS, core::Glo
         rbiGS.errorQueue->flushAllErrors(rbiGS);
     }
 
-    pipeline::setPackagerOptions(rbiGS, opts);
+    // We explicitly disable `stripePackages` in realmain for this call, which makes the packager call a no-op here.
     pipeline::package(rbiGS, absl::MakeSpan(rbiIndexed.result()), opts, workers);
     // Only need to compute FoundDefHashes when running to compute a FileHash
     auto foundHashes = nullptr;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -105,6 +105,8 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
 
 #ifndef SORBET_REALMAIN_MIN
     if (opts.stripePackages) {
+        ENFORCE(!gs.packageDB().enabled());
+
         core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
         gs.setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -102,6 +102,9 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
         }
     }
     gs.suggestUnsafe = opts.suggestUnsafe;
+
+    // TODO(jez) Goal is to be able to get rid of setPackagerOptions, and just have it be a part of this function.
+    setPackagerOptions(gs, opts);
 }
 
 vector<core::FileRef> reserveFiles(core::GlobalState &gs, const vector<string> &files) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -105,8 +105,6 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
 
 #ifndef SORBET_REALMAIN_MIN
     if (opts.stripePackages) {
-        ENFORCE(!gs.packageDB().enabled());
-
         core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
         gs.setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -48,7 +48,6 @@ size_t partitionPackageFiles(const core::GlobalState &gs, absl::Span<core::FileR
 void unpartitionPackageFiles(std::vector<ast::ParsedFile> &packageFiles,
                              std::vector<ast::ParsedFile> &&nonPackageFiles);
 
-void setPackagerOptions(core::GlobalState &gs, const options::Options &opts);
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers);
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -658,7 +658,6 @@ int realmain(int argc, char *argv[]) {
 
             auto inputFilesSpan = absl::Span<core::FileRef>(inputFiles);
             if (opts.stripePackages) {
-                pipeline::setPackagerOptions(*gs, opts);
                 auto numPackageFiles = pipeline::partitionPackageFiles(*gs, inputFilesSpan);
                 auto inputPackageFiles = inputFilesSpan.first(numPackageFiles);
                 inputFilesSpan = inputFilesSpan.subspan(numPackageFiles);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -343,8 +343,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     vector<ast::ParsedFile> trees;
     auto filesSpan = absl::Span<core::FileRef>(files);
     if (opts.stripePackages) {
-        realmain::pipeline::setPackagerOptions(*gs, opts);
-
         auto numPackageFiles = realmain::pipeline::partitionPackageFiles(*gs, filesSpan);
         auto inputPackageFiles = filesSpan.first(numPackageFiles);
         filesSpan = filesSpan.subspan(numPackageFiles);
@@ -364,6 +362,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     if (opts.stripePackages) {
         if (test.expectations.contains("rbi-gen")) {
             auto rbiGenGs = emptyGs->deepCopy();
+            realmain::pipeline::setGlobalStateOptions(*rbiGenGs, opts);
             rbiGenGs->errorQueue = make_shared<core::ErrorQueue>(*logger, *logger, errorCollector);
             // If there is a rbi-gen exp file, we need to retypecheck the files w/o packager mode and run RBI
             // generation for every package.
@@ -398,7 +397,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             }
 
             // Initialize the package DB
-            realmain::pipeline::setPackagerOptions(*rbiGenGs, opts);
             packager::Packager::findPackages(*rbiGenGs, absl::Span<ast::ParsedFile>(packageTrees));
             packager::Packager::setPackageNameOnFiles(*rbiGenGs, packageTrees);
             packager::Packager::setPackageNameOnFiles(*rbiGenGs, trees);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There should be no places where we care about populating command-line options
into `GlobalState` and do not also care about correctly setting up the packager
options.

Note that the `minimizeRBI` stuff is all in the first commit. We used to use
`deepCopy` as a way to avoid needing to duplicate all the option parsing for
`minimizeRBI`. Now that the option parsing is in its own helper, we can just
call that.

This has the added benefit that the `GlobalState` we get is even more empty: it
doesn't have any of the things in the kvstore. Another benefit is that all the
`minimizeRBI` code lives in one place, instead of being sprinkled throughout the
function.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests