### PR TITLE
Inline commitFileUpdates in LSPTypechecker

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -342,19 +342,26 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
     }
     logger->debug("Taking slow path");
 
-    auto finalGS = move(updates.updatedGS.value());
+    ENFORCE(this->cancellationUndoState == nullptr);
+    if (cancelable) {
+        this->cancellationUndoState =
+            std::make_unique<UndoState>(std::move(gs), std::move(this->indexedFinalGS), updates.epoch);
+    }
+
+    this->gs = std::move(updates.updatedGS.value());
+
     const uint32_t epoch = updates.epoch;
-    auto &epochManager = *finalGS->epochManager;
+    auto &epochManager = *this->gs->epochManager;
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
     // cancelation feature is enabled.
-    auto committed = epochManager.tryCommitEpoch(*finalGS, epoch, cancelable, preemptManager, [&]() -> void {
+    auto committed = epochManager.tryCommitEpoch(*this->gs, epoch, cancelable, preemptManager, [&]() -> void {
         vector<ast::ParsedFile> indexed, nonPackagedIndexed;
 
         {
             // Replace error queue with one that is owned by this thread.
             auto savedErrorQueue = std::exchange(
-                finalGS->errorQueue,
-                make_shared<core::ErrorQueue>(finalGS->errorQueue->logger, finalGS->errorQueue->tracer, errorFlusher));
+                this->gs->errorQueue, make_shared<core::ErrorQueue>(this->gs->errorQueue->logger,
+                                                                    this->gs->errorQueue->tracer, errorFlusher));
 
             std::optional<Timer> timeit;
             ShowOperation op(*config, ShowOperation::Kind::Indexing);
@@ -365,7 +372,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                     ENFORCE(!this->initialized);
                     timeit.emplace(this->config->logger, "initial_index");
 
-                    this->workspaceFiles = pipeline::reserveFiles(*finalGS, config->opts.inputFileNames);
+                    this->workspaceFiles = pipeline::reserveFiles(*this->gs, config->opts.inputFileNames);
                     break;
                 }
 
@@ -380,7 +387,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                     if (!updates.updatedFiles.empty()) {
                         for (auto &ast : updates.updatedFileIndexes) {
                             if (ast.tree) {
-                                updates.updatedFinalGSFileIndexes.emplace_back(std::move(ast));
+                                this->indexedFinalGS[ast.file.id()] = std::move(ast);
                             }
                         }
 
@@ -389,12 +396,12 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                     }
 
                     this->workspaceFiles.clear();
-                    this->workspaceFiles.reserve(finalGS->filesUsed());
+                    this->workspaceFiles.reserve(this->gs->filesUsed());
 
                     // Rebuild the set of filerefs we're going to index. We're explicitly skipping the `0` file, as
                     // that's always a nullptr.
                     auto ix = 0;
-                    for (const auto &file : finalGS->getFiles().subspan(1)) {
+                    for (const auto &file : this->gs->getFiles().subspan(1)) {
                         ++ix;
 
                         ENFORCE(file != nullptr);
@@ -416,13 +423,8 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                 }
             }
 
-            // Before making preemption or cancelation possible, pre-commit the changes from this slow path so that
-            // preempted queries can use them and the code after this lambda can assume that this step happened.
-            updates.updatedGS = move(finalGS);
-            commitFileUpdates(updates, cancelable);
-
-            // IMPORTANT: We use `this->gs` rather than the moved `finalGS` from this point forward.
-
+            ENFORCE(updates.updatedFileIndexes.empty());
+            ENFORCE(updates.updatedFiles.empty());
             ENFORCE(gs->lspQuery.isEmpty());
 
             // Test-only hook: Stall for as long as `slowPathBlocked` is set.
@@ -618,7 +620,6 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
         pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, preemptManager, presorted);
     });
 
-    // Note: `gs` now holds the value of `finalGS`.
     gs->lspQuery = core::lsp::Query::noQuery();
 
     if (committed) {
@@ -630,11 +631,11 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
     } else {
         prodCategoryCounterInc("lsp.updates", "slowpath_canceled");
         timeit.setTag("canceled", "true");
+        ENFORCE(cancelable);
         // Eagerly restore the state to how it was before this slow path, so that we're not holding the old state for an
         // arbitrarily long time. The next update will be responsible for freeing the underlying UndoState after it
         // makes use of the epoch field to determine additional files to include in the edit.
         cancellationUndoState->restore(this->gs, this->indexedFinalGS);
-        ENFORCE(cancelable);
         logger->debug("[Typechecker] Typecheck run for epoch {} was canceled.", updates.epoch);
     }
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -650,36 +650,6 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
     }
 }
 
-void LSPTypechecker::commitFileUpdates(LSPFileUpdates &updates, bool couldBeCanceled) {
-    // The fast path cannot be canceled.
-    ENFORCE(!(updates.typecheckingPath == TypecheckingPath::Fast && couldBeCanceled));
-    if (couldBeCanceled) {
-        ENFORCE(updates.updatedGS.has_value());
-        cancellationUndoState =
-            make_unique<UndoState>(std::move(this->gs), std::move(this->indexedFinalGS), updates.epoch);
-    }
-
-    // Both the fast and slow path clear these vectors out before we see a call to this method.
-    ENFORCE(updates.updatedFileIndexes.empty());
-    ENFORCE(updates.updatedFiles.empty());
-
-    // Clear out state associated with old finalGS.
-    if (updates.typecheckingPath != TypecheckingPath::Fast) {
-        this->indexedFinalGS.clear();
-    }
-
-    for (auto &ast : updates.updatedFinalGSFileIndexes) {
-        this->indexedFinalGS[ast.file.id()] = move(ast);
-    }
-
-    if (updates.updatedGS.has_value()) {
-        ENFORCE(updates.typecheckingPath != TypecheckingPath::Fast);
-        this->gs = move(updates.updatedGS.value());
-    } else {
-        ENFORCE(updates.typecheckingPath == TypecheckingPath::Fast);
-    }
-}
-
 unique_ptr<core::GlobalState> LSPTypechecker::destroy() {
     return move(gs);
 }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -150,7 +150,14 @@ bool LSPTypechecker::typecheck(std::unique_ptr<LSPFileUpdates> updates, WorkerPo
         if (isFastPath) {
             bool isNoopUpdateForRetypecheck = false;
             filesTypechecked = runFastPath(*updates, workers, errorFlusher, isNoopUpdateForRetypecheck);
-            commitFileUpdates(*updates, /* cancelable */ false);
+
+            ENFORCE(updates->updatedFileIndexes.empty());
+            ENFORCE(updates->updatedFiles.empty());
+
+            for (auto &ast : updates->updatedFinalGSFileIndexes) {
+                this->indexedFinalGS[ast.file.id()] = move(ast);
+            }
+
             prodCategoryCounterInc("lsp.updates", "fastpath");
         } else {
             auto result = runSlowPath(*updates, this->getKvStore(), workers, errorFlusher, SlowPathMode::Cancelable);

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -115,9 +115,6 @@ class LSPTypechecker final {
                                            std::shared_ptr<core::ErrorFlusher> errorFlusher,
                                            bool isNoopUpdateForRetypecheck) const;
 
-    /** Commits the given file updates to LSPTypechecker. Does not send diagnostics. */
-    void commitFileUpdates(LSPFileUpdates &updates, bool couldBeCanceled);
-
     /**
      * Returns a the indexed tree for the given file ref. The associated tree may be `nullptr` if the file ref given
      * points to a payload RBI. This function will first consult the `this->indexedFinalGS` cache before falling back on


### PR DESCRIPTION
This function has a lot of conditional behavior for when it's on the fast or slow path, and doesn't really make sense on its own at this point. This PR removes it, by inlining the behavior into `typecheck` and `runSlowPath` where appropriate, which simplifies both cases.

I didn't inline the fast-path behavior directly into `runFastPath`, because `runFastPath` is a const function, and we need to update the `indexedFinalGS` map.

### Motivation
Simplifying `LSPTypechecker` now that there's less internal state to manage.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
