### PR TITLE
Treat `--no-stdlib` as a cache-sensitive option

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1070,11 +1070,7 @@ void readOptions(Options &opts,
 
         opts.noErrorCount = raw["no-error-count"].as<bool>();
 
-        opts.noStdlib = raw["no-stdlib"].as<bool>();
-        if (opts.noStdlib && !opts.cacheDir.empty()) {
-            logger->error("--no-stdlib is incompatible with --cache-dir. Ignoring cache");
-            opts.cacheDir = "";
-        }
+        opts.cacheSensitiveOptions.noStdlib = raw["no-stdlib"].as<bool>();
 
         opts.minimizeRBI = raw["minimize-to-rbi"].as<string>();
         if (!opts.minimizeRBI.empty() && !opts.print.MinimizeRBI.enabled) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1313,7 +1313,7 @@ void readOptions(Options &opts,
         }
 
         if (opts.print.PayloadSources.enabled) {
-            if (opts.noStdlib) {
+            if (opts.cacheSensitiveOptions.noStdlib) {
                 logger->error("You can't pass both `{}` and `{}`.", "--print=payload-sources", "--no-stdlib");
                 throw EarlyReturnWithCode(1);
             } else if (raw.count("e") > 0) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -179,6 +179,11 @@ struct Options {
     // Options which affect the contents of the `--cache-dir`.
     // If these options change, the cache needs to be invalidated.
     struct CacheSensitiveOptions {
+        // Ideally, we would have named this option something like `--stdlib=false`, because by
+        // nature of this option being a boolean option with cxxopts, you can do `--no-stdlib=false`
+        // which is a no-op, and also confusing.
+        bool noStdlib : 1;
+
         bool typedSuper : 1;
 
         // Enable experimental support for RBS signatures
@@ -194,10 +199,10 @@ struct Options {
 
         // In C++20 we can replace this with bit field initializers
         CacheSensitiveOptions()
-            : typedSuper(true), rbsSignaturesEnabled(false), rbsAssertionsEnabled(false),
+            : noStdlib(false), typedSuper(true), rbsSignaturesEnabled(false), rbsAssertionsEnabled(false),
               requiresAncestorEnabled(false), runningUnderAutogen(false) {}
 
-        constexpr static uint8_t NUMBER_OF_FLAGS = 4;
+        constexpr static uint8_t NUMBER_OF_FLAGS = 6;
         constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         uint8_t serialize() const {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -119,7 +119,6 @@ constexpr size_t MAX_CACHE_SIZE_BYTES = 1L * 1024 * 1024 * 1024; // 1 GiB
 struct Options {
     Printers print;
     Phase stopAfterPhase = Phase::INFERENCER;
-    bool noStdlib = false;
 
     // Should we monitor STDOUT for HUP and exit if it hangs up. This is a
     // workaround for https://bugzilla.mindrot.org/show_bug.cgi?id=2863

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -10,8 +10,7 @@ namespace sorbet::payload {
 
 void createInitialGlobalState(core::GlobalState &gs, const realmain::options::Options &options,
                               const unique_ptr<const OwnedKeyValueStore> &kvstore) {
-    if (options.noStdlib) {
-        ENFORCE(kvstore == nullptr, "--no-stdlib and --cache-dir are incompatible");
+    if (options.cacheSensitiveOptions.noStdlib) {
         gs.initEmpty();
         return;
     }

--- a/test/cli/no-stdlib-caching/test.out
+++ b/test/cli/no-stdlib-caching/test.out
@@ -6,7 +6,6 @@ test.rb:3: Revealed type: `T.class_of(Net::BufferedIO)` https://srb.help/7014
      3 |T.reveal_type(Net::BufferedIO)
                       ^^^^^^^^^^^^^^^
 Errors: 1
---no-stdlib is incompatible with --cache-dir. Ignoring cache
 test.rb:3: Unable to resolve constant `BufferedIO` https://srb.help/5002
      3 |T.reveal_type(Net::BufferedIO)
                       ^^^^^^^^^^^^^^^

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -674,7 +674,7 @@ RangeAssertion::parseAssertions(const UnorderedMap<string, shared_ptr<core::File
 realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeAssertion>> &assertions) {
     realmain::options::Options opts;
 
-    opts.noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
+    opts.cacheSensitiveOptions.noStdlib = BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false);
     opts.cacheSensitiveOptions.rbsSignaturesEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-rbs-signatures", assertions).value_or(false);
     opts.cacheSensitiveOptions.rbsAssertionsEnabled =


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Also: fixed a bug that snuck in during my rebase, where the
NUMBER_OF_FLAGS const was off by one.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CLI test