### PR TITLE
Emit the fast path duration in logs

### DIFF
--- a/common/timers/Timer.cc
+++ b/common/timers/Timer.cc
@@ -141,8 +141,9 @@ void Timer::setTag(ConstExprStr name, ConstExprStr value) {
     tags->push_back(make_pair(name, value));
 }
 
-void Timer::setEndTime() {
+microseconds Timer::setEndTime() {
     endTime = clock_gettime_coarse();
+    return microseconds{endTime.usec - start.usec};
 }
 
 Timer::~Timer() {

--- a/common/timers/Timer.h
+++ b/common/timers/Timer.h
@@ -61,7 +61,7 @@ public:
     static microseconds get_clock_threshold_coarse();
     static microseconds clock_gettime_coarse();
 
-    void setEndTime();
+    microseconds setEndTime();
 
 private:
     spdlog::logger &log;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -271,7 +271,6 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     fast_sort(toTypecheck);
     toTypecheck.erase(std::unique(toTypecheck.begin(), toTypecheck.end()), toTypecheck.end());
 
-    config->logger->debug("Running fast path over num_files={}", toTypecheck.size());
     std::optional<ShowOperation> op;
     if (toTypecheck.size() > config->opts.lspMaxFilesOnFastPath / 2) {
         op.emplace(*config, ShowOperation::Kind::FastPath);
@@ -309,6 +308,9 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     const auto cancelable = false;
     pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, std::nullopt, presorted);
     gs->lspTypecheckCount++;
+
+    auto duration = timeit.setEndTime();
+    config->logger->debug("Running fast path over num_files={} duration={}", toTypecheck.size(), duration.usec);
 
     return toTypecheck;
 }


### PR DESCRIPTION
Start emitting the fast-path duration in the log.

### Motivation
Debugging slowdowns.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
