### PR TITLE
packager.cc: `prependRoot` is obsolete

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -708,16 +708,6 @@ PackageName getPackageName(core::Context ctx, const ast::UnresolvedConstantLit *
     return pName;
 }
 
-ast::ExpressionPtr prependRoot(ast::ExpressionPtr scope) {
-    auto *lastConstLit = &ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(scope);
-    while (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(lastConstLit->scope)) {
-        lastConstLit = constLit;
-    }
-    auto loc = lastConstLit->scope.loc();
-    lastConstLit->scope = ast::MK::Constant(loc, core::Symbols::root());
-    return scope;
-}
-
 bool recursiveVerifyConstant(core::Context ctx, core::NameRef fun, const ast::ExpressionPtr &root,
                              const ast::ExpressionPtr &expr) {
     if (ast::isa_tree<ast::EmptyTree>(expr)) {
@@ -1236,8 +1226,6 @@ struct PackageSpecBodyWalk {
             // null indicates an invalid export.
             if (auto target = verifyConstant(ctx, core::Names::export_(), send.getPosArg(0))) {
                 exported.emplace_back(getFullyQualifiedName(ctx, target));
-                auto &arg = send.getPosArg(0);
-                arg = prependRoot(std::move(arg));
             }
         }
 

--- a/test/cli/package-export-suggestion-boundary/test.out
+++ b/test/cli/package-export-suggestion-boundary/test.out
@@ -34,4 +34,11 @@ example/__package.rb:6: Unable to resolve constant `Exmpl` https://srb.help/5002
 example/__package.rb:7: Unable to resolve constant `So` https://srb.help/5002
      7 |  export So
                  ^^
+  Did you mean `Some`? Use `-a` to autocorrect
+    example/__package.rb:7: Replace with `Some`
+     7 |  export So
+                 ^^
+    example/__package.rb:3: `Some` defined here
+     3 |class Some::Example < PackageSpec
+              ^^^^
 Errors: 4

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -3,9 +3,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
 
-    <self>.export(::<root>::<C Package>::<C PackageClass>)
+    <self>.export(<emptyTree>::<C Package>::<C PackageClass>)
 
-    <self>.export(::<root>::<C Package>::<C InnerClass>)
+    <self>.export(<emptyTree>::<C Package>::<C InnerClass>)
   end
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb --
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>)
 
-    <self>.export(::<root>::<C Package>::<C Subpackage>::<C SubpackageClass>)
+    <self>.export(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end
 end
 # -- test/testdata/packager/deeply_nested_packages/mainpackage.rb --

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.test_import(::<PackageSpecRegistry>::<C Opus>::<C TestImported>)
 
-    <self>.export(::<root>::<C Opus>::<C Foo>::<C FooClass>)
+    <self>.export(<emptyTree>::<C Opus>::<C Foo>::<C FooClass>)
 
     <self>.export_for_test(<emptyTree>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>)
 
@@ -22,27 +22,27 @@ end
 # -- test/testdata/packager/export_for_test/foo/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
+    <self>.export(<emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
 
-    <self>.export(::<root>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
+    <self>.export(<emptyTree>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
   end
 end
 # -- test/testdata/packager/export_for_test/test_imported/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Opus>::<C TestImported><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Opus>::<C TestImported>::<C TIClass>)
+    <self>.export(<emptyTree>::<C Opus>::<C TestImported>::<C TIClass>)
 
-    <self>.export(::<root>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
+    <self>.export(<emptyTree>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
   end
 end
 # -- test/testdata/packager/export_for_test/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Opus>::<C Util><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Opus>::<C Util>::<C UtilClass>)
+    <self>.export(<emptyTree>::<C Opus>::<C Util>::<C UtilClass>)
 
-    <self>.export(::<root>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)
+    <self>.export(<emptyTree>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)
 
-    <self>.export(::<root>::<C Opus>::<C Util>::<C Nesting>::<C Public>)
+    <self>.export(<emptyTree>::<C Opus>::<C Util>::<C Nesting>::<C Public>)
 
     <self>.export_for_test(<emptyTree>::<C Opus>::<C Util>::<C Nesting>)
   end

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -3,13 +3,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C A><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C B>)
 
-    <self>.export(::<root>::<C B>::<C BClass>)
+    <self>.export(<emptyTree>::<C B>::<C BClass>)
   end
 end
 # -- test/testdata/packager/export_imported/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C B>::<C BClass>)
+    <self>.export(<emptyTree>::<C B>::<C BClass>)
   end
 end
 # -- test/testdata/packager/export_imported/b/b.rb --

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -11,23 +11,23 @@ end
 # -- test/testdata/packager/extra_package_paths/baz/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C C>)
+    <self>.export(<emptyTree>::<C Project>::<C Baz>::<C Package>::<C C>)
 
-    <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C E>)
+    <self>.export(<emptyTree>::<C Project>::<C Baz>::<C Package>::<C E>)
   end
 end
 # -- test/testdata/packager/extra_package_paths/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Project>::<C Foo>::<C B>)
+    <self>.export(<emptyTree>::<C Project>::<C Foo>::<C B>)
 
-    <self>.export(::<root>::<C Project>::<C Foo>::<C D>)
+    <self>.export(<emptyTree>::<C Project>::<C Foo>::<C D>)
   end
 end
 # -- test/testdata/packager/extra_package_paths/foo_bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Project>::<C FooBar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Project>::<C FooBar>::<C Z>)
+    <self>.export(<emptyTree>::<C Project>::<C FooBar>::<C Z>)
   end
 end
 # -- test/testdata/packager/extra_package_paths/bar/bar.rb --

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -7,7 +7,7 @@ end
 # -- test/testdata/packager/import_subpackage/a/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Root>::<C B><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Root>::<C B>::<C Foo>)
+    <self>.export(<emptyTree>::<C Root>::<C B>::<C Foo>)
   end
 end
 # -- test/testdata/packager/import_subpackage/a/b/foo.rb --

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -19,11 +19,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.export(<self>.method())
 
-    <self>.export(::<root>::<C A>::<C REFERENCE>)
+    <self>.export(<emptyTree>::<C A>::<C REFERENCE>)
 
-    <self>.export(::<root>::<C A>::<C AClass>)
+    <self>.export(<emptyTree>::<C A>::<C AClass>)
 
-    <self>.export(::<root>::<C A>::<C AModule>)
+    <self>.export(<emptyTree>::<C A>::<C AModule>)
 
     <self>.test_import(::<PackageSpecRegistry>::<C B>)
 
@@ -37,9 +37,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C B><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C A>)
 
-    <self>.export(::<root>::<C B>::<C BClass>)
+    <self>.export(<emptyTree>::<C B>::<C BClass>)
 
-    <self>.export(::<root>::<C B>::<C BModule>)
+    <self>.export(<emptyTree>::<C B>::<C BModule>)
   end
 end
 # -- test/testdata/packager/invalid_imports_and_exports/c/__package.rb --

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -7,11 +7,11 @@ end
 # -- test/testdata/packager/nested_inner_namespaces/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C RootPackage>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C RootPackage>::<C Foo>::<C Constant>)
+    <self>.export(<emptyTree>::<C RootPackage>::<C Foo>::<C Constant>)
 
-    <self>.export(::<root>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)
+    <self>.export(<emptyTree>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)
 
-    <self>.export(::<root>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>)
+    <self>.export(<emptyTree>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>)
   end
 end
 # -- test/testdata/packager/nested_inner_namespaces/bar.rb --

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -3,7 +3,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Package><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
 
-    <self>.export(::<root>::<C Package>::<C PackageClass>)
+    <self>.export(<emptyTree>::<C Package>::<C PackageClass>)
   end
 end
 # -- test/testdata/packager/nested_packages/subpackage/__package.rb --
@@ -11,7 +11,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Package>::<C Subpackage><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Package>)
 
-    <self>.export(::<root>::<C Package>::<C Subpackage>::<C SubpackageClass>)
+    <self>.export(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end
 end
 # -- test/testdata/packager/nested_packages/mainpackage.rb --

--- a/test/testdata/packager/shared_prefix/pass.package-tree.exp
+++ b/test/testdata/packager/shared_prefix/pass.package-tree.exp
@@ -1,13 +1,13 @@
 # -- test/testdata/packager/shared_prefix/bar/that/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C That><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Project>::<C Bar>::<C That>::<C Thing>)
+    <self>.export(<emptyTree>::<C Project>::<C Bar>::<C That>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/this/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Project>::<C Bar>::<C This><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Project>::<C Bar>::<C This>::<C Thing>)
+    <self>.export(<emptyTree>::<C Project>::<C Bar>::<C This>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/foo/__package.rb --

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -3,9 +3,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Project>::<C Bar><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
 
-    <self>.export(::<root>::<C Project>::<C Bar>::<C Bar>)
+    <self>.export(<emptyTree>::<C Project>::<C Bar>::<C Bar>)
 
-    <self>.export(::<root>::<C Project>::<C Bar>::<C CallsFoo>)
+    <self>.export(<emptyTree>::<C Project>::<C Bar>::<C CallsFoo>)
   end
 end
 # -- test/testdata/packager/simple_package/foo/__package.rb --
@@ -13,9 +13,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Project>::<C Foo><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(::<PackageSpecRegistry>::<C Project>::<C Bar>)
 
-    <self>.export(::<root>::<C Project>::<C Foo>::<C Foo>)
+    <self>.export(<emptyTree>::<C Project>::<C Foo>::<C Foo>)
 
-    <self>.export(::<root>::<C Project>::<C Foo>::<C CallsBar>)
+    <self>.export(<emptyTree>::<C Project>::<C Foo>::<C CallsBar>)
   end
 end
 # -- test/testdata/packager/simple_package/bar/bar.rb --

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -11,15 +11,15 @@ end
 # -- test/testdata/packager/simple_test_import/test_only/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Project>::<C TestOnly><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Project>::<C TestOnly>::<C SomeHelper>)
+    <self>.export(<emptyTree>::<C Project>::<C TestOnly>::<C SomeHelper>)
   end
 end
 # -- test/testdata/packager/simple_test_import/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C Project>::<C Util><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C Project>::<C Util>::<C MyUtil>)
+    <self>.export(<emptyTree>::<C Project>::<C Util>::<C MyUtil>)
 
-    <self>.export(::<root>::<C Test>::<C Project>::<C Util>::<C UtilHelper>)
+    <self>.export(<emptyTree>::<C Test>::<C Project>::<C Util>::<C UtilHelper>)
   end
 end
 # -- test/testdata/packager/simple_test_import/main_lib/lib.rb --

--- a/test/testdata/packager/unimported_namespace/pass.package-tree.exp
+++ b/test/testdata/packager/unimported_namespace/pass.package-tree.exp
@@ -1,7 +1,7 @@
 # -- test/testdata/packager/unimported_namespace/aaa/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class ::<PackageSpecRegistry>::<C AAA><<C <todo sym>>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.export(::<root>::<C AAA>::<C AClass>)
+    <self>.export(<emptyTree>::<C AAA>::<C AClass>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/bbb/__package.rb --


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously, we needed to prepend `Symbols::root()` to every `export`
because the rewrite-based approach to package visibility meant that the
exported constants would not actually resolve the right way.

Now that we have dramatically simpler visibility checking, we can stop
doing these rewrites. The exported constant symbols and the package
declarations are always in different namespaces, so it's as if they're
always resolving from `Symbols::root()`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests