### PR TITLE
Add RBS alternative to Sorbet class and module helpers

### DIFF
--- a/parser/helper.h
+++ b/parser/helper.h
@@ -189,6 +189,13 @@ public:
     }
 
     /*
+     * Create a `T::Helpers` constant node.
+     */
+    static std::unique_ptr<parser::Node> T_Helpers(core::LocOffsets loc) {
+        return Const(loc, T(loc), core::Names::Constants::Helpers());
+    }
+
+    /*
      * Create a `T::Set` constant node.
      */
     static std::unique_ptr<parser::Node> T_Set(core::LocOffsets loc) {

--- a/rbs/SignatureTranslator.cc
+++ b/rbs/SignatureTranslator.cc
@@ -37,8 +37,9 @@ SignatureTranslator::translateAssertionType(vector<std::pair<core::LocOffsets, c
     return typeToParserNode.toParserNode(rbsType, assertion.typeLoc);
 }
 
-unique_ptr<parser::Node> SignatureTranslator::translateType(const parser::Send *send, const rbs::Comment &signature,
-                                                            const vector<Comment> &annotations) {
+unique_ptr<parser::Node> SignatureTranslator::translateAttrSignature(const parser::Send *send,
+                                                                     const rbs::Comment &signature,
+                                                                     const vector<Comment> &annotations) {
     rbs_string_t rbsString = makeRBSString(signature.string);
     const rbs_encoding_t *encoding = &rbs_encodings[RBS_ENCODING_UTF_8];
 
@@ -68,9 +69,9 @@ unique_ptr<parser::Node> SignatureTranslator::translateType(const parser::Send *
     return methodTypeToParserNode.attrSignature(send, rbsType, signature.typeLoc, signature.commentLoc, annotations);
 }
 
-unique_ptr<parser::Node> SignatureTranslator::translateSignature(const parser::Node *methodDef,
-                                                                 const rbs::Comment &signature,
-                                                                 const vector<Comment> &annotations) {
+unique_ptr<parser::Node> SignatureTranslator::translateMethodSignature(const parser::Node *methodDef,
+                                                                       const rbs::Comment &signature,
+                                                                       const vector<Comment> &annotations) {
     rbs_string_t rbsString = makeRBSString(signature.string);
     const rbs_encoding_t *encoding = &rbs_encodings[RBS_ENCODING_UTF_8];
 

--- a/rbs/SignatureTranslator.h
+++ b/rbs/SignatureTranslator.h
@@ -16,10 +16,10 @@ public:
     translateAssertionType(std::vector<std::pair<core::LocOffsets, core::NameRef>> typeParams,
                            const rbs::Comment &assertion);
 
-    std::unique_ptr<parser::Node> translateType(const parser::Send *send, const rbs::Comment &signature,
-                                                const std::vector<Comment> &annotations);
-    std::unique_ptr<parser::Node> translateSignature(const parser::Node *methodDef, const rbs::Comment &signature,
-                                                     const std::vector<Comment> &annotations);
+    std::unique_ptr<parser::Node> translateAttrSignature(const parser::Send *send, const rbs::Comment &signature,
+                                                         const std::vector<Comment> &annotations);
+    std::unique_ptr<parser::Node> translateMethodSignature(const parser::Node *methodDef, const rbs::Comment &signature,
+                                                           const std::vector<Comment> &annotations);
 
 private:
     core::MutableContext ctx;

--- a/rbs/SignatureTranslator.h
+++ b/rbs/SignatureTranslator.h
@@ -21,6 +21,8 @@ public:
     std::unique_ptr<parser::Node> translateMethodSignature(const parser::Node *methodDef, const rbs::Comment &signature,
                                                            const std::vector<Comment> &annotations);
 
+    std::unique_ptr<parser::Node> translateType(core::LocOffsets loc, const std::string_view typeString);
+
 private:
     core::MutableContext ctx;
 };

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -176,11 +176,11 @@ unique_ptr<parser::NodeVec> signaturesForNode(core::MutableContext ctx, parser::
 
     for (auto &signature : comments.signatures) {
         if (parser::isa_node<parser::DefMethod>(node) || parser::isa_node<parser::DefS>(node)) {
-            auto sig = signatureTranslator.translateSignature(node, signature, comments.annotations);
+            auto sig = signatureTranslator.translateMethodSignature(node, signature, comments.annotations);
 
             signatures->emplace_back(move(sig));
         } else if (auto send = parser::cast_node<parser::Send>(node)) {
-            auto sig = signatureTranslator.translateType(send, signature, comments.annotations);
+            auto sig = signatureTranslator.translateAttrSignature(send, signature, comments.annotations);
             signatures->emplace_back(move(sig));
         } else {
             Exception::raise("Unimplemented node type: {}", node->nodeName());

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -246,12 +246,6 @@ parser::NodeVec extractHelpers(core::MutableContext ctx, vector<Comment> annotat
             auto send = parser::MK::Send0(annotation.typeLoc, parser::MK::Self(annotation.typeLoc),
                                           core::Names::declareSealed(), annotation.typeLoc);
             helpers.emplace_back(move(send));
-        } else if (absl::StartsWith(annotation.string, "mixes_in_class_methods:")) {
-            if (auto type = extractHelperArgument(ctx, annotation, 23)) {
-                auto send = parser::MK::Send1(annotation.typeLoc, parser::MK::Self(annotation.typeLoc),
-                                              core::Names::mixesInClassMethods(), annotation.typeLoc, move(type));
-                helpers.emplace_back(move(send));
-            }
         } else if (absl::StartsWith(annotation.string, "requires_ancestor:")) {
             if (auto type = extractHelperArgument(ctx, annotation, 18)) {
                 auto body = make_unique<parser::Begin>(annotation.typeLoc, parser::NodeVec());

--- a/rbs/SigsRewriter.h
+++ b/rbs/SigsRewriter.h
@@ -37,6 +37,7 @@ private:
     std::unique_ptr<parser::Node> rewriteBegin(std::unique_ptr<parser::Node> tree);
     std::unique_ptr<parser::Node> rewriteBody(std::unique_ptr<parser::Node> tree);
     std::unique_ptr<parser::Node> rewriteNode(std::unique_ptr<parser::Node> tree);
+    std::unique_ptr<parser::Node> rewriteClass(std::unique_ptr<parser::Node> tree);
     parser::NodeVec rewriteNodes(parser::NodeVec nodes);
 };
 

--- a/test/testdata/rbs/annotations_helpers.rb
+++ b/test/testdata/rbs/annotations_helpers.rb
@@ -1,0 +1,104 @@
+# typed: strict
+# enable-experimental-rbs-signatures: true
+
+# @abstract
+class Abstract1; end
+
+# @abstract
+class Abstract2
+  extend T::Helpers
+end
+
+# @abstract
+class Abstract3
+  extend ::T::Helpers
+end
+
+# @abstract
+# @abstract
+class Abstract4
+  extend ::T::Helpers
+  abstract!
+end
+
+# @abstract
+module Abstract5; end
+
+module Abstract6
+  # @abstract
+  class << self; end
+end
+
+# @interface
+#  ^^^^^^^^^ error: Classes can't be interfaces. Use `abstract!` instead of `interface!`
+class Interface1; end
+
+# @interface
+module Interface2
+  extend ::T::Helpers
+  interface!
+end
+
+module Interface3
+  # @interface
+  #  ^^^^^^^^^ error: Classes can't be interfaces. Use `abstract!` instead of `interface!`
+  class << self; end
+end
+
+# @final
+class Final1
+  # @final
+  module Final2
+    # @final
+    class << self; end
+  end
+end
+
+# @sealed
+class Sealed1
+  # @sealed
+  module Sealed2
+    # @sealed
+    class << self; end
+  end
+end
+
+# @abstract
+# @final
+class Multiple1
+  # @interface
+  # @final
+  module Multiple2
+    # @abstract
+    # @final
+    class << self; end
+  end
+end
+
+# @mixes_in_class_methods:
+#                         ^ error: Failed to parse RBS type (unexpected token for simple type)
+module MixesInClassMethods1; end
+
+# @mixes_in_class_methods: _
+#                          ^ error: Failed to parse RBS type (unexpected token for simple type)
+module MixesInClassMethods2; end
+
+# @mixes_in_class_methods: untyped
+#                          ^^^^^^^ error: Expected `Module` but found `Runtime object representing type: T.untyped` for argument `mod`
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Argument to `mixes_in_class_methods` must be statically resolvable to a module
+module MixesInClassMethods3; end
+
+# @mixes_in_class_methods: ClassMethods
+module ClassMethods1
+  module ClassMethods
+  end
+end
+
+# @mixes_in_class_methods: ClassMethods1::ClassMethods
+module ClassMethods2; end
+
+# @mixes_in_class_methods: ::ClassMethods1::ClassMethods
+module ClassMethods2; end
+
+# @requires_ancestor: BasicObject
+module RequiresAncestor1; end

--- a/test/testdata/rbs/annotations_helpers.rb
+++ b/test/testdata/rbs/annotations_helpers.rb
@@ -75,30 +75,11 @@ class Multiple1
   end
 end
 
-# @mixes_in_class_methods:
-#                         ^ error: Failed to parse RBS type (unexpected token for simple type)
-module MixesInClassMethods1; end
-
-# @mixes_in_class_methods: _
-#                          ^ error: Failed to parse RBS type (unexpected token for simple type)
-module MixesInClassMethods2; end
-
-# @mixes_in_class_methods: untyped
-#                          ^^^^^^^ error: Expected `Module` but found `Runtime object representing type: T.untyped` for argument `mod`
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Argument to `mixes_in_class_methods` must be statically resolvable to a module
-module MixesInClassMethods3; end
-
-# @mixes_in_class_methods: ClassMethods
-module ClassMethods1
-  module ClassMethods
-  end
-end
-
-# @mixes_in_class_methods: ClassMethods1::ClassMethods
-module ClassMethods2; end
-
-# @mixes_in_class_methods: ::ClassMethods1::ClassMethods
-module ClassMethods2; end
-
 # @requires_ancestor: BasicObject
 module RequiresAncestor1; end
+
+# @requires_ancestor: ::BasicObject
+module RequiresAncestor2; end
+
+# @requires_ancestor: Multiple1::Multiple2
+module RequiresAncestor3; end

--- a/test/testdata/rbs/annotations_helpers.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/annotations_helpers.rb.rewrite-tree.exp
@@ -123,44 +123,27 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.final!()
   end
 
-  module <emptyTree>::<C MixesInClassMethods1><<C <todo sym>>> < ()
-  end
-
-  module <emptyTree>::<C MixesInClassMethods2><<C <todo sym>>> < ()
-  end
-
-  module <emptyTree>::<C MixesInClassMethods3><<C <todo sym>>> < ()
-    <self>.extend(::<root>::<C T>::<C Helpers>)
-
-    <self>.mixes_in_class_methods(::<root>::<C T>.untyped())
-  end
-
-  module <emptyTree>::<C ClassMethods1><<C <todo sym>>> < ()
-    module <emptyTree>::<C ClassMethods><<C <todo sym>>> < ()
-    end
-
-    <self>.extend(::<root>::<C T>::<C Helpers>)
-
-    <self>.mixes_in_class_methods(<emptyTree>::<C ClassMethods>)
-  end
-
-  module <emptyTree>::<C ClassMethods2><<C <todo sym>>> < ()
-    <self>.extend(::<root>::<C T>::<C Helpers>)
-
-    <self>.mixes_in_class_methods(<emptyTree>::<C ClassMethods1>::<C ClassMethods>)
-  end
-
-  module <emptyTree>::<C ClassMethods2><<C <todo sym>>> < ()
-    <self>.extend(::<root>::<C T>::<C Helpers>)
-
-    <self>.mixes_in_class_methods(::<root>::<C ClassMethods1>::<C ClassMethods>)
-  end
-
   module <emptyTree>::<C RequiresAncestor1><<C <todo sym>>> < ()
     <self>.extend(::<root>::<C T>::<C Helpers>)
 
     <self>.requires_ancestor() do ||
       <emptyTree>::<C BasicObject>
+    end
+  end
+
+  module <emptyTree>::<C RequiresAncestor2><<C <todo sym>>> < ()
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.requires_ancestor() do ||
+      ::<root>::<C BasicObject>
+    end
+  end
+
+  module <emptyTree>::<C RequiresAncestor3><<C <todo sym>>> < ()
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.requires_ancestor() do ||
+      <emptyTree>::<C Multiple1>::<C Multiple2>
     end
   end
 end

--- a/test/testdata/rbs/annotations_helpers.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/annotations_helpers.rb.rewrite-tree.exp
@@ -1,0 +1,166 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Abstract1><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+  end
+
+  class <emptyTree>::<C Abstract2><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(<emptyTree>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+  end
+
+  class <emptyTree>::<C Abstract3><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+  end
+
+  class <emptyTree>::<C Abstract4><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+
+    <self>.abstract!()
+
+    <self>.abstract!()
+  end
+
+  module <emptyTree>::<C Abstract5><<C <todo sym>>> < ()
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+  end
+
+  module <emptyTree>::<C Abstract6><<C <todo sym>>> < ()
+    class <singleton class><<C <todo sym>>> < ()
+      <self>.extend(::<root>::<C T>::<C Helpers>)
+
+      <self>.abstract!()
+    end
+  end
+
+  class <emptyTree>::<C Interface1><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.interface!()
+  end
+
+  module <emptyTree>::<C Interface2><<C <todo sym>>> < ()
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.interface!()
+
+    <self>.interface!()
+  end
+
+  module <emptyTree>::<C Interface3><<C <todo sym>>> < ()
+    class <singleton class><<C <todo sym>>> < ()
+      <self>.extend(::<root>::<C T>::<C Helpers>)
+
+      <self>.interface!()
+    end
+  end
+
+  class <emptyTree>::<C Final1><<C <todo sym>>> < (::<todo sym>)
+    module <emptyTree>::<C Final2><<C <todo sym>>> < ()
+      class <singleton class><<C <todo sym>>> < ()
+        <self>.extend(::<root>::<C T>::<C Helpers>)
+
+        <self>.final!()
+      end
+
+      <self>.extend(::<root>::<C T>::<C Helpers>)
+
+      <self>.final!()
+    end
+
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.final!()
+  end
+
+  class <emptyTree>::<C Sealed1><<C <todo sym>>> < (::<todo sym>)
+    module <emptyTree>::<C Sealed2><<C <todo sym>>> < ()
+      class <singleton class><<C <todo sym>>> < ()
+        <self>.extend(::<root>::<C T>::<C Helpers>)
+
+        <self>.sealed!()
+      end
+
+      <self>.extend(::<root>::<C T>::<C Helpers>)
+
+      <self>.sealed!()
+    end
+
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.sealed!()
+  end
+
+  class <emptyTree>::<C Multiple1><<C <todo sym>>> < (::<todo sym>)
+    module <emptyTree>::<C Multiple2><<C <todo sym>>> < ()
+      class <singleton class><<C <todo sym>>> < ()
+        <self>.extend(::<root>::<C T>::<C Helpers>)
+
+        <self>.abstract!()
+
+        <self>.final!()
+      end
+
+      <self>.extend(::<root>::<C T>::<C Helpers>)
+
+      <self>.interface!()
+
+      <self>.final!()
+    end
+
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+
+    <self>.final!()
+  end
+
+  module <emptyTree>::<C MixesInClassMethods1><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C MixesInClassMethods2><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C MixesInClassMethods3><<C <todo sym>>> < ()
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.mixes_in_class_methods(::<root>::<C T>.untyped())
+  end
+
+  module <emptyTree>::<C ClassMethods1><<C <todo sym>>> < ()
+    module <emptyTree>::<C ClassMethods><<C <todo sym>>> < ()
+    end
+
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.mixes_in_class_methods(<emptyTree>::<C ClassMethods>)
+  end
+
+  module <emptyTree>::<C ClassMethods2><<C <todo sym>>> < ()
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.mixes_in_class_methods(<emptyTree>::<C ClassMethods1>::<C ClassMethods>)
+  end
+
+  module <emptyTree>::<C ClassMethods2><<C <todo sym>>> < ()
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.mixes_in_class_methods(::<root>::<C ClassMethods1>::<C ClassMethods>)
+  end
+
+  module <emptyTree>::<C RequiresAncestor1><<C <todo sym>>> < ()
+    <self>.extend(::<root>::<C T>::<C Helpers>)
+
+    <self>.requires_ancestor() do ||
+      <emptyTree>::<C BasicObject>
+    end
+  end
+end

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -315,13 +315,10 @@ end
 The [`@interface!`](abstract), [`@final!`](final), and [`@sealed!`](sealed)
 annotations are supported in the same way.
 
-The annotations
-[`@mixes_in_class_methods`](abstract#interfaces-and-the-included-hook) and
-[`@requires_ancestor`](requires-ancestor) expect an argument to represent the
-constant to be mixed in or required:
+The [`@requires_ancestor`](requires-ancestor) annotation expects an argument to
+represent the ancestor to require:
 
 ```ruby
-# @mixes_in_class_methods: Some::Constant
 # @requires_ancestor: ::Some::Ancestor
 class Foo; end
 ```
@@ -332,7 +329,6 @@ This is equivalent to:
 class Foo
   extend T::Helpers
 
-  mixes_in_class_methods Some::Constant
   requires_ancestor { Some::Ancestor }
 end
 ```

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -294,7 +294,7 @@ YARD or RDoc annotations.
 ## Class and module annotations
 
 RBS annotations can be used to add Sorbet helpers to classes like
-[`abstract!`](abstract):
+[`abstract!`](abstract.md):
 
 ```ruby
 # @abstract
@@ -312,11 +312,11 @@ class Foo
 end
 ```
 
-The [`@interface!`](abstract), [`@final!`](final), and [`@sealed!`](sealed)
-annotations are supported in the same way.
+The [`@interface!`](abstract.md), [`@final!`](final.md), and
+[`@sealed!`](sealed.md) annotations are supported in the same way.
 
-The [`@requires_ancestor`](requires-ancestor) annotation expects an argument to
-represent the ancestor to require:
+The [`@requires_ancestor`](requires-ancestor.md) annotation expects an argument
+to represent the ancestor to require:
 
 ```ruby
 # @requires_ancestor: ::Some::Ancestor
@@ -418,7 +418,8 @@ You can also consider using [`T::Enum`](tenum.md).
 
 ### `T.let` assertions
 
-[`T.let`](type-assertions#tlet) assertions can be expressed using RBS comments:
+[`T.let`](type-assertions.md#tlet) assertions can be expressed using RBS
+comments:
 
 ```ruby
 x = 42 #: Integer
@@ -455,8 +456,8 @@ MSG
 
 ### `T.cast` assertions
 
-[`T.cast`](type-assertions#tcast) assertions can be expressed using RBS comments
-with the `as` keyword:
+[`T.cast`](type-assertions.md#tcast) assertions can be expressed using RBS
+comments with the `as` keyword:
 
 ```ruby
 x = 42 #: as Integer
@@ -519,7 +520,7 @@ end #: as Integer
 
 ### `T.must` assertions
 
-[`T.must`](type-assertions#tmust) are denoted with the special `as !nil`
+[`T.must`](type-assertions.md#tmust) are denoted with the special `as !nil`
 comment:
 
 ```ruby
@@ -543,7 +544,7 @@ foo(
 
 ### `T.unsafe` escape hatch
 
-[`T.unsafe`](static#call-site-granularity-tunsafe) can be replaced with the
+[`T.unsafe`](static.md#call-site-granularity-tunsafe) can be replaced with the
 special `as untyped` annotation:
 
 ```ruby

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -250,7 +250,7 @@ attr_writer :bar
 attr_accessor :baz
 ```
 
-## Annotations
+## Method annotations
 
 While RBS does not support the same modifiers as Sorbet, it is possible to
 specify them using `@` annotation comments.
@@ -290,6 +290,52 @@ def qux2(x); end
 Note: these annotations like `@abstract` use normal comments, like `# @abstract`
 (not the special `#:` comment). This makes it possible to reuse any existing
 YARD or RDoc annotations.
+
+## Class and module annotations
+
+RBS annotations can be used to add Sorbet helpers to classes like
+[`abstract!`](abstract):
+
+```ruby
+# @abstract
+class Foo; end
+end
+```
+
+This is equivalent to:
+
+```ruby
+class Foo
+  extend T::Helpers
+
+  abstract!
+end
+```
+
+The [`@interface!`](abstract), [`@final!`](final), and [`@sealed!`](sealed)
+annotations are supported in the same way.
+
+The annotations
+[`@mixes_in_class_methods`](abstract#interfaces-and-the-included-hook) and
+[`@requires_ancestor`](requires-ancestor) expect an argument to represent the
+constant to be mixed in or required:
+
+```ruby
+# @mixes_in_class_methods: Some::Constant
+# @requires_ancestor: ::Some::Ancestor
+class Foo; end
+```
+
+This is equivalent to:
+
+```ruby
+class Foo
+  extend T::Helpers
+
+  mixes_in_class_methods Some::Constant
+  requires_ancestor { Some::Ancestor }
+end
+```
 
 ## Special behaviors
 


### PR DESCRIPTION
### Motivation

> This feature is gated behind the `--enable-experimental-rbs-signatures` option.

Description from the documentation:

<img width="814" alt="image" src="https://github.com/user-attachments/assets/13844dab-ab97-4caf-ae19-7dfe1019c394" />



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
