### PR TITLE
Add generic methods to the RBS quick reference

### DIFF
--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -216,23 +216,24 @@ understanding the cases where there is no suitable RBS replacement.
 Most RBS features can be used and will be translated to equivalent Sorbet syntax
 during type checking:
 
-| RBS Feature            | RBS syntax                               | Sorbet syntax                                           |
-| ---------------------- | ---------------------------------------- | ------------------------------------------------------- |
-| [Class instance type]  | `Foo`                                    | [`Foo`](class-types.md)                                 |
-| [Class singleton type] | `singleton(Foo)`                         | [`T.class_of(Foo)`](class-of.md)                        |
-| [Union type]           | <span><code>Foo &#124; Bar</code></span> | [`T.any(Foo, Bar)`](union-types.md)                     |
-| [Intersection type]    | `Foo & Bar`                              | [`T.all(Foo, Bar)`](intersection-types.md)              |
-| [Optional type]        | `Foo?`                                   | [`T.nilable(Foo)`](nilable-types.md)                    |
-| [Untyped type]         | `untyped`                                | [`T.untyped`](untyped.md)                               |
-| [Boolean type]         | `bool`                                   | [`T::Boolean`](class-types.md#booleans)                 |
-| [Nil type]             | `nil`                                    | [`NilClass`](class-types.md#nil)                        |
-| [Top type]             | `top`                                    | [`T.anything`](anything.md)                             |
-| [Bottom type]          | `bot`                                    | [`T.noreturn`](noreturn.md)                             |
-| [Void type]            | `void`                                   | [`void`](sigs.md#returns--void-annotating-return-types) |
-| [Generic type]         | `Foo[Bar]`                               | [`Foo[Bar]`](generics.md)                               |
-| [Tuple type]           | `[Foo, Bar]`                             | [`[Foo, Bar]`](tuples.md)                               |
-| [Shape type]           | `{ a: Foo, b: Bar }`                     | [`{ a: Foo, b: Bar }`](shapes.md)                       |
-| [Proc type]            | `^(Foo) -> Bar`                          | [`T.proc.params(arg: Foo).returns(Bar)`](procs.md)      |
+| RBS Feature            | RBS syntax                               | Sorbet syntax                                                                                                        |
+| ---------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| [Class instance type]  | `Foo`                                    | [`Foo`](class-types.md)                                                                                              |
+| [Class singleton type] | `singleton(Foo)`                         | [`T.class_of(Foo)`](class-of.md)                                                                                     |
+| [Union type]           | <span><code>Foo &#124; Bar</code></span> | [`T.any(Foo, Bar)`](union-types.md)                                                                                  |
+| [Intersection type]    | `Foo & Bar`                              | [`T.all(Foo, Bar)`](intersection-types.md)                                                                           |
+| [Optional type]        | `Foo?`                                   | [`T.nilable(Foo)`](nilable-types.md)                                                                                 |
+| [Untyped type]         | `untyped`                                | [`T.untyped`](untyped.md)                                                                                            |
+| [Boolean type]         | `bool`                                   | [`T::Boolean`](class-types.md#booleans)                                                                              |
+| [Nil type]             | `nil`                                    | [`NilClass`](class-types.md#nil)                                                                                     |
+| [Top type]             | `top`                                    | [`T.anything`](anything.md)                                                                                          |
+| [Bottom type]          | `bot`                                    | [`T.noreturn`](noreturn.md)                                                                                          |
+| [Void type]            | `void`                                   | [`void`](sigs.md#returns--void-annotating-return-types)                                                              |
+| [Generic type]         | `Foo[Bar]`                               | [`Foo[Bar]`](generics.md)                                                                                            |
+| [Generic method]       | `[U] (U foo) -> U`                       | [`type_parameters(:U).params(foo: T.type_parameter(:U)).returns(T.type_parameter(:U))`](generics.md#generic-methods) |
+| [Tuple type]           | `[Foo, Bar]`                             | [`[Foo, Bar]`](tuples.md)                                                                                            |
+| [Shape type]           | `{ a: Foo, b: Bar }`                     | [`{ a: Foo, b: Bar }`](shapes.md)                                                                                    |
+| [Proc type]            | `^(Foo) -> Bar`                          | [`T.proc.params(arg: Foo).returns(Bar)`](procs.md)                                                                   |
 
 ## Attribute accessor types
 
@@ -436,6 +437,8 @@ no `T.cast` nor `T.must` alternative).
 [Bottom type]: https://github.com/ruby/rbs/blob/master/docs/syntax.md#base-types
 [Void type]: https://github.com/ruby/rbs/blob/master/docs/syntax.md#base-types
 [Generic type]:
+  https://github.com/ruby/rbs/blob/master/docs/syntax.md#type-variable
+[Generic method]:
   https://github.com/ruby/rbs/blob/master/docs/syntax.md#type-variable
 [Tuple type]: https://github.com/ruby/rbs/blob/master/docs/syntax.md#tuple-type
 [Shape type]: https://github.com/ruby/rbs/blob/master/docs/syntax.md#record-type


### PR DESCRIPTION
Adds a row for generic methods to the RBS quick reference table on the website.

### Motivation
It's supported by sorbet, but it was missing from the list.

### Test plan
Docs only.