### PR TITLE
Change the return type of getFileHash to a plain pointer

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -137,8 +137,8 @@ void File::setFileHash(unique_ptr<const FileHash> hash) {
     }
 }
 
-const shared_ptr<const FileHash> &File::getFileHash() const {
-    return hash_;
+const FileHash *File::getFileHash() const {
+    return hash_.get();
 }
 
 FileRef::FileRef(unsigned int id) : _id(id) {}

--- a/core/Files.h
+++ b/core/Files.h
@@ -91,7 +91,7 @@ public:
     std::string_view getLine(int i) const;
 
     void setFileHash(std::unique_ptr<const FileHash> hash);
-    const std::shared_ptr<const FileHash> &getFileHash() const;
+    const FileHash *getFileHash() const;
 
     static constexpr std::string_view URL_PREFIX = "https://github.com/sorbet/sorbet/tree/master/";
     static std::string censorFilePathForSnapshotTests(std::string_view orig);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -40,7 +40,7 @@ public:
     static void pickle(Pickler &p, const ast::ExpressionPtr &what);
     static void pickle(Pickler &p, core::LocOffsets loc);
     static void pickle(Pickler &p, core::Loc loc);
-    static void pickle(Pickler &p, shared_ptr<const FileHash> fh);
+    static void pickle(Pickler &p, const FileHash *fh);
     static void pickle(Pickler &p, const ast::UnresolvedConstantLit &lit);
 
     static shared_ptr<File> unpickleFile(UnPickler &p);
@@ -245,7 +245,7 @@ int64_t UnPickler::getS8() {
     return absl::bit_cast<int64_t>(res);
 }
 
-void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
+void SerializerImpl::pickle(Pickler &p, const FileHash *fh) {
     if (fh == nullptr) {
         p.putU1(0);
         return;


### PR DESCRIPTION
We never use the fact that `File::getFileHash` returns a `shared_ptr &`, and always treat it like a pointer. Let's fetch the pointer's value eagerly in the method definition instead of returning the reference.

### Motivation
Avoiding extra pointer indirection.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a Should not affect behavior.
