### PR TITLE
Revert "Bump mimalloc to 2.1.9 (#8654)"

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -115,10 +115,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "mimalloc",
-        url = "https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.9.zip",  # 2.1.9
-        sha256 = "efc9531e88bf64403dd4955131ad5d0d24c0ff63be6561344dff77e1bcebcc78",
+        url = "https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.2.zip",  # 2.1.2
+        sha256 = "86281c918921c1007945a8a31e5ad6ae9af77e510abfec20d000dd05d15123c7",
         build_file = "@com_stripe_ruby_typer//third_party:mimalloc.BUILD",
-        strip_prefix = "mimalloc-2.1.9",
+        strip_prefix = "mimalloc-2.1.2",
     )
 
     http_archive(


### PR DESCRIPTION
This reverts commit 0ee63e6097ee79df870c9046166144b83591ea49.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This seems to have caused a memory increase?


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

testing on stripe's codebase