### PR TITLE
Don't fail on ANY initialization options

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -120,12 +120,16 @@ LSPClientConfiguration::LSPClientConfiguration(const InitializeParams &params) {
     }
 
     if (params.initializationOptions) {
-        auto &initOptions = *params.initializationOptions;
-        enableOperationNotifications = initOptions->supportsOperationNotifications.value_or(false);
-        enableTypecheckInfo = initOptions->enableTypecheckInfo.value_or(false);
-        enableSorbetURIs = initOptions->supportsSorbetURIs.value_or(false);
-        enableHighlightUntyped = parseEnableHighlightUntyped(*initOptions, core::TrackUntyped::Nowhere);
-        enableTypedFalseCompletionNudges = initOptions->enableTypedFalseCompletionNudges.value_or(true);
+        try {
+            auto &initOptions = *params.initializationOptions;
+            enableOperationNotifications = initOptions->supportsOperationNotifications.value_or(false);
+            enableTypecheckInfo = initOptions->enableTypecheckInfo.value_or(false);
+            enableSorbetURIs = initOptions->supportsSorbetURIs.value_or(false);
+            enableHighlightUntyped = parseEnableHighlightUntyped(*initOptions, core::TrackUntyped::Nowhere);
+            enableTypedFalseCompletionNudges = initOptions->enableTypedFalseCompletionNudges.value_or(true);
+        } catch (const DeserializationError &e) {
+            // Default values are already set in the class definition
+        }
     }
 }
 

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -10,6 +10,45 @@ namespace sorbet::test::lsp {
 using namespace std;
 using namespace sorbet::realmain::lsp;
 
+// Test that initialization with non-object initializationOptions doesn't fail
+TEST_CASE_FIXTURE(ProtocolTest, "InitializeWithNonObjectOptions") {
+    // Create a raw initialize message with an array as initializationOptions instead of an object
+    string rawInitMessage = R"(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "processId": null,
+                "rootPath": "",
+                "rootUri": "file:///test",
+                "initializationOptions": [],
+                "capabilities": {
+                    "workspace": {
+                        "applyEdit": true
+                    },
+                    "textDocument": {
+                        "completion": {
+                            "completionItem": {
+                                "snippetSupport": true
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    )";
+
+    // This should not throw an exception
+    auto responses = sendRaw(rawInitMessage);
+
+    // Verify that we get a successful initialize response
+    REQUIRE_GE(responses.size(), 1);
+    auto &response = responses[0];
+    REQUIRE(response->isResponse());
+    REQUIRE_FALSE(response->asResponse().error.has_value());
+}
+
 // Adds two new files that have errors, and asserts that Sorbet returns errors for both of them.
 TEST_CASE_FIXTURE(ProtocolTest, "AddFile") {
     assertErrorDiagnostics(initializeLSP(), {});


### PR DESCRIPTION
The LSP protocol defines `initializationOptions` as `LSPAny`, however Sorbet was strictly failing with anything other than an object.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation

I started getting errors using neovim + ALE along with sorbet. 

```
Error executing vim.schedule lua callback: ...nvimEllFDd/usr/share/nvim/runtime/lua/vim/lsp/client.lua:548: RPC[Error] code_name = InvalidParams, message = "Unable to deserialize LSP request: Error deserializing JSON message: Expected field `InitializeParams.initializationOptions` to have value of type `object`, but had value `[]`."
stack traceback:
        [C]: in function 'assert'
        ...nvimEllFDd/usr/share/nvim/runtime/lua/vim/lsp/cl…
```

Lua serializes empty tables as arrays which caused this error to surface from Sorbet. I initially thought of [fixing it up in neovim](https://github.com/neovim/neovim/pull/33551#issue-3007154732) by only serializing empty objects but their maintainers pointed out the LSP Procotol defines these options as accepting anything and that some servers actually use the array.

I've filed a PR with ALE to default to some initializationOptions (using Sorbet's defaults) so at least it prevents the error from happening there https://github.com/dense-analysis/ale/pull/4954. 

However, I figured I'd take a stab at relaxing the strictness of the deserialization in Sorbet for these options to prevent the error in the first place.

### Test plan

A sample test was added to ensure an error is not raised during the initialize request with an empty array as initializationOptions



>[!NOTE]
> I'm not super familiar with C++ and the testing strategy but I'm happy to iterate over this if the change makes sense 🙇 
