### PR TITLE
Simplify typechecker initialization in LSP

### DIFF
--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -82,9 +82,9 @@ public:
     void computeFileHashes(const std::vector<std::shared_ptr<core::File>> &files) const;
 
     /**
-     * Initializes the indexer with the state produced on the typechecking thread.
+     * Finalizes indexer initialization.
      */
-    void initialize(IndexerInitializationTask &task, std::unique_ptr<core::GlobalState> initialGS);
+    void initialize(IndexerInitializationTask &task);
 
     /**
      * Commits the given edit to `initialGS`, and returns a canonical LSPFileUpdates object containing indexed trees

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -92,23 +92,10 @@ class LSPTypechecker final {
         Cancelable,
     };
 
-    /**
-     * The result of a slow path operation depends on the mode that it was run in:
-     * - Init indicates that the LSPTypechecker is being initialized by the indexer. One implication of this is that the
-     *   slow path operation will not be cancelable, meaning that the result will always be committed. As we know that
-     *   the result will be committed, and the indexer needs a copy of the GlobalState to be taken after indexing, we
-     *   return that copy as the result of the slow path.
-     * - Cancelable indicates that the slow path may be canceled before it completes. As this mode does not require a
-     *   copy of the typechecker's GlobalState to be returned, and the slow path operation may be canceled, we return a
-     *   boolean indicating whether or not the result of the slow path was committed.
-     */
-    using SlowPathResult = std::variant<std::unique_ptr<core::GlobalState>, bool>;
-
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */
-    SlowPathResult runSlowPath(LSPFileUpdates &updates, std::unique_ptr<const OwnedKeyValueStore> ownedKvstore,
-                               WorkerPool &workers, std::shared_ptr<core::ErrorFlusher> errorFlusher,
-                               SlowPathMode mode);
+    bool runSlowPath(LSPFileUpdates &updates, std::unique_ptr<const OwnedKeyValueStore> ownedKvstore,
+                     WorkerPool &workers, std::shared_ptr<core::ErrorFlusher> errorFlusher, SlowPathMode mode);
 
     /** Runs incremental typechecking on the provided updates. Returns the final list of files typechecked. */
     std::vector<core::FileRef> runFastPath(LSPFileUpdates &updates, WorkerPool &workers,

--- a/main/lsp/notifications/indexer_initialization.cc
+++ b/main/lsp/notifications/indexer_initialization.cc
@@ -3,16 +3,15 @@
 
 namespace sorbet::realmain::lsp {
 
-IndexerInitializationTask::IndexerInitializationTask(const LSPConfiguration &config,
-                                                     std::unique_ptr<core::GlobalState> initialGS)
-    : LSPTask(config, LSPMethod::SorbetIndexerInitialization), initialGS{std::move(initialGS)} {}
+IndexerInitializationTask::IndexerInitializationTask(const LSPConfiguration &config)
+    : LSPTask(config, LSPMethod::SorbetIndexerInitialization) {}
 
 LSPTask::Phase IndexerInitializationTask::finalPhase() const {
     return LSPTask::Phase::INDEX;
 }
 
 void IndexerInitializationTask::index(LSPIndexer &indexer) {
-    indexer.initialize(*this, std::move(this->initialGS));
+    indexer.initialize(*this);
 }
 
 void IndexerInitializationTask::run(LSPTypecheckerDelegate &typechecker) {}

--- a/main/lsp/notifications/indexer_initialization.h
+++ b/main/lsp/notifications/indexer_initialization.h
@@ -6,10 +6,8 @@
 namespace sorbet::realmain::lsp {
 
 class IndexerInitializationTask final : public LSPTask {
-    std::unique_ptr<core::GlobalState> initialGS;
-
 public:
-    IndexerInitializationTask(const LSPConfiguration &config, std::unique_ptr<core::GlobalState> initialGS);
+    IndexerInitializationTask(const LSPConfiguration &config);
 
     Phase finalPhase() const override;
 


### PR DESCRIPTION
As we no longer need to share the name table between the indexer and typechecker threads, we can also stop sending a copy of the `GlobalState` back after the typechecker has successfully initialized.

This does mean that the file tables will no longer match up between the two, but we also have gone to lengths to avoid sharing `core::FileRef` values between the two threads, which means that it's fine for them to diverge.

### Motivation
Simplifying LSP initialization.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
