### PR TITLE
getPackageForFile: Return MangledName

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -181,7 +181,7 @@ void PackageDB::setPackageNameForFile(FileRef file, MangledName mangledName) {
     this->packageForFile_[file.id()] = mangledName;
 }
 
-const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, core::FileRef file) const {
+MangledName PackageDB::getPackageForFile(const core::GlobalState &gs, core::FileRef file) const {
     ENFORCE(frozen);
     ENFORCE(enabled_);
 
@@ -189,7 +189,7 @@ const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, cor
     // update the vector if we fall back on the slow path.
     auto name = this->getPackageNameForFile(file);
     if (name.exists()) {
-        return this->getPackageInfo(name);
+        return name;
     }
 
     // Note about safety: we're only using the file data for two pieces of information: the file path and the
@@ -204,9 +204,7 @@ const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, cor
     while (curPrefixPos > 0) {
         const auto &it = packagesByPathPrefix.find(path.substr(0, curPrefixPos + 1));
         if (it != packagesByPathPrefix.end()) {
-            const auto &pkg = getPackageInfo(it->second);
-            ENFORCE(pkg.exists());
-            return pkg;
+            return it->second;
         }
 
         if (fileData.isPackage(gs)) {
@@ -215,7 +213,7 @@ const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, cor
         }
         curPrefixPos = path.find_last_of('/', curPrefixPos - 1);
     }
-    return NONE_PKG;
+    return MangledName();
 }
 
 const PackageInfo &PackageDB::getPackageInfo(const core::GlobalState &gs, std::string_view nameStr) const {

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -35,7 +35,7 @@ public:
     // Set the associated package for the file.
     void setPackageNameForFile(FileRef file, MangledName mangledName);
 
-    const PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
+    MangledName getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
     const PackageInfo &getPackageInfo(MangledName mangledName) const;
     PackageInfo *getPackageInfoNonConst(MangledName mangledName);
 

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -409,9 +409,9 @@ com::stripe::rubytyper::FileTable Proto::filesToProto(const GlobalState &gs,
         }
 
         if (stripePackages) {
-            const auto &packageInfo = packageDB.getPackageForFile(gs, file);
-            if (packageInfo.exists()) {
-                entry->set_pkg(packageInfo.show(gs));
+            const auto &pkg = packageDB.getPackageForFile(gs, file);
+            if (pkg.exists()) {
+                entry->set_pkg(packageDB.getPackageInfo(pkg).show(gs));
             }
         }
     }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -250,12 +250,15 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             // files don't take the fast path. We'll want (or maybe need) to revisit this when we start
             // making edits to `__package.rb` take fast paths.
             if (!(fref.data(*gs).isPackage(*gs))) {
-                auto &pkg = gs->packageDB().getPackageForFile(*gs, fref);
+                auto pkg = gs->packageDB().getPackageForFile(*gs, fref);
                 if (pkg.exists()) {
                     // Since even no-op (e.g. whitespace-only) edits will cause constants to be deleted
                     // and re-added, we have to add the __package.rb files to set of files to retypecheck
                     // so that we can re-run PropagateVisibility to set export bits for any constants.
-                    auto packageFref = pkg.fullLoc().file();
+                    // TODO(jez) Make PropagateVisibility a function of the packageDB so that we
+                    // don't have to completely retypecheck the `__package.rb` file again just to
+                    // make sure one file's constants have the right visibility flags.
+                    auto packageFref = gs->packageDB().getPackageInfo(pkg).fullLoc().file();
                     if (!packageFref.exists()) {
                         continue;
                     }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1544,7 +1544,7 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
             if (!pkg.exists()) {
                 writer.String("<none>");
             } else {
-                writer.String(pkg.show(gs));
+                writer.String(gs.packageDB().getPackageInfo(pkg).show(gs));
             }
 
         } else {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -578,10 +578,11 @@ private:
 
                         // Can't use pkg.ownsSymbol since it uses symbol definition locs, which have an edge case that
                         // isn't handled until the VisibilityChecker pass.
-                        auto &enclosingPackage = ctx.state.packageDB().getPackageForFile(ctx.state, ctx.file);
+                        auto enclosingPackage = ctx.state.packageDB().getPackageForFile(ctx.state, ctx.file);
                         if (enclosingPackage.exists()) {
-                            const auto pkgRootSymbol =
-                                enclosingPackage.getRootSymbolForAutocorrectSearch(ctx.state, suggestScope);
+                            const auto pkgRootSymbol = ctx.state.packageDB()
+                                                           .getPackageInfo(enclosingPackage)
+                                                           .getRootSymbolForAutocorrectSearch(ctx.state, suggestScope);
 
                             auto it = std::remove_if(suggested.begin(), suggested.end(),
                                                      [&pkgRootSymbol, &gs](auto &suggestion) -> bool {

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -132,7 +132,7 @@ vector<ast::ParsedFile> enterPackages(core::GlobalState &gs, vector<pair<string,
 }
 
 const core::packages::PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) {
-    return gs.packageDB().getPackageForFile(gs, file);
+    return gs.packageDB().getPackageInfo(gs.packageDB().getPackageForFile(gs, file));
 }
 
 const core::SymbolRef getConstantRef(core::GlobalState &gs, vector<string> rawName) {

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -131,7 +131,7 @@ vector<ast::ParsedFile> enterPackages(core::GlobalState &gs, vector<pair<string,
     return parsedFiles;
 }
 
-const core::packages::PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) {
+const core::packages::PackageInfo &packageInfoFor(const core::GlobalState &gs, core::FileRef file) {
     return gs.packageDB().getPackageInfo(gs.packageDB().getPackageForFile(gs, file));
 }
 
@@ -161,8 +161,8 @@ TEST_CASE("Simple add import") {
 
     auto parsedFiles =
         enterPackages(gs, {{examplePackagePath, examplePackage}, {"my_package/__package.rb", pkg_source}});
-    auto &examplePkg = getPackageForFile(gs, parsedFiles[0].file);
-    auto &myPkg = getPackageForFile(gs, parsedFiles[1].file);
+    auto &examplePkg = packageInfoFor(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[1].file);
     ENFORCE(examplePkg.exists());
     ENFORCE(myPkg.exists());
 
@@ -187,8 +187,8 @@ TEST_CASE("Simple test import") {
 
     auto parsedFiles =
         enterPackages(gs, {{examplePackagePath, examplePackage}, {"my_package/__package.rb", pkg_source}});
-    auto &examplePkg = getPackageForFile(gs, parsedFiles[0].file);
-    auto &myPkg = getPackageForFile(gs, parsedFiles[1].file);
+    auto &examplePkg = packageInfoFor(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[1].file);
     ENFORCE(examplePkg.exists());
     ENFORCE(myPkg.exists());
 
@@ -213,8 +213,8 @@ TEST_CASE("Add import with only existing exports") {
 
     auto parsedFiles =
         enterPackages(gs, {{examplePackagePath, examplePackage}, {"my_package/__package.rb", pkg_source}});
-    auto &examplePkg = getPackageForFile(gs, parsedFiles[0].file);
-    auto &myPkg = getPackageForFile(gs, parsedFiles[1].file);
+    auto &examplePkg = packageInfoFor(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[1].file);
     ENFORCE(examplePkg.exists());
     ENFORCE(myPkg.exists());
 
@@ -241,8 +241,8 @@ TEST_CASE("Add import and test_import to package with imports and test imports")
                                           {"b/__package.rb", "class B < PackageSpec\nend\n"},
                                           {"c/__package.rb", "class C < PackageSpec\nend\n"},
                                           {"d/__package.rb", "class D < PackageSpec\nend\n"}});
-    auto &examplePkg = getPackageForFile(gs, parsedFiles[0].file);
-    auto &myPkg = getPackageForFile(gs, parsedFiles[1].file);
+    auto &examplePkg = packageInfoFor(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[1].file);
     ENFORCE(examplePkg.exists());
     ENFORCE(myPkg.exists());
 
@@ -290,8 +290,8 @@ TEST_CASE("Add test import with only existing exports") {
 
     auto parsedFiles =
         enterPackages(gs, {{examplePackagePath, examplePackage}, {"my_package/__package.rb", pkg_source}});
-    auto &examplePkg = getPackageForFile(gs, parsedFiles[0].file);
-    auto &myPkg = getPackageForFile(gs, parsedFiles[1].file);
+    auto &examplePkg = packageInfoFor(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[1].file);
     ENFORCE(examplePkg.exists());
     ENFORCE(myPkg.exists());
 
@@ -314,8 +314,8 @@ TEST_CASE("Add import to package with neither imports nor exports") {
 
     auto parsedFiles =
         enterPackages(gs, {{examplePackagePath, examplePackage}, {"my_package/__package.rb", pkg_source}});
-    auto &examplePkg = getPackageForFile(gs, parsedFiles[0].file);
-    auto &myPkg = getPackageForFile(gs, parsedFiles[1].file);
+    auto &examplePkg = packageInfoFor(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[1].file);
     ENFORCE(examplePkg.exists());
     ENFORCE(myPkg.exists());
 
@@ -338,8 +338,8 @@ TEST_CASE("Add test import to package with neither imports nor exports") {
 
     auto parsedFiles =
         enterPackages(gs, {{examplePackagePath, examplePackage}, {"my_package/__package.rb", pkg_source}});
-    auto &examplePkg = getPackageForFile(gs, parsedFiles[0].file);
-    auto &myPkg = getPackageForFile(gs, parsedFiles[1].file);
+    auto &examplePkg = packageInfoFor(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[1].file);
     ENFORCE(examplePkg.exists());
     ENFORCE(myPkg.exists());
 
@@ -363,7 +363,7 @@ TEST_CASE("Add export that goes before existing exports") {
                       "end\n";
 
     auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[0].file);
     ENFORCE(myPkg.exists());
 
     auto addExport = myPkg.addExport(gs, getConstantRef(gs, {"MyPackage", "NewExport"}));
@@ -384,7 +384,7 @@ TEST_CASE("Add export to package with no existing exports") {
                       "end\n";
 
     auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[0].file);
     ENFORCE(myPkg.exists());
 
     auto addExport = myPkg.addExport(gs, getConstantRef(gs, {"MyPackage", "NewExport"}));
@@ -409,7 +409,7 @@ TEST_CASE("Add export that goes in the middle of existing exports") {
                       "end\n";
 
     auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[0].file);
     ENFORCE(myPkg.exists());
 
     auto addExport = myPkg.addExport(gs, getConstantRef(gs, {"MyPackage", "NewExport"}));
@@ -432,7 +432,7 @@ TEST_CASE("Add export that goes at the end") {
                       "end\n";
 
     auto parsedFiles = enterPackages(gs, {{"my_package/__package.rb", pkg_source}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[0].file);
     ENFORCE(myPkg.exists());
 
     auto addExport = myPkg.addExport(gs, getConstantRef(gs, {"MyPackage", "NewExport"}));
@@ -458,11 +458,11 @@ TEST_CASE("Add imports to strict_dependencies 'false' package") {
                                           {layeredPackageBPath, layeredPackageB},
                                           {layeredDagPackageBPath, layeredDagPackageB},
                                           {dagPackageBPath, dagPackageB}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[0].file);
     ENFORCE(myPkg.exists());
 
     {
-        auto &falsePkgB = getPackageForFile(gs, parsedFiles[5].file);
+        auto &falsePkgB = packageInfoFor(gs, parsedFiles[5].file);
         ENFORCE(falsePkgB.exists());
         auto addImport = myPkg.addImport(gs, falsePkgB, false);
         string expected =
@@ -474,7 +474,7 @@ TEST_CASE("Add imports to strict_dependencies 'false' package") {
     }
 
     {
-        auto &layeredPkgB = getPackageForFile(gs, parsedFiles[6].file);
+        auto &layeredPkgB = packageInfoFor(gs, parsedFiles[6].file);
         ENFORCE(layeredPkgB.exists());
         auto addImport = myPkg.addImport(gs, layeredPkgB, false);
         string expected =
@@ -486,7 +486,7 @@ TEST_CASE("Add imports to strict_dependencies 'false' package") {
     }
 
     {
-        auto &layeredDagPkgB = getPackageForFile(gs, parsedFiles[7].file);
+        auto &layeredDagPkgB = packageInfoFor(gs, parsedFiles[7].file);
         ENFORCE(layeredDagPkgB.exists());
         auto addImport = myPkg.addImport(gs, layeredDagPkgB, false);
         string expected = makePackageRB(
@@ -498,7 +498,7 @@ TEST_CASE("Add imports to strict_dependencies 'false' package") {
     }
 
     {
-        auto &dagPkgB = getPackageForFile(gs, parsedFiles[8].file);
+        auto &dagPkgB = packageInfoFor(gs, parsedFiles[8].file);
         ENFORCE(dagPkgB.exists());
         auto addImport = myPkg.addImport(gs, dagPkgB, false);
         string expected =
@@ -526,11 +526,11 @@ TEST_CASE("Add imports to strict_dependencies 'layered' package") {
                                           {layeredPackageBPath, layeredPackageB},
                                           {layeredDagPackageBPath, layeredDagPackageB},
                                           {dagPackageBPath, dagPackageB}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[0].file);
     ENFORCE(myPkg.exists());
 
     {
-        auto &falsePkgB = getPackageForFile(gs, parsedFiles[5].file);
+        auto &falsePkgB = packageInfoFor(gs, parsedFiles[5].file);
         ENFORCE(falsePkgB.exists());
         auto addImport = myPkg.addImport(gs, falsePkgB, false);
         string expected =
@@ -542,7 +542,7 @@ TEST_CASE("Add imports to strict_dependencies 'layered' package") {
     }
 
     {
-        auto &layeredPkgB = getPackageForFile(gs, parsedFiles[6].file);
+        auto &layeredPkgB = packageInfoFor(gs, parsedFiles[6].file);
         ENFORCE(layeredPkgB.exists());
         auto addImport = myPkg.addImport(gs, layeredPkgB, false);
         string expected =
@@ -554,7 +554,7 @@ TEST_CASE("Add imports to strict_dependencies 'layered' package") {
     }
 
     {
-        auto &layeredDagPkgB = getPackageForFile(gs, parsedFiles[7].file);
+        auto &layeredDagPkgB = packageInfoFor(gs, parsedFiles[7].file);
         ENFORCE(layeredDagPkgB.exists());
         auto addImport = myPkg.addImport(gs, layeredDagPkgB, false);
         string expected = makePackageRB(
@@ -566,7 +566,7 @@ TEST_CASE("Add imports to strict_dependencies 'layered' package") {
     }
 
     {
-        auto &dagPkgB = getPackageForFile(gs, parsedFiles[8].file);
+        auto &dagPkgB = packageInfoFor(gs, parsedFiles[8].file);
         ENFORCE(dagPkgB.exists());
         auto addImport = myPkg.addImport(gs, dagPkgB, false);
         string expected =
@@ -594,11 +594,11 @@ TEST_CASE("Add imports to strict_dependencies 'layered_dag' package") {
                                           {layeredPackageBPath, layeredPackageB},
                                           {layeredDagPackageBPath, layeredDagPackageB},
                                           {dagPackageBPath, dagPackageB}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[0].file);
     ENFORCE(myPkg.exists());
 
     {
-        auto &falsePkgB = getPackageForFile(gs, parsedFiles[5].file);
+        auto &falsePkgB = packageInfoFor(gs, parsedFiles[5].file);
         ENFORCE(falsePkgB.exists());
         auto addImport = myPkg.addImport(gs, falsePkgB, false);
         string expected =
@@ -610,7 +610,7 @@ TEST_CASE("Add imports to strict_dependencies 'layered_dag' package") {
     }
 
     {
-        auto &layeredPkgB = getPackageForFile(gs, parsedFiles[6].file);
+        auto &layeredPkgB = packageInfoFor(gs, parsedFiles[6].file);
         ENFORCE(layeredPkgB.exists());
         auto addImport = myPkg.addImport(gs, layeredPkgB, false);
         string expected =
@@ -622,7 +622,7 @@ TEST_CASE("Add imports to strict_dependencies 'layered_dag' package") {
     }
 
     {
-        auto &layeredDagPkgB = getPackageForFile(gs, parsedFiles[7].file);
+        auto &layeredDagPkgB = packageInfoFor(gs, parsedFiles[7].file);
         ENFORCE(layeredDagPkgB.exists());
         auto addImport = myPkg.addImport(gs, layeredDagPkgB, false);
         string expected = makePackageRB(
@@ -634,7 +634,7 @@ TEST_CASE("Add imports to strict_dependencies 'layered_dag' package") {
     }
 
     {
-        auto &dagPkgB = getPackageForFile(gs, parsedFiles[8].file);
+        auto &dagPkgB = packageInfoFor(gs, parsedFiles[8].file);
         ENFORCE(dagPkgB.exists());
         auto addImport = myPkg.addImport(gs, dagPkgB, false);
         string expected =
@@ -662,11 +662,11 @@ TEST_CASE("Add imports to strict_dependencies 'dag' package") {
                                           {layeredPackageBPath, layeredPackageB},
                                           {layeredDagPackageBPath, layeredDagPackageB},
                                           {dagPackageBPath, dagPackageB}});
-    auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+    auto &myPkg = packageInfoFor(gs, parsedFiles[0].file);
     ENFORCE(myPkg.exists());
 
     {
-        auto &falsePkgB = getPackageForFile(gs, parsedFiles[5].file);
+        auto &falsePkgB = packageInfoFor(gs, parsedFiles[5].file);
         ENFORCE(falsePkgB.exists());
         auto addImport = myPkg.addImport(gs, falsePkgB, false);
         string expected =
@@ -678,7 +678,7 @@ TEST_CASE("Add imports to strict_dependencies 'dag' package") {
     }
 
     {
-        auto &layeredPkgB = getPackageForFile(gs, parsedFiles[6].file);
+        auto &layeredPkgB = packageInfoFor(gs, parsedFiles[6].file);
         ENFORCE(layeredPkgB.exists());
         auto addImport = myPkg.addImport(gs, layeredPkgB, false);
         string expected =
@@ -690,7 +690,7 @@ TEST_CASE("Add imports to strict_dependencies 'dag' package") {
     }
 
     {
-        auto &layeredDagPkgB = getPackageForFile(gs, parsedFiles[7].file);
+        auto &layeredDagPkgB = packageInfoFor(gs, parsedFiles[7].file);
         ENFORCE(layeredDagPkgB.exists());
         auto addImport = myPkg.addImport(gs, layeredDagPkgB, false);
         string expected = makePackageRB(
@@ -702,7 +702,7 @@ TEST_CASE("Add imports to strict_dependencies 'dag' package") {
     }
 
     {
-        auto &dagPkgB = getPackageForFile(gs, parsedFiles[8].file);
+        auto &dagPkgB = packageInfoFor(gs, parsedFiles[8].file);
         ENFORCE(dagPkgB.exists());
         auto addImport = myPkg.addImport(gs, dagPkgB, false);
         string expected =
@@ -753,9 +753,9 @@ TEST_CASE("Edge cases") {
 
     {
         // Import list contains non-existent package
-        auto &fakeImportPkg = getPackageForFile(gs, parsedFiles[0].file);
+        auto &fakeImportPkg = packageInfoFor(gs, parsedFiles[0].file);
         ENFORCE(fakeImportPkg.exists());
-        auto &layeredPkgA = getPackageForFile(gs, parsedFiles[2].file);
+        auto &layeredPkgA = packageInfoFor(gs, parsedFiles[2].file);
         ENFORCE(layeredPkgA.exists());
 
         auto addImport = fakeImportPkg.addImport(gs, layeredPkgA, false);
@@ -767,9 +767,9 @@ TEST_CASE("Edge cases") {
 
     {
         // Import added to start of import list
-        auto &libPkg = getPackageForFile(gs, parsedFiles[3].file);
+        auto &libPkg = packageInfoFor(gs, parsedFiles[3].file);
         ENFORCE(libPkg.exists());
-        auto &appPkg = getPackageForFile(gs, parsedFiles[4].file);
+        auto &appPkg = packageInfoFor(gs, parsedFiles[4].file);
         ENFORCE(appPkg.exists());
 
         auto addImport = libPkg.addImport(gs, appPkg, false);
@@ -781,9 +781,9 @@ TEST_CASE("Edge cases") {
 
     {
         // Import list with comments in it
-        auto &hasCommentsPkg = getPackageForFile(gs, parsedFiles[5].file);
+        auto &hasCommentsPkg = packageInfoFor(gs, parsedFiles[5].file);
         ENFORCE(hasCommentsPkg.exists());
-        auto &layeredPkgA = getPackageForFile(gs, parsedFiles[2].file);
+        auto &layeredPkgA = packageInfoFor(gs, parsedFiles[2].file);
         ENFORCE(layeredPkgA.exists());
 
         auto addImport = hasCommentsPkg.addImport(gs, layeredPkgA, false);
@@ -800,9 +800,9 @@ TEST_CASE("Edge cases") {
 
     {
         // Add import to a package with a bunch of test imports
-        auto &hasTestImportsPkg = getPackageForFile(gs, parsedFiles[6].file);
+        auto &hasTestImportsPkg = packageInfoFor(gs, parsedFiles[6].file);
         ENFORCE(hasTestImportsPkg.exists());
-        auto &dagPkgA = getPackageForFile(gs, parsedFiles[7].file);
+        auto &dagPkgA = packageInfoFor(gs, parsedFiles[7].file);
         ENFORCE(dagPkgA.exists());
 
         auto addImport = hasTestImportsPkg.addImport(gs, dagPkgA, false);
@@ -814,9 +814,9 @@ TEST_CASE("Edge cases") {
 
     {
         // Add import to a package with layering violations
-        auto &hasLayeringViolationsPkg = getPackageForFile(gs, parsedFiles[8].file);
+        auto &hasLayeringViolationsPkg = packageInfoFor(gs, parsedFiles[8].file);
         ENFORCE(hasLayeringViolationsPkg.exists());
-        auto &falsePkgA = getPackageForFile(gs, parsedFiles[1].file);
+        auto &falsePkgA = packageInfoFor(gs, parsedFiles[1].file);
         ENFORCE(falsePkgA.exists());
 
         auto addImport = hasLayeringViolationsPkg.addImport(gs, falsePkgA, false);
@@ -840,9 +840,9 @@ TEST_CASE("Convert test_import to import") {
                                           {dagPackageAPath, dagPackageA}});
 
     {
-        auto &myPkg = getPackageForFile(gs, parsedFiles[0].file);
+        auto &myPkg = packageInfoFor(gs, parsedFiles[0].file);
         ENFORCE(myPkg.exists());
-        auto &layeredPkgA = getPackageForFile(gs, parsedFiles[2].file);
+        auto &layeredPkgA = packageInfoFor(gs, parsedFiles[2].file);
         ENFORCE(layeredPkgA.exists());
 
         auto addImport = myPkg.addImport(gs, layeredPkgA, false);
@@ -880,9 +880,9 @@ TEST_CASE("Ordering by alphabetical") {
                            {"my_package/__package.rb", myPackage}});
 
     {
-        auto &myPkg = getPackageForFile(gs, parsedFiles[5].file);
+        auto &myPkg = packageInfoFor(gs, parsedFiles[5].file);
         ENFORCE(myPkg.exists());
-        auto &libFooB = getPackageForFile(gs, parsedFiles[1].file);
+        auto &libFooB = packageInfoFor(gs, parsedFiles[1].file);
         ENFORCE(libFooB.exists());
 
         string expected = makePackageRB("MyPackage", "layered", "lib", {"Lib::Foo::B", "Lib::Foo::B::A"});
@@ -893,9 +893,9 @@ TEST_CASE("Ordering by alphabetical") {
     }
 
     {
-        auto &myPkg = getPackageForFile(gs, parsedFiles[5].file);
+        auto &myPkg = packageInfoFor(gs, parsedFiles[5].file);
         ENFORCE(myPkg.exists());
-        auto &libFooC = getPackageForFile(gs, parsedFiles[3].file);
+        auto &libFooC = packageInfoFor(gs, parsedFiles[3].file);
         ENFORCE(libFooC.exists());
 
         string expected = makePackageRB("MyPackage", "layered", "lib", {"Lib::Foo::B::A", "Lib::Foo::C"});
@@ -906,9 +906,9 @@ TEST_CASE("Ordering by alphabetical") {
     }
 
     {
-        auto &myPkg = getPackageForFile(gs, parsedFiles[5].file);
+        auto &myPkg = packageInfoFor(gs, parsedFiles[5].file);
         ENFORCE(myPkg.exists());
-        auto &libFooD = getPackageForFile(gs, parsedFiles[4].file);
+        auto &libFooD = packageInfoFor(gs, parsedFiles[4].file);
         ENFORCE(libFooD.exists());
 
         string expected = makePackageRB("MyPackage", "layered", "lib", {"Lib::Foo::D", "Lib::Foo::B::A"});


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Trying to iteratively turn `PackageInfo` into a `core::Package` symbol and also
`MangledName` into a `core::PackageRef`.

Part of that involves getting rid of the fact that `PackageInfo` is this weird
abstract class, and doing that means getting rid of this `NonePackage`
implementation.

Working one API at a time to get rid of usages of `NONE_PKG`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.