### PR TITLE
Remove outdated comment in resolver about packager

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -761,9 +761,6 @@ private:
         // This name is an artifact of parser recovery--no need to leak the parser implementation to the user,
         // because an error will have already been reported.
         auto constantNameMissing = original.cnst == core::Names::Constants::ConstantNameMissing();
-        // If a package exports a name that does not exist only one error should appear at the
-        // export site. Ignore resolution failures in the aliases/modules created by packaging to
-        // avoid this resulting in duplicate errors.
         if (!constantNameMissing && !alreadyReported) {
             if (auto e = ctx.beginError(original.loc, core::errors::Resolver::StubConstant)) {
                 e.setHeader("Unable to resolve constant `{}`", original.cnst.show(ctx));


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This comment was added in 
ba2dcca12600298c1f3cd41935ec85e669c0d71d when a call to a method named `isPackagerMaterializedConstantRef` was added to the following `if` condition.

In 49b02c3d9b87992fd639b3d6eb76d32e567598ee that method was deleted and removed from the condition, but the comment was not removed.

This comment references the old implementation of package visibility which worked based on syntactic rewrites instead of first-class visibility checking.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
