### PR TITLE
drop extraneous checks in `T::Types::ClassOf#valid?`

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/class_of.rb
+++ b/gems/sorbet-runtime/lib/types/types/class_of.rb
@@ -21,7 +21,7 @@ module T::Types
 
     # overrides Base
     def valid?(obj)
-      obj.is_a?(Module) && (obj.is_a?(@type.singleton_class) || false)
+      obj.is_a?(@type.singleton_class)
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1376,6 +1376,12 @@ module Opus::Types::Test
         assert_nil(msg)
       end
 
+      it 'fails validation with a superclass' do
+        type = T.class_of(Sub)
+        msg = check_error_message_for_obj(type, Base)
+        assert_equal("Expected type T.class_of(Opus::Types::Test::TypesTest::Sub), got Opus::Types::Test::TypesTest::Base", msg)
+      end
+
       it 'fails validation with some other class' do
         msg = check_error_message_for_obj(@type, InterfaceImplementor1)
         assert_equal("Expected type T.class_of(Opus::Types::Test::TypesTest::Base), got Opus::Types::Test::TypesTest::InterfaceImplementor1", msg)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't need the extra checking for `obj.is_a?(Module)` because we're never doing anything with `obj` that depends on `Module`-ness.  (We do have test for non-`Module` objs, so if tests pass, this change should be fine.)

#6810 is defunct now, I think, but it had a test that seems reasonable to import.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
