### PR TITLE
Fix `viml` / `lua` syntax confusion in website/

### DIFF
--- a/website/docs/lsp.md
+++ b/website/docs/lsp.md
@@ -395,7 +395,7 @@ like this:
 ```lua
 vim.lsp.commands['sorbet.savePackageFiles'] = function(command)
   -- ...
-endfunction
+end
 ```
 
 Sorbet includes this `sorbet.savePackageFiles` command in the `command` field of


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Typo from #8793

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
