### PR TITLE
getPackageForFile → {getPackageNameForFile,findPackageByPath}

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -181,16 +181,8 @@ void PackageDB::setPackageNameForFile(FileRef file, MangledName mangledName) {
     this->packageForFile_[file.id()] = mangledName;
 }
 
-MangledName PackageDB::getPackageForFile(const core::GlobalState &gs, core::FileRef file) const {
-    ENFORCE(frozen);
+MangledName PackageDB::findPackageByPath(const core::GlobalState &gs, core::FileRef file) const {
     ENFORCE(enabled_);
-
-    // If we already have the package name cached, we can skip the slow path below. As this function is const, we cannot
-    // update the vector if we fall back on the slow path.
-    auto name = this->getPackageNameForFile(file);
-    if (name.exists()) {
-        return name;
-    }
 
     // Note about safety: we're only using the file data for two pieces of information: the file path and the
     // sourceType. The path is present even on unloaded files, and the sourceType we're interested in is `Package`,

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -35,7 +35,7 @@ public:
     // Set the associated package for the file.
     void setPackageNameForFile(FileRef file, MangledName mangledName);
 
-    MangledName getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
+    MangledName findPackageByPath(const core::GlobalState &gs, core::FileRef file) const;
     const PackageInfo &getPackageInfo(MangledName mangledName) const;
     PackageInfo *getPackageInfoNonConst(MangledName mangledName);
 

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -409,7 +409,7 @@ com::stripe::rubytyper::FileTable Proto::filesToProto(const GlobalState &gs,
         }
 
         if (stripePackages) {
-            const auto &pkg = packageDB.getPackageForFile(gs, file);
+            const auto &pkg = packageDB.getPackageNameForFile(file);
             if (pkg.exists()) {
                 entry->set_pkg(packageDB.getPackageInfo(pkg).show(gs));
             }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1119,7 +1119,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     if (it->main.method.exists() && it->main.method.data(ctx)->flags.isPackagePrivate) {
                         core::ClassOrModuleRef klass = it->main.method.data(ctx)->owner;
                         if (klass.exists()) {
-                            auto curPkg = ctx.state.packageDB().getPackageForFile(ctx, ctx.file);
+                            auto curPkg = ctx.state.packageDB().getPackageNameForFile(ctx.file);
                             if (curPkg.exists()) {
                                 auto &curPkgInfo = ctx.state.packageDB().getPackageInfo(curPkg);
                                 if (!curPkgInfo.ownsSymbol(ctx, klass)) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -250,7 +250,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             // files don't take the fast path. We'll want (or maybe need) to revisit this when we start
             // making edits to `__package.rb` take fast paths.
             if (!(fref.data(*gs).isPackage(*gs))) {
-                auto pkg = gs->packageDB().getPackageForFile(*gs, fref);
+                auto pkg = gs->packageDB().getPackageNameForFile(fref);
                 if (pkg.exists()) {
                     // Since even no-op (e.g. whitespace-only) edits will cause constants to be deleted
                     // and re-added, we have to add the __package.rb files to set of files to retypecheck

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1540,7 +1540,7 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
         writer.String("package");
         if (sym.exists() && sym.loc(gs).exists()) {
             const auto file = sym.loc(gs).file();
-            const auto &pkg = gs.packageDB().getPackageForFile(gs, file);
+            const auto &pkg = gs.packageDB().getPackageNameForFile(file);
             if (!pkg.exists()) {
                 writer.String("<none>");
             } else {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -278,7 +278,7 @@ public:
 
     bool ownsSymbol(const core::GlobalState &gs, core::SymbolRef symbol) const {
         auto file = symbol.loc(gs).file();
-        auto pkg = gs.packageDB().getPackageForFile(gs, file);
+        auto pkg = gs.packageDB().getPackageNameForFile(file);
         return this->mangledName() == pkg;
     }
 
@@ -1803,8 +1803,8 @@ void validateLayering(const core::Context &ctx, const Import &i) {
 
     const auto &packageDB = ctx.state.packageDB();
     ENFORCE(packageDB.getPackageInfo(i.name.mangledName).exists())
-    ENFORCE(packageDB.getPackageForFile(ctx, ctx.file).exists())
-    auto &thisPkg = PackageInfoImpl::from(ctx, packageDB.getPackageForFile(ctx, ctx.file));
+    ENFORCE(packageDB.getPackageNameForFile(ctx.file).exists())
+    auto &thisPkg = PackageInfoImpl::from(ctx, packageDB.getPackageNameForFile(ctx.file));
     auto &otherPkg = PackageInfoImpl::from(packageDB.getPackageInfo(i.name.mangledName));
     ENFORCE(thisPkg.sccID().has_value(), "computeSCCs should already have been called and set sccID");
     ENFORCE(otherPkg.sccID().has_value(), "computeSCCs should already have been called and set sccID");
@@ -1871,7 +1871,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
 
 void validateVisibility(const core::Context &ctx, const PackageInfoImpl &absPkg, const Import i) {
     ENFORCE(ctx.state.packageDB().getPackageInfo(i.name.mangledName).exists())
-    ENFORCE(ctx.state.packageDB().getPackageForFile(ctx, ctx.file).exists())
+    ENFORCE(ctx.state.packageDB().getPackageNameForFile(ctx.file).exists())
     auto &otherPkg = ctx.state.packageDB().getPackageInfo(i.name.mangledName);
 
     const auto &visibleTo = otherPkg.visibleTo();
@@ -1900,7 +1900,7 @@ void validateVisibility(const core::Context &ctx, const PackageInfoImpl &absPkg,
 
 void validatePackage(core::Context ctx) {
     const auto &packageDB = ctx.state.packageDB();
-    auto absPkg = packageDB.getPackageForFile(ctx, ctx.file);
+    auto absPkg = packageDB.getPackageNameForFile(ctx.file);
     if (!absPkg.exists()) {
         // We already produced an error on this package when producing its package info.
         // The correct course of action is to abort the transform.
@@ -1956,7 +1956,7 @@ void validatePackagedFile(core::Context ctx, const ast::ExpressionPtr &tree) {
         return;
     }
 
-    auto pkg = ctx.state.packageDB().getPackageForFile(ctx, ctx.file);
+    auto pkg = ctx.state.packageDB().getPackageNameForFile(ctx.file);
     if (!pkg.exists()) {
         // Don't transform, but raise an error on the first line.
         if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::UnpackagedFile)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2016,7 +2016,12 @@ void Packager::setPackageNameOnFiles(core::GlobalState &gs, absl::Span<const ast
     {
         auto &db = gs.packageDB();
         for (auto &f : files) {
-            auto pkg = db.getPackageForFile(gs, f.file);
+            auto pkg = db.getPackageNameForFile(f.file);
+            if (pkg.exists()) {
+                continue;
+            }
+
+            pkg = db.findPackageByPath(gs, f.file);
             if (!pkg.exists()) {
                 continue;
             }
@@ -2040,7 +2045,12 @@ void Packager::setPackageNameOnFiles(core::GlobalState &gs, absl::Span<const cor
     {
         auto &db = gs.packageDB();
         for (auto &f : files) {
-            auto pkg = db.getPackageForFile(gs, f);
+            auto pkg = db.getPackageNameForFile(f);
+            if (pkg.exists()) {
+                continue;
+            }
+
+            pkg = db.findPackageByPath(gs, f);
             if (!pkg.exists()) {
                 continue;
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -578,7 +578,7 @@ private:
 
                         // Can't use pkg.ownsSymbol since it uses symbol definition locs, which have an edge case that
                         // isn't handled until the VisibilityChecker pass.
-                        auto enclosingPackage = ctx.state.packageDB().getPackageForFile(ctx.state, ctx.file);
+                        auto enclosingPackage = ctx.state.packageDB().getPackageNameForFile(ctx.file);
                         if (enclosingPackage.exists()) {
                             const auto pkgRootSymbol = ctx.state.packageDB()
                                                            .getPackageInfo(enclosingPackage)

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -132,7 +132,7 @@ vector<ast::ParsedFile> enterPackages(core::GlobalState &gs, vector<pair<string,
 }
 
 const core::packages::PackageInfo &packageInfoFor(const core::GlobalState &gs, core::FileRef file) {
-    return gs.packageDB().getPackageInfo(gs.packageDB().getPackageForFile(gs, file));
+    return gs.packageDB().getPackageInfo(gs.packageDB().getPackageNameForFile(file));
 }
 
 const core::SymbolRef getConstantRef(core::GlobalState &gs, vector<string> rawName) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The `getPackageForFile` was doing double-duty: it usually had a fast path, but
it also had a slow path that would fall back to looking up a package by a file
path.

The slow path should only ever be used by `setPackageNameOnFiles`, which happens
very early in pipeline. This splits that function into two, so that we can't
accidentally get the slow behavior.

This doesn't actually make any "package db into symbol table" changes easier,
it's just something I found and want to fix.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.