### PR TITLE
Don't make `Cast` instructions if there's a block

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3117,7 +3117,7 @@ public:
                 case core::Names::assumeType().rawId():
                 case core::Names::assertType().rawId():
                 case core::Names::cast().rawId(): {
-                    if (send.numPosArgs() < 2) {
+                    if (send.numPosArgs() < 2 || send.hasBlock()) {
                         return;
                     }
 

--- a/rewriter/TypeAssertion.cc
+++ b/rewriter/TypeAssertion.cc
@@ -21,7 +21,7 @@ ast::ExpressionPtr TypeAssertion::run(core::MutableContext ctx, ast::Send *send)
             return nullptr;
     }
 
-    if (send->numPosArgs() < 2) {
+    if (send->numPosArgs() < 2 || send->hasBlock()) {
         return nullptr;
     }
 

--- a/test/testdata/rewriter/cast_block.rb
+++ b/test/testdata/rewriter/cast_block.rb
@@ -1,4 +1,5 @@
 # typed: strict
+extend T::Sig
 
 T.let(0, Integer) { puts }
 #                ^^^^^^^^^ error: Method `T.let` does not take a block
@@ -6,3 +7,10 @@ T.let(0, Integer) { puts }
 X = T.let(0, Integer) { puts }
 #                    ^^^^^^^^^ error: Method `T.let` does not take a block
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Constants must have type annotations with `T.let`
+
+
+sig { params(x: T.nilable(Integer)).void }
+def takes_nilable(x)
+  T.must(x) { puts }
+  #        ^^^^^^^^^ error: Method `T.must` does not take a block
+end

--- a/test/testdata/rewriter/cast_block.rb
+++ b/test/testdata/rewriter/cast_block.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+T.let(0, Integer) { puts }
+#                ^^^^^^^^^ error: Method `T.let` does not take a block
+
+X = T.let(0, Integer) { puts }
+#                    ^^^^^^^^^ error: Method `T.let` does not take a block
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Constants must have type annotations with `T.let`

--- a/test/testdata/rewriter/cast_block.rb.autocorrects.exp
+++ b/test/testdata/rewriter/cast_block.rb.autocorrects.exp
@@ -1,0 +1,10 @@
+# -- test/testdata/rewriter/cast_block.rb --
+# typed: strict
+
+T.let(0, Integer)
+#                ^^^^^^^^^ error: Method `T.let` does not take a block
+
+X = T.let(0, Integer)
+#                    ^^^^^^^^^ error: Method `T.let` does not take a block
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Constants must have type annotations with `T.let`
+# ------------------------------

--- a/test/testdata/rewriter/cast_block.rb.autocorrects.exp
+++ b/test/testdata/rewriter/cast_block.rb.autocorrects.exp
@@ -1,5 +1,6 @@
 # -- test/testdata/rewriter/cast_block.rb --
 # typed: strict
+extend T::Sig
 
 T.let(0, Integer)
 #                ^^^^^^^^^ error: Method `T.let` does not take a block
@@ -7,4 +8,11 @@ T.let(0, Integer)
 X = T.let(0, Integer)
 #                    ^^^^^^^^^ error: Method `T.let` does not take a block
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Constants must have type annotations with `T.let`
+
+
+sig { params(x: T.nilable(Integer)).void }
+def takes_nilable(x)
+  T.must(x)
+  #        ^^^^^^^^^ error: Method `T.must` does not take a block
+end
 # ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Instead, let the "does not take a block" error be reported by `infer`.

This might also mean there are errors that arise from a required type
annotation being missing, but hopefully it's not confusing.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.