### PR TITLE
Fix Coverage.start and Coverage.result signatures

### DIFF
--- a/rbi/stdlib/coverage.rbi
+++ b/rbi/stdlib/coverage.rbi
@@ -77,6 +77,7 @@ module Coverage
   # Enables coverage measurement.
   sig do
     params(
+        all: T.nilable(Symbol),
         lines: T::Boolean,
         branches: T::Boolean,
         methods: T::Boolean,
@@ -84,5 +85,5 @@ module Coverage
     )
     .returns(NilClass)
   end
-  def self.start(lines: T.unsafe(nil), branches: T.unsafe(nil), methods: T.unsafe(nil), oneshot_lines: T.unsafe(nil)); end
+  def self.start(all = T.unsafe(nil), lines: T.unsafe(nil), branches: T.unsafe(nil), methods: T.unsafe(nil), oneshot_lines: T.unsafe(nil)); end
 end

--- a/rbi/stdlib/coverage.rbi
+++ b/rbi/stdlib/coverage.rbi
@@ -62,7 +62,7 @@ module Coverage
         stop: T::Boolean,
         clear: T::Boolean
     )
-    .returns(T::Hash[String, T::Array[T.nilable(Integer)]])
+    .returns(T::Hash[String, T.untyped])
   end
   def self.result(stop: T.unsafe(nil), clear: T.unsafe(nil)); end
 


### PR DESCRIPTION
This PR fixes the signatures for `Coverage.start` and `Coverage.result`, accounting for a couple of things that were missing.

### Motivation

For `Coverage.start`, the method accepts either one of the keyword arguments or the symbol `:all` to enable all types of coverage https://docs.ruby-lang.org/en/master/Coverage.html#method-c-start.

And for `Coverage.result`, the return is significantly more complicated than the current type. There's a complete explanation in the [source code](https://github.com/ruby/ruby/blob/2183899fd184ab1cfee80d57c0dd6f4dcd370375/ext/coverage/coverage.c#L471), but this is the general structure returned:

```ruby
{
  "/path/to/file.rb" => {
    # Lines is an array of execution count, with one entry for each line of the file
    lines: [1, nil, 2, nil],

    # Branches is the branch coverage information. It is a hash where the keys are arrays
    # in the format of [LABEL, ID, START_LINE, START_CHAR, END_LINE, END_CHAR]
    # The values are also hashes, where the keys are also this same type of array and the
    # values are the number of times that branch was executed
    branches: {
      [:"&.", 0, 6, 21, 6, 65] => { [:then, 1, 6, 21, 6, 65] => 0, [:else, 5, 7, 0, 7, 87] => 1 }
    },

    # Finally, method coverage uses a similar structure as branches, where we have
    # the keys as [CLASS, method, START_LINE, START_CHAR, END_LINE, END_CHAR] and the values
    # are the number of times the method was executed
    methods: {
       ["Foo", :bar, 6, 21, 6, 65] => 0
    }
  }
}
```

The return is so complex, that I would vote for us to simply return `T.untyped`. If people have a different opinion, let me know and we can try to provide something more specific.

### Test plan

Just an RBI change.