### PR TITLE
Rename the default cache flavor to "default"

### DIFF
--- a/docs/lmdb.md
+++ b/docs/lmdb.md
@@ -102,7 +102,7 @@ with ENV.begin() as txn:
 
 # Print a list of key<TAB>len(val) pairs to out.txt:
 with open('/tmp/out.txt', 'wb') as f:
-  with ENV.begin(db=ENV.open_db(b'experimentalfastpath')) as txn:
+  with ENV.begin(db=ENV.open_db(b'default')) as txn:
       cursor = txn.cursor()
       for key, val in cursor:
           f.write(key)
@@ -111,7 +111,7 @@ with open('/tmp/out.txt', 'wb') as f:
           f.write(b'\n')
 
 # Get the value for a single key (in the shell):
-with ENV.begin(db=ENV.open_db(b'experimentalfastpath')) as txn:
+with ENV.begin(db=ENV.open_db(b'default')) as txn:
   txn.get(b'DB_FORMAT_VERSION')
 
 # open another database in the shell, for comparison purposes
@@ -129,7 +129,7 @@ env = '/home/jez/sorbet-cache.bak'
 ENV = lmdb.open(env, map_size=10_485_760, max_dbs=128, create=False)
 
 with open('/tmp/out.txt', 'wb') as f:
-  with ENV.begin(db=ENV.open_db(b'experimentalfastpath')) as txn:
+  with ENV.begin(db=ENV.open_db(b'default')) as txn:
       cursor = txn.cursor()
       for key, val in cursor:
           f.write(key)


### PR DESCRIPTION
We currently drop all existing cache flavors when we detect a version match, so this should end up being a no-op.

https://github.com/sorbet/sorbet/blob/94dfa9cb14a8ea796863d62daa77b3588b4846b1/common/kvstore/KeyValueStore.cc#L323-L340

### Motivation
The name of the cache flavor that we open by default has been `"experimentalfastpath"` for a while, which is a bit confusing given how stable our use of it is. Let's rename it to `"default"`, which is a bit more accurate.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests
