### PR TITLE
Remove dead code from resolver

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3218,19 +3218,6 @@ public:
         if (send && (sym.isTypeAlias(ctx) || sym.isTypeMember())) {
             ENFORCE(!sym.isTypeMember() || send->recv.isSelfReference());
 
-            // This is for a special case that happens with the generation of
-            // reflection.rbi: it re-creates the type aliases of the payload,
-            // without the knowledge that they are type aliases. The manifestation
-            // of this, is that there are entries like:
-            //
-            // > module T
-            // >   Boolean = T.let(nil, T.untyped)
-            // > end
-            if (sym.isTypeAlias(ctx) && send->fun == core::Names::let()) {
-                todoUntypedResultTypes_.emplace_back(sym);
-                return;
-            }
-
             if ((sym.isTypeAlias(ctx) && send->fun != core::Names::typeAlias()) ||
                 (sym.isTypeMember() && send->fun != core::Names::typeMember() &&
                  send->fun != core::Names::typeTemplate())) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This code is dead. The commit that added the comment added a test
exactly like what the comment looks like, and the test passes even after
this logic is deleted.

This code is dead because `T.let` will get translated into a `Cast`
node, and then not hit this codepath anymore (e.g., there will not be a
`send` node at all).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests