### PR TITLE
Remove the definitions of methods removed in #8808

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -68,12 +68,6 @@ public:
         return false;
     }
 
-    std::vector<MangledName> imports() const {
-        return {};
-    }
-    std::vector<MangledName> testImports() const {
-        return {};
-    }
     std::vector<VisibleTo> visibleTo() const {
         return {};
     }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -543,24 +543,6 @@ public:
         return {suggestion};
     }
 
-    vector<core::packages::MangledName> imports() const {
-        vector<core::packages::MangledName> rv;
-        for (auto &i : importedPackageNames) {
-            if (i.type == core::packages::ImportType::Normal) {
-                rv.emplace_back(i.name.mangledName);
-            }
-        }
-        return rv;
-    }
-    vector<core::packages::MangledName> testImports() const {
-        vector<core::packages::MangledName> rv;
-        for (auto &i : importedPackageNames) {
-            if (i.type == core::packages::ImportType::Test) {
-                rv.emplace_back(i.name.mangledName);
-            }
-        }
-        return rv;
-    }
     vector<core::packages::VisibleTo> visibleTo() const {
         vector<core::packages::VisibleTo> rv;
         for (auto &v : visibleTo_) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`imports` and `testImports` were removed from the header file but not the `.cc` file.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Cleanup.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.