### PR TITLE
Fix option RBS names in error message

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1383,8 +1383,8 @@ void readOptions(Options &opts,
 
         if (opts.print.RBSRewriteTree.enabled &&
             (!opts.cacheSensitiveOptions.rbsSignaturesEnabled && !opts.cacheSensitiveOptions.rbsAssertionsEnabled)) {
-            logger->error("--print=rbs-rewrite-tree must also include `{}` or `{}`", "--rbs-signatures-enabled",
-                          "--rbs-assertions-enabled");
+            logger->error("--print=rbs-rewrite-tree must also include `{}` or `{}`",
+                          "--enable-experimental-rbs-signatures", "--enable-experimental-rbs-assertions");
             throw EarlyReturnWithCode(1);
         }
 

--- a/test/cli/rbs-print-rewrite-tree/test.out
+++ b/test/cli/rbs-print-rewrite-tree/test.out
@@ -90,4 +90,4 @@ Begin {
   ]
 }
 --------------------------------------------------------------------------
---print=rbs-rewrite-tree must also include `--rbs-signatures-enabled` or `--rbs-assertions-enabled`
+--print=rbs-rewrite-tree must also include `--enable-experimental-rbs-signatures` or `--enable-experimental-rbs-assertions`


### PR DESCRIPTION
### Motivation

Those names were wrong.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
