### PR TITLE
Introduce T::NonForcingConstants.static_inheritance_check

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -165,6 +165,7 @@ NameDef names[] = {
     {"revealType", "reveal_type"},
     {"absurd"},
     {"nonForcingIsA_p", "non_forcing_is_a?"},
+    {"staticInheritanceCheck", "static_inheritance_check"},
     {"valid_p", "valid?"},
     {"recursivelyValid_p", "recursively_valid?"},
     {"subtypeOf_p", "subtype_of?"},

--- a/gems/sorbet-runtime/lib/types/non_forcing_constants.rb
+++ b/gems/sorbet-runtime/lib/types/non_forcing_constants.rb
@@ -56,7 +56,7 @@ module T::NonForcingConstants
   class InheritanceChecked
     T::Sig::WithoutRuntime.sig {params(classname: String).void}
     def initialize(classname)
-      @classname = T.let(classname, String)
+      @classname = T.let(classname.delete_prefix("::"), String)
     end
 
     T::Sig::WithoutRuntime.sig {returns(String)}

--- a/gems/sorbet-runtime/lib/types/non_forcing_constants.rb
+++ b/gems/sorbet-runtime/lib/types/non_forcing_constants.rb
@@ -52,4 +52,11 @@ module T::NonForcingConstants
 
     current_klass.===(val)
   end
+
+  # Note that this method is only used for static enforcement. At runtime, it is a noop;
+  # calling T::NonForcingConstants.static_inheritance_check("Foo") always returns "Foo".
+  T::Sig::WithoutRuntime.sig {params(classname: String, base: T::Class[T.anything]).returns(String)}
+  def self.static_inheritance_check(classname, base)
+    classname
+  end
 end

--- a/gems/sorbet-runtime/test/types/non_forcing_constants.rb
+++ b/gems/sorbet-runtime/test/types/non_forcing_constants.rb
@@ -96,4 +96,29 @@ class Opus::Types::Test::NonForcingConstantsTest < Critic::Unit::UnitTest
       assert_match(/is not a class or module/, exn.message)
     end
   end
+
+  describe "T::NonForcingConstants.static_inheritance_check" do
+    class Base
+    end
+
+    class Foo
+    end
+
+    it "empty string" do
+      assert_raises(ArgumentError) do
+        T::NonForcingConstants.static_inheritance_check('', Base)
+      end
+    end
+
+    it "empty base class" do
+      assert_raises(ArgumentError) do
+        T::NonForcingConstants.static_inheritance_check('::Foo', nil)
+      end
+    end
+
+    it 'returns an InheritanceChecked object' do
+      r = T::NonForcingConstants.static_inheritance_check('::Foo', Base)
+      assert_match('::Foo', r.get)
+    end
+  end
 end

--- a/gems/sorbet-runtime/test/types/non_forcing_constants.rb
+++ b/gems/sorbet-runtime/test/types/non_forcing_constants.rb
@@ -118,7 +118,7 @@ class Opus::Types::Test::NonForcingConstantsTest < Critic::Unit::UnitTest
 
     it 'returns an InheritanceChecked object' do
       r = T::NonForcingConstants.static_inheritance_check('::Foo', Base)
-      assert_match('::Foo', r.get)
+      assert_equal('Foo', r.get)
     end
   end
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -489,4 +489,7 @@ module T::NonForcingConstants
   # See <https://sorbet.org/docs/non-forcing-constants> for full docs.
   sig {params(val: BasicObject, klass: String).returns(T::Boolean)}
   def self.non_forcing_is_a?(val, klass); end
+
+  sig {params(classname: String, base: T::Class[T.anything]).returns(String)}
+  def self.static_inheritance_check(classname, base); end
 end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -490,6 +490,9 @@ module T::NonForcingConstants
   sig {params(val: BasicObject, klass: String).returns(T::Boolean)}
   def self.non_forcing_is_a?(val, klass); end
 
-  sig {params(classname: String, base: T::Class[T.anything]).returns(String)}
+  class InheritanceChecked
+  end
+
+  sig {params(classname: String, base: T::Class[T.anything]).returns(InheritanceChecked)}
   def self.static_inheritance_check(classname, base); end
 end

--- a/test/testdata/infer/non_forcing_static_inheritance_check.rb
+++ b/test/testdata/infer/non_forcing_static_inheritance_check.rb
@@ -1,0 +1,39 @@
+# typed: true
+
+x = T.unsafe(nil)
+
+class Base
+end
+
+class Derived < Base
+end
+
+class Derived2 < Derived
+end
+
+class Derived3 < Derived
+end
+
+NotClass = 1
+
+T::NonForcingConstants.static_inheritance_check # error: Not enough arguments
+
+str = "foo"
+T::NonForcingConstants.static_inheritance_check(str, Base)
+#                                               ^^^  error: only accepts string literals
+
+T::NonForcingConstants.static_inheritance_check("X", Base) # error: must be an absolute constant reference
+
+T::NonForcingConstants.static_inheritance_check("::NotFound", Base)
+#                                               ^^^^^^^^^^^^  error: Unable to resolve constant `::NotFound`
+
+T::NonForcingConstants.static_inheritance_check("::NotClass", Derived2)
+#                                               ^^^^^^^^^^^^  error: The string given to `T::NonForcingConstants.static_inheritance_check` must resolve to a class or module
+
+T::NonForcingConstants.static_inheritance_check("::Derived3", Derived2)
+#                                               ^^^^^^^^^^^^  error: Derived3 does not inherit from Derived2
+
+# No errors below
+T::NonForcingConstants.static_inheritance_check("::Derived", Base)
+T::NonForcingConstants.static_inheritance_check("::Derived2", Derived)
+T::NonForcingConstants.static_inheritance_check("::Derived2", Base)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Introduces a new method to the `T::NonForcingConstants` library called `.static_inheritance_check`, that basically tries to resolve a string literal to a class constant (like `non_forcing_is_a?`), but also tries to check if the constant inherits from a given class:

```
class Base
end

class Base1
end

class Derived < Base
end

T::NonForcingConstants.static_inheritance_check("::Derived", Base) # works
T::NonForcingConstants.static_inheritance_check("::Derived", Base1) # error
```

Note that the difference between `non_forcing_is_a?` and this is that we don't actually do anything at runtime here. `non_forcing_is_a?` attempts to check if the class is loaded, whereas here, we don't care -- the check is purely static.

See attached unit test for more details.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
At Stripe, we often have code that performs non-loading inheritance checks, where we aim to check the constant referenced by a string literal at runtime against a base class. We don't do this by trying to load the constant in question -- in fact, trying to load the class or check if it's loaded defeats the purpose of the check, which is trying to do accurate inheritance checks even in a context where the class might not be loaded. Instead of loading, we leverage autogenerated subclass lists from the autogen pass. This is problematic because it significantly reduces the effectiveness of our test selectivity algorithms.

This new paradigm allows us to enforce the same inheritance check statically while removing the need for using subclass lists.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase
