### PR TITLE
Fix errors with slow path reindexing

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -286,7 +286,7 @@ bool PackageDB::allowRelaxedPackagerChecksFor(MangledName mangledName) const {
 
 PackageDB PackageDB::deepCopy() const {
     ENFORCE(frozen);
-    PackageDB result;
+    PackageDB result = this->copyOptionsOnly();
 
     // --- data ---
     result.packages_.reserve(this->packages_.size());
@@ -297,6 +297,13 @@ PackageDB PackageDB::deepCopy() const {
     // This assumes that the GlobalState this PackageDB is getting copied into also has these
     // interned mangledName NameRefs at the same IDs as the current PackageDB.
     result.mangledNames = this->mangledNames;
+
+    return result;
+}
+
+PackageDB PackageDB::copyOptionsOnly() const {
+    ENFORCE(frozen);
+    PackageDB result;
 
     // --- options ---
     result.enabled_ = this->enabled_;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -49,6 +49,9 @@ public:
 
     PackageDB deepCopy() const;
 
+    // Copy the options of the PackageDB, but leave all the data out.
+    PackageDB copyOptionsOnly() const;
+
     UnfreezePackages unfreeze();
 
     PackageDB() = default;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -152,7 +152,7 @@ bool LSPTypechecker::typecheck(std::unique_ptr<LSPFileUpdates> updates, WorkerPo
             commitFileUpdates(*updates, /* cancelable */ false);
             prodCategoryCounterInc("lsp.updates", "fastpath");
         } else {
-            auto result = runSlowPath(*updates, nullptr, workers, errorFlusher, SlowPathMode::Cancelable);
+            auto result = runSlowPath(*updates, this->getKvStore(), workers, errorFlusher, SlowPathMode::Cancelable);
             ENFORCE(std::holds_alternative<bool>(result));
             committed = std::get<bool>(result);
         }
@@ -237,6 +237,9 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         toTypecheck.emplace_back(fref);
     }
 
+    updates.updatedFiles.clear();
+    updates.updatedFileIndexes.clear();
+
     if (shouldRunIncrementalNamer && gs->packageDB().enabled()) {
         std::vector<core::FileRef> packageFiles;
 
@@ -308,68 +311,6 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     return toTypecheck;
 }
 
-ast::ParsedFilesOrCancelled LSPTypechecker::copyIndexed(WorkerPool &workers) const {
-    auto &logger = *config->logger;
-    Timer timeit(logger, "slow_path.copy_indexes");
-    shared_ptr<ConcurrentBoundedQueue<int>> fileq = make_shared<ConcurrentBoundedQueue<int>>(indexed.size());
-    for (int i = 0; i < indexed.size(); i++) {
-        fileq->push(i, 1);
-    }
-
-    const auto &epochManager = *gs->epochManager;
-    shared_ptr<BlockingBoundedQueue<vector<ast::ParsedFile>>> resultq =
-        make_shared<BlockingBoundedQueue<vector<ast::ParsedFile>>>(indexed.size());
-    workers.multiplexJob("copyParsedFiles", [fileq, resultq, &indexed = this->indexed, &epochManager]() {
-        vector<ast::ParsedFile> threadResult;
-        int processedByThread = 0;
-        int job;
-        {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                if (result.gotItem()) {
-                    processedByThread++;
-
-                    // Stop if typechecking was canceled.
-                    if (!epochManager.wasTypecheckingCanceled()) {
-                        const auto &tree = indexed[job];
-                        // Note: indexed entries for payload files don't have any contents.
-                        if (tree.tree) {
-                            threadResult.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
-                        }
-                    }
-                }
-            }
-        }
-
-        if (processedByThread > 0) {
-            resultq->push(move(threadResult), processedByThread);
-        }
-    });
-    std::vector<ast::ParsedFile> out;
-    {
-        vector<ast::ParsedFile> threadResult;
-        out.reserve(indexed.size());
-        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
-             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
-            if (result.gotItem()) {
-                for (auto &copy : threadResult) {
-                    out.push_back(move(copy));
-                }
-            }
-        }
-    }
-
-    if (epochManager.wasTypecheckingCanceled()) {
-        return ast::ParsedFilesOrCancelled::cancel(std::move(out), workers);
-    }
-
-    fast_sort(out, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-
-    if (epochManager.wasTypecheckingCanceled()) {
-        return ast::ParsedFilesOrCancelled::cancel(std::move(out), workers);
-    }
-    return out;
-}
-
 LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updates,
                                                            std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
                                                            shared_ptr<core::ErrorFlusher> errorFlusher,
@@ -380,7 +321,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
     // This is populated when running in `SlowPathMode::Init`.
     std::unique_ptr<core::GlobalState> indexedState;
 
-    bool cancelable = mode == SlowPathMode::Cancelable;
+    const bool cancelable = mode == SlowPathMode::Cancelable;
 
     auto &logger = config->logger;
     auto slowPathOp = std::make_optional<ShowOperation>(*config, ShowOperation::Kind::SlowPathBlocking);
@@ -398,141 +339,216 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
     // cancelation feature is enabled.
     auto committed = epochManager.tryCommitEpoch(*finalGS, epoch, cancelable, preemptManager, [&]() -> void {
-        // Replace error queue with one that is owned by this thread.
-        auto savedErrorQueue = std::exchange(
-            finalGS->errorQueue,
-            make_shared<core::ErrorQueue>(finalGS->errorQueue->logger, finalGS->errorQueue->tracer, errorFlusher));
+        vector<ast::ParsedFile> indexed, nonPackagedIndexed;
 
-        switch (mode) {
-            case SlowPathMode::Init: {
-                ENFORCE(!this->initialized);
-                Timer timeit(config->logger, "initial_index");
+        {
+            // Replace error queue with one that is owned by this thread.
+            auto savedErrorQueue = std::exchange(
+                finalGS->errorQueue,
+                make_shared<core::ErrorQueue>(finalGS->errorQueue->logger, finalGS->errorQueue->tracer, errorFlusher));
 
-                ShowOperation op(*config, ShowOperation::Kind::Indexing);
+            std::optional<Timer> timeit;
+            ShowOperation op(*config, ShowOperation::Kind::Indexing);
 
-                std::unique_ptr<const OwnedKeyValueStore> ownedKvstore =
-                    cache::ownIfUnchanged(*finalGS, std::move(kvstore));
+            switch (mode) {
+                // Initialization fetches the list of files to index from the options
+                case SlowPathMode::Init: {
+                    ENFORCE(!this->initialized);
+                    timeit.emplace(this->config->logger, "initial_index");
 
-                {
-                    Timer timeit(config->logger, "reIndexFromFileSystem");
-
-                    auto inputFiles = pipeline::reserveFiles(*finalGS, config->opts.inputFileNames);
-                    this->indexed.clear();
-                    this->indexed.resize(finalGS->filesUsed());
-
-                    auto asts = hashing::Hashing::indexAndComputeFileHashes(*finalGS, config->opts, *config->logger,
-                                                                            absl::Span<core::FileRef>(inputFiles),
-                                                                            workers, ownedKvstore);
-                    ENFORCE(asts.hasResult(), "LSP initialization does not support cancellation");
-                    // asts are in fref order, but we (currently) don't index and compute file hashes for payload files,
-                    // so vector index != FileRef ID. Fix that by slotting them into `indexed`.
-                    for (auto &ast : asts.result()) {
-                        int id = ast.file.id();
-                        ENFORCE_NO_TIMER(id < this->indexed.size());
-                        this->indexed[id] = std::move(ast);
-                    }
+                    this->workspaceFiles = pipeline::reserveFiles(*finalGS, config->opts.inputFileNames);
+                    break;
                 }
 
-                cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(std::move(ownedKvstore)), config->opts,
-                                                     *finalGS, workers, indexed);
+                // Reindexing on the slow path derives the list of inputs files from the file table
+                case SlowPathMode::Cancelable: {
+                    timeit.emplace(this->config->logger, "slow_path_reindex");
 
-                ENFORCE_NO_TIMER(indexed.size() == finalGS->filesUsed());
+                    ENFORCE(updates.updatedFiles.size() == updates.updatedFileIndexes.size());
 
-                // At this point finalGS has a name table that's initialized enough for the indexer thread, so we make a
-                // copy to pass back over.
-                indexedState = finalGS->deepCopy();
-                indexedState->errorQueue = std::move(savedErrorQueue);
+                    // Move the indexed trees into our local cache for open files. We will still reindex them again to
+                    // force any errors, but this is a convenient way to pre-populate our cache.
+                    if (!updates.updatedFiles.empty()) {
+                        for (auto &ast : updates.updatedFileIndexes) {
+                            if (ast.tree) {
+                                updates.updatedFinalGSFileIndexes.emplace_back(std::move(ast));
+                            }
+                        }
 
-                this->initialized = true;
+                        updates.updatedFiles.clear();
+                        updates.updatedFileIndexes.clear();
+                    }
 
-                break;
-            }
+                    this->workspaceFiles.clear();
+                    this->workspaceFiles.reserve(finalGS->filesUsed());
 
-            case SlowPathMode::Cancelable: {
-                // If we're not initializing, there's no need to hold on to the old error queue.
-                savedErrorQueue = nullptr;
+                    // Rebuild the set of filerefs we're going to index. We're explicitly skipping the `0` file, as
+                    // that's always a nullptr.
+                    auto ix = 0;
+                    for (const auto &file : finalGS->getFiles().subspan(1)) {
+                        ++ix;
 
-                // As finalGS is a copy of the indexer's GlobalState, all of the indexed trees in the update are valid
-                // with it. Additionally, the file table is guaranteed to be up-to-date, as it's also a copy of the
-                // indexer's file table. As a result, if there are updates to perform we can ignore updating our file
-                // table. We can't however skip re-indexing the updated files, as that's what will cause the indexer
-                // errors to show up in the editor.
-                if (!updates.updatedFiles.empty()) {
-                    auto &gs = *finalGS;
+                        ENFORCE(file != nullptr);
 
-                    // Verify that our file table is sane.
-                    if constexpr (debug_mode) {
-                        auto ix = -1;
-                        for (auto &file : updates.updatedFiles) {
-                            ++ix;
-                            auto fref = gs.findFileByPath(file->path());
-                            auto &parsedFile = updates.updatedFileIndexes[ix];
-                            ENFORCE_NO_TIMER(fref == parsedFile.file);
+                        switch (file->sourceType) {
+                            case core::File::Type::NotYetRead:
+                            case core::File::Type::Normal:
+                                this->workspaceFiles.emplace_back(ix);
+                                break;
+
+                            case core::File::Type::PayloadGeneration:
+                            case core::File::Type::Payload:
+                            case core::File::Type::TombStone:
+                                break;
                         }
                     }
 
-                    for (auto &parsedFile : updates.updatedFileIndexes) {
-                        auto ast = pipeline::indexOne(this->config->opts, gs, parsedFile.file);
-                        if (ast.tree != nullptr) {
-                            updates.updatedFinalGSFileIndexes.emplace_back(std::move(ast));
-                        }
-                    }
-                }
-
-                break;
-            }
-        }
-
-        // Before making preemption or cancelation possible, pre-commit the changes from this slow path so that
-        // preempted queries can use them and the code after this lambda can assume that this step happened.
-        updates.updatedGS = move(finalGS);
-        commitFileUpdates(updates, cancelable);
-        // We use `gs` rather than the moved `finalGS` from this point forward.
-
-        // Copy the indexes of unchanged files.
-        vector<ast::ParsedFile> indexedCopies;
-        {
-            auto result = copyIndexed(workers);
-            if (!result.hasResult()) {
-                // Canceled.
-                return;
-            }
-            indexedCopies = std::move(result.result());
-        }
-
-        ENFORCE(gs->lspQuery.isEmpty());
-
-        // Test-only hook: Stall for as long as `slowPathBlocked` is set.
-        {
-            absl::MutexLock lck(&slowPathBlockedMutex);
-            slowPathBlockedMutex.Await(absl::Condition(
-                +[](bool *slowPathBlocked) -> bool { return !*slowPathBlocked; }, &slowPathBlocked));
-        }
-
-        if (gs->sleepInSlowPathSeconds.has_value()) {
-            auto sleepDuration = gs->sleepInSlowPathSeconds.value();
-            for (int i = 0; i < sleepDuration * 10; i++) {
-                Timer::timedSleep(100ms, *logger, "slow_path.resolve.sleep");
-                if (epochManager.wasTypecheckingCanceled()) {
                     break;
                 }
             }
+
+            // Before making preemption or cancelation possible, pre-commit the changes from this slow path so that
+            // preempted queries can use them and the code after this lambda can assume that this step happened.
+            updates.updatedGS = move(finalGS);
+            commitFileUpdates(updates, cancelable);
+
+            // IMPORTANT: We use `this->gs` rather than the moved `finalGS` from this point forward.
+
+            ENFORCE(gs->lspQuery.isEmpty());
+
+            // Test-only hook: Stall for as long as `slowPathBlocked` is set.
+            {
+                absl::MutexLock lck(&slowPathBlockedMutex);
+                slowPathBlockedMutex.Await(absl::Condition(
+                    +[](bool *slowPathBlocked) -> bool { return !*slowPathBlocked; }, &slowPathBlocked));
+            }
+
+            if (gs->sleepInSlowPathSeconds.has_value()) {
+                auto sleepDuration = gs->sleepInSlowPathSeconds.value();
+                for (int i = 0; i < sleepDuration * 10; i++) {
+                    Timer::timedSleep(100ms, *logger, "slow_path.resolve.sleep");
+                    if (epochManager.wasTypecheckingCanceled()) {
+                        break;
+                    }
+                }
+            }
+
+            {
+                Timer timeit(config->logger, "reIndexFromFileSystem");
+
+                std::unique_ptr<const OwnedKeyValueStore> ownedKvstore =
+                    cache::ownIfUnchanged(*this->gs, std::move(kvstore));
+
+                auto workspaceFilesSpan = absl::MakeSpan(this->workspaceFiles);
+                if (this->config->opts.stripePackages) {
+                    auto numPackageFiles = pipeline::partitionPackageFiles(*this->gs, workspaceFilesSpan);
+                    auto inputPackageFiles = workspaceFilesSpan.first(numPackageFiles);
+                    workspaceFilesSpan = workspaceFilesSpan.subspan(numPackageFiles);
+
+                    {
+                        auto result = hashing::Hashing::indexAndComputeFileHashes(
+                            *this->gs, this->config->opts, *this->config->logger, inputPackageFiles, workers,
+                            ownedKvstore, cancelable);
+                        if (!result.hasResult()) {
+                            return;
+                        }
+                        indexed = std::move(result.result());
+                    }
+
+                    // Only write the cache during initialization to avoid unbounded growth.
+                    if (mode == SlowPathMode::Init) {
+                        // Cache these before any pipeline::package rewrites, so that the cache is still
+                        // usable regardless of whether `--stripe-packages` was passed.
+                        // Want to keep the kvstore around so we can still write to it later.
+                        ownedKvstore = cache::ownIfUnchanged(
+                            *this->gs,
+                            cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(std::move(ownedKvstore)),
+                                                                 this->config->opts, *this->gs, workers, indexed));
+                    }
+
+                    // First run: only the __package.rb files. This populates the packageDB
+                    pipeline::buildPackageDB(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers);
+                }
+
+                {
+                    auto result = hashing::Hashing::indexAndComputeFileHashes(*this->gs, this->config->opts,
+                                                                              *this->config->logger, workspaceFilesSpan,
+                                                                              workers, ownedKvstore, cancelable);
+                    if (!result.hasResult()) {
+                        ast::ParsedFilesOrCancelled::cancel(std::move(indexed), workers);
+                        return;
+                    }
+                    nonPackagedIndexed = std::move(result.result());
+                }
+
+                // Only write the cache during initialization to avoid unbounded growth.
+                if (mode == SlowPathMode::Init) {
+                    // Cache these before any pipeline::package rewrites, so that the cache is still usable
+                    // regardless of whether `--stripe-packages` was passed.
+                    ownedKvstore = cache::ownIfUnchanged(
+                        *this->gs, cache::maybeCacheGlobalStateAndFiles(
+                                       OwnedKeyValueStore::abort(std::move(ownedKvstore)), this->config->opts,
+                                       *this->gs, workers, nonPackagedIndexed));
+                }
+
+                // Second run: all the other files (the packageDB shouldn't change)
+                pipeline::validatePackagedFiles(*this->gs, absl::MakeSpan(nonPackagedIndexed), this->config->opts,
+                                                workers);
+
+                if (mode == SlowPathMode::Init) {
+                    Timer timeit(config->logger, "copy_state");
+
+                    // At this point this->gs has a name table that's initialized enough for the indexer thread, so we
+                    // make a copy to pass back over.
+                    indexedState = this->gs->deepCopy();
+                    indexedState->errorQueue = std::move(savedErrorQueue);
+
+                    this->sessionCache =
+                        cache::SessionCache::make(std::move(ownedKvstore), *this->config->logger, this->config->opts);
+
+                    this->initialized = true;
+                } else {
+                    // We don't need to hold on to the saved error queue.
+                    // We were only holding onto it for the Init case, so that we could give a GlobalState
+                    // back to the indexer thread (with an ErrorQueue owned by that thread).
+                    savedErrorQueue.reset();
+
+                    // We don't write in the cancelable slow path, and all our read operations have completed.
+                    OwnedKeyValueStore::abort(std::move(ownedKvstore));
+                }
+            }
+        } // Indexing is done at this point
+
+        if (epochManager.wasTypecheckingCanceled()) {
+            return;
         }
 
-        // TODO(jez) Splitting this like how the pipeline intersperses this with indexing is going
-        // to take more work. Punting for now.
-        pipeline::package(*gs, absl::Span<ast::ParsedFile>(indexedCopies), config->opts, workers);
+        if (this->config->opts.stripePackages) {
+            // Only need to compute FoundDefHashes when running to compute a FileHash
+            auto foundHashes = nullptr;
+            auto cancelled =
+                pipeline::name(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers, foundHashes);
+            if (cancelled) {
+                ast::ParsedFilesOrCancelled::cancel(move(indexed), workers);
+                ast::ParsedFilesOrCancelled::cancel(move(nonPackagedIndexed), workers);
+                return;
+            }
+        }
 
         // Only need to compute FoundDefHashes when running to compute a FileHash
         auto foundHashes = nullptr;
         auto canceled =
-            pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexedCopies), config->opts, workers, foundHashes);
+            pipeline::name(*gs, absl::Span<ast::ParsedFile>(nonPackagedIndexed), config->opts, workers, foundHashes);
         if (canceled) {
-            ast::ParsedFilesOrCancelled::cancel(move(indexedCopies), workers);
+            ast::ParsedFilesOrCancelled::cancel(move(indexed), workers);
+            ast::ParsedFilesOrCancelled::cancel(move(nonPackagedIndexed), workers);
             return;
         }
 
-        auto maybeResolved = pipeline::resolve(*gs, move(indexedCopies), config->opts, workers);
+        pipeline::unpartitionPackageFiles(indexed, std::move(nonPackagedIndexed));
+        // TODO(jez) At this point, it's not correct to call it `indexed` anymore: we've run namer too
+
+        auto maybeResolved = pipeline::resolve(*gs, move(indexed), config->opts, workers);
         if (!maybeResolved.hasResult()) {
             return;
         }
@@ -606,7 +622,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
         // Eagerly restore the state to how it was before this slow path, so that we're not holding the old state for an
         // arbitrarily long time. The next update will be responsible for freeing the underlying UndoState after it
         // makes use of the epoch field to determine additional files to include in the edit.
-        cancellationUndoState->restore(gs, indexed, indexedFinalGS);
+        cancellationUndoState->restore(this->gs, this->indexedFinalGS);
         ENFORCE(cancelable);
         logger->debug("[Typechecker] Typecheck run for epoch {} was canceled.", updates.epoch);
     }
@@ -627,53 +643,26 @@ void LSPTypechecker::commitFileUpdates(LSPFileUpdates &updates, bool couldBeCanc
     ENFORCE(!(updates.typecheckingPath == TypecheckingPath::Fast && couldBeCanceled));
     if (couldBeCanceled) {
         ENFORCE(updates.updatedGS.has_value());
-        cancellationUndoState = make_unique<UndoState>(move(gs), std::move(indexedFinalGS), updates.epoch);
+        cancellationUndoState =
+            make_unique<UndoState>(std::move(this->gs), std::move(this->indexedFinalGS), updates.epoch);
     }
+
+    // Both the fast and slow path clear these vectors out before we see a call to this method.
+    ENFORCE(updates.updatedFileIndexes.empty());
+    ENFORCE(updates.updatedFiles.empty());
 
     // Clear out state associated with old finalGS.
     if (updates.typecheckingPath != TypecheckingPath::Fast) {
-        indexedFinalGS.clear();
-    }
-
-    ENFORCE(updates.updatedFileIndexes.size() == updates.updatedFiles.size());
-    for (auto &ast : updates.updatedFileIndexes) {
-        const int id = ast.file.id();
-
-        DEBUG_ONLY({
-            // When typechecking on the fast path, the trees in `updatedFileIndexes` will have been indexed with the
-            // GlobalState that's owned by the indexer and not `this->gs`. As we will be moving those trees into
-            // `this->indexed`, we need to ensure that there is also a version of that tree in the
-            // `this->indexedFinalGS` map that acts as an overlay for `this->indexed`. Ensuring that the overlay is
-            // correctly populated is what allows us to hold on to the indexer's version of the tree for the next
-            // slow path, but also handle fast path requests for modified files.
-            if (updates.typecheckingPath == TypecheckingPath::Fast) {
-                // We don't support package files on the fast path, so package files won't have a tree indexed with
-                // `this->gs` present in `updatedFinalGSFileIndexes`.
-                if (!ast.file.data(*this->gs).isPackage(*gs)) {
-                    auto indexedForTypechecker = absl::c_any_of(
-                        updates.updatedFinalGSFileIndexes, [id](auto &updated) { return updated.file.id() == id; });
-                    ENFORCE(indexedForTypechecker);
-                }
-            }
-        });
-
-        if (id >= indexed.size()) {
-            indexed.resize(id + 1);
-        }
-        if (cancellationUndoState != nullptr) {
-            // Move the evicted values before they get replaced.
-            cancellationUndoState->recordEvictedState(move(indexed[id]));
-        }
-        indexed[id] = move(ast);
+        this->indexedFinalGS.clear();
     }
 
     for (auto &ast : updates.updatedFinalGSFileIndexes) {
-        indexedFinalGS[ast.file.id()] = move(ast);
+        this->indexedFinalGS[ast.file.id()] = move(ast);
     }
 
     if (updates.updatedGS.has_value()) {
         ENFORCE(updates.typecheckingPath != TypecheckingPath::Fast);
-        gs = move(updates.updatedGS.value());
+        this->gs = move(updates.updatedGS.value());
     } else {
         ENFORCE(updates.typecheckingPath == TypecheckingPath::Fast);
     }
@@ -749,11 +738,8 @@ std::unique_ptr<LSPFileUpdates> LSPTypechecker::getNoopUpdate(std::vector<core::
     noop.epoch = 0;
     for (auto fref : frefs) {
         ENFORCE(fref.exists());
-        ENFORCE(fref.id() < indexed.size());
-        auto &index = indexed[fref.id()];
-
         // Note: `index.tree` can be null if the file is a stdlib file.
-        noop.updatedFileIndexes.push_back({(index.tree ? index.tree.deepCopy() : nullptr), index.file});
+        noop.updatedFileIndexes.emplace_back(this->getIndexed(fref));
         noop.updatedFiles.push_back(gs->getFiles()[fref.id()]);
     }
     return result;
@@ -775,10 +761,34 @@ ast::ExpressionPtr LSPTypechecker::getLocalVarTrees(core::FileRef fref) const {
     return local_vars::LocalVars::run(*gs, {move(afterDesugar), fref}).tree;
 }
 
+ast::ParsedFile LSPTypechecker::getIndexed(core::FileRef fref) const {
+    const auto id = fref.id();
+    auto treeFinalGS = this->indexedFinalGS.find(id);
+    if (treeFinalGS != this->indexedFinalGS.end()) {
+        auto &indexed = treeFinalGS->second;
+        if (indexed.tree) {
+            return ast::ParsedFile{indexed.tree.deepCopy(), indexed.file};
+        }
+    }
+
+    ENFORCE(id < this->gs->filesUsed());
+    return pipeline::indexOne(this->config->opts, *this->gs, fref);
+}
+
+std::unique_ptr<KeyValueStore> LSPTypechecker::getKvStore() const {
+    if (this->sessionCache == nullptr) {
+        return nullptr;
+    }
+
+    return this->sessionCache->open(this->config->logger, this->config->opts);
+}
+
 vector<ast::ParsedFile> LSPTypechecker::getResolved(absl::Span<const core::FileRef> frefs, WorkerPool &workers) const {
     ENFORCE(this_thread::get_id() == typecheckerThreadId, "Typechecker can only be used from the typechecker thread.");
     vector<ast::ParsedFile> updatedIndexed;
 
+    std::vector<core::FileRef> toIndex;
+    toIndex.reserve(frefs.size());
     for (auto fref : frefs) {
         const auto id = fref.id();
         auto treeFinalGS = this->indexedFinalGS.find(id);
@@ -788,12 +798,21 @@ vector<ast::ParsedFile> LSPTypechecker::getResolved(absl::Span<const core::FileR
                 updatedIndexed.emplace_back(ast::ParsedFile{indexed.tree.deepCopy(), indexed.file});
             }
         } else {
-            ENFORCE(id < this->indexed.size());
-            auto &indexed = this->indexed[id];
-            if (indexed.tree) {
-                updatedIndexed.emplace_back(ast::ParsedFile{indexed.tree.deepCopy(), indexed.file});
-            }
+            ENFORCE(id < this->gs->filesUsed());
+            toIndex.emplace_back(fref);
         }
+    }
+
+    if (!toIndex.empty()) {
+        auto cancelable = false;
+        auto kvstore = std::make_unique<OwnedKeyValueStore>(this->getKvStore());
+        auto result = pipeline::index(*this->gs, toIndex, this->config->opts, workers, std::move(kvstore), cancelable);
+        ENFORCE(result.hasResult());
+        auto indexed = std::move(result.result());
+        indexed.erase(
+            std::remove_if(indexed.begin(), indexed.end(), [](auto &indexed) { return indexed.tree == nullptr; }),
+            indexed.end());
+        absl::c_move(std::move(indexed), std::back_inserter(updatedIndexed));
     }
 
     // There are two incrementalResolve modes: one when running for the purpose of processing a file update,

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -502,6 +502,11 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                     indexedState = this->gs->deepCopy();
                     indexedState->errorQueue = std::move(savedErrorQueue);
 
+                    // We need to ensure that the package DB we build up during indexing isn't accidentaly persisted in
+                    // the indexer, as that would feed it back into all subsequent slow path runs and prevent any
+                    // deletions to the package db structure.
+                    indexedState->packageDB() = indexedState->packageDB().copyOptionsOnly();
+
                     this->sessionCache =
                         cache::SessionCache::make(std::move(ownedKvstore), *this->config->logger, this->config->opts);
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -11,6 +11,7 @@
 namespace sorbet {
 class WorkerPool;
 class KeyValueStore;
+class OwnedKeyValueStore;
 } // namespace sorbet
 
 namespace sorbet::core::lsp {
@@ -105,8 +106,9 @@ class LSPTypechecker final {
 
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */
-    SlowPathResult runSlowPath(LSPFileUpdates &updates, std::unique_ptr<KeyValueStore> kvstore, WorkerPool &workers,
-                               std::shared_ptr<core::ErrorFlusher> errorFlusher, SlowPathMode mode);
+    SlowPathResult runSlowPath(LSPFileUpdates &updates, std::unique_ptr<const OwnedKeyValueStore> ownedKvstore,
+                               WorkerPool &workers, std::shared_ptr<core::ErrorFlusher> errorFlusher,
+                               SlowPathMode mode);
 
     /** Runs incremental typechecking on the provided updates. Returns the final list of files typechecked. */
     std::vector<core::FileRef> runFastPath(LSPFileUpdates &updates, WorkerPool &workers,
@@ -126,7 +128,7 @@ class LSPTypechecker final {
     /**
      * Open the session-local kvstore.
      */
-    std::unique_ptr<KeyValueStore> getKvStore() const;
+    std::unique_ptr<OwnedKeyValueStore> getKvStore() const;
 
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -18,6 +18,10 @@ class PreemptionTaskManager;
 class QueryResponse;
 } // namespace sorbet::core::lsp
 
+namespace sorbet::realmain::cache {
+class SessionCache;
+}
+
 namespace sorbet::realmain::lsp {
 class ResponseError;
 class InitializedTask;
@@ -45,23 +49,18 @@ class LSPTypechecker final {
      * GlobalState back over to the typechecker to use as the starting point for the next slow path.
      */
     std::unique_ptr<core::GlobalState> gs;
+
     /**
-     * Trees that have been indexed with the GlobalState that was originally supplied during initialization
-     * (initialGS). As all values of this->gs will derive from that initial GlobalState, none of these trees will be
-     * re-indexed for subsequent slow path runs. An additional consequence of this->gs deriving from the initialization
-     * value of GlobalState is that they will continue to be valid when used with this->gs (see the comment on this->gs
-     * for an explanation of how this derivation is ensured).
-     *
-     * WARNING:
-     * Updates to this vector can happen through this->commitFileUpdates and LSPFileUpdates::updatedFileIndexes, however
-     * those updates will only be valid when used with the indexer's GlobalState. As a result it is absolutely necessary
-     * to ensure that any updates to this vector are either already valid with this->gs, or have a corresponding tree in
-     * this->indexedFinalGS, as otherwise there is a possibility that the tree used will reference names that aren't
-     * consistent with this->gs. Once a slow path is kicked off this problem will resolve itself, as this->gs will be
-     * re-initialized with a copy of the indexer's GlobalState, making all of the names stored in the trees of
-     * this->indexed valid again.
+     * A copy of the kvstore produced during initialization, that's private to this LSP session.
      */
-    std::vector<ast::ParsedFile> indexed;
+    std::unique_ptr<cache::SessionCache> sessionCache;
+
+    /**
+     * A vector of file refs that we clear and reuse on slow paths. It's held here instead of as a temporary in the slow
+     * path to ensure we're not aggressively reallocating memory.
+     */
+    std::vector<core::FileRef> workspaceFiles;
+
     /**
      * Trees that have been indexed with this->gs between slow path runs, which means that they may have names that are
      * not present in the name table of the indexer. This is a sparse diff of trees indexed by position in
@@ -117,9 +116,17 @@ class LSPTypechecker final {
     /** Commits the given file updates to LSPTypechecker. Does not send diagnostics. */
     void commitFileUpdates(LSPFileUpdates &updates, bool couldBeCanceled);
 
-    /** Deep copy all entries in `indexed` that contain ASTs. Returns true on success, false if the operation was
-     * canceled. */
-    ast::ParsedFilesOrCancelled copyIndexed(WorkerPool &workers) const;
+    /**
+     * Returns a the indexed tree for the given file ref. The associated tree may be `nullptr` if the file ref given
+     * points to a payload RBI. This function will first consult the `this->indexedFinalGS` cache before falling back on
+     * re-indexing the file on disk.
+     */
+    ast::ParsedFile getIndexed(core::FileRef fref) const;
+
+    /**
+     * Open the session-local kvstore.
+     */
+    std::unique_ptr<KeyValueStore> getKvStore() const;
 
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,
@@ -162,7 +169,8 @@ public:
     ast::ExpressionPtr getLocalVarTrees(core::FileRef fref) const;
 
     /**
-     * Returns copies of the indexed trees that have been run through the incremental resolver.
+     * Returns copies of the indexed trees that have been run through the incremental resolver. There is no guarantee
+     * that the resolved trees are returned in the same order that the FileRefs appear in the input span.
      */
     std::vector<ast::ParsedFile> getResolved(absl::Span<const core::FileRef> frefs, WorkerPool &workers) const;
 

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -12,26 +12,7 @@ UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, 
                      uint32_t epoch)
     : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)), epoch(epoch) {}
 
-void UndoState::recordEvictedState(ast::ParsedFile evictedIndexTree) {
-    const auto id = evictedIndexTree.file.id();
-    // The first time a file gets evicted, it's an index tree from the old global state.
-    // Subsequent times it is evicting old index trees from the new global state, and we don't care.
-    // Also, ignore updates to new files (id >= size of file table)
-    if (id < evictedGs->getFiles().size() && !evictedIndexed.contains(id)) {
-        evictedIndexed[id] = move(evictedIndexTree);
-    }
-}
-
-void UndoState::restore(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> &indexed,
-                        UnorderedMap<int, ast::ParsedFile> &indexedFinalGS) {
-    // We should never apply this twice, as that would end up dropping the other GlobalState
-    ENFORCE(this->evictedGs != nullptr);
-
-    // Replace evicted index trees.
-    for (auto &entry : evictedIndexed) {
-        indexed[entry.first] = move(entry.second);
-    }
-
+void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS) {
     indexedFinalGS = std::move(evictedIndexedFinalGS);
     gs = move(evictedGs);
 }

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -15,8 +15,6 @@ class UndoState final {
     // Stores the pre-slow-path global state.
     std::unique_ptr<core::GlobalState> evictedGs;
     // Stores index trees containing data stored in `gs` that have been evicted during the slow path operation.
-    UnorderedMap<int, ast::ParsedFile> evictedIndexed;
-    // Stores the index trees stored in `gs` that were evicted because the slow path operation replaced `gs`.
     UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
 
 public:
@@ -27,15 +25,9 @@ public:
               uint32_t epoch);
 
     /**
-     * Records that the given items were evicted from LSPTypechecker following a typecheck run.
-     */
-    void recordEvictedState(ast::ParsedFile evictedIndexTree);
-
-    /**
      * Undoes the slow path changes represented by this class.
      */
-    void restore(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> &indexed,
-                 UnorderedMap<int, ast::ParsedFile> &indexedFinalGS);
+    void restore(std::unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS);
 
     /**
      * Retrieves the evicted global state.

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -176,6 +176,14 @@ unique_ptr<LSPMessage> makeDefinitionRequest(int id, std::string_view uri, int l
                                                 make_unique<Position>(line, character))));
 }
 
+unique_ptr<LSPMessage> makeReferenceRequest(int id, std::string_view uri, int line, int character, bool includeDecl) {
+    return make_unique<LSPMessage>(
+        make_unique<RequestMessage>("2.0", id, LSPMethod::TextDocumentReferences,
+                                    make_unique<ReferenceParams>(make_unique<TextDocumentIdentifier>(string(uri)),
+                                                                 make_unique<Position>(line, character),
+                                                                 make_unique<ReferenceContext>(includeDecl))));
+}
+
 unique_ptr<LSPMessage> makeHover(int id, std::string_view uri, int line, int character) {
     return make_unique<LSPMessage>(make_unique<RequestMessage>(
         "2.0", id, LSPMethod::TextDocumentHover,

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -47,6 +47,10 @@ std::unique_ptr<LSPMessage> makeClose(std::string_view uri);
 /** Create an LSPMessage containing a workspace/didChangeConfiguration notification */
 std::unique_ptr<LSPMessage> makeConfigurationChange(std::unique_ptr<DidChangeConfigurationParams> params);
 
+/** Create an LSPMessage containing a textDocument/references notification */
+std::unique_ptr<LSPMessage> makeReferenceRequest(int id, std::string_view uri, int line, int character,
+                                                 bool includeDecl = true);
+
 /** Checks that we are properly advertising Sorbet LSP's capabilities to clients. */
 void checkServerCapabilities(const ServerCapabilities &capabilities);
 

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -69,6 +69,8 @@ protected:
 
     std::unique_ptr<LSPMessage> getDefinition(std::string_view path, int line, int character);
 
+    std::unique_ptr<LSPMessage> getReference(std::string_view path, int line, int character);
+
     std::unique_ptr<LSPMessage> hover(std::string_view path, int line, int character);
 
     std::unique_ptr<LSPMessage> codeAction(std::string_view path, int line, int character);
@@ -104,6 +106,7 @@ protected:
     std::string readFile(std::string_view uri);
 
     std::vector<std::unique_ptr<Location>> getDefinitions(std::string_view uri, int line, int character);
+    std::vector<std::unique_ptr<Location>> getReferences(std::string_view uri, int line, int character);
 
     /**
      * ProtocolTest maintains the latest diagnostics for files received over a session, as LSP is not required to

--- a/website/docs/lsp.md
+++ b/website/docs/lsp.md
@@ -124,6 +124,15 @@ A short list of useful LSP-related command line flags:
   [Including and excluding files](cli.md#including-and-excluding-files) or
   `srb tc --help` for more information.
 
+- `--cache-dir=...`
+
+  When an edit causes Sorbet to
+  [retypecheck the whole workspace](server-status#why-do-some-of-my-edits-make-sorbet-go-back-to-typechecking),
+  supplying a cache directory with the
+  [`--cache-dir`](cli#--cache-dir-caching-parse-results) flag allows it to avoid
+  reindexing files that haven't changed. This improves performance, shortening
+  the duration of that slow path operation.
+
 - `--disable-watchman` / `--watchman-path=...`
 
   Configure whether or how the `watchman` binary is invoked.

--- a/website/docs/server-status.md
+++ b/website/docs/server-status.md
@@ -86,9 +86,10 @@ below.)
 Sorbet is currently reading files from disk and parsing them into abstract
 syntax trees.
 
-This operation only happens when Sorbet initially starts up in LSP mode for the
-first time. If this operation is taking a long time, it can be sped up by
-passing the [`--cache-dir`](cli.md#--cache-dir-caching-parse-results) flag.
+This operation happens when Sorbet determines it needs to
+[retypecheck the whole codebase](server-status#why-do-some-of-my-edits-make-sorbet-go-back-to-typechecking).
+If this operation is taking a long time, it can be sped up by passing the
+[`--cache-dir`](cli.md#--cache-dir-caching-parse-results) flag.
 
 ### Typechecking...
 


### PR DESCRIPTION
Reapply the reindexing changes, after fixing two bugs that showed up during the initial rollout.

1. The `getKvStore` function could potentially return `nullptr` if sorbet was started without a `--cache-dir` flag, but there was a direct use of it as the argument to the constructor of `OwnedKeyValueStore`, which assumes it's never `nullptr`. The solution here was to change `getKvStore`'s return type to `OwnedKeyValueStore`, as that allows us to centralize the error checking.
2. The package database created during the indexing pass of initialization was being persisted through the indexer's copy of the `GlobalState`, which meant that subsequent slow paths that modify the package database by deleting information would never see those changes take effect. As a result, deleting a `__package.rb` file would mean that we would generate autocorrects for that file based on stale metadata, and trigger an ENFORCE when translating those stale locs to offsets in the now empty file.

I would suggest ignoring the first commit, as it's the re-applied squash commit of the original reindexing PR #8589.

### Motivation
Fixing issues with the rollout of slow-path reindexing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
