### PR TITLE
Stop sending indexed trees to the typechecker

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -11,25 +11,18 @@ void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
     cancellationExpected = cancellationExpected || older.cancellationExpected;
     preemptionsExpected += older.preemptionsExpected;
 
-    ENFORCE(updatedFiles.size() == updatedFileIndexes.size());
-    ENFORCE(older.updatedFiles.size() == older.updatedFileIndexes.size());
-
     // For updates, we prioritize _newer_ updates.
     UnorderedSet<string> encountered;
     for (auto &f : updatedFiles) {
         encountered.emplace(f->path());
     }
 
-    int i = -1;
     for (auto &f : older.updatedFiles) {
-        i++;
         if (encountered.contains(f->path())) {
             continue;
         }
         encountered.emplace(f->path());
         updatedFiles.push_back(f);
-        auto &ast = older.updatedFileIndexes[i];
-        updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
     }
     typecheckingPath = TypecheckingPath::Slow;
 }
@@ -44,9 +37,6 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     copy.updatedFiles = updatedFiles;
     copy.cancellationExpected = cancellationExpected;
     copy.preemptionsExpected = preemptionsExpected;
-    for (auto &ast : updatedFileIndexes) {
-        copy.updatedFileIndexes.push_back(ast::ParsedFile{ast.tree.deepCopy(), ast.file});
-    }
     return copy;
 }
 

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -22,9 +22,6 @@ public:
 
     std::vector<std::shared_ptr<core::File>> updatedFiles;
 
-    // Indexed versions of `updatedFiles`, tied to the `initialGS` global state in the indexer.
-    std::vector<ast::ParsedFile> updatedFileIndexes;
-
     TypecheckingPath typecheckingPath = TypecheckingPath::Slow;
 
     // Indicates whether or not the incremental namer should be used on the fast path.

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -338,11 +338,6 @@ std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams
         auto trees = hashing::Hashing::indexAndComputeFileHashes(*initialGS, config->opts, *config->logger,
                                                                  absl::Span<core::FileRef>(frefs), workers, kvstore);
         ENFORCE(trees.hasResult(), "The indexer thread doesn't support cancellation");
-        update.updatedFileIndexes.resize(trees.result().size());
-        for (auto &ast : trees.result()) {
-            const int i = fileToPos[ast.file];
-            update.updatedFileIndexes[i] = move(ast);
-        }
     }
 
     // _Now_ that we've computed file hashes, we can make a fast path determination.
@@ -368,8 +363,6 @@ std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams
             update.canceledSlowPath = true;
         }
     }
-
-    ENFORCE(update.updatedFiles.size() == update.updatedFileIndexes.size());
 
     if (update.canceledSlowPath) {
         // Merge diagnostic latency timers; this edit contains the previous slow path.

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -520,8 +520,8 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
             return;
         }
 
-        this->cacheOpenFiles(indexed, openFiles);
-        this->cacheOpenFiles(nonPackagedIndexed, openFiles);
+        this->cacheUpdatedFiles(indexed, openFiles);
+        this->cacheUpdatedFiles(nonPackagedIndexed, openFiles);
 
         // First run: only the __package.rb files. This populates the packageDB
         pipeline::buildPackageDB(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers);
@@ -639,8 +639,8 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
     }
 }
 
-void LSPTypechecker::cacheOpenFiles(absl::Span<const ast::ParsedFile> indexed,
-                                    const UnorderedSet<core::FileRef> &openFiles) {
+void LSPTypechecker::cacheUpdatedFiles(absl::Span<const ast::ParsedFile> indexed,
+                                       const UnorderedSet<core::FileRef> &openFiles) {
     auto &logger = *config->logger;
     Timer timeit(logger, "slow_path.cache_open_files");
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -131,8 +131,7 @@ class LSPTypechecker final {
      * Populate `this->indexedFinalGS` with copies of indexed trees from the `indexed` span, whose files are mentioned
      * in the `openFiles` vector.
      */
-    void cacheOpenFiles(absl::Span<const ast::ParsedFile> indexed, std::vector<core::FileRef> openFiles,
-                        WorkerPool &workers);
+    void cacheOpenFiles(absl::Span<const ast::ParsedFile> indexed, const UnorderedSet<core::FileRef> &openFiles);
 
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -131,7 +131,7 @@ class LSPTypechecker final {
      * Populate `this->indexedFinalGS` with copies of indexed trees from the `indexed` span, whose files are mentioned
      * in the `openFiles` vector.
      */
-    void cacheOpenFiles(absl::Span<const ast::ParsedFile> indexed, const UnorderedSet<core::FileRef> &openFiles);
+    void cacheUpdatedFiles(absl::Span<const ast::ParsedFile> indexed, const UnorderedSet<core::FileRef> &openFiles);
 
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -127,6 +127,13 @@ class LSPTypechecker final {
      */
     std::unique_ptr<OwnedKeyValueStore> getKvStore() const;
 
+    /**
+     * Populate `this->indexedFinalGS` with copies of indexed trees from the `indexed` span, whose files are mentioned
+     * in the `openFiles` vector.
+     */
+    void cacheOpenFiles(absl::Span<const ast::ParsedFile> indexed, std::vector<core::FileRef> openFiles,
+                        WorkerPool &workers);
+
 public:
     LSPTypechecker(std::shared_ptr<const LSPConfiguration> config,
                    std::shared_ptr<core::lsp::PreemptionTaskManager> preemptionTaskManager);


### PR DESCRIPTION
It's not necessary to send indexed trees to the typechecker thread now that we don't keep a cache of those trees for bootstrapping the slow path. Let's remove that field, and stop copying the trees to the typechecker thread.

This raises the question of what to do with the open files cache that the LSPTypechecker maintains, as we're no longer using the trees sent over by the indexer. One option would be to simply leave the tree empty and rely on the fast path to repopulate it. This would happen naturally as the file was edited, and as we'll be updating the cache anyway this is perhaps the best option.

This PR takes a different approach and instead explicitly populates the `indexedFinalGS` map with the indexed contents of the `LSPFileUpdate::updatedFiles` vector. I think this change is the most conservative right now as it better matches the current behavior, but it would be worth experimenting with not maintaining that map at all, and allowing the fast path to fill the cache back in.

### Motivation
Avoiding unnecessary tree copying in the indexer.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests
