### PR TITLE
Sorbet Extension API

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version history
 
+## 0.3.41
+- New extension API to track status changes on the Language Service.
+
 ## 0.3.40
 - Upgrade VS Language Client to [protocol 3.17.3](https://github.com/microsoft/vscode-languageserver-node/blob/main/README.md#3173-protocol-810-json-rpc-810-client-and-810-server)
 - Remove `cwd` from Sorbet configuration (it has never been used).

--- a/vscode_extension/README.md
+++ b/vscode_extension/README.md
@@ -38,3 +38,19 @@ See [docs/lsp-dev-guide.md] for information on how to get started with LSP and
 VS Code extension development.
 
 [docs/lsp-dev-guide.md]: https://github.com/sorbet/sorbet/blob/master/docs/lsp-dev-guide.md
+
+
+## Sorbet Extension API
+
+From 0.3.41, Sorbet exports a public API. Check VS Code's `getExtension` API. To ensure backward and forward compatibility,
+all properties should be treated as are nullable.
+
+ - `status()`: Sorbet status, or `undefined`.
+ - `onStatusChanged`: event raised whenever status changes.
+
+### Available Status Values
+These are string values:
+  - `disabled`: Sorbet Language Server has been disabled.
+  - `error`:  Sorbet Language Server encountered an error. This state does not correlate to code typing errors.
+  - `running`: Sorbet Language Server is running.
+  - `start`: Sorbet Language Server is being started. The event might repeat in case of error.

--- a/vscode_extension/README.md
+++ b/vscode_extension/README.md
@@ -42,15 +42,15 @@ VS Code extension development.
 
 ## Sorbet Extension API
 
-From 0.3.41, Sorbet exports a public API. Check VS Code's `getExtension` API. To ensure backward and forward compatibility,
-all properties should be treated as are nullable.
+Starting from version 0.3.41, Sorbet exports a public API. You can access it using VS Code's `getExtension` API. To ensure backward and forward compatibility, all properties are nullable.
 
- - `status()`: Sorbet status, or `undefined`.
- - `onStatusChanged`: event raised whenever status changes.
+- `status`: Represents the Sorbet status, or `undefined` if the state is unknown.
+- `onStatusChanged`: An event triggered whenever the status changes.
 
 ### Available Status Values
-These are string values:
-  - `disabled`: Sorbet Language Server has been disabled.
-  - `error`:  Sorbet Language Server encountered an error. This state does not correlate to code typing errors.
-  - `running`: Sorbet Language Server is running.
-  - `start`: Sorbet Language Server is being started. The event might repeat in case of error.
+The following are string values:
+
+- `disabled`: Indicates that the Sorbet Language Server has been disabled.
+- `error`: Indicates that the Sorbet Language Server encountered an error. This status does not correlate to code typing errors.
+- `running`: Indicates that the Sorbet Language Server is running.
+- `start`: Indicates that the Sorbet Language Server is starting. This status may repeat in case of an error.

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -12,6 +12,7 @@ import {
 import { toggleTypedFalseCompletionNudges } from "./commands/toggleTypedFalseCompletionNudges";
 import { getLogLevelFromEnvironment, LogLevel } from "./log";
 import { SorbetContentProvider, SORBET_SCHEME } from "./sorbetContentProvider";
+import { SorbetExtensionApiImpl } from "./sorbetExtensionApi";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { SorbetStatusBarEntry } from "./sorbetStatusBarEntry";
 import { ServerStatus, RestartReason } from "./types";
@@ -19,7 +20,7 @@ import { ServerStatus, RestartReason } from "./types";
 /**
  * Extension entrypoint.
  */
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
   const sorbetExtensionContext = new SorbetExtensionContext(context);
   sorbetExtensionContext.log.logLevel = getLogLevelFromEnvironment();
 
@@ -97,5 +98,10 @@ export function activate(context: ExtensionContext) {
   );
 
   // Start the extension.
-  return sorbetExtensionContext.statusProvider.startSorbet();
+  await sorbetExtensionContext.statusProvider.startSorbet();
+
+  // This exposes Sorbet Extension API.
+  const api = new SorbetExtensionApiImpl(sorbetExtensionContext);
+  context.subscriptions.push(api);
+  return api.toApi();
 }

--- a/vscode_extension/src/sorbetExtensionApi.ts
+++ b/vscode_extension/src/sorbetExtensionApi.ts
@@ -16,7 +16,7 @@ const enum Status {
    */
   Error = "error",
   /**
-   * Sorbet Language Server us running.
+   * Sorbet Language Server is running.
    */
   Running = "running",
   /**

--- a/vscode_extension/src/sorbetExtensionApi.ts
+++ b/vscode_extension/src/sorbetExtensionApi.ts
@@ -1,0 +1,91 @@
+import { Disposable, Event, EventEmitter } from "vscode";
+import { SorbetExtensionContext } from "./sorbetExtensionContext";
+import { ServerStatus } from "./types";
+import { Log } from "./log";
+
+/**
+ * Status changes reported by extension.
+ */
+const enum Status {
+  /**
+   * Extension starts in disabled state. It then can enter this state after
+   * user explicitly disables Sorbet.
+   */
+  Disabled = "disabled",
+  /**
+   * Sorbet Language Server has started up and it is ready to process.
+   */
+  Ready = "ready",
+  /**
+   * Sorbet server is being started, event might repeat in case of error or if
+   * the server was shutdown.
+   */
+  Start = "start",
+}
+
+/**
+ * Sorbet Extension API.
+ *
+ * IMPORTANT!
+ * Maintain backward and forward compatibility in all changes to prevent breaking
+ * consumer extensions:
+ *  1. Use optional properties.
+ *  2. NEVER expose internal types directly.
+ */
+export interface SorbetExtensionApi {
+  status?(): Status | undefined;
+  readonly onStatusChanged?: Event<Status>;
+}
+
+export class SorbetExtensionApiImpl implements Disposable {
+  private readonly disposables: Disposable[];
+  private readonly onStatusChangedEmitter: EventEmitter<Status>;
+  private readonly log: Log;
+  public status?: Status;
+
+  constructor({ statusProvider, log }: SorbetExtensionContext) {
+    this.log = log;
+    this.onStatusChangedEmitter = new EventEmitter();
+    this.status = this.mapStatus(statusProvider.serverStatus);
+    this.disposables = [
+      this.onStatusChangedEmitter,
+      statusProvider.onStatusChanged((e) => {
+        const mappedStatus = this.mapStatus(e.status);
+        this.log.trace("EVENT", this.status, mappedStatus);
+        if (mappedStatus) {
+          this.status = mappedStatus;
+          this.onStatusChangedEmitter.fire(mappedStatus);
+        }
+      }),
+    ];
+  }
+
+  dispose() {
+    Disposable.from(...this.disposables).dispose();
+  }
+
+  private mapStatus(status: ServerStatus): Status | undefined {
+    switch (status) {
+      case ServerStatus.DISABLED:
+        return Status.Disabled;
+      case ServerStatus.INITIALIZING:
+      case ServerStatus.RESTARTING:
+        return Status.Start;
+      case ServerStatus.RUNNING:
+        return Status.Ready;
+      default:
+        return undefined;
+    }
+  }
+
+  public get onStatusChanged(): Event<Status> | undefined {
+    return this.onStatusChangedEmitter.event;
+  }
+
+  public toApi(): SorbetExtensionApi {
+    return {
+      status: () => this.status,
+      onStatusChanged: this.onStatusChanged
+    };
+  }
+}

--- a/vscode_extension/src/sorbetExtensionApi.ts
+++ b/vscode_extension/src/sorbetExtensionApi.ts
@@ -36,24 +36,24 @@ const enum Status {
  *  2. NEVER expose internal types directly.
  */
 export interface SorbetExtensionApi {
-  status?(): Status | undefined;
+  status?: Status;
   readonly onStatusChanged?: Event<Status>;
 }
 
 export class SorbetExtensionApiImpl implements Disposable {
   private readonly disposables: Disposable[];
   private readonly onStatusChangedEmitter: EventEmitter<Status>;
-  public status?: Status;
+  private status?: Status;
 
   constructor({ statusProvider }: SorbetExtensionContext) {
     this.onStatusChangedEmitter = new EventEmitter();
     this.status = this.mapStatus(statusProvider.serverStatus);
+
     this.disposables = [
       this.onStatusChangedEmitter,
       statusProvider.onStatusChanged((e) => {
         const mappedStatus = this.mapStatus(e.status);
-        if (mappedStatus && this.status !== mappedStatus) {
-          this.status = mappedStatus;
+        if (mappedStatus  && this.status !== mappedStatus) {
           this.onStatusChangedEmitter.fire(mappedStatus);
         }
       }),
@@ -84,10 +84,10 @@ export class SorbetExtensionApiImpl implements Disposable {
    * Public API.
    */
   public toApi(): SorbetExtensionApi {
-    // This should be used instead of returning `this` because that would expose
-    // the internal implementations, e.g. `onStatusChangedEmitter`.
+    // API returned to other extensions should be specific not use `this` as
+    // that would expose internal implementation, e.g. `onStatusChangedEmitter`.
     return {
-      status: () => this.status,
+      status: this.status,
       onStatusChanged: this.onStatusChangedEmitter.event,
     };
   }

--- a/vscode_extension/src/sorbetExtensionApi.ts
+++ b/vscode_extension/src/sorbetExtensionApi.ts
@@ -53,7 +53,7 @@ export class SorbetExtensionApiImpl implements Disposable {
       this.onStatusChangedEmitter,
       statusProvider.onStatusChanged((e) => {
         const mappedStatus = this.mapStatus(e.status);
-        if (mappedStatus  && this.status !== mappedStatus) {
+        if (mappedStatus && this.status !== mappedStatus) {
           this.onStatusChangedEmitter.fire(mappedStatus);
         }
       }),

--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -67,7 +67,7 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
 
     this.onStatusChangeEmitter = new EventEmitter<ServerStatus>();
     this.restart = restart;
-    this.wrappedStatus = ServerStatus.DISABLED;
+    this.wrappedStatus = ServerStatus.INITIALIZING;
   }
 
   /**


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Provide an extension API for other extensions to use. 

 - Changing `SorbetLanguageClient` initial state to  `INITIALIZING` vs `DISABLED` (as it used to be pre- Language Client update) makes more practical sense.  It is odd to report a transition to `disabled` when a new client is created just to transition to `started` immediately after and it could cause some issue to consumers which might react by shutting something down just to be immediately woken up by a `start` event.   The state being undone was supposed to more accurately reflect current state of the Language Client (since `start` has not been called yet and it is effectively disabled).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Enable tracking of Language Server status changes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
