### PR TITLE
Store the payload in multiple buffers

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -57,7 +57,6 @@ public:
     static Method unpickleMethod(UnPickler &p, const GlobalState *gs);
     static Field unpickleField(UnPickler &p, const GlobalState *gs);
     static TypeParameter unpickleTypeParameter(UnPickler &p, const GlobalState *gs);
-    static void unpickleGS(UnPickler &p, GlobalState &result);
     static void unpickleSymbolTable(UnPickler &g, GlobalState &result);
     static void unpickleNameTable(UnPickler &g, GlobalState &result);
     static void unpickleFileTable(UnPickler &g, GlobalState &result);
@@ -842,22 +841,6 @@ uint32_t SerializerImpl::unpickleGSUUID(UnPickler &p) {
         Exception::raise("Payload version mismatch");
     }
     return p.getU4();
-}
-
-void SerializerImpl::unpickleGS(UnPickler &p, GlobalState &result) {
-    Timer timeit(result.tracer(), "unpickleGS");
-    result.creation = timeit.getFlowEdge();
-    if (p.getU4() != Serializer::VERSION) {
-        Exception::raise("Payload version mismatch");
-    }
-
-    result.kvstoreUuid = p.getU4();
-
-    unpickleFileTable(p, result);
-    unpickleNameTable(p, result);
-    unpickleSymbolTable(p, result);
-
-    result.sanityCheck();
 }
 
 Pickler SerializerImpl::pickleFileTable(const GlobalState &gs, bool payloadOnly) {

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -14,8 +14,14 @@ public:
     // through the indexing, as they won't have any non-well-known symbols present.
     static std::vector<uint8_t> storeNameTable(const GlobalState &gs);
 
+    struct SerializedGlobalState {
+        std::vector<uint8_t> symbolTableData;
+        std::vector<uint8_t> nameTableData;
+        std::vector<uint8_t> fileTableData;
+    };
+
     // Serialize a global state.
-    static std::vector<uint8_t> store(const GlobalState &gs);
+    static SerializedGlobalState store(const GlobalState &gs);
 
     static std::string fileKey(const core::File &file);
 
@@ -25,7 +31,10 @@ public:
     // Augment a global state with the name table stored in the cache.
     static void loadAndOverwriteNameTable(GlobalState &gs, const uint8_t *const data);
 
-    static void loadGlobalState(GlobalState &gs, const uint8_t *const data);
+    // Load the global state out of buffers that contain the symbol table, name table, and file table. This is only
+    // intended to be used for loading the payload out of buffers that are compiled in to the binary.
+    static void loadGlobalState(GlobalState &gs, const uint8_t *const symbolTableData,
+                                const uint8_t *const nameTableData, const uint8_t *const fileTableData);
 
     static uint32_t loadGlobalStateUUID(const GlobalState &gs, const uint8_t *const data);
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -704,8 +704,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                  "Exit 0 unless there was a critical error (i.e., an uncaught exception)");
     options.add_options(section)("no-stdlib",
                                  "Do not load Sorbet's payload which defines RBI files for the Ruby standard library");
-    options.add_options(section)("store-state", "Store state into file",
-                                 cxxopts::value<string>()->default_value(empty.storeState), "file");
+    options.add_options(section)(
+        "store-state", "Store state into three files, separated by commas: <symbol-table>,<name-table>,<file-table>",
+        cxxopts::value<string>()->default_value(""), "file");
     options.add_options(section)("silence-dev-message", "Silence \"You are running a development build\" message");
     options.add_options(section)("censor-for-snapshot-tests",
                                  "When printing raw location information, don't show line numbers");
@@ -1084,7 +1085,15 @@ void readOptions(Options &opts,
             throw EarlyReturnWithCode(1);
         }
         opts.stdoutHUPHack = raw["stdout-hup-hack"].as<bool>();
-        opts.storeState = raw["store-state"].as<string>();
+        auto storeStateRaw = raw["store-state"].as<string>();
+        if (!storeStateRaw.empty()) {
+            opts.storeState = absl::StrSplit(storeStateRaw, ',');
+            if (!opts.storeState.empty() && opts.storeState.size() != 3) {
+                logger->error("--store-state must be given three paths, separated by commas");
+                throw EarlyReturnWithCode(1);
+            }
+        }
+
         opts.forceHashing = raw["force-hashing"].as<bool>();
 
         opts.threads = (opts.runLSP || !opts.storeState.empty())
@@ -1101,7 +1110,8 @@ void readOptions(Options &opts,
         }
         if (raw["license"].as<bool>()) {
             fmt::print(
-                "Sorbet typechecker is licensed under Apache License Version 2.0.\n\nSorbet is built on top of:\n{}",
+                "Sorbet typechecker is licensed under Apache License Version 2.0.\n\nSorbet is built on top "
+                "of:\n{}",
                 fmt::map_join(third_party::licenses::all(), "\n\n", [](const auto &pair) { return pair.second; }));
             throw EarlyReturnWithCode(0);
         }
@@ -1210,8 +1220,8 @@ void readOptions(Options &opts,
 
         if (raw.count("packager-layers")) {
             if (opts.stripePackages) {
-                // TODO(neil): This regex was picked on a whim, so open to changing to be more or less restrictive based
-                // on feedback/usecases.
+                // TODO(neil): This regex was picked on a whim, so open to changing to be more or less restrictive
+                // based on feedback/usecases.
                 std::regex layerValid("[a-zA-Z0-9]+");
                 for (const string &layer : raw["packager-layers"].as<vector<string>>()) {
                     if (!std::regex_match(layer, layerValid)) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1110,8 +1110,7 @@ void readOptions(Options &opts,
         }
         if (raw["license"].as<bool>()) {
             fmt::print(
-                "Sorbet typechecker is licensed under Apache License Version 2.0.\n\nSorbet is built on top "
-                "of:\n{}",
+                "Sorbet typechecker is licensed under Apache License Version 2.0.\n\nSorbet is built on top of:\n{}",
                 fmt::map_join(third_party::licenses::all(), "\n\n", [](const auto &pair) { return pair.second; }));
             throw EarlyReturnWithCode(0);
         }
@@ -1220,8 +1219,8 @@ void readOptions(Options &opts,
 
         if (raw.count("packager-layers")) {
             if (opts.stripePackages) {
-                // TODO(neil): This regex was picked on a whim, so open to changing to be more or less restrictive
-                // based on feedback/usecases.
+                // TODO(neil): This regex was picked on a whim, so open to changing to be more or less restrictive based
+                // on feedback/usecases.
                 std::regex layerValid("[a-zA-Z0-9]+");
                 for (const string &layer : raw["packager-layers"].as<vector<string>>()) {
                     if (!std::regex_match(layer, layerValid)) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -166,7 +166,7 @@ struct Options {
     // Needs to be a multiple of getpagesize(2) which is 4096 by default on macOS and Linux
     size_t maxCacheSizeBytes = MAX_CACHE_SIZE_BYTES;
     UnorderedMap<std::string, core::StrictLevel> strictnessOverrides;
-    std::string storeState = "";
+    std::vector<std::string> storeState;
     bool enableCounters = false;
     std::string errorUrlBase = "https://srb.help/";
     bool ruby3KeywordArgs = false;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -850,8 +850,12 @@ int realmain(int argc, char *argv[]) {
         logger->trace("sorbet done");
 
         if (!opts.storeState.empty()) {
+            ENFORCE(opts.storeState.size() == 3);
             gs->markAsPayload();
-            FileOps::write(opts.storeState.c_str(), core::serialize::Serializer::store(*gs));
+            auto result = core::serialize::Serializer::store(*gs);
+            FileOps::write(opts.storeState[0].c_str(), result.symbolTableData);
+            FileOps::write(opts.storeState[1].c_str(), result.nameTableData);
+            FileOps::write(opts.storeState[2].c_str(), result.fileTableData);
         }
 
         auto untypedBlames = getAndClearHistogram("untyped.blames");

--- a/payload/binary/BUILD
+++ b/payload/binary/BUILD
@@ -58,11 +58,21 @@ cc_binary(
 
 genrule(
     name = "generate-state-payload-cc",
-    srcs = ["state-payload-raw"],
+    srcs = [
+        "state-payload-raw-symbol-table",
+        "state-payload-raw-name-table",
+        "state-payload-raw-file-table",
+    ],
     outs = [
         "binary.cc",
     ],
-    cmd = "$(location :gen_state_payload) $(location state-payload-raw) $(location binary.cc)",
+    cmd = """
+    $(location :gen_state_payload) \
+        $(location state-payload-raw-symbol-table) \
+        $(location state-payload-raw-name-table) \
+        $(location state-payload-raw-file-table) \
+        $(location binary.cc)
+    """,
     tools = [
         ":gen_state_payload",
     ],
@@ -72,8 +82,15 @@ genrule(
     name = "generate-state-payload-raw",
     srcs = [],
     outs = [
-        "state-payload-raw",
+        "state-payload-raw-symbol-table",
+        "state-payload-raw-name-table",
+        "state-payload-raw-file-table",
     ],
-    cmd = "$(location //main:sorbet-orig) --silence-dev-message  --store-state $(location state-payload-raw) --no-error-count",
+    cmd = """
+    $(location //main:sorbet-orig) \
+        --silence-dev-message \
+        --no-error-count \
+        --store-state $(location state-payload-raw-symbol-table),$(location state-payload-raw-name-table),$(location state-payload-raw-file-table)
+    """,
     tools = ["//main:sorbet-orig"],
 )

--- a/payload/binary/binary.h
+++ b/payload/binary/binary.h
@@ -2,6 +2,9 @@
 #define SORBET_PAYLOAD_H
 
 #include "common/common.h"
-extern const uint8_t *const GLOBAL_STATE_PAYLOAD;
+extern const uint8_t *const PAYLOAD_SYMBOL_TABLE;
+extern const uint8_t *const PAYLOAD_NAME_TABLE;
+extern const uint8_t *const PAYLOAD_FILE_TABLE;
+extern const bool PAYLOAD_EMPTY;
 
 #endif // SORBET_PAYLOAD_H

--- a/payload/binary/empty.cc
+++ b/payload/binary/empty.cc
@@ -1,3 +1,6 @@
 #include "common/common.h"
 
-extern const uint8_t *const GLOBAL_STATE_PAYLOAD = nullptr;
+extern const uint8_t *const PAYLOAD_SYMBOL_TABLE = nullptr;
+extern const uint8_t *const PAYLOAD_NAME_TABLE = nullptr;
+extern const uint8_t *const PAYLOAD_FILE_TABLE = nullptr;
+extern const bool PAYLOAD_EMPTY = true;

--- a/payload/binary/tools/gen_state_payload.cc
+++ b/payload/binary/tools/gen_state_payload.cc
@@ -8,13 +8,13 @@
 
 using namespace std;
 
-int main(int argc, char **argv) {
-    ifstream fin(argv[1], ios::binary);
+vector<uint8_t> readBinary(char *path) {
+    ifstream fin{path, ios::binary};
     if (!fin.good()) {
-        throw sorbet::FileNotFoundException(string(argv[1]));
+        throw sorbet::FileNotFoundException(string(path));
     }
-    vector<uint8_t> data;
 
+    vector<uint8_t> data;
     fin.seekg(0, ios::end);
     size_t filesize = fin.tellg();
     fin.seekg(0, ios::beg);
@@ -23,25 +23,50 @@ int main(int argc, char **argv) {
 
     fin.read((char *)data.data(), filesize);
 
-    ofstream classfile(argv[2], ios::trunc);
+    return data;
+}
 
-    classfile << "#include \"common/common.h\"\n" << '\n' << "const uint8_t nameTablePayload[] = {\n";
-    int i = -1;
+void writeConstant(ofstream &out, string_view name, const vector<uint8_t> data) {
+    out << "const uint8_t " << name << "[] = {";
     bool first = true;
+    int i = -1;
     for (auto c : data) {
         ++i;
         if (!first) {
-            classfile << ", ";
+            out << ",";
         }
         first = false;
         if (i % 10 == 0) {
-            classfile << "\n    ";
+            out << endl << "    ";
+        } else {
+            out << " ";
         }
-        classfile << (int)c;
+        out << (int)c;
     }
-    classfile << "};\n";
-    classfile << "extern const uint8_t * const GLOBAL_STATE_PAYLOAD = (const uint8_t * const)&nameTablePayload;"
-              << '\n';
+    out << endl << "};" << endl;
+}
+
+int main(int argc, char **argv) {
+    auto symtabData = readBinary(argv[1]);
+    auto nametabData = readBinary(argv[2]);
+    auto filetabData = readBinary(argv[3]);
+
+    ofstream classfile(argv[4], ios::trunc);
+
+    classfile << "#include \"common/common.h\"" << endl;
+    classfile << "namespace {" << endl;
+
+    writeConstant(classfile, "symbolTablePayload", std::move(symtabData));
+    writeConstant(classfile, "nameTablePayload", std::move(nametabData));
+    writeConstant(classfile, "fileTablePayload", std::move(filetabData));
+
+    classfile << "}" << endl;
+
+    classfile << "extern const uint8_t * const PAYLOAD_SYMBOL_TABLE = (const uint8_t * const)&symbolTablePayload;"
+              << endl;
+    classfile << "extern const uint8_t * const PAYLOAD_NAME_TABLE = (const uint8_t * const)&nameTablePayload;" << endl;
+    classfile << "extern const uint8_t * const PAYLOAD_FILE_TABLE = (const uint8_t * const)&fileTablePayload;" << endl;
+    classfile << "extern const bool PAYLOAD_EMPTY = false;" << endl;
 
     classfile.close();
 

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -15,12 +15,12 @@ void createInitialGlobalState(core::GlobalState &gs, const realmain::options::Op
         return;
     }
 
-    if (GLOBAL_STATE_PAYLOAD == nullptr) {
+    if (PAYLOAD_EMPTY) {
         Timer timeit(gs.tracer(), "read_global_state.source");
         sorbet::rbi::populateRBIsInto(gs);
     } else {
         Timer timeit(gs.tracer(), "read_global_state.binary");
-        core::serialize::Serializer::loadGlobalState(gs, GLOBAL_STATE_PAYLOAD);
+        core::serialize::Serializer::loadGlobalState(gs, PAYLOAD_SYMBOL_TABLE, PAYLOAD_NAME_TABLE, PAYLOAD_FILE_TABLE);
     }
     ENFORCE(gs.utf8NamesUsed() < core::GlobalState::PAYLOAD_MAX_UTF8_NAME_COUNT,
             "Payload defined `{}` UTF8 names, which is greater than the expected maximum of `{}`. Consider updating "

--- a/test/cli/store-state/test.sh
+++ b/test/cli/store-state/test.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 set -e
-main/sorbet --silence-dev-message -e 'class Foo; end' --store-state state
-if [ ! -f state ]; then
-  echo "state file wasn't created"
+main/sorbet --silence-dev-message -e 'class Foo; end' --store-state symtab1,names1,files1
+if [ ! -f symtab1 ]; then
+  echo "symbol table wasn't created"
   exit 1
 fi
-main/sorbet --silence-dev-message -e 'class Foo; end' --store-state state1
-diff state state1 # there should be no difference
+if [ ! -f names1 ]; then
+  echo "name table wasn't created"
+  exit 1
+fi
+if [ ! -f files1 ]; then
+  echo "file table wasn't created"
+  exit 1
+fi
+main/sorbet --silence-dev-message -e 'class Foo; end' --store-state symtab2,names2,files2
+diff symtab1 symtab2 # there should be no difference
+diff names1 names2 # there should be no difference
+diff files1 files2 # there should be no difference

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -154,7 +154,8 @@ TEST_CASE("CloneSubstitutePayload") {
     auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
     sorbet::core::GlobalState gs(errorQueue);
-    sorbet::core::serialize::Serializer::loadGlobalState(gs, GLOBAL_STATE_PAYLOAD);
+    sorbet::core::serialize::Serializer::loadGlobalState(gs, PAYLOAD_SYMBOL_TABLE, PAYLOAD_NAME_TABLE,
+                                                         PAYLOAD_FILE_TABLE);
 
     auto c1 = gs.deepCopy();
     auto c2 = gs.deepCopy();

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -95,7 +95,7 @@ TEST_CASE("WhitequarkParserTest") {
     if (BooleanPropertyAssertion::getValue("no-stdlib", assertions).value_or(false)) {
         gs.initEmpty();
     } else {
-        core::serialize::Serializer::loadGlobalState(gs, GLOBAL_STATE_PAYLOAD);
+        core::serialize::Serializer::loadGlobalState(gs, PAYLOAD_SYMBOL_TABLE, PAYLOAD_NAME_TABLE, PAYLOAD_FILE_TABLE);
     }
     // Parser
     vector<core::FileRef> files;

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -405,7 +405,8 @@ Usage:
                                 uncaught exception)
       --no-stdlib               Do not load Sorbet's payload which defines RBI files for
                                 the Ruby standard library
-      --store-state file        Store state into file (default: "")
+      --store-state file        Store state into three files, separated by commas:
+                                <symbol-table>,<name-table>,<file-table> (default: "")
       --silence-dev-message     Silence "You are running a development build" message
       --censor-for-snapshot-tests
                                 When printing raw location information, don't show line


### PR DESCRIPTION
This change is prework for no longer copying the indexer thread's `GlobalState` as a starting point for the slow path on the typechecker thread.

This PR splits the payload up into three separate constants: one for the symbol table; one for the name table; and one for the file table. This allows us to selectively reload parts of the payload in the future, by decomposing it now.

This also enables removing the generic `GlobalState` pickling/unpickling code, as we now never serialize a whole `GlobalState` into a single buffer or kvstore entry.

### Motivation
The indexer thread currently takes a full copy of the name table 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.