### PR TITLE
Revert "Reindex on the slow path"

### DIFF
--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -18,10 +18,6 @@ class PreemptionTaskManager;
 class QueryResponse;
 } // namespace sorbet::core::lsp
 
-namespace sorbet::realmain::cache {
-class SessionCache;
-}
-
 namespace sorbet::realmain::lsp {
 class ResponseError;
 class InitializedTask;
@@ -49,18 +45,23 @@ class LSPTypechecker final {
      * GlobalState back over to the typechecker to use as the starting point for the next slow path.
      */
     std::unique_ptr<core::GlobalState> gs;
-
     /**
-     * A copy of the kvstore produced during initialization, that's private to this LSP session.
+     * Trees that have been indexed with the GlobalState that was originally supplied during initialization
+     * (initialGS). As all values of this->gs will derive from that initial GlobalState, none of these trees will be
+     * re-indexed for subsequent slow path runs. An additional consequence of this->gs deriving from the initialization
+     * value of GlobalState is that they will continue to be valid when used with this->gs (see the comment on this->gs
+     * for an explanation of how this derivation is ensured).
+     *
+     * WARNING:
+     * Updates to this vector can happen through this->commitFileUpdates and LSPFileUpdates::updatedFileIndexes, however
+     * those updates will only be valid when used with the indexer's GlobalState. As a result it is absolutely necessary
+     * to ensure that any updates to this vector are either already valid with this->gs, or have a corresponding tree in
+     * this->indexedFinalGS, as otherwise there is a possibility that the tree used will reference names that aren't
+     * consistent with this->gs. Once a slow path is kicked off this problem will resolve itself, as this->gs will be
+     * re-initialized with a copy of the indexer's GlobalState, making all of the names stored in the trees of
+     * this->indexed valid again.
      */
-    std::unique_ptr<cache::SessionCache> sessionCache;
-
-    /**
-     * A vector of file refs that we clear and reuse on slow paths. It's held here instead of as a temporary in the slow
-     * path to ensure we're not aggressively reallocating memory.
-     */
-    std::vector<core::FileRef> workspaceFiles;
-
+    std::vector<ast::ParsedFile> indexed;
     /**
      * Trees that have been indexed with this->gs between slow path runs, which means that they may have names that are
      * not present in the name table of the indexer. This is a sparse diff of trees indexed by position in
@@ -116,17 +117,9 @@ class LSPTypechecker final {
     /** Commits the given file updates to LSPTypechecker. Does not send diagnostics. */
     void commitFileUpdates(LSPFileUpdates &updates, bool couldBeCanceled);
 
-    /**
-     * Returns a the indexed tree for the given file ref. The associated tree may be `nullptr` if the file ref given
-     * points to a payload RBI. This function will first consult the `this->indexedFinalGS` cache before falling back on
-     * re-indexing the file on disk.
-     */
-    ast::ParsedFile getIndexed(core::FileRef fref) const;
-
-    /**
-     * Open the session-local kvstore.
-     */
-    std::unique_ptr<KeyValueStore> getKvStore() const;
+    /** Deep copy all entries in `indexed` that contain ASTs. Returns true on success, false if the operation was
+     * canceled. */
+    ast::ParsedFilesOrCancelled copyIndexed(WorkerPool &workers) const;
 
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,
@@ -169,8 +162,7 @@ public:
     ast::ExpressionPtr getLocalVarTrees(core::FileRef fref) const;
 
     /**
-     * Returns copies of the indexed trees that have been run through the incremental resolver. There is no guarantee
-     * that the resolved trees are returned in the same order that the FileRefs appear in the input span.
+     * Returns copies of the indexed trees that have been run through the incremental resolver.
      */
     std::vector<ast::ParsedFile> getResolved(absl::Span<const core::FileRef> frefs, WorkerPool &workers) const;
 

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -12,7 +12,26 @@ UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, 
                      uint32_t epoch)
     : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)), epoch(epoch) {}
 
-void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS) {
+void UndoState::recordEvictedState(ast::ParsedFile evictedIndexTree) {
+    const auto id = evictedIndexTree.file.id();
+    // The first time a file gets evicted, it's an index tree from the old global state.
+    // Subsequent times it is evicting old index trees from the new global state, and we don't care.
+    // Also, ignore updates to new files (id >= size of file table)
+    if (id < evictedGs->getFiles().size() && !evictedIndexed.contains(id)) {
+        evictedIndexed[id] = move(evictedIndexTree);
+    }
+}
+
+void UndoState::restore(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> &indexed,
+                        UnorderedMap<int, ast::ParsedFile> &indexedFinalGS) {
+    // We should never apply this twice, as that would end up dropping the other GlobalState
+    ENFORCE(this->evictedGs != nullptr);
+
+    // Replace evicted index trees.
+    for (auto &entry : evictedIndexed) {
+        indexed[entry.first] = move(entry.second);
+    }
+
     indexedFinalGS = std::move(evictedIndexedFinalGS);
     gs = move(evictedGs);
 }

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -15,6 +15,8 @@ class UndoState final {
     // Stores the pre-slow-path global state.
     std::unique_ptr<core::GlobalState> evictedGs;
     // Stores index trees containing data stored in `gs` that have been evicted during the slow path operation.
+    UnorderedMap<int, ast::ParsedFile> evictedIndexed;
+    // Stores the index trees stored in `gs` that were evicted because the slow path operation replaced `gs`.
     UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
 
 public:
@@ -25,9 +27,15 @@ public:
               uint32_t epoch);
 
     /**
+     * Records that the given items were evicted from LSPTypechecker following a typecheck run.
+     */
+    void recordEvictedState(ast::ParsedFile evictedIndexTree);
+
+    /**
      * Undoes the slow path changes represented by this class.
      */
-    void restore(std::unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS);
+    void restore(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> &indexed,
+                 UnorderedMap<int, ast::ParsedFile> &indexedFinalGS);
 
     /**
      * Retrieves the evicted global state.

--- a/website/docs/lsp.md
+++ b/website/docs/lsp.md
@@ -124,15 +124,6 @@ A short list of useful LSP-related command line flags:
   [Including and excluding files](cli.md#including-and-excluding-files) or
   `srb tc --help` for more information.
 
-- `--cache-dir=...`
-
-  When an edit causes Sorbet to
-  [retypecheck the whole workspace](server-status#why-do-some-of-my-edits-make-sorbet-go-back-to-typechecking),
-  supplying a cache directory with the
-  [`--cache-dir`](cli#--cache-dir-caching-parse-results) flag allows it to avoid
-  reindexing files that haven't changed. This improves performance, shortening
-  the duration of that slow path operation.
-
 - `--disable-watchman` / `--watchman-path=...`
 
   Configure whether or how the `watchman` binary is invoked.

--- a/website/docs/server-status.md
+++ b/website/docs/server-status.md
@@ -86,10 +86,9 @@ below.)
 Sorbet is currently reading files from disk and parsing them into abstract
 syntax trees.
 
-This operation happens when Sorbet determines it needs to
-[retypecheck the whole codebase](server-status#why-do-some-of-my-edits-make-sorbet-go-back-to-typechecking).
-If this operation is taking a long time, it can be sped up by passing the
-[`--cache-dir`](cli.md#--cache-dir-caching-parse-results) flag.
+This operation only happens when Sorbet initially starts up in LSP mode for the
+first time. If this operation is taking a long time, it can be sped up by
+passing the [`--cache-dir`](cli.md#--cache-dir-caching-parse-results) flag.
 
 ### Typechecking...
 


### PR DESCRIPTION
There are some situations where the source from File objects is missing during error construction that need to be debugged.

Reverts sorbet/sorbet#8723