### PR TITLE
Fix parsed location for `defined?` token

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1062,8 +1062,15 @@ public:
         return make_unique<Break>(loc, std::move(args));
     }
 
-    unique_ptr<Node> keywordDefined(const token *keyword, unique_ptr<Node> arg) {
-        return make_unique<Defined>(tokLoc(keyword).join(arg->loc), std::move(arg));
+    unique_ptr<Node> keywordDefined(const token *keyword, const token *lparen, unique_ptr<Node> arg,
+                                    const token *rparen) {
+        auto loc = tokLoc(keyword);
+        if (rparen != nullptr) {
+            loc = loc.join(tokLoc(rparen));
+        } else {
+            loc = loc.join(arg->loc);
+        }
+        return make_unique<Defined>(loc, std::move(arg));
     }
 
     unique_ptr<Node> keywordNext(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
@@ -2296,9 +2303,10 @@ ForeignPtr keywordBreak(SelfPtr builder, const token *keyword, const token *lpar
     return build->toForeign(build->keywordBreak(keyword, lparen, build->convertNodeList(args), rparen));
 }
 
-ForeignPtr keywordDefined(SelfPtr builder, const token *keyword, ForeignPtr arg) {
+ForeignPtr keywordDefined(SelfPtr builder, const token *keyword, const token *lparen, ForeignPtr arg,
+                          const token *rparen) {
     auto build = cast_builder(builder);
-    return build->toForeign(build->keywordDefined(keyword, build->cast_node(arg)));
+    return build->toForeign(build->keywordDefined(keyword, lparen, build->cast_node(arg), rparen));
 }
 
 ForeignPtr keywordNext(SelfPtr builder, const token *keyword, const token *lparen, const node_list *args,

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1710,7 +1710,7 @@ lbrace_cmd_block_start:
                   arg
                     {
                       driver.lex.context.inDefined = false;
-                      $$ = driver.build.keywordDefined(self, $1, $4);
+                      $$ = driver.build.keywordDefined(self, $1, nullptr, $4, nullptr);
                     }
                 | arg tEH arg opt_nl tCOLON arg
                     {
@@ -2116,7 +2116,7 @@ array_premature_end: eof
                   expr rparen
                     {
                       driver.lex.context.inDefined = false;
-                      $$ = driver.build.keywordDefined(self, $1, $5);
+                      $$ = driver.build.keywordDefined(self, $1, $3, $5, $6);
                     }
 
                 | kNOT tLPAREN2 expr rparen

--- a/parser/parser/include/ruby_parser/builder.hh
+++ b/parser/parser/include/ruby_parser/builder.hh
@@ -102,7 +102,8 @@ struct builder {
     ForeignPtr (*ivar)(SelfPtr builder, const token *tok);
     ForeignPtr (*keywordBreak)(SelfPtr builder, const token *keyword, const token *lparen, const node_list *args,
                                const token *rparen);
-    ForeignPtr (*keywordDefined)(SelfPtr builder, const token *keyword, ForeignPtr arg);
+    ForeignPtr (*keywordDefined)(SelfPtr builder, const token *keyword, const token *lparen, ForeignPtr arg,
+                                 const token *rparen);
     ForeignPtr (*keywordNext)(SelfPtr builder, const token *keyword, const token *lparen, const node_list *args,
                               const token *rparen);
     ForeignPtr (*keywordRedo)(SelfPtr builder, const token *keyword);


### PR DESCRIPTION
### Motivation

While working on a PR that is exposing the location of some tokens I noticed the one for `defined?` was mangled when using parenthesis:

```rb
# good:
   defined? A
#  ^^^^^^^^^^

# bad:
   defined?(A)
#  ^^^^^^^^^^
```

This is because we only consider the argument and not the location of the closing parenthesis if any.

I changed the parser to we properly set the end position using the parenthesis if any

### Test plan

I couldn't figure how to test that the location is correct. Looks like we do not have tests for token locations?

I though about using a pipeline test for it but the way we desugar it makes it difficult:

```rb
def foo; end
foo(defined?(A))
           # ^ error: Too many arguments provided for method `Object#foo`
```

Should I also fix this location in the desugar?