### PR TITLE
Auto-save codeAction changes to __package.rb files for the "Apply All" quickfix too

### DIFF
--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -187,6 +187,9 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
             action->kind = kind;
             auto workspaceEdit = make_unique<WorkspaceEdit>();
             workspaceEdit->documentChanges = getQuickfixEdits(config, gs, allEdits);
+            if (absl::c_any_of(allEdits, [&](auto edit) { return edit.loc.file().isPackage(gs); })) {
+                action->command = make_unique<Command>("Save package files", "sorbet.savePackageFiles");
+            }
             action->edit = move(workspaceEdit);
             result.emplace_back(move(action));
         }

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -156,6 +156,10 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
                 action->kind = CodeActionKind::Quickfix;
                 auto workspaceEdit = make_unique<WorkspaceEdit>();
                 workspaceEdit->documentChanges = getQuickfixEdits(config, gs, autocorrect.edits);
+                // TODO(neil): this is specifc to just package files, but the root problem is when a code action edits a
+                // file that the user doesn't have open in their editor. The more generic fix would be to save all files
+                // that this code action edits that are also not open in the editor. This also applies below to "Apply
+                // All" code action we construct.
                 if (absl::c_any_of(autocorrect.edits, [&](auto edit) { return edit.loc.file().isPackage(gs); })) {
                     action->command = make_unique<Command>("Save package files", "sorbet.savePackageFiles");
                 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Follow up to #7214 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were only sending the command for the individual quickfixes, but the combined quickfix could also modify a `__package.rb` file.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested manually by running the "Apply All" quickfix and making sure the `__package.rb` file was saved.