### PR TITLE
Store lineBreaks with uint32_t

### DIFF
--- a/common/common.cc
+++ b/common/common.cc
@@ -488,9 +488,8 @@ uint32_t sorbet::nextPowerOfTwo(uint32_t v) {
     return v;
 }
 
-vector<int> sorbet::findLineBreaks(string_view s) {
-    vector<int> res;
-    res.emplace_back(-1);
+vector<uint32_t> sorbet::findLineBreaks(string_view s) {
+    vector<uint32_t> res;
     size_t next_pos = 0;
     while (true) {
         auto pos = s.find_first_of('\n', next_pos);

--- a/common/common.h
+++ b/common/common.h
@@ -127,7 +127,7 @@ template <class From, class To> To *fast_cast(From *what) {
 // Rounds the provided number up to the nearest power of two. If v is already a power of two, it returns v.
 uint32_t nextPowerOfTwo(uint32_t v);
 
-std::vector<int> findLineBreaks(std::string_view s);
+std::vector<uint32_t> findLineBreaks(std::string_view s);
 
 // To get exhaustiveness checking with std::visit.
 // From: https://en.cppreference.com/w/cpp/utility/variant/visit#Example

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -250,7 +250,7 @@ int File::lineCount() const {
 // 1-indexed line number
 string_view File::getLine(int i) const {
     auto lineBreaks = this->lineBreaks();
-    ENFORCE(i < lineBreaks.size());
+    ENFORCE(i <= lineBreaks.size());
     ENFORCE(i > 0);
     auto start = i == 1 ? 0 : lineBreaks[i - 2] + 1;
     auto end = lineBreaks[i - 1];

--- a/core/Files.h
+++ b/core/Files.h
@@ -74,7 +74,7 @@ public:
     File(const File &other) = delete;
     File() = delete;
     std::unique_ptr<File> deepCopy(GlobalState &) const;
-    absl::Span<const int> lineBreaks() const;
+    absl::Span<const uint32_t> lineBreaks() const;
     int lineCount() const;
     StrictLevel minErrorLevel() const;
 
@@ -114,7 +114,7 @@ private:
 public:
     const std::string path_;
     const std::string source_;
-    mutable std::shared_ptr<std::vector<int>> lineBreaks_;
+    mutable std::shared_ptr<std::vector<uint32_t>> lineBreaks_;
 
     mutable StrictLevel minErrorLevel_ = StrictLevel::Max;
 

--- a/core/Files.h
+++ b/core/Files.h
@@ -74,6 +74,15 @@ public:
     File(const File &other) = delete;
     File() = delete;
     std::unique_ptr<File> deepCopy(GlobalState &) const;
+
+    // Maps a 0-indexed line number to the offset of the end of the line
+    //
+    // If the line ends with the end of the file, then the offset points to the end of the file
+    // If the line ends with a newline character, then the offset points to the newline character.
+    //
+    // This means that for a file contents like "foo\n", this is considered two lines:
+    // - line 0: "foo"
+    // - line 1: ""
     absl::Span<const uint32_t> lineBreaks() const;
     int lineCount() const;
     StrictLevel minErrorLevel() const;
@@ -114,6 +123,10 @@ private:
 public:
     const std::string path_;
     const std::string source_;
+
+    // This is always a pure function of the `source_` string, so it is computed lazily, thus the
+    // `mutable`. We generally don't need `lineBreaks_` for every file, unless we're showing errors
+    // for that file, and computing lazily allows saving space.
     mutable std::shared_ptr<std::vector<uint32_t>> lineBreaks_;
 
     mutable StrictLevel minErrorLevel_ = StrictLevel::Max;

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -57,7 +57,7 @@ Loc::Detail Loc::pos2Detail(const File &file, uint32_t off) {
         detail.column = off + 1;
         return detail;
     }
-    detail.line = (it - lineBreaks.begin()) + 1;
+    detail.line = std::distance(lineBreaks.begin(), it) + 1;
     --it;
     detail.column = off - *it;
     return detail;

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -88,7 +88,7 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
     // Don't format `__package.rb` files, since currently formatting them
     // can potentially break some pay-server tooling
     if (!sourceView.empty() && !core::File::isPackagePath(path) && !core::File::isRBIPath(path)) {
-        auto originalLineCount = findLineBreaks(sourceView).size() - 1;
+        auto originalLineCount = findLineBreaks(sourceView).size();
         auto processResponse = sorbet::Subprocess::spawn(config.opts.rubyfmtPath, vector<string>(), sourceView);
 
         auto returnCode = processResponse->status;

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -234,24 +234,21 @@ size_t lexer::line_start(token_type type, size_t beginPos) {
     }
 
     // If this assertion ever fires, we'll have to change File::lineBreaks to operate on size_t
-    assert(beginPos < INT_MAX);
-    int beginPosInt = static_cast<int>(beginPos);
+    assert(beginPos < UINT32_MAX);
+    auto beginPosInt = static_cast<uint32_t>(beginPos);
 
-    // Gets the first element which compares greater than or equal to `beginPos`.
+    // Easier to think of this as "least upper bound," i.e. first element which is great than or equal to beginPos
     // Since we already handled newline characters, it should be just the first elem greater.
     auto it = absl::c_lower_bound(this->lineBreaks, beginPosInt);
-    if (it != this->lineBreaks.begin()) {
-        // First element of lineBreaks is always -1 (as if there was an
-        // imaginary `\n`) one character before the start of a file. But we're
-        // actually looking for the start of the line (i.e., the offset right
-        // after the newline).
-        //
-        // If we're not at begin, that means we found something the first newline after beginPos,
-        // and we want last newline before beginPos.
-        --it;
+    if (it == this->lineBreaks.begin()) {
+        // If the least upper bound newline is the first linebreak in the list,
+        // then the start of the line is the start of the file.
+        return 0;
     }
+
+    auto prevLineBreak = it - 1;
     // return offset immediately after offset of newline char
-    return (*it) + 1;
+    return (*prevLineBreak) + 1;
 }
 
 void lexer::check_stack_capacity() {

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -237,7 +237,7 @@ size_t lexer::line_start(token_type type, size_t beginPos) {
     assert(beginPos < UINT32_MAX);
     auto beginPosInt = static_cast<uint32_t>(beginPos);
 
-    // Easier to think of this as "least upper bound," i.e. first element which is great than or equal to beginPos
+    // Easier to think of this as "least upper bound," i.e. first element which is greater than or equal to beginPos
     // Since we already handled newline characters, it should be just the first elem greater.
     auto it = absl::c_lower_bound(this->lineBreaks, beginPosInt);
     if (it == this->lineBreaks.begin()) {

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -59,7 +59,7 @@ private:
     ruby_version version;
     std::string_view source_buffer;
     sorbet::StableStringStorage<> &scratch;
-    const std::vector<int> lineBreaks;
+    const std::vector<uint32_t> lineBreaks;
 
     std::stack<environment> static_env;
     std::stack<literal> literal_stack;

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -572,10 +572,6 @@ vector<shared_ptr<RangeAssertion>> parseAssertionsForFile(const shared_ptr<core:
     auto lineBreaks = file->lineBreaks();
 
     for (auto lineBreak : lineBreaks) {
-        // Ignore first line break entry.
-        if (lineBreak == -1) {
-            continue;
-        }
         string_view lineView = source.substr(nextChar, lineBreak - nextChar);
         auto line = string(lineView);
         nextChar = lineBreak + 1;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This lets us not lie when we call `c_lower_bound`, because we need the list
be sorted, but it appears not sorted when the comparison forces an upcast
to unsigned values (and the `-1` became `UINT32_MAX`).

See the first commit where I was _about_ to just land a large comment talking
about why that call to `c_lower_bound` is nonsensical, before thinking to
myself, "maybe it's not that hard to change."


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, also going to test on Stripe's codebase.