### PR TITLE
Don't accidently turn on packager in `copyForIndex` and `copyForSlowPath`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2245,13 +2245,12 @@ unique_ptr<GlobalState> GlobalState::deepCopyGlobalState(bool keepId) const {
     return result;
 }
 
-unique_ptr<GlobalState>
-GlobalState::copyForIndex(const vector<string> &extraPackageFilesDirectoryUnderscorePrefixes,
-                          const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                          const vector<string> &extraPackageFilesDirectorySlashPrefixes,
-                          const vector<string> &packageSkipRBIExportEnforcementDirs,
-                          const vector<string> &allowRelaxedPackagerChecksFor, const vector<string> &packagerLayers,
-                          string errorHint) const {
+unique_ptr<GlobalState> GlobalState::copyForIndex(
+    const bool packagerEnabled, const vector<string> &extraPackageFilesDirectoryUnderscorePrefixes,
+    const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
+    const vector<string> &extraPackageFilesDirectorySlashPrefixes,
+    const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
+    const vector<string> &packagerLayers, string errorHint) const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     result->initEmpty();
@@ -2262,7 +2261,7 @@ GlobalState::copyForIndex(const vector<string> &extraPackageFilesDirectoryUnders
     result->fileRefByPath = this->fileRefByPath;
     result->kvstoreUuid = this->kvstoreUuid;
 
-    {
+    if (packagerEnabled) {
         core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*result);
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = result->unfreezePackages();
         result->setPackagerOptions(extraPackageFilesDirectoryUnderscorePrefixes,
@@ -2307,7 +2306,7 @@ GlobalState::copyForSlowPath(const vector<string> &extraPackageFilesDirectoryUnd
     result->typeArguments.reserve(this->typeArguments.capacity());
     result->typeMembers.reserve(this->typeMembers.capacity());
 
-    {
+    if (packageDB().enabled()) {
         core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*result);
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = result->unfreezePackages();
         result->setPackagerOptions(extraPackageFilesDirectoryUnderscorePrefixes,

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -280,7 +280,8 @@ public:
     // NOTE: this very intentionally will not copy the symbol or name tables. The symbol tables aren't used or populated
     // during indexing, and the name tables will only be written to.
     std::unique_ptr<GlobalState>
-    copyForIndex(const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
+    copyForIndex(const bool packagerEnabled,
+                 const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                  const std::vector<std::string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
                  const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
                  const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -275,7 +275,8 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
     // indexer and typechecker's file tables will almost immediately diverge, but that's not an issue as we don't share
     // `core::FileRef` values between the two.
     auto typecheckerGS = std::exchange(
-        this->gs, this->gs->copyForIndex(this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
+        this->gs, this->gs->copyForIndex(this->config->opts.cacheSensitiveOptions.stripePackages,
+                                         this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
                                          this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                          this->config->opts.extraPackageFilesDirectorySlashPrefixes,
                                          this->config->opts.packageSkipRBIExportEnforcementDirs,

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -696,9 +696,10 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
     }
 
     shared_ptr<const core::GlobalState> emptyGs = baseGs.copyForIndex(
-        opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
-        opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
-        opts.allowRelaxedPackagerChecksFor, opts.packagerLayers, opts.stripePackagesHint);
+        opts.cacheSensitiveOptions.stripePackages, opts.extraPackageFilesDirectoryUnderscorePrefixes,
+        opts.extraPackageFilesDirectorySlashDeprecatedPrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
+        opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor, opts.packagerLayers,
+        opts.stripePackagesHint);
 
     workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, resultq, &kvstore, cancelable]() {
         Timer timeit(emptyGs->tracer(), "indexSuppliedFilesWorker");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

In `copyForIndex` and `copyForSlowPath`, we call `setPackagerOptions`, which unconditionally sets the `enabled_` flag on the package DB to be true. However, these are called even when the packager may not be enabled, so we're accidentally turning the packager on.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not sure how to test this, because we don't use `enabled()` in many places, and we have other checks in place wherever we do such that this being `true` by accident doesn't cause any problems.