### PR TITLE
Revert "rewrite `TypePtr` untagging for efficient codegen (#8637)"

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -93,7 +93,7 @@ vector<TypePtr> ClassOrModule::selfTypeArgs(const GlobalState &gs) const {
     for (auto tm : typeMembers()) {
         auto tmData = tm.data(gs);
         if (tmData->flags.isFixed) {
-            auto lambdaParam = cast_type<LambdaParam>(tmData->resultType);
+            auto *lambdaParam = cast_type<LambdaParam>(tmData->resultType);
             ENFORCE(lambdaParam != nullptr);
             targs.emplace_back(lambdaParam->upperBound);
         } else {
@@ -141,7 +141,7 @@ TypePtr ClassOrModule::unsafeComputeExternalType(GlobalState &gs) {
 
         for (auto &tm : typeMembers()) {
             auto tmData = tm.data(gs);
-            auto lambdaParam = cast_type<LambdaParam>(tmData->resultType);
+            auto *lambdaParam = cast_type<LambdaParam>(tmData->resultType);
             ENFORCE(lambdaParam != nullptr);
 
             if (ref.isLegacyStdlibGeneric()) {
@@ -1868,7 +1868,7 @@ void ClassOrModule::recordSealedSubclass(GlobalState &gs, ClassOrModuleRef subcl
     const OrType *orT = nullptr;
     while ((orT = cast_type<OrType>(*iter))) {
         core::ClassOrModuleRef subclass;
-        if (auto right = cast_type<AppliedType>(orT->right)) {
+        if (auto *right = cast_type<AppliedType>(orT->right)) {
             subclass = right->klass;
         } else if (isa_type<ClassType>(orT->right)) {
             auto right = cast_type_nonnull<ClassType>(orT->right);
@@ -1883,7 +1883,7 @@ void ClassOrModule::recordSealedSubclass(GlobalState &gs, ClassOrModuleRef subcl
     }
 
     core::ClassOrModuleRef lastClass;
-    if (auto lastType = cast_type<AppliedType>(*iter)) {
+    if (auto *lastType = cast_type<AppliedType>(*iter)) {
         lastClass = lastType->klass.data(gs)->attachedClass(gs);
     } else if (isa_type<ClassType>(*iter)) {
         auto lastType = cast_type_nonnull<ClassType>(*iter);
@@ -1929,7 +1929,7 @@ TypePtr ClassOrModule::sealedSubclassesToUnion(const GlobalState &gs) const {
     auto result = Types::bottom();
     while (auto orType = cast_type<OrType>(currentClasses)) {
         core::ClassOrModuleRef subclass;
-        if (auto right = cast_type<AppliedType>(orType->right)) {
+        if (auto *right = cast_type<AppliedType>(orType->right)) {
             subclass = right->klass.data(gs)->attachedClass(gs);
         } else if (isa_type<ClassType>(orType->right)) {
             auto right = cast_type_nonnull<ClassType>(orType->right);
@@ -1944,7 +1944,7 @@ TypePtr ClassOrModule::sealedSubclassesToUnion(const GlobalState &gs) const {
     }
 
     core::ClassOrModuleRef subclass;
-    if (auto lastType = cast_type<AppliedType>(currentClasses)) {
+    if (auto *lastType = cast_type<AppliedType>(currentClasses)) {
         subclass = lastType->klass.data(gs)->attachedClass(gs);
     } else if (isa_type<ClassType>(currentClasses)) {
         auto lastType = cast_type_nonnull<ClassType>(currentClasses);

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -6,7 +6,6 @@
 #include "core/Polarity.h"
 #include "core/ShowOptions.h"
 #include "core/SymbolRef.h"
-#include "core/UntaggedPtr.h"
 #include <memory>
 
 namespace sorbet::core {
@@ -134,10 +133,6 @@ private:
         return maskedPtr | val | NOT_INLINED_MASK;
     }
 
-    uint16_t tagMaybeZero() const noexcept {
-        return store & TAG_MASK;
-    }
-
     // Inlined TypePtr constructor
     TypePtr(Tag tag, uint64_t inlinedValue) noexcept : store(tagValue(tag, inlinedValue)) {}
 
@@ -247,18 +242,6 @@ public:
         return store == 0;
     }
 
-    template <class To> core::UntaggedPtr<To> as_type() {
-        bool isValid = tagMaybeZero() == uint16_t(TypeToTag<To>::value);
-        auto *ptr = isValid ? reinterpret_cast<To *>(get()) : nullptr;
-        return core::UntaggedPtr<To>(ptr, isValid);
-    }
-
-    template <class To> core::UntaggedPtr<const To> as_type() const {
-        bool isValid = tagMaybeZero() == uint16_t(TypeToTag<To>::value);
-        auto *ptr = isValid ? reinterpret_cast<const To *>(get()) : nullptr;
-        return core::UntaggedPtr<const To>(ptr, isValid);
-    }
-
     bool isUntyped() const;
 
     bool isNilClass() const;
@@ -337,8 +320,7 @@ public:
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
     template <class T, class... Args> friend TypePtr make_type(Args &&...args);
-    template <class To> friend bool isa_type(const TypePtr &what);
-    template <class To> friend core::UntaggedPtr<const To> cast_type(const TypePtr &what);
+    template <class To> friend To const *cast_type(const TypePtr &what);
     template <class To>
     friend typename TypeToCastType<To, TypeToIsInlined<To>::value>::type cast_type_nonnull(const TypePtr &what);
     friend class TypePtrTestHelper;

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -16,7 +16,7 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
     if (core::is_proxy_type(receiver)) {
         receiver = receiver.underlying(gs);
     }
-    if (auto applied = core::cast_type<core::AppliedType>(receiver)) {
+    if (auto *applied = core::cast_type<core::AppliedType>(receiver)) {
         /* instantiate generic classes */
         resultType = core::Types::resultTypeAsSeenFrom(gs, resultType, inWhat.enclosingClass(gs), applied->klass,
                                                        applied->targs);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -589,7 +589,7 @@ void maybeSuggestUnsafeKwsplat(const core::GlobalState &gs, core::ErrorBuilder &
 
 // Ensure that a ShapeType used as a keyword args splat in a send has only symbol keys present.
 const ShapeType *fromKwargsHash(const GlobalState &gs, const TypePtr &ty) {
-    auto hash = cast_type<ShapeType>(ty);
+    auto *hash = cast_type<ShapeType>(ty);
     if (hash == nullptr) {
         return nullptr;
     }
@@ -1287,7 +1287,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         // Mark the keyword args as consumed
         ait += numKwargs;
 
-        if (auto hash = cast_type<ShapeType>(kwargs)) {
+        if (auto *hash = cast_type<ShapeType>(kwargs)) {
             // find keyword arguments and advance `pend` before them; We'll walk
             // `kwit` ahead below
             auto kwit = pit;
@@ -1670,7 +1670,7 @@ bool canCallNew(const GlobalState &gs, const TypePtr &wrapped) {
         }
     }
 
-    if (auto appliedType = cast_type<AppliedType>(wrapped)) {
+    if (auto *appliedType = cast_type<AppliedType>(wrapped)) {
         if (appliedType->klass == core::Symbols::Class()) {
             // T::Class[...].new is not implemented--users should just use Class.new(super_class)
             return false;
@@ -1710,7 +1710,7 @@ DispatchResult badMetaTypeCall(const GlobalState &gs, const DispatchArgs &args, 
                                "which doesn't work at runtime");
                 e.replaceWith("Replace with class name", args.callLoc(), "{}", appliedType->klass.show(gs));
             }
-        } else if (auto appliedType = cast_type<AppliedType>(wrapped)) {
+        } else if (auto *appliedType = cast_type<AppliedType>(wrapped)) {
             // For T.class_of(Foo), we'll suggest replacing it with the attached class (Foo).
             if (appliedType->klass.data(gs)->isSingletonClass(gs)) {
                 auto receiverLoc = core::Loc(args.locs.file, args.locs.receiver);
@@ -1763,7 +1763,7 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
             return original;
         }
         case Names::squareBrackets().rawId(): {
-            auto applied = cast_type<AppliedType>(this->wrapped);
+            auto *applied = cast_type<AppliedType>(this->wrapped);
             if (applied == nullptr) {
                 return badMetaTypeCall(gs, args, errLoc, this->wrapped);
             }
@@ -1776,7 +1776,7 @@ DispatchResult MetaType::dispatchCall(const GlobalState &gs, const DispatchArgs 
         case Names::bind().rawId():
         case Names::returns().rawId():
         case Names::void_().rawId(): {
-            auto applied = cast_type<AppliedType>(this->wrapped);
+            auto *applied = cast_type<AppliedType>(this->wrapped);
             if (applied == nullptr) {
                 return badMetaTypeCall(gs, args, errLoc, this->wrapped);
             }
@@ -2174,7 +2174,7 @@ public:
     }
 
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto selfApp = cast_type<AppliedType>(args.thisType);
+        auto *selfApp = cast_type<AppliedType>(args.thisType);
         if (selfApp == nullptr) {
             return;
         }
@@ -2373,11 +2373,11 @@ public:
 
 class Magic_expandSplat : public IntrinsicMethod {
     static TypePtr expandArray(const GlobalState &gs, const TypePtr &type, int expandTo) {
-        if (auto ot = cast_type<OrType>(type)) {
+        if (auto *ot = cast_type<OrType>(type)) {
             return Types::any(gs, expandArray(gs, ot->left, expandTo), expandArray(gs, ot->right, expandTo));
         }
 
-        auto tuple = cast_type<TupleType>(type);
+        auto *tuple = cast_type<TupleType>(type);
         if (tuple == nullptr && core::Types::approximate(gs, type, core::TypeConstraint::EmptyFrozenConstraint)
                                     .derivesFrom(gs, Symbols::Array())) {
             // If this is an array and not a tuple, just pass it through. We
@@ -2497,7 +2497,7 @@ public:
             res.returnType = args.args[2]->type;
             return;
         }
-        auto posTuple = cast_type<TupleType>(args.args[2]->type);
+        auto *posTuple = cast_type<TupleType>(args.args[2]->type);
         if (posTuple == nullptr) {
             if (auto e = gs.beginError(args.argLoc(2), core::errors::Infer::UntypedSplat)) {
                 e.setHeader("Splats are only supported where the size of the array is known statically");
@@ -2506,7 +2506,7 @@ public:
         }
 
         auto kwArgsType = args.args[3]->type;
-        auto kwTuple = cast_type<TupleType>(kwArgsType);
+        auto *kwTuple = cast_type<TupleType>(kwArgsType);
         if (kwTuple == nullptr && !kwArgsType.isNilClass()) {
             if (auto e = gs.beginError(args.argLoc(2), core::errors::Infer::UntypedSplat)) {
                 e.setHeader(
@@ -2592,7 +2592,7 @@ private:
     }
 
     static std::optional<int> getArityForBlock(const TypePtr &blockType) {
-        if (auto appliedType = cast_type<AppliedType>(blockType)) {
+        if (auto *appliedType = cast_type<AppliedType>(blockType)) {
             return Types::getProcArity(*appliedType);
         }
 
@@ -2850,7 +2850,7 @@ public:
             res.returnType = args.args[2]->type;
             return;
         }
-        auto posTuple = cast_type<TupleType>(args.args[2]->type);
+        auto *posTuple = cast_type<TupleType>(args.args[2]->type);
         if (posTuple == nullptr) {
             if (auto e = gs.beginError(args.argLoc(2), core::errors::Infer::UntypedSplat)) {
                 e.setHeader("Splats are only supported where the size of the array is known statically");
@@ -2861,7 +2861,7 @@ public:
         uint16_t numPosArgs = posTuple->elems.size();
 
         auto kwType = args.args[3]->type;
-        auto kwTuple = cast_type<TupleType>(kwType);
+        auto *kwTuple = cast_type<TupleType>(kwType);
         if (kwTuple == nullptr && !kwType.isNilClass()) {
             if (auto e = gs.beginError(args.argLoc(2), core::errors::Infer::UntypedSplat)) {
                 e.setHeader(
@@ -3222,7 +3222,7 @@ public:
             return;
         }
 
-        auto tuple = cast_type<TupleType>(args.thisType);
+        auto *tuple = cast_type<TupleType>(args.thisType);
         ENFORCE(tuple);
         auto tupleSize = tuple->elems.size();
 
@@ -3284,7 +3284,7 @@ public:
 class Tuple_last : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto tuple = cast_type<TupleType>(args.thisType);
+        auto *tuple = cast_type<TupleType>(args.thisType);
         ENFORCE(tuple);
 
         if (!args.args.empty()) {
@@ -3301,7 +3301,7 @@ public:
 class Tuple_first : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto tuple = cast_type<TupleType>(args.thisType);
+        auto *tuple = cast_type<TupleType>(args.thisType);
         ENFORCE(tuple);
 
         if (!args.args.empty()) {
@@ -3318,7 +3318,7 @@ public:
 class Tuple_minMax : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto tuple = cast_type<TupleType>(args.thisType);
+        auto *tuple = cast_type<TupleType>(args.thisType);
         ENFORCE(tuple);
 
         if (!args.args.empty()) {
@@ -3335,7 +3335,7 @@ public:
 class Tuple_sum : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto tuple = cast_type<TupleType>(args.thisType);
+        auto *tuple = cast_type<TupleType>(args.thisType);
         ENFORCE(tuple);
 
         if (!args.args.empty()) {
@@ -3355,7 +3355,7 @@ public:
 class Tuple_sample : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto tuple = cast_type<TupleType>(args.thisType);
+        auto *tuple = cast_type<TupleType>(args.thisType);
         ENFORCE(tuple);
 
         if (args.args.size() > 1) {
@@ -3391,11 +3391,11 @@ class Tuple_concat : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         vector<TypePtr> elems;
-        auto tuple = cast_type<TupleType>(args.thisType);
+        auto *tuple = cast_type<TupleType>(args.thisType);
         ENFORCE(tuple);
         elems = tuple->elems;
         for (auto elem : args.args) {
-            if (auto tuple = cast_type<TupleType>(elem->type)) {
+            if (auto *tuple = cast_type<TupleType>(elem->type)) {
                 elems.insert(elems.end(), tuple->elems.begin(), tuple->elems.end());
             } else {
                 return;
@@ -3521,7 +3521,7 @@ public:
 class Shape_merge : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto shape = cast_type<ShapeType>(args.thisType);
+        auto *shape = cast_type<ShapeType>(args.thisType);
         ENFORCE(shape);
 
         if (args.args.empty() || args.block != nullptr) {
@@ -3542,7 +3542,7 @@ public:
 
         // Deliberately copy the keys and values, since we may be adding entries.
         auto copyTypePtr = make_type<ShapeType>(shape->keys, shape->values);
-        auto copy = cast_type<ShapeType>(copyTypePtr);
+        auto *copy = cast_type<ShapeType>(copyTypePtr);
         ENFORCE(copy != nullptr);
         auto addShapeEntry = [&copy](const TypePtr &keyType, const TypePtr &value) {
             if (auto optind = copy->indexForKey(keyType)) {
@@ -3777,7 +3777,7 @@ class Magic_checkMatchArray : public IntrinsicMethod {
         auto testedSym = Symbols::noClassOrModule();
         if (isa_type<ClassType>(testedType)) {
             testedSym = cast_type_nonnull<ClassType>(testedType).symbol;
-        } else if (auto app = cast_type<AppliedType>(testedType)) {
+        } else if (auto *app = cast_type<AppliedType>(testedType)) {
             testedSym = app->klass;
         }
         if (testedSym.exists() && testedSym.data(gs)->flags.isSealed) {
@@ -4024,7 +4024,7 @@ public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         // Unwrap the array one time to get the element type (we'll rewrap it down at the bottom)
         TypePtr element;
-        auto ap = cast_type<AppliedType>(args.thisType);
+        auto *ap = cast_type<AppliedType>(args.thisType);
         ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()));
         ENFORCE(!ap->targs.empty());
         element = ap->targs.front();
@@ -4069,18 +4069,18 @@ public:
         vector<TypePtr> unwrappedElems;
         unwrappedElems.reserve(args.args.size() + 1);
 
-        auto ap = cast_type<AppliedType>(args.thisType);
+        auto *ap = cast_type<AppliedType>(args.thisType);
         ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()));
         ENFORCE(!ap->targs.empty());
         unwrappedElems.emplace_back(ap->targs.front());
 
         for (auto arg : args.args) {
             auto argTyp = arg->type;
-            if (auto ap = cast_type<AppliedType>(argTyp)) {
+            if (auto *ap = cast_type<AppliedType>(argTyp)) {
                 ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()));
                 ENFORCE(!ap->targs.empty());
                 unwrappedElems.emplace_back(ap->targs.front());
-            } else if (auto tuple = cast_type<TupleType>(argTyp)) {
+            } else if (auto *tuple = cast_type<TupleType>(argTyp)) {
                 unwrappedElems.emplace_back(tuple->elementType(gs));
             } else {
                 // Arg type didn't match; we already reported an error for the arg type; just return untyped to recover.
@@ -4098,7 +4098,7 @@ public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         TypePtr element;
 
-        auto ap = cast_type<AppliedType>(args.thisType);
+        auto *ap = cast_type<AppliedType>(args.thisType);
         ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()));
         ENFORCE(!ap->targs.empty());
         element = ap->targs.front();
@@ -4114,19 +4114,19 @@ public:
         vector<TypePtr> unwrappedElems;
         unwrappedElems.reserve(args.args.size() + 1);
 
-        auto ap = cast_type<AppliedType>(args.thisType);
+        auto *ap = cast_type<AppliedType>(args.thisType);
         ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()));
         ENFORCE(!ap->targs.empty());
         unwrappedElems.emplace_back(ap->targs.front());
 
         for (auto arg : args.args) {
             auto argTyp = arg->type;
-            if (auto ap = cast_type<AppliedType>(argTyp)) {
+            if (auto *ap = cast_type<AppliedType>(argTyp)) {
                 ENFORCE(ap->klass == Symbols::Enumerable() ||
                         ap->klass.data(gs)->derivesFrom(gs, Symbols::Enumerable()));
                 ENFORCE(!ap->targs.empty());
                 unwrappedElems.emplace_back(Types::any(gs, ap->targs.front(), Types::nilClass()));
-            } else if (auto tuple = cast_type<TupleType>(argTyp)) {
+            } else if (auto *tuple = cast_type<TupleType>(argTyp)) {
                 unwrappedElems.emplace_back(Types::any(gs, tuple->elementType(gs), Types::nilClass()));
             } else {
                 // Arg type didn't match; we already reported an error for the arg type; just return untyped to
@@ -4139,7 +4139,7 @@ public:
         if (args.block != nullptr) {
             res.returnType = Types::nilClass();
 
-            if (auto blockAppliedType = cast_type<AppliedType>(res.main.blockPreType)) {
+            if (auto *blockAppliedType = cast_type<AppliedType>(res.main.blockPreType)) {
                 ENFORCE(blockAppliedType->targs.size() == 2, "calls.cc out of date w.r.t. array.rbi");
                 blockAppliedType->targs[1] = make_type<TupleType>(move(unwrappedElems));
             }
@@ -4152,12 +4152,12 @@ public:
 class Array_transpose : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        auto ap = cast_type<AppliedType>(args.thisType);
+        auto *ap = cast_type<AppliedType>(args.thisType);
         ENFORCE(ap->klass == Symbols::Array() || ap->klass.data(gs)->derivesFrom(gs, Symbols::Array()));
         ENFORCE(!ap->targs.empty());
         auto &elementType = ap->targs.front();
 
-        auto tuple = cast_type<TupleType>(elementType);
+        auto *tuple = cast_type<TupleType>(elementType);
         if (tuple == nullptr) {
             return;
         }
@@ -4413,7 +4413,7 @@ public:
         auto rhsSym = Symbols::noClassOrModule();
         if (isa_type<ClassType>(rhs)) {
             rhsSym = cast_type_nonnull<ClassType>(rhs).symbol;
-        } else if (auto app = cast_type<AppliedType>(rhs)) {
+        } else if (auto *app = cast_type<AppliedType>(rhs)) {
             rhsSym = app->klass;
         }
 
@@ -4459,7 +4459,7 @@ public:
         auto rhsSym = Symbols::noClassOrModule();
         if (isa_type<ClassType>(rhs)) {
             rhsSym = cast_type_nonnull<ClassType>(rhs).symbol;
-        } else if (auto app = cast_type<AppliedType>(rhs)) {
+        } else if (auto *app = cast_type<AppliedType>(rhs)) {
             rhsSym = app->klass;
         }
 
@@ -4492,7 +4492,7 @@ class GenericForwarder_tripleEq : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         auto forwarderSingleton = Symbols::noClassOrModule();
-        if (auto app = cast_type<AppliedType>(args.thisType)) {
+        if (auto *app = cast_type<AppliedType>(args.thisType)) {
             forwarderSingleton = app->klass;
         } else {
             forwarderSingleton = cast_type_nonnull<ClassType>(args.thisType).symbol;

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -45,7 +45,7 @@ string UnresolvedAppliedType::toStringWithTabs(const GlobalState &gs, int tabs) 
 
 namespace {
 string argTypeForUnresolvedAppliedType(const GlobalState &gs, const TypePtr &t, ShowOptions options) {
-    if (auto m = cast_type<MetaType>(t)) {
+    if (auto *m = cast_type<MetaType>(t)) {
         return m->wrapped.show(gs, options);
     }
     return t.show(gs, options);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -76,7 +76,7 @@ const TypePtr underlying(const GlobalState &gs, const TypePtr &t1) {
 }
 
 void fillInOrComponents(InlinedVector<TypePtr, 4> &orComponents, const TypePtr &type) {
-    auto o = cast_type<OrType>(type);
+    auto *o = cast_type<OrType>(type);
     if (o == nullptr) {
         orComponents.emplace_back(type);
     } else {
@@ -86,7 +86,7 @@ void fillInOrComponents(InlinedVector<TypePtr, 4> &orComponents, const TypePtr &
 }
 
 TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<TypePtr, 4> &typeFilter) {
-    auto o = cast_type<OrType>(originalType);
+    auto *o = cast_type<OrType>(originalType);
     if (o == nullptr) {
         if (absl::c_linear_search(typeFilter, originalType)) {
             return nullptr;
@@ -111,7 +111,7 @@ TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<Type
 TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     InlinedVector<TypePtr, 4> originalOrComponents;
     InlinedVector<TypePtr, 4> typesConsumed;
-    auto o1 = cast_type<OrType>(t1);
+    auto *o1 = cast_type<OrType>(t1);
     ENFORCE(o1 != nullptr);
     fillInOrComponents(originalOrComponents, o1->left);
     fillInOrComponents(originalOrComponents, o1->right);
@@ -145,7 +145,7 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
 }
 
 TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    auto a1 = cast_type<AndType>(t1);
+    auto *a1 = cast_type<AndType>(t1);
     ENFORCE(t1 != nullptr);
     TypePtr n1 = Types::all(gs, a1->left, t2);
     if (n1 == a1->left) {
@@ -185,7 +185,7 @@ TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr
 
 // only keep knowledge in t1 that is not already present in t2. Return the same reference if unchanged
 TypePtr dropLubComponents(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
-    if (auto a1 = cast_type<AndType>(t1)) {
+    if (auto *a1 = cast_type<AndType>(t1)) {
         auto a1a = dropLubComponents(gs, a1->left, t2);
         auto a1b = dropLubComponents(gs, a1->right, t2);
         auto subl = Types::isSubType(gs, a1a, t2);
@@ -196,7 +196,7 @@ TypePtr dropLubComponents(const GlobalState &gs, const TypePtr &t1, const TypePt
         if (a1a != a1->left || a1b != a1->right) {
             return Types::all(gs, a1a, a1b);
         }
-    } else if (auto o1 = cast_type<OrType>(t1)) {
+    } else if (auto *o1 = cast_type<OrType>(t1)) {
         auto subl = Types::isSubType(gs, o1->left, t2);
         auto subr = Types::isSubType(gs, o1->right, t2);
         if (subl && subr) {
@@ -255,8 +255,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     if (isa_type<OrType>(t2)) { // 3, 5, 6
         categoryCounterInc("lub", "or>");
         return lubDistributeOr(gs, t2, t1);
-    } else if (auto a2 = cast_type<AndType>(t2)) { // 2, 4
-        if (auto a1 = cast_type<AndType>(t1)) {
+    } else if (auto *a2 = cast_type<AndType>(t2)) { // 2, 4
+        if (auto *a1 = cast_type<AndType>(t1)) {
             // Check if the members of a1 and a2 are referentially equivalent. This helps simplify T.all types created
             // during type inference.
             if (compositeTypeDeepRefEqual(*a1, *a2)) {
@@ -280,8 +280,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         return lubDistributeOr(gs, t1, t2);
     }
 
-    if (auto a1 = cast_type<AppliedType>(t1)) {
-        auto a2 = cast_type<AppliedType>(t2);
+    if (auto *a1 = cast_type<AppliedType>(t1)) {
+        auto *a2 = cast_type<AppliedType>(t2);
         if (a2 == nullptr) {
             if (isSubType(gs, t2, t1)) {
                 return t1;
@@ -359,7 +359,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             typecase(
                 t1,
                 [&](const TupleType &a1) { // Warning: this implements COVARIANT arrays
-                    if (auto a2 = cast_type<TupleType>(t2)) {
+                    if (auto *a2 = cast_type<TupleType>(t2)) {
                         if (a1.elems.size() == a2->elems.size()) { // lub arrays only if they have same element count
                             vector<TypePtr> elemLubs;
                             int i = -1;
@@ -386,7 +386,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     }
                 },
                 [&](const ShapeType &h1) { // Warning: this implements COVARIANT hashes
-                    if (auto h2 = cast_type<ShapeType>(t2)) {
+                    if (auto *h2 = cast_type<ShapeType>(t2)) {
                         if (h2->keys.size() == h1.keys.size()) {
                             // have enough keys.
                             int i = -1;
@@ -499,8 +499,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
     {
         if (isa_type<MetaType>(t1) || isa_type<MetaType>(t2)) {
-            auto m1 = cast_type<MetaType>(t1);
-            auto m2 = cast_type<MetaType>(t2);
+            auto *m1 = cast_type<MetaType>(t1);
+            auto *m2 = cast_type<MetaType>(t2);
             if (m1 != nullptr && m2 != nullptr && Types::equiv(gs, m1->wrapped, m2->wrapped)) {
                 return t1;
             }
@@ -861,8 +861,8 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
     {
         if (isa_type<MetaType>(t1) || isa_type<MetaType>(t2)) {
-            auto m1 = cast_type<MetaType>(t1);
-            auto m2 = cast_type<MetaType>(t2);
+            auto *m1 = cast_type<MetaType>(t1);
+            auto *m2 = cast_type<MetaType>(t2);
             if (m1 != nullptr && m2 != nullptr && Types::equiv(gs, m1->wrapped, m2->wrapped)) {
                 return t1;
             }
@@ -871,7 +871,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
     }
 
-    if (auto o2 = cast_type<OrType>(t2)) { // 3, 6
+    if (auto *o2 = cast_type<OrType>(t2)) { // 3, 6
         bool collapseInLeft = Types::isAsSpecificAs(gs, t1, t2);
         if (collapseInLeft) {
             categoryCounterInc("glb", "Zor");
@@ -903,7 +903,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             }
         }
 
-        if (auto o1 = cast_type<OrType>(t1)) { // 6
+        if (auto *o1 = cast_type<OrType>(t1)) { // 6
             auto t11 = Types::all(gs, o1->left, o2->left);
             auto t12 = Types::all(gs, o1->left, o2->right);
             auto t21 = Types::all(gs, o1->right, o2->left);
@@ -937,8 +937,8 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         return AndType::make_shared(t1, t2);
     }
 
-    if (auto a1 = cast_type<AppliedType>(t1)) {
-        auto a2 = cast_type<AppliedType>(t2);
+    if (auto *a1 = cast_type<AppliedType>(t1)) {
+        auto *a2 = cast_type<AppliedType>(t2);
         if (a2 == nullptr) {
             if (a1->klass.data(gs)->isModule() || !isa_type<ClassType>(t2)) {
                 return AndType::make_shared(t1, t2);
@@ -1110,22 +1110,22 @@ void compareToUntyped(const GlobalState &gs, TypeConstraint &constr, const TypeP
         compareToUntyped(gs, constr, ty.underlying(gs), blame);
     }
 
-    if (auto t = cast_type<AppliedType>(ty)) {
+    if (auto *t = cast_type<AppliedType>(ty)) {
         for (auto &targ : t->targs) {
             compareToUntyped(gs, constr, targ, blame);
         }
-    } else if (auto t = cast_type<ShapeType>(ty)) {
+    } else if (auto *t = cast_type<ShapeType>(ty)) {
         for (auto &val : t->values) {
             compareToUntyped(gs, constr, val, blame);
         }
-    } else if (auto t = cast_type<TupleType>(ty)) {
+    } else if (auto *t = cast_type<TupleType>(ty)) {
         for (auto &val : t->elems) {
             compareToUntyped(gs, constr, val, blame);
         }
-    } else if (auto t = cast_type<OrType>(ty)) {
+    } else if (auto *t = cast_type<OrType>(ty)) {
         compareToUntyped(gs, constr, t->left, blame);
         compareToUntyped(gs, constr, t->right, blame);
-    } else if (auto t = cast_type<AndType>(ty)) {
+    } else if (auto *t = cast_type<AndType>(ty)) {
         compareToUntyped(gs, constr, t->left, blame);
         compareToUntyped(gs, constr, t->right, blame);
     } else if (isa_type<TypeVar>(ty)) {
@@ -1197,8 +1197,8 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
     //    original signatures using lub ENFORCE(cast_type<LambdaParam>(t2) == nullptr);
 
     {
-        auto lambda1 = cast_type<LambdaParam>(t1);
-        auto lambda2 = cast_type<LambdaParam>(t2);
+        auto *lambda1 = cast_type<LambdaParam>(t1);
+        auto *lambda2 = cast_type<LambdaParam>(t2);
         if (lambda1 != nullptr || lambda2 != nullptr) {
             // This should only be reachable in resolver.
             if (lambda1 == nullptr || lambda2 == nullptr) {
@@ -1216,7 +1216,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             // we can only check bounds when a LambdaParam is present.
             if (!isSelfTypeT1) {
                 auto self2 = cast_type_nonnull<SelfTypeParam>(t2);
-                if (auto lambdaParam = cast_type<LambdaParam>(self2.definition.resultType(gs))) {
+                if (auto *lambdaParam = cast_type<LambdaParam>(self2.definition.resultType(gs))) {
                     auto result = Types::isSubTypeUnderConstraint(gs, constr, t1, lambdaParam->lowerBound, mode,
                                                                   errorDetailsCollector);
                     if constexpr (shouldAddErrorDetails) {
@@ -1231,7 +1231,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                 }
             } else if (!isSelfTypeT2) {
                 auto self1 = cast_type_nonnull<SelfTypeParam>(t1);
-                if (auto lambdaParam = cast_type<LambdaParam>(self1.definition.resultType(gs))) {
+                if (auto *lambdaParam = cast_type<LambdaParam>(self1.definition.resultType(gs))) {
                     return Types::isSubTypeUnderConstraint(gs, constr, lambdaParam->upperBound, t2, mode,
                                                            errorDetailsCollector);
                 } else {
@@ -1244,8 +1244,8 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     return true;
                 }
 
-                auto lambda1 = cast_type<LambdaParam>(self1.definition.resultType(gs));
-                auto lambda2 = cast_type<LambdaParam>(self2.definition.resultType(gs));
+                auto *lambda1 = cast_type<LambdaParam>(self1.definition.resultType(gs));
+                auto *lambda2 = cast_type<LambdaParam>(self2.definition.resultType(gs));
                 return lambda1 && lambda2 &&
                        Types::isSubTypeUnderConstraint(gs, constr, lambda1->upperBound, lambda2->lowerBound, mode,
                                                        errorDetailsCollector);
@@ -1265,8 +1265,8 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
 
     {
         if (isa_type<MetaType>(t1) || isa_type<MetaType>(t2)) {
-            auto m1 = cast_type<MetaType>(t1);
-            auto m2 = cast_type<MetaType>(t2);
+            auto *m1 = cast_type<MetaType>(t1);
+            auto *m2 = cast_type<MetaType>(t2);
             if (m1 != nullptr && m2 != nullptr) {
                 // TODO(jez) Should this actually run under EmptyFrozenConstraint? Leaving for backwards
                 // compatibility, but maybe we should do this under the `constr` that's in scope.
@@ -1301,8 +1301,8 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         }
     }
 
-    if (auto a1 = cast_type<AppliedType>(t1)) {
-        auto a2 = cast_type<AppliedType>(t2);
+    if (auto *a1 = cast_type<AppliedType>(t1)) {
+        auto *a2 = cast_type<AppliedType>(t2);
         bool result;
         if (a2 == nullptr) {
             if (isa_type<ClassType>(t2)) {
@@ -1397,7 +1397,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
         // alight type params.
         return result;
     }
-    if (auto a2 = cast_type<AppliedType>(t2)) {
+    if (auto *a2 = cast_type<AppliedType>(t2)) {
         if (is_proxy_type(t1)) {
             return Types::isSubTypeUnderConstraint(gs, constr, t1.underlying(gs), t2, mode, errorDetailsCollector);
         }
@@ -1427,7 +1427,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             typecase(
                 t1,
                 [&](const TupleType &a1) { // Warning: this implements COVARIANT arrays
-                    auto a2 = cast_type<TupleType>(t2);
+                    auto *a2 = cast_type<TupleType>(t2);
                     result = a2 != nullptr && a1.elems.size() >= a2->elems.size();
                     if (result) {
                         int i = -1;
@@ -1452,7 +1452,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     }
                 },
                 [&](const ShapeType &h1) { // Warning: this implements COVARIANT hashes
-                    auto h2 = cast_type<ShapeType>(t2);
+                    auto *h2 = cast_type<ShapeType>(t2);
                     result = h2 != nullptr && h2->keys.size() <= h1.keys.size();
                     if constexpr (shouldAddErrorDetails) {
                         if (h2 == nullptr) {
@@ -1577,12 +1577,12 @@ bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &cons
 
     // Note: order of cases here matters! We can't lose "and" information in t1 early and we can't
     // lose "or" information in t2 early.
-    if (auto o1 = cast_type<OrType>(t1)) { // 7, 8, 9
+    if (auto *o1 = cast_type<OrType>(t1)) { // 7, 8, 9
         return Types::isSubTypeUnderConstraint(gs, constr, o1->left, t2, mode, errorDetailsCollector) &&
                Types::isSubTypeUnderConstraint(gs, constr, o1->right, t2, mode, errorDetailsCollector);
     }
 
-    if (auto a2 = cast_type<AndType>(t2)) { // 2, 5
+    if (auto *a2 = cast_type<AndType>(t2)) { // 2, 5
         auto subCollectorLeft = errorDetailsCollector.newCollector();
         auto isSubTypeOfLeft = Types::isSubTypeUnderConstraint(gs, constr, t1, a2->left, mode, subCollectorLeft);
         if (!isSubTypeOfLeft) {
@@ -1608,8 +1608,8 @@ bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &cons
         return isSubTypeOfRight;
     }
 
-    auto a1 = cast_type<AndType>(t1);
-    auto o2 = cast_type<OrType>(t2);
+    auto *a1 = cast_type<AndType>(t1);
+    auto *o2 = cast_type<OrType>(t2);
 
     if (a1 != nullptr) {
         // If the left is an And of an Or, then we can reorder it to be an Or of
@@ -1619,7 +1619,7 @@ bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &cons
         if (isa_type<OrType>(*r)) {
             swap(r, l);
         }
-        auto a1o = cast_type<OrType>(*l);
+        auto *a1o = cast_type<OrType>(*l);
         if (a1o != nullptr) {
             // This handles `(A | B) & C` -> `(A & C) | (B & C)`
 
@@ -1639,7 +1639,7 @@ bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &cons
         if (isa_type<AndType>(*r)) {
             swap(r, l);
         }
-        auto o2a = cast_type<AndType>(*l);
+        auto *o2a = cast_type<AndType>(*l);
         if (o2a != nullptr) {
             // This handles `(A & B) | C` -> `(A | C) & (B | C)`
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -477,7 +477,7 @@ OrType::OrType(const TypePtr &left, const TypePtr &right) : left(move(left)), ri
 void TupleType::_sanityCheck(const GlobalState &gs) const {
     sanityCheckProxyType(gs, underlying(gs));
     auto underlying = this->underlying(gs);
-    auto applied = cast_type<AppliedType>(underlying);
+    auto *applied = cast_type<AppliedType>(underlying);
     ENFORCE(applied);
     ENFORCE(applied->klass == Symbols::Array());
 }
@@ -691,7 +691,7 @@ TypePtr Types::getProcReturnType(const GlobalState &gs, const TypePtr &procType)
     if (!procType.derivesFrom(gs, Symbols::Proc())) {
         return Types::untypedUntracked();
     }
-    auto applied = cast_type<AppliedType>(procType);
+    auto *applied = cast_type<AppliedType>(procType);
     if (applied == nullptr || applied->targs.empty()) {
         return Types::untypedUntracked();
     }
@@ -806,7 +806,7 @@ optional<int> SendAndBlockLink::fixedArity() const {
 
 TypePtr TupleType::elementType(const GlobalState &gs) const {
     auto underlying = this->underlying(gs);
-    auto ap = cast_type<AppliedType>(underlying);
+    auto *ap = cast_type<AppliedType>(underlying);
     ENFORCE(ap);
     ENFORCE(ap->klass == Symbols::Array());
     ENFORCE(ap->targs.size() == 1);
@@ -915,7 +915,7 @@ core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const T
         auto s = cast_type_nonnull<ClassType>(ty);
         singleton = s.symbol;
     } else {
-        auto at = cast_type<AppliedType>(ty);
+        auto *at = cast_type<AppliedType>(ty);
         if (at == nullptr) {
             return core::Symbols::noClassOrModule();
         }
@@ -926,7 +926,7 @@ core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const T
 }
 
 TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
-    if (auto metaType = cast_type<MetaType>(tp)) {
+    if (auto *metaType = cast_type<MetaType>(tp)) {
         return metaType->wrapped;
     }
 
@@ -962,7 +962,7 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
         return attachedClass.data(gs)->externalType();
     }
 
-    if (auto appType = cast_type<AppliedType>(tp)) {
+    if (auto *appType = cast_type<AppliedType>(tp)) {
         ClassOrModuleRef attachedClass = appType->klass.data(gs)->attachedClass(gs);
         if (!attachedClass.exists()) {
             if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
@@ -974,14 +974,14 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
         return attachedClass.data(gs)->externalType();
     }
 
-    if (auto shapeType = cast_type<ShapeType>(tp)) {
+    if (auto *shapeType = cast_type<ShapeType>(tp)) {
         vector<TypePtr> unwrappedValues;
         unwrappedValues.reserve(shapeType->values.size());
         for (auto &value : shapeType->values) {
             unwrappedValues.emplace_back(unwrapType(gs, loc, value));
         }
         return make_type<ShapeType>(shapeType->keys, move(unwrappedValues));
-    } else if (auto tupleType = cast_type<TupleType>(tp)) {
+    } else if (auto *tupleType = cast_type<TupleType>(tp)) {
         vector<TypePtr> unwrappedElems;
         unwrappedElems.reserve(tupleType->elems.size());
         for (auto &elem : tupleType->elems) {
@@ -1076,7 +1076,7 @@ TypePtr Types::applyTypeArguments(const GlobalState &gs, const CallLocs &locs, u
 
         auto memData = mem.data(gs);
 
-        auto memType = cast_type<LambdaParam>(memData->resultType);
+        auto *memType = cast_type<LambdaParam>(memData->resultType);
         ENFORCE(memType != nullptr);
 
         if (memData->flags.isFixed) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -14,7 +14,7 @@ namespace sorbet::infer {
 
 namespace {
 core::TypePtr dropConstructor(core::Context ctx, core::Loc loc, core::TypePtr tp) {
-    if (auto mt = core::cast_type<core::MetaType>(tp)) {
+    if (auto *mt = core::cast_type<core::MetaType>(tp)) {
         if (!mt->wrapped.isUntyped()) {
             if (auto e = ctx.state.beginError(loc, core::errors::Infer::BareTypeUsage)) {
                 e.setHeader("Unsupported usage of bare type");
@@ -531,7 +531,7 @@ void Environment::updateKnowledgeKindOf(core::Context ctx, cfg::LocalRef local, 
             whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, ref, ty);
             whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, ref, ty);
         }
-    } else if (auto klassTypeApp = core::cast_type<core::AppliedType>(klassType)) {
+    } else if (auto *klassTypeApp = core::cast_type<core::AppliedType>(klassType)) {
         if (klassTypeApp->klass == core::Symbols::Class()) {
             auto currentAlignment =
                 core::Types::alignBaseTypeArgs(ctx, klassTypeApp->klass, klassTypeApp->targs, core::Symbols::Class());
@@ -1374,7 +1374,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 // rule doesn't apply. We don't model the distinction accurately
                 // yet.
                 auto &blkArgs = insn.link->argFlags;
-                auto tuple = core::cast_type<core::TupleType>(params);
+                auto *tuple = core::cast_type<core::TupleType>(params);
                 if (blkArgs.size() > 1 && !blkArgs.front().isRepeated && tuple && tuple->elems.size() == 1 &&
                     tuple->elems.front().derivesFrom(ctx, core::Symbols::Array())) {
                     tp.type = std::move(tuple->elems.front());

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -371,7 +371,7 @@ string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatch
     auto hasBlockType = blkArg.type != nullptr && !blkArg.type.isUntyped();
     if (hasBlockType && !core::Types::isSubType(gs, core::Types::nilClass(), blkArg.type)) {
         string blkArgs;
-        if (auto appliedType = core::cast_type<core::AppliedType>(blkArg.type)) {
+        if (auto *appliedType = core::cast_type<core::AppliedType>(blkArg.type)) {
             if (appliedType->targs.size() >= 2) {
                 // The first element in targs is the return type.
                 auto targs_it = appliedType->targs.begin();

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -238,7 +238,7 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
             // with RuntimeProfiled.
             auto attachedClass = singleton.data(gs)->findMember(gs, core::Names::Constants::AttachedClass());
             if (attachedClass.exists()) {
-                auto lambdaParam =
+                auto *lambdaParam =
                     core::cast_type<core::LambdaParam>(attachedClass.asTypeMemberRef().data(gs)->resultType);
                 ENFORCE(lambdaParam != nullptr);
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2147,7 +2147,7 @@ class ResolveTypeMembersAndFieldsWalk {
 
     static bool isLHSResolved(core::Context ctx, core::SymbolRef sym) {
         if (sym.isTypeMember()) {
-            auto lambdaParam = core::cast_type<core::LambdaParam>(sym.resultType(ctx));
+            auto *lambdaParam = core::cast_type<core::LambdaParam>(sym.resultType(ctx));
             ENFORCE(lambdaParam != nullptr);
 
             // both bounds are set to todo in the namer, so it's sufficient to
@@ -2501,7 +2501,7 @@ class ResolveTypeMembersAndFieldsWalk {
         // Initialize the resultType to a LambdaParam with default bounds
         auto lambdaParam = core::make_type<core::LambdaParam>(lhs, core::Types::bottom(), core::Types::top());
         data->resultType = lambdaParam;
-        auto memberType = core::cast_type<core::LambdaParam>(lambdaParam);
+        auto *memberType = core::cast_type<core::LambdaParam>(lambdaParam);
 
         core::Loc lowerBoundTypeLoc;
         core::Loc upperBoundTypeLoc;
@@ -2635,7 +2635,7 @@ class ResolveTypeMembersAndFieldsWalk {
             return;
         }
         auto attachedClassTypeMember = attachedClass.asTypeMemberRef();
-        auto lambdaParam = core::cast_type<core::LambdaParam>(attachedClassTypeMember.data(ctx)->resultType);
+        auto *lambdaParam = core::cast_type<core::LambdaParam>(attachedClassTypeMember.data(ctx)->resultType);
         ENFORCE(lambdaParam != nullptr);
 
         if (isTodo(lambdaParam->lowerBound)) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -574,7 +574,7 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
 // This function recurses through an OrType, and accumulates all the class names,
 // wrapped in T.class_of, and checks if the type is only made up of Classes and OrTypes
 bool recurseOrType(core::Context ctx, core::TypePtr type, std::vector<std::string> &v) {
-    if (auto o = core::cast_type<core::OrType>(type)) {
+    if (auto *o = core::cast_type<core::OrType>(type)) {
         return recurseOrType(ctx, o->left, v) && recurseOrType(ctx, o->right, v);
     } else if (core::isa_type<core::ClassType>(type)) {
         v.push_back(fmt::format("T.class_of({})", type.show(ctx)));
@@ -1457,7 +1457,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
             result.type = core::make_type<core::UnresolvedAppliedType>(genericClass, move(targPtrs));
             return result;
         }
-        if (auto mt = core::cast_type<core::MetaType>(out)) {
+        if (auto *mt = core::cast_type<core::MetaType>(out)) {
             result.type = mt->wrapped;
             return result;
         }


### PR DESCRIPTION
This reverts commit dede2609f2f1a6ed38ada9b4c43d64242459e2ed.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Trying to diagnose slowdown in Stripe's CI.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.