### PR TITLE
Rewrite RBS comments found inside blocks

### DIFF
--- a/rewriter/RBSSignatures.cc
+++ b/rewriter/RBSSignatures.cc
@@ -212,7 +212,7 @@ class RBSSignaturesWalk {
 public:
     RBSSignaturesWalk(core::MutableContext ctx) {}
 
-    void preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+    void postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
         auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         auto newRHS = ast::ClassDef::RHS_store();

--- a/test/testdata/rewriter/rbs_signatures_blocks.rb
+++ b/test/testdata/rewriter/rbs_signatures_blocks.rb
@@ -1,0 +1,27 @@
+# typed: strict
+# enable-experimental-rbs-signatures: true
+
+Class.new do
+  #: -> String
+  def foo
+    nil # error: Expected `String` but found `NilClass` for method result type
+  end
+end
+
+Class.new do
+  #: -> String
+  def bar
+    nil # error: Expected `String` but found `NilClass` for method result type
+  end
+
+  puts "bar"
+
+  #: -> String
+  def baz
+    nil # error: Expected `String` but found `NilClass` for method result type
+  end
+
+  # Note that attr accessors can't have a sig (either RBS or Sorbet sig block) when found in a block.
+  attr_reader :qux1
+  attr_reader :qux2
+end

--- a/test/testdata/rewriter/rbs_signatures_blocks.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rbs_signatures_blocks.rb.rewrite-tree.exp
@@ -1,0 +1,43 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+    <self>.returns(<emptyTree>::<C String>)
+  end
+
+  def foo<<todo method>>(&<blk>)
+    nil
+  end
+
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+    <self>.returns(<emptyTree>::<C String>)
+  end
+
+  def bar<<todo method>>(&<blk>)
+    nil
+  end
+
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+    <self>.returns(<emptyTree>::<C String>)
+  end
+
+  def baz<<todo method>>(&<blk>)
+    nil
+  end
+
+  <emptyTree>::<C Class>.new() do ||
+    begin
+      <cast:<synthetic bind>>(<self>, <todo sym>, ::T::Class.[](::Object))
+      <runtime method definition of foo>
+    end
+  end
+
+  <emptyTree>::<C Class>.new() do ||
+    begin
+      <cast:<synthetic bind>>(<self>, <todo sym>, ::T::Class.[](::Object))
+      <runtime method definition of bar>
+      <self>.puts("bar")
+      <runtime method definition of baz>
+      <self>.attr_reader(:qux1)
+      <self>.attr_reader(:qux2)
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

Support RBS signature comments found inside blocks:

```rb
Class.new do
  #: -> void
  def foo; end
end
```

Will be rewritten as:

```rb
Class.new do
  sig { void }
  def foo; end
end
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
