### PR TITLE
Remove Serializer::storePayloadAndNameTable

### DIFF
--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -17,12 +17,6 @@ public:
     // Serialize a global state.
     static std::vector<uint8_t> store(const GlobalState &gs);
 
-    // Stores a GlobalState, but only includes `File`s with Type == Payload.
-    // This can be used in conjunction with `storeFile` to store
-    // a global state containing a name table along side a large number of
-    // individual cached files, which can be loaded independently.
-    static std::vector<uint8_t> storePayloadAndNameTable(const GlobalState &gs);
-
     static std::string fileKey(const core::File &file);
 
     // Serializes an AST and file hash.


### PR DESCRIPTION
Remove the `Serializer::storePayloadAndNameTable` function, as it's no longer used. Additionally, remove the `payloadOnly` flag from the `SerializerImpl::pickle` case for `GlobalState`, as it was only used with a `true` value in `Serializer::storePayloadAndNameTable`.

### Motivation
Cleaning up unused code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests
