### PR TITLE
Avoid possibly using a freed global state from a worker

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -506,8 +506,8 @@ ast::ParsedFilesOrCancelled mergeIndexResults(core::GlobalState &cgs, const opti
         Timer timeit(cgs.tracer(), "substituteTrees");
         auto resultq = make_shared<BlockingBoundedQueue<vector<ast::ParsedFile>>>(batchq->bound);
 
-        workers.multiplexJob("substituteTrees", [&cgs, batchq, resultq, cancelable]() {
-            Timer timeit(cgs.tracer(), "substituteTreesWorker");
+        workers.multiplexJob("substituteTrees", [&cgs, &logger = cgs.tracer(), batchq, resultq, cancelable]() {
+            Timer timeit(logger, "substituteTreesWorker");
             IndexSubstitutionJob job;
             int numTreesProcessed = 0;
             std::vector<ast::ParsedFile> trees;
@@ -535,7 +535,9 @@ ast::ParsedFilesOrCancelled mergeIndexResults(core::GlobalState &cgs, const opti
                 }
             }
 
-            resultq->push(std::move(trees), numTreesProcessed);
+            if (numTreesProcessed > 0) {
+                resultq->push(std::move(trees), numTreesProcessed);
+            }
         });
 
         ret.reserve(totalNumTrees);


### PR DESCRIPTION
There's a potential race condition where one worker finishes substitution for all trees before another starts. In this case, we need to ensure that any state captured in the substituteTreesWorker's closure will remain valid.

As `cgs` could belong to a global state that's used from the slow path, there is a slim chance that it is freed due to cancelation before the worker task has a chance to start. This turns the construction of the timer with `cgs.tracer()` into a potential use-after-free.

We can avoid this by taking a reference to the spdlog instance in the closure, as it will be long-lived (it belongs to an error queue that lives for the duration of the LSPTypechecker) and using that when constructing the timer instead.

### Motivation
Fixing a race condition with the cancelable indexer.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a as there are no uses of the cancelable indexer on master. This was surfaced on #8589, where the `multithreaded_protol_test_corpus` test started flaking.
