### PR TITLE
Allow duplicate imports in packages

### DIFF
--- a/.buildkite/test-static-sanitized.sh
+++ b/.buildkite/test-static-sanitized.sh
@@ -64,7 +64,7 @@ if [ "$err" -ne 0 ]; then
   # Use --config=dbg instead of sanitized because it's more likely that they've
   # already built this config locally, and most test failures reproduce outside
   # of sanitized mode anyways.
-  echo '  --config=dbg' >> "$failing_tests"
+  echo '  --config=dbg --test_output=errors' >> "$failing_tests"
   echo '```' >> "$failing_tests"
 
   buildkite-agent annotate --context "test-static-sanitized.sh" --style error --append < "$failing_tests"

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -17,9 +17,7 @@ class A < PackageSpec
        # ^^^^^^^^^ error: Unable to resolve constant `REFERENCE`
   # Despite the above, this import should work.
   import B
-  # But this one will fail; no duplicate imports allowed.
   import B
-# ^^^^^^^^ error: Duplicate package import
 
   export 123 # error: Argument to `export` must be a constant
   export "hello" # error: Argument to `export` must be a constant
@@ -29,7 +27,7 @@ class A < PackageSpec
   export A::AClass
   export A::AModule
 
+  test_import B
   test_import C
   test_import C
-# ^^^^^^^^^^^^^ error: Duplicate package import
 end

--- a/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
@@ -18,8 +18,7 @@ class A < PackageSpec
        # ^^^^^^^^^ error: Unable to resolve constant `REFERENCE`
   # Despite the above, this import should work.
   import B
-  # But this one will fail; no duplicate imports allowed.
-# ^^^^^^^^ error: Duplicate package import
+  import B
 
   export 123 # error: Argument to `export` must be a constant
   export "hello" # error: Argument to `export` must be a constant
@@ -29,8 +28,9 @@ class A < PackageSpec
   export A::AClass
   export A::AModule
 
+  test_import B
   test_import C
-# ^^^^^^^^^^^^^ error: Duplicate package import
+  test_import C
 end
 # ------------------------------
 # -- test/testdata/packager/invalid_imports_and_exports/a.rb --

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -25,6 +25,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.export(::<root>::<C A>::<C AModule>)
 
+    <self>.test_import(::<PackageSpecRegistry>::<C B>)
+
     <self>.test_import(::<PackageSpecRegistry>::<C C>)
 
     <self>.test_import(::<PackageSpecRegistry>::<C C>)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This error often fires when there's merge race between 2 PRs that add the same import, and there's not really a downside of having a duplicate import in the import list, so we can get rid of the error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
