### PR TITLE
packager: Report all other ClassDef as "illegal node"

### DIFF
--- a/test/testdata/packager/illegal_classdef/after/__package.rb
+++ b/test/testdata/packager/illegal_classdef/after/__package.rb
@@ -5,4 +5,4 @@
 class After < PackageSpec
 end
 
-class A; end # error: Package files can only declare one package
+class A; end # error: Invalid expression in package: `ClassDef` not allowed

--- a/test/testdata/packager/illegal_classdef/after/__package.rb
+++ b/test/testdata/packager/illegal_classdef/after/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class After < PackageSpec
+end
+
+class A; end # error: Package files can only declare one package

--- a/test/testdata/packager/illegal_classdef/before/__package.rb
+++ b/test/testdata/packager/illegal_classdef/before/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class A; end # error-with-dupes: `__package.rb` file must contain a package definition
+
+class Before < PackageSpec
+end

--- a/test/testdata/packager/illegal_classdef/before/__package.rb
+++ b/test/testdata/packager/illegal_classdef/before/__package.rb
@@ -2,7 +2,7 @@
 # typed: strict
 # enable-packager: true
 
-class A; end # error-with-dupes: `__package.rb` file must contain a package definition
+class A; end # error: `__package.rb` file must contain a package definition
 
 class Before < PackageSpec
 end

--- a/test/testdata/packager/illegal_classdef/inside/__package.rb
+++ b/test/testdata/packager/illegal_classdef/inside/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Inside < PackageSpec
+  class A; end # error: Package files can only declare one package
+end

--- a/test/testdata/packager/illegal_classdef/inside/__package.rb
+++ b/test/testdata/packager/illegal_classdef/inside/__package.rb
@@ -3,5 +3,5 @@
 # enable-packager: true
 
 class Inside < PackageSpec
-  class A; end # error: Package files can only declare one package
+  class A; end # error: Invalid expression in package: `ClassDef` not allowed
 end

--- a/test/testdata/packager/multiple_packages_in_file/__package.rb
+++ b/test/testdata/packager/multiple_packages_in_file/__package.rb
@@ -5,5 +5,5 @@
 class MyPackage < PackageSpec
 end
 
-class SecondPackage < PackageSpec; end # error: Package files can only declare one package
+class SecondPackage < PackageSpec; end # error: Invalid expression in package: `ClassDef` not allowed
 #                     ^^^^^^^^^^^ error: Unable to resolve constant `PackageSpec`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This simplifies some error messages when parsing `__package.rb` files:

- We only say that "package file must contain a package definition" for
  `ClassDef` nodes that occur before any `PackageSpec` subclass has been found.

  - If the class is after finding the PackageSpec (or inside the PackageSpec
    body), we report the more clear error message that `ClassDef` nodes are
    illegal (i.e., it's not that the package lacks a package spec in that case)

- As a result, we only report an error once per bad `ClassDef`, avoiding a use
  of `error-with-dupes`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The test shows the old behavior first.