### PR TITLE
Add definition for NoMatchingPatternKeyError to errors.rbi

### DIFF
--- a/rbi/core/errors.rbi
+++ b/rbi/core/errors.rbi
@@ -342,6 +342,9 @@ end
 class NoMatchingPatternError < StandardError
 end
 
+class NoMatchingPatternKeyError < NoMatchingPatternError
+end
+
 # Raised when a given numerical value is out of range.
 #
 # ```ruby

--- a/test/cli/not_stripe_packages/test.out
+++ b/test/cli/not_stripe_packages/test.out
@@ -5,7 +5,7 @@ test/cli/not_stripe_packages/__package.rb:2: Unable to resolve constant `DoesNot
     test/cli/not_stripe_packages/__package.rb:2: Replace with `SystemExit`
      2 |DoesNotExist
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/errors.rbi#L560: `SystemExit` defined here
-     560 |class SystemExit < Exception
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/errors.rbi#L563: `SystemExit` defined here
+     563 |class SystemExit < Exception
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1

--- a/test/cli/not_stripe_packages/test.out
+++ b/test/cli/not_stripe_packages/test.out
@@ -5,7 +5,7 @@ test/cli/not_stripe_packages/__package.rb:2: Unable to resolve constant `DoesNot
     test/cli/not_stripe_packages/__package.rb:2: Replace with `SystemExit`
      2 |DoesNotExist
         ^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/errors.rbi#L563: `SystemExit` defined here
-     563 |class SystemExit < Exception
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/errors.rbi#LCENSORED: `SystemExit` defined here
+      NN |class SystemExit < Exception
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1

--- a/test/cli/not_stripe_packages/test.sh
+++ b/test/cli/not_stripe_packages/test.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #
 # This makes it easy to have behavior that leaks `--stripe-packages`-specific
 # behavior into the pipeline. Long term, we should figure out how to fix this.
-if main/sorbet --silence-dev-message test/cli/not_stripe_packages/__package.rb 2>&1; then
+if main/sorbet --silence-dev-message --censor-for-snapshot-tests test/cli/not_stripe_packages/__package.rb 2>&1; then
   echo "Expected to fail!"
   exit 1
 fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
### Summary
This PR adds the missing RBI definition for the `NoMatchingPatternKeyError` class to `rbi/core/errors.rbi`. 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This resolves `Unable to resolve constant NoMatchingPatternKeyError`.


