### PR TITLE
getNoopUpdate can take a span

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -719,7 +719,7 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const std::vecto
     return LSPQueryResult{queryCollector->drainQueryResponses(), nullptr};
 }
 
-std::unique_ptr<LSPFileUpdates> LSPTypechecker::getNoopUpdate(std::vector<core::FileRef> frefs) const {
+std::unique_ptr<LSPFileUpdates> LSPTypechecker::getNoopUpdate(absl::Span<const core::FileRef> frefs) const {
     auto result = std::make_unique<LSPFileUpdates>();
     auto &noop = *result;
     noop.typecheckingPath = TypecheckingPath::Fast;
@@ -734,7 +734,7 @@ std::unique_ptr<LSPFileUpdates> LSPTypechecker::getNoopUpdate(std::vector<core::
 
 std::vector<std::unique_ptr<core::Error>> LSPTypechecker::retypecheck(vector<core::FileRef> frefs,
                                                                       WorkerPool &workers) const {
-    auto updates = getNoopUpdate(move(frefs));
+    auto updates = getNoopUpdate(frefs);
     auto errorCollector = make_shared<core::ErrorCollector>();
     bool isNoopUpdateForRetypecheck = true;
     runFastPath(*updates, workers, errorCollector, isNoopUpdateForRetypecheck);
@@ -914,7 +914,7 @@ void LSPTypecheckerDelegate::updateGsFromOptions(const DidChangeConfigurationPar
     typechecker.updateGsFromOptions(options);
 }
 
-std::unique_ptr<LSPFileUpdates> LSPTypecheckerDelegate::getNoopUpdate(std::vector<core::FileRef> frefs) const {
+std::unique_ptr<LSPFileUpdates> LSPTypecheckerDelegate::getNoopUpdate(absl::Span<const core::FileRef> frefs) const {
     return typechecker.getNoopUpdate(frefs);
 }
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -215,7 +215,7 @@ public:
      * Get an LSPFileUpdates containing the latest versions of the given files. It's a "no-op" file update because it
      * doesn't actually change anything.
      */
-    std::unique_ptr<LSPFileUpdates> getNoopUpdate(std::vector<core::FileRef> frefs) const;
+    std::unique_ptr<LSPFileUpdates> getNoopUpdate(absl::Span<const core::FileRef> frefs) const;
 };
 
 /**
@@ -260,7 +260,7 @@ public:
     const core::GlobalState &state() const;
 
     void updateGsFromOptions(const DidChangeConfigurationParams &options) const;
-    std::unique_ptr<LSPFileUpdates> getNoopUpdate(std::vector<core::FileRef> frefs) const;
+    std::unique_ptr<LSPFileUpdates> getNoopUpdate(absl::Span<const core::FileRef> frefs) const;
 };
 } // namespace sorbet::realmain::lsp
 #endif


### PR DESCRIPTION
To avoid accidental copying, `getNoopUpdate` can be modified to take `const` spans of file refs.

### Motivation
Avoiding accidental copies with `getNoopUpdate`, which doesn't need to own the vector of file refs that it iterates.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests
