### PR TITLE
Fix formatting of class interface error

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1218,7 +1218,7 @@ private:
             symbolData->flags.isInterface = true;
             if (!symbolData->isModule()) {
                 if (auto e = ctx.beginError(mod.loc, core::errors::Namer::InterfaceClass)) {
-                    e.setHeader("Classes can't be interfaces. Use `abstract!` instead of `interface!`");
+                    e.setHeader("Classes can't be interfaces. Use `{}` instead of `{}`", "abstract!", "interface!");
                     e.replaceWith("Change `interface!` to `abstract!`", ctx.locAt(mod.loc), "abstract!");
                 }
             }

--- a/test/testdata/namer/interface_class.rb
+++ b/test/testdata/namer/interface_class.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class Foo
+  extend T::Helpers
+
+  interface!
+# ^^^^^^^^^^ error: Classes can't be interfaces. Use `abstract!` instead of `interface!`
+end


### PR DESCRIPTION
### Motivation

The method names are not highlighted properly:

Before ([sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Foo%0A%20%20extend%20T%3A%3AHelpers%0A%0A%20%20interface!%0Aend)):

<img width="708" alt="image" src="https://github.com/user-attachments/assets/fd0eea1b-1a66-4594-9a05-b4b01cbd0a28" />

After:

<img width="694" alt="image" src="https://github.com/user-attachments/assets/6c29bbdf-3a86-4781-ba78-3646f6e814d5" />


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
