### PR TITLE
Add support for multiline RBS signatures

### DIFF
--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -119,7 +119,10 @@ parseComment(core::MutableContext ctx, InlineComment comment,
     }
 
     auto signatureTranslator = rbs::SignatureTranslator(ctx);
-    auto type = signatureTranslator.translateAssertionType(typeParams, comment.comment);
+    vector<Comment> comments;
+    comments.push_back(comment.comment);
+    auto declaration = RBSDeclaration(comments);
+    auto type = signatureTranslator.translateAssertionType(typeParams, declaration);
 
     if (type == nullptr) {
         // We couldn't parse the type, we produced an error, we don't return anything

--- a/rbs/MethodTypeToParserNode.h
+++ b/rbs/MethodTypeToParserNode.h
@@ -19,7 +19,7 @@ public:
      * For example the signature comment `#: () -> void` will be translated as `sig { void }`.
      */
     std::unique_ptr<parser::Node> methodSignature(const parser::Node *methodDef, const rbs_method_type_t *methodType,
-                                                  const core::LocOffsets typeLoc, const core::LocOffsets commentLoc,
+                                                  const RBSDeclaration &declaration,
                                                   const std::vector<Comment> &annotations);
 
     /**
@@ -28,7 +28,7 @@ public:
      * For example the attribute type comment `#: Integer` will be translated as `sig { returns(Integer) }`.
      */
     std::unique_ptr<parser::Node> attrSignature(const parser::Send *send, const rbs_node_t *type,
-                                                const core::LocOffsets typeLoc, const core::LocOffsets commentLoc,
+                                                const RBSDeclaration &declaration,
                                                 const std::vector<Comment> &annotations);
 };
 

--- a/rbs/SignatureTranslator.h
+++ b/rbs/SignatureTranslator.h
@@ -14,14 +14,15 @@ public:
 
     std::unique_ptr<parser::Node>
     translateAssertionType(std::vector<std::pair<core::LocOffsets, core::NameRef>> typeParams,
-                           const rbs::Comment &assertion);
+                           const RBSDeclaration &declaration);
 
-    std::unique_ptr<parser::Node> translateAttrSignature(const parser::Send *send, const rbs::Comment &signature,
+    std::unique_ptr<parser::Node> translateAttrSignature(const parser::Send *send, const RBSDeclaration &declaration,
                                                          const std::vector<Comment> &annotations);
-    std::unique_ptr<parser::Node> translateMethodSignature(const parser::Node *methodDef, const rbs::Comment &signature,
+    std::unique_ptr<parser::Node> translateMethodSignature(const parser::Node *methodDef,
+                                                           const RBSDeclaration &declaration,
                                                            const std::vector<Comment> &annotations);
 
-    std::unique_ptr<parser::Node> translateType(core::LocOffsets loc, const std::string_view typeString);
+    std::unique_ptr<parser::Node> translateType(const RBSDeclaration &declaration);
 
 private:
     core::MutableContext ctx;

--- a/rbs/SigsRewriter.h
+++ b/rbs/SigsRewriter.h
@@ -23,7 +23,7 @@ struct Comments {
      *
      * Signatures are formatted as `#: () -> void`.
      */
-    std::vector<Comment> signatures;
+    std::vector<RBSDeclaration> signatures;
 };
 
 class SigsRewriter {

--- a/rbs/TypeToParserNode.h
+++ b/rbs/TypeToParserNode.h
@@ -23,21 +23,32 @@ public:
      * - `Integer?` -> `T.nilable(Integer)`
      * - `(A | B)` -> `T.any(A, B)`
      */
-    std::unique_ptr<parser::Node> toParserNode(const rbs_node_t *node, core::LocOffsets loc);
+    std::unique_ptr<parser::Node> toParserNode(const rbs_node_t *node, const RBSDeclaration &declaration);
 
 private:
-    std::unique_ptr<parser::Node> typeNameType(const rbs_type_name_t *typeName, bool isGeneric, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> classInstanceType(const rbs_types_class_instance_t *node, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> classSingletonType(const rbs_types_class_singleton_t *node, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> intersectionType(const rbs_types_intersection_t *node, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> unionType(const rbs_types_union_t *node, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> optionalType(const rbs_types_optional_t *node, core::LocOffsets loc);
+    std::unique_ptr<parser::Node> typeNameType(const rbs_type_name_t *typeName, bool isGeneric,
+                                               const RBSDeclaration &declaration);
+    std::unique_ptr<parser::Node> classInstanceType(const rbs_types_class_instance_t *node, core::LocOffsets loc,
+                                                    const RBSDeclaration &declaration);
+    std::unique_ptr<parser::Node> classSingletonType(const rbs_types_class_singleton_t *node, core::LocOffsets loc,
+                                                     const RBSDeclaration &declaration);
+    std::unique_ptr<parser::Node> intersectionType(const rbs_types_intersection_t *node, core::LocOffsets loc,
+                                                   const RBSDeclaration &declaration);
+    std::unique_ptr<parser::Node> unionType(const rbs_types_union_t *node, core::LocOffsets loc,
+                                            const RBSDeclaration &declaration);
+    std::unique_ptr<parser::Node> optionalType(const rbs_types_optional_t *node, core::LocOffsets loc,
+                                               const RBSDeclaration &declaration);
     std::unique_ptr<parser::Node> voidType(const rbs_types_bases_void_t *node, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> functionType(const rbs_types_function_t *node, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> procType(const rbs_types_proc_t *node, core::LocOffsets docLoc);
-    std::unique_ptr<parser::Node> blockType(const rbs_types_block_t *node, core::LocOffsets docLoc);
-    std::unique_ptr<parser::Node> tupleType(const rbs_types_tuple_t *node, core::LocOffsets loc);
-    std::unique_ptr<parser::Node> recordType(const rbs_types_record_t *node, core::LocOffsets loc);
+    std::unique_ptr<parser::Node> functionType(const rbs_types_function_t *node, core::LocOffsets loc,
+                                               const RBSDeclaration &declaration);
+    std::unique_ptr<parser::Node> procType(const rbs_types_proc_t *node, core::LocOffsets loc,
+                                           const RBSDeclaration &declaration);
+    std::unique_ptr<parser::Node> blockType(const rbs_types_block_t *node, core::LocOffsets loc,
+                                            const RBSDeclaration &declaration);
+    std::unique_ptr<parser::Node> tupleType(const rbs_types_tuple_t *node, core::LocOffsets loc,
+                                            const RBSDeclaration &declaration);
+    std::unique_ptr<parser::Node> recordType(const rbs_types_record_t *node, core::LocOffsets loc,
+                                             const RBSDeclaration &declaration);
     std::unique_ptr<parser::Node> variableType(const rbs_types_variable_t *node, core::LocOffsets loc);
 };
 

--- a/rbs/rbs_common.h
+++ b/rbs/rbs_common.h
@@ -22,7 +22,73 @@ struct Comment {
                                  // this is only a view on the string owned by the File.source() data.
 };
 
-core::LocOffsets locFromRange(core::LocOffsets loc, const rbs_range_t &range);
+/**
+ * A collection of RBS type comments that collectively describe a method signature, attribute type, or type assertion.
+ */
+class RBSDeclaration {
+public:
+    std::vector<Comment> comments;
+
+    RBSDeclaration(std::vector<Comment> comments) : comments(comments) {}
+
+    /**
+     * Combines all the comments into a single string.
+     */
+    std::string string() const;
+
+    /**
+     * Returns the location that all the comments cover.
+     *
+     * For multiline comments, this starts at the first comment's location and ends at the last comment's location.
+     *
+     * ```
+     * v starts from here
+     * #: (Integer) ->
+     * #| void
+     *       ^ ends here
+     * ```
+     */
+    core::LocOffsets commentLoc() const;
+
+    /**
+     * Returns entire type location
+     *
+     * ```
+     *   v starts from here
+     * #: (Integer) ->
+     * #| void
+     *       ^ ends here
+     * ```
+     */
+    core::LocOffsets fullTypeLoc() const;
+
+    /**
+     * Returns the type location of the first comment.
+     *
+     * ```
+     *   v starts from here
+     * #: (Integer) ->
+     *               ^ ends here
+     * #| void
+     * ```
+     *
+     * Usually used for generating `sig` nodes only.
+     */
+    core::LocOffsets firstLineTypeLoc() const;
+
+    /**
+     * Returns the type location of the RBS declaration that covers the given range.
+     * For example, if given the range of the `void` token:
+     *
+     * ```
+     * #: (Integer) ->
+     *    v starts from here
+     * #| void
+     *       ^ ends here
+     * ```
+     */
+    core::LocOffsets typeLocFromRange(const rbs_range_t &range) const;
+};
 
 } // namespace sorbet::rbs
 

--- a/test/testdata/rbs/signatures_defs_multiline.rb
+++ b/test/testdata/rbs/signatures_defs_multiline.rb
@@ -1,0 +1,198 @@
+# typed: strict
+# enable-experimental-rbs-signatures: true
+
+extend T::Sig
+
+class P1; end
+class P2; end
+class P3; end
+class P4; end
+class P5; end
+class P6; end
+
+#: (P1, P2
+#| -> void
+#  ^^ error: Failed to parse RBS signature (unexpected token for function parameter name)
+def parse_error1; T.unsafe(nil); end # error: The method `parse_error1` does not have a `sig`
+
+#: (P1,
+#| P2
+#|   -> void
+#    ^^ error: Failed to parse RBS signature (unexpected token for function parameter name)
+def parse_error2; T.unsafe(nil); end # error: The method `parse_error2` does not have a `sig`
+
+#: (
+#| P1,
+#|  P2
+#| -> void
+#  ^^ error: Failed to parse RBS signature (unexpected token for function parameter name)
+def parse_error3; T.unsafe(nil); end # error: The method `parse_error3` does not have a `sig`
+
+#: (
+#|   String x ) -> String
+#           ^ error: Unknown argument name `x`
+def named_args1(y)
+  #             ^ error: Malformed `sig`. Type not specified for argument `y`
+  T.reveal_type(y) # error: Revealed type: `T.untyped`
+end
+
+#: (
+#|   String
+#| x ) -> String
+#  ^ error: Unknown argument name `x`
+def named_args2(y)
+  #             ^ error: Malformed `sig`. Type not specified for argument `y`
+  T.reveal_type(y) # error: Revealed type: `T.untyped`
+end
+
+#: ->
+#| String
+def method2; T.unsafe(nil); end
+T.reveal_type(method2) # error: Revealed type: `String`
+
+#:      ->
+#| String
+def method4; T.unsafe(nil); end
+T.reveal_type(method4) # error: Revealed type: `String`
+
+# some comment
+#: ->
+#| String
+# some comment
+def method5; T.unsafe(nil); end
+T.reveal_type(method5) # error: Revealed type: `String`
+
+  #: -> String
+# ^^^^^^^^^^^^ error: Unused type annotation. No method def before next annotation
+  #: ->
+  #| void
+  def method6; T.unsafe(nil); end
+  T.reveal_type(method6) # error: Revealed type: `Sorbet::Private::Static::Void`
+
+#: (P1) ->
+#| P10
+#  ^^^ error: Unable to resolve constant `P10`
+def method_with_missing_type_1(p1)
+  T.reveal_type(p1) # error: Revealed type: `P1`
+end
+
+#: [X] (
+#|   X & Object
+#| ) -> Class[Y]
+#             ^ error: Unable to resolve constant `Y`
+def method_with_missing_type_2(x)
+  T.reveal_type(x) # error: Revealed type: `T.all(Object, T.type_parameter(:X) (of Object#method_with_missing_type_2))`
+  x.class
+end
+
+#: (P1) ->
+#| void
+def method7(p1)
+  T.reveal_type(p1) # error: Revealed type: `P1`
+end
+method7(P1.new)
+method7(42) # error: Expected `P1` but found `Integer(42)` for argument `p1`
+
+#: (
+#|   P1,
+#|   P2
+#| ) -> void
+def method8(p1, p2)
+  T.reveal_type(p1) # error: Revealed type: `P1`
+  T.reveal_type(p2) # error: Revealed type: `P2`
+end
+method8(P1.new, 42) # error: Expected `P2` but found `Integer(42)` for argument `p2`
+
+#: (
+#|   ?Integer
+#| ) -> void
+def method9(p1 = 42)
+  T.reveal_type(p1) # error: Revealed type: `Integer`
+end
+method9
+method9(42)
+
+#: (
+#|   P1,
+#|   ?P2?
+#| ) -> void
+def method10(p1, p2 = nil)
+  T.reveal_type(p1) # error: Revealed type: `P1`
+  T.reveal_type(p2) # error: Revealed type: `T.nilable(P2)`
+end
+method10(P1.new, nil)
+method10(P1.new, P2.new)
+method10(P1.new)
+
+# Named args
+
+#: (
+#|   String x
+#| ) -> String
+def method11(x)
+  T.reveal_type(x) # error: Revealed type: `String`
+end
+method11("foo")
+
+
+#: (
+#|   String   ?x
+#| ) -> void
+def method13(x)
+  T.reveal_type(x) # error: Revealed type: `T.nilable(String)`
+end
+
+#: (
+#|   ?String x
+#| ) -> void
+def method14(x)
+  T.reveal_type(x) # error: Revealed type: `String`
+end
+
+#: (
+#|   String ?x
+#| ) -> void
+def method16(x = nil)
+  T.reveal_type(x) # error: Revealed type: `T.nilable(String)`
+end
+
+#: ?{ -> void } ->
+#| void
+def method18(&block)
+  T.reveal_type(block) # error: Revealed type: `T.nilable(T.proc.void)`
+end
+
+#: [X] (
+#|   X & Object
+#| ) -> Class[X]
+def method19(x)
+  T.reveal_type(x) # error: Revealed type: `T.all(Object, T.type_parameter(:X) (of Object#method19))`
+  x.class
+end
+T.reveal_type(method19(42)) # error: Revealed type: `T::Class[Integer]`
+
+#: ?{
+#|   (?) -> untyped
+#| } -> void
+def method20(&block)
+  T.reveal_type(block) # error: Revealed type: `T.untyped`
+end
+
+class FooProc
+  #: (p: ^() -> Integer)
+  #| ?{
+  #|   (Integer) [self: FooProc] -> String
+  #| } -> void
+  def initialize(p: -> { 42 }, &block)
+    T.reveal_type(p) # error: Revealed type: `T.proc.returns(Integer)`
+    T.reveal_type(block) # error: Revealed type: `T.nilable(T.proc.params(arg0: Integer).returns(String))`
+    T.reveal_type(p.call) # error: Revealed type: `Integer`
+    T.reveal_type(block&.call(42)) # error: Revealed type: `T.nilable(String)`
+  end
+end
+
+FooProc.new do |foo|
+  T.reveal_type(self) # error: Revealed type: `FooProc`
+  T.reveal_type(foo) # error: Revealed type: `Integer`
+  "foo"
+end

--- a/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
@@ -1,0 +1,307 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def parse_error1<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  def parse_error2<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  def parse_error3<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+  end
+
+  def named_args1<<todo method>>(y, &<blk>)
+    <emptyTree>::<C T>.reveal_type(y)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+  end
+
+  def named_args2<<todo method>>(y, &<blk>)
+    <emptyTree>::<C T>.reveal_type(y)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.returns(<emptyTree>::<C String>)
+  end
+
+  def method2<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.returns(<emptyTree>::<C String>)
+  end
+
+  def method4<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.returns(<emptyTree>::<C String>)
+  end
+
+  def method5<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.returns(<emptyTree>::<C String>)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.void()
+  end
+
+  def method6<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p1, <emptyTree>::<C P1>).returns(<emptyTree>::<C P10>)
+  end
+
+  def method_with_missing_type_1<<todo method>>(p1, &<blk>)
+    <emptyTree>::<C T>.reveal_type(p1)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.[](<emptyTree>::<C Y>))
+  end
+
+  def method_with_missing_type_2<<todo method>>(x, &<blk>)
+    begin
+      <emptyTree>::<C T>.reveal_type(x)
+      x.class()
+    end
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p1, <emptyTree>::<C P1>).void()
+  end
+
+  def method7<<todo method>>(p1, &<blk>)
+    <emptyTree>::<C T>.reveal_type(p1)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p1, <emptyTree>::<C P1>, :p2, <emptyTree>::<C P2>).void()
+  end
+
+  def method8<<todo method>>(p1, p2, &<blk>)
+    begin
+      <emptyTree>::<C T>.reveal_type(p1)
+      <emptyTree>::<C T>.reveal_type(p2)
+    end
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p1, <emptyTree>::<C Integer>).void()
+  end
+
+  def method9<<todo method>>(p1 = 42, &<blk>)
+    <emptyTree>::<C T>.reveal_type(p1)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p1, <emptyTree>::<C P1>, :p2, ::<root>::<C T>.nilable(<emptyTree>::<C P2>)).void()
+  end
+
+  def method10<<todo method>>(p1, p2 = nil, &<blk>)
+    begin
+      <emptyTree>::<C T>.reveal_type(p1)
+      <emptyTree>::<C T>.reveal_type(p2)
+    end
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+  end
+
+  def method11<<todo method>>(x, &<blk>)
+    <emptyTree>::<C T>.reveal_type(x)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
+  end
+
+  def method13<<todo method>>(x, &<blk>)
+    <emptyTree>::<C T>.reveal_type(x)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:x, <emptyTree>::<C String>).void()
+  end
+
+  def method14<<todo method>>(x, &<blk>)
+    <emptyTree>::<C T>.reveal_type(x)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
+  end
+
+  def method16<<todo method>>(x = nil, &<blk>)
+    <emptyTree>::<C T>.reveal_type(x)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().void())).void()
+  end
+
+  def method18<<todo method>>(&block)
+    <emptyTree>::<C T>.reveal_type(block)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.[](::<root>::<C T>.type_parameter(:X)))
+  end
+
+  def method19<<todo method>>(x, &<blk>)
+    begin
+      <emptyTree>::<C T>.reveal_type(x)
+      x.class()
+    end
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:block, ::<root>::<C T>.untyped()).void()
+  end
+
+  def method20<<todo method>>(&block)
+    <emptyTree>::<C T>.reveal_type(block)
+  end
+
+  <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+  class <emptyTree>::<C P1><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C P2><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C P3><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C P4><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C P5><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C P6><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  <runtime method definition of parse_error1>
+
+  <runtime method definition of parse_error2>
+
+  <runtime method definition of parse_error3>
+
+  <runtime method definition of named_args1>
+
+  <runtime method definition of named_args2>
+
+  <runtime method definition of method2>
+
+  <emptyTree>::<C T>.reveal_type(<self>.method2())
+
+  <runtime method definition of method4>
+
+  <emptyTree>::<C T>.reveal_type(<self>.method4())
+
+  <runtime method definition of method5>
+
+  <emptyTree>::<C T>.reveal_type(<self>.method5())
+
+  <runtime method definition of method6>
+
+  <emptyTree>::<C T>.reveal_type(<self>.method6())
+
+  <runtime method definition of method_with_missing_type_1>
+
+  <runtime method definition of method_with_missing_type_2>
+
+  <runtime method definition of method7>
+
+  <self>.method7(<emptyTree>::<C P1>.new())
+
+  <self>.method7(42)
+
+  <runtime method definition of method8>
+
+  <self>.method8(<emptyTree>::<C P1>.new(), 42)
+
+  <runtime method definition of method9>
+
+  <self>.method9()
+
+  <self>.method9(42)
+
+  <runtime method definition of method10>
+
+  <self>.method10(<emptyTree>::<C P1>.new(), nil)
+
+  <self>.method10(<emptyTree>::<C P1>.new(), <emptyTree>::<C P2>.new())
+
+  <self>.method10(<emptyTree>::<C P1>.new())
+
+  <runtime method definition of method11>
+
+  <self>.method11("foo")
+
+  <runtime method definition of method13>
+
+  <runtime method definition of method14>
+
+  <runtime method definition of method16>
+
+  <runtime method definition of method18>
+
+  <runtime method definition of method19>
+
+  <emptyTree>::<C T>.reveal_type(<self>.method19(42))
+
+  <runtime method definition of method20>
+
+  class <emptyTree>::<C FooProc><<C <todo sym>>> < (::<todo sym>)
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.params(:p, ::<root>::<C T>.proc().returns(<emptyTree>::<C Integer>), :block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>).bind(<emptyTree>::<C FooProc>))).void()
+    end
+
+    def initialize<<todo method>>(p: = <emptyTree>::<C Kernel>.lambda() do ||
+        42
+      end, &block)
+      begin
+        <emptyTree>::<C T>.reveal_type(p)
+        <emptyTree>::<C T>.reveal_type(block)
+        <emptyTree>::<C T>.reveal_type(p.call())
+        <emptyTree>::<C T>.reveal_type(begin
+            <assignTemp>$2 = block
+            if ::NilClass.===(<assignTemp>$2)
+              ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$2)
+            else
+              <assignTemp>$2.call(42)
+            end
+          end)
+      end
+    end
+
+    <runtime method definition of initialize>
+  end
+
+  <emptyTree>::<C FooProc>.new() do |foo|
+    begin
+      <emptyTree>::<C T>.reveal_type(<self>)
+      <emptyTree>::<C T>.reveal_type(foo)
+      "foo"
+    end
+  end
+end

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -37,6 +37,17 @@ def foo(x)
 end
 ```
 
+Long signatures can be broken into multiple lines using the `#|` continuation
+comment:
+
+```ruby
+#: (
+#|  Integer,
+#|  String
+#| ) -> Float
+def foo(x, y); end
+```
+
 ## Caveats
 
 > Support for this feature is experimental, and we actively discourage depending


### PR DESCRIPTION
### Motivation

So long signatures can be broken into multiple lines using the `#|` continuation comment:

```ruby
#: (
#|  Integer,
#|  String
#| ) -> Float
def foo(x, y); end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
