### PR TITLE
getFiles: `continue;` → `subspan(1)`

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -193,12 +193,10 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
 
     core::WithoutUniqueNameHash::sortAndDedupe(changedSymbolNameHashes);
 
-    int i = -1;
-    for (auto &oldFile : gs.getFiles()) {
+    size_t i = 0;
+    // skip idx 0 (corresponds to File that does not exist, so it contains nullptr)
+    for (auto &oldFile : gs.getFiles().subspan(1)) {
         i++;
-        if (oldFile == nullptr) {
-            continue;
-        }
 
         auto ref = core::FileRef(i);
         if (changedFiles.contains(ref)) {

--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -104,12 +104,10 @@ LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypechecker
     const core::GlobalState &gs = typechecker.state();
     const core::WithoutUniqueNameHash symShortNameHash(gs, symbol.name(gs));
     // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.
-    int i = -1;
-    for (auto &file : typechecker.state().getFiles()) {
+    size_t i = 0;
+    // skip idx 0 (corresponds to File that does not exist, so it contains nullptr)
+    for (auto &file : typechecker.state().getFiles().subspan(1)) {
         i++;
-        if (file == nullptr) {
-            continue;
-        }
 
         auto ref = core::FileRef(i);
         if (pkgName.exists() && gs.packageDB().getPackageNameForFile(ref) != pkgName) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -489,11 +489,8 @@ int realmain(int argc, char *argv[]) {
         auto dumpDir = opts.print.PayloadSources.outputPath;
         FileOps::ensureDir(dumpDir);
 
-        for (auto &payloadFile : gs->getFiles()) {
-            if (payloadFile == nullptr) {
-                continue;
-            }
-
+        // skip idx 0 (corresponds to File that does not exist, so it contains nullptr)
+        for (auto &payloadFile : gs->getFiles().subspan(1)) {
             auto payloadVersion = sorbet_is_release_build ? sorbet_build_scm_revision : "master";
             auto payloadPath = payloadFile->path();
             auto payloadPrefix = absl::StrCat("https://github.com/sorbet/sorbet/tree/", payloadVersion, "/rbi/");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In 5a733f244e2a89fc59608a1f831fd53bc5d46361, Trevor made it so that
`getFiles` returns a span instead of a const vector, which means that we
now have access to the `subspan` method, and we can avoid doing some
branches inside a loop.

Slight performance improvement, but really just a nice to have.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavior change