### PR TITLE
POC: Error for explicit `return` in `void` method

### DIFF
--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -55,6 +55,7 @@ constexpr ErrorClass UnknownSuperMethod{7048, StrictLevel::True};
 constexpr ErrorClass TypecheckOverloadBody{7049, StrictLevel::True};
 constexpr ErrorClass RedundantMust{7050, StrictLevel::Strict};
 constexpr ErrorClass BranchOnVoid{7051, StrictLevel::True};
+constexpr ErrorClass ExplicitVoidReturn{7052, StrictLevel::True}; // TODO(jez) maybe strict?
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 
 ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file, const TypePtr &ptr);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1470,7 +1470,8 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     // wrote the `return` keyword in the code. We might want to track that with some
                     // sort of flag on the instruction. The exists and empty checks are defensive
                     if (i.whatLoc != bind.loc && i.whatLoc.exists() && !i.whatLoc.empty() &&
-                        typeAndOrigin.type != core::Types::nilClass() && !typeAndOrigin.type.isUntyped()) {
+                        typeAndOrigin.type != core::Types::nilClass() && !typeAndOrigin.type.isUntyped() &&
+                        typeAndOrigin.type != core::Types::void_()) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::ExplicitVoidReturn)) {
                             e.setHeader("Explicitly returning from a `{}` function", "void");
                             // TODO(jez) Error context

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -241,7 +241,8 @@ public:
 
     core::TypePtr
     processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Binding &bind, int loopCount, int bindMinLoops,
-                   KnowledgeFilter &knowledgeFilter, core::TypeConstraint &constr, core::TypePtr &methodReturnType,
+                   KnowledgeFilter &knowledgeFilter, core::TypeConstraint &constr,
+                   const core::TypePtr &methodReturnType,
                    const std::optional<cfg::BasicBlock::BlockExitCondInfo> &parentUpdateKnowledgeReceiver);
 
     core::Loc locForUninitialized() const {

--- a/test/testdata/infer/explicit_return_void.rb
+++ b/test/testdata/infer/explicit_return_void.rb
@@ -1,0 +1,40 @@
+# typed: true
+extend T::Sig
+
+sig { returns(T::Boolean) }
+def bool = false
+
+sig { void }
+def example
+  -> () { return }
+  -> () { return 1 }
+
+  lambda { return }
+  lambda { return 1 }
+
+  proc { return }
+  proc { return 2 }
+
+  2.times { return }
+  2.times { return 3 }
+
+  return if bool
+  return 4 if bool
+
+  return nil if bool
+  return T.unsafe(nil) if bool
+  nil
+end
+
+sig { void }
+def implicit_return
+end
+
+sig { void }
+def implicit_return_conditional
+  if bool
+    1
+  else
+    2
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

- [ ] @jez Figure out what the escape hatch should be for `.checked(:tests)` /
  `.checked(:never)`. Can't use the sig builder as the source of truth because
  the default level can be configured via `T::Configuration`.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This trips people up.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

- [ ] @jez Test for `return returns_void`