### PR TITLE
Document why dynamic constant references are unsupported

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -1540,6 +1540,10 @@ class MyCachable < Cachable
 end
 ```
 
+See
+[Unsupported features: Dynamic constant references](unsupported.md#dynamic-constant-references)
+for a more thorough explanation.
+
 ## 5002
 
 This means that the typechecker has been unable to resolve a reference to a

--- a/website/docs/unsupported.md
+++ b/website/docs/unsupported.md
@@ -4,8 +4,7 @@ title: Unsupported Ruby Features
 ---
 
 Some features of Ruby Sorbet intentionally does not support. This doc aims to
-document the most commonly Ruby features which are not supported in Sorbet
-**and** for which Sorbet will not produce an error.
+document the most common such features with explanations and alternatives.
 
 > **Note**: This page is not exhaustive.
 >


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.