### PR TITLE
runtime: Correct `T.class_of` for module singleton classes

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/class_of.rb
+++ b/gems/sorbet-runtime/lib/types/types/class_of.rb
@@ -21,14 +21,14 @@ module T::Types
 
     # overrides Base
     def valid?(obj)
-      obj.is_a?(Module) && (obj <= @type || false)
+      obj.is_a?(Module) && (obj.is_a?(@type.singleton_class) || false)
     end
 
     # overrides Base
     def subtype_of_single?(other)
       case other
       when ClassOf
-        @type <= other.type
+        @type.is_a?(other.type.singleton_class)
       when Simple
         @type.is_a?(other.raw_type)
       when TypedClass

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1616,8 +1616,12 @@ module Opus::Types::Test
           assert_equal(true, subtype?(T.class_of(mod), custom_module))
         end
 
-        it "returns false for module singleton classes against Class" do
+        it "returns true for module singleton classes against Module" do
           assert_equal(true, subtype?(T.class_of(Mixin1), Module))
+        end
+
+        it "returns false for module singleton classes against Class" do
+          assert_equal(false, subtype?(T.class_of(Mixin1), Class))
         end
 
         it "returns false for a simple unrelated class" do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

**This change is likely to cause new runtime errors, due to mistaken use of `T.class(SomeModule)`.**


Given this snippet:

```ruby
module IParent
  def self.foo; end
end

module IChild
  include IParent
end
```

Sorbet has always rejected code like this:

```ruby
sig { params(mod: T.class_of(IParent)).void }
def takes_iparent(mod)
  mod.foo
end

takes_iparent(IChild)
```

The reason is that the singleton class of `IChild` does not descend from the singleton class of `IParent`:

```
irb(main):001> module IParent; end
=> nil
irb(main):002> module IChild; include IParent; end
=> IChild
irb(main):003> IChild.singleton_class.ancestors
=> [#<Class:IChild>, Module, Object, PP::ObjectMixin, Kernel, BasicObject]
```

This contrasts with normal classes, where that relationship would actually hold:

```
irb(main):001> class Parent; end
=> nil
irb(main):002> class Child < Parent; end
=> nil
irb(main):003> Child.singleton_class.ancestors
=> [#<Class:Child>, #<Class:Parent>, #<Class:Object>, #<Class:BasicObject>, Class, Module, Object, PP::ObjectMixin, Kernel, BasicObject]
```

Since `#<Class:IParent>` is not an ancestor of `IChild.singleton_class`, the call to `mod.foo` in `takes_iparent` fails—there is no `IChild.foo` method.

So again: statically, Sorbet has always worked this way.

But until this PR, that check was not accurately modeled in `sorbet-runtime`. The implementation mistakenly assumed that module singleton classes work the same way as class singleton classes, and so the runtime type system did not raise an exception for the call `takes_iparent(IChild)` (however, the call to `mod.foo` still raises an exception at runtime according to the Ruby VM).


Unless the code literally needs a way to refer to the type of exactly the `IParent` module object, using `T.class_of(IParent)` is the wrong type. Some types that might work better:

- `Module` (the `IParent` module object is an instance of `Module`—but not `Class`!)
- `T::Class[IParent]` (if you want the type of "some class object which can be instantiated that happens to also `include IParent`, and you're okay with just classes, i.e. excluding other module objects that `include IParent`)
- `T.untyped` (chances are that to work around the already-implemented static semantics, the code already needs to `T.unsafe` or `T.cast` the problem away. In such cases, using `T.untyped` is in some sense no worse).

For more, see [`T.class_of` and modules](https://sorbet.org/docs/class-of#tclass_of-and-modules), as well as [Inheritance in Ruby, in pictures](https://blog.jez.io/inheritance-in-ruby/).



### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes a bug in the runtime type checker w.r.t. how `T.class_of` models the subtyping relationship of module singleton classes.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.