### PR TITLE
pull `pos` out to a local in `getU4`

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -188,10 +188,12 @@ uint32_t UnPickler::getU4() {
         zeroCounter--;
         return 0;
     }
-    uint8_t r = data[pos++];
+    uint32_t lpos = pos;
+    uint8_t r = data[lpos++];
     if (r == 0) {
-        zeroCounter = data[pos++];
+        zeroCounter = data[lpos++];
         zeroCounter--;
+        pos = lpos;
         return r;
     } else {
         uint32_t res = r & 127;
@@ -200,31 +202,32 @@ uint32_t UnPickler::getU4() {
             goto done;
         }
 
-        vle = data[pos++];
+        vle = data[lpos++];
         res |= (vle & 127) << 7;
         if ((vle & 128) == 0) {
             goto done;
         }
 
-        vle = data[pos++];
+        vle = data[lpos++];
         res |= (vle & 127) << 14;
         if ((vle & 128) == 0) {
             goto done;
         }
 
-        vle = data[pos++];
+        vle = data[lpos++];
         res |= (vle & 127) << 21;
         if ((vle & 128) == 0) {
             goto done;
         }
 
-        vle = data[pos++];
+        vle = data[lpos++];
         res |= (vle & 127) << 28;
         if ((vle & 128) == 0) {
             goto done;
         }
 
     done:
+        pos = lpos;
         return res;
     }
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When you have a class member that's repeatedly accessed in a non-`const` function -- like `pos` is in `getU4` -- the compiler is not smart enough to see that you could potentially load the member _once_ for the whole function and then store it back at the end (inlining, exceptions, etc. complicate this picture, so it's not entirely the compiler's fault).

This PR essentially performs the optimization we wish the compiler could see, since we know there's no potential side-effects the compiler needs to be concerned about here.  I would show you the assembly, but since this change makes `getU4` simple enough that the compiler thinks it's worth inlining (!), there no easy side-by-side comparison.

I don't have numbers at hand, but ISTR `getU4` taking something in the range of 10-15% of deserialization, and this optimization speeding up `getU4` by 10% or so (roughly, since it's inlined; I was getting my numbers out of valgrind's cachegrind tool), which would be only 1%, but wins are wins, right?  (Maybe the numbers are off; I can try to remeasure if people would like that.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.