### PR TITLE
Document RBS block syntax

### DIFF
--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -548,6 +548,46 @@ T.proc.params(arg: Foo).returns(Bar)
 </a></td></tr>
 
 <!-- end of Proc type -->
+
+<tr><td>
+
+[Block type]
+
+</td><td>
+
+```plaintext
+{ (Foo) -> Bar }
+```
+
+</td><td><a href="procs">
+
+```ruby
+T.proc.params(arg: Foo).returns(Bar)
+```
+
+</a></td></tr>
+
+<!-- end of Block type -->
+
+<tr><td>
+
+[Optional Block type]
+
+</td><td>
+
+```plaintext
+?{ (Foo) -> Bar }
+```
+
+</td><td><a href="procs#optional-blocks">
+
+```ruby
+T.nilable(T.proc.params(arg: Foo).returns(Bar))
+```
+
+</a></td></tr>
+
+<!-- end of Optional Block type -->
 </tbody>
 </table>
 
@@ -910,3 +950,7 @@ x.undefined_method
 [Tuple type]: https://github.com/ruby/rbs/blob/master/docs/syntax.md#tuple-type
 [Shape type]: https://github.com/ruby/rbs/blob/master/docs/syntax.md#record-type
 [Proc type]: https://github.com/ruby/rbs/blob/master/docs/syntax.md#proc-type
+[Block type]:
+  https://github.com/ruby/rbs/blob/master/docs/syntax.md#method-types-and-proc-types
+[Optional Block type]:
+  https://github.com/ruby/rbs/blob/master/docs/syntax.md#method-types-and-proc-types


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This adds entries to the RBS "quick reference" table for (mandatory) and optional blocks.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

While `sig` style signatures use the same syntax to describe blocks as `Proc`s, RBS syntax doesn't.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is a documentation only change.
