### PR TITLE
Update float.rbi to add `round`'s `half` parameter (added in Ruby 2.4)

### DIFF
--- a/rbi/core/float.rbi
+++ b/rbi/core/float.rbi
@@ -1045,11 +1045,12 @@ class Float < Numeric
   sig {returns(Integer)}
   sig do
     params(
-        arg0: Numeric,
+      ndigits: Numeric,
+      half: T.nilable(Symbol)
     )
     .returns(T.any(Integer, Float))
   end
-  def round(arg0=T.unsafe(nil)); end
+  def round(ndigits = 0, half: :up); end
 
   sig {returns(Complex)}
   def to_c(); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Update float.rbi to add `round`'s `half` parameter (added in Ruby 2.4). Also updates its first parameter to be named `ndigits` defaulting to `0` to match [the official Ruby documentation](https://docs.ruby-lang.org/en/3.4/Float.html#method-i-round).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This parameter was already described in the associated documentation comment, but when I went to use it in a script I encountered a Sorbet type error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
