### PR TITLE
Add concept of "cache-sensitive" options

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -230,7 +230,7 @@ ExpressionPtr desugarBegin(DesugarContext dctx, core::LocOffsets loc, parser::No
 }
 
 core::NameRef maybeTypedSuper(DesugarContext dctx) {
-    return (dctx.ctx.state.typedSuper && !dctx.inAnyBlock && !dctx.inModule) ? core::Names::super()
+    return (dctx.ctx.state.cacheSensitiveOptions.typedSuper && !dctx.inAnyBlock && !dctx.inModule) ? core::Names::super()
                                                                              : core::Names::untypedSuper();
 }
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -230,8 +230,9 @@ ExpressionPtr desugarBegin(DesugarContext dctx, core::LocOffsets loc, parser::No
 }
 
 core::NameRef maybeTypedSuper(DesugarContext dctx) {
-    return (dctx.ctx.state.cacheSensitiveOptions.typedSuper && !dctx.inAnyBlock && !dctx.inModule) ? core::Names::super()
-                                                                             : core::Names::untypedSuper();
+    return (dctx.ctx.state.cacheSensitiveOptions.typedSuper && !dctx.inAnyBlock && !dctx.inModule)
+               ? core::Names::super()
+               : core::Names::untypedSuper();
 }
 
 bool isStringLit(DesugarContext dctx, ExpressionPtr &expr) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2078,14 +2078,14 @@ void GlobalState::copyOptions(const core::GlobalState &other) {
     this->autocorrect = other.autocorrect;
     this->didYouMean = other.didYouMean;
     this->ensureCleanStrings = other.ensureCleanStrings;
-    this->runningUnderAutogen = other.runningUnderAutogen;
     this->censorForSnapshotTests = other.censorForSnapshotTests;
     this->sleepInSlowPathSeconds = other.sleepInSlowPathSeconds;
     this->rbsSignaturesEnabled = other.rbsSignaturesEnabled;
     this->rbsAssertionsEnabled = other.rbsAssertionsEnabled;
     this->requiresAncestorEnabled = other.requiresAncestorEnabled;
-    this->ruby3KeywordArgs = other.ruby3KeywordArgs;
     this->typedSuper = other.typedSuper;
+    this->runningUnderAutogen = other.runningUnderAutogen;
+    this->ruby3KeywordArgs = other.ruby3KeywordArgs;
     this->suppressPayloadSuperclassRedefinitionFor = other.suppressPayloadSuperclassRedefinitionFor;
     this->trackUntyped = other.trackUntyped;
     this->printingFileTable = other.printingFileTable;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2080,11 +2080,7 @@ void GlobalState::copyOptions(const core::GlobalState &other) {
     this->ensureCleanStrings = other.ensureCleanStrings;
     this->censorForSnapshotTests = other.censorForSnapshotTests;
     this->sleepInSlowPathSeconds = other.sleepInSlowPathSeconds;
-    this->rbsSignaturesEnabled = other.rbsSignaturesEnabled;
-    this->rbsAssertionsEnabled = other.rbsAssertionsEnabled;
-    this->requiresAncestorEnabled = other.requiresAncestorEnabled;
-    this->typedSuper = other.typedSuper;
-    this->runningUnderAutogen = other.runningUnderAutogen;
+    this->cacheSensitiveOptions = other.cacheSensitiveOptions;
     this->ruby3KeywordArgs = other.ruby3KeywordArgs;
     this->suppressPayloadSuperclassRedefinitionFor = other.suppressPayloadSuperclassRedefinitionFor;
     this->trackUntyped = other.trackUntyped;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -249,12 +249,6 @@ public:
     //
     // If this attribute is set to `true`, all strings will be checked for `<` and `>` characters in them.
     bool ensureCleanStrings = false;
-
-    // So we can know whether we're running in autogen mode.
-    // Right now this is only used to turn certain Rewriter passes on or off.
-    // Think very hard before looking at this value in namer / resolver!
-    // (hint: probably you want to find an alternate solution)
-    bool runningUnderAutogen = false;
     bool censorForSnapshotTests = false;
 
     std::optional<int> sleepInSlowPathSeconds = std::nullopt;
@@ -310,6 +304,23 @@ public:
     // Some calls to `super` are not type checked due to incomplete/imperfect information.
     bool typedSuper = true;
 
+    // Whether to parse RBS-style type annotations out of comments
+    bool rbsSignaturesEnabled = false;
+
+    // Whether to parse RBS-style type assertions out of end-of-line comments
+    bool rbsAssertionsEnabled = false;
+
+    // Whether to allow `requires_ancestor`, which allows modeling certain kinds of indirect
+    // inheritance hierarchies, at the expense of implementation complexity and soundness
+    // problems.
+    bool requiresAncestorEnabled = false;
+
+    // So we can know whether we're running in autogen mode.
+    // Right now this is only used to turn certain Rewriter passes on or off.
+    // Think very hard before looking at this value in namer / resolver!
+    // (hint: probably you want to find an alternate solution)
+    bool runningUnderAutogen = false;
+
     std::vector<std::string> suppressPayloadSuperclassRedefinitionFor;
 
     // When present, this indicates that single-package rbi generation is being performed, and contains metadata about
@@ -323,10 +334,6 @@ public:
     std::optional<std::string> suggestUnsafe;
 
     std::vector<std::unique_ptr<pipeline::semantic_extension::SemanticExtension>> semanticExtensions;
-
-    bool rbsSignaturesEnabled = false;
-    bool rbsAssertionsEnabled = false;
-    bool requiresAncestorEnabled = false;
 
     bool shouldReportErrorOn(FileRef file, ErrorClass what) const;
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -300,6 +300,13 @@ public:
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
 
+    // Some options change the behavior of things that might be cached, including ASTs, the file
+    // table, the name table, the symbol table, etc.
+    //
+    // If these options change, it's no longer safe to read things out of the cache, because the
+    // cache. For example, `typedSuper` controls how Ruby's `super` keyword is desugared, and the
+    // result of desugar is cached.
+    struct CacheSensitiveOptions {
     // If 'true', attempt to typecheck calls to `super` as often as possible.
     // Some calls to `super` are not type checked due to incomplete/imperfect information.
     bool typedSuper = true;
@@ -320,6 +327,8 @@ public:
     // Think very hard before looking at this value in namer / resolver!
     // (hint: probably you want to find an alternate solution)
     bool runningUnderAutogen = false;
+    };
+    CacheSensitiveOptions cacheSensitiveOptions;
 
     std::vector<std::string> suppressPayloadSuperclassRedefinitionFor;
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -307,26 +307,26 @@ public:
     // cache. For example, `typedSuper` controls how Ruby's `super` keyword is desugared, and the
     // result of desugar is cached.
     struct CacheSensitiveOptions {
-    // If 'true', attempt to typecheck calls to `super` as often as possible.
-    // Some calls to `super` are not type checked due to incomplete/imperfect information.
-    bool typedSuper = true;
+        // If 'true', attempt to typecheck calls to `super` as often as possible.
+        // Some calls to `super` are not type checked due to incomplete/imperfect information.
+        bool typedSuper = true;
 
-    // Whether to parse RBS-style type annotations out of comments
-    bool rbsSignaturesEnabled = false;
+        // Whether to parse RBS-style type annotations out of comments
+        bool rbsSignaturesEnabled = false;
 
-    // Whether to parse RBS-style type assertions out of end-of-line comments
-    bool rbsAssertionsEnabled = false;
+        // Whether to parse RBS-style type assertions out of end-of-line comments
+        bool rbsAssertionsEnabled = false;
 
-    // Whether to allow `requires_ancestor`, which allows modeling certain kinds of indirect
-    // inheritance hierarchies, at the expense of implementation complexity and soundness
-    // problems.
-    bool requiresAncestorEnabled = false;
+        // Whether to allow `requires_ancestor`, which allows modeling certain kinds of indirect
+        // inheritance hierarchies, at the expense of implementation complexity and soundness
+        // problems.
+        bool requiresAncestorEnabled = false;
 
-    // So we can know whether we're running in autogen mode.
-    // Right now this is only used to turn certain Rewriter passes on or off.
-    // Think very hard before looking at this value in namer / resolver!
-    // (hint: probably you want to find an alternate solution)
-    bool runningUnderAutogen = false;
+        // So we can know whether we're running in autogen mode.
+        // Right now this is only used to turn certain Rewriter passes on or off.
+        // Think very hard before looking at this value in namer / resolver!
+        // (hint: probably you want to find an alternate solution)
+        bool runningUnderAutogen = false;
     };
     CacheSensitiveOptions cacheSensitiveOptions;
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -303,9 +303,9 @@ public:
     // Some options change the behavior of things that might be cached, including ASTs, the file
     // table, the name table, the symbol table, etc.
     //
-    // If these options change, it's no longer safe to read things out of the cache, because the
-    // cache. For example, `typedSuper` controls how Ruby's `super` keyword is desugared, and the
-    // result of desugar is cached.
+    // If these options change, it's no longer safe to read things out of the cache.
+    // For example, `typedSuper` controls how Ruby's `super` keyword is desugared, and the
+    // result of desugar (where `typedSuper` is used) is cached.
     struct CacheSensitiveOptions {
         // If 'true', attempt to typecheck calls to `super` as often as possible.
         // Some calls to `super` are not type checked due to incomplete/imperfect information.

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2105,12 +2105,12 @@ ClassOrModule::requiredAncestorsTransitiveInternal(GlobalState &gs, std::vector<
 
 // All required ancestors by this class or module
 vector<ClassOrModule::RequiredAncestor> ClassOrModule::requiredAncestorsTransitive(const GlobalState &gs) const {
-    ENFORCE(gs.requiresAncestorEnabled);
+    ENFORCE(gs.cacheSensitiveOptions.requiresAncestorEnabled);
     return readRequiredAncestorsInternal(gs, Names::requiredAncestorsLin());
 }
 
 void ClassOrModule::computeRequiredAncestorLinearization(GlobalState &gs) {
-    ENFORCE(gs.requiresAncestorEnabled);
+    ENFORCE(gs.cacheSensitiveOptions.requiresAncestorEnabled);
     std::vector<ClassOrModuleRef> seen;
     requiredAncestorsTransitiveInternal(gs, seen);
 }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -84,7 +84,7 @@ public:
               isIncompatibleOverride(false), isPackagePrivate(false) {}
 
         uint16_t serialize() const {
-            ENFORCE(sizeof(Flags) == sizeof(uint16_t));
+            static_assert(sizeof(Flags) == sizeof(uint16_t));
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint16_t *>(this);
 
@@ -233,7 +233,7 @@ public:
               isExported(false) {}
 
         uint8_t serialize() const {
-            ENFORCE(sizeof(Flags) == sizeof(uint8_t));
+            static_assert(sizeof(Flags) == sizeof(uint8_t));
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint8_t *>(this);
             // We need to mask the valid bits since uninitialized memory isn't zeroed in C++.
@@ -306,6 +306,7 @@ public:
               isContravariant(false), isFixed(false) {}
 
         uint8_t serialize() const {
+            static_assert(sizeof(Flags) == sizeof(uint8_t));
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint8_t *>(this);
             // Mask the valid bits since uninitialized bits can be any value.
@@ -389,6 +390,7 @@ public:
               isBehaviorDefining(false) {}
 
         uint16_t serialize() const {
+            static_assert(sizeof(Flags) == sizeof(uint16_t));
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint16_t *>(this);
             // Mask the valid bits since uninitialized bits can be any value.

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2133,7 +2133,8 @@ public:
         ClassOrModuleRef self = unwrapSymbol(gs, args.thisType, mustExist);
         auto tClassSelfType = Types::tClass(Types::widen(gs, args.selfType));
         if (self.data(gs)->isModule()) {
-            ENFORCE(gs.cacheSensitiveOptions.requiresAncestorEnabled, "Congrats, you've found a test case. Please add it, then delete this.");
+            ENFORCE(gs.cacheSensitiveOptions.requiresAncestorEnabled,
+                    "Congrats, you've found a test case. Please add it, then delete this.");
             // This normally can't happen, because `Object` is not an ancestor of any module
             // instance by default. But Sorbet supports requires ancestor in a really weird way (by
             // simply dispatching to a completely unrelated method) which means that sometimes we

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -695,7 +695,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         mayBeOverloaded = symbol.data(gs)->findMethodTransitive(gs, targetName);
     }
 
-    if (!mayBeOverloaded.exists() && gs.requiresAncestorEnabled) {
+    if (!mayBeOverloaded.exists() && gs.cacheSensitiveOptions.requiresAncestorEnabled) {
         // Before raising any error, we look if the method exists in all required ancestors by this symbol
         auto ancestors = symbol.data(gs)->requiredAncestorsTransitive(gs);
         for (auto ancst : ancestors) {
@@ -743,7 +743,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             if (args.name == core::Names::declareInterface() || args.name == core::Names::declareAbstract() ||
                 args.name == core::Names::declareFinal() || args.name == core::Names::declareSealed() ||
                 args.name == core::Names::mixesInClassMethods() ||
-                (args.name == core::Names::requiresAncestor() && gs.requiresAncestorEnabled)) {
+                (args.name == core::Names::requiresAncestor() && gs.cacheSensitiveOptions.requiresAncestorEnabled)) {
                 auto attachedClass = symbol.data(gs)->attachedClass(gs);
                 TypeErrorDiagnostics::maybeInsertDSLMethod(gs, e, args.locs.file, args.callLoc(), attachedClass,
                                                            Symbols::T_Helpers(), "");
@@ -2133,7 +2133,7 @@ public:
         ClassOrModuleRef self = unwrapSymbol(gs, args.thisType, mustExist);
         auto tClassSelfType = Types::tClass(Types::widen(gs, args.selfType));
         if (self.data(gs)->isModule()) {
-            ENFORCE(gs.requiresAncestorEnabled, "Congrats, you've found a test case. Please add it, then delete this.");
+            ENFORCE(gs.cacheSensitiveOptions.requiresAncestorEnabled, "Congrats, you've found a test case. Please add it, then delete this.");
             // This normally can't happen, because `Object` is not an ancestor of any module
             // instance by default. But Sorbet supports requires ancestor in a really weird way (by
             // simply dispatching to a completely unrelated method) which means that sometimes we

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -1144,7 +1144,7 @@ public:
             // is a `class << self` ClassDef)
             validateAbstract(ctx, sym, classDef);
 
-            if (ctx.state.requiresAncestorEnabled) {
+            if (ctx.state.cacheSensitiveOptions.requiresAncestorEnabled) {
                 validateRequiredAncestors(ctx, sym);
             }
         }
@@ -1153,7 +1153,7 @@ public:
         validateSealed(ctx, sym, classDef);
         validateSuperClass(ctx, sym, classDef);
 
-        if (ctx.state.requiresAncestorEnabled) {
+        if (ctx.state.cacheSensitiveOptions.requiresAncestorEnabled) {
             validateRequiredAncestors(ctx, singleton);
         }
     }

--- a/main/cache/cache-orig.cc
+++ b/main/cache/cache-orig.cc
@@ -30,7 +30,8 @@ std::unique_ptr<SessionCache> SessionCache::make(std::unique_ptr<const OwnedKeyV
     return nullptr;
 }
 
-std::unique_ptr<KeyValueStore> SessionCache::open(std::shared_ptr<::spdlog::logger> logger) const {
+std::unique_ptr<KeyValueStore> SessionCache::open(std::shared_ptr<::spdlog::logger> logger,
+                                                  const options::Options &opts) const {
     return nullptr;
 }
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -13,14 +13,15 @@ namespace sorbet::realmain::cache {
 
 namespace {
 unique_ptr<KeyValueStore> openCache(std::shared_ptr<::spdlog::logger> logger, std::string cacheDir,
-                                    size_t maxCacheSizeBytes) {
+                                    const options::Options &opts) {
     // We currently only support one flavor of cache: "default". Each flavor is a separate database in the LMDB
     // environment, and we'll write all cached trees to that database during indexing. This means that supporting
     // multiple populated flavors in a single environment will increase the size of the environment proportionally to
     // the number of files stored * the number of flavors used. For this reason, we need to be very careful when
     // considering adding a new cache flavor.
-    return make_unique<KeyValueStore>(std::move(logger), sorbet_full_version_string, std::move(cacheDir), "default",
-                                      maxCacheSizeBytes);
+    auto flavor = "default";
+    return make_unique<KeyValueStore>(std::move(logger), sorbet_full_version_string, std::move(cacheDir), flavor,
+                                      opts.maxCacheSizeBytes);
 }
 } // namespace
 
@@ -29,7 +30,7 @@ unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::log
     if (opts.cacheDir.empty()) {
         return nullptr;
     }
-    return make_unique<OwnedKeyValueStore>(openCache(std::move(logger), opts.cacheDir, opts.maxCacheSizeBytes));
+    return make_unique<OwnedKeyValueStore>(openCache(std::move(logger), opts.cacheDir, opts));
 }
 
 namespace {
@@ -204,8 +205,7 @@ unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(unique_ptr<KeyValueStore
     return kvstore;
 }
 
-SessionCache::SessionCache(std::string path, size_t maxCacheBytes)
-    : path{std::move(path)}, maxCacheBytes{maxCacheBytes} {}
+SessionCache::SessionCache(std::string path) : path{std::move(path)} {}
 
 SessionCache::~SessionCache() noexcept(false) {
     if (!FileOps::dirExists(this->path)) {
@@ -256,22 +256,22 @@ std::unique_ptr<SessionCache> SessionCache::make(std::unique_ptr<const OwnedKeyV
     OwnedKeyValueStore::abort(std::move(kvstore));
 
     // Explicit construction because the constructor is private.
-    return std::unique_ptr<SessionCache>(new SessionCache{std::move(path), opts.maxCacheSizeBytes});
+    return std::unique_ptr<SessionCache>(new SessionCache{std::move(path)});
 }
 
 std::string_view SessionCache::kvstorePath() const {
     return std::string_view(this->path);
 }
 
-std::unique_ptr<KeyValueStore> SessionCache::open(std::shared_ptr<::spdlog::logger> logger) const {
+std::unique_ptr<KeyValueStore> SessionCache::open(std::shared_ptr<::spdlog::logger> logger,
+                                                  const options::Options &opts) const {
     // If the session copy has disappeared, we return a nullptr to force downstream consumers to explicitly handle the
     // empty cache.
     if (!FileOps::dirExists(this->path)) {
         return nullptr;
     }
 
-    auto kvstore =
-        std::make_unique<const OwnedKeyValueStore>(openCache(std::move(logger), this->path, this->maxCacheBytes));
+    auto kvstore = std::make_unique<const OwnedKeyValueStore>(openCache(std::move(logger), this->path, opts));
 
     // If the name table entry is missing, this indicates that the cache is completely fresh and doesn't originate in a
     // copy from the result of indexing. This can happen if only the `data.mdb` file was removed from `this->path`, and

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -20,8 +20,8 @@ unique_ptr<KeyValueStore> openCache(std::shared_ptr<::spdlog::logger> logger, st
     // the number of files stored * the number of flavors used. For this reason, we need to be very careful when
     // considering adding a new cache flavor.
     auto flavor = "default";
-    return make_unique<KeyValueStore>(std::move(logger), sorbet_full_version_string, std::move(cacheDir), flavor,
-                                      opts.maxCacheSizeBytes);
+    auto version = fmt::format("{}|{}", sorbet_full_version_string, opts.cacheSensitiveOptions.serialize());
+    return make_unique<KeyValueStore>(std::move(logger), version, std::move(cacheDir), flavor, opts.maxCacheSizeBytes);
 }
 } // namespace
 

--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -46,10 +46,9 @@ std::unique_ptr<KeyValueStore> maybeCacheGlobalStateAndFiles(std::unique_ptr<Key
 class SessionCache {
     // The path to the session-unique copy of the cache that was created during initialization.
     std::string path;
-    size_t maxCacheBytes;
 
     SessionCache() = delete;
-    SessionCache(std::string path, size_t maxCacheBytes);
+    SessionCache(std::string path);
 
 public:
     // Removes the session cache.
@@ -64,7 +63,7 @@ public:
                                               ::spdlog::logger &logger, const options::Options &opts);
 
     // Open the session cache for use.
-    std::unique_ptr<KeyValueStore> open(std::shared_ptr<::spdlog::logger> logger) const;
+    std::unique_ptr<KeyValueStore> open(std::shared_ptr<::spdlog::logger> logger, const options::Options &opts) const;
 };
 
 } // namespace sorbet::realmain::cache

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -927,19 +927,19 @@ void readOptions(Options &opts,
 
         opts.cacheDir = raw["cache-dir"].as<string>();
 
-        opts.rbsSignaturesEnabled = raw["enable-experimental-rbs-signatures"].as<bool>();
-        if (opts.rbsSignaturesEnabled && !opts.cacheDir.empty()) {
+        opts.cacheSensitiveOptions.rbsSignaturesEnabled = raw["enable-experimental-rbs-signatures"].as<bool>();
+        if (opts.cacheSensitiveOptions.rbsSignaturesEnabled && !opts.cacheDir.empty()) {
             logger->error("--enable-experimental-rbs-signatures is incompatible with --cache-dir. Ignoring cache");
             opts.cacheDir = "";
         }
 
-        opts.rbsAssertionsEnabled = raw["enable-experimental-rbs-assertions"].as<bool>();
-        if (opts.rbsAssertionsEnabled && !opts.cacheDir.empty()) {
+        opts.cacheSensitiveOptions.rbsAssertionsEnabled = raw["enable-experimental-rbs-assertions"].as<bool>();
+        if (opts.cacheSensitiveOptions.rbsAssertionsEnabled && !opts.cacheDir.empty()) {
             logger->error("--enable-experimental-rbs-assertions is incompatible with --cache-dir. Ignoring cache");
             opts.cacheDir = "";
         }
 
-        opts.requiresAncestorEnabled = raw["enable-experimental-requires-ancestor"].as<bool>();
+        opts.cacheSensitiveOptions.requiresAncestorEnabled = raw["enable-experimental-requires-ancestor"].as<bool>();
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
         opts.lspAllBetaFeaturesEnabled = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();
@@ -1014,7 +1014,7 @@ void readOptions(Options &opts,
                 throw EarlyReturnWithCode(1);
             }
 
-            opts.runningUnderAutogen = isAutogen;
+            opts.cacheSensitiveOptions.runningUnderAutogen = isAutogen;
         }
 
         if (raw.count("autogen-version") > 0) {
@@ -1048,7 +1048,7 @@ void readOptions(Options &opts,
         }
 
         if (raw.count("autogen-behavior-allowed-in-rbi-files-paths") > 0) {
-            if (!opts.runningUnderAutogen) {
+            if (!opts.cacheSensitiveOptions.runningUnderAutogen) {
                 logger->error("autogen-behavior-allowed-in-rbi-files-paths can only be used with -p autogen or -p "
                               "autogen-msgpack");
                 throw EarlyReturnWithCode(1);
@@ -1293,7 +1293,7 @@ void readOptions(Options &opts,
         opts.errorUrlBase = raw["error-url-base"].as<string>();
         opts.noErrorSections = raw["no-error-sections"].as<bool>();
         opts.ruby3KeywordArgs = raw["experimental-ruby3-keyword-args"].as<bool>();
-        opts.typedSuper = raw["typed-super"].as<bool>();
+        opts.cacheSensitiveOptions.typedSuper = raw["typed-super"].as<bool>();
 
         if (raw.count("suppress-payload-superclass-redefinition-for") > 0) {
             for (const auto &childClassName :

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -928,16 +928,8 @@ void readOptions(Options &opts,
         opts.cacheDir = raw["cache-dir"].as<string>();
 
         opts.cacheSensitiveOptions.rbsSignaturesEnabled = raw["enable-experimental-rbs-signatures"].as<bool>();
-        if (opts.cacheSensitiveOptions.rbsSignaturesEnabled && !opts.cacheDir.empty()) {
-            logger->error("--enable-experimental-rbs-signatures is incompatible with --cache-dir. Ignoring cache");
-            opts.cacheDir = "";
-        }
 
         opts.cacheSensitiveOptions.rbsAssertionsEnabled = raw["enable-experimental-rbs-assertions"].as<bool>();
-        if (opts.cacheSensitiveOptions.rbsAssertionsEnabled && !opts.cacheDir.empty()) {
-            logger->error("--enable-experimental-rbs-assertions is incompatible with --cache-dir. Ignoring cache");
-            opts.cacheDir = "";
-        }
 
         opts.cacheSensitiveOptions.requiresAncestorEnabled = raw["enable-experimental-requires-ancestor"].as<bool>();
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -26,6 +26,8 @@ using namespace std;
 
 namespace sorbet::realmain::options {
 
+namespace {
+
 enum class Group {
     INPUT,
     OUTPUT,
@@ -147,6 +149,8 @@ const vector<PrintOptions> print_options({
     {"untyped-blame", &Printers::UntypedBlame, true, true, true},
 });
 
+} // namespace
+
 PrinterConfig::PrinterConfig() : state(make_shared<GuardedState>()){};
 
 void PrinterConfig::print(const string_view &contents) const {
@@ -222,6 +226,8 @@ vector<reference_wrapper<PrinterConfig>> Printers::printers() {
 bool Printers::isAutogen() const {
     return Autogen.enabled || AutogenMsgPack.enabled || AutogenSubclasses.enabled;
 }
+
+namespace {
 
 struct StopAfterOptions {
     string option;
@@ -805,11 +811,15 @@ string_view stripTrailingSlashes(string_view path) {
     return path;
 }
 
+} // namespace
+
 void Options::flushPrinters() {
     for (PrinterConfig &cfg : print.printers()) {
         cfg.flush();
     }
 }
+
+namespace {
 
 void parseIgnorePatterns(const vector<string> &rawIgnorePatterns, vector<string> &absoluteIgnorePatterns,
                          vector<string> &relativeIgnorePatterns) {
@@ -846,6 +856,8 @@ void addFilesFromDir(Options &opts, string_view dir, WorkerPool &workerPool, sha
                                    std::make_move_iterator(containedFiles.end()));
     }
 }
+
+} // namespace
 
 void readOptions(Options &opts,
                  vector<unique_ptr<pipeline::semantic_extension::SemanticExtension>> &configuredExtensions, int argc,

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -150,7 +150,6 @@ struct Options {
     bool forceHashing = false;
     int threads = 0;
     int logLevel = 0; // number of time -v was passed
-    bool runningUnderAutogen = false;
     int autogenVersion = 0;
     bool uniquelyDefinedBehavior = false;
     bool stripePackages = false;
@@ -170,13 +169,28 @@ struct Options {
     bool enableCounters = false;
     std::string errorUrlBase = "https://srb.help/";
     bool ruby3KeywordArgs = false;
-    bool typedSuper = true;
     std::vector<std::string> suppressPayloadSuperclassRedefinitionFor;
     std::set<int> isolateErrorCode;
     std::set<int> suppressErrorCode;
     bool noErrorSections = false;
     /** Prefix to remove from all printed paths. */
     std::string pathPrefix;
+
+    struct CacheSensitiveOptions {
+        bool typedSuper = true;
+
+        // Enable experimental support for RBS signatures
+        bool rbsSignaturesEnabled = false;
+
+        // Enable experimental support for RBS assertions such as `T.let`
+        bool rbsAssertionsEnabled = false;
+
+        // Experimental feature `requires_ancestor`
+        bool requiresAncestorEnabled = false;
+
+        bool runningUnderAutogen = false;
+    };
+    CacheSensitiveOptions cacheSensitiveOptions;
 
     uint32_t reserveClassTableCapacity = 0;
     uint32_t reserveMethodTableCapacity = 0;
@@ -251,15 +265,6 @@ struct Options {
     // Enables out-of-order reference checking
     bool outOfOrderReferenceChecksEnabled = false;
     core::TrackUntyped trackUntyped = core::TrackUntyped::Nowhere;
-
-    // Enable experimental support for RBS signatures
-    bool rbsSignaturesEnabled = false;
-
-    // Enable experimental support for RBS assertions such as `T.let`
-    bool rbsAssertionsEnabled = false;
-
-    // Experimental feature `requires_ancestor`
-    bool requiresAncestorEnabled = false;
 
     std::string inlineInput; // passed via -e
     std::string debugLogFile;

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -194,6 +194,17 @@ struct Options {
         CacheSensitiveOptions()
             : typedSuper(true), rbsSignaturesEnabled(false), rbsAssertionsEnabled(false),
               requiresAncestorEnabled(false), runningUnderAutogen(false) {}
+
+        constexpr static uint8_t NUMBER_OF_FLAGS = 4;
+        constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
+
+        uint8_t serialize() const {
+            static_assert(sizeof(CacheSensitiveOptions) == sizeof(uint8_t));
+            // Can replace this with std::bit_cast in C++20
+            auto rawBits = *reinterpret_cast<const uint8_t *>(this);
+            // Mask the valid bits since uninitialized bits can be any value.
+            return rawBits & VALID_BITS_MASK;
+        }
     };
     CacheSensitiveOptions cacheSensitiveOptions;
 

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -176,6 +176,8 @@ struct Options {
     /** Prefix to remove from all printed paths. */
     std::string pathPrefix;
 
+    // Options which affect the contents of the `--cache-dir`.
+    // If these options change, the cache needs to be invalidated.
     struct CacheSensitiveOptions {
         bool typedSuper : 1;
 

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -177,18 +177,23 @@ struct Options {
     std::string pathPrefix;
 
     struct CacheSensitiveOptions {
-        bool typedSuper = true;
+        bool typedSuper : 1;
 
         // Enable experimental support for RBS signatures
-        bool rbsSignaturesEnabled = false;
+        bool rbsSignaturesEnabled : 1;
 
         // Enable experimental support for RBS assertions such as `T.let`
-        bool rbsAssertionsEnabled = false;
+        bool rbsAssertionsEnabled : 1;
 
         // Experimental feature `requires_ancestor`
-        bool requiresAncestorEnabled = false;
+        bool requiresAncestorEnabled : 1;
 
-        bool runningUnderAutogen = false;
+        bool runningUnderAutogen : 1;
+
+        // In C++20 we can replace this with bit field initializers
+        CacheSensitiveOptions()
+            : typedSuper(true), rbsSignaturesEnabled(false), rbsAssertionsEnabled(false),
+              requiresAncestorEnabled(false), runningUnderAutogen(false) {}
     };
     CacheSensitiveOptions cacheSensitiveOptions;
 

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -90,7 +90,6 @@ struct Printers {
     // Ensure everything here is in PrinterConfig::printers().
 
     std::vector<std::reference_wrapper<PrinterConfig>> printers();
-    bool isAutogen() const;
 };
 
 enum class Phase {
@@ -151,6 +150,7 @@ struct Options {
     bool forceHashing = false;
     int threads = 0;
     int logLevel = 0; // number of time -v was passed
+    bool runningUnderAutogen = false;
     int autogenVersion = 0;
     bool uniquelyDefinedBehavior = false;
     bool stripePackages = false;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -52,10 +52,10 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
     gs.pathPrefix = opts.pathPrefix;
     gs.errorUrlBase = opts.errorUrlBase;
 
-    gs.cacheSensitiveOptions.rbsSignaturesEnabled = opts.rbsSignaturesEnabled;
-    gs.cacheSensitiveOptions.rbsAssertionsEnabled = opts.rbsAssertionsEnabled;
-    gs.cacheSensitiveOptions.requiresAncestorEnabled = opts.requiresAncestorEnabled;
-    gs.cacheSensitiveOptions.typedSuper = opts.typedSuper;
+    gs.cacheSensitiveOptions.rbsSignaturesEnabled = opts.cacheSensitiveOptions.rbsSignaturesEnabled;
+    gs.cacheSensitiveOptions.rbsAssertionsEnabled = opts.cacheSensitiveOptions.rbsAssertionsEnabled;
+    gs.cacheSensitiveOptions.requiresAncestorEnabled = opts.cacheSensitiveOptions.requiresAncestorEnabled;
+    gs.cacheSensitiveOptions.typedSuper = opts.cacheSensitiveOptions.typedSuper;
 
     if (opts.silenceErrors) {
         gs.silenceErrors = true;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -55,6 +55,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
     gs.rbsSignaturesEnabled = opts.rbsSignaturesEnabled;
     gs.rbsAssertionsEnabled = opts.rbsAssertionsEnabled;
     gs.requiresAncestorEnabled = opts.requiresAncestorEnabled;
+    gs.typedSuper = opts.typedSuper;
 
     if (opts.silenceErrors) {
         gs.silenceErrors = true;
@@ -75,7 +76,6 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
         gs.includeErrorSections = false;
     }
     gs.ruby3KeywordArgs = opts.ruby3KeywordArgs;
-    gs.typedSuper = opts.typedSuper;
     gs.suppressPayloadSuperclassRedefinitionFor = opts.suppressPayloadSuperclassRedefinitionFor;
     if (!opts.uniquelyDefinedBehavior) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced in Stripe code.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -52,10 +52,10 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
     gs.pathPrefix = opts.pathPrefix;
     gs.errorUrlBase = opts.errorUrlBase;
 
-    gs.rbsSignaturesEnabled = opts.rbsSignaturesEnabled;
-    gs.rbsAssertionsEnabled = opts.rbsAssertionsEnabled;
-    gs.requiresAncestorEnabled = opts.requiresAncestorEnabled;
-    gs.typedSuper = opts.typedSuper;
+    gs.cacheSensitiveOptions.rbsSignaturesEnabled = opts.rbsSignaturesEnabled;
+    gs.cacheSensitiveOptions.rbsAssertionsEnabled = opts.rbsAssertionsEnabled;
+    gs.cacheSensitiveOptions.requiresAncestorEnabled = opts.requiresAncestorEnabled;
+    gs.cacheSensitiveOptions.typedSuper = opts.typedSuper;
 
     if (opts.silenceErrors) {
         gs.silenceErrors = true;
@@ -169,7 +169,7 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
         }
     }
 
-    if (gs.runningUnderAutogen) {
+    if (gs.cacheSensitiveOptions.runningUnderAutogen) {
         // Autogen stops before infer but needs to see all definitions
         level = core::StrictLevel::False;
     }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -468,7 +468,7 @@ int realmain(int argc, char *argv[]) {
                           opts.reserveTypeMemberTableCapacity, opts.reserveUtf8NameTableCapacity,
                           opts.reserveConstantNameTableCapacity, opts.reserveUniqueNameTableCapacity);
 
-    if (opts.print.isAutogen()) {
+    if (opts.runningUnderAutogen) {
         gs->runningUnderAutogen = true;
     }
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -468,7 +468,7 @@ int realmain(int argc, char *argv[]) {
                           opts.reserveTypeMemberTableCapacity, opts.reserveUtf8NameTableCapacity,
                           opts.reserveConstantNameTableCapacity, opts.reserveUniqueNameTableCapacity);
 
-    if (opts.runningUnderAutogen) {
+    if (opts.cacheSensitiveOptions.runningUnderAutogen) {
         gs->cacheSensitiveOptions.runningUnderAutogen = true;
     }
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -469,10 +469,10 @@ int realmain(int argc, char *argv[]) {
                           opts.reserveConstantNameTableCapacity, opts.reserveUniqueNameTableCapacity);
 
     if (opts.runningUnderAutogen) {
-        gs->runningUnderAutogen = true;
+        gs->cacheSensitiveOptions.runningUnderAutogen = true;
     }
 
-    if (gs->runningUnderAutogen) {
+    if (gs->cacheSensitiveOptions.runningUnderAutogen) {
         gs->suppressErrorClass(core::errors::Namer::RedefinitionOfMethod.code);
         gs->suppressErrorClass(core::errors::Namer::ModuleKindRedefinition.code);
         gs->suppressErrorClass(core::errors::Namer::ConstantKindRedefinition.code);
@@ -717,7 +717,7 @@ int realmain(int argc, char *argv[]) {
             }
         }
 
-        if (gs->runningUnderAutogen) {
+        if (gs->cacheSensitiveOptions.runningUnderAutogen) {
             runAutogen(*gs, opts, *workers, indexed);
         } else {
             indexed = move(pipeline::resolve(*gs, move(indexed), opts, *workers).result());

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2132,7 +2132,7 @@ enum class PackagerMode {
 
 template <PackagerMode Mode>
 void packageRunCore(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files) {
-    ENFORCE(!gs.runningUnderAutogen, "Packager pass does not run in autogen");
+    ENFORCE(!gs.cacheSensitiveOptions.runningUnderAutogen, "Packager pass does not run in autogen");
 
     Timer timeit(gs.tracer(), "packager");
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -396,7 +396,7 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
             auto sym = core::ClassOrModuleRef(gs, i);
             resolveTypeMembers(gs, sym, typeAliases, resolved);
 
-            if (gs.requiresAncestorEnabled) {
+            if (gs.cacheSensitiveOptions.requiresAncestorEnabled) {
                 // Precompute the list of all required ancestors for this symbol
                 sym.data(gs)->computeRequiredAncestorLinearization(gs);
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1639,7 +1639,7 @@ public:
             if (send.fun == core::Names::mixesInClassMethods()) {
                 this->todoClassMethods_.emplace_back(ctx.file, ctx.owner, &send);
             } else if (send.fun == core::Names::requiresAncestor()) {
-                if (ctx.state.requiresAncestorEnabled) {
+                if (ctx.state.cacheSensitiveOptions.requiresAncestorEnabled) {
                     this->todoRequiredAncestors_.emplace_back(ctx.file, ctx.owner.asClassOrModuleRef(), &send);
                 }
             }
@@ -1839,7 +1839,7 @@ public:
         fast_sort(todoClassMethods, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
         fast_sort(todoRequiredAncestors, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
 
-        ENFORCE(todoRequiredAncestors.empty() || gs.requiresAncestorEnabled);
+        ENFORCE(todoRequiredAncestors.empty() || gs.cacheSensitiveOptions.requiresAncestorEnabled);
         fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
 
         Timer timeit1(gs.tracer(), "resolver.resolve_constants.fixed_point");

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -143,7 +143,7 @@ ast::ExpressionPtr toWriterSigForName(ast::Send *sharedSig, const core::NameRef 
 vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *send, ast::ExpressionPtr *prevStat) {
     vector<ast::ExpressionPtr> empty;
 
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return empty;
     }
 

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -24,7 +24,7 @@ bool isRewrittenBind(ast::ExpressionPtr &expr) {
 vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) {
     vector<ast::ExpressionPtr> empty;
 
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         // This is not safe to run under autogen, because we'd be outputting
         // autoloader files that predeclare the class and cause "warning:
         // already initialized constant" errors

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -24,7 +24,7 @@ bool isCommand(const ast::ClassDef *klass) {
 }
 
 void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return;
     }
 

--- a/rewriter/Concern.cc
+++ b/rewriter/Concern.cc
@@ -59,7 +59,7 @@ bool doesExtendConcern(core::MutableContext ctx, ast::ClassDef *klass) {
 // Knowledge of `class_methods` and its source code will help you understand the steps taken here.
 // See https://api.rubyonrails.org/classes/ActiveSupport/Concern.html#method-i-class_methods.
 void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return;
     }
     if (!doesExtendConcern(ctx, klass)) {

--- a/rewriter/ConstantAssumeType.cc
+++ b/rewriter/ConstantAssumeType.cc
@@ -9,7 +9,7 @@ using namespace std;
 namespace sorbet::rewriter {
 
 void ConstantAssumeType::run(core::MutableContext ctx, ast::Assign *asgn) {
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return;
     }
 

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -21,7 +21,7 @@ namespace sorbet::rewriter {
 vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *send) {
     vector<ast::ExpressionPtr> empty;
 
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return empty;
     }
 

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -46,7 +46,7 @@ bool isMissingInitialize(const core::GlobalState &gs, const ast::Send *send) {
 vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn) {
     vector<ast::ExpressionPtr> empty;
 
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return empty;
     }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -493,7 +493,7 @@ ast::ExpressionPtr recurse(core::MutableContext ctx, bool isClass, ast::Expressi
 
 vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass, ast::Send *send) {
     vector<ast::ExpressionPtr> stats;
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return stats;
     }
 

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -30,7 +30,7 @@ ast::ExpressionPtr mkNilableString(core::LocOffsets loc) {
 vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast::Send *send) {
     vector<ast::ExpressionPtr> empty;
 
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return empty;
     }
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -53,7 +53,7 @@ void selfScopeToEmptyTree(ast::UnresolvedConstantLit &cnst) {
 vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *asgn) {
     vector<ast::ExpressionPtr> empty;
 
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return empty;
     }
 

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -187,7 +187,7 @@ core::TypePtr collectNewStats(core::MutableContext ctx, ast::ClassDef *klass, as
 } // namespace
 
 void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
-    if (ctx.state.runningUnderAutogen) {
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return;
     }
 

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -46,7 +46,7 @@ public:
 
         auto isClass = classDef->kind == ast::ClassDef::Kind::Class;
 
-        if (ctx.state.rbsAssertionsEnabled) {
+        if (ctx.state.cacheSensitiveOptions.rbsAssertionsEnabled) {
             RBSAssertions::run(ctx, classDef);
         }
 
@@ -210,7 +210,7 @@ ast::ExpressionPtr Rewriter::run(core::MutableContext ctx, ast::ExpressionPtr tr
 
     Rewriterer rewriter;
 
-    if (ctx.state.rbsSignaturesEnabled) {
+    if (ctx.state.cacheSensitiveOptions.rbsSignaturesEnabled) {
         // This rewriter must run before the others, because it creates signatures that other rewriters depend on.
         ast = RBSSignatures::run(ctx, std::move(ast));
     }

--- a/test/cli/rbs-cache-dir/test.out
+++ b/test/cli/rbs-cache-dir/test.out
@@ -1,4 +1,3 @@
---enable-experimental-rbs-signatures is incompatible with --cache-dir. Ignoring cache
 No errors! Great job.
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)

--- a/test/cli/typed-super-cache/test.out
+++ b/test/cli/typed-super-cache/test.out
@@ -1,0 +1,40 @@
+----- populate cache: should have no errors -----
+No errors! Great job.
+----- index-tree, with typed super -----
+No errors! Great job.
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
+    def foo<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <runtime method definition of foo>
+  end
+
+  class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
+    def foo<<todo method>>(&<blk>)
+      ::<Magic>.<call-with-block>(<self>, :<super>, <blk>)
+    end
+
+    <runtime method definition of foo>
+  end
+end
+----- index-tree, without typed super -----
+No errors! Great job.
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
+    def foo<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <runtime method definition of foo>
+  end
+
+  class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
+    def foo<<todo method>>(&<blk>)
+      ::<Magic>.<call-with-block>(<self>, :<super>, <blk>)
+    end
+
+    <runtime method definition of foo>
+  end
+end

--- a/test/cli/typed-super-cache/test.out
+++ b/test/cli/typed-super-cache/test.out
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
     def foo<<todo method>>(&<blk>)
-      ::<Magic>.<call-with-block>(<self>, :<super>, <blk>)
+      ::<Magic>.<call-with-block>(<self>, :<untypedSuper>, <blk>)
     end
 
     <runtime method definition of foo>

--- a/test/cli/typed-super-cache/test.rb
+++ b/test/cli/typed-super-cache/test.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class Parent
+  def foo
+  end
+end
+
+class Child < Parent
+  def foo
+    super
+  end
+end

--- a/test/cli/typed-super-cache/test.sh
+++ b/test/cli/typed-super-cache/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+dir=$(mktemp -d)
+cleanup() {
+    rm -r "$dir"
+}
+trap cleanup EXIT
+
+mkdir "$dir/cache"
+
+common_opts=(
+  --silence-dev-message
+  --cache-dir "$dir/cache"
+  test/cli/typed-super-cache/test.rb
+)
+
+echo ----- populate cache: should have no errors -----
+main/sorbet "${common_opts[@]}" 2>&1
+echo ----- index-tree, with typed super -----
+main/sorbet "${common_opts[@]}" --print=index-tree 2>&1
+echo ----- index-tree, without typed super -----
+main/sorbet "${common_opts[@]}" --typed-super=false --print=index-tree 2>&1

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -683,7 +683,8 @@ realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeA
         BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
     opts.ruby3KeywordArgs =
         BooleanPropertyAssertion::getValue("experimental-ruby3-keyword-args", assertions).value_or(false);
-    opts.cacheSensitiveOptions.typedSuper = BooleanPropertyAssertion::getValue("typed-super", assertions).value_or(true);
+    opts.cacheSensitiveOptions.typedSuper =
+        BooleanPropertyAssertion::getValue("typed-super", assertions).value_or(true);
     // TODO(jez) Allow allow suppressPayloadSuperclassRedefinitionFor in a testdata test assertion?
 
     opts.uniquelyDefinedBehavior =

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -675,15 +675,15 @@ realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeA
     realmain::options::Options opts;
 
     opts.noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
-    opts.rbsSignaturesEnabled =
+    opts.cacheSensitiveOptions.rbsSignaturesEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-rbs-signatures", assertions).value_or(false);
-    opts.rbsAssertionsEnabled =
+    opts.cacheSensitiveOptions.rbsAssertionsEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-rbs-assertions", assertions).value_or(false);
-    opts.requiresAncestorEnabled =
+    opts.cacheSensitiveOptions.requiresAncestorEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
     opts.ruby3KeywordArgs =
         BooleanPropertyAssertion::getValue("experimental-ruby3-keyword-args", assertions).value_or(false);
-    opts.typedSuper = BooleanPropertyAssertion::getValue("typed-super", assertions).value_or(true);
+    opts.cacheSensitiveOptions.typedSuper = BooleanPropertyAssertion::getValue("typed-super", assertions).value_or(true);
     // TODO(jez) Allow allow suppressPayloadSuperclassRedefinitionFor in a testdata test assertion?
 
     opts.uniquelyDefinedBehavior =

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -378,7 +378,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "CopyCacheAfterInit") {
 
     // Create a session copy of the cache, consuming the original
     auto sessionCache = realmain::cache::SessionCache::make(std::move(kvstore), *logger, *opts);
-    auto copy = std::make_unique<OwnedKeyValueStore>(sessionCache->open(logger));
+    auto copy = std::make_unique<OwnedKeyValueStore>(sessionCache->open(logger, *opts));
 
     // Make sure that the same key exists
     std::vector<uint8_t> copyContent;
@@ -414,7 +414,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "CopyCacheAfterInit") {
     OwnedKeyValueStore::abort(std::move(kvstore));
 
     // Reopen the copy, and make sure it still has our new value
-    copy = std::make_unique<OwnedKeyValueStore>(sessionCache->open(logger));
+    copy = std::make_unique<OwnedKeyValueStore>(sessionCache->open(logger, *opts));
 
     {
         auto contents = copy->read("new key");
@@ -482,7 +482,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "RemoveSessionCacheDirectory") {
 
     // Verify that we can get a handle to the kvstore
     {
-        auto copy = sessionCache->open(logger);
+        auto copy = sessionCache->open(logger, *opts);
         REQUIRE_NE(copy, nullptr);
     }
 
@@ -507,7 +507,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "RemoveSessionCacheDirectory") {
     }
 
     {
-        auto copy = sessionCache->open(logger);
+        auto copy = sessionCache->open(logger, *opts);
         REQUIRE_EQ(copy, nullptr);
     }
 
@@ -519,7 +519,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "RemoveSessionCacheDirectory") {
     REQUIRE(FileOps::removeEmptyDir(sessionCacheDir));
 
     {
-        auto copy = sessionCache->open(logger);
+        auto copy = sessionCache->open(logger, *opts);
         REQUIRE_EQ(copy, nullptr);
     }
 }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -235,11 +235,11 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
             core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
 
             core::MutableContext ctx(gs, core::Symbols::root(), desugared.file);
-            bool previous = gs.runningUnderAutogen;
-            gs.runningUnderAutogen = test.expectations.contains("autogen");
+            bool previous = gs.cacheSensitiveOptions.runningUnderAutogen;
+            gs.cacheSensitiveOptions.runningUnderAutogen = test.expectations.contains("autogen");
             rewritten =
                 testSerialize(gs, ast::ParsedFile{rewriter::Rewriter::run(ctx, move(desugared.tree)), desugared.file});
-            gs.runningUnderAutogen = previous;
+            gs.cacheSensitiveOptions.runningUnderAutogen = previous;
         }
 
         handler.addObserved(gs, "rewrite-tree", [&]() { return rewritten.tree.toString(gs); });

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -358,16 +358,18 @@ tracked and unmodified files will still be in the cache.
 This compact binary representation has no stability guarantees, meaning it is
 not forward nor backward compatible with new versions of Sorbet. Instead, Sorbet
 completely flushes the cache whenever the Sorbet version string
-(`srb tc --version`) changes.
+(`srb tc --version`) changes, or certain
+[cache-sensitive options](https://github.com/search?q=repo%3Asorbet%2Fsorbet%20%2Fstruct%20CacheSensitiveOptions%20%5C%7B%24%2F&type=code)
+change.
 
-(This version string is only populated correctly for release builds of
-Sorbet—when using a custom source build of Sorbet which doesn't build Sorbet in
-release mode, avoid using `--cache-dir`.)
+The version string is only populated correctly for release builds of Sorbet—when
+using a custom source build of Sorbet which doesn't build Sorbet in release
+mode, avoid using `--cache-dir`.
 
-Apart from evictions when the Sorbet version changes (e.g. upgrading Sorbet in
-the Gemfile, or checking out an old commit with an older Sorbet version), Sorbet
-never evicts data from this cache. It can grow without bound. If disk space is
-limited, consider
+Apart from evictions when the Sorbet version or those cache-sensitive options
+changes (e.g. upgrading Sorbet in the Gemfile, or checking out an old commit
+with an older Sorbet version), Sorbet never evicts data from this cache. It can
+grow without bound. If disk space is limited, consider
 [Collecting metrics from Sorbet](metrics.md#collecting-metrics-from-sorbet),
 paying attention to these metrics:
 
@@ -385,6 +387,14 @@ can use the `--max-cache-size-bytes` to set a larger cache size. If you find
 yourself needing to pass this option, please reach out to the Sorbet development
 team, as your codebase is likely huge (possibly the largest known Sorbet
 codebase) and we'd like to talk to you.
+
+Whether an option is "cache-sensitive" is implementation-defined. Implementing
+some of Sorbet's options requires that Sorbet alter the parsed representation of
+a Ruby file. If this altered representation were cached with one set of options
+and read back out in a different run of Sorbet with incompatible options, Sorbet
+would produce incorrect results. If you frequently alternate between runs of
+Sorbet with and without cache-sensitive options, you may wish to specify
+multiple different cache folders, so that the cache isn't thrashed.
 
 ## Is there a way to get errors in JSON format?
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

1.  The `--typed-super` feature is currently broken when used with
    `--cache-dir`: Sorbet will always think that a file should have typed
    `super` calls, even after the `--typed-super=false` flag is passed (when
    used with `--cache-dir`).

1.  Some existing features explicitly disable the cache, like the RBS parsing
    ones.

1.  I want to be able to do some packager-specific things in the `rewriter`
    pass, which would also mean treating `--stripe-packages` as a
    cache-sensitive option.


While not strictly required, I've chosen to group the cache-sensitive options
into a `cacheSensitiveOptions` field on both `core::GlobalState` and
`options::Options`. This is to provide a visual indication to a reviewer that
someone is depending on a cache-sensitive option in a new place.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.