### PR TITLE
Always capture mutable GlobalState with as const

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -11,7 +11,7 @@ template <typename T> class SubstWalk {
 private:
     T &subst;
 
-    void substClassName(core::MutableContext ctx, ExpressionPtr &node) {
+    void substClassName(core::Context ctx, ExpressionPtr &node) {
         ExpressionPtr *cur = &node;
         while (true) {
             auto constLit = cast_tree<UnresolvedConstantLit>(*cur);
@@ -28,7 +28,7 @@ private:
         }
     }
 
-    void substArg(core::MutableContext ctx, ExpressionPtr &argp) {
+    void substArg(ExpressionPtr &argp) {
         ExpressionPtr *arg = &argp;
         while (arg != nullptr) {
             typecase(
@@ -55,7 +55,7 @@ private:
 public:
     SubstWalk(T &subst) : subst(subst) {}
 
-    void preTransformClassDef(core::MutableContext ctx, ExpressionPtr &tree) {
+    void preTransformClassDef(core::Context ctx, ExpressionPtr &tree) {
         auto &original = cast_tree_nonnull<ClassDef>(tree);
         substClassName(ctx, original.name);
         for (auto &anc : original.ancestors) {
@@ -63,22 +63,22 @@ public:
         }
     }
 
-    void preTransformMethodDef(core::MutableContext ctx, ExpressionPtr &tree) {
+    void preTransformMethodDef(core::Context ctx, ExpressionPtr &tree) {
         auto &original = cast_tree_nonnull<MethodDef>(tree);
         original.name = subst.substituteSymbolName(original.name);
         for (auto &arg : original.args) {
-            substArg(ctx, arg);
+            substArg(arg);
         }
     }
 
-    void preTransformBlock(core::MutableContext ctx, ExpressionPtr &tree) {
+    void preTransformBlock(core::Context ctx, ExpressionPtr &tree) {
         auto &original = cast_tree_nonnull<Block>(tree);
         for (auto &arg : original.args) {
-            substArg(ctx, arg);
+            substArg(arg);
         }
     }
 
-    void postTransformUnresolvedIdent(core::MutableContext ctx, ExpressionPtr &original) {
+    void postTransformUnresolvedIdent(core::Context ctx, ExpressionPtr &original) {
         auto &id = cast_tree_nonnull<UnresolvedIdent>(original);
         if (id.kind != ast::UnresolvedIdent::Kind::Local) {
             id.name = subst.substituteSymbolName(cast_tree<UnresolvedIdent>(original)->name);
@@ -87,12 +87,12 @@ public:
         }
     }
 
-    void postTransformLocal(core::MutableContext ctx, ExpressionPtr &local) {
+    void postTransformLocal(core::Context ctx, ExpressionPtr &local) {
         cast_tree_nonnull<Local>(local).localVariable._name =
             subst.substitute(cast_tree_nonnull<Local>(local).localVariable._name);
     }
 
-    void preTransformSend(core::MutableContext ctx, ExpressionPtr &original) {
+    void preTransformSend(core::Context ctx, ExpressionPtr &original) {
         auto &send = cast_tree_nonnull<Send>(original);
         if (send.fun == core::Names::aliasMethod()) {
             // `alias_method :foo :bar` is very similar to `def foo; self.bar(); end`, so in
@@ -136,7 +136,7 @@ public:
         }
     }
 
-    void postTransformLiteral(core::MutableContext ctx, ExpressionPtr &tree) {
+    void postTransformLiteral(core::Context ctx, ExpressionPtr &tree) {
         auto &original = cast_tree_nonnull<Literal>(tree);
         auto nameRef = unwrapLiteralToName(tree);
         if (!nameRef.exists()) {
@@ -157,26 +157,26 @@ public:
         }
     }
 
-    void postTransformUnresolvedConstantLit(core::MutableContext ctx, ExpressionPtr &tree) {
+    void postTransformUnresolvedConstantLit(core::Context ctx, ExpressionPtr &tree) {
         auto &original = cast_tree_nonnull<UnresolvedConstantLit>(tree);
         original.cnst = subst.substituteSymbolName(original.cnst);
         substClassName(ctx, original.scope);
     }
 
-    void postTransformRuntimeMethodDefinition(core::MutableContext ctx, ExpressionPtr &original) {
+    void postTransformRuntimeMethodDefinition(core::Context ctx, ExpressionPtr &original) {
         auto &def = cast_tree_nonnull<RuntimeMethodDefinition>(original);
         def.name = subst.substitute(def.name);
     }
 };
 } // namespace
 
-ParsedFile Substitute::run(core::MutableContext ctx, const core::NameSubstitution &subst, ParsedFile what) {
+ParsedFile Substitute::run(core::Context ctx, const core::NameSubstitution &subst, ParsedFile what) {
     SubstWalk walk(subst);
     TreeWalk::apply(ctx, walk, what.tree);
     return what;
 }
 
-ParsedFile Substitute::run(core::MutableContext ctx, core::LazyNameSubstitution &subst, ParsedFile what) {
+ParsedFile Substitute::run(core::Context ctx, core::LazyNameSubstitution &subst, ParsedFile what) {
     SubstWalk walk(subst);
     TreeWalk::apply(ctx, walk, what.tree);
     return what;

--- a/ast/substitute/substitute.h
+++ b/ast/substitute/substitute.h
@@ -11,8 +11,8 @@ class LazyNameSubstitution;
 namespace sorbet::ast {
 class Substitute {
 public:
-    static ParsedFile run(core::MutableContext ctx, const core::NameSubstitution &subst, ParsedFile what);
-    static ParsedFile run(core::MutableContext ctx, core::LazyNameSubstitution &subst, ParsedFile what);
+    static ParsedFile run(core::Context ctx, const core::NameSubstitution &subst, ParsedFile what);
+    static ParsedFile run(core::Context ctx, core::LazyNameSubstitution &subst, ParsedFile what);
 };
 } // namespace sorbet::ast
 #endif // SORBET_SUBSTITUTE_H

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -578,7 +578,7 @@ ast::ParsedFilesOrCancelled mergeIndexResults(core::GlobalState &cgs, const opti
         Timer timeit(cgs.tracer(), "substituteTrees");
         auto resultq = make_shared<BlockingBoundedQueue<vector<ast::ParsedFile>>>(batchq->bound);
 
-        workers.multiplexJob("substituteTrees", [&cgs, &logger = cgs.tracer(), batchq, resultq, cancelable]() {
+        workers.multiplexJob("substituteTrees", [&cgs = as_const(cgs), &logger = cgs.tracer(), batchq, resultq, cancelable]() {
             Timer timeit(logger, "substituteTreesWorker");
             IndexSubstitutionJob job;
             int numTreesProcessed = 0;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -598,7 +598,7 @@ ast::ParsedFilesOrCancelled mergeIndexResults(core::GlobalState &cgs, const opti
                         if (job.subst.has_value()) {
                             for (auto &tree : job.trees) {
                                 if (!tree.cached()) {
-                                    core::MutableContext ctx(cgs, core::Symbols::root(), tree.file);
+                                    core::Context ctx(cgs, core::Symbols::root(), tree.file);
                                     tree = ast::Substitute::run(ctx, *job.subst, move(tree));
                                 }
                             }

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -12,6 +12,8 @@
 #include <algorithm>
 #include <iterator>
 
+using namespace std;
+
 using namespace std::literals::string_view_literals;
 
 namespace sorbet::packager {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2096,7 +2096,7 @@ void packageRunCore(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::
             }
         }
 
-        workers.multiplexJob("rewritePackagesAndFiles", [&gs, &files, &barrier, taskq]() {
+        workers.multiplexJob("rewritePackagesAndFiles", [&gs = as_const(gs), &files, &barrier, taskq]() {
             Timer timeit(gs.tracer(), "packager.rewritePackagesAndFilesWorker");
             size_t idx;
             for (auto result = taskq->try_pop(idx); !result.done(); result = taskq->try_pop(idx)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3266,7 +3266,7 @@ public:
         }
         trees.clear();
 
-        workers.multiplexJob("resolveTypeParamsWalk", [&gs, inputq, outputq]() -> void {
+        workers.multiplexJob("resolveTypeParamsWalk", [&gs = as_const(gs), inputq, outputq]() -> void {
             Timer timeit(gs.tracer(), "resolveTypeParamsWalkWorker");
             ResolveTypeMembersAndFieldsWalk walk;
             ResolveTypeMembersAndFieldsWorkerResult output;
@@ -4133,7 +4133,7 @@ vector<ast::ParsedFile> resolveSigs(core::GlobalState &gs, vector<ast::ParsedFil
 
     trees.clear();
 
-    workers.multiplexJob("resolveSignaturesWalk", [&gs, inputq, outputq]() -> void {
+    workers.multiplexJob("resolveSignaturesWalk", [&gs = as_const(gs), inputq, outputq]() -> void {
         ResolveSignaturesWalk walk;
         ResolveSignaturesWalk::ResolveSignaturesWalkResult output;
         ast::ParsedFile job;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These `multiplexJob` calls are places where we could accidentally
concurrently mutate `GlobalState`. Luckily we're not doing that in any of
these places today, but I want to make sure it stays that way by explicitly
using `as_const`.

In particular, this revealed that `mergeIndexResults` technically was using a
`MutableContext` instead of a `Context` in a `multiplexJob`, but we were only
calling `const` methods (if any) on `ctx` so it happened to be fine.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests