### PR TITLE
Assorted `PackageName` cleanups

### DIFF
--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -53,6 +53,8 @@ public:
     virtual MangledName mangledName() const = 0;
     virtual absl::Span<const core::NameRef> fullName() const = 0;
     virtual absl::Span<const std::string> pathPrefixes() const = 0;
+    // TODO(jez) Why do these methods not return the `Import`/`Export`/`VisibleTo` data structures
+    // that PackageInfoImpl operates on?
     virtual std::vector<std::vector<core::NameRef>> exports() const = 0;
     virtual std::vector<std::vector<core::NameRef>> imports() const = 0;
     virtual std::vector<std::vector<core::NameRef>> testImports() const = 0;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1599,7 +1599,7 @@ void rewritePackageSpec(const core::GlobalState &gs, ast::ParsedFile &package, P
 }
 
 // TODO(jez) Rename this to lookupMangledName, and make it take a const GlobalState
-template <typename PackageName> void populateMangledName(core::GlobalState &gs, PackageName &pName) {
+void populateMangledName(core::GlobalState &gs, PackageName &pName) {
     pName.mangledName = core::packages::MangledName::mangledNameFromParts(gs, pName.fullName.parts);
 }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -429,7 +429,7 @@ public:
                     importToInsertAfter = import.name.fullName.loc;
                 }
             }
-            if (importToInsertAfter.exists()) {
+            if (!importToInsertAfter.exists()) {
                 // Insert before the first import
                 core::Loc beforePackageName = {loc.file(), importedPackageNames.front().name.fullName.loc};
                 auto [beforeImport, numWhitespace] = beforePackageName.findStartOfIndentation(gs);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -101,14 +101,6 @@ struct PackageName {
     string toString(const core::GlobalState &gs) const {
         return absl::StrJoin(fullName.parts, "::", core::packages::NameFormatter(gs));
     }
-
-    bool operator==(const PackageName &rhs) const {
-        return mangledName == rhs.mangledName;
-    }
-
-    bool operator!=(const PackageName &rhs) const {
-        return mangledName != rhs.mangledName;
-    }
 };
 
 struct Import {
@@ -400,7 +392,7 @@ public:
         if (!importedPackageNames.empty()) {
             packager::PackageName const *importToInsertAfter = nullptr;
             for (auto &import : importedPackageNames) {
-                if (import.name == info.name) {
+                if (import.name.mangledName == info.name.mangledName) {
                     if (!isTestImport && import.type == core::packages::ImportType::Test) {
                         // There's already a test import for this package, so we'll convert it to a regular import.
                         // importToInsertAfter already tracks where we need to insert the import.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These structs store a lot of redundant information. Let's stop doing that


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests