### PR TITLE
Fix file member variable visibility

### DIFF
--- a/core/Files.h
+++ b/core/Files.h
@@ -117,10 +117,8 @@ private:
 
     Flags flags;
 
-private:
     const PackagedLevel packagedLevel;
 
-public:
     const std::string path_;
     const std::string source_;
 


### PR DESCRIPTION
There were some fields on `core::File` that don't need to be public.

### Motivation
Ensuring that we're not giving unnecessary access to `core::File` internals.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
