### PR TITLE
Get rid of `_Package` suffix from `MangledName`

### DIFF
--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -66,8 +66,6 @@ struct NameRefDebugCheck {
     void check(const NameSubstitution &subst) const;
 };
 
-constexpr std::string_view PACKAGE_SUFFIX = "_Package";
-
 class NameRef final : private DebugOnlyCheck<NameRefDebugCheck> {
 private:
     // NameKind takes up this many bits in _id.

--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -8,8 +8,8 @@ using namespace std;
 
 namespace sorbet::core::packages {
 MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::vector<std::string_view> &parts) {
-    // Foo::Bar => Foo_Bar_Package
-    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_"), core::PACKAGE_SUFFIX);
+    // Foo::Bar => Foo_Bar
+    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_"));
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
     auto packagerName = gs.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
@@ -17,8 +17,8 @@ MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::
 }
 
 MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::vector<core::NameRef> &parts) {
-    // Foo::Bar => Foo_Bar_Package
-    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(gs)), core::PACKAGE_SUFFIX);
+    // Foo::Bar => Foo_Bar
+    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(gs)));
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
     auto packagerName = gs.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
@@ -26,7 +26,7 @@ MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::
 }
 
 MangledName MangledName::mangledNameFromHuman(const core::GlobalState &gs, string_view nameStr) {
-    auto mangled = absl::StrCat(absl::StrReplaceAll(nameStr, {{"::", "_"}}), core::PACKAGE_SUFFIX);
+    auto mangled = absl::StrCat(absl::StrReplaceAll(nameStr, {{"::", "_"}}));
     auto utf8Name = gs.lookupNameUTF8(mangled);
     if (!utf8Name.exists()) {
         return MangledName();

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -18,11 +18,11 @@ public:
 
     MangledName() = default;
 
-    // ["Foo", "Bar"] => :Foo_Bar_Package
+    // ["Foo", "Bar"] => :Foo_Bar
     static MangledName mangledNameFromParts(core::GlobalState &gs, const std::vector<std::string_view> &parts);
-    // [:Foo, :Bar] => :Foo_Bar_Package
+    // [:Foo, :Bar] => :Foo_Bar
     static MangledName mangledNameFromParts(core::GlobalState &gs, const std::vector<core::NameRef> &parts);
-    // "Foo::Bar" -> :Foo_Bar_Package
+    // "Foo::Bar" -> :Foo_Bar
     static MangledName mangledNameFromHuman(const core::GlobalState &gs, std::string_view human);
 
     bool operator==(const MangledName &rhs) const {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1649,7 +1649,7 @@ unique_ptr<PackageInfoImpl> createAndPopulatePackageInfo(core::GlobalState &gs, 
     info->packagePathPrefixes.emplace_back(packageFilePath.substr(0, packageFilePath.find_last_of('/') + 1));
     const string_view shortName = info->name.mangledName.mangledName.shortName(gs);
     const string slashDirName = absl::StrJoin(info->name.fullName.parts, "/", core::packages::NameFormatter(gs)) + "/";
-    const string_view dirNameFromShortName = shortName.substr(0, shortName.rfind(core::PACKAGE_SUFFIX));
+    const string_view dirNameFromShortName = shortName;
 
     for (const string &prefix : extraPackageFilesDirectoryUnderscorePrefixes) {
         // Project_FooBar -- munge with underscore

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1211,7 +1211,7 @@ public:
 
     RBIGenerator::RBIOutput emit() {
         RBIGenerator::RBIOutput output;
-        output.baseFilePath = pkg.mangledName().mangledName.show(gs);
+        output.baseFilePath = fmt::format("{}_Package", pkg.mangledName().mangledName.show(gs));
 
         vector<core::SymbolRef> exports;
         vector<core::SymbolRef> testExports;

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -442,7 +442,7 @@ TEST_CASE("Add imports to strict_dependencies 'false' package") {
     string pkg_source = makePackageRB("MyPackage", "false", "app",
                                       {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
 
-    auto parsedFiles = enterPackages(gs, {{"my_Package/__package.rb", pkg_source},
+    auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source},
                                           {falsePackageAPath, falsePackageA},
                                           {layeredPackageAPath, layeredPackageA},
                                           {layeredDagPackageAPath, layeredDagPackageA},
@@ -510,7 +510,7 @@ TEST_CASE("Add imports to strict_dependencies 'layered' package") {
     string pkg_source = makePackageRB("MyPackage", "layered", "app",
                                       {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
 
-    auto parsedFiles = enterPackages(gs, {{"my_Package/__package.rb", pkg_source},
+    auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source},
                                           {falsePackageAPath, falsePackageA},
                                           {layeredPackageAPath, layeredPackageA},
                                           {layeredDagPackageAPath, layeredDagPackageA},
@@ -578,7 +578,7 @@ TEST_CASE("Add imports to strict_dependencies 'layered_dag' package") {
     string pkg_source = makePackageRB("MyPackage", "layered_dag", "app",
                                       {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
 
-    auto parsedFiles = enterPackages(gs, {{"my_Package/__package.rb", pkg_source},
+    auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source},
                                           {falsePackageAPath, falsePackageA},
                                           {layeredPackageAPath, layeredPackageA},
                                           {layeredDagPackageAPath, layeredDagPackageA},
@@ -646,7 +646,7 @@ TEST_CASE("Add imports to strict_dependencies 'dag' package") {
     string pkg_source = makePackageRB("MyPackage", "dag", "app",
                                       {"FalsePackageA", "LayeredPackageA", "LayeredDagPackageA", "DagPackageA"});
 
-    auto parsedFiles = enterPackages(gs, {{"my_Package/__package.rb", pkg_source},
+    auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source},
                                           {falsePackageAPath, falsePackageA},
                                           {layeredPackageAPath, layeredPackageA},
                                           {layeredDagPackageAPath, layeredDagPackageA},

--- a/test/rbi_gen_package_runner.cc
+++ b/test/rbi_gen_package_runner.cc
@@ -46,13 +46,13 @@ struct PackageInfo {
     vector<string> testImports;
     vector<string> files;
     vector<string> testFiles;
-    string mangledName;
+    string baseFilePath;
 
     PackageInfo() = default;
     PackageInfo(string name, vector<string> imports, vector<string> testImports, vector<string> files,
                 vector<string> testFiles)
         : name(name), imports(imports), testImports(testImports), files(files), testFiles(testFiles),
-          mangledName(absl::StrReplaceAll(name, {{"::", "_"}}) + "_Package"s) {}
+          baseFilePath(absl::StrReplaceAll(name, {{"::", "_"}}) + "_Package"s) {}
 
     static PackageInfo fromJson(const rapidjson::Value &d) {
         return PackageInfo(d["name"].GetString(), fromJsonStringArray(d["imports"]),
@@ -108,11 +108,11 @@ struct PackageDB {
     }
 
     string lookupRbiFor(PackageInfo info) {
-        return rbis.at(info.mangledName);
+        return rbis.at(info.baseFilePath);
     }
 
     DependencyInfo lookupDepsFor(PackageInfo info) {
-        return deps.at(info.mangledName);
+        return deps.at(info.baseFilePath);
     }
 
     PackageInfo lookupPackageFor(string name) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't actually need this `_Package` suffix.

I'm working on some changes which will completely replace `MangledName`
with `PackageRef` IDs. Eventually, nothing will operate on
`MangledName`.

I also thought that we might have an optimization that meant that the
strings backing two names like `Opus_Foo` and `Opus_Foo_Bar` could
overlap in the string table, but I don't actually know if that's the
case now that I'm looking at the code—it looks like if a name doesn't
exist we unconditionally copy the whole string into the string table.

Regardless, this should save memory because we're not storing `8 *
num_packages` extra bytes in the name table.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests