### PR TITLE
Stop fuzzy searching the whole symbol table

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -886,12 +886,8 @@ bool SymbolRef::isUnderNamespace(const GlobalState &gs, ClassOrModuleRef otherCl
 
 vector<ClassOrModule::FuzzySearchResult>
 ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name, int betterThan) const {
-    // Performance of this method is bad, to say the least.
-    // It's written under assumption that it's called rarely
-    // and that it's worth spending a lot of time finding a good candidate in ALL scopes.
-    // It may return multiple candidates:
-    //   - best candidate per every outer scope if it's better than all the candidates in inner scope
-    //   - globally best candidate in ALL scopes.
+    // This function is somewhat expensive, as it will crawl all owning scopes to determine if there's a reasonable
+    // match for `name`.
     vector<ClassOrModule::FuzzySearchResult> result;
 
     FuzzySearchResult best;
@@ -905,95 +901,40 @@ ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
 
     bool onlySuggestPackageSpecs = ref(gs).isPackageSpecSymbol(gs);
     Levenstein levenstein;
+    vector<ClassOrModuleRef> candidateScopes;
+    vector<ClassOrModule::FuzzySearchResult> scopeBest;
+
+    // Ensure that we start the search from the attached class -- we're interested in constants, which aren't present on
+    // the singleton.
+    ClassOrModuleRef base = this->isSingletonClass(gs) ? this->attachedClass(gs) : this->ref(gs);
 
     // Find the closest by following outer scopes
-    {
-        ClassOrModuleRef base = ref(gs);
+    do {
+        // find scopes that would be considered for search
+        candidateScopes.clear();
+        candidateScopes.emplace_back(base);
+        int i = 0;
 
-        do {
-            // follow outer scopes
-
-            // find scopes that would be considered for search
-            vector<ClassOrModuleRef> candidateScopes;
-            vector<ClassOrModule::FuzzySearchResult> scopeBest;
-            candidateScopes.emplace_back(base);
-            int i = 0;
-            // this is quadratic in number of scopes that we traverse, but YOLO, this should rarely run
-            while (i < candidateScopes.size()) {
-                const auto &sym = candidateScopes[i].data(gs);
-                if (sym->superClass().exists()) {
-                    if (!absl::c_linear_search(candidateScopes, sym->superClass())) {
-                        candidateScopes.emplace_back(sym->superClass());
-                    }
-                }
-                for (auto ancestor : sym->mixins()) {
-                    if (!absl::c_linear_search(candidateScopes, ancestor)) {
-                        candidateScopes.emplace_back(ancestor);
-                    }
-                }
-                i++;
-            }
-            for (const auto scope : candidateScopes) {
-                scopeBest.clear();
-                for (auto member : scope.data(gs)->members()) {
-                    if (member.first.kind() == NameKind::CONSTANT &&
-                        member.first.dataCnst(gs)->original.kind() == NameKind::UTF8 && member.second.exists()) {
-                        if (onlySuggestPackageSpecs) {
-                            if (!member.second.isClassOrModule() ||
-                                !member.second.asClassOrModuleRef().isPackageSpecSymbol(gs)) {
-                                continue;
-                            }
-                        }
-
-                        auto thisDistance = levenstein.distance(
-                            currentName, member.first.dataCnst(gs)->original.dataUtf8(gs)->utf8, best.distance);
-                        if (thisDistance <= best.distance) {
-                            if (thisDistance < best.distance) {
-                                scopeBest.clear();
-                            }
-                            best.distance = thisDistance;
-                            best.symbol = member.second;
-                            best.name = member.first;
-                            scopeBest.emplace_back(best);
-                        }
-                    }
-                }
-                if (!scopeBest.empty()) {
-                    // NOTE: Iteration order over members is nondeterministic, so we use SymbolId to deterministically
-                    // order the recommendations from this scope.
-                    // We order in decreasing symbol ID order because `result` is later reversed and we want earlier
-                    // ID'd symbols to be recommended first.
-                    fast_sort(scopeBest, [&](const auto &lhs, const auto &rhs) -> bool {
-                        return lhs.symbol._id > rhs.symbol._id;
-                    });
-                    for (auto &item : scopeBest) {
-                        result.emplace_back(item);
-                    }
+        // this is quadratic in number of scopes that we traverse, but YOLO, this should rarely run
+        while (i < candidateScopes.size()) {
+            const auto &sym = candidateScopes[i].data(gs);
+            if (sym->superClass().exists()) {
+                if (!absl::c_linear_search(candidateScopes, sym->superClass())) {
+                    candidateScopes.emplace_back(sym->superClass());
                 }
             }
-
-            base = base.data(gs)->owner;
-        } while (best.distance > 0 && base.data(gs)->owner.exists() && base != Symbols::root());
-    }
-
-    // At this point, `result` is in a deterministic order, and is ordered with _decreasing_ edit distance
-
-    if (best.distance > 0) {
-        // find the closest by global dfs.
-        auto globalBestDistance = best.distance - 1;
-        vector<ClassOrModule::FuzzySearchResult> globalBest;
-        vector<ClassOrModuleRef> yetToGoDeeper;
-        yetToGoDeeper.emplace_back(Symbols::root());
-        while (!yetToGoDeeper.empty()) {
-            const ClassOrModuleRef thisIter = yetToGoDeeper.back();
-            yetToGoDeeper.pop_back();
-            for (auto member : thisIter.data(gs)->members()) {
-                if (member.second.exists() && member.first.exists() && member.first.kind() == NameKind::CONSTANT &&
-                    member.first.dataCnst(gs)->original.kind() == NameKind::UTF8) {
-                    if (member.second.isClassOrModule() &&
-                        member.second.asClassOrModuleRef().data(gs)->derivesFrom(gs, core::Symbols::StubModule())) {
-                        continue;
-                    }
+            for (auto ancestor : sym->mixins()) {
+                if (!absl::c_linear_search(candidateScopes, ancestor)) {
+                    candidateScopes.emplace_back(ancestor);
+                }
+            }
+            i++;
+        }
+        for (const auto scope : candidateScopes) {
+            scopeBest.clear();
+            for (auto member : scope.data(gs)->members()) {
+                if (member.first.kind() == NameKind::CONSTANT &&
+                    member.first.dataCnst(gs)->original.kind() == NameKind::UTF8 && member.second.exists()) {
                     if (onlySuggestPackageSpecs) {
                         if (!member.second.isClassOrModule() ||
                             !member.second.asClassOrModuleRef().isPackageSpecSymbol(gs)) {
@@ -1003,33 +944,38 @@ ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
 
                     auto thisDistance = levenstein.distance(
                         currentName, member.first.dataCnst(gs)->original.dataUtf8(gs)->utf8, best.distance);
-                    if (thisDistance <= globalBestDistance) {
-                        if (thisDistance < globalBestDistance) {
-                            globalBest.clear();
+                    if (thisDistance <= best.distance) {
+                        if (thisDistance < best.distance) {
+                            scopeBest.clear();
                         }
-                        globalBestDistance = thisDistance;
                         best.distance = thisDistance;
                         best.symbol = member.second;
                         best.name = member.first;
-                        globalBest.emplace_back(best);
-                    }
-                    if (member.second.isClassOrModule()) {
-                        yetToGoDeeper.emplace_back(member.second.asClassOrModuleRef());
+                        scopeBest.emplace_back(best);
                     }
                 }
             }
+            if (!scopeBest.empty()) {
+                // NOTE: Iteration order over members is nondeterministic, so we use SymbolId to deterministically
+                // order the recommendations from this scope.
+                // We order in decreasing symbol ID order because `result` is later reversed and we want earlier
+                // ID'd symbols to be recommended first.
+                fast_sort(scopeBest,
+                          [&](const auto &lhs, const auto &rhs) -> bool { return lhs.symbol._id > rhs.symbol._id; });
+                for (auto &item : scopeBest) {
+                    result.emplace_back(item);
+                }
+            }
         }
-        // globalBest is nondeterministically ordered since iteration over `members()` is non deterministic.
-        // Everything in globalBest has the same edit distance, so we just have to sort by symbol ID to get a
-        // deterministic order.
-        // We order in decreasing symbol ID order because `result` is later reversed and we want earlier
-        // ID'd symbols to be recommended first.
-        fast_sort(globalBest,
-                  [&](const auto &lhs, const auto &rhs) -> bool { return lhs.symbol._id > rhs.symbol._id; });
-        for (auto &e : globalBest) {
-            result.emplace_back(e);
+
+        // <root>'s owner is <root>, so we explicitly break that cycle here.
+        auto owner = base.data(gs)->owner;
+        if (!owner.exists() || base == owner) {
+            break;
         }
-    }
+
+        base = owner;
+    } while (best.distance > 0);
 
     // result is ordered in decreasing edit distance order. We want to flip the order so the items w/ the smallest edit
     // distance are first.

--- a/test/cli/constant-fuzzy/test.out
+++ b/test/cli/constant-fuzzy/test.out
@@ -1,13 +1,6 @@
 test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Yieldr` https://srb.help/5002
      3 |Yieldr.foo(Intege, Int)
         ^^^^^^
-  Did you mean `Enumerator::Yielder`? Use `-a` to autocorrect
-    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Enumerator::Yielder`
-     3 |Yieldr.foo(Intege, Int)
-        ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/enumerator.rbi#LCENSORED: `Enumerator::Yielder` defined here
-      NN |class Enumerator::Yielder < Object
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Did you mean `File`? Use `-a` to autocorrect
     test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `File`
      3 |Yieldr.foo(Intege, Int)
@@ -22,6 +15,13 @@ test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Yieldr`
     https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
     NN |class Dir < Object
         ^^^^^^^^^^^^^^^^^^
+  Did you mean `Fiber`? Use `-a` to autocorrect
+    test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Fiber`
+     3 |Yieldr.foo(Intege, Int)
+        ^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/fiber.rbi#LCENSORED: `Fiber` defined here
+      NN |class Fiber < Object
+          ^^^^^^^^^^^^^^^^^^^^
 
 test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Intege` https://srb.help/5002
      3 |Yieldr.foo(Intege, Int)

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -8,20 +8,6 @@ use_other_package/foo.rb:16: Unable to resolve constant `MyClass` https://srb.he
     https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#LCENSORED: `Class` defined here
     NN |class Class < Module
         ^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_other_package/foo.rb:16: Replaced with `T::Class`
-    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
-          ^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#LCENSORED: `T::Class` defined here
-      NN |module T::Class
-          ^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_other_package/foo.rb:16: Replaced with `Digest::Class`
-    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
-          ^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/digest.rbi#LCENSORED: `Digest::Class` defined here
-      NN |class Digest::Class
-          ^^^^^^^^^^^^^^^^^^^
 
 use_other_package/foo.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root

--- a/test/cli/packager-layers/test.out
+++ b/test/cli/packager-layers/test.out
@@ -5,13 +5,6 @@ Errors: 1
 __package.rb:3: Unable to resolve constant `PackageSpec` https://srb.help/5002
      3 |class Project::Root < PackageSpec
                               ^^^^^^^^^^^
-  Did you mean `Sorbet::Private::Static::PackageSpec`? Use `-a` to autocorrect
-    __package.rb:3: Replace with `Sorbet::Private::Static::PackageSpec`
-     3 |class Project::Root < PackageSpec
-                              ^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/packages.rbi#L2: `Sorbet::Private::Static::PackageSpec` defined here
-     2 |class Sorbet::Private::Static::PackageSpec; end
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 __package.rb:4: Method `strict_dependencies` does not exist on `T.class_of(Project::Root)` https://srb.help/7003
      4 |  strict_dependencies 'false'

--- a/test/cli/suggest-kernel/test.out
+++ b/test/cli/suggest-kernel/test.out
@@ -38,18 +38,6 @@ test/cli/suggest-kernel/suggest-kernel.rb:5: Method `Integer` does not exist on 
     test/cli/suggest-kernel/suggest-kernel.rb:5: Insert `.new`
      .. |    Integer(0)
                    ^
-  Note:
-    Ruby uses `.new` to invoke a class's constructor
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/suggest-kernel/suggest-kernel.rb:5: Insert `.new`
-     .. |    Integer(0)
-                   ^
-  Note:
-    Ruby uses `.new` to invoke a class's constructor
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/suggest-kernel/suggest-kernel.rb:5: Insert `.new`
-     .. |    Integer(0)
-                   ^
 
 test/cli/suggest-kernel/suggest-kernel.rb:6: Method `Array` does not exist on `Foo` https://srb.help/7003
      .. |    Array(0)
@@ -62,16 +50,4 @@ test/cli/suggest-kernel/suggest-kernel.rb:6: Method `Array` does not exist on `F
     test/cli/suggest-kernel/suggest-kernel.rb:6: Insert `Kernel.`
      .. |    Array(0)
             ^
-  Note:
-    Ruby uses `.new` to invoke a class's constructor
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/suggest-kernel/suggest-kernel.rb:6: Insert `.new`
-     .. |    Array(0)
-                 ^
-  Note:
-    Ruby uses `.new` to invoke a class's constructor
-  Autocorrect: Use `-a` to autocorrect
-    test/cli/suggest-kernel/suggest-kernel.rb:6: Insert `.new`
-     .. |    Array(0)
-                 ^
 Errors: 4

--- a/test/cli/suggest-not-stub/test.out
+++ b/test/cli/suggest-not-stub/test.out
@@ -1,6 +1,20 @@
 test/cli/suggest-not-stub/suggest-not-stub.rb:3: Unable to resolve constant `B` https://srb.help/5002
      3 |  B
           ^
+  Did you mean `T`? Use `-a` to autocorrect
+    test/cli/suggest-not-stub/suggest-not-stub.rb:3: Replace with `T`
+     3 |  B
+          ^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#LCENSORED: `T` defined here
+    NN |module T
+        ^^^^^^^^
+  Did you mean `A`? Use `-a` to autocorrect
+    test/cli/suggest-not-stub/suggest-not-stub.rb:3: Replace with `A`
+     3 |  B
+          ^
+    test/cli/suggest-not-stub/suggest-not-stub.rb:2: `A` defined here
+     2 |class A
+        ^^^^^^^
 
 test/cli/suggest-not-stub/suggest-not-stub.rb:6: Unable to resolve constant `B` https://srb.help/5002
      6 |B


### PR DESCRIPTION
When handling constant resolution failures, we call the `ClassOrModule::findMemberFuzzyMatch` method. This method would first try traversing the owning hierarchy to determine if there was a reasonable match, and then fall back on traversing the whole symbol table (which is pretty expensive on a large codebase).

This PR improves the performance of this function by making two changes:
1. Removing the traversal of the whole symbol table, as it would often yield irrelevant results anyway.
2. Fixing the initial traversal of the owning hierarchy, which was frequently traversing from the singleton class, yielding no results as constants are present on the attached class.

This does change the behavior of suggestions for resolution failures, most notably that we will no longer make suggestions that would be on different branches of the hierarchy. For example, we'll no longer make a suggestion for `Enumerator::Yielder` if you type `Yieldr` at the root scope. I think this is a worthwhile tradeoff, especially for large codebases, as the suggestions are often irrelevant, and the size of the list returned on a large codebase with a relatively common name is too much to really make use of.

### Motivation
Improving fast path performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests. Some test outputs changed with this PR.
