### PR TITLE
Bump RBS parser for namespaced functions and structs

### DIFF
--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -133,7 +133,7 @@ void collectKeywords(core::LocOffsets docLoc, rbs_hash_t *field, vector<RBSArg> 
 } // namespace
 
 unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::Node *methodDef,
-                                                                 const rbs_methodtype_t *methodType,
+                                                                 const rbs_method_type_t *methodType,
                                                                  const core::LocOffsets typeLoc,
                                                                  const core::LocOffsets commentLoc,
                                                                  const vector<Comment> &annotations) {
@@ -156,11 +156,11 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
     for (rbs_node_list_node_t *list_node = node.type_params->head; list_node != nullptr; list_node = list_node->next) {
         auto loc = locFromRange(typeLoc, list_node->node->location->rg);
 
-        ENFORCE(list_node->node->type == RBS_AST_TYPEPARAM,
+        ENFORCE(list_node->node->type == RBS_AST_TYPE_PARAM,
                 "Unexpected node type `{}` in type parameter list, expected `{}`", rbs_node_type_name(list_node->node),
                 "TypeParam");
 
-        auto node = (rbs_ast_typeparam_t *)list_node->node;
+        auto node = (rbs_ast_type_param_t *)list_node->node;
         auto str = parser.resolveConstant(node->name);
         typeParams.emplace_back(loc, ctx.state.enterNameUTF8(str));
     }

--- a/rbs/MethodTypeToParserNode.h
+++ b/rbs/MethodTypeToParserNode.h
@@ -18,7 +18,7 @@ public:
      *
      * For example the signature comment `#: () -> void` will be translated as `sig { void }`.
      */
-    std::unique_ptr<parser::Node> methodSignature(const parser::Node *methodDef, const rbs_methodtype_t *methodType,
+    std::unique_ptr<parser::Node> methodSignature(const parser::Node *methodDef, const rbs_method_type_t *methodType,
                                                   const core::LocOffsets typeLoc, const core::LocOffsets commentLoc,
                                                   const std::vector<Comment> &annotations);
 

--- a/rbs/Parser.cc
+++ b/rbs/Parser.cc
@@ -26,22 +26,22 @@ RBSLibraryInitializer rbsLibraryInitializer;
 } // namespace
 
 Parser::Parser(rbs_string_t rbsString, const rbs_encoding_t *encoding)
-    : parser(alloc_parser(rbsString, encoding, 0, rbsString.end - rbsString.start), free_parser) {}
+    : parser(rbs_parser_new(rbsString, encoding, 0, rbsString.end - rbsString.start), rbs_parser_free) {}
 
 std::string_view Parser::resolveConstant(const rbs_ast_symbol_t *symbol) const {
     auto constant = rbs_constant_pool_id_to_constant(&parser->constant_pool, symbol->constant_id);
     return std::string_view(reinterpret_cast<const char *>(constant->start), constant->length);
 }
 
-rbs_methodtype_t *Parser::parseMethodType() {
-    rbs_methodtype_t *methodType = nullptr;
-    parse_method_type(parser.get(), &methodType);
+rbs_method_type_t *Parser::parseMethodType() {
+    rbs_method_type_t *methodType = nullptr;
+    rbs_parse_method_type(parser.get(), &methodType);
     return methodType;
 }
 
 rbs_node_t *Parser::parseType() {
     rbs_node_t *type = nullptr;
-    parse_type(parser.get(), &type);
+    rbs_parse_type(parser.get(), &type);
     return type;
 }
 
@@ -49,7 +49,7 @@ bool Parser::hasError() const {
     return parser->error != nullptr;
 }
 
-const error *Parser::getError() const {
+const rbs_error_t *Parser::getError() const {
     return parser->error;
 }
 

--- a/rbs/Parser.h
+++ b/rbs/Parser.h
@@ -8,18 +8,18 @@ namespace sorbet::rbs {
 
 class Parser {
 private:
-    std::shared_ptr<parserstate> parser;
+    std::shared_ptr<rbs_parser_t> parser;
 
 public:
     Parser(rbs_string_t rbsString, const rbs_encoding_t *encoding);
 
     std::string_view resolveConstant(const rbs_ast_symbol_t *symbol) const;
 
-    rbs_methodtype_t *parseMethodType();
+    rbs_method_type_t *parseMethodType();
     rbs_node_t *parseType();
 
     bool hasError() const;
-    const error *getError() const;
+    const rbs_error_t *getError() const;
 };
 
 } // namespace sorbet::rbs

--- a/rbs/SignatureTranslator.cc
+++ b/rbs/SignatureTranslator.cc
@@ -75,7 +75,7 @@ unique_ptr<parser::Node> SignatureTranslator::translateSignature(const parser::N
     const rbs_encoding_t *encoding = &rbs_encodings[RBS_ENCODING_UTF_8];
 
     Parser parser(rbsString, encoding);
-    rbs_methodtype_t *rbsMethodType = parser.parseMethodType();
+    rbs_method_type_t *rbsMethodType = parser.parseMethodType();
 
     if (parser.hasError()) {
         core::LocOffsets offset = locFromRange(signature.typeLoc, parser.getError()->token.range);

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -16,7 +16,7 @@ bool hasTypeParam(absl::Span<const std::pair<core::LocOffsets, core::NameRef>> t
 
 } // namespace
 
-unique_ptr<parser::Node> TypeToParserNode::typeNameType(const rbs_typename_t *typeName, bool isGeneric,
+unique_ptr<parser::Node> TypeToParserNode::typeNameType(const rbs_type_name_t *typeName, bool isGeneric,
                                                         core::LocOffsets loc) {
     rbs_node_list *typePath = typeName->rbs_namespace->path;
 
@@ -86,7 +86,7 @@ unique_ptr<parser::Node> TypeToParserNode::typeNameType(const rbs_typename_t *ty
     return parser::MK::Const(loc, move(parent), nameConstant);
 }
 
-unique_ptr<parser::Node> TypeToParserNode::classInstanceType(const rbs_types_classinstance_t *node,
+unique_ptr<parser::Node> TypeToParserNode::classInstanceType(const rbs_types_class_instance_t *node,
                                                              core::LocOffsets loc) {
     auto offsets = locFromRange(loc, ((rbs_node_t *)node)->location->rg);
     auto argsValue = node->args;
@@ -107,7 +107,7 @@ unique_ptr<parser::Node> TypeToParserNode::classInstanceType(const rbs_types_cla
     return typeConstant;
 }
 
-unique_ptr<parser::Node> TypeToParserNode::classSingletonType(const rbs_types_classsingleton_t *node,
+unique_ptr<parser::Node> TypeToParserNode::classSingletonType(const rbs_types_class_singleton_t *node,
                                                               core::LocOffsets loc) {
     auto offsets = locFromRange(loc, ((rbs_node_t *)node)->location->rg);
     auto innerType = typeNameType(node->name, false, offsets);
@@ -197,7 +197,7 @@ unique_ptr<parser::Node> TypeToParserNode::procType(const rbs_types_proc_t *node
             function = functionType((rbs_types_function_t *)functionTypeNode, loc);
             break;
         }
-        case RBS_TYPES_UNTYPEDFUNCTION: {
+        case RBS_TYPES_UNTYPED_FUNCTION: {
             return function;
         }
         default: {
@@ -229,7 +229,7 @@ unique_ptr<parser::Node> TypeToParserNode::blockType(const rbs_types_block_t *no
             function = functionType((rbs_types_function_t *)functionTypeNode, docLoc);
             break;
         }
-        case RBS_TYPES_UNTYPEDFUNCTION: {
+        case RBS_TYPES_UNTYPED_FUNCTION: {
             return function;
         }
         default: {
@@ -298,7 +298,7 @@ unique_ptr<parser::Node> TypeToParserNode::recordType(const rbs_types_record_t *
             }
         }
 
-        if (hash_node->value->type != RBS_TYPES_RECORD_FIELDTYPE) {
+        if (hash_node->value->type != RBS_TYPES_RECORD_FIELD_TYPE) {
             if (auto e = ctx.beginError(loc, core::errors::Internal::InternalError)) {
                 e.setHeader("Unexpected node type `{}` in record value type, expected `{}`",
                             rbs_node_type_name(hash_node->value), "RecordFieldtype");
@@ -307,7 +307,7 @@ unique_ptr<parser::Node> TypeToParserNode::recordType(const rbs_types_record_t *
             continue;
         }
 
-        rbs_types_record_fieldtype_t *valueNode = (rbs_types_record_fieldtype_t *)hash_node->value;
+        rbs_types_record_field_type_t *valueNode = (rbs_types_record_field_type_t *)hash_node->value;
         auto innerType = toParserNode(valueNode->type, loc);
         pairs.emplace_back(make_unique<parser::Pair>(loc, move(key), move(innerType)));
     }
@@ -356,10 +356,10 @@ unique_ptr<parser::Node> TypeToParserNode::toParserNode(const rbs_node_t *node, 
             return voidType((rbs_types_bases_void_t *)node, docLoc);
         case RBS_TYPES_BLOCK:
             return blockType((rbs_types_block_t *)node, docLoc);
-        case RBS_TYPES_CLASSINSTANCE:
-            return classInstanceType((rbs_types_classinstance_t *)node, docLoc);
-        case RBS_TYPES_CLASSSINGLETON:
-            return classSingletonType((rbs_types_classsingleton_t *)node, docLoc);
+        case RBS_TYPES_CLASS_INSTANCE:
+            return classInstanceType((rbs_types_class_instance_t *)node, docLoc);
+        case RBS_TYPES_CLASS_SINGLETON:
+            return classSingletonType((rbs_types_class_singleton_t *)node, docLoc);
         case RBS_TYPES_FUNCTION:
             return functionType((rbs_types_function_t *)node, docLoc);
         case RBS_TYPES_INTERFACE: {

--- a/rbs/TypeToParserNode.h
+++ b/rbs/TypeToParserNode.h
@@ -26,9 +26,9 @@ public:
     std::unique_ptr<parser::Node> toParserNode(const rbs_node_t *node, core::LocOffsets loc);
 
 private:
-    std::unique_ptr<parser::Node> typeNameType(const rbs_typename_t *typeName, bool isGeneric, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> classInstanceType(const rbs_types_classinstance_t *node, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> classSingletonType(const rbs_types_classsingleton_t *node, core::LocOffsets loc);
+    std::unique_ptr<parser::Node> typeNameType(const rbs_type_name_t *typeName, bool isGeneric, core::LocOffsets loc);
+    std::unique_ptr<parser::Node> classInstanceType(const rbs_types_class_instance_t *node, core::LocOffsets loc);
+    std::unique_ptr<parser::Node> classSingletonType(const rbs_types_class_singleton_t *node, core::LocOffsets loc);
     std::unique_ptr<parser::Node> intersectionType(const rbs_types_intersection_t *node, core::LocOffsets loc);
     std::unique_ptr<parser::Node> unionType(const rbs_types_union_t *node, core::LocOffsets loc);
     std::unique_ptr<parser::Node> optionalType(const rbs_types_optional_t *node, core::LocOffsets loc);

--- a/rbs/rbs_common.cc
+++ b/rbs/rbs_common.cc
@@ -2,7 +2,7 @@
 
 namespace sorbet::rbs {
 
-core::LocOffsets locFromRange(core::LocOffsets loc, const range &range) {
+core::LocOffsets locFromRange(core::LocOffsets loc, const rbs_range_t &range) {
     return {
         loc.beginPos() + range.start.char_pos,
         loc.beginPos() + range.end.char_pos,

--- a/rbs/rbs_common.h
+++ b/rbs/rbs_common.h
@@ -22,7 +22,7 @@ struct Comment {
                                  // this is only a view on the string owned by the File.source() data.
 };
 
-core::LocOffsets locFromRange(core::LocOffsets loc, const range &range);
+core::LocOffsets locFromRange(core::LocOffsets loc, const rbs_range_t &range);
 
 } // namespace sorbet::rbs
 

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -317,8 +317,8 @@ def register_sorbet_dependencies():
     # while we're upstreaming their changes.
     http_archive(
         name = "rbs_parser",
-        url = "https://github.com/shopify/rbs/archive/260670d43b8ef1949e8e79a6303a0edf8c234f93.zip",
-        sha256 = "5c870b95a78c656684efe8fd7a95117544252cdb2d168df538a15fef77d14fed",
-        strip_prefix = "rbs-260670d43b8ef1949e8e79a6303a0edf8c234f93",
+        url = "https://github.com/shopify/rbs/archive/91dfbbda3cc43cdc4f47048abb9de597a15c1ada.zip",
+        sha256 = "1166b6d7dc1268213fb8a936125b7a28da89c881802946e11f87a4560263c107",
+        strip_prefix = "rbs-91dfbbda3cc43cdc4f47048abb9de597a15c1ada",
         build_file = "@com_stripe_ruby_typer//third_party:rbs_parser.BUILD",
     )


### PR DESCRIPTION
### Motivation

We've renamed RBS parser library's struct and function names to all have `rbs_` prefixes and better naming conventions.

This should address https://github.com/sorbet/sorbet/pull/8702#pullrequestreview-2715296208


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
