### PR TITLE
Revert "Insert exports in the correct position by alphabetical order"

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -87,10 +87,6 @@ struct FullyQualifiedName {
 
         return std::equal(prefix.parts.begin(), prefix.parts.end(), parts.begin());
     }
-
-    string show(const core::GlobalState &gs) const {
-        return absl::StrJoin(parts, "::", core::packages::NameFormatter(gs));
-    }
 };
 
 struct PackageName {
@@ -490,24 +486,14 @@ public:
     optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs,
                                                     const core::SymbolRef newExport) const {
         auto insertionLoc = core::Loc::none(loc.file());
+        // first let's try adding it to the end of the imports.
         if (!exports_.empty()) {
-            FullyQualifiedName const *exportToInsertAfter = nullptr;
-            for (auto &e : exports_) {
-                if (newExport.show(gs) > e.fqn.show(gs)) {
-                    exportToInsertAfter = &e.fqn;
-                }
-            }
-            if (!exportToInsertAfter) {
-                // Insert before the first export
-                auto beforeConstantName = exports_.front().fqn.loc;
-                auto [beforeExport, numWhitespace] = beforeConstantName.findStartOfIndentation(gs);
-                auto endOfPrevLine = beforeExport.adjust(gs, -numWhitespace - 1, 0);
-                insertionLoc = endOfPrevLine.copyWithZeroLength();
-            } else {
-                insertionLoc = exportToInsertAfter->loc.copyEndWithZeroLength();
-            }
+            auto lastOffset = exports_.back().fqn.loc.offsets();
+            insertionLoc = core::Loc{loc.file(), lastOffset.copyEndWithZeroLength()};
         } else {
-            // if we don't have any exports, then we can try adding it right before the final `end`
+            // if we don't have any imports, then we can try adding it
+            // either before the first export, or if we have no
+            // exports, then right before the final `end`
             uint32_t exportLoc = loc.endPos() - "end"sv.size() - 1;
             // we want to find the end of the last non-empty line, so
             // let's do something gross: walk backward until we find non-whitespace
@@ -524,6 +510,8 @@ public:
         }
         ENFORCE(insertionLoc.exists());
 
+        // now find the appropriate place for it, specifically by
+        // finding the import that directly precedes it, if any
         auto strName = newExport.show(gs);
         core::AutocorrectSuggestion suggestion(fmt::format("Export `{}` in package `{}`", strName, name.toString(gs)),
                                                {{insertionLoc, fmt::format("\n  export {}", strName)}});

--- a/test/cli/package-disallow-enum-value-exports/test.out
+++ b/test/cli/package-disallow-enum-value-exports/test.out
@@ -16,7 +16,7 @@ other_package/b.rb:5: `MyPackage::A::Val2` resolves but is not exported from `My
      7 |      Val2 = new
               ^^^^
   Autocorrect: Use `-a` to autocorrect
-    my_package/__package.rb:3: Insert `export MyPackage::A`
-     3 |class MyPackage < PackageSpec
-                                     ^
+    my_package/__package.rb:4: Insert `export MyPackage::A`
+     4 |  export MyPackage::A::Val1 # error
+                                   ^
 Errors: 2

--- a/test/cli/package-error-missing-export/test.out
+++ b/test/cli/package-error-missing-export/test.out
@@ -5,9 +5,9 @@ foo_class.rb:10: `Foo::Bar::OtherPackage::NotExported` resolves but is not expor
      7 |  class NotExported
           ^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:3: Insert `export Foo::Bar::OtherPackage::NotExported`
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-                                                  ^
+    other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::NotExported`
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+                                                   ^
   Note:
     Try running generate-packages.sh
 
@@ -18,9 +18,9 @@ foo_class.rb:11: `Foo::Bar::OtherPackage::NotExported` resolves but is not expor
      7 |  class NotExported
           ^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:3: Insert `export Foo::Bar::OtherPackage::NotExported`
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-                                                  ^
+    other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::NotExported`
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+                                                   ^
   Note:
     Try running generate-packages.sh
 
@@ -31,9 +31,9 @@ foo_class.rb:12: `Foo::Bar::OtherPackage::Inner::AlsoNotExported` resolves but i
     10 |  class Inner::AlsoNotExported
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:3: Insert `export Foo::Bar::OtherPackage::Inner::AlsoNotExported`
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-                                                  ^
+    other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::Inner::AlsoNotExported`
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+                                                   ^
   Note:
     Try running generate-packages.sh
 
@@ -44,9 +44,9 @@ foo_class.rb:13: `Foo::Bar::OtherPackage::Inner::AlsoNotExported` resolves but i
     10 |  class Inner::AlsoNotExported
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:3: Insert `export Foo::Bar::OtherPackage::Inner::AlsoNotExported`
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-                                                  ^
+    other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::Inner::AlsoNotExported`
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+                                                   ^
   Note:
     Try running generate-packages.sh
 Errors: 4

--- a/test/cli/package-implicit-parent-namespace-export/test.out
+++ b/test/cli/package-implicit-parent-namespace-export/test.out
@@ -16,7 +16,7 @@ other_package/reference.rb:10: `MyPackage::BehaviorDefiningParentNamespace` reso
     10 |  module BehaviorDefiningParentNamespace
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    my_package/__package.rb:3: Insert `export MyPackage::BehaviorDefiningParentNamespace`
-     3 |class MyPackage < PackageSpec
-                                     ^
+    my_package/__package.rb:6: Insert `export MyPackage::BehaviorDefiningParentNamespace`
+     6 |  export MyPackage::BehaviorDefiningParentNamespace::Const1
+                                                                   ^
 Errors: 2

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -340,7 +340,7 @@ TEST_CASE("Add test import to package with neither imports nor exports") {
     CHECK_EQ(expected, replaced);
 }
 
-TEST_CASE("Add export that goes before existing exports") {
+TEST_CASE("Simple add export") {
     core::GlobalState gs(errorQueue);
     makeDefaultPackagerGlobalState(gs);
 
@@ -349,76 +349,7 @@ TEST_CASE("Add export that goes before existing exports") {
                         "end\n";
 
     string expected = "class MyPackage < PackageSpec\n"
-                      "  export MyPackage::NewExport\n"
                       "  export MyPackage::This\n"
-                      "end\n";
-
-    auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
-    ENFORCE(myPkg.exists());
-
-    auto addExport = myPkg.addExport(gs, getConstantRef(gs, {"MyPackage", "NewExport"}));
-    ENFORCE(addExport, "Expected to get an autocorrect from `addExport`");
-    auto replaced = applySuggestion(gs, *addExport);
-    CHECK_EQ(expected, replaced);
-}
-
-TEST_CASE("Add export to package with no existing exports") {
-    core::GlobalState gs(errorQueue);
-    makeDefaultPackagerGlobalState(gs);
-
-    string pkg_source = "class MyPackage < PackageSpec\n"
-                        "end\n";
-
-    string expected = "class MyPackage < PackageSpec\n"
-                      "  export MyPackage::NewExport\n"
-                      "end\n";
-
-    auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
-    ENFORCE(myPkg.exists());
-
-    auto addExport = myPkg.addExport(gs, getConstantRef(gs, {"MyPackage", "NewExport"}));
-    ENFORCE(addExport, "Expected to get an autocorrect from `addExport`");
-    auto replaced = applySuggestion(gs, *addExport);
-    CHECK_EQ(expected, replaced);
-}
-
-TEST_CASE("Add export that goes in the middle of existing exports") {
-    core::GlobalState gs(errorQueue);
-    makeDefaultPackagerGlobalState(gs);
-
-    string pkg_source = "class MyPackage < PackageSpec\n"
-                        "  export MyPackage::A\n"
-                        "  export MyPackage::This\n"
-                        "end\n";
-
-    string expected = "class MyPackage < PackageSpec\n"
-                      "  export MyPackage::A\n"
-                      "  export MyPackage::NewExport\n"
-                      "  export MyPackage::This\n"
-                      "end\n";
-
-    auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
-    ENFORCE(myPkg.exists());
-
-    auto addExport = myPkg.addExport(gs, getConstantRef(gs, {"MyPackage", "NewExport"}));
-    ENFORCE(addExport, "Expected to get an autocorrect from `addExport`");
-    auto replaced = applySuggestion(gs, *addExport);
-    CHECK_EQ(expected, replaced);
-}
-
-TEST_CASE("Add export that goes at the end") {
-    core::GlobalState gs(errorQueue);
-    makeDefaultPackagerGlobalState(gs);
-
-    string pkg_source = "class MyPackage < PackageSpec\n"
-                        "  export MyPackage::A\n"
-                        "end\n";
-
-    string expected = "class MyPackage < PackageSpec\n"
-                      "  export MyPackage::A\n"
                       "  export MyPackage::NewExport\n"
                       "end\n";
 


### PR DESCRIPTION
We're seeing some crashes from the changes introduced on packager.cc:503.

Reverts sorbet/sorbet#8712