### PR TITLE
Desugar `||= T.let` with a fully qualified `T`

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -576,8 +576,7 @@ Send *asTLet(ExpressionPtr &arg) {
         return nullptr;
     }
 
-    auto recv = cast_tree<UnresolvedConstantLit>(send->recv);
-    if (recv == nullptr || recv->cnst != core::Names::Constants::T() || !isa_tree<EmptyTree>(recv->scope)) {
+    if (!ast::MK::isT(send->recv)) {
         return nullptr;
     }
 

--- a/test/testdata/desugar/oror_ivar.rb
+++ b/test/testdata/desugar/oror_ivar.rb
@@ -21,6 +21,13 @@ module Config
     @initialized_to_nilable ||= T.let(nil, T.nilable(String))
   end # error: Expected `String` but found `T.nilable(String)` for method result type
 
+  sig {returns(Integer)}
+  def self.initialized_with_qualified_let
+    @initialized_with_qualified_let ||= ::T.let(42, T.nilable(Integer))
+    T.reveal_type(@initialized_with_qualified_let) # error: Revealed type: `Integer`
+    T.must(@initialized_with_qualified_let) # error: `T.must` called on `Integer`, which is never `nil`
+  end
+
   sig {returns(T::Boolean)}
   def self.lazy_boolean
     # This is dangerous, but it's dangerous in normal Ruby, too. (The `||`

--- a/test/testdata/desugar/oror_ivar.rb.autocorrects.exp
+++ b/test/testdata/desugar/oror_ivar.rb.autocorrects.exp
@@ -22,6 +22,13 @@ module Config
     @initialized_to_nilable ||= T.let(nil, T.nilable(String))
   end # error: Expected `String` but found `T.nilable(String)` for method result type
 
+  sig {returns(Integer)}
+  def self.initialized_with_qualified_let
+    @initialized_with_qualified_let ||= ::T.let(42, T.nilable(Integer))
+    T.reveal_type(@initialized_with_qualified_let) # error: Revealed type: `Integer`
+    @initialized_with_qualified_let # error: `T.must` called on `Integer`, which is never `nil`
+  end
+
   sig {returns(T::Boolean)}
   def self.lazy_boolean
     # This is dangerous, but it's dangerous in normal Ruby, too. (The `||`

--- a/test/testdata/desugar/oror_ivar.rb.desugar-tree.exp
+++ b/test/testdata/desugar/oror_ivar.rb.desugar-tree.exp
@@ -55,6 +55,26 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     <self>.sig() do ||
+      <self>.returns(<emptyTree>::<C Integer>)
+    end
+
+    def self.initialized_with_qualified_let<<todo method>>(&<blk>)
+      begin
+        if @initialized_with_qualified_let
+          @initialized_with_qualified_let
+        else
+          begin
+            @initialized_with_qualified_let = ::<root>::<C T>.let(@initialized_with_qualified_let, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+            <statTemp>$2 = 42
+            @initialized_with_qualified_let = <statTemp>$2
+          end
+        end
+        <emptyTree>::<C T>.reveal_type(@initialized_with_qualified_let)
+        <emptyTree>::<C T>.must(@initialized_with_qualified_let)
+      end
+    end
+
+    <self>.sig() do ||
       <self>.returns(<emptyTree>::<C T>::<C Boolean>)
     end
 


### PR DESCRIPTION
### Motivation

#6081 introduced a desugar level rewrite that eased the pain of initializing lazy instance variables, but the rewrite didn't consider rooted `::T` calls. So while those two cases should be similar, one is properly desugared, the other one is not:

```rb
# typed: strict

extend T::Sig

sig { returns(Integer) }
def foo
  @x ||= T.let(42, T.nilable(Integer))
end

sig { returns(Integer) }
def bar
  @y ||= ::T.let(42, T.nilable(Integer))
end # error: Expected `Integer` but found `T.nilable(Integer)` for method result type 
```

See [sorbet.run](https://sorbet.run/#%23%20typed%3A%20strict%0A%0Aextend%20T%3A%3ASig%0A%0Asig%20%7B%20returns%28Integer%29%20%7D%0Adef%20foo%0A%20%20%40x%20%7C%7C%3D%20T.let%2842%2C%20T.nilable%28Integer%29%29%0Aend%0A%0Asig%20%7B%20returns%28Integer%29%20%7D%0Adef%20bar%0A%20%20%40y%20%7C%7C%3D%20%3A%3AT.let%2842%2C%20T.nilable%28Integer%29%29%0Aend).

This PR uses `MK::isT` so we rewrite both cases in the same way.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
