### PR TITLE
Implement the sqlite4 variable encoding of integers

### DIFF
--- a/core/serialize/pickler.h
+++ b/core/serialize/pickler.h
@@ -6,7 +6,6 @@
 namespace sorbet::core::serialize {
 class Pickler {
     std::vector<uint8_t> data;
-    uint8_t zeroCounter = 0;
 
 public:
     void putU4(uint32_t u);
@@ -19,7 +18,6 @@ public:
 
 class UnPickler {
     int pos;
-    uint8_t zeroCounter = 0;
     std::vector<uint8_t> data;
 
 public:

--- a/core/serialize/test/serialize_test.cc
+++ b/core/serialize/test/serialize_test.cc
@@ -15,10 +15,16 @@ TEST_CASE("U4") { // NOLINT
     Pickler p;
     p.putU4(0);
     p.putU4(1);
+    p.putU4(247);
+    p.putU4(42877);
+    p.putU4(16777215);
     p.putU4(4294967295);
     UnPickler u(p.result().data(), *logger);
     CHECK_EQ(u.getU4(), 0);
     CHECK_EQ(u.getU4(), 1);
+    CHECK_EQ(u.getU4(), 247);
+    CHECK_EQ(u.getU4(), 42877);
+    CHECK_EQ(u.getU4(), 16777215);
     CHECK_EQ(u.getU4(), 4294967295);
 }
 


### PR DESCRIPTION
Implement the [sqlite4 variable byte encoding](https://sqlite.org/src4/doc/trunk/www/varint.wiki) instead of the RLE encoding of zeros when serializing.

### Motivation
Performance

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
