### PR TITLE
Skip linearization during the fast+incremental path

### DIFF
--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -384,7 +384,11 @@ void Resolver::finalizeSymbols(core::GlobalState &gs,
         }
     }
 
-    gs.computeLinearization();
+    // As we don't mutate mixins during incremental resolution, seeing a partial list of symbols to update indicates
+    // that we're in the incremental path, allowing us to skip linearization.
+    if (!symbolsToRecompute.has_value()) {
+        gs.computeLinearization();
+    }
 
     {
         Timer timer(gs.tracer(), "resolver.resolve_type_members");


### PR DESCRIPTION
We can avoid computing linearization during the fast+incremental path, as nothing will have changed that would require that step.

I believe this is safe because as @jez pointed out, we already [document the fact that we don't need to compute linearization](https://github.com/sorbet/sorbet/blob/759e481aaed0eca3c755d88eb8f4e374b5cc832c/resolver/resolver.cc#L3967-L3968) in `Resolver::runIncremental` where we instead call `verifyLinearizationComputed`.

The first commit is the simplest version of this change, and the second refactors a bit to merge the checks for whether we're on the incremental path together. The second commit is definitely not necessary, and I'm happy to revert it if it seems too much like it's obscuring the original change.

### Motivation
LSP performance on large codebases.

### Test plan
Existing tests.
