### PR TITLE
Move some PackageSpec rewrites to `rewriter`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2172,7 +2172,13 @@ unique_ptr<GlobalState> GlobalState::deepCopyGlobalState(bool keepId) const {
     return result;
 }
 
-unique_ptr<GlobalState> GlobalState::copyForIndex() const {
+unique_ptr<GlobalState>
+GlobalState::copyForIndex(const vector<string> &extraPackageFilesDirectoryUnderscorePrefixes,
+                          const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                          const vector<string> &extraPackageFilesDirectorySlashPrefixes,
+                          const vector<string> &packageSkipRBIExportEnforcementDirs,
+                          const vector<string> &allowRelaxedPackagerChecksFor, const vector<string> &packagerLayers,
+                          string errorHint) const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     result->initEmpty();
@@ -2182,6 +2188,15 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->files = this->files;
     result->fileRefByPath = this->fileRefByPath;
     result->kvstoreUuid = this->kvstoreUuid;
+
+    {
+        core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*result);
+        core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = result->unfreezePackages();
+        result->setPackagerOptions(extraPackageFilesDirectorySlashPrefixes,
+                                   extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                                   extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
+                                   allowRelaxedPackagerChecksFor, packagerLayers, errorHint);
+    }
 
     return result;
 }

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -259,7 +259,13 @@ public:
     // Copy the file table and other parts of GlobalState that are required for the indexing pass.
     // NOTE: this very intentionally will not copy the symbol or name tables. The symbol tables aren't used or populated
     // during indexing, and the name tables will only be written to.
-    std::unique_ptr<GlobalState> copyForIndex() const;
+    std::unique_ptr<GlobalState>
+    copyForIndex(const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
+                 const std::vector<std::string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                 const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
+                 const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
+                 const std::vector<std::string> &allowRelaxedPackagerChecksFor,
+                 const std::vector<std::string> &packagerLayers, std::string errorHint) const;
 
     // Merge the contents of one file table into this GlobalState. This is used during the index pass to make sure that
     // changes made to the file table in worker threads are propagated back to the main GlobalState.

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -143,7 +143,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
         // path logic in LSPPreprocessor.
         ENFORCE(fref.exists());
         ENFORCE(updatedFile->getFileHash() != nullptr);
-        if (config.opts.stripePackages && updatedFile->isPackage(gs)) {
+        if (config.opts.cacheSensitiveOptions.stripePackages && updatedFile->isPackage(gs)) {
             // Only relevant in --stripe-packages mode. Package declarations do not have method
             // hashes. Instead we rely on recomputing packages if any __package.rb source
             // changes.
@@ -205,7 +205,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
             continue;
         }
 
-        if (config.opts.stripePackages && oldFile->isPackage(gs)) {
+        if (config.opts.cacheSensitiveOptions.stripePackages && oldFile->isPackage(gs)) {
             continue; // See note above about --stripe-packages.
         }
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -117,7 +117,8 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
         // Only relevant in `--stripe-packages` mode. This prevents LSP editing features like autocomplete from
         // working in `__package.rb` since every edit causes a slow path.
         // Note: We don't use File::isPackage because we have not necessarily set the packager options on initialGS yet
-        if (this->config->opts.stripePackages && oldFile.hasPackageRbPath() && oldFile.source() != f->source()) {
+        if (this->config->opts.cacheSensitiveOptions.stripePackages && oldFile.hasPackageRbPath() &&
+            oldFile.source() != f->source()) {
             logger.debug("Taking slow path because {} is a package file", f->path());
             prodCategoryCounterInc("lsp.slow_path_reason", "package_file");
             timeit.setTag("path_chosen", "slow");

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -439,7 +439,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                 Timer timeit(config->logger, "reIndexFromFileSystem");
 
                 auto workspaceFilesSpan = absl::MakeSpan(this->workspaceFiles);
-                if (this->config->opts.stripePackages) {
+                if (this->config->opts.cacheSensitiveOptions.stripePackages) {
                     auto numPackageFiles = pipeline::partitionPackageFiles(*this->gs, workspaceFilesSpan);
                     auto inputPackageFiles = workspaceFilesSpan.first(numPackageFiles);
                     workspaceFilesSpan = workspaceFilesSpan.subspan(numPackageFiles);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1164,7 +1164,7 @@ void readOptions(Options &opts,
         opts.reserveTypeArgumentTableCapacity = raw["reserve-type-argument-table-capacity"].as<uint32_t>();
         opts.reserveTypeMemberTableCapacity = raw["reserve-type-member-table-capacity"].as<uint32_t>();
         opts.uniquelyDefinedBehavior = raw["uniquely-defined-behavior"].as<bool>();
-        opts.stripePackages = raw["stripe-packages"].as<bool>();
+        opts.cacheSensitiveOptions.stripePackages = raw["stripe-packages"].as<bool>();
 
         if (raw.count("extra-package-files-directory-prefix-underscore")) {
             for (const string &dirName : raw["extra-package-files-directory-prefix-underscore"].as<vector<string>>()) {
@@ -1202,7 +1202,7 @@ void readOptions(Options &opts,
         }
 
         if (raw.count("allow-relaxed-packager-checks-for")) {
-            if (!opts.stripePackages) {
+            if (!opts.cacheSensitiveOptions.stripePackages) {
                 logger->error("--allow-relaxed-packager-checks-for can only be specified in --stripe-packages mode");
                 throw EarlyReturnWithCode(1);
             }
@@ -1218,7 +1218,7 @@ void readOptions(Options &opts,
         }
 
         if (raw.count("packager-layers")) {
-            if (opts.stripePackages) {
+            if (opts.cacheSensitiveOptions.stripePackages) {
                 // TODO(neil): This regex was picked on a whim, so open to changing to be more or less restrictive based
                 // on feedback/usecases.
                 std::regex layerValid("[a-zA-Z0-9]+");
@@ -1236,8 +1236,8 @@ void readOptions(Options &opts,
         }
 
         opts.stripePackagesHint = raw["stripe-packages-hint-message"].as<string>();
-        if (!opts.stripePackagesHint.empty() && !opts.stripePackages) {
-            if (!opts.stripePackages) {
+        if (!opts.stripePackagesHint.empty() && !opts.cacheSensitiveOptions.stripePackages) {
+            if (!opts.cacheSensitiveOptions.stripePackages) {
                 logger->error("--stripe-packages-hint-message can only be specified in --stripe-packages mode");
                 throw EarlyReturnWithCode(1);
             }
@@ -1247,14 +1247,14 @@ void readOptions(Options &opts,
 
         opts.packageRBIDir = raw["package-rbi-dir"].as<string>();
         if (!opts.packageRBIDir.empty()) {
-            if (opts.stripePackages) {
+            if (opts.cacheSensitiveOptions.stripePackages) {
                 logger->error("--package-rbi-dir must not be specified in --stripe-packages mode");
                 throw EarlyReturnWithCode(1);
             }
         }
 
         if (raw.count("package-skip-rbi-export-enforcement")) {
-            if (!opts.stripePackages) {
+            if (!opts.cacheSensitiveOptions.stripePackages) {
                 logger->error("--package-skip-rbi-export-enforcement can only be specified in --stripe-packages mode");
                 throw EarlyReturnWithCode(1);
             }
@@ -1265,7 +1265,7 @@ void readOptions(Options &opts,
 
         opts.singlePackage = raw["single-package"].as<string>();
         if (!opts.singlePackage.empty()) {
-            if (opts.stripePackages) {
+            if (opts.cacheSensitiveOptions.stripePackages) {
                 logger->error("--single-package must not be specified in --stripe-packages mode");
                 throw EarlyReturnWithCode(1);
             }
@@ -1283,7 +1283,7 @@ void readOptions(Options &opts,
 
         opts.dumpPackageInfo = raw["dump-package-info"].as<string>();
         if (!opts.dumpPackageInfo.empty()) {
-            if (!opts.stripePackages) {
+            if (!opts.cacheSensitiveOptions.stripePackages) {
                 logger->error("--dump-package-info can only be specified in --stripe-packages mode");
                 throw EarlyReturnWithCode(1);
             }

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -153,7 +153,6 @@ struct Options {
     int logLevel = 0; // number of time -v was passed
     int autogenVersion = 0;
     bool uniquelyDefinedBehavior = false;
-    bool stripePackages = false;
     std::string stripePackagesHint = "";
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
     std::vector<std::string> extraPackageFilesDirectorySlashDeprecatedPrefixes;
@@ -198,12 +197,14 @@ struct Options {
 
         bool runningUnderAutogen : 1;
 
+        bool stripePackages : 1;
+
         // In C++20 we can replace this with bit field initializers
         CacheSensitiveOptions()
             : noStdlib(false), typedSuper(true), rbsSignaturesEnabled(false), rbsAssertionsEnabled(false),
-              requiresAncestorEnabled(false), runningUnderAutogen(false) {}
+              requiresAncestorEnabled(false), runningUnderAutogen(false), stripePackages(false) {}
 
-        constexpr static uint8_t NUMBER_OF_FLAGS = 6;
+        constexpr static uint8_t NUMBER_OF_FLAGS = 7;
         constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         uint8_t serialize() const {

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -75,7 +75,6 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.debugLogFile, opts.debugLogFile);
     CHECK_EQ(empty.webTraceFile, opts.webTraceFile);
     CHECK_EQ(empty.uniquelyDefinedBehavior, opts.uniquelyDefinedBehavior);
-    CHECK_EQ(empty.stripePackages, opts.stripePackages);
     CHECK_EQ(empty.forceHashing, opts.forceHashing);
     CHECK_EQ(empty.lspErrorCap, opts.lspErrorCap);
     CHECK_EQ(empty.forciblySilenceLspMultipleDirError, opts.forciblySilenceLspMultipleDirError);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -612,7 +612,10 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
         fileq->push(move(file), 1);
     }
 
-    std::shared_ptr<const core::GlobalState> emptyGs = baseGs.copyForIndex();
+    std::shared_ptr<const core::GlobalState> emptyGs = baseGs.copyForIndex(
+        opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
+        opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
+        opts.allowRelaxedPackagerChecksFor, opts.packagerLayers, opts.stripePackagesHint);
 
     workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, resultq, &kvstore, cancelable]() {
         Timer timeit(emptyGs->tracer(), "indexSuppliedFilesWorker");

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -107,7 +107,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
     gs.suggestUnsafe = opts.suggestUnsafe;
 
 #ifndef SORBET_REALMAIN_MIN
-    if (opts.stripePackages) {
+    if (opts.cacheSensitiveOptions.stripePackages) {
         core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
         gs.setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,
@@ -728,7 +728,7 @@ void unpartitionPackageFiles(vector<ast::ParsedFile> &packageFiles, vector<ast::
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
-    if (!opts.stripePackages) {
+    if (!opts.cacheSensitiveOptions.stripePackages) {
         return;
     }
 
@@ -753,7 +753,7 @@ void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const opti
 void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
                     WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
-    if (!opts.stripePackages) {
+    if (!opts.cacheSensitiveOptions.stripePackages) {
         return;
     }
 
@@ -778,7 +778,7 @@ void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, con
 void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
                            WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
-    if (!opts.stripePackages) {
+    if (!opts.cacheSensitiveOptions.stripePackages) {
         return;
     }
 
@@ -941,7 +941,7 @@ ast::ParsedFilesOrCancelled resolve(core::GlobalState &gs, vector<ast::ParsedFil
             }
 
 #ifndef SORBET_REALMAIN_MIN
-            if (opts.stripePackages) {
+            if (opts.cacheSensitiveOptions.stripePackages) {
                 Timer timeit(gs.tracer(), "visibility_checker");
                 what = packager::VisibilityChecker::run(gs, workers, std::move(what));
             }
@@ -1106,7 +1106,7 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
                    const options::Options &opts, WorkerPool &workers) {
     try {
 #ifndef SORBET_REALMAIN_MIN
-        if (opts.stripePackages) {
+        if (opts.cacheSensitiveOptions.stripePackages) {
             Timer timeit(gs.tracer(), "incremental_packager");
             // For simplicity, we still call Packager::runIncremental here, even though
             // pipeline::nameAndResolve no longer calls Packager::run.
@@ -1157,7 +1157,7 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
         }
 
 #ifndef SORBET_REALMAIN_MIN
-        if (opts.stripePackages) {
+        if (opts.cacheSensitiveOptions.stripePackages) {
             what = packager::VisibilityChecker::run(gs, workers, std::move(what));
         }
 #endif

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -557,7 +557,7 @@ int realmain(int argc, char *argv[]) {
 #else
             Timer rbiGenTimer(logger, "rbiGeneration.setup");
 
-            if (opts.stripePackages) {
+            if (opts.cacheSensitiveOptions.stripePackages) {
                 logger->error("Cannot serialize package RBIs in legacy stripe packages mode.");
                 return 1;
             }
@@ -657,7 +657,7 @@ int realmain(int argc, char *argv[]) {
             // ----- index -----
 
             auto inputFilesSpan = absl::Span<core::FileRef>(inputFiles);
-            if (opts.stripePackages) {
+            if (opts.cacheSensitiveOptions.stripePackages) {
                 auto numPackageFiles = pipeline::partitionPackageFiles(*gs, inputFilesSpan);
                 auto inputPackageFiles = inputFilesSpan.first(numPackageFiles);
                 inputFilesSpan = inputFilesSpan.subspan(numPackageFiles);
@@ -753,7 +753,7 @@ int realmain(int argc, char *argv[]) {
             auto optsForMinimize = opts.clone();
             // Explicitly turn off the packager, because it doesn't make sense when the whole
             // project is a single RBI file.
-            optsForMinimize.stripePackages = false;
+            optsForMinimize.cacheSensitiveOptions.stripePackages = false;
 
             unique_ptr<core::GlobalState> gsForMinimize = make_unique<core::GlobalState>(gs->errorQueue);
             auto kvstore = nullptr;
@@ -814,7 +814,7 @@ int realmain(int argc, char *argv[]) {
             logger->warn("Dumping package info is disabled in sorbet-orig for faster builds");
             return 1;
 #else
-            if (!opts.stripePackages) {
+            if (!opts.cacheSensitiveOptions.stripePackages) {
                 logger->error("stripe packages mode needs to be enabled");
                 return 1;
             }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -712,11 +712,6 @@ PackageName getPackageName(core::Context ctx, const ast::UnresolvedConstantLit *
     return pName;
 }
 
-// TODO(jez) Rename this to lookupMangledName, and make it take a const GlobalState
-void populateMangledName(core::GlobalState &gs, PackageName &pName) {
-    pName.mangledName = core::packages::MangledName::mangledNameFromParts(gs, pName.fullName.parts);
-}
-
 bool startsWithPackageSpecRegistry(const ast::UnresolvedConstantLit &cnst) {
     if (auto scope = ast::cast_tree<ast::ConstantLit>(cnst.scope)) {
         return scope->symbol() == core::Symbols::PackageSpecRegistry();
@@ -1593,6 +1588,11 @@ void rewritePackageSpec(const core::GlobalState &gs, ast::ParsedFile &package, P
         }
     }
     bodyWalk.finalize(ctx);
+}
+
+// TODO(jez) Rename this to lookupMangledName, and make it take a const GlobalState
+void populateMangledName(core::GlobalState &gs, PackageName &pName) {
+    pName.mangledName = core::packages::MangledName::mangledNameFromParts(gs, pName.fullName.parts);
 }
 
 unique_ptr<PackageInfoImpl> createAndPopulatePackageInfo(core::GlobalState &gs, ast::ParsedFile &package) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1,7 +1,5 @@
 #include "packager/packager.h"
-#include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
-#include "absl/strings/str_replace.h"
 #include "absl/synchronization/blocking_counter.h"
 #include "ast/Helpers.h"
 #include "ast/packager/packager.h"
@@ -688,35 +686,6 @@ bool isTestOnlyPackage(const core::GlobalState &gs, const PackageInfoImpl &pkg) 
     return pkg.loc.file().data(gs).isPackagedTest();
 }
 
-[[nodiscard]] bool validatePackageName(core::Context ctx, const ast::UnresolvedConstantLit *constLit) {
-    bool valid = true;
-    while (constLit != nullptr) {
-        if (absl::StrContains(constLit->cnst.shortName(ctx), "_")) {
-            // By forbidding package names to have an underscore, we can trivially convert between
-            // mangled names and unmangled names by replacing `_` with `::`.
-            //
-            // Even with packages into the symbol table this restriction is useful, because we have
-            // a lot of tooling that will create directory structures like Foo_Bar to store
-            // generated files associated with package Foo::Bar
-            if (auto e = ctx.beginError(constLit->loc, core::errors::Packager::InvalidPackageName)) {
-                e.setHeader("Package names cannot contain an underscore");
-                auto replacement = absl::StrReplaceAll(constLit->cnst.shortName(ctx), {{"_", ""}});
-                auto nameLoc = constLit->loc;
-                // cnst is the last characters in the constant literal
-                nameLoc.beginLoc = nameLoc.endLoc - constLit->cnst.shortName(ctx).size();
-
-                e.addAutocorrect(core::AutocorrectSuggestion{
-                    fmt::format("Replace `{}` with `{}`", constLit->cnst.shortName(ctx), replacement),
-                    {core::AutocorrectSuggestion::Edit{ctx.locAt(nameLoc), replacement}}});
-            }
-            valid = false;
-        }
-        constLit = ast::cast_tree<ast::UnresolvedConstantLit>(constLit->scope);
-    }
-
-    return valid;
-}
-
 FullyQualifiedName getFullyQualifiedName(core::Context ctx, const ast::UnresolvedConstantLit *constantLit) {
     FullyQualifiedName fqn;
     fqn.loc = ctx.locAt(constantLit->loc);
@@ -746,19 +715,6 @@ PackageName getPackageName(core::Context ctx, const ast::UnresolvedConstantLit *
 // TODO(jez) Rename this to lookupMangledName, and make it take a const GlobalState
 void populateMangledName(core::GlobalState &gs, PackageName &pName) {
     pName.mangledName = core::packages::MangledName::mangledNameFromParts(gs, pName.fullName.parts);
-}
-
-void mustContainPackageDef(core::Context ctx, core::LocOffsets loc) {
-    // HACKFIX: Tolerate completely empty packages. LSP does not support the notion of a deleted file, and
-    // instead replaces deleted files with the empty string. It should really mark files as Tombstones instead.
-    if (!ctx.file.data(ctx).source().empty()) {
-        if (auto e = ctx.beginError(loc, core::errors::Packager::InvalidPackageDefinition)) {
-            e.setHeader("`{}` file must contain a package definition", "__package.rb");
-            e.addErrorNote("Package definitions are class definitions like `{}`.\n"
-                           "    For more information, see http://go/package-layout",
-                           "class Foo::Bar < PackageSpec");
-        }
-    }
 }
 
 bool startsWithPackageSpecRegistry(const ast::UnresolvedConstantLit &cnst) {
@@ -1616,82 +1572,6 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
     core::Context ctx(gs, core::Symbols::root(), package.file);
 
     auto &rootClass = ast::cast_tree_nonnull<ast::ClassDef>(package.tree);
-
-    bool reportedError = false;
-    for (auto &rootStmt : rootClass.rhs) {
-        auto packageSpecClass = ast::cast_tree<ast::ClassDef>(rootStmt);
-        if (packageSpecClass == nullptr) {
-            // No error here; let this be reported in the tree walk later as a bad node type,
-            // or at the end of this function if no PackageSpec is found.
-            continue;
-        }
-
-        if (packageSpecClass->ancestors.size() != 1 ||
-            !ast::isa_tree<ast::UnresolvedConstantLit>(packageSpecClass->name)) {
-            mustContainPackageDef(ctx, packageSpecClass->declLoc);
-            reportedError = true;
-            continue;
-        }
-
-        auto &superClass = packageSpecClass->ancestors[0];
-        auto superClassLit = ast::cast_tree<ast::UnresolvedConstantLit>(superClass);
-        if (superClassLit == nullptr || superClassLit->cnst != core::Names::Constants::PackageSpec()) {
-            mustContainPackageDef(ctx, superClass.loc());
-            reportedError = true;
-            continue;
-        }
-
-        // ---- Mutates the tree ----
-        // We can't do these rewrites in rewriter, because this rewrite should only happen if
-        // `opts.stripePackages` is set. That would mean we would have to add another cache flavor,
-        // which would double the size of Sorbet's disk cache.
-        //
-        // Other than being able to say "we don't mutate the trees in packager" there's not much
-        // value in going that far (even namer mutates the trees; the packager fills a similar role).
-
-        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
-        if (!validatePackageName(ctx, nameTree)) {
-            reportedError = true;
-
-            // "Remove" the superclass.
-            //
-            // `::PackageSpec` doesn't exist. Normally we would rewrite it
-            // to Sorbet::Private::Static::PackageSpec, but we don't do that if the package spec
-            // definition is invalid.
-            //
-            // To avoid the chance that the user only sees the "Unable to resolve PackageSpec" error
-            // and then gets confused, we "remove" the super class here, treating it like the user
-            // omitted the superclass.
-            //
-            // This establishes an invariant that if the superClass is a resolved constant and
-            // equal to Symbols::PackageSpec(), then it's the canonical package def in this file
-            superClass = ast::MK::Constant(packageSpecClass->loc, core::Symbols::todo());
-
-            continue;
-        }
-
-        // Pre-resolve the super class. This makes it easier to detect that this is a package
-        // spec-related class def in later passes without having to recursively walk up the constant
-        // lit's scope to find if it starts with <PackageSpecRegistry>.
-        superClass = ast::make_expression<ast::ConstantLit>(core::Symbols::PackageSpec(),
-                                                            superClass.toUnique<ast::UnresolvedConstantLit>());
-
-        // `class Foo < PackageSpec` -> `class <PackageSpecRegistry>::Foo < PackageSpec`
-        // This removes the PackageSpec's themselves from the top-level namespace
-        packageSpecClass->name = ast::packager::prependRegistry(move(packageSpecClass->name));
-
-        // Return eagerly so we don't report duplicate errors on subsequent statements:
-        // we'll let those errors be reported in the tree walk later as a bad node type.
-        return make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree), ctx.locAt(packageSpecClass->loc),
-                                            ctx.locAt(packageSpecClass->declLoc));
-    }
-
-    // Only report an error if we didn't already
-    // (the one we reported will have been more descriptive than this one)
-    if (!reportedError) {
-        auto errLoc = rootClass.rhs.empty() ? core::LocOffsets{0, 0} : rootClass.rhs[0].loc();
-        mustContainPackageDef(ctx, errLoc);
-    }
 
     return nullptr;
 }

--- a/rewriter/BUILD
+++ b/rewriter/BUILD
@@ -16,6 +16,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//ast",
+        "//ast/packager",
         "//ast/treemap",
         "//ast/verifier",
         "//common",

--- a/rewriter/PackageSpec.cc
+++ b/rewriter/PackageSpec.cc
@@ -1,9 +1,137 @@
 #include "rewriter/PackageSpec.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_replace.h"
+#include "ast/Helpers.h"
+#include "ast/packager/packager.h"
 #include "core/core.h"
+#include "core/errors/packager.h"
 
 using namespace std;
 
 namespace sorbet::rewriter {
+
+namespace {
+
+void mustContainPackageDef(core::Context ctx, core::LocOffsets loc) {
+    // HACKFIX: Tolerate completely empty packages. LSP does not support the notion of a deleted file, and
+    // instead replaces deleted files with the empty string. It should really mark files as Tombstones instead.
+    if (!ctx.file.data(ctx).source().empty()) {
+        if (auto e = ctx.beginError(loc, core::errors::Packager::InvalidPackageDefinition)) {
+            e.setHeader("`{}` file must contain a package definition", "__package.rb");
+            e.addErrorNote("Package definitions are class definitions like `{}`.\n"
+                           "    For more information, see http://go/package-layout",
+                           "class Foo::Bar < PackageSpec");
+        }
+    }
+}
+
+[[nodiscard]] bool validatePackageName(core::Context ctx, const ast::UnresolvedConstantLit *constLit) {
+    bool valid = true;
+    while (constLit != nullptr) {
+        if (absl::StrContains(constLit->cnst.shortName(ctx), "_")) {
+            // By forbidding package names to have an underscore, we can trivially convert between
+            // mangled names and unmangled names by replacing `_` with `::`.
+            //
+            // Even with packages into the symbol table this restriction is useful, because we have
+            // a lot of tooling that will create directory structures like Foo_Bar to store
+            // generated files associated with package Foo::Bar
+            if (auto e = ctx.beginError(constLit->loc, core::errors::Packager::InvalidPackageName)) {
+                e.setHeader("Package names cannot contain an underscore");
+                auto replacement = absl::StrReplaceAll(constLit->cnst.shortName(ctx), {{"_", ""}});
+                auto nameLoc = constLit->loc;
+                // cnst is the last characters in the constant literal
+                nameLoc.beginLoc = nameLoc.endLoc - constLit->cnst.shortName(ctx).size();
+
+                e.addAutocorrect(core::AutocorrectSuggestion{
+                    fmt::format("Replace `{}` with `{}`", constLit->cnst.shortName(ctx), replacement),
+                    {core::AutocorrectSuggestion::Edit{ctx.locAt(nameLoc), replacement}}});
+            }
+            valid = false;
+        }
+        constLit = ast::cast_tree<ast::UnresolvedConstantLit>(constLit->scope);
+    }
+
+    return valid;
+}
+
+void findAndRewritePackageSpecClass(core::Context ctx, ast::ClassDef &rootClass) {
+    bool reportedError = false;
+    for (auto &rootStmt : rootClass.rhs) {
+        auto packageSpecClass = ast::cast_tree<ast::ClassDef>(rootStmt);
+        if (packageSpecClass == nullptr) {
+            // No error here; let this be reported in the tree walk later as a bad node type,
+            // or at the end of this function if no PackageSpec is found.
+            continue;
+        }
+
+        if (packageSpecClass->ancestors.size() != 1 ||
+            !ast::isa_tree<ast::UnresolvedConstantLit>(packageSpecClass->name)) {
+            mustContainPackageDef(ctx, packageSpecClass->declLoc);
+            reportedError = true;
+            continue;
+        }
+
+        auto &superClass = packageSpecClass->ancestors[0];
+        auto superClassLit = ast::cast_tree<ast::UnresolvedConstantLit>(superClass);
+        if (superClassLit == nullptr || superClassLit->cnst != core::Names::Constants::PackageSpec()) {
+            mustContainPackageDef(ctx, superClass.loc());
+            reportedError = true;
+            continue;
+        }
+
+        // ---- Mutates the tree ----
+        // We can't do these rewrites in rewriter, because this rewrite should only happen if
+        // `opts.stripePackages` is set. That would mean we would have to add another cache flavor,
+        // which would double the size of Sorbet's disk cache.
+        //
+        // Other than being able to say "we don't mutate the trees in packager" there's not much
+        // value in going that far (even namer mutates the trees; the packager fills a similar role).
+
+        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
+        if (!validatePackageName(ctx, nameTree)) {
+            reportedError = true;
+
+            // "Remove" the superclass.
+            //
+            // `::PackageSpec` doesn't exist. Normally we would rewrite it
+            // to Sorbet::Private::Static::PackageSpec, but we don't do that if the package spec
+            // definition is invalid.
+            //
+            // To avoid the chance that the user only sees the "Unable to resolve PackageSpec" error
+            // and then gets confused, we "remove" the super class here, treating it like the user
+            // omitted the superclass.
+            //
+            // This establishes an invariant that if the superClass is a resolved constant and
+            // equal to Symbols::PackageSpec(), then it's the canonical package def in this file
+            superClass = ast::MK::Constant(packageSpecClass->loc, core::Symbols::todo());
+
+            continue;
+        }
+
+        // Pre-resolve the super class. This makes it easier to detect that this is a package
+        // spec-related class def in later passes without having to recursively walk up the constant
+        // lit's scope to find if it starts with <PackageSpecRegistry>.
+        superClass = ast::make_expression<ast::ConstantLit>(core::Symbols::PackageSpec(),
+                                                            superClass.toUnique<ast::UnresolvedConstantLit>());
+
+        // `class Foo < PackageSpec` -> `class <PackageSpecRegistry>::Foo < PackageSpec`
+        // This removes the PackageSpec's themselves from the top-level namespace
+        packageSpecClass->name = ast::packager::prependRegistry(move(packageSpecClass->name));
+
+        // Return eagerly so we don't report duplicate errors on subsequent statements:
+        // we'll let those errors be reported in the tree walk later as a bad node type.
+        return;
+    }
+
+    // Only report an error if we didn't already
+    // (the one we reported will have been more descriptive than this one)
+    if (!reportedError) {
+        auto errLoc = rootClass.rhs.empty() ? core::LocOffsets{0, 0} : rootClass.rhs[0].loc();
+        mustContainPackageDef(ctx, errLoc);
+    }
+}
+
+} // namespace
 
 void PackageSpec::run(core::MutableContext ctx, ast::ClassDef *klass) {
     ENFORCE(ctx.state.packageDB().enabled(), "Should only run on __package.rb files");
@@ -15,7 +143,7 @@ void PackageSpec::run(core::MutableContext ctx, ast::ClassDef *klass) {
         return;
     }
 
-    return;
+    findAndRewritePackageSpecClass(ctx, *klass);
 }
 
 } // namespace sorbet::rewriter

--- a/rewriter/PackageSpec.cc
+++ b/rewriter/PackageSpec.cc
@@ -57,12 +57,13 @@ void mustContainPackageDef(core::MutableContext ctx, core::LocOffsets loc) {
 } // namespace
 
 void PackageSpec::run(core::MutableContext ctx, ast::ClassDef *klass) {
-    ENFORCE(ctx.state.packageDB().enabled(), "Should only run on __package.rb files");
-    ENFORCE(ctx.file.data(ctx).isPackage(ctx), "Should only run on __package.rb files");
+    // Aware of whether the --stripe-packages option was passed
+    if (!ctx.file.data(ctx).isPackage(ctx)) {
+        return;
+    }
 
-    if (ctx.owner != core::Symbols::root()) {
+    if (klass->symbol != core::Symbols::root()) {
         // Only process ClassDef that are at the top level
-        ENFORCE(ctx.owner == core::Symbols::todo());
         return;
     }
 

--- a/rewriter/PackageSpec.cc
+++ b/rewriter/PackageSpec.cc
@@ -80,12 +80,6 @@ void findAndRewritePackageSpecClass(core::Context ctx, ast::ClassDef &rootClass)
         }
 
         // ---- Mutates the tree ----
-        // We can't do these rewrites in rewriter, because this rewrite should only happen if
-        // `opts.stripePackages` is set. That would mean we would have to add another cache flavor,
-        // which would double the size of Sorbet's disk cache.
-        //
-        // Other than being able to say "we don't mutate the trees in packager" there's not much
-        // value in going that far (even namer mutates the trees; the packager fills a similar role).
 
         auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
         if (!validatePackageName(ctx, nameTree)) {

--- a/rewriter/PackageSpec.cc
+++ b/rewriter/PackageSpec.cc
@@ -1,0 +1,21 @@
+#include "rewriter/PackageSpec.h"
+#include "core/core.h"
+
+using namespace std;
+
+namespace sorbet::rewriter {
+
+void PackageSpec::run(core::MutableContext ctx, ast::ClassDef *klass) {
+    ENFORCE(ctx.state.packageDB().enabled(), "Should only run on __package.rb files");
+    ENFORCE(ctx.file.data(ctx).isPackage(ctx), "Should only run on __package.rb files");
+
+    if (ctx.owner != core::Symbols::root()) {
+        // Only process ClassDef that are at the top level
+        ENFORCE(ctx.owner == core::Symbols::todo());
+        return;
+    }
+
+    return;
+}
+
+} // namespace sorbet::rewriter

--- a/rewriter/PackageSpec.h
+++ b/rewriter/PackageSpec.h
@@ -1,0 +1,19 @@
+#ifndef SORBET_REWRITER_PACKAGE_SPEC_H
+#define SORBET_REWRITER_PACKAGE_SPEC_H
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * TODO(jez) Document me
+ */
+class PackageSpec final {
+public:
+    static void run(core::MutableContext ctx, ast::ClassDef *klass);
+
+    PackageSpec() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif

--- a/rewriter/PackageSpec.h
+++ b/rewriter/PackageSpec.h
@@ -5,7 +5,23 @@
 namespace sorbet::rewriter {
 
 /**
- * TODO(jez) Document me
+ * Does some syntactic rewrites of `__package.rb` files.
+ *
+ * This rewriter only has an effect if `--stripe-packages` has been passed.
+ *
+ * Rewrites:
+ *
+ *     class Foo::Bar < PackageSpec
+ *     end
+ *
+ * to
+ *
+ *     class <PackageSpecRegistry>::Foo::Bar < ::Sorbet::Private::Static::PackageSpec
+ *     end
+ *
+ * TODO(jez) When we move packages into the symbol table, we can drop the `<PackageSpecRegistry>`
+ * bit, which is only required because there could be a class or module symbol with the `Foo::Bar`
+ * name that collides with the package definition.
  */
 class PackageSpec final {
 public:

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -21,6 +21,7 @@
 #include "rewriter/Minitest.h"
 #include "rewriter/MixinEncryptedProp.h"
 #include "rewriter/ModuleFunction.h"
+#include "rewriter/PackageSpec.h"
 #include "rewriter/Private.h"
 #include "rewriter/Prop.h"
 #include "rewriter/Rails.h"
@@ -52,6 +53,11 @@ public:
         TypeMembers::run(ctx, classDef);
         Concern::run(ctx, classDef);
         TestCase::run(ctx, classDef);
+
+        // Aware of whether the --stripe-packages option was passed
+        if (ctx.file.data(ctx).isPackage(ctx)) {
+            PackageSpec::run(ctx, classDef);
+        }
 
         for (auto &extension : ctx.state.semanticExtensions) {
             extension->run(ctx, classDef);

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -54,10 +54,7 @@ public:
         Concern::run(ctx, classDef);
         TestCase::run(ctx, classDef);
 
-        // Aware of whether the --stripe-packages option was passed
-        if (ctx.file.data(ctx).isPackage(ctx)) {
-            PackageSpec::run(ctx, classDef);
-        }
+        PackageSpec::run(ctx, classDef);
 
         for (auto &extension : ctx.state.semanticExtensions) {
             extension->run(ctx, classDef);

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -697,7 +697,8 @@ realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeA
         opts.suggestUnsafe = "T.unsafe";
     }
 
-    opts.stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
+    opts.cacheSensitiveOptions.stripePackages =
+        BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
     auto extraDirUnderscore =
         StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);
     if (extraDirUnderscore.has_value()) {

--- a/test/lsp/watchman_test_corpus.cc
+++ b/test/lsp/watchman_test_corpus.cc
@@ -122,7 +122,7 @@ TEST_CASE_FIXTURE(ProtocolTest, "MergesMultipleWatchmanUpdates") {
 
 TEST_CASE_FIXTURE(ProtocolTest, "ZeroingOutPackageFiles") {
     auto opts = std::make_shared<realmain::options::Options>();
-    opts->stripePackages = true;
+    opts->cacheSensitiveOptions.stripePackages = true;
     this->resetState(std::move(opts));
 
     writeFilesToFS({

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -605,7 +605,7 @@ TEST_CASE("LSPTest") {
             auto responses = getLSPResponsesFor(*lspWrapper, make_unique<LSPMessage>(make_unique<NotificationMessage>(
                                                                  "2.0", LSPMethod::TextDocumentDidOpen, move(params))));
             // Sorbet will complain about missing packages in packaging mode. Ignore them.
-            if (!lspWrapper->opts->stripePackages) {
+            if (!lspWrapper->opts->cacheSensitiveOptions.stripePackages) {
                 INFO("Should not receive any response to opening an empty file.");
                 CHECK_EQ(0, countNonTestMessages(responses));
             }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -380,7 +380,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     vector<ast::ParsedFile> trees;
     auto filesSpan = absl::Span<core::FileRef>(files);
-    if (opts.stripePackages) {
+    if (opts.cacheSensitiveOptions.stripePackages) {
         auto numPackageFiles = realmain::pipeline::partitionPackageFiles(*gs, filesSpan);
         auto inputPackageFiles = filesSpan.first(numPackageFiles);
         filesSpan = filesSpan.subspan(numPackageFiles);
@@ -397,7 +397,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     name(*gs, absl::Span<ast::ParsedFile>(nonPackageTrees), *workers);
     realmain::pipeline::unpartitionPackageFiles(trees, move(nonPackageTrees));
 
-    if (opts.stripePackages) {
+    if (opts.cacheSensitiveOptions.stripePackages) {
         if (test.expectations.contains("rbi-gen")) {
             auto rbiGenGs = emptyGs->deepCopyGlobalState();
             realmain::pipeline::setGlobalStateOptions(*rbiGenGs, opts);
@@ -526,7 +526,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters stubs
         trees = move(resolver::Resolver::run(*gs, move(trees), *workers).result());
 
-        if (opts.stripePackages) {
+        if (opts.cacheSensitiveOptions.stripePackages) {
             trees = packager::VisibilityChecker::run(*gs, *workers, move(trees));
         }
 
@@ -801,7 +801,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     trees = move(newTrees);
     fast_sort(trees, [](auto &lhs, auto &rhs) { return lhs.file < rhs.file; });
 
-    if (opts.stripePackages) {
+    if (opts.cacheSensitiveOptions.stripePackages) {
         absl::c_stable_partition(trees, [&](const auto &pf) { return pf.file.isPackage(*gs); });
         trees = packager::Packager::runIncremental(*gs, move(trees), *workers);
         for (auto &tree : trees) {
@@ -842,7 +842,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         trees = move(resolver::Resolver::runIncremental(*gs, move(trees), ranIncrementalNamer, *workers).result());
     }
 
-    if (opts.stripePackages) {
+    if (opts.cacheSensitiveOptions.stripePackages) {
         trees = packager::VisibilityChecker::run(*gs, *workers, move(trees));
     }
 

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -84,7 +84,7 @@ const vector<string> LAYERS_UTIL_LIB_APP = {"util", "lib", "app"};
 void makeDefaultPackagerGlobalState(core::GlobalState &gs, const vector<string> &packagerLayers = NO_LAYERS) {
     gs.initEmpty();
     realmain::options::Options opts;
-    opts.stripePackages = true;
+    opts.cacheSensitiveOptions.stripePackages = true;
     opts.packagerLayers = packagerLayers;
     realmain::pipeline::setGlobalStateOptions(gs, opts);
 }

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -14,6 +14,7 @@
 #include "main/pipeline/pipeline.h"
 #include "packager/packager.h"
 #include "parser/parser.h"
+#include "rewriter/rewriter.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
 #include "test/helpers/MockFileSystem.h"
@@ -110,6 +111,7 @@ vector<ast::ParsedFile> enterPackages(core::GlobalState &gs, vector<pair<string,
 
             core::MutableContext ctx(gs, core::Symbols::root(), file);
             auto parsedFile = ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), file};
+            parsedFile.tree = rewriter::Rewriter::run(ctx, move(parsedFile.tree));
             parsedFiles.emplace_back(local_vars::LocalVars::run(ctx, move(parsedFile)));
         }
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- This allows us to cache certain rewrites, which means less work that we have
  to do if a file's contents have not changed on a slow path.

- This ensures that the rewrite to pre-resolve the super class of a
  `PackageSpec` subclass happens before `namer`. Currently, it happens in
  `packager` which runs after namer, but we want to be able to detect whether a
  class def is a PackageSpec in namer for the purpose of defining package
  symbols (in a future change).

This builds on changes in #8683 to introduce "cache-sensitive" options. We now
treat `--stripe-packages` as such, which is what justifies being able to call
`core::File::isPackage` from `rewriter/`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.