### PR TITLE
Add uplevel and category parameters to Kernel#warn

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -2895,11 +2895,13 @@ module Kernel
   # :   Used for experimental features that may change in future releases.
   sig do
     params(
-        msg: String,
+        msgs: String,
+        uplevel: T.nilable(Integer),
+        category: T.nilable(Symbol)
     )
     .returns(NilClass)
   end
-  def warn(*msg); end
+  def warn(*msgs, uplevel: nil, category: nil); end
 
   # With no arguments, raises the exception in `$!` or raises a
   # [`RuntimeError`](https://docs.ruby-lang.org/en/2.7.0/RuntimeError.html) if


### PR DESCRIPTION
https://ruby-doc.org/core-3.0.2/Kernel.html#method-i-warn

### Motivation

Failing to be able to use `uplevel` https://github.com/ruby/prism/actions/runs/13950706900/job/39049204194?pr=3501.

### Test plan

Tested manually.