### PR TITLE
Accept `env` argument for `Open3.popen3`

### DIFF
--- a/rbi/stdlib/open3.rbi
+++ b/rbi/stdlib/open3.rbi
@@ -98,12 +98,13 @@ module Open3
   # [`Open3.capture3`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-capture3).
   sig do
     params(
+      first_command_or_env: T.any(String, T::Hash[String, String]),
       cmd: T.any(String, T::Array[String]),
       opts: T.untyped,
       block: T.nilable(T.proc.params(stdin: IO, stdout: IO, stderr: IO, wait_thr: Process::Waiter).void)
     ).returns([IO, IO, IO, Process::Waiter])
   end
-  module_function def popen3(*cmd, **opts, &block); end
+  module_function def popen3(first_command_or_env, *cmd, **opts, &block); end
 
   # [`Open3.popen2`](https://docs.ruby-lang.org/en/2.6.0/Open3.html#method-c-popen2)
   # is similar to

--- a/test/testdata/rbi/open3.rb
+++ b/test/testdata/rbi/open3.rb
@@ -1,0 +1,12 @@
+# typed: strict
+
+Open3.popen3("bundle", "install", { chdir: 'my_directory' })
+Open3.popen3("bundle", { chdir: 'my_directory' })
+Open3.popen3({ "VAR" => "true" }, "bundle", "install", { chdir: 'my_directory' })
+Open3.popen3({ "VAR" => "true" }, "bundle", { chdir: 'my_directory' })
+
+Open3.popen3("bundle", "install", { chdir: 'my_directory' }) do |stdin, stdout, stderr, wait_thread|
+end
+
+Open3.popen3({ "VAR" => "true" }, "bundle", "install", { chdir: 'my_directory' }) do |stdin, stdout, stderr, wait_thread|
+end


### PR DESCRIPTION
Changed the RBI to accept an `env` argument, which also works as the first command for the splat chain.

### Motivation

The `popen3` method and family all accept that the first argument of the splat be additional environment variables ([docs](https://docs.ruby-lang.org/en/master/Open3.html#method-i-popen3)).

### Test plan

I added a test case for the `testdata/rbi` directory.