### PR TITLE
Fix a typo when setting package options in copyForIndex

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2192,7 +2192,7 @@ GlobalState::copyForIndex(const vector<string> &extraPackageFilesDirectoryUnders
     {
         core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*result);
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = result->unfreezePackages();
-        result->setPackagerOptions(extraPackageFilesDirectorySlashPrefixes,
+        result->setPackagerOptions(extraPackageFilesDirectoryUnderscorePrefixes,
                                    extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                    extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
                                    allowRelaxedPackagerChecksFor, packagerLayers, errorHint);


### PR DESCRIPTION
`extraPackageFilesDirectorySlashPrefixes` was used where `extraPackageFilesDirectoryUnderscorePrefixes` should have been. This didn't cause any problems because we're not currently running the packager in a context where we'd have a copy of the `GlobalState` created with `copyForIndex`.

### Motivation
Fixing a bug with packager configuration.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This isn't really possible to test without coming up with a contrived standalone test, as we don't currently run the packager during the indexing pass.
