### PR TITLE
Rework documentSymbol to use the resolved tree

### DIFF
--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/requests/document_symbol.h"
 #include "absl/strings/match.h"
 #include "ast/treemap/treemap.h"
+#include "common/sort/sort.h"
 #include "core/lsp/QueryResponse.h"
 #include "main/lsp/LSPLoop.h"
 #include "main/lsp/json_types.h"
@@ -12,174 +13,172 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 namespace {
 
-// Document symbols in the LSP spec include two different ranges: one that covers
-// the entire extent of the definition and one that covers just what should be
-// shown when the symbol is selected.  Sorbet's loc for a symbol covers the latter
-// (e.g. ClassDef::declLoc, MethodDef::declLoc).
-//
-// We do store the former, but that loc lives in the AST, not in the symbol table
-// (e.g. ClassDef::loc, MethodDef::loc).  So we have to walk the AST to retrieve
-// that loc...and then we might as well record `declLoc` when we do so we can
-// ensure that both of the locs we're looking at are referencing the same file.
-// (We could do this with the locs from the symbol table, but it seems simpler
-// to do things this way.)
-struct ASTSymbolInfo {
+struct Node {
+    // The parent node, or nullptr if this is `<root>`.
+    std::shared_ptr<Node> parent;
+
+    // The symbol defined.
+    core::SymbolRef symbol;
+
+    // The location of the full declaration in the file being processed (i.e. the whole class definition).
     core::Loc loc;
+
+    // The location of only the declaration (i.e. the `def` of a method definition).
     core::Loc declLoc;
-    bool isAttrBestEffortUIOnly;
+
+    // Propagated from the `MethodDef` when `symbol` is a method.
+    bool isAttrBestEffortUIOnly = false;
+
+    // Any child symbols.
+    std::vector<std::shared_ptr<Node>> children;
+
+    Node(std::shared_ptr<Node> parent, core::SymbolRef symbol, core::Loc loc)
+        : parent{std::move(parent)}, symbol{symbol}, loc{loc}, declLoc{loc} {}
+
+    std::unique_ptr<DocumentSymbol> genNode(const core::GlobalState &gs) const {
+        if (!this->symbol.exists()) {
+            return nullptr;
+        }
+        if (hideSymbol(gs, this->symbol)) {
+            return nullptr;
+        }
+
+        auto range = Range::fromLoc(gs, this->loc);
+        auto selectionRange = Range::fromLoc(gs, this->declLoc);
+        bool isAttr = this->symbol.isMethod() && this->isAttrBestEffortUIOnly;
+        auto kind = symbolRef2SymbolKind(gs, this->symbol, isAttr);
+
+        string name;
+        auto owner = this->symbol.owner(gs);
+        if (owner.exists() && owner.isClassOrModule() &&
+            owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()) {
+            name = "self.";
+        }
+        auto symName = this->symbol.name(gs).show(gs);
+        string_view view{symName};
+        if (absl::StartsWith(view, "<") && view.size() > 1) {
+            string_view describeStr = "<describe '";
+            string_view itStr = "<it '";
+            if (absl::StartsWith(view, describeStr) || absl::StartsWith(view, itStr)) {
+                view.remove_prefix(1);
+                view.remove_suffix(1);
+            }
+        }
+        name += view;
+
+        auto result =
+            std::make_unique<DocumentSymbol>(std::move(name), kind, std::move(range), std::move(selectionRange));
+
+        // Previous versions of VSCode have a bug that requires this non-optional field to be present.
+        // This previously tried to include the method signature but due to issues where large signatures were not
+        // readable when put on one line and given that currently details are only visible in the outline view but not
+        // seen in the symbol search. Additionally, no other language server implementations we could find used this
+        // field.
+        result->detail = "";
+
+        result->children = this->genChildren(gs);
+
+        return result;
+    }
+
+    std::vector<std::unique_ptr<DocumentSymbol>> genChildren(const core::GlobalState &gs) const {
+        std::vector<std::unique_ptr<DocumentSymbol>> result;
+
+        result.reserve(this->children.size());
+        for (auto &child : this->children) {
+            if (auto res = child->genNode(gs)) {
+                result.emplace_back(std::move(res));
+            }
+        }
+
+        return result;
+    }
 };
 
-class SymbolFileLocSaver {
-public:
-    core::FileRef fref;
-    UnorderedMap<core::SymbolRef, ASTSymbolInfo> &mapping;
+// Reify the outline of the tree, so that we can post-process it into a documentSymbol response.
+class Outliner {
+    std::shared_ptr<Node> scope;
 
-    SymbolFileLocSaver(core::FileRef fref, UnorderedMap<core::SymbolRef, ASTSymbolInfo> &mapping)
-        : fref(fref), mapping(mapping) {}
+    Outliner() = default;
+
+    // When processing all the members of a class/module, only add the ones that occur syntactically within the current
+    // node.
+    void addChild(const core::Context ctx, core::SymbolRef child) {
+        for (auto childLoc : child.locs(ctx)) {
+            if (childLoc.file() == ctx.file && this->scope->loc.contains(childLoc)) {
+                this->scope->children.emplace_back(std::make_shared<Node>(this->scope, child, childLoc));
+                return;
+            }
+        }
+    }
+
+public:
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &expr) {
+        auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(expr);
+        if (klass.symbol == core::Symbols::root()) {
+            return;
+        }
+
+        auto next = std::make_shared<Node>(this->scope, klass.symbol, ctx.locAt(klass.loc));
+        next->declLoc = ctx.locAt(klass.declLoc);
+        this->scope->children.emplace_back(next);
+        this->scope = std::move(next);
+
+        for (auto member : klass.symbol.data(ctx)->members()) {
+            if (member.second.isClassOrModule() || member.second.isMethod()) {
+                continue;
+            }
+
+            this->addChild(ctx, member.second);
+        }
+
+        auto singleton = klass.symbol.data(ctx)->lookupSingletonClass(ctx);
+        if (singleton.exists()) {
+            for (auto member : singleton.data(ctx)->members()) {
+                if (member.second.isClassOrModule() || member.second.isMethod()) {
+                    continue;
+                }
+
+                this->addChild(ctx, member.second);
+            }
+        }
+    }
 
     void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &expr) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(expr);
-        if (!klass.symbol.exists()) {
+        if (klass.symbol == core::Symbols::root()) {
             return;
         }
 
-        auto isAttrBestEffortUIOnly = false;
-        mapping[klass.symbol] =
-            ASTSymbolInfo{core::Loc{fref, klass.loc}, core::Loc{fref, klass.declLoc}, isAttrBestEffortUIOnly};
+        fast_sort(this->scope->children,
+                  [](auto &left, auto &right) { return left->loc.beginPos() < right->loc.beginPos(); });
+
+        this->scope = this->scope->parent;
     }
 
-    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &expr) {
+    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &expr) {
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(expr);
-        if (!method.symbol.exists()) {
-            return;
-        }
 
-        auto isAttrBestEffortUIOnly = method.flags.isAttrBestEffortUIOnly;
-        mapping[method.symbol] =
-            ASTSymbolInfo{core::Loc{fref, method.loc}, core::Loc{fref, method.declLoc}, isAttrBestEffortUIOnly};
+        // We avoid using `this->addChild` here because we know the method occurs within `this->scope`, and we also want
+        // to give it a different `declLoc` and propagate `isAttrBestEffortUIOnly`.
+        auto node = std::make_shared<Node>(this->scope, method.symbol, ctx.locAt(method.loc));
+        node->declLoc = ctx.locAt(method.declLoc);
+        node->isAttrBestEffortUIOnly = method.flags.isAttrBestEffortUIOnly;
+        this->scope->children.emplace_back(node);
+    }
+
+    static std::vector<std::unique_ptr<DocumentSymbol>> documentSymbol(core::Context ctx, ast::ExpressionPtr &tree) {
+        core::Loc fullFile{ctx.file, core::LocOffsets{0, static_cast<uint32_t>(ctx.file.data(ctx).source().size())}};
+
+        Outliner outliner;
+        outliner.scope = std::make_shared<Node>(nullptr, core::Symbols::root(), fullFile);
+
+        ast::ShallowWalk::apply(ctx, outliner, tree);
+
+        ENFORCE(outliner.scope->symbol == core::Symbols::root());
+        return outliner.scope->genChildren(ctx);
     }
 };
-
-std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef,
-                                                         core::FileRef filter,
-                                                         const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping,
-                                                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced);
-
-void symbolRef2DocumentSymbolWalkMembers(const core::GlobalState &gs, core::SymbolRef sym, core::FileRef filter,
-                                         const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping,
-                                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced,
-                                         vector<unique_ptr<DocumentSymbol>> &out) {
-    if (!sym.isClassOrModule()) {
-        return;
-    }
-
-    for (auto mem : sym.asClassOrModuleRef().data(gs)->membersStableOrderSlow(gs)) {
-        if (mem.first == core::Names::attached() || mem.first == core::Names::singleton()) {
-            continue;
-        }
-        if (!absl::c_any_of(mem.second.locs(gs), [&filter](const auto &loc) { return loc.file() == filter; })) {
-            if (!forced.contains(mem.second)) {
-                continue;
-            }
-        }
-        auto inner = symbolRef2DocumentSymbol(gs, mem.second, filter, defMapping, forced);
-        if (inner) {
-            out.push_back(move(inner));
-        }
-    }
-}
-
-struct RangeInfo {
-    unique_ptr<Range> range;
-    unique_ptr<Range> selectionRange;
-};
-
-std::optional<RangeInfo> rangesForSymbol(const core::GlobalState &gs, core::SymbolRef symRef,
-                                         const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping,
-                                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced) {
-    RangeInfo info;
-    auto it = defMapping.find(symRef);
-    if (it != defMapping.end()) {
-        info.range = Range::fromLoc(gs, it->second.loc);
-        info.selectionRange = Range::fromLoc(gs, it->second.declLoc);
-    } else {
-        auto it = forced.find(symRef);
-        if (it != forced.end()) {
-            return rangesForSymbol(gs, it->second, defMapping, forced);
-        }
-
-        auto loc = symRef.loc(gs);
-        if (!loc.file().exists()) {
-            return nullopt;
-        }
-
-        info.range = Range::fromLoc(gs, loc);
-        info.selectionRange = Range::fromLoc(gs, loc);
-    }
-
-    if (info.range == nullptr || info.selectionRange == nullptr) {
-        return nullopt;
-    }
-
-    return info;
-}
-
-bool symbolIsAttr(core::SymbolRef symRef, const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping) {
-    auto it = defMapping.find(symRef);
-    return it != defMapping.end() && it->second.isAttrBestEffortUIOnly;
-}
-
-std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState &gs, core::SymbolRef symRef,
-                                                         core::FileRef filter,
-                                                         const UnorderedMap<core::SymbolRef, ASTSymbolInfo> &defMapping,
-                                                         const UnorderedMap<core::SymbolRef, core::SymbolRef> &forced) {
-    if (!symRef.exists()) {
-        return nullptr;
-    }
-    if (hideSymbol(gs, symRef)) {
-        return nullptr;
-    }
-    auto info = rangesForSymbol(gs, symRef, defMapping, forced);
-    if (!info.has_value()) {
-        return nullptr;
-    }
-    auto kind = symbolRef2SymbolKind(gs, symRef, symbolIsAttr(symRef, defMapping));
-
-    string name;
-    auto owner = symRef.owner(gs);
-    if (owner.exists() && owner.isClassOrModule() && owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()) {
-        name = "self.";
-    }
-    auto symName = symRef.name(gs).show(gs);
-    string_view view{symName};
-    if (absl::StartsWith(view, "<") && view.size() > 1) {
-        string_view describeStr = "<describe '";
-        string_view itStr = "<it '";
-        if (absl::StartsWith(view, describeStr) || absl::StartsWith(view, itStr)) {
-            view.remove_prefix(1);
-            view.remove_suffix(1);
-        }
-    }
-    name += view;
-    auto result = make_unique<DocumentSymbol>(move(name), kind, move(info->range), move(info->selectionRange));
-
-    // Previous versions of VSCode have a bug that requires this non-optional field to be present.
-    // This previously tried to include the method signature but due to issues where large signatures were not readable
-    // when put on one line and given that currently details are only visible in the outline view but not seen in the
-    // symbol search. Additionally, no other language server implementations we could find used this field.
-    result->detail = "";
-
-    vector<unique_ptr<DocumentSymbol>> children;
-    symbolRef2DocumentSymbolWalkMembers(gs, symRef, filter, defMapping, forced, children);
-    if (symRef.isClassOrModule()) {
-        auto singleton = symRef.asClassOrModuleRef().data(gs)->lookupSingletonClass(gs);
-        if (singleton.exists()) {
-            symbolRef2DocumentSymbolWalkMembers(gs, singleton, filter, defMapping, forced, children);
-        }
-    }
-    result->children = move(children);
-    return result;
-}
 
 } // namespace
 
@@ -203,130 +202,15 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
         return response;
     }
 
-    vector<pair<core::SymbolRef::Kind, uint32_t>> symbolTypes = {
-        {core::SymbolRef::Kind::ClassOrModule, gs.classAndModulesUsed()},
-        {core::SymbolRef::Kind::Method, gs.methodsUsed()},
-        {core::SymbolRef::Kind::FieldOrStaticField, gs.fieldsUsed()},
-        {core::SymbolRef::Kind::TypeArgument, gs.typeArgumentsUsed()},
-        {core::SymbolRef::Kind::TypeMember, gs.typeMembersUsed()},
-    };
-    vector<core::SymbolRef> candidates;
-    for (auto [kind, used] : symbolTypes) {
-        for (uint32_t idx = 1; idx < used; idx++) {
-            core::SymbolRef ref(gs, kind, idx);
-            if (hideSymbol(gs, ref)) {
-                continue;
-            }
-
-            // If the owner lives in this file, then the owner will be caught elsewhere
-            // in this loop and `ref` will be output as a child of owner.  So we should
-            // avoid outputting `ref` at this point.  Symbols owned by root, however,
-            // should always be output, as we don't output root itself.
-            if (ref.owner(gs).loc(gs).file() == fref && ref.owner(gs) != core::Symbols::root()) {
-                continue;
-            }
-
-            if (absl::c_any_of(ref.locs(gs), [&fref](const auto &loc) { return loc.file() == fref; })) {
-                candidates.emplace_back(ref);
-            }
-        }
-    }
-
-    // Despite our best efforts above, we might still output duplicates from the
-    // list of candidate symbols.  For instance, given an ownership chain:
-    //
-    // A -> B -> C
-    //
-    // Consider the case where B was defined in a different file and C was defined
-    // in the current file: then C will be in our candidate list.
-    //
-    // But if B has a loc in the current file and A was defined in a different file,
-    // then B will also be in our candidate list!
-    //
-    // To avoid that case, we need to walk the ownership chains of each symbol to
-    // deduplicate the candidate list.
-    UnorderedSet<core::SymbolRef> deduplicatedCandidates(candidates.begin(), candidates.end());
-
-    // We may wind up in a situation where we have something like:
-    //
-    // module A::B; class C::D::E; ...; end; end
-    //
-    // B and E are candidates, but neither C nor D have locs in the current
-    // file.  We'll eliminate E from candidacy, but then when we go to get
-    // children for B, we find that C doesn't appear in the current file, so
-    // we won't walk C's children.  Which means we'll never walk D's children
-    // and therefore E won't appear in the list of document symbols.
-    //
-    // So we need to ensure that both C and D are represented in the document
-    // symbols for the file.  But this raises a separate issue: what ranges do
-    // we assign to the symbols for C and D?  Giving them ranges representing
-    // their actual definitions is not correct, because their locs appear in an
-    // entirely different file.  Giving them null ranges seems reasonable, but
-    // that solution breaks cursor following in VSCode.
-    //
-    // As a sort of hacky compromise, we will give them ranges corresponding to
-    // the nearest owner that appears in the file.  For C and D above, that
-    // would be B.  (It would probably be more technically correct to give C and
-    // D ranges corresponding to E, but this is complicated to do with our setup
-    // here.).
-    //
-    // This map's keys record symbols that appear in an ownership chain between two
-    // candidates; the corresponding values are the closest ancestor that appears
-    // in this file.
-    UnorderedMap<core::SymbolRef, core::SymbolRef> forced;
-    for (auto ref : candidates) {
-        auto owner = ref.owner(gs);
-        while (owner != core::Symbols::root()) {
-            if (deduplicatedCandidates.contains(owner)) {
-                deduplicatedCandidates.erase(ref);
-                auto forcedOwner = ref.owner(gs);
-                while (forcedOwner != owner) {
-                    // We could record `owner` here, but `owner` itself may
-                    // eventually wind up in `forced`, which implies that the
-                    // value for `forcedOwner` should really be something
-                    // further up the ownership chain.  We'll fixup the values
-                    // later once we're sure of where all the original candidates
-                    // go.
-                    forced[forcedOwner] = core::Symbols::noSymbol();
-                    forcedOwner = forcedOwner.owner(gs);
-                }
-                break;
-            }
-
-            owner = owner.owner(gs);
-        }
-    }
-
-    for (auto &slot : forced) {
-        ENFORCE(!deduplicatedCandidates.contains(slot.first));
-        auto owner = slot.first.owner(gs);
-        while (!deduplicatedCandidates.contains(owner)) {
-            ENFORCE(owner != core::Symbols::root());
-            ENFORCE(owner.exists());
-            owner = owner.owner(gs);
-        }
-        ENFORCE(owner.exists());
-        slot.second = owner;
-    }
-
-    candidates.erase(
-        std::remove_if(candidates.begin(), candidates.end(),
-                       [&deduplicatedCandidates](const auto ref) { return !deduplicatedCandidates.contains(ref); }),
-        candidates.end());
-
-    UnorderedMap<core::SymbolRef, ASTSymbolInfo> defMapping;
-    SymbolFileLocSaver saver{fref, defMapping};
-    core::Context ctx{gs, core::Symbols::root(), fref};
     auto resolved = typechecker.getResolved(fref);
-    ast::ShallowWalk::apply(ctx, saver, resolved.tree);
-
-    for (auto ref : candidates) {
-        auto data = symbolRef2DocumentSymbol(gs, ref, fref, defMapping, forced);
-        if (data) {
-            result.push_back(move(data));
-        }
+    if (resolved.tree == nullptr) {
+        response->result = std::move(result);
+        return response;
     }
-    response->result = move(result);
+
+    core::Context ctx{gs, core::Symbols::root(), fref};
+    response->result = Outliner::documentSymbol(ctx, resolved.tree);
+
     return response;
 }
 

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -66,8 +66,7 @@ struct Node {
         }
         name += view;
 
-        auto result =
-            make_unique<DocumentSymbol>(move(name), kind, move(range), move(selectionRange));
+        auto result = make_unique<DocumentSymbol>(move(name), kind, move(range), move(selectionRange));
 
         // Previous versions of VSCode have a bug that requires this non-optional field to be present.
         // This previously tried to include the method signature but due to issues where large signatures were not

--- a/test/testdata/lsp/document_symbols.rb
+++ b/test/testdata/lsp/document_symbols.rb
@@ -87,3 +87,19 @@ class OuterModule
   class InnerClass; end
   module InnerModule; end
 end
+
+module Container; end
+module Container::Services; end
+
+module Container
+  class Services::TestService
+    extend T::Sig
+
+    def method1
+    end
+
+    sig { void }
+    def method2
+    end
+  end
+end

--- a/test/testdata/lsp/document_symbols.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols.rb.document-symbols.exp
@@ -502,6 +502,139 @@
                     "children": []
                 }
             ]
+        },
+        {
+            "name": "Container",
+            "detail": "",
+            "kind": 2,
+            "range": {
+                "start": {
+                    "line": 93,
+                    "character": 0
+                },
+                "end": {
+                    "line": 104,
+                    "character": 3
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 93,
+                    "character": 0
+                },
+                "end": {
+                    "line": 93,
+                    "character": 16
+                }
+            },
+            "children": [
+                {
+                    "name": "Services",
+                    "detail": "",
+                    "kind": 2,
+                    "range": {
+                        "start": {
+                            "line": 91,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 91,
+                            "character": 31
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 91,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 91,
+                            "character": 26
+                        }
+                    },
+                    "children": [
+                        {
+                            "name": "TestService",
+                            "detail": "",
+                            "kind": 5,
+                            "range": {
+                                "start": {
+                                    "line": 94,
+                                    "character": 2
+                                },
+                                "end": {
+                                    "line": 103,
+                                    "character": 5
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 94,
+                                    "character": 2
+                                },
+                                "end": {
+                                    "line": 94,
+                                    "character": 29
+                                }
+                            },
+                            "children": [
+                                {
+                                    "name": "method1",
+                                    "detail": "",
+                                    "kind": 6,
+                                    "range": {
+                                        "start": {
+                                            "line": 97,
+                                            "character": 4
+                                        },
+                                        "end": {
+                                            "line": 98,
+                                            "character": 7
+                                        }
+                                    },
+                                    "selectionRange": {
+                                        "start": {
+                                            "line": 97,
+                                            "character": 4
+                                        },
+                                        "end": {
+                                            "line": 97,
+                                            "character": 15
+                                        }
+                                    },
+                                    "children": []
+                                },
+                                {
+                                    "name": "method2",
+                                    "detail": "",
+                                    "kind": 6,
+                                    "range": {
+                                        "start": {
+                                            "line": 101,
+                                            "character": 4
+                                        },
+                                        "end": {
+                                            "line": 102,
+                                            "character": 7
+                                        }
+                                    },
+                                    "selectionRange": {
+                                        "start": {
+                                            "line": 101,
+                                            "character": 4
+                                        },
+                                        "end": {
+                                            "line": 101,
+                                            "character": 15
+                                        }
+                                    },
+                                    "children": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/test/testdata/lsp/document_symbols.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols.rb.document-symbols.exp
@@ -29,32 +29,6 @@
             },
             "children": [
                 {
-                    "name": "@ivar",
-                    "detail": "",
-                    "kind": 8,
-                    "range": {
-                        "start": {
-                            "line": 7,
-                            "character": 4
-                        },
-                        "end": {
-                            "line": 7,
-                            "character": 9
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 7,
-                            "character": 4
-                        },
-                        "end": {
-                            "line": 7,
-                            "character": 9
-                        }
-                    },
-                    "children": []
-                },
-                {
                     "name": "initialize",
                     "detail": "",
                     "kind": 9,
@@ -76,6 +50,32 @@
                         "end": {
                             "line": 6,
                             "character": 16
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "@ivar",
+                    "detail": "",
+                    "kind": 8,
+                    "range": {
+                        "start": {
+                            "line": 7,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 7,
+                            "character": 9
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 7,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 7,
+                            "character": 9
                         }
                     },
                     "children": []
@@ -186,32 +186,6 @@
                     "children": []
                 },
                 {
-                    "name": "bye",
-                    "detail": "",
-                    "kind": 6,
-                    "range": {
-                        "start": {
-                            "line": 37,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 40,
-                            "character": 5
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 37,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 37,
-                            "character": 12
-                        }
-                    },
-                    "children": []
-                },
-                {
                     "name": "hi",
                     "detail": "",
                     "kind": 6,
@@ -233,6 +207,32 @@
                         "end": {
                             "line": 32,
                             "character": 11
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "bye",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 37,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 40,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 37,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 37,
+                            "character": 12
                         }
                     },
                     "children": []
@@ -509,6 +509,58 @@
             "kind": 2,
             "range": {
                 "start": {
+                    "line": 90,
+                    "character": 0
+                },
+                "end": {
+                    "line": 90,
+                    "character": 21
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 90,
+                    "character": 0
+                },
+                "end": {
+                    "line": 90,
+                    "character": 16
+                }
+            },
+            "children": []
+        },
+        {
+            "name": "Services",
+            "detail": "",
+            "kind": 2,
+            "range": {
+                "start": {
+                    "line": 91,
+                    "character": 0
+                },
+                "end": {
+                    "line": 91,
+                    "character": 31
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 91,
+                    "character": 0
+                },
+                "end": {
+                    "line": 91,
+                    "character": 26
+                }
+            },
+            "children": []
+        },
+        {
+            "name": "Container",
+            "detail": "",
+            "kind": 2,
+            "range": {
+                "start": {
                     "line": 93,
                     "character": 0
                 },
@@ -529,108 +581,81 @@
             },
             "children": [
                 {
-                    "name": "Services",
+                    "name": "TestService",
                     "detail": "",
-                    "kind": 2,
+                    "kind": 5,
                     "range": {
                         "start": {
-                            "line": 91,
-                            "character": 0
+                            "line": 94,
+                            "character": 2
                         },
                         "end": {
-                            "line": 91,
-                            "character": 31
+                            "line": 103,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 91,
-                            "character": 0
+                            "line": 94,
+                            "character": 2
                         },
                         "end": {
-                            "line": 91,
-                            "character": 26
+                            "line": 94,
+                            "character": 29
                         }
                     },
                     "children": [
                         {
-                            "name": "TestService",
+                            "name": "method1",
                             "detail": "",
-                            "kind": 5,
+                            "kind": 6,
                             "range": {
                                 "start": {
-                                    "line": 94,
-                                    "character": 2
+                                    "line": 97,
+                                    "character": 4
                                 },
                                 "end": {
-                                    "line": 103,
-                                    "character": 5
+                                    "line": 98,
+                                    "character": 7
                                 }
                             },
                             "selectionRange": {
                                 "start": {
-                                    "line": 94,
-                                    "character": 2
+                                    "line": 97,
+                                    "character": 4
                                 },
                                 "end": {
-                                    "line": 94,
-                                    "character": 29
+                                    "line": 97,
+                                    "character": 15
                                 }
                             },
-                            "children": [
-                                {
-                                    "name": "method1",
-                                    "detail": "",
-                                    "kind": 6,
-                                    "range": {
-                                        "start": {
-                                            "line": 97,
-                                            "character": 4
-                                        },
-                                        "end": {
-                                            "line": 98,
-                                            "character": 7
-                                        }
-                                    },
-                                    "selectionRange": {
-                                        "start": {
-                                            "line": 97,
-                                            "character": 4
-                                        },
-                                        "end": {
-                                            "line": 97,
-                                            "character": 15
-                                        }
-                                    },
-                                    "children": []
+                            "children": []
+                        },
+                        {
+                            "name": "method2",
+                            "detail": "",
+                            "kind": 6,
+                            "range": {
+                                "start": {
+                                    "line": 101,
+                                    "character": 4
                                 },
-                                {
-                                    "name": "method2",
-                                    "detail": "",
-                                    "kind": 6,
-                                    "range": {
-                                        "start": {
-                                            "line": 101,
-                                            "character": 4
-                                        },
-                                        "end": {
-                                            "line": 102,
-                                            "character": 7
-                                        }
-                                    },
-                                    "selectionRange": {
-                                        "start": {
-                                            "line": 101,
-                                            "character": 4
-                                        },
-                                        "end": {
-                                            "line": 101,
-                                            "character": 15
-                                        }
-                                    },
-                                    "children": []
+                                "end": {
+                                    "line": 102,
+                                    "character": 7
                                 }
-                            ]
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 101,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 101,
+                                    "character": 15
+                                }
+                            },
+                            "children": []
                         }
                     ]
                 }

--- a/test/testdata/lsp/document_symbols_attr.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_attr.rb.document-symbols.exp
@@ -29,27 +29,53 @@
             },
             "children": [
                 {
-                    "name": "@bar",
+                    "name": "initialize",
                     "detail": "",
-                    "kind": 8,
+                    "kind": 9,
                     "range": {
                         "start": {
-                            "line": 6,
-                            "character": 8
+                            "line": 2,
+                            "character": 0
                         },
                         "end": {
-                            "line": 6,
-                            "character": 11
+                            "line": 16,
+                            "character": 3
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 6,
-                            "character": 8
+                            "line": 2,
+                            "character": 0
                         },
                         "end": {
-                            "line": 6,
-                            "character": 11
+                            "line": 2,
+                            "character": 19
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "foo",
+                    "detail": "",
+                    "kind": 7,
+                    "range": {
+                        "start": {
+                            "line": 5,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 5,
+                            "character": 21
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 5,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 5,
+                            "character": 21
                         }
                     },
                     "children": []
@@ -133,105 +159,27 @@
                     "children": []
                 },
                 {
-                    "name": "checked_qux",
+                    "name": "@bar",
                     "detail": "",
-                    "kind": 7,
+                    "kind": 8,
                     "range": {
                         "start": {
-                            "line": 12,
-                            "character": 2
+                            "line": 6,
+                            "character": 8
                         },
                         "end": {
-                            "line": 12,
-                            "character": 26
+                            "line": 6,
+                            "character": 11
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 12,
-                            "character": 2
+                            "line": 6,
+                            "character": 8
                         },
                         "end": {
-                            "line": 12,
-                            "character": 26
-                        }
-                    },
-                    "children": []
-                },
-                {
-                    "name": "checked_zap",
-                    "detail": "",
-                    "kind": 7,
-                    "range": {
-                        "start": {
-                            "line": 15,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 15,
-                            "character": 26
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 15,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 15,
-                            "character": 26
-                        }
-                    },
-                    "children": []
-                },
-                {
-                    "name": "foo",
-                    "detail": "",
-                    "kind": 7,
-                    "range": {
-                        "start": {
-                            "line": 5,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 5,
-                            "character": 21
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 5,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 5,
-                            "character": 21
-                        }
-                    },
-                    "children": []
-                },
-                {
-                    "name": "initialize",
-                    "detail": "",
-                    "kind": 9,
-                    "range": {
-                        "start": {
-                            "line": 2,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 16,
-                            "character": 3
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 2,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 2,
-                            "character": 19
+                            "line": 6,
+                            "character": 11
                         }
                     },
                     "children": []
@@ -310,6 +258,58 @@
                         "end": {
                             "line": 9,
                             "character": 20
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "checked_qux",
+                    "detail": "",
+                    "kind": 7,
+                    "range": {
+                        "start": {
+                            "line": 12,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 12,
+                            "character": 26
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 12,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 12,
+                            "character": 26
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "checked_zap",
+                    "detail": "",
+                    "kind": 7,
+                    "range": {
+                        "start": {
+                            "line": 15,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 15,
+                            "character": 26
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 15,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 15,
+                            "character": 26
                         }
                     },
                     "children": []

--- a/test/testdata/lsp/document_symbols_enum.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_enum.rb.document-symbols.exp
@@ -29,6 +29,32 @@
             },
             "children": [
                 {
+                    "name": "serialize",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 2,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 7,
+                            "character": 3
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 2,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 22
+                        }
+                    },
+                    "children": []
+                },
+                {
                     "name": "X",
                     "detail": "",
                     "kind": 14,
@@ -76,58 +102,6 @@
                         "end": {
                             "line": 5,
                             "character": 5
-                        }
-                    },
-                    "children": []
-                },
-                {
-                    "name": "serialize",
-                    "detail": "",
-                    "kind": 6,
-                    "range": {
-                        "start": {
-                            "line": 2,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 7,
-                            "character": 3
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 2,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 2,
-                            "character": 22
-                        }
-                    },
-                    "children": []
-                },
-                {
-                    "name": "self.sealed_subclasses",
-                    "detail": "",
-                    "kind": 6,
-                    "range": {
-                        "start": {
-                            "line": 2,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 2,
-                            "character": 22
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 2,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 2,
-                            "character": 22
                         }
                     },
                     "children": []

--- a/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
@@ -54,32 +54,6 @@
                     },
                     "children": [
                         {
-                            "name": "it 'runs another test'",
-                            "detail": "",
-                            "kind": 6,
-                            "range": {
-                                "start": {
-                                    "line": 16,
-                                    "character": 4
-                                },
-                                "end": {
-                                    "line": 17,
-                                    "character": 7
-                                }
-                            },
-                            "selectionRange": {
-                                "start": {
-                                    "line": 16,
-                                    "character": 4
-                                },
-                                "end": {
-                                    "line": 16,
-                                    "character": 4
-                                }
-                            },
-                            "children": []
-                        },
-                        {
                             "name": "it 'runs one test'",
                             "detail": "",
                             "kind": 6,
@@ -100,6 +74,32 @@
                                 },
                                 "end": {
                                     "line": 13,
+                                    "character": 4
+                                }
+                            },
+                            "children": []
+                        },
+                        {
+                            "name": "it 'runs another test'",
+                            "detail": "",
+                            "kind": 6,
+                            "range": {
+                                "start": {
+                                    "line": 16,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "character": 7
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 16,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 16,
                                     "character": 4
                                 }
                             },

--- a/test/testdata/lsp/document_symbols_nested_methods.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_nested_methods.rb.document-symbols.exp
@@ -29,32 +29,6 @@
             },
             "children": [
                 {
-                    "name": "b_func",
-                    "detail": "",
-                    "kind": 6,
-                    "range": {
-                        "start": {
-                            "line": 4,
-                            "character": 4
-                        },
-                        "end": {
-                            "line": 6,
-                            "character": 7
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 4,
-                            "character": 4
-                        },
-                        "end": {
-                            "line": 4,
-                            "character": 14
-                        }
-                    },
-                    "children": []
-                },
-                {
                     "name": "self.a_func",
                     "detail": "",
                     "kind": 6,
@@ -76,6 +50,32 @@
                         "end": {
                             "line": 3,
                             "character": 17
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "b_func",
+                    "detail": "",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 4,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 7
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 4,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 4,
+                            "character": 14
                         }
                     },
                     "children": []

--- a/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/dropped_document_symbols__1.rb.document-symbols.exp
@@ -29,135 +29,81 @@
             },
             "children": [
                 {
-                    "name": "Private",
+                    "name": "Actual",
                     "detail": "",
-                    "kind": 2,
+                    "kind": 5,
                     "range": {
                         "start": {
-                            "line": 2,
-                            "character": 0
+                            "line": 3,
+                            "character": 2
                         },
                         "end": {
-                            "line": 7,
-                            "character": 3
+                            "line": 6,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 2,
-                            "character": 0
+                            "line": 3,
+                            "character": 2
                         },
                         "end": {
-                            "line": 2,
-                            "character": 32
+                            "line": 3,
+                            "character": 33
                         }
                     },
                     "children": [
                         {
-                            "name": "Basement",
+                            "name": "interesting_function",
                             "detail": "",
-                            "kind": 2,
+                            "kind": 6,
                             "range": {
                                 "start": {
-                                    "line": 2,
-                                    "character": 0
+                                    "line": 4,
+                                    "character": 4
                                 },
                                 "end": {
-                                    "line": 7,
-                                    "character": 3
+                                    "line": 4,
+                                    "character": 33
                                 }
                             },
                             "selectionRange": {
                                 "start": {
-                                    "line": 2,
-                                    "character": 0
+                                    "line": 4,
+                                    "character": 4
                                 },
                                 "end": {
-                                    "line": 2,
-                                    "character": 32
+                                    "line": 4,
+                                    "character": 28
                                 }
                             },
-                            "children": [
-                                {
-                                    "name": "Actual",
-                                    "detail": "",
-                                    "kind": 5,
-                                    "range": {
-                                        "start": {
-                                            "line": 3,
-                                            "character": 2
-                                        },
-                                        "end": {
-                                            "line": 6,
-                                            "character": 5
-                                        }
-                                    },
-                                    "selectionRange": {
-                                        "start": {
-                                            "line": 3,
-                                            "character": 2
-                                        },
-                                        "end": {
-                                            "line": 3,
-                                            "character": 33
-                                        }
-                                    },
-                                    "children": [
-                                        {
-                                            "name": "boring_function",
-                                            "detail": "",
-                                            "kind": 6,
-                                            "range": {
-                                                "start": {
-                                                    "line": 5,
-                                                    "character": 4
-                                                },
-                                                "end": {
-                                                    "line": 5,
-                                                    "character": 28
-                                                }
-                                            },
-                                            "selectionRange": {
-                                                "start": {
-                                                    "line": 5,
-                                                    "character": 4
-                                                },
-                                                "end": {
-                                                    "line": 5,
-                                                    "character": 23
-                                                }
-                                            },
-                                            "children": []
-                                        },
-                                        {
-                                            "name": "interesting_function",
-                                            "detail": "",
-                                            "kind": 6,
-                                            "range": {
-                                                "start": {
-                                                    "line": 4,
-                                                    "character": 4
-                                                },
-                                                "end": {
-                                                    "line": 4,
-                                                    "character": 33
-                                                }
-                                            },
-                                            "selectionRange": {
-                                                "start": {
-                                                    "line": 4,
-                                                    "character": 4
-                                                },
-                                                "end": {
-                                                    "line": 4,
-                                                    "character": 28
-                                                }
-                                            },
-                                            "children": []
-                                        }
-                                    ]
+                            "children": []
+                        },
+                        {
+                            "name": "boring_function",
+                            "detail": "",
+                            "kind": 6,
+                            "range": {
+                                "start": {
+                                    "line": 5,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "character": 28
                                 }
-                            ]
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 5,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "character": 23
+                                }
+                            },
+                            "children": []
                         }
                     ]
                 }

--- a/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
+++ b/test/testdata/lsp/multi_file_duplicate_document_symbols__1.rb.document-symbols.exp
@@ -4,7 +4,7 @@
     "requestMethod": "textDocument/documentSymbol",
     "result": [
         {
-            "name": "Top",
+            "name": "Lower",
             "detail": "",
             "kind": 2,
             "range": {
@@ -13,8 +13,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
-                    "character": 10
+                    "line": 6,
+                    "character": 3
                 }
             },
             "selectionRange": {
@@ -24,114 +24,60 @@
                 },
                 "end": {
                     "line": 2,
-                    "character": 10
+                    "character": 24
                 }
             },
             "children": [
                 {
-                    "name": "Upper",
+                    "name": "Bottom",
                     "detail": "",
                     "kind": 2,
                     "range": {
                         "start": {
-                            "line": 2,
-                            "character": 0
+                            "line": 3,
+                            "character": 2
                         },
                         "end": {
-                            "line": 2,
-                            "character": 10
+                            "line": 5,
+                            "character": 5
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 2,
-                            "character": 0
+                            "line": 3,
+                            "character": 2
                         },
                         "end": {
-                            "line": 2,
-                            "character": 10
+                            "line": 3,
+                            "character": 15
                         }
                     },
                     "children": [
                         {
-                            "name": "Lower",
+                            "name": "func",
                             "detail": "",
-                            "kind": 2,
+                            "kind": 6,
                             "range": {
                                 "start": {
-                                    "line": 2,
-                                    "character": 0
+                                    "line": 4,
+                                    "character": 4
                                 },
                                 "end": {
-                                    "line": 6,
-                                    "character": 3
+                                    "line": 4,
+                                    "character": 17
                                 }
                             },
                             "selectionRange": {
                                 "start": {
-                                    "line": 2,
-                                    "character": 0
+                                    "line": 4,
+                                    "character": 4
                                 },
                                 "end": {
-                                    "line": 2,
-                                    "character": 24
+                                    "line": 4,
+                                    "character": 12
                                 }
                             },
-                            "children": [
-                                {
-                                    "name": "Bottom",
-                                    "detail": "",
-                                    "kind": 2,
-                                    "range": {
-                                        "start": {
-                                            "line": 3,
-                                            "character": 2
-                                        },
-                                        "end": {
-                                            "line": 5,
-                                            "character": 5
-                                        }
-                                    },
-                                    "selectionRange": {
-                                        "start": {
-                                            "line": 3,
-                                            "character": 2
-                                        },
-                                        "end": {
-                                            "line": 3,
-                                            "character": 15
-                                        }
-                                    },
-                                    "children": [
-                                        {
-                                            "name": "func",
-                                            "detail": "",
-                                            "kind": 6,
-                                            "range": {
-                                                "start": {
-                                                    "line": 4,
-                                                    "character": 4
-                                                },
-                                                "end": {
-                                                    "line": 4,
-                                                    "character": 17
-                                                }
-                                            },
-                                            "selectionRange": {
-                                                "start": {
-                                                    "line": 4,
-                                                    "character": 4
-                                                },
-                                                "end": {
-                                                    "line": 4,
-                                                    "character": 12
-                                                }
-                                            },
-                                            "children": []
-                                        }
-                                    ]
-                                }
-                            ]
+                            "children": []
                         }
                     ]
                 }


### PR DESCRIPTION
This a re-implementation of `textDocument/documentSymbol` that avoids traversing the whole symbol table to determine what to show.

Previously we would collect candidate symbols by first traversing the whole symbol table, keeping symbols that were defined in the current file. Then we would perform a traversal of the AST to determine the relevant declaration locations for all of the candidates, and finally we would build the result by traversing the candidate list and recursively building the response.

This PR skips the expensive traversal of the symbol table, as we're already iterating over the resolved tree. Instead, we can mirror the structure of the document in a separate data structure, and collect symbols that are included in the defining ranges of class/module declarations. This simplifies keeping entries in the right order in the containing definition, as we can sort based on their `Loc::beginPos`. This has the nice effect of moving some `initialize` definitions above the instance variables they initialize, keeping the outline in document order.

One difference to the previous implementation is that we now only generate class/module entries in the server response when it corresponds to a class/module declaration in the document. I think this is a good change, but it does mean that declarations like `class Services::MyService` will now show up only as `MyService`, as there's technically only one class definition present.

I would recommend reviewing this as a re-implementation instead of a diff, there's very little in common with the previous version at this point.

### Motivation
Performance, and correctness of generated ranges.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing and updated tests.