### PR TITLE
Allow pushing trivially copyable values onto queues

### DIFF
--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -41,7 +41,7 @@ public:
     // When `Elem` is a fundamental type (int, bool, etc) push takes a value, but if it's anything else it expects an
     // rvalue reference so that we don't forget to move the argument.
     // TODO: is it valuable to make this check use `std::is_trivially_copyable` instead?
-    inline void push(typename std::conditional<std::is_fundamental<Elem>::value, Elem, Elem &&>::type elem,
+    inline void push(typename std::conditional<std::is_trivially_copyable_v<Elem>, Elem, Elem &&>::type elem,
                      int count) noexcept {
         _queue.enqueue(std::move(elem));
         elementsLeftToPush.fetch_add(-count, std::memory_order_release);

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -40,7 +40,6 @@ public:
 
     // When `Elem` is a fundamental type (int, bool, etc) push takes a value, but if it's anything else it expects an
     // rvalue reference so that we don't forget to move the argument.
-    // TODO: is it valuable to make this check use `std::is_trivially_copyable` instead?
     inline void push(typename std::conditional<std::is_trivially_copyable_v<Elem>, Elem, Elem &&>::type elem,
                      int count) noexcept {
         _queue.enqueue(std::move(elem));


### PR DESCRIPTION
The signature for `AbstractConcurrentBoundedQueue::push` was unnecessarily restrictive when it allowed a non-rvalue case, as it would only permit copies for fundamental types (`int`, `char`, etc.). Relaxing it to trivially copyable types means that we can push values of type `core::FileRef` without needing to add a call to `std::move`, which looks a bit odd on a type that manages no resources.

### Motivation
Code clarity when using bounded queues.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
