### PR TITLE
packager.cc: Only pre-resolve superClass if no errors

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1607,12 +1607,6 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
             continue;
         }
 
-        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
-        if (!validatePackageName(ctx, nameTree)) {
-            reportedError = true;
-            continue;
-        }
-
         // ---- Mutates the tree ----
         // We can't do these rewrites in rewriter, because this rewrite should only happen if
         // `opts.stripePackages` is set. That would mean we would have to add another cache flavor,
@@ -1620,6 +1614,27 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
         //
         // Other than being able to say "we don't mutate the trees in packager" there's not much
         // value in going that far (even namer mutates the trees; the packager fills a similar role).
+
+        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
+        if (!validatePackageName(ctx, nameTree)) {
+            reportedError = true;
+
+            // "Remove" the superclass.
+            //
+            // `::PackageSpec` doesn't exist. Normally we would rewrite it
+            // to Sorbet::Private::Static::PackageSpec, but we don't do that if the package spec
+            // definition is invalid.
+            //
+            // To avoid the chance that the user only sees the "Unable to resolve PackageSpec" error
+            // and then gets confused, we "remove" the super class here, treating it like the user
+            // omitted the superclass.
+            //
+            // This establishes an invariant that if the superClass is a resolved constant and
+            // equal to Symbols::PackageSpec(), then it's the canonical package def in this file
+            superClass = ast::MK::Constant(packageSpecClass->loc, core::Symbols::todo());
+
+            continue;
+        }
 
         // Pre-resolve the super class. This makes it easier to detect that this is a package
         // spec-related class def in later passes without having to recursively walk up the constant

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1607,6 +1607,12 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
             continue;
         }
 
+        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
+        if (!validatePackageName(ctx, nameTree)) {
+            reportedError = true;
+            continue;
+        }
+
         // ---- Mutates the tree ----
         // We can't do these rewrites in rewriter, because this rewrite should only happen if
         // `opts.stripePackages` is set. That would mean we would have to add another cache flavor,
@@ -1620,12 +1626,6 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
         // lit's scope to find if it starts with <PackageSpecRegistry>.
         superClass = ast::make_expression<ast::ConstantLit>(core::Symbols::PackageSpec(),
                                                             superClass.toUnique<ast::UnresolvedConstantLit>());
-
-        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
-        if (!validatePackageName(ctx, nameTree)) {
-            reportedError = true;
-            continue;
-        }
 
         // `class Foo < PackageSpec` -> `class <PackageSpecRegistry>::Foo < PackageSpec`
         // This removes the PackageSpec's themselves from the top-level namespace


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Establish the invariant mentioned in the comment.

When we move packager into namer, there become multiple places where we need to match up a `__package.rb` PackageInfo with the tree that encloses that package info, and the easiest way to do that is to use the superclass as a signifier.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests
