### PR TITLE
`--max-threads=0` to make a test not flake

### DIFF
--- a/test/cli/package-strict-dependencies-show-cycle/test.sh
+++ b/test/cli/package-strict-dependencies-show-cycle/test.sh
@@ -1,3 +1,3 @@
 cd test/cli/package-strict-dependencies-show-cycle || exit 1
 
-../../../main/sorbet --silence-dev-message --stripe-packages --packager-layers . 2>&1
+../../../main/sorbet --silence-dev-message --stripe-packages --packager-layers --max-threads=0 . 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This test has flaked twice in the past few days:

- <https://buildkite.com/sorbet/sorbet/builds/35161#0195edf0-655c-4b38-8bd5-eb784c5f7f02/140-376>
- <https://buildkite.com/sorbet/sorbet/builds/35147#0195e053-8775-46aa-a905-431dc2d7f7a2/213-462>

We use `--max-threads=0` in ~all of our other `--stripe-packages` tests,
because they tend to have multiple files, which might get scheduled onto
workers in different orders every run.

Spot checking the failures, it seems like that's the only problem with
the flakes this time (that sometimes the errors for one file show up
sooner or later in the output).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Hopefully CI stops flaking?