### PR TITLE
beginError → beginIndexerError in rewriter

### DIFF
--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -75,7 +75,7 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
     ast::ClassDef::RHS_store body;
 
     if (auto dup = ASTUtil::findDuplicateArg(ctx, send)) {
-        if (auto e = ctx.beginError(dup->secondLoc, core::errors::Rewriter::InvalidStructMember)) {
+        if (auto e = ctx.beginIndexerError(dup->secondLoc, core::errors::Rewriter::InvalidStructMember)) {
             e.setHeader("Duplicate member `{}` in Data definition", dup->name.show(ctx));
             e.addErrorLine(ctx.locAt(dup->firstLoc), "First occurrence of `{}` in Data definition",
                            dup->name.show(ctx));

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -111,7 +111,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
     }
 
     if (auto dup = ASTUtil::findDuplicateArg(ctx, send)) {
-        if (auto e = ctx.beginError(dup->secondLoc, core::errors::Rewriter::InvalidStructMember)) {
+        if (auto e = ctx.beginIndexerError(dup->secondLoc, core::errors::Rewriter::InvalidStructMember)) {
             e.setHeader("Duplicate member `{}` in Struct definition", dup->name.show(ctx));
             e.addErrorLine(ctx.locAt(dup->firstLoc), "First occurrence of `{}` in Struct definition",
                            dup->name.show(ctx));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This amends some new code in #8572 that I forgot to catch in review.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I have not tested this.

This would affect whether the error messages are flushed on a second type check
run if the `--cache-dir` option is present, but I don't feel like writing a test
for that.