### PR TITLE
Speed up `SigsRewriter` for RBS comment extraction

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -24,6 +24,7 @@ constexpr ErrorClass DuplicateProp{3515, StrictLevel::True};
 constexpr ErrorClass RBSSyntaxError{3550, StrictLevel::False};
 constexpr ErrorClass RBSUnsupported{3551, StrictLevel::False};
 constexpr ErrorClass RBSParameterMismatch{3552, StrictLevel::False};
+constexpr ErrorClass RBSUnusedComment{3553, StrictLevel::False};
 
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rbs/SigsRewriter.h
+++ b/rbs/SigsRewriter.h
@@ -7,37 +7,40 @@
 
 namespace sorbet::rbs {
 
-/**
- * A collection of annotations and signatures comments found on a method definition.
- */
-struct Comments {
-    /**
-     * RBS annotation comments found on a method definition.
-     *
-     * Annotations are formatted as `@some_annotation`.
-     */
-    std::vector<Comment> annotations;
-
-    /**
-     * RBS signature comments found on a method definition.
-     *
-     * Signatures are formatted as `#: () -> void`.
-     */
-    std::vector<Comment> signatures;
-};
-
 class SigsRewriter {
 public:
+    /**
+     * A collection of annotations and signatures comments found on a method definition.
+     */
+    struct Comments {
+        /**
+         * RBS annotation comments found on a method definition.
+         *
+         * Annotations are formatted as `@some_annotation`.
+         */
+        std::vector<Comment> annotations;
+
+        /**
+         * RBS signature comments found on a method definition.
+         *
+         * Signatures are formatted as `#: () -> void`.
+         */
+        std::vector<Comment> signatures;
+    };
+
     SigsRewriter(core::MutableContext ctx) : ctx(ctx){};
     std::unique_ptr<parser::Node> run(std::unique_ptr<parser::Node> tree);
 
 private:
     core::MutableContext ctx;
+    UnorderedMap<uint32_t, Comments> methodSignatures;
 
     std::unique_ptr<parser::Node> rewriteBegin(std::unique_ptr<parser::Node> tree);
     std::unique_ptr<parser::Node> rewriteBody(std::unique_ptr<parser::Node> tree);
     std::unique_ptr<parser::Node> rewriteNode(std::unique_ptr<parser::Node> tree);
     parser::NodeVec rewriteNodes(parser::NodeVec nodes);
+    void extractCommentsFromFile();
+    void checkForUnusedComments();
 };
 
 } // namespace sorbet::rbs

--- a/test/testdata/rbs/signatures_attrs.rb
+++ b/test/testdata/rbs/signatures_attrs.rb
@@ -79,3 +79,20 @@ class AttrAnnotations
     attr_reader :foo
   end
 end
+
+
+class UnusedComments
+  extend T::Sig
+
+  #: Integer # error: Unused RBS signature comment. No method definition found after it
+  sig { returns(String) }
+  attr_reader :foo
+
+  #: -> void
+  def initialize
+    @foo = T.let("foo", String)
+  end
+end
+
+x = UnusedComments.new
+T.reveal_type(x.foo) # error: Revealed type: `String`

--- a/test/testdata/rbs/signatures_attrs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_attrs.rb.rewrite-tree.exp
@@ -184,4 +184,32 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <runtime method definition of foo>
     end
   end
+
+  class <emptyTree>::<C UnusedComments><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def foo<<todo method>>(&<blk>)
+      @foo
+    end
+
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.void()
+    end
+
+    def initialize<<todo method>>(&<blk>)
+      @foo = <cast:let>("foo", <todo sym>, <emptyTree>::<C String>)
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of foo>
+
+    <runtime method definition of initialize>
+  end
+
+  x = <emptyTree>::<C UnusedComments>.new()
+
+  <emptyTree>::<C T>.reveal_type(x.foo())
 end

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -70,6 +70,7 @@ T.reveal_type(method4) # error: Revealed type: `String`
 def method5; T.unsafe(nil); end
 T.reveal_type(method5) # error: Revealed type: `String`
 
+  # TODO: Raise RBSUnusedComment error instead
   #: -> String
 # ^^^^^^^^^^^^ error: Unused type annotation. No method def before next annotation
   #: -> void
@@ -179,6 +180,39 @@ T.reveal_type(method19(42)) # error: Revealed type: `T::Class[Integer]`
 #: ?{ (?) -> untyped } -> void
 def method20(&block)
   T.reveal_type(block) # error: Revealed type: `T.untyped`
+end
+
+# Some comment
+#: (String) -> void
+
+def method21(x)
+  T.reveal_type(x) # error: Revealed type: `String`
+end
+
+#: (Integer) -> void # error: Unused RBS signature comment. No method definition found after it
+sig { params(x: String).void }
+def method22(x)
+  T.reveal_type(x) # error: Revealed type: `String`
+end
+
+#: (Integer) -> void # error: Unused RBS signature comment. No method definition found after it
+sig do
+  params(x: String).void
+end
+def method23(x)
+  T.reveal_type(x) # error: Revealed type: `String`
+end
+
+class UnusedTypeAnnotation
+  #: -> void # error: Unused RBS signature comment. No method definition found after it
+  class Inner
+    def foo; end # error: The method `foo` does not have a `sig`
+  end
+
+  def foo # error: The method `foo` does not have a `sig`
+    #: -> void # error: Unused RBS signature comment. No method definition found after it
+  end
+  def bar; end # error: The method `bar` does not have a `sig`
 end
 
 class FooProc

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -212,6 +212,30 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(block)
   end
 
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:x, <emptyTree>::<C String>).void()
+  end
+
+  def method21<<todo method>>(x, &<blk>)
+    <emptyTree>::<C T>.reveal_type(x)
+  end
+
+  ::Sorbet::Private::Static.sig(<self>) do ||
+    <self>.params(:x, <emptyTree>::<C String>).void()
+  end
+
+  def method22<<todo method>>(x, &<blk>)
+    <emptyTree>::<C T>.reveal_type(x)
+  end
+
+  ::Sorbet::Private::Static.sig(<self>) do ||
+    <self>.params(:x, <emptyTree>::<C String>).void()
+  end
+
+  def method23<<todo method>>(x, &<blk>)
+    <emptyTree>::<C T>.reveal_type(x)
+  end
+
   <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
   class <emptyTree>::<C P1><<C <todo sym>>> < (::<todo sym>)
@@ -343,6 +367,34 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(<self>.method19(42))
 
   <runtime method definition of method20>
+
+  <runtime method definition of method21>
+
+  <runtime method definition of method22>
+
+  <runtime method definition of method23>
+
+  class <emptyTree>::<C UnusedTypeAnnotation><<C <todo sym>>> < (::<todo sym>)
+    def foo<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    def bar<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    class <emptyTree>::<C Inner><<C <todo sym>>> < (::<todo sym>)
+      def foo<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      <runtime method definition of foo>
+    end
+
+    <runtime method definition of foo>
+
+    <runtime method definition of bar>
+  end
 
   class <emptyTree>::<C FooProc><<C <todo sym>>> < (::<todo sym>)
     ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -622,6 +622,14 @@ supported by Sorbet. See
 This error is raised when a RBS signature comment has more parameters than the
 method definition it represents.
 
+## 3553
+
+> This error is specific to RBS support when using the
+> `--enable-experimental-rbs-signatures` flag.
+
+This error is raised when Sorbet couldn't match a RBS signature comment with a
+method definition. Ensure your comment is followed by a method definition.
+
 ## 3702
 
 > This error is specific to Stripe's custom `--stripe-packages` mode. If you are


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->



### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This PR refactors RBS comment extraction and significantly reduces the overhead for using RBS comments as signatures. In our monolith this brought down the total type checking time with RBS signatures enabled to within 5% of type checking time without RBS (Note there isn't many sigs being translated yet). Previously we were observing a ~80% difference.


For each file we extract the RBS comments and store them in a hash. Afterwards we match the comments with the method definitions we see while parsing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
