### PR TITLE
Flip pipeline::name and pipeline::package

### DIFF
--- a/ast/packager/packager.cc
+++ b/ast/packager/packager.cc
@@ -17,7 +17,7 @@ ExpressionPtr prependRegistry(ExpressionPtr scope) {
 
 const ast::ClassDef *asPackageSpecClass(const ast::ExpressionPtr &expr) {
     auto packageSpecClass = ast::cast_tree<ast::ClassDef>(expr);
-    if (packageSpecClass == nullptr || packageSpecClass->ancestors.size() != 1) {
+    if (packageSpecClass == nullptr || packageSpecClass->ancestors.empty()) {
         return nullptr;
     }
 

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -420,12 +420,12 @@ void Minimize::indexAndResolveForMinimize(core::GlobalState &sourceGS, core::Glo
         rbiGS.errorQueue->flushAllErrors(rbiGS);
     }
 
-    // We explicitly disable `stripePackages` in realmain for this call, which makes the packager call a no-op here.
-    pipeline::package(rbiGS, absl::MakeSpan(rbiIndexed.result()), opts, workers);
     // Only need to compute FoundDefHashes when running to compute a FileHash
     auto foundHashes = nullptr;
     auto canceled = pipeline::name(rbiGS, absl::MakeSpan(rbiIndexed.result()), opts, workers, foundHashes);
     ENFORCE(!canceled, "Can only cancel in LSP mode");
+    // We explicitly disable `stripePackages` in realmain for this call, which makes the packager call a no-op here.
+    pipeline::package(rbiGS, absl::MakeSpan(rbiIndexed.result()), opts, workers);
 
     auto resolved = pipeline::resolve(rbiGS, std::move(rbiIndexed.result()), opts, workers);
     ENFORCE(resolved.hasResult(), "Can only cancel in LSP mode");

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -585,11 +585,11 @@ int realmain(int argc, char *argv[]) {
                                                               *workers, indexed));
 
                 // Populate the packageDB by processing only the __package.rb files.
-                pipeline::buildPackageDB(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers);
                 // Only need to compute hashes when running to compute a FileHash
                 auto foundHashes = nullptr;
                 auto canceled = pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers, foundHashes);
                 ENFORCE(!canceled, "There's no cancellation in batch mode");
+                pipeline::buildPackageDB(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers);
             }
 
             auto nonPackageIndexedResult =
@@ -605,13 +605,12 @@ int realmain(int argc, char *argv[]) {
             cache::maybeCacheGlobalStateAndFiles(OwnedKeyValueStore::abort(move(kvstore)), opts, *gs, *workers,
                                                  nonPackageIndexed);
 
-            // Now validate all the other files (the packageDB shouldn't change)
-            pipeline::validatePackagedFiles(*gs, absl::MakeSpan(nonPackageIndexed), opts, *workers);
-
             // Only need to compute hashes when running to compute a FileHash
             auto foundHashes = nullptr;
             auto canceled = pipeline::name(*gs, absl::MakeSpan(nonPackageIndexed), opts, *workers, foundHashes);
             ENFORCE(!canceled, "There's no cancellation in batch mode");
+            // Now validate all the other files (the packageDB shouldn't change)
+            pipeline::validatePackagedFiles(*gs, absl::MakeSpan(nonPackageIndexed), opts, *workers);
 
             pipeline::unpartitionPackageFiles(indexed, move(nonPackageIndexed));
             // TODO(jez) At this point, it's not correct to call it `indexed` anymore: we've run namer too

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -973,6 +973,12 @@ class EnforcePackagePrefix final {
     // - Upon emitting an error increment
     // - Once greater than 0, all preTransform* increment, postTransform* decrement
     int errorDepth = 0;
+
+    // Meant to track when we're inside something like `class ::A; class B; end; end` instead of
+    // `class A; class B; end; end`. Classes that start from an absolutely qualified "cbase" with a
+    // leading `::` are opted out of the EnforcePackagePrefix checks.
+    // TODO(jez) Document this in the public docs for the packager (at least in the error reference,
+    // but also in any eventual docs on the package system).
     int rootConsts = 0;
     bool useTestNamespace = false;
     vector<std::pair<core::NameRef, core::LocOffsets>> tmpNameParts;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -693,7 +693,11 @@ FullyQualifiedName getFullyQualifiedName(core::Context ctx, const ast::Unresolve
     fqn.loc = constantLit->loc;
     while (constantLit != nullptr) {
         fqn.parts.emplace_back(constantLit->cnst);
-        constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(constantLit->scope);
+        if (auto resolvedLit = ast::cast_tree<ast::ConstantLit>(constantLit->scope)) {
+            constantLit = resolvedLit->original();
+        } else {
+            constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(constantLit->scope);
+        }
     }
     reverse(fqn.parts.begin(), fqn.parts.end());
     ENFORCE(!fqn.parts.empty());

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1547,10 +1547,10 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
             continue;
         }
 
-        auto nameTree = ast::cast_tree<ast::UnresolvedConstantLit>(packageSpecClass->name);
+        auto nameTree = ast::cast_tree<ast::ConstantLit>(packageSpecClass->name);
         ENFORCE(nameTree != nullptr, "Invariant from rewriter");
 
-        return make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree), ctx.locAt(packageSpecClass->loc),
+        return make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree->original()), ctx.locAt(packageSpecClass->loc),
                                             ctx.locAt(packageSpecClass->declLoc));
     }
 

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/deeply_nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Package<<C Package>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
 
     <self>.export(<emptyTree>::<C Package>::<C PackageClass>)
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Package::Subpackage<<C Subpackage>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>)
 
     <self>.export(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
@@ -18,12 +18,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/deeply_nested_packages/mainpackage.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Package>::<C PackageClass><<C <todo sym>>> < (::<todo sym>)
+  class ::Package::PackageClass<<C PackageClass>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.returns(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
     end
 
-    def self.subpkg_class<<todo method>>(&<blk>)
+    def self.subpkg_class(<blk>)
       <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>.new()
     end
 
@@ -34,17 +34,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/inner_class.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Package>::<C InnerClass><<C <todo sym>>> < (::<todo sym>)
+  class ::Package::InnerClass<<C InnerClass>> < (::<todo sym>)
   end
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/subpackage.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass><<C <todo sym>>> < (::<todo sym>)
+  class ::Package::Subpackage::SubpackageClass<<C SubpackageClass>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.returns(<emptyTree>::<C Package>::<C PackageClass>)
     end
 
-    def self.package_class<<todo method>>(&<blk>)
+    def self.package_class(<blk>)
       return <emptyTree>::<C Package>::<C PackageClass>.new()
     end
 

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -1,11 +1,11 @@
 # -- test/testdata/packager/export_for_test/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPkg><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::RootPkg<<C RootPkg>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/export_for_test/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Opus::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar>)
 
     <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Util>)
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/foo/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Opus::Foo::Bar<<C Bar>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
 
     <self>.export(<emptyTree>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/test_imported/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C TestImported><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Opus::TestImported<<C TestImported>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Opus>::<C TestImported>::<C TIClass>)
 
     <self>.export(<emptyTree>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Opus>::<C Util><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Opus::Util<<C Util>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Opus>::<C Util>::<C UtilClass>)
 
     <self>.export(<emptyTree>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)
@@ -49,32 +49,32 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/foo/bar/bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass><<C <todo sym>>> < (::<todo sym>)
+  class ::Opus::Foo::Bar::BarClass<<C BarClass>> < (::<todo sym>)
   end
 end
 # -- test/testdata/packager/export_for_test/foo/bar/bar.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Test>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-    class <emptyTree>::<C BarClassTest><<C <todo sym>>> < (::<todo sym>)
+  module ::Test::Opus::Foo::Bar<<C Bar>> < ()
+    class ::Test::Opus::Foo::Bar::BarClassTest<<C BarClassTest>> < (::<todo sym>)
     end
   end
 end
 # -- test/testdata/packager/export_for_test/foo/foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Opus>::<C Foo><<C <todo sym>>> < ()
-    class <emptyTree>::<C FooClass><<C <todo sym>>> < (::<todo sym>)
-      <emptyTree>::<C Inner> = 1
+  module ::Opus::Foo<<C Foo>> < ()
+    class ::Opus::Foo::FooClass<<C FooClass>> < (::<todo sym>)
+      ::Opus::Foo::FooClass::Inner = 1
     end
 
-    class <emptyTree>::<C FooUnexported><<C <todo sym>>> < (::<todo sym>)
+    class ::Opus::Foo::FooUnexported<<C FooUnexported>> < (::<todo sym>)
     end
 
-    class <emptyTree>::<C Private>::<C ImplDetail><<C <todo sym>>> < (::<todo sym>)
+    class ::Opus::Foo::Private::ImplDetail<<C ImplDetail>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.void()
       end
 
-      def self.stub_stuff!<<todo method>>(&<blk>)
+      def self.stub_stuff!(<blk>)
         <emptyTree>
       end
 
@@ -106,7 +106,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/foo/foo.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Test>::<C Opus>::<C Foo>::<C FooTest><<C <todo sym>>> < (::<todo sym>)
+  class ::Test::Opus::Foo::FooTest<<C FooTest>> < (::<todo sym>)
     <emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
 
     <emptyTree>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>
@@ -134,30 +134,30 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/test_imported/test_imported.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
-    class <emptyTree>::<C TIClass><<C <todo sym>>> < (::<todo sym>)
+  module ::Opus::TestImported<<C TestImported>> < ()
+    class ::Opus::TestImported::TIClass<<C TIClass>> < (::<todo sym>)
     end
   end
 end
 # -- test/testdata/packager/export_for_test/test_imported/test_imported.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Test>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
-    class <emptyTree>::<C TITestClass><<C <todo sym>>> < (::<todo sym>)
+  module ::Test::Opus::TestImported<<C TestImported>> < ()
+    class ::Test::Opus::TestImported::TITestClass<<C TITestClass>> < (::<todo sym>)
     end
   end
 end
 # -- test/testdata/packager/export_for_test/util/util.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Opus>::<C Util><<C <todo sym>>> < ()
-    class <emptyTree>::<C UtilClass><<C <todo sym>>> < (::<todo sym>)
+  module ::Opus::Util<<C Util>> < ()
+    class ::Opus::Util::UtilClass<<C UtilClass>> < (::<todo sym>)
     end
 
-    module <emptyTree>::<C Nesting><<C <todo sym>>> < ()
+    module ::Opus::Util::Nesting<<C Nesting>> < ()
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.void()
       end
 
-      def self.nesting_method<<todo method>>(&<blk>)
+      def self.nesting_method(<blk>)
         <emptyTree>
       end
 
@@ -165,15 +165,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       <runtime method definition of self.nesting_method>
 
-      class <emptyTree>::<C OnlyForSelf><<C <todo sym>>> < (::<todo sym>)
+      class ::Opus::Util::Nesting::OnlyForSelf<<C OnlyForSelf>> < (::<todo sym>)
       end
 
-      class <emptyTree>::<C Public><<C <todo sym>>> < (::<todo sym>)
+      class ::Opus::Util::Nesting::Public<<C Public>> < (::<todo sym>)
         ::Sorbet::Private::Static.sig(<self>) do ||
           <self>.void()
         end
 
-        def self.public_method<<todo method>>(&<blk>)
+        def self.public_method(<blk>)
           <emptyTree>
         end
 
@@ -186,8 +186,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/util/util.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Test>::<C Opus>::<C Util><<C <todo sym>>> < ()
-    class <emptyTree>::<C TestUtil><<C <todo sym>>> < (::<todo sym>)
+  module ::Test::Opus::Util<<C Util>> < ()
+    class ::Test::Opus::Util::TestUtil<<C TestUtil>> < (::<todo sym>)
     end
 
     <emptyTree>::<C Opus>::<C Util>::<C Nesting>.nesting_method()

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/export_imported/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::A<<C A>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C B>)
 
     <self>.export(<emptyTree>::<C B>::<C BClass>)
@@ -8,12 +8,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_imported/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::B<<C B>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C B>::<C BClass>)
   end
 end
 # -- test/testdata/packager/export_imported/b/b.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C B>::<C BClass><<C <todo sym>>> < (::<todo sym>)
+  class ::B::BClass<<C BClass>> < (::<todo sym>)
   end
 end

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/extra_package_paths/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::Bar<<C Bar>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
 
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package>)
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/baz/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::Baz::Package<<C Package>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Baz>::<C Package>::<C C>)
 
     <self>.export(<emptyTree>::<C Project>::<C Baz>::<C Package>::<C E>)
@@ -18,7 +18,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Foo>::<C B>)
 
     <self>.export(<emptyTree>::<C Project>::<C Foo>::<C D>)
@@ -26,18 +26,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo_bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C FooBar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::FooBar<<C FooBar>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C FooBar>::<C Z>)
   end
 end
 # -- test/testdata/packager/extra_package_paths/bar/bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Bar>::<C Bar><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end
 
-    def bar1<<todo method>>(&<blk>)
+    def bar1(<blk>)
       begin
         <emptyTree>::<C Project>::<C Foo>::<C B>.b()
         <emptyTree>::<C Project>::<C Foo>::<C D>.d()
@@ -49,7 +49,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def bar2<<todo method>>(&<blk>)
+    def bar2(<blk>)
       begin
         <emptyTree>::<C Project>::<C Baz>::<C Package>::<C C>.c()
         <emptyTree>::<C Project>::<C Baz>::<C Package>::<C E>.e()
@@ -65,13 +65,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/extra/Project_Baz_Package/c.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < ()
-    class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
+  module ::Project::Baz::Package<<C Package>> < ()
+    class ::Project::Baz::Package::C<<C C>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.void()
       end
 
-      def self.c<<todo method>>(&<blk>)
+      def self.c(<blk>)
         <emptyTree>
       end
 
@@ -83,12 +83,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/extra/Project_Foo/b.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::Foo::B<<C B>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end
 
-    def self.b<<todo method>>(&<blk>)
+    def self.b(<blk>)
       <emptyTree>
     end
 
@@ -99,13 +99,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/extra_slash/Project/Baz/Package/E.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < ()
-    class <emptyTree>::<C E><<C <todo sym>>> < (::<todo sym>)
+  module ::Project::Baz::Package<<C Package>> < ()
+    class ::Project::Baz::Package::E<<C E>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.void()
       end
 
-      def self.e<<todo method>>(&<blk>)
+      def self.e(<blk>)
         <emptyTree>
       end
 
@@ -117,12 +117,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/extra_slash/Project/Foo/D.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Foo>::<C D><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::Foo::D<<C D>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end
 
-    def self.d<<todo method>>(&<blk>)
+    def self.d(<blk>)
       <emptyTree>
     end
 
@@ -133,12 +133,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/extra_slash/Project/FooBar/Z.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C FooBar>::<C Z><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::FooBar::Z<<C Z>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end
 
-    def self.z<<todo method>>(&<blk>)
+    def self.z(<blk>)
       <emptyTree>
     end
 
@@ -149,13 +149,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/extra_slash_deprecated/Project/Baz/Package/E.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < ()
-    class <emptyTree>::<C E><<C <todo sym>>> < (::<todo sym>)
+  module ::Project::Baz::Package<<C Package>> < ()
+    class ::Project::Baz::Package::E<<C E>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.void()
       end
 
-      def self.e<<todo method>>(&<blk>)
+      def self.e(<blk>)
         <emptyTree>
       end
 
@@ -167,12 +167,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/extra_slash_deprecated/Project/Foo/D.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Foo>::<C D><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::Foo::D<<C D>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end
 
-    def self.d<<todo method>>(&<blk>)
+    def self.d(<blk>)
       <emptyTree>
     end
 
@@ -183,12 +183,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/extra_slash_deprecated/Project/Foo_bar/Z.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C FooBar>::<C Z><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::FooBar::Z<<C Z>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end
 
-    def self.z<<todo method>>(&<blk>)
+    def self.z(<blk>)
       <emptyTree>
     end
 

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -1,17 +1,17 @@
 # -- test/testdata/packager/import_subpackage/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Root><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Root<<C Root>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Root>::<C B>)
   end
 end
 # -- test/testdata/packager/import_subpackage/a/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Root>::<C B><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Root::B<<C B>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Root>::<C B>::<C Foo>)
   end
 end
 # -- test/testdata/packager/import_subpackage/a/b/foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Root>::<C B>::<C Foo><<C <todo sym>>> < ()
+  module ::Root::B::Foo<<C Foo>> < ()
   end
 end

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/invalid_imports_and_exports/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::A<<C A>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(123)
 
     <self>.import("hello")
@@ -34,7 +34,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/invalid_imports_and_exports/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::B<<C B>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C A>)
 
     <self>.export(<emptyTree>::<C B>::<C BClass>)
@@ -44,23 +44,23 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/invalid_imports_and_exports/c/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C C><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::C<<C C>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/invalid_imports_and_exports/a.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C A><<C <todo sym>>> < ()
-    <emptyTree>::<C REFERENCE> = <emptyTree>::<C ASecondClass>
+  module ::A<<C A>> < ()
+    ::A::REFERENCE = <emptyTree>::<C ASecondClass>
 
-    class <emptyTree>::<C ASecondClass><<C <todo sym>>> < (::<todo sym>)
+    class ::A::ASecondClass<<C ASecondClass>> < (::<todo sym>)
     end
 
-    class <emptyTree>::<C AClass><<C <todo sym>>> < (::<todo sym>)
+    class ::A::AClass<<C AClass>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C AClass>)
       end
 
-      def get_a<<todo method>>(&<blk>)
+      def get_a(<blk>)
         <emptyTree>::<C B>::<C BModule>.get_a()
       end
 
@@ -69,12 +69,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <runtime method definition of get_a>
     end
 
-    module <emptyTree>::<C AModule><<C <todo sym>>> < ()
+    module ::A::AModule<<C AModule>> < ()
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Integer>)
       end
 
-      def self.one<<todo method>>(&<blk>)
+      def self.one(<blk>)
         1
       end
 
@@ -86,13 +86,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/invalid_imports_and_exports/b/b.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C B><<C <todo sym>>> < ()
-    class <emptyTree>::<C BClass><<C <todo sym>>> < (::<todo sym>)
+  module ::B<<C B>> < ()
+    class ::B::BClass<<C BClass>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Integer>)
       end
 
-      def get_one<<todo method>>(&<blk>)
+      def get_one(<blk>)
         <emptyTree>::<C A>::<C AModule>.one()
       end
 
@@ -101,12 +101,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <runtime method definition of get_one>
     end
 
-    module <emptyTree>::<C BModule><<C <todo sym>>> < ()
+    module ::B::BModule<<C BModule>> < ()
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C A>::<C AClass>)
       end
 
-      def self.get_a<<todo method>>(&<blk>)
+      def self.get_a(<blk>)
         <emptyTree>::<C A>::<C AClass>.new()
       end
 

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -1,13 +1,13 @@
 # -- test/testdata/packager/invalid_package_control_flow/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  <emptyTree>::<C SomeConstant> = <emptyTree>::<C PackageSpec>
+  ::SomeConstant = <emptyTree>::<C PackageSpec>
 
-  class ::<PackageSpecRegistry>::<C MyPackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::MyPackage<<C MyPackage>> < (::Sorbet::Private::Static::PackageSpec, <emptyTree>::<C T>::<C Helpers>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end
 
-    def package_method<<todo method>>(&<blk>)
+    def package_method(<blk>)
       <emptyTree>
     end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def self.static_method<<todo method>>(&<blk>)
+    def self.static_method(<blk>)
       <emptyTree>
     end
 
@@ -48,12 +48,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/invalid_package_control_flow/package_spec_additions.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<root>::<C Sorbet>::<C Private>::<C Static>::<C PackageSpec><<C <todo sym>>> < (::<todo sym>)
-    def self.some_method<<todo method>>(x, &<blk>)
+  class ::Sorbet::Private::Static::PackageSpec<<C PackageSpec>> < (::<todo sym>)
+    def self.some_method(x, <blk>)
       <emptyTree>
     end
 
-    def self.method_call_arg<<todo method>>(&<blk>)
+    def self.method_call_arg(<blk>)
       <emptyTree>
     end
 
@@ -63,6 +63,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of self.method_call_arg>
 
-    <emptyTree>::<C ConstantArg> = 10
+    ::Sorbet::Private::Static::PackageSpec::ConstantArg = 10
   end
 end

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -1,12 +1,12 @@
 # -- test/testdata/packager/nested_inner_namespaces/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::RootPackage<<C RootPackage>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C RootPackage>::<C Foo>)
   end
 end
 # -- test/testdata/packager/nested_inner_namespaces/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C RootPackage>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::RootPackage::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C RootPackage>::<C Foo>::<C Constant>)
 
     <self>.export(<emptyTree>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)
@@ -16,12 +16,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/nested_inner_namespaces/bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C RootPackage>::<C Bar><<C <todo sym>>> < ()
+  module ::RootPackage::Bar<<C Bar>> < ()
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.params(:a, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
     end
 
-    def main<<todo method>>(a, &<blk>)
+    def main(a, <blk>)
       if a.>(10)
         <emptyTree>::<C RootPackage>::<C Foo>::<C Constant>
       else
@@ -40,14 +40,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/nested_inner_namespaces/foo/foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
-    <emptyTree>::<C Constant> = "Foo"
+  module ::RootPackage::Foo<<C Foo>> < ()
+    ::RootPackage::Foo::Constant = "Foo"
 
-    module <emptyTree>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = "Bar"
+    module ::RootPackage::Foo::Bar<<C Bar>> < ()
+      ::RootPackage::Foo::Bar::Constant = "Bar"
 
-      module <emptyTree>::<C Baz><<C <todo sym>>> < ()
-        <emptyTree>::<C Constant> = "Baz"
+      module ::RootPackage::Foo::Bar::Baz<<C Baz>> < ()
+        ::RootPackage::Foo::Bar::Baz::Constant = "Baz"
       end
     end
   end

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Package<<C Package>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
 
     <self>.export(<emptyTree>::<C Package>::<C PackageClass>)
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/nested_packages/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Package::Subpackage<<C Subpackage>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>)
 
     <self>.export(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
@@ -16,12 +16,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/nested_packages/mainpackage.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Package>::<C PackageClass><<C <todo sym>>> < (::<todo sym>)
+  class ::Package::PackageClass<<C PackageClass>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.returns(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
     end
 
-    def self.subpkg_class<<todo method>>(&<blk>)
+    def self.subpkg_class(<blk>)
       <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>.new()
     end
 
@@ -32,12 +32,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/nested_packages/subpackage/subpackage.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass><<C <todo sym>>> < (::<todo sym>)
+  class ::Package::Subpackage::SubpackageClass<<C SubpackageClass>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.returns(<emptyTree>::<C Package>::<C PackageClass>)
     end
 
-    def self.package_class<<todo method>>(&<blk>)
+    def self.package_class(<blk>)
       return <emptyTree>::<C Package>::<C PackageClass>.new()
     end
 

--- a/test/testdata/packager/shared_prefix/pass.package-tree.exp
+++ b/test/testdata/packager/shared_prefix/pass.package-tree.exp
@@ -1,35 +1,35 @@
 # -- test/testdata/packager/shared_prefix/bar/that/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C That><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::Bar::That<<C That>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Bar>::<C That>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/this/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C This><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::Bar::This<<C This>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Bar>::<C This>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/that/that.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Project>::<C Bar>::<C That><<C <todo sym>>> < ()
-    <emptyTree>::<C Thing> = <cast:let>(:yeah, <todo sym>, <emptyTree>::<C Symbol>)
+  module ::Project::Bar::That<<C That>> < ()
+    ::Project::Bar::That::Thing = <cast:let>(:yeah, <todo sym>, <emptyTree>::<C Symbol>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/this/this.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Project>::<C Bar>::<C This><<C <todo sym>>> < ()
-    <emptyTree>::<C Thing> = <cast:let>(:hey, <todo sym>, <emptyTree>::<C Symbol>)
+  module ::Project::Bar::This<<C This>> < ()
+    ::Project::Bar::This::Thing = <cast:let>(:hey, <todo sym>, <emptyTree>::<C Symbol>)
   end
 end
 # -- test/testdata/packager/shared_prefix/foo/foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Foo>::<C Foo><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
     <self>.puts(<emptyTree>::<C Project>::<C Bar>::<C This>)
   end
 end

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/simple_package/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::Bar<<C Bar>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
 
     <self>.export(<emptyTree>::<C Project>::<C Bar>::<C Bar>)
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Bar>)
 
     <self>.export(<emptyTree>::<C Project>::<C Foo>::<C Foo>)
@@ -20,12 +20,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/bar/bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Bar>::<C Bar><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.params(:value, <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<todo method>>(value, &<blk>)
+    def initialize(value, <blk>)
       @value = <cast:let>(value, <todo sym>, <emptyTree>::<C Integer>)
     end
 
@@ -36,12 +36,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/bar/calls_foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Project>::<C Bar>::<C CallsFoo><<C <todo sym>>> < ()
+  module ::Project::Bar::CallsFoo<<C CallsFoo>> < ()
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.returns(<emptyTree>::<C Project>::<C Foo>::<C Foo>)
     end
 
-    def self.build_foo<<todo method>>(&<blk>)
+    def self.build_foo(<blk>)
       <emptyTree>::<C Project>::<C Foo>::<C Foo>.new(10)
     end
 
@@ -49,7 +49,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(<emptyTree>::<C Project>::<C Bar>::<C Bar>)
     end
 
-    def self.build_bar<<todo method>>(&<blk>)
+    def self.build_bar(<blk>)
       <emptyTree>::<C Project>::<C Foo>::<C CallsBar>.build_bar()
     end
 
@@ -62,12 +62,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/foo/calls_bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C Project>::<C Foo>::<C CallsBar><<C <todo sym>>> < ()
+  module ::Project::Foo::CallsBar<<C CallsBar>> < ()
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.returns(<emptyTree>::<C Project>::<C Bar>::<C Bar>)
     end
 
-    def self.build_bar<<todo method>>(&<blk>)
+    def self.build_bar(<blk>)
       <emptyTree>::<C Project>::<C Bar>::<C Bar>.new(10)
     end
 
@@ -78,12 +78,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/foo/foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Foo>::<C Foo><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.params(:value, <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<todo method>>(value, &<blk>)
+    def initialize(value, <blk>)
       @value = <cast:let>(value, <todo sym>, <emptyTree>::<C Integer>)
     end
 

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -1,6 +1,6 @@
 # -- test/testdata/packager/simple_test_import/main_lib/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C MainLib><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::MainLib<<C MainLib>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Util>)
 
     <self>.test_import(::<PackageSpecRegistry>::<C Project>::<C TestOnly>)
@@ -10,13 +10,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_test_import/test_only/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C TestOnly><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::TestOnly<<C TestOnly>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C TestOnly>::<C SomeHelper>)
   end
 end
 # -- test/testdata/packager/simple_test_import/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C Project>::<C Util><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::Project::Util<<C Util>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Util>::<C MyUtil>)
 
     <self>.export(<emptyTree>::<C Test>::<C Project>::<C Util>::<C UtilHelper>)
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_test_import/main_lib/lib.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C MainLib>::<C Lib><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::MainLib::Lib<<C Lib>> < (::<todo sym>)
     <emptyTree>::<C Project>::<C Util>::<C MyUtil>.new()
 
     <emptyTree>::<C Project>::<C TestOnly>::<C SomeHelper>.new()
@@ -36,7 +36,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_test_import/main_lib/lib.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Test>::<C Project>::<C MainLib>::<C LibTest><<C <todo sym>>> < (::<todo sym>)
+  class ::Test::Project::MainLib::LibTest<<C LibTest>> < (::<todo sym>)
     <emptyTree>::<C Project>::<C MainLib>::<C Lib>.new()
 
     <emptyTree>::<C Project>::<C Util>::<C MyUtil>.new()
@@ -50,21 +50,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_test_import/test_only/some_helper.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C TestOnly>::<C SomeHelper><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::TestOnly::SomeHelper<<C SomeHelper>> < (::<todo sym>)
   end
 end
 # -- test/testdata/packager/simple_test_import/util/my_util.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Project>::<C Util>::<C MyUtil><<C <todo sym>>> < (::<todo sym>)
+  class ::Project::Util::MyUtil<<C MyUtil>> < (::<todo sym>)
   end
 end
 # -- test/testdata/packager/simple_test_import/util/unexported.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Test>::<C Project>::<C Util>::<C Unexported><<C <todo sym>>> < (::<todo sym>)
+  class ::Test::Project::Util::Unexported<<C Unexported>> < (::<todo sym>)
   end
 end
 # -- test/testdata/packager/simple_test_import/util/util_helper.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Test>::<C Project>::<C Util>::<C UtilHelper><<C <todo sym>>> < (::<todo sym>)
+  class ::Test::Project::Util::UtilHelper<<C UtilHelper>> < (::<todo sym>)
   end
 end

--- a/test/testdata/packager/unimported_namespace/pass.package-tree.exp
+++ b/test/testdata/packager/unimported_namespace/pass.package-tree.exp
@@ -1,23 +1,23 @@
 # -- test/testdata/packager/unimported_namespace/aaa/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C AAA><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::AAA<<C AAA>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C AAA>::<C AClass>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/bbb/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C BBB><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::BBB<<C BBB>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C AAA>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/ccc/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::<C CCC><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::<PackageSpecRegistry>::CCC<<C CCC>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/unimported_namespace/aaa/a_class.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C AAA>::<C AClass><<C <todo sym>>> < (::<todo sym>)
+  class ::AAA::AClass<<C AClass>> < (::<todo sym>)
     <emptyTree>::<C BBB>
 
     <emptyTree>::<C CCC>
@@ -27,6 +27,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/unimported_namespace/bbb/b_class.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C BBB>::<C BClass><<C <todo sym>>> < (::<todo sym>)
+  class ::BBB::BClass<<C BClass>> < (::<todo sym>)
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Currently there is no dependency between these two phases.

In a future change, namer is going to be in charge of creating `Package`
symbols, which will replace `PackageInfo`.

Since it currently doesn't matter which order they happen in, I may as well flip
them now, so that people don't start to assume the other way around.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.