### PR TITLE
Interleave packager and namer calls in LSPTypechecker

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -286,7 +286,7 @@ bool PackageDB::allowRelaxedPackagerChecksFor(MangledName mangledName) const {
 
 PackageDB PackageDB::deepCopy() const {
     ENFORCE(frozen);
-    PackageDB result = this->copyOptionsOnly();
+    PackageDB result;
 
     // --- data ---
     result.packages_.reserve(this->packages_.size());
@@ -297,13 +297,6 @@ PackageDB PackageDB::deepCopy() const {
     // This assumes that the GlobalState this PackageDB is getting copied into also has these
     // interned mangledName NameRefs at the same IDs as the current PackageDB.
     result.mangledNames = this->mangledNames;
-
-    return result;
-}
-
-PackageDB PackageDB::copyOptionsOnly() const {
-    ENFORCE(frozen);
-    PackageDB result;
 
     // --- options ---
     result.enabled_ = this->enabled_;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -49,9 +49,6 @@ public:
 
     PackageDB deepCopy() const;
 
-    // Copy the options of the PackageDB, but leave all the data out.
-    PackageDB copyOptionsOnly() const;
-
     UnfreezePackages unfreeze();
 
     PackageDB() = default;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -520,12 +520,11 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
             return;
         }
 
-                    // First run: only the __package.rb files. This populates the packageDB
-                    pipeline::buildPackageDB(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers);
+        // First run: only the __package.rb files. This populates the packageDB
+        pipeline::buildPackageDB(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers);
 
-                // Second run: all the other files (the packageDB shouldn't change)
-                pipeline::validatePackagedFiles(*this->gs, absl::MakeSpan(nonPackagedIndexed), this->config->opts,
-                                                workers);
+        // Second run: all the other files (the packageDB shouldn't change)
+        pipeline::validatePackagedFiles(*this->gs, absl::MakeSpan(nonPackagedIndexed), this->config->opts, workers);
 
         // Only need to compute FoundDefHashes when running to compute a FileHash
         auto foundHashes = nullptr;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -520,9 +520,6 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
         // First run: only the __package.rb files. This populates the packageDB
         pipeline::buildPackageDB(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers);
 
-        // Second run: all the other files (the packageDB shouldn't change)
-        pipeline::validatePackagedFiles(*this->gs, absl::MakeSpan(nonPackagedIndexed), this->config->opts, workers);
-
         // Only need to compute FoundDefHashes when running to compute a FileHash
         auto foundHashes = nullptr;
         auto cancelled = pipeline::name(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers, foundHashes);
@@ -531,6 +528,9 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
             ast::ParsedFilesOrCancelled::cancel(move(nonPackagedIndexed), workers);
             return;
         }
+
+        // Second run: all the other files (the packageDB shouldn't change)
+        pipeline::validatePackagedFiles(*this->gs, absl::MakeSpan(nonPackagedIndexed), this->config->opts, workers);
 
         // Only need to compute FoundDefHashes when running to compute a FileHash
         auto canceled =

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -492,13 +492,10 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
 
                     // At this point this->gs has a name table that's initialized enough for the indexer thread, so we
                     // make a copy to pass back over.
+                    ENFORCE(this->gs->packageDB().packages().empty(),
+                            "Don't want symbols or packages in indexer GlobalState");
                     indexedState = this->gs->deepCopyGlobalState();
                     indexedState->errorQueue = std::move(savedErrorQueue);
-
-                    // We need to ensure that the package DB we build up during indexing isn't accidentaly persisted in
-                    // the indexer, as that would feed it back into all subsequent slow path runs and prevent any
-                    // deletions to the package db structure.
-                    indexedState->packageDB() = indexedState->packageDB().copyOptionsOnly();
 
                     this->sessionCache =
                         cache::SessionCache::make(std::move(ownedKvstore), *this->config->logger, this->config->opts);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -527,7 +527,6 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
             return;
         }
 
-        if (this->config->opts.stripePackages) {
             // Only need to compute FoundDefHashes when running to compute a FileHash
             auto foundHashes = nullptr;
             auto cancelled =
@@ -537,10 +536,8 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
                 ast::ParsedFilesOrCancelled::cancel(move(nonPackagedIndexed), workers);
                 return;
             }
-        }
 
         // Only need to compute FoundDefHashes when running to compute a FileHash
-        auto foundHashes = nullptr;
         auto canceled =
             pipeline::name(*gs, absl::Span<ast::ParsedFile>(nonPackagedIndexed), config->opts, workers, foundHashes);
         if (canceled) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -527,15 +527,14 @@ LSPTypechecker::SlowPathResult LSPTypechecker::runSlowPath(LSPFileUpdates &updat
             return;
         }
 
-            // Only need to compute FoundDefHashes when running to compute a FileHash
-            auto foundHashes = nullptr;
-            auto cancelled =
-                pipeline::name(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers, foundHashes);
-            if (cancelled) {
-                ast::ParsedFilesOrCancelled::cancel(move(indexed), workers);
-                ast::ParsedFilesOrCancelled::cancel(move(nonPackagedIndexed), workers);
-                return;
-            }
+        // Only need to compute FoundDefHashes when running to compute a FileHash
+        auto foundHashes = nullptr;
+        auto cancelled = pipeline::name(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers, foundHashes);
+        if (cancelled) {
+            ast::ParsedFilesOrCancelled::cancel(move(indexed), workers);
+            ast::ParsedFilesOrCancelled::cancel(move(nonPackagedIndexed), workers);
+            return;
+        }
 
         // Only need to compute FoundDefHashes when running to compute a FileHash
         auto canceled =


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is one step towards eventually interleaving "index + packager + namer" for
all `__package.rb` files before all non-`__package.rb` files.

This is also required for the changes I'm working on to move the packager into
the symbol table, because for that work, the call to the `packager` functions
will happen **after** namer: there's two ways that can work:

- hoist the `pipeline::name` call up to be right after the call to
  `buildPackageDB` / `validatePackagedFiles`
- lower the two packager calls to be right after the `pipeline::name` calls

The hoist approach can't work, because then we would also need something like
`deepCopyWithoutSymbolTable` in the same way that we have `copyWithoutOptions`
for the `PackageDB`, which is clunky.

Lowering is also better because then we don't have to _overwrite_ the
`PackageDB`: when we `deepCopy` the `GlobalState`, we naturally don't copy a
package database that has not yet been populated, so we do less work in the
first place.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Trevor's tests in #8732 should cover this change (they pass).