### PR TITLE
GlobalState::deepCopy -> deepCopyGlobalState

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2094,7 +2094,7 @@ void GlobalState::copyOptions(const core::GlobalState &other) {
     this->pathPrefix = other.pathPrefix;
 }
 
-unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
+unique_ptr<GlobalState> GlobalState::deepCopyGlobalState(bool keepId) const {
     Timer timeit(tracer(), "GlobalState::deepCopy", this->creation);
     this->sanityCheck();
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -253,7 +253,7 @@ public:
 
     std::optional<int> sleepInSlowPathSeconds = std::nullopt;
 
-    std::unique_ptr<GlobalState> deepCopy(bool keepId = false) const;
+    std::unique_ptr<GlobalState> deepCopyGlobalState(bool keepId = false) const;
     mutable std::shared_ptr<ErrorQueue> errorQueue;
 
     // Copy the file table and other parts of GlobalState that are required for the indexing pass.

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -396,7 +396,7 @@ std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams
         }
         case TypecheckingPath::Slow: {
             // Completely replace `pendingTypecheckUpdates` if this was a slow path update.
-            update.updatedGS = initialGS->deepCopy();
+            update.updatedGS = initialGS->deepCopyGlobalState();
             pendingTypecheckUpdates = update.copy();
             break;
         }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -499,7 +499,7 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
 
                     // At this point this->gs has a name table that's initialized enough for the indexer thread, so we
                     // make a copy to pass back over.
-                    indexedState = this->gs->deepCopy();
+                    indexedState = this->gs->deepCopyGlobalState();
                     indexedState->errorQueue = std::move(savedErrorQueue);
 
                     // We need to ensure that the package DB we build up during indexing isn't accidentaly persisted in

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -619,7 +619,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
 
         // clone the empty global state to avoid manually re-entering everything, and copy the base filetable so that
         // file sources are available.
-        unique_ptr<core::GlobalState> localGs = emptyGs->deepCopy();
+        unique_ptr<core::GlobalState> localGs = emptyGs->deepCopyGlobalState();
         auto &epochManager = *localGs->epochManager;
 
         IndexThreadResultPack threadResult;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to be able to more easily grep for places where we deeply copy
`GlobalState`.

There are a lot of deep copy functions, but those are usually less interesting
to see (e.g., deep copying trees or symbols or names).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

compiler