### PR TITLE
Reuse the vector in the Levenshtein distance implementation

### DIFF
--- a/common/Levenstein.cc
+++ b/common/Levenstein.cc
@@ -21,7 +21,7 @@ int sorbet::Levenstein::distance(string_view s1, string_view s2, int bound) noex
         return INT_MAX;
     }
 
-    vector<int> column(s1len + 1);
+    column.resize(s1len + 1);
     absl::c_iota(column, 0);
 
     for (int x = 1; x <= s2len; x++) {

--- a/common/Levenstein.h
+++ b/common/Levenstein.h
@@ -1,12 +1,15 @@
 #ifndef SORBET_LEVENSTEIN_H
 #define SORBET_LEVENSTEIN_H
 #include <string_view>
+#include <vector>
 
 namespace sorbet {
 
 class Levenstein {
+    std::vector<int> column;
+
 public:
-    static int distance(std::string_view s1, std::string_view s2, int bound) noexcept;
+    int distance(std::string_view s1, std::string_view s2, int bound) noexcept;
 };
 
 } // namespace sorbet

--- a/common/test/common_test.cc
+++ b/common/test/common_test.cc
@@ -9,10 +9,11 @@
 namespace sorbet::common {
 
 TEST_CASE("Levenstein") { // NOLINT
-    CHECK_EQ(2, Levenstein::distance("Mama", "Papa", 10));
-    CHECK_EQ(5, Levenstein::distance("Ruby", "Scala", 10));
-    CHECK_EQ(3, Levenstein::distance("Java", "Scala", 10));
-    CHECK_EQ(INT_MAX, Levenstein::distance("Java", "S", 1));
+    Levenstein levenstein;
+    CHECK_EQ(2, levenstein.distance("Mama", "Papa", 10));
+    CHECK_EQ(5, levenstein.distance("Ruby", "Scala", 10));
+    CHECK_EQ(3, levenstein.distance("Java", "Scala", 10));
+    CHECK_EQ(INT_MAX, levenstein.distance("Java", "S", 1));
 }
 
 TEST_CASE("FileOps::ensureDir") {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -903,6 +903,7 @@ ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
     }
 
     bool onlySuggestPackageSpecs = ref(gs).isPackageSpecSymbol(gs);
+    Levenstein levenstein;
 
     // Find the closest by following outer scopes
     {
@@ -943,7 +944,7 @@ ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
                             }
                         }
 
-                        auto thisDistance = Levenstein::distance(
+                        auto thisDistance = levenstein.distance(
                             currentName, member.first.dataCnst(gs)->original.dataUtf8(gs)->utf8, best.distance);
                         if (thisDistance <= best.distance) {
                             if (thisDistance < best.distance) {
@@ -999,7 +1000,7 @@ ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
                         }
                     }
 
-                    auto thisDistance = Levenstein::distance(
+                    auto thisDistance = levenstein.distance(
                         currentName, member.first.dataCnst(gs)->original.dataUtf8(gs)->utf8, best.distance);
                     if (thisDistance <= globalBestDistance) {
                         if (thisDistance < globalBestDistance) {
@@ -1047,13 +1048,14 @@ ClassOrModule::FuzzySearchResult ClassOrModule::findMemberFuzzyMatchUTF8(const G
         result.distance = 1 + (currentName.size() / 2);
     }
 
+    Levenstein levenstein;
     for (auto pair : members()) {
         auto thisName = pair.first;
         if (thisName.kind() != NameKind::UTF8) {
             continue;
         }
         auto utf8 = thisName.dataUtf8(gs)->utf8;
-        int thisDistance = Levenstein::distance(currentName, utf8, result.distance);
+        int thisDistance = levenstein.distance(currentName, utf8, result.distance);
         if (thisDistance < result.distance ||
             (thisDistance == result.distance && result.symbol._id > pair.second._id)) {
             result.distance = thisDistance;


### PR DESCRIPTION
We were allocating a vector for each call to `Levenstein::distance`, and the main use of that function is in the body of three hot loops. This PR moves the vector to an instance variable that's re-initialized with each call, so that the allocation can be reused.

### Motivation
Reducing allocations.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
