### PR TITLE
Add a new type for managing kvstore copies

### DIFF
--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -79,6 +79,10 @@ public:
     OwnedKeyValueStore(std::unique_ptr<KeyValueStore> kvstore);
     ~OwnedKeyValueStore();
 
+    /** Copies the env to the path given. After a call to `copyTo`, a new kvstore may be opened using the path that was
+     * given. */
+    void copyTo(const std::string &path) const;
+
     /** returns nullptr if not found*/
     KeyValueStoreValue read(std::string_view key) const;
     /** Reads a string from the key value store. Lifetime of string is tied to the lifetime of the database. Returns an

--- a/main/cache/cache-orig.cc
+++ b/main/cache/cache-orig.cc
@@ -19,4 +19,19 @@ unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore
     return kvstore;
 }
 
+SessionCache::~SessionCache() noexcept(false) {}
+
+std::string_view SessionCache::kvstorePath() const {
+    return std::string_view(this->path);
+}
+
+std::unique_ptr<SessionCache> SessionCache::make(std::unique_ptr<const OwnedKeyValueStore> kvstore,
+                                                 ::spdlog::logger &logger, const options::Options &opts) {
+    return nullptr;
+}
+
+std::unique_ptr<KeyValueStore> SessionCache::open(std::shared_ptr<::spdlog::logger> logger) const {
+    return nullptr;
+}
+
 } // namespace sorbet::realmain::cache

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -278,12 +278,14 @@ std::unique_ptr<KeyValueStore> SessionCache::open(std::shared_ptr<::spdlog::logg
         openCache(std::move(logger), std::move(flavor), this->path, this->maxCacheBytes));
 
     // If the name table entry is missing, this indicates that the cache is completely fresh and doesn't originate in a
-    // copy from the result of indexing.
+    // copy from the result of indexing. This can happen if only the `data.mdb` file was removed from `this->path`, and
+    // the KeyValueStore created a fresh database when created.
     const auto nameTableEntry = kvstore->read(core::serialize::Serializer::NAME_TABLE_KEY);
     if (nameTableEntry.len == 0) {
         return nullptr;
     }
 
+    // We abort here because there will be no outstanding transactions present.
     return OwnedKeyValueStore::abort(std::move(kvstore));
 }
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -236,6 +236,8 @@ std::unique_ptr<SessionCache> SessionCache::make(std::unique_ptr<const OwnedKeyV
     std::string path;
 
     for (int i = 0; i < 10; i++) {
+        // Store the session cache as a sub folder of the cacheDir, so we don't write additional cache data to
+        // an unexpected location.
         path = fmt::format("{}/session-{:x}", opts.cacheDir, Random::uniformU4());
         if (!FileOps::dirExists(path)) {
             break;

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -1,4 +1,5 @@
 #include "main/cache/cache.h"
+#include "common/FileOps.h"
 #include "common/Random.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "common/kvstore/KeyValueStore.h"
@@ -9,6 +10,15 @@
 using namespace std;
 
 namespace sorbet::realmain::cache {
+
+namespace {
+unique_ptr<KeyValueStore> openCache(std::shared_ptr<::spdlog::logger> logger, std::string flavor, std::string cacheDir,
+                                    size_t maxCacheSizeBytes) {
+    return make_unique<KeyValueStore>(std::move(logger), sorbet_full_version_string, std::move(cacheDir),
+                                      std::move(flavor), maxCacheSizeBytes);
+}
+} // namespace
+
 unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::logger> logger,
                                                         const options::Options &opts) {
     if (opts.cacheDir.empty()) {
@@ -18,8 +28,8 @@ unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::log
     // bust all existing caches when we promoted the experimental-at-the-time incremental fast path
     // to the stable version.
     auto flavor = "experimentalfastpath";
-    return make_unique<OwnedKeyValueStore>(make_unique<KeyValueStore>(logger, sorbet_full_version_string, opts.cacheDir,
-                                                                      move(flavor), opts.maxCacheSizeBytes));
+    return make_unique<OwnedKeyValueStore>(
+        openCache(std::move(logger), std::move(flavor), opts.cacheDir, opts.maxCacheSizeBytes));
 }
 
 namespace {
@@ -192,6 +202,69 @@ unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore
     }
 
     return kvstore;
+}
+
+SessionCache::SessionCache(std::string path, size_t maxCacheBytes)
+    : path{std::move(path)}, maxCacheBytes{maxCacheBytes} {}
+
+SessionCache::~SessionCache() noexcept(false) {
+    if (!FileOps::dirExists(this->path)) {
+        return;
+    }
+
+    auto dataMdb = fmt::format("{}/data.mdb", this->path);
+    if (FileOps::exists(dataMdb)) {
+        FileOps::removeFile(dataMdb);
+    }
+
+    auto lockMdb = fmt::format("{}/lock.mdb", this->path);
+    if (FileOps::exists(lockMdb)) {
+        FileOps::removeFile(lockMdb);
+    }
+
+    // Fail silently if the directory has files other than those created by LMDB. This should be fine though, as we will
+    // have removed the largest files.
+    FileOps::removeEmptyDir(this->path);
+}
+
+std::unique_ptr<SessionCache> SessionCache::make(std::unique_ptr<const OwnedKeyValueStore> kvstore,
+                                                 ::spdlog::logger &logger, const options::Options &opts) {
+    if (kvstore == nullptr || opts.cacheDir.empty()) {
+        return nullptr;
+    }
+
+    std::string path;
+
+    for (int i = 0; i < 10; i++) {
+        path = fmt::format("{}/session-{:x}", opts.cacheDir, Random::uniformU4());
+        if (!FileOps::dirExists(path)) {
+            break;
+        }
+        path.clear();
+    }
+
+    if (path.empty()) {
+        Exception::raise("Cache copying failed: failed to make a unique temp directory");
+    }
+
+    kvstore->copyTo(path);
+
+    OwnedKeyValueStore::abort(std::move(kvstore));
+
+    // Explicit construction because the constructor is private.
+    return std::unique_ptr<SessionCache>(new SessionCache{std::move(path), opts.maxCacheSizeBytes});
+}
+
+std::string_view SessionCache::kvstorePath() const {
+    return std::string_view(this->path);
+}
+
+std::unique_ptr<KeyValueStore> SessionCache::open(std::shared_ptr<::spdlog::logger> logger) const {
+    // Despite being called "experimental," this feature is actually stable. We just didn't want to
+    // bust all existing caches when we promoted the experimental-at-the-time incremental fast path
+    // to the stable version.
+    auto flavor = "experimentalfastpath";
+    return openCache(std::move(logger), std::move(flavor), this->path, this->maxCacheBytes);
 }
 
 } // namespace sorbet::realmain::cache

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -235,7 +235,9 @@ std::unique_ptr<SessionCache> SessionCache::make(std::unique_ptr<const OwnedKeyV
 
     std::string path;
 
-    for (int i = 0; i < 10; i++) {
+    // Pretty unlikely that we'll see a collision, as we're removing the directory on exit and also generating random
+    // names, but make two attempts to find a new one anyway.
+    for (int i = 0; i < 2; i++) {
         // Store the session cache as a sub folder of the cacheDir, so we don't write additional cache data to
         // an unexpected location.
         path = fmt::format("{}/session-{:x}", opts.cacheDir, Random::uniformU4());

--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -2,6 +2,7 @@
 #define RUBY_TYPER_CACHE_CACHE_H
 
 #include <memory>
+#include <string>
 
 namespace spdlog {
 class logger;
@@ -36,6 +37,32 @@ std::unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(std::unique_ptr<Key
                                                              const options::Options &opts, core::GlobalState &gs,
                                                              WorkerPool &workers,
                                                              const std::vector<ast::ParsedFile> &indexed);
+
+// A handle to a copy of the kvstore that is removed when the current session ends.
+class SessionCache {
+    // The path to the session-unique copy of the cache that was created during initialization.
+    std::string path;
+    size_t maxCacheBytes;
+
+    SessionCache() = delete;
+    SessionCache(std::string path, size_t maxCacheBytes);
+
+public:
+    // Removes the session cache.
+    ~SessionCache() noexcept(false);
+
+    // The path to the unique copy.
+    std::string_view kvstorePath() const;
+
+    // Close out the kvstore, and create a copy that's stored at `opts.cacheDir + '/' + randomUuid`. If the creation
+    // failed, or the kvstore was a `nullptr`, this returns a null pointer.
+    static std::unique_ptr<SessionCache> make(std::unique_ptr<const OwnedKeyValueStore> kvstore,
+                                              ::spdlog::logger &logger, const options::Options &opts);
+
+    // Open the session cache for use.
+    std::unique_ptr<KeyValueStore> open(std::shared_ptr<::spdlog::logger> logger) const;
+};
+
 } // namespace sorbet::realmain::cache
 
 #endif

--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -38,7 +38,11 @@ std::unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(std::unique_ptr<Key
                                                              WorkerPool &workers,
                                                              const std::vector<ast::ParsedFile> &indexed);
 
-// A handle to a copy of the kvstore that is removed when the current session ends.
+// For situations where it's necessary to have unique ownership of the cache for the duration of the session, the
+// `SessionCache` is a good option. It makes a copy of an existing `KeyValueStore`, and provides a mechanism for
+// reopening that unique copy. This ensures that the name table present in the kvstore will not change unless it's by
+// something with access to the `SessionCache`, making it easier to coexist with other processes that might want to use
+// and mutate the cache directory specified by `--cache-dir`.
 class SessionCache {
     // The path to the session-unique copy of the cache that was created during initialization.
     std::string path;

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -511,8 +511,8 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "RemoveSessionCacheDirectory") {
         REQUIRE_EQ(copy, nullptr);
     }
 
-    // Verify that we can't open when the database files have been removed (the previous open attempt will create an
-    // empty db, so we have to remove it again)
+    // Verify that we can't open when the database directory has been removed (the previous open attempt will create an
+    // empty db, so we have to remove the files again again)
     for (auto &file : toRemove) {
         FileOps::removeFile(file);
     }


### PR DESCRIPTION
This PR adds the `cache::SessionCache` type, which makes it easy to manage the lifetime of a copy of the kvstore that's only meant to live until the end of the current LSP session.

### Motivation
Make it easier to manage a copy of the kvstore for a single LSP session.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
