### PR TITLE
Stop using "pos" to mean "detail"

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2346,9 +2346,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = std::move(res);
             },
             [&](parser::LineLiteral *line) {
-                auto pos = dctx.ctx.locAt(loc).toDetails(dctx.ctx);
-                ENFORCE(pos.first.line == pos.second.line, "position corrupted");
-                auto res = MK::Int(loc, pos.first.line);
+                auto details = dctx.ctx.locAt(loc).toDetails(dctx.ctx);
+                ENFORCE(details.first.line == details.second.line, "position corrupted");
+                auto res = MK::Int(loc, details.first.line);
                 result = std::move(res);
             },
             [&](parser::XString *xstring) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2346,7 +2346,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = std::move(res);
             },
             [&](parser::LineLiteral *line) {
-                auto pos = dctx.ctx.locAt(loc).position(dctx.ctx);
+                auto pos = dctx.ctx.locAt(loc).toDetails(dctx.ctx);
                 ENFORCE(pos.first.line == pos.second.line, "position corrupted");
                 auto res = MK::Int(loc, pos.first.line);
                 result = std::move(res);

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -44,7 +44,7 @@ Loc::Detail Loc::pos2Detail(const File &file, uint32_t off) {
     Loc::Detail pos;
 
     if (off > file.source().size()) {
-        fatalLogger->error(R"(msg="Bad pos2Detail off" path="{}" off="{}"")", absl::CEscape(file.path()), off);
+        fatalLogger->error(R"(msg="Bad offset2Pos off" path="{}" off="{}"")", absl::CEscape(file.path()), off);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
         ENFORCE_NO_TIMER(false);
     }

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -61,7 +61,7 @@ Loc::Detail Loc::offset2Pos(const File &file, uint32_t off) {
     return pos;
 }
 
-optional<uint32_t> Loc::pos2Offset(const File &file, Loc::Detail pos) {
+optional<uint32_t> Loc::detail2Pos(const File &file, Loc::Detail pos) {
     auto l = pos.line - 1;
     auto lineBreaks = file.lineBreaks();
     if (!(0 <= l && l < lineBreaks.size())) {
@@ -78,11 +78,11 @@ optional<uint32_t> Loc::pos2Offset(const File &file, Loc::Detail pos) {
 
 optional<Loc> Loc::fromDetails(const GlobalState &gs, FileRef fileRef, Loc::Detail begin, Loc::Detail end) {
     const auto &file = fileRef.data(gs);
-    const auto beginOff = pos2Offset(file, begin);
+    const auto beginOff = detail2Pos(file, begin);
     if (!beginOff.has_value()) {
         return nullopt;
     }
-    const auto endOff = pos2Offset(file, end);
+    const auto endOff = detail2Pos(file, end);
     if (!endOff.has_value()) {
         return nullopt;
     }
@@ -371,7 +371,7 @@ Loc Loc::adjustLen(const GlobalState &gs, int32_t beginAdjust, int32_t len) cons
 
 pair<Loc, uint32_t> Loc::findStartOfLine(const GlobalState &gs) const {
     auto startDetail = this->position(gs).first;
-    auto maybeLineStart = Loc::pos2Offset(this->file().data(gs), {startDetail.line, 1});
+    auto maybeLineStart = Loc::detail2Pos(this->file().data(gs), {startDetail.line, 1});
     ENFORCE_NO_TIMER(maybeLineStart.has_value());
     auto lineStart = maybeLineStart.value();
     std::string_view lineView = this->file().data(gs).source().substr(lineStart);

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -41,7 +41,7 @@ Loc Loc::join(Loc other) const {
 }
 
 Loc::Detail Loc::pos2Detail(const File &file, uint32_t off) {
-    Loc::Detail pos;
+    Loc::Detail detail;
 
     if (off > file.source().size()) {
         fatalLogger->error(R"(msg="Bad offset2Pos off" path="{}" off="{}"")", absl::CEscape(file.path()), off);
@@ -51,18 +51,18 @@ Loc::Detail Loc::pos2Detail(const File &file, uint32_t off) {
     auto lineBreaks = file.lineBreaks();
     auto it = absl::c_lower_bound(lineBreaks, off);
     if (it == lineBreaks.begin()) {
-        pos.line = 1;
-        pos.column = off + 1;
-        return pos;
+        detail.line = 1;
+        detail.column = off + 1;
+        return detail;
     }
     --it;
-    pos.line = (it - file.lineBreaks().begin()) + 1;
-    pos.column = off - *it;
-    return pos;
+    detail.line = (it - file.lineBreaks().begin()) + 1;
+    detail.column = off - *it;
+    return detail;
 }
 
-optional<uint32_t> Loc::detail2Pos(const File &file, Loc::Detail pos) {
-    auto l = pos.line - 1;
+optional<uint32_t> Loc::detail2Pos(const File &file, Loc::Detail detail) {
+    auto l = detail.line - 1;
     auto lineBreaks = file.lineBreaks();
     if (!(0 <= l && l < lineBreaks.size())) {
         return nullopt;
@@ -70,10 +70,10 @@ optional<uint32_t> Loc::detail2Pos(const File &file, Loc::Detail pos) {
     auto lineOffset = lineBreaks[l];
     auto nextLineStart = l + 1 < lineBreaks.size() ? lineBreaks[l + 1] : file.source().size();
     auto lineLength = nextLineStart - lineOffset;
-    if (pos.column > lineLength) {
+    if (detail.column > lineLength) {
         return nullopt;
     }
-    return lineOffset + pos.column;
+    return lineOffset + detail.column;
 }
 
 optional<Loc> Loc::fromDetails(const GlobalState &gs, FileRef fileRef, Loc::Detail begin, Loc::Detail end) {

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -117,13 +117,14 @@ constexpr unsigned int WINDOW_SIZE = 10; // how many lines of source to print
 constexpr unsigned int WINDOW_HALF_SIZE = WINDOW_SIZE / 2;
 static_assert((WINDOW_SIZE & 1) == 0, "WINDOW_SIZE should be divisible by 2");
 
-void addLocLine(stringstream &buf, int line, const File &file, int tabs, int posWidth, bool censorForSnapshotTests) {
+void addLocLine(stringstream &buf, int line, const File &file, int tabs, int lineNumPadding,
+                bool censorForSnapshotTests) {
     printTabs(buf, tabs);
     buf << rang::fgB::black;
     if (censorForSnapshotTests) {
-        buf << leftPad("NN", posWidth);
+        buf << leftPad("NN", lineNumPadding);
     } else {
-        buf << leftPad(to_string(line + 1), posWidth);
+        buf << leftPad(to_string(line + 1), lineNumPadding);
     }
     buf << " |" << rang::style::reset;
     if (file.lineBreaks().size() <= line + 1) {
@@ -158,7 +159,7 @@ string Loc::toStringWithTabs(const GlobalState &gs, int tabs) const {
     const File &file = this->file().data(gs);
     auto censorForSnapshotTests = gs.censorForSnapshotTests && file.isPayload();
     auto details = this->toDetails(gs);
-    int posWidth = details.second.line < 100 ? 2 : details.second.line < 10000 ? 4 : 8;
+    int lineNumPadding = details.second.line < 100 ? 2 : details.second.line < 10000 ? 4 : 8;
 
     const auto firstLine = details.first.line - 1;
     auto lineIt = firstLine;
@@ -168,19 +169,19 @@ string Loc::toStringWithTabs(const GlobalState &gs, int tabs) const {
             buf << '\n';
         }
         first = false;
-        addLocLine(buf, lineIt, file, tabs, posWidth, censorForSnapshotTests);
+        addLocLine(buf, lineIt, file, tabs, lineNumPadding, censorForSnapshotTests);
         lineIt++;
     }
     if (lineIt != details.second.line && lineIt < details.second.line - WINDOW_HALF_SIZE) {
         buf << '\n';
         printTabs(buf, tabs);
-        string space(posWidth, ' ');
+        string space(lineNumPadding, ' ');
         buf << space << rang::fgB::black << " |" << rang::style::reset << "...";
         lineIt = details.second.line - WINDOW_HALF_SIZE;
     }
     while (lineIt != details.second.line) {
         buf << '\n';
-        addLocLine(buf, lineIt, file, tabs, posWidth, censorForSnapshotTests);
+        addLocLine(buf, lineIt, file, tabs, lineNumPadding, censorForSnapshotTests);
         lineIt++;
     }
 
@@ -188,7 +189,7 @@ string Loc::toStringWithTabs(const GlobalState &gs, int tabs) const {
         // add squigly
         buf << '\n';
         printTabs(buf, tabs);
-        for (int i = 0; i <= posWidth; i++) {
+        for (int i = 0; i <= lineNumPadding; i++) {
             buf << ' ';
         }
         int p;

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -40,11 +40,11 @@ Loc Loc::join(Loc other) const {
     return Loc(this->file(), min(this->beginPos(), other.beginPos()), max(this->endPos(), other.endPos()));
 }
 
-Loc::Detail Loc::offset2Pos(const File &file, uint32_t off) {
+Loc::Detail Loc::pos2Detail(const File &file, uint32_t off) {
     Loc::Detail pos;
 
     if (off > file.source().size()) {
-        fatalLogger->error(R"(msg="Bad offset2Pos off" path="{}" off="{}"")", absl::CEscape(file.path()), off);
+        fatalLogger->error(R"(msg="Bad pos2Detail off" path="{}" off="{}"")", absl::CEscape(file.path()), off);
         fatalLogger->error("source=\"{}\"", absl::CEscape(file.source()));
         ENFORCE_NO_TIMER(false);
     }
@@ -90,8 +90,8 @@ optional<Loc> Loc::fromDetails(const GlobalState &gs, FileRef fileRef, Loc::Deta
 }
 
 pair<Loc::Detail, Loc::Detail> Loc::position(const GlobalState &gs) const {
-    Loc::Detail begin(offset2Pos(this->file().data(gs), beginPos()));
-    Loc::Detail end(offset2Pos(this->file().data(gs), endPos()));
+    Loc::Detail begin(pos2Detail(this->file().data(gs), beginPos()));
+    Loc::Detail end(pos2Detail(this->file().data(gs), endPos()));
     return make_pair(begin, end);
 }
 namespace {

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -91,7 +91,7 @@ public:
     };
 
     bool contains(const Loc &other) const;
-    std::pair<Detail, Detail> position(const GlobalState &gs) const;
+    std::pair<Detail, Detail> toDetails(const GlobalState &gs) const;
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string toString(const GlobalState &gs) const {
         return toStringWithTabs(gs);

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -104,7 +104,7 @@ public:
 
     bool operator!=(const Loc &rhs) const;
     static std::optional<uint32_t> detail2Pos(const File &file, Detail pos);
-    static Detail offset2Pos(const File &file, uint32_t off);
+    static Detail pos2Detail(const File &file, uint32_t off);
     static std::optional<Loc> fromDetails(const GlobalState &gs, FileRef fileRef, Detail begin, Detail end);
 
     // Create a new Loc by adjusting the beginPos and endPos of this Loc, like this:

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -103,7 +103,7 @@ public:
     bool operator==(const Loc &rhs) const;
 
     bool operator!=(const Loc &rhs) const;
-    static std::optional<uint32_t> pos2Offset(const File &file, Detail pos);
+    static std::optional<uint32_t> detail2Pos(const File &file, Detail pos);
     static Detail offset2Pos(const File &file, uint32_t off);
     static std::optional<Loc> fromDetails(const GlobalState &gs, FileRef fileRef, Detail begin, Detail end);
 

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -103,7 +103,7 @@ public:
     bool operator==(const Loc &rhs) const;
 
     bool operator!=(const Loc &rhs) const;
-    static std::optional<uint32_t> detail2Pos(const File &file, Detail pos);
+    static std::optional<uint32_t> detail2Pos(const File &file, Detail detail);
     static Detail pos2Detail(const File &file, uint32_t off);
     static std::optional<Loc> fromDetails(const GlobalState &gs, FileRef fileRef, Detail begin, Detail end);
 

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -142,7 +142,7 @@ TypeErrorDiagnostics::editForDSLMethod(const GlobalState &gs, FileRef fileToEdit
             // If they're writing methods at the top level, it's probably a small script.
             // Just put the `extend` immediately above the sig.
 
-            auto [sigStart, _sigEnd] = defaultInsertLoc.position(gs);
+            auto [sigStart, _sigEnd] = defaultInsertLoc.toDetails(gs);
             auto thisLineStart = core::Loc::Detail{sigStart.line, 1};
             auto thisLineLoc = core::Loc::fromDetails(gs, defaultInsertLoc.file(), thisLineStart, thisLineStart);
             ENFORCE(thisLineLoc.has_value());
@@ -155,7 +155,7 @@ TypeErrorDiagnostics::editForDSLMethod(const GlobalState &gs, FileRef fileToEdit
         }
     }
 
-    auto [classStart, classEnd] = classLoc->position(gs);
+    auto [classStart, classEnd] = classLoc->toDetails(gs);
 
     core::Loc::Detail thisLineStart = {classStart.line, 1};
     auto thisLineLoc = core::Loc::fromDetails(gs, classLoc->file(), thisLineStart, thisLineStart);

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -262,11 +262,11 @@ com::stripe::rubytyper::Loc Proto::toProto(const GlobalState &gs, Loc loc) {
         auto path = loc.file().data(gs).path();
         protoLoc.set_path(string(path));
 
-        auto pos = loc.toDetails(gs);
-        start->set_line(pos.first.line);
-        start->set_column(pos.first.column);
-        end->set_line(pos.second.line);
-        end->set_column(pos.second.column);
+        auto details = loc.toDetails(gs);
+        start->set_line(details.first.line);
+        start->set_column(details.first.column);
+        end->set_line(details.second.line);
+        end->set_column(details.second.column);
     }
 
     return protoLoc;

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -262,7 +262,7 @@ com::stripe::rubytyper::Loc Proto::toProto(const GlobalState &gs, Loc loc) {
         auto path = loc.file().data(gs).path();
         protoLoc.set_path(string(path));
 
-        auto pos = loc.position(gs);
+        auto pos = loc.toDetails(gs);
         start->set_line(pos.first.line);
         start->set_column(pos.first.column);
         end->set_line(pos.second.line);

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -62,7 +62,7 @@ TEST_CASE("TestOffset2Pos2Offset") {
         CHECK_EQ(tc.line, detail.line);
 
         // Test that it's reversible
-        auto offset = Loc::pos2Offset(f.data(gs), detail);
+        auto offset = Loc::detail2Pos(f.data(gs), detail);
         CHECK_EQ(tc.off, offset);
 
         i++;
@@ -106,7 +106,7 @@ TEST_CASE("TestPos2OffsetNull") {
         auto name = string("case: ") + to_string(i);
         FileRef f = gs.enterFile(name, tc.src);
 
-        auto actualOffset = Loc::pos2Offset(f.data(gs), Loc::Detail{tc.line, tc.col});
+        auto actualOffset = Loc::detail2Pos(f.data(gs), Loc::Detail{tc.line, tc.col});
 
         INFO(fmt::format("i={}, CHECK_EQ({}, {})", i, showOffset(tc.off), showOffset(actualOffset)));
         CHECK_EQ(tc.off, actualOffset);

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -56,7 +56,7 @@ TEST_CASE("TestOffset2Pos2Offset") {
         INFO(name);
         FileRef f = gs.enterFile(name, tc.src);
 
-        auto detail = Loc::offset2Pos(f.data(gs), tc.off.value());
+        auto detail = Loc::pos2Detail(f.data(gs), tc.off.value());
 
         CHECK_EQ(tc.col, detail.column);
         CHECK_EQ(tc.line, detail.line);

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -1037,7 +1037,7 @@ private:
         auto classOrModuleDeclaredAt = ctx.locAt(classDef.declLoc);
         auto classOrModuleEndsAt = ctx.locAt(classDef.loc.copyEndWithZeroLength());
         auto hasSingleLineDefinition =
-            classOrModuleDeclaredAt.position(ctx).first.line == classOrModuleEndsAt.position(ctx).second.line;
+            classOrModuleDeclaredAt.toDetails(ctx).first.line == classOrModuleEndsAt.toDetails(ctx).second.line;
 
         auto hasEmptyBody = classDef.rhs.empty();
         if (classDef.rhs.size() == 1) {

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -158,7 +158,7 @@ void MsgpackWriterFull::packReference(mpack_writer_t *writer, core::Context ctx,
     mpack_write_u32(writer, ref.nestingId);
 
     // expression_range
-    auto expression_range = ctx.locAt(ref.definitionLoc).position(ctx);
+    auto expression_range = ctx.locAt(ref.definitionLoc).toDetails(ctx);
     packRange(writer, expression_range.first.line, expression_range.second.line);
     // expression_pos_range
     packRange(writer, ref.loc.beginPos(), ref.loc.endPos());

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -257,7 +257,7 @@ unique_ptr<Location> LSPConfiguration::loc2Location(const core::GlobalState &gs,
         // https://git.corp.stripe.com/stripe-internal/ruby-typer/tree/master/rbi/core/string.rbi#L18%2318,7
         // but shows you the same thing as
         // https://git.corp.stripe.com/stripe-internal/ruby-typer/tree/master/rbi/core/string.rbi#L18
-        uri = fmt::format("{}#L{}", uri, loc.position(gs).first.line);
+        uri = fmt::format("{}#L{}", uri, loc.toDetails(gs).first.line);
     }
     return make_unique<Location>(uri, std::move(range));
 }

--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -187,7 +187,7 @@ vector<unique_ptr<TextEdit>> moveMethod(LSPTypecheckerDelegate &typechecker, con
 
     // This manipulations with the positions are required to remove leading tabs and whitespaces at the original method
     // position
-    auto [oldMethodStart, oldMethodEnd] = methodSourceLoc.position(gs);
+    auto [oldMethodStart, oldMethodEnd] = methodSourceLoc.toDetails(gs);
     auto oldMethodLoc = core::Loc::fromDetails(gs, fref, {oldMethodStart.line, 0}, oldMethodEnd);
     ENFORCE(oldMethodLoc.has_value());
 

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -106,7 +106,7 @@ unique_ptr<Range> Range::fromLoc(const core::GlobalState &gs, core::Loc loc) {
         // this will happen if e.g. we disable the stdlib (e.g. to speed up testing in fuzzers).
         return nullptr;
     }
-    auto pair = loc.position(gs);
+    auto pair = loc.toDetails(gs);
     // All LSP numbers are zero-based, ours are 1-based.
     return make_unique<Range>(make_unique<Position>(pair.first.line - 1, pair.first.column - 1),
                               make_unique<Position>(pair.second.line - 1, pair.second.column - 1));

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -189,7 +189,7 @@ string Position::showRaw() const {
 // Returns nullopt if the position does not represent a valid location.
 optional<core::Loc> Position::toLoc(const core::GlobalState &gs, const core::FileRef fref) const {
     core::Loc::Detail reqPos{static_cast<uint32_t>(this->line + 1), static_cast<uint32_t>(this->character + 1)};
-    if (auto maybeOffset = core::Loc::pos2Offset(fref.data(gs), reqPos)) {
+    if (auto maybeOffset = core::Loc::detail2Pos(fref.data(gs), reqPos)) {
         auto offset = maybeOffset.value();
         return core::Loc{fref, offset, offset};
     } else {
@@ -227,8 +227,8 @@ string TextDocumentContentChangeEvent::apply(string_view oldSource) const {
         end.column = r->end->character + 1;
         core::File old("./fake/path.rb", string(oldSource), core::File::Type::Normal);
         // These offsets are non-nullopt assuming the input range is a valid range.
-        auto startOffset = core::Loc::pos2Offset(old, start).value();
-        auto endOffset = core::Loc::pos2Offset(old, end).value();
+        auto startOffset = core::Loc::detail2Pos(old, start).value();
+        auto endOffset = core::Loc::detail2Pos(old, end).value();
         return string(oldSource).replace(startOffset, endOffset - startOffset, text);
     } else {
         return text;

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -146,7 +146,7 @@ private:
             if (methodNameLoc->file().exists()) {
                 auto path = methodNameLoc->file().data(gs).path();
                 error = fmt::format("Failed to rename `{}` method call at {}:{}", oldName, path,
-                                    methodNameLoc->position(gs).first.line);
+                                    methodNameLoc->toDetails(gs).first.line);
             }
             return "";
         }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -824,8 +824,8 @@ private:
     }
 
     void checkLoc(core::Context ctx, core::Loc loc) {
-        auto detailStart = core::Loc::offset2Pos(file.data(ctx), loc.beginPos());
-        auto detailEnd = core::Loc::offset2Pos(file.data(ctx), loc.endPos());
+        auto detailStart = core::Loc::pos2Detail(file.data(ctx), loc.beginPos());
+        auto detailEnd = core::Loc::pos2Detail(file.data(ctx), loc.endPos());
         ENFORCE(!(detailStart.line >= prohibitedLinesStart && detailEnd.line <= prohibitedLinesEnd));
     }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1849,7 +1849,7 @@ public:
         auto multiline = false;
         auto indent = ""s;
         auto sendLoc = ctx.locAt(send->loc);
-        auto [beginDetail, endDetail] = sendLoc.position(ctx);
+        auto [beginDetail, endDetail] = sendLoc.toDetails(ctx);
         if (endDetail.line > beginDetail.line && send->funLoc.exists() && !send->funLoc.empty() &&
             send->numPosArgs() == 0) {
             deleteLoc = core::Loc(ctx.file, send->funLoc.endPos(), send->loc.endPos());
@@ -1863,7 +1863,7 @@ public:
         auto insertLoc = ctx.locAt(send->loc).copyEndWithZeroLength();
         auto kwArgsSource = kwArgsLoc.source(ctx).value();
         if (multiline) {
-            auto [kwBeginDetail, kwEndDetail] = kwArgsLoc.position(ctx);
+            auto [kwBeginDetail, kwEndDetail] = kwArgsLoc.toDetails(ctx);
             if (kwEndDetail.line > kwBeginDetail.line) {
                 auto reindentedSource = absl::StrReplaceAll(kwArgsSource, {{"\n", "\n  "}});
                 if (kwBeginDetail.line == beginDetail.line) {

--- a/resolver/CorrectTypeAlias.cc
+++ b/resolver/CorrectTypeAlias.cc
@@ -37,7 +37,7 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
         return;
     }
 
-    auto [start, end] = ctx.locAt(send->loc).position(ctx);
+    auto [start, end] = ctx.locAt(send->loc).toDetails(ctx);
 
     if (start.line == end.line) {
         if (wrapHash) {
@@ -54,7 +54,7 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
         if (wrapHash) {
             argSrc = fmt::format("{}{{\n{}\n{}}}", argIndent, indented(argSrc), argIndent);
         }
-        if (ctx.locAt(send->loc).position(ctx).second.line == endLoc.position(ctx).second.line) {
+        if (ctx.locAt(send->loc).toDetails(ctx).second.line == endLoc.toDetails(ctx).second.line) {
             argSrc = indented(argSrc);
         }
         e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias do\n{}\n{}end", argSrc,

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1215,7 +1215,7 @@ private:
                 }
 
                 string replacement = "";
-                int indent = core::Loc::offset2Pos(todo.file.data(gs), send->loc.beginPos()).column - 1;
+                int indent = core::Loc::pos2Detail(todo.file.data(gs), send->loc.beginPos()).column - 1;
                 int index = 1;
                 const auto numPosArgs = send->numPosArgs();
                 for (auto i = 0; i < numPosArgs; ++i) {

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -549,13 +549,13 @@ namespace {
 string applyEdit(string_view source, const core::File &file, const Range &range, string_view newText, bool reindent) {
     auto beginLine = static_cast<uint32_t>(range.start->line + 1);
     auto beginCol = static_cast<uint32_t>(range.start->character + 1);
-    auto beginOffset = core::Loc::pos2Offset(file, {beginLine, beginCol}).value();
+    auto beginOffset = core::Loc::detail2Pos(file, {beginLine, beginCol}).value();
 
     auto endLine = static_cast<uint32_t>(range.end->line + 1);
     auto endCol = static_cast<uint32_t>(range.end->character + 1);
-    auto endOffset = core::Loc::pos2Offset(file, {endLine, endCol}).value();
+    auto endOffset = core::Loc::detail2Pos(file, {endLine, endCol}).value();
 
-    auto lineStartOffset = core::Loc::pos2Offset(file, {beginLine, 1}).value();
+    auto lineStartOffset = core::Loc::detail2Pos(file, {beginLine, 1}).value();
     auto lineStartView = source.substr(lineStartOffset);
     auto firstNonWhitespace = lineStartView.find_first_not_of(" \t\n");
     auto indentAfterNewline = absl::StrCat("\n", source.substr(lineStartOffset, firstNonWhitespace));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We're kind of inconsistent w.r.t. how we use the word "position."

In the LSP spec, a [`Position`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position) is a line + column pair.

Sorbet (which chose its names before the LSP spec chose its) calls that same
data structure a `Detail`.

But even still, there is some difference: a Sorbet `Detail` is 1-indexed, but
an LSP `Position` is 0-indexed. So I think that there's value in not aligning on
the name `Position`, because maybe people would mistake it.

Instead, I'm going to align on the name `Detail` for the `line`/`col` pair, and
leave "position" or "pos" for what Sorbet also sometimes calls `offset`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.