### PR TITLE
Allow passing `*.exp` paths to update_testdata_exp.sh

### DIFF
--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -81,6 +81,7 @@ else
         break;
     esac
   done
+  paths=()
   for path in "${@}"; do
     if [[ "$path" = *.exp ]]; then
       # delete shortest match of pattern from back of path

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -90,7 +90,7 @@ else
       fi
     fi
 
-    paths=("$path")
+    paths+=("$path")
   done
 fi
 

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -81,7 +81,17 @@ else
         break;
     esac
   done
-  paths=("$@")
+  for path in "${@}"; do
+    if [[ "$path" = *.exp ]]; then
+      # delete shortest match of pattern from back of path
+      path=${path%.*.exp}
+      if [[ "$path" = */pass ]]; then
+        path=${path%/pass}
+      fi
+    fi
+
+    paths=("$path")
+  done
 fi
 
 if [ "$BUILD" != "" ]; then


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sometimes I want to be able to regenerate all the `*.exp` files for a
certain kind of expectation. There are two ways to do this:

1.  regenerate everything
2.  list out each `*.rb` file that has that kind of exp

Doing the second approach always requires writing some fiddly shell
code, and it's easier to just have it here. Now you can do something
like this:

    tools/scripts/update_testdata_exp.sh test/testdata/**/*.package.exp

which saves time.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested manually on another branch where I'm changing exp files.