### PR TITLE
Fix `T::Enum` typo in RBS docs

### DIFF
--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -365,7 +365,7 @@ to use the literal's underlying type instead:
 - `false` is `FalseClass`
 - `nil` is `NilClass`
 
-You can also consider using [`T.::Enum`](tenum.md).
+You can also consider using [`T::Enum`](tenum.md).
 
 ## Type assertions comments
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

On the tin -- just a small typo (`T.::Enum` -> `T::Enum`) I noticed while glancing at the RBS documentation.