### PR TITLE
rbi: Add RactorLocalSingleton

### DIFF
--- a/rbi/stdlib/singleton.rbi
+++ b/rbi/stdlib/singleton.rbi
@@ -123,3 +123,15 @@ module Singleton
   end
   mixes_in_class_methods(SingletonClassMethods)
 end
+
+module RactorLocalSingleton
+  include Singleton::SingletonInstanceMethods
+
+  module RactorLocalSingletonClassMethods
+    include Singleton::SingletonClassMethods
+    has_attached_class!
+
+    sig {returns(T.attached_class)}
+    def instance; end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #8822

It looks like the `singleton` gem added a new module which is a subclass
of `SingletonClassMethods`:

- https://bugs.ruby-lang.org/issues/18127
- https://github.com/ruby/singleton/pull/4

It's not documented and the feature seems to have been accepted in the
face of pushback but we may as well have RBI definitions for it so that
it doesn't generate a hidden-definitions error.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Have not tested