### PR TITLE
Avoid copying FoundDefHashes

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -137,8 +137,8 @@ void File::setFileHash(unique_ptr<const FileHash> hash) {
     }
 }
 
-const FileHash *File::getFileHash() const {
-    return hash_.get();
+const shared_ptr<const FileHash> &File::getFileHash() const {
+    return hash_;
 }
 
 FileRef::FileRef(unsigned int id) : _id(id) {}

--- a/core/Files.h
+++ b/core/Files.h
@@ -91,7 +91,7 @@ public:
     std::string_view getLine(int i) const;
 
     void setFileHash(std::unique_ptr<const FileHash> hash);
-    const FileHash *getFileHash() const;
+    const std::shared_ptr<const FileHash> &getFileHash() const;
 
     static constexpr std::string_view URL_PREFIX = "https://github.com/sorbet/sorbet/tree/master/";
     static std::string censorFilePathForSnapshotTests(std::string_view orig);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -44,7 +44,7 @@ public:
     static void pickle(Pickler &p, const ast::ExpressionPtr &what);
     static void pickle(Pickler &p, core::LocOffsets loc);
     static void pickle(Pickler &p, core::Loc loc);
-    static void pickle(Pickler &p, const FileHash *fh);
+    static void pickle(Pickler &p, shared_ptr<const FileHash> fh);
     static void pickle(Pickler &p, const ast::UnresolvedConstantLit &lit);
 
     static shared_ptr<File> unpickleFile(UnPickler &p);
@@ -250,7 +250,7 @@ int64_t UnPickler::getS8() {
     return absl::bit_cast<int64_t>(res);
 }
 
-void SerializerImpl::pickle(Pickler &p, const FileHash *fh) {
+void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
     if (fh == nullptr) {
         p.putU1(0);
         return;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1105,7 +1105,7 @@ ast::ParsedFilesOrCancelled nameAndResolve(core::GlobalState &gs, vector<ast::Pa
 
 vector<ast::ParsedFile>
 incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
-                   optional<UnorderedMap<core::FileRef, core::FoundDefHashes>> &&foundHashesForFiles,
+                   optional<UnorderedMap<core::FileRef, std::shared_ptr<const core::FileHash>>> &&foundHashesForFiles,
                    const options::Options &opts, WorkerPool &workers) {
     try {
 #ifndef SORBET_REALMAIN_MIN

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -75,10 +75,10 @@ ast::ParsedFilesOrCancelled nameAndResolve(core::GlobalState &gs, std::vector<as
 //
 // It's not required when running incrementalResolve just to turn an AST into a resolved AST, if
 // that AST has already been resolved once before on the fast path
-std::vector<ast::ParsedFile>
-incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
-                   std::optional<UnorderedMap<core::FileRef, core::FoundDefHashes>> &&foundHashesForFiles,
-                   const options::Options &opts, WorkerPool &workers);
+std::vector<ast::ParsedFile> incrementalResolve(
+    core::GlobalState &gs, std::vector<ast::ParsedFile> what,
+    std::optional<UnorderedMap<core::FileRef, std::shared_ptr<const core::FileHash>>> &&foundHashesForFiles,
+    const options::Options &opts, WorkerPool &workers);
 
 // ----- typecheck ------------------------------------------------------------
 

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -11,9 +11,10 @@ class WorkerPool;
 namespace sorbet::namer {
 
 class Namer final {
-    [[nodiscard]] static bool runInternal(core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, WorkerPool &workers,
-                                          UnorderedMap<core::FileRef, core::FoundDefHashes> &&oldFoundDefHashesForFiles,
-                                          core::FoundDefHashes *foundHashesOut);
+    [[nodiscard]] static bool
+    runInternal(core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, WorkerPool &workers,
+                UnorderedMap<core::FileRef, std::shared_ptr<const core::FileHash>> &&oldFoundDefHashesForFiles,
+                core::FoundDefHashes *foundHashesOut);
 
 public:
     // Note: foundHashes is an optional out parameter.
@@ -34,7 +35,8 @@ public:
     // allocations for phases that don't actually need to operate on the `FoundDefHashes`.)
     [[nodiscard]] static bool
     runIncremental(core::GlobalState &gs, absl::Span<ast::ParsedFile> trees,
-                   UnorderedMap<core::FileRef, core::FoundDefHashes> &&oldFoundDefHashesForFiles, WorkerPool &workers);
+                   UnorderedMap<core::FileRef, std::shared_ptr<const core::FileHash>> &&oldFoundDefHashesForFiles,
+                   WorkerPool &workers);
 
     Namer() = delete;
 };


### PR DESCRIPTION
Despite using `std::move` on the `FoundDefHashes` of a file about to be replaced on the fast path, a copy was taking place due to the underlying hashes being a const pointer. This PR fixes the problem by making the following changes:

* Reverting cf926ba1f so that we have access to the underlying shared pointer that holds the `FileHash` again
* Reworking the oldFoundHashes map to have values that are `std::shared_ptr<const FileHash>` instead, allowing us to copy the shared pointers rather than the whole `FoundDefHashes` value.

These two changes together mean that we stop copying hash values, and instead extend their lifetime to at least the end of the fast path. It also means that we no longer copy the hashes of files we're not replacing, which should be a win overall.

### Motivation
These changes reduce the amount of vector copying we're doing in the fast path, trading it instead for incrementing the refcount on the shared pointer that holds the `FileHash` value.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
