### PR TITLE
RBS: Check signature parameters kind match the actual Ruby definition

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -27,6 +27,7 @@ constexpr ErrorClass RBSParameterMismatch{3552, StrictLevel::False};
 constexpr ErrorClass RBSAssertionError{3553, StrictLevel::False};
 constexpr ErrorClass RBSUnusedComment{3554, StrictLevel::False};
 constexpr ErrorClass RBSMultilineMisformatted{3555, StrictLevel::False};
+constexpr ErrorClass RBSIncorrectParameterKind{3556, StrictLevel::False};
 
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -20,6 +20,18 @@ struct RBSArg {
     core::LocOffsets loc;
     rbs_ast_symbol_t *name;
     rbs_node_t *type;
+
+    enum class Kind {
+        Positional,
+        OptionalPositional,
+        RestPositional,
+        Keyword,
+        OptionalKeyword,
+        RestKeyword,
+        Block,
+    };
+
+    Kind kind;
 };
 
 unique_ptr<parser::Node> handleAnnotations(unique_ptr<parser::Node> sigBuilder, const vector<Comment> &annotations) {
@@ -69,6 +81,69 @@ core::NameRef nodeName(const parser::Node *node) {
     return name;
 }
 
+string argKindToString(RBSArg::Kind kind) {
+    switch (kind) {
+        case RBSArg::Kind::Positional:
+            return "positional";
+        case RBSArg::Kind::OptionalPositional:
+            return "optional positional";
+        case RBSArg::Kind::RestPositional:
+            return "rest positional";
+        case RBSArg::Kind::Keyword:
+            return "keyword";
+        case RBSArg::Kind::OptionalKeyword:
+            return "optional keyword";
+        case RBSArg::Kind::RestKeyword:
+            return "rest keyword";
+        case RBSArg::Kind::Block:
+            return "block";
+    }
+}
+
+string nodeKindToString(const parser::Node *node) {
+    string kind;
+
+    typecase(
+        node, [&](const parser::Arg *parserArg) { kind = "positional"; },
+        [&](const parser::Optarg *parserArg) { kind = "optional positional"; },
+        [&](const parser::Restarg *parserArg) { kind = "rest positional"; },
+        [&](const parser::Kwarg *parserArg) { kind = "keyword"; },
+        [&](const parser::Kwoptarg *parserArg) { kind = "optional keyword"; },
+        [&](const parser::Kwrestarg *parserArg) { kind = "rest keyword"; },
+        [&](const parser::Blockarg *parserArg) { kind = "block"; },
+        [&](const parser::Node *other) {
+            Exception::raise("Unexpected expression type: {}", ((parser::Node *)node)->nodeName());
+        });
+
+    return kind;
+}
+
+bool checkParameterKind(core::MutableContext ctx, const RBSDeclaration &declaration, const RBSArg &arg,
+                        const parser::Node *methodArg) {
+    auto error = false;
+
+    typecase(
+        methodArg, [&](const parser::Arg *parserArg) { error = arg.kind != RBSArg::Kind::Positional; },
+        [&](const parser::Optarg *parserArg) { error = arg.kind != RBSArg::Kind::OptionalPositional; },
+        [&](const parser::Restarg *parserArg) { error = arg.kind != RBSArg::Kind::RestPositional; },
+        [&](const parser::Kwarg *parserArg) { error = arg.kind != RBSArg::Kind::Keyword; },
+        [&](const parser::Kwoptarg *parserArg) { error = arg.kind != RBSArg::Kind::OptionalKeyword; },
+        [&](const parser::Kwrestarg *parserArg) { error = arg.kind != RBSArg::Kind::RestKeyword; },
+        [&](const parser::Blockarg *parserArg) { error = arg.kind != RBSArg::Kind::Block; },
+        [&](const parser::Node *other) {
+            Exception::raise("Unexpected expression type: {}", ((parser::Node *)methodArg)->nodeName());
+        });
+
+    if (error) {
+        if (auto e = ctx.beginError(arg.loc, core::errors::Rewriter::RBSIncorrectParameterKind)) {
+            e.setHeader("Argument kind mismatch for `{}`, expected `{}`, got `{}`", nodeName(methodArg).show(ctx.state),
+                        nodeKindToString(methodArg), argKindToString(arg.kind));
+        }
+    }
+
+    return error;
+}
+
 parser::Args *getMethodArgs(const parser::Node *node) {
     parser::Node *args;
 
@@ -82,7 +157,7 @@ parser::Args *getMethodArgs(const parser::Node *node) {
     return parser::cast_node<parser::Args>(args);
 }
 
-void collectArgs(const RBSDeclaration &declaration, rbs_node_list_t *field, vector<RBSArg> &args) {
+void collectArgs(const RBSDeclaration &declaration, rbs_node_list_t *field, vector<RBSArg> &args, RBSArg::Kind kind) {
     if (field == nullptr || field->length == 0) {
         return;
     }
@@ -103,12 +178,12 @@ void collectArgs(const RBSDeclaration &declaration, rbs_node_list_t *field, vect
 
         auto loc = declaration.typeLocFromRange(range);
         auto node = (rbs_types_function_param_t *)list_node->node;
-        auto arg = RBSArg{loc, node->name, node->type};
+        auto arg = RBSArg{loc, node->name, node->type, kind};
         args.emplace_back(arg);
     }
 }
 
-void collectKeywords(const RBSDeclaration &declaration, rbs_hash_t *field, vector<RBSArg> &args) {
+void collectKeywords(const RBSDeclaration &declaration, rbs_hash_t *field, vector<RBSArg> &args, RBSArg::Kind kind) {
     if (field == nullptr) {
         return;
     }
@@ -125,7 +200,7 @@ void collectKeywords(const RBSDeclaration &declaration, rbs_hash_t *field, vecto
         auto loc = declaration.typeLocFromRange(hash_node->key->location->rg);
         rbs_ast_symbol_t *keyNode = (rbs_ast_symbol_t *)hash_node->key;
         rbs_types_function_param_t *valueNode = (rbs_types_function_param_t *)hash_node->value;
-        auto arg = RBSArg{loc, keyNode, valueNode->type};
+        auto arg = RBSArg{loc, keyNode, valueNode->type, kind};
         args.emplace_back(arg);
     }
 }
@@ -188,8 +263,8 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
 
     vector<RBSArg> args;
 
-    collectArgs(declaration, functionType->required_positionals, args);
-    collectArgs(declaration, functionType->optional_positionals, args);
+    collectArgs(declaration, functionType->required_positionals, args, RBSArg::Kind::Positional);
+    collectArgs(declaration, functionType->optional_positionals, args, RBSArg::Kind::OptionalPositional);
 
     rbs_node_t *restPositionals = functionType->rest_positionals;
     if (restPositionals) {
@@ -199,16 +274,16 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
 
         auto loc = declaration.typeLocFromRange(restPositionals->location->rg);
         auto node = (rbs_types_function_param_t *)restPositionals;
-        auto arg = RBSArg{loc, node->name, node->type};
+        auto arg = RBSArg{loc, node->name, node->type, RBSArg::Kind::RestPositional};
         args.emplace_back(arg);
     }
 
-    collectArgs(declaration, functionType->trailing_positionals, args);
+    collectArgs(declaration, functionType->trailing_positionals, args, RBSArg::Kind::Positional);
 
     // Collect keywords
 
-    collectKeywords(declaration, functionType->required_keywords, args);
-    collectKeywords(declaration, functionType->optional_keywords, args);
+    collectKeywords(declaration, functionType->required_keywords, args, RBSArg::Kind::Keyword);
+    collectKeywords(declaration, functionType->optional_keywords, args, RBSArg::Kind::OptionalKeyword);
 
     rbs_node_t *restKeywords = functionType->rest_keywords;
     if (restKeywords) {
@@ -218,7 +293,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
 
         auto loc = declaration.typeLocFromRange(restKeywords->location->rg);
         auto node = (rbs_types_function_param_t *)restKeywords;
-        auto arg = RBSArg{loc, node->name, node->type};
+        auto arg = RBSArg{loc, node->name, node->type, RBSArg::Kind::RestKeyword};
         args.emplace_back(arg);
     }
 
@@ -226,8 +301,8 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
 
     auto *block = node.block;
     if (block) {
-        // TODO: RBS doesn't have location on blocks yet
-        auto arg = RBSArg{fullTypeLoc, nullptr, (rbs_node_t *)block};
+        auto loc = declaration.typeLocFromRange(block->base.location->rg);
+        auto arg = RBSArg{loc, nullptr, (rbs_node_t *)block, RBSArg::Kind::Block};
         args.emplace_back(arg);
     }
 
@@ -241,26 +316,29 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
         auto &arg = args[i];
         auto type = typeToParserNode.toParserNode(arg.type, declaration);
 
+        if (!methodArgs || i >= methodArgs->args.size()) {
+            if (auto e = ctx.beginError(fullTypeLoc, core::errors::Rewriter::RBSParameterMismatch)) {
+                e.setHeader("RBS signature has more parameters than in the method definition");
+            }
+
+            return nullptr;
+        }
+
+        auto methodArg = methodArgs->args[i].get();
+
         if (auto nameSymbol = arg.name) {
             // The RBS arg is named in the signature, so we use the explicit name used
             auto nameStr = parser.resolveConstant(nameSymbol);
             auto name = ctx.state.enterNameUTF8(nameStr);
             sigParams.emplace_back(make_unique<parser::Pair>(arg.loc, parser::MK::Symbol(arg.loc, name), move(type)));
         } else {
-            if (!methodArgs || i >= methodArgs->args.size()) {
-                if (auto e = ctx.beginError(fullTypeLoc, core::errors::Rewriter::RBSParameterMismatch)) {
-                    e.setHeader("RBS signature has more parameters than in the method definition");
-                }
-
-                return nullptr;
-            }
-
             // The RBS arg is not named in the signature, so we get it from the method definition
-            auto methodArg = methodArgs->args[i].get();
             auto name = nodeName(methodArg);
             sigParams.emplace_back(
                 make_unique<parser::Pair>(arg.loc, parser::MK::Symbol(methodArg->loc, name), move(type)));
         }
+
+        checkParameterKind(ctx, declaration, arg, methodArg);
     }
 
     // Build the sig

--- a/test/testdata/lsp/hover_rbs.rb
+++ b/test/testdata/lsp/hover_rbs.rb
@@ -72,7 +72,7 @@ def hover_named_params_1(x, y, z); T.unsafe(nil); end
 #                          ^ hover: Symbol
 #                              ^ hover: T.class_of(Symbol)
 #                                  ^ hover: T.class_of(Symbol)
-def hover_keyword_params_1(x, y, z); T.unsafe(nil); end
+def hover_keyword_params_1(x:, y:, z:); T.unsafe(nil); end
 
 # Block params hover
 

--- a/test/testdata/rbs/assertions_block.rb
+++ b/test/testdata/rbs/assertions_block.rb
@@ -2,7 +2,7 @@
 # enable-experimental-rbs-signatures: true
 # enable-experimental-rbs-assertions: true
 
-#: (untyped) {(String?) -> String} -> untyped
+#: (*untyped) {(String?) -> String} -> untyped
 def take_block(*args, &); end
 
 take_block { |x|

--- a/test/testdata/rbs/assertions_csend_assign.rb
+++ b/test/testdata/rbs/assertions_csend_assign.rb
@@ -5,7 +5,7 @@
 # let
 
 class Let
-  #: (untyped) -> void
+  #: (*untyped) -> void
   def foo=(*args); end
 
   #: -> untyped

--- a/test/testdata/rbs/assertions_send_assign.rb
+++ b/test/testdata/rbs/assertions_send_assign.rb
@@ -5,7 +5,7 @@
 # let
 
 class Let
-  #: (untyped) -> void
+  #: (*untyped) -> void
   def foo=(*args); end
 
   #: -> untyped

--- a/test/testdata/rbs/signatures_attrs.rb
+++ b/test/testdata/rbs/signatures_attrs.rb
@@ -67,7 +67,7 @@ class AttrAnnotations
     #: Integer?
     attr_reader :foo
 
-    #: (Integer?) -> void
+    #: (?Integer?) -> void
     def initialize(foo = nil)
       @foo = foo
     end

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -49,6 +49,38 @@ def sig_mismatch2(p1); end
 #: (P1, P2, P3) -> void # error: RBS signature has more parameters than in the method definition
 def sig_mismatch3; end # error: The method `sig_mismatch3` does not have a `sig`
 
+#: (?Integer) -> void
+#    ^^^^^^^ error: Argument kind mismatch for `p`, expected `positional`, got `optional positional`
+def sig_mismatch4(p); end
+
+#: (Integer) -> void
+#   ^^^^^^^ error: Argument kind mismatch for `p`, expected `optional positional`, got `positional`
+def sig_mismatch5(p = 42); end
+
+#: (Integer) -> void
+#   ^^^^^^^ error: Argument kind mismatch for `p`, expected `keyword`, got `positional`
+def sig_mismatch6(p:); end
+
+#: (Integer) -> void
+#   ^^^^^^^ error: Argument kind mismatch for `p`, expected `rest positional`, got `positional`
+def sig_mismatch7(*p); end
+
+#: (?p: Integer) -> void
+#    ^ error: Argument kind mismatch for `p`, expected `keyword`, got `optional keyword`
+def sig_mismatch8(p:); end
+
+#: (p: Integer) -> void
+#   ^ error: Argument kind mismatch for `p`, expected `optional keyword`, got `keyword`
+def sig_mismatch9(p: 42); end
+
+#: (*Integer) -> void
+#    ^^^^^^^ error: Argument kind mismatch for `p`, expected `rest keyword`, got `rest positional`
+def sig_mismatch10(**p); end
+
+#: (^() -> void) -> void
+#   ^^^^^^^^^^^ error: Argument kind mismatch for `blk`, expected `block`, got `positional`
+def sig_mismatch11(&blk); end
+
 # Sigs
 
 # We do not create any sig if there is no RBS comment

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -40,7 +40,9 @@ end
 def sig_mismatch1(p1, p2); end
 #                     ^^ error: Malformed `sig`. Type not specified for argument `p2`
 
-#: (foo: P1) -> void # error: Unknown argument name `foo`
+#: (foo: P1) -> void
+#   ^^^ error: Argument kind mismatch for `p1`, expected `positional`, got `keyword`
+#   ^^^ error: Unknown argument name `foo`
 def sig_mismatch2(p1); end
 #                 ^^ error: Malformed `sig`. Type not specified for argument `p1`
 
@@ -136,16 +138,16 @@ def method13(x)
 end
 
 #: (?String x) -> void
-def method14(x)
+def method14(x = "")
   T.reveal_type(x) # error: Revealed type: `String`
 end
 
-#: (String x) -> void
+#: (?String x) -> void
 def method15(x = nil) # error: Argument does not have asserted type `String`
   T.reveal_type(x) # error: Revealed type: `T.nilable(String)`
 end
 
-#: (String ?x) -> void
+#: (?String? x) -> void
 def method16(x = nil)
   T.reveal_type(x) # error: Revealed type: `T.nilable(String)`
 end
@@ -224,7 +226,7 @@ class UnusedTypeAnnotation
 end
 
 class FooProc
-  #: (p: ^() -> Integer ) ?{ (Integer) [self: FooProc] -> String } -> void
+  #: (?p: ^() -> Integer ) ?{ (Integer) [self: FooProc] -> String } -> void
   def initialize(p: -> { 42 }, &block)
     T.reveal_type(p) # error: Revealed type: `T.proc.returns(Integer)`
     T.reveal_type(block) # error: Revealed type: `T.nilable(T.proc.params(arg0: Integer).returns(String))`

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -149,7 +149,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
-  def method14<<todo method>>(x, &<blk>)
+  def method14<<todo method>>(x = "", &<blk>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -27,6 +27,70 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p, <emptyTree>::<C Integer>).void()
+  end
+
+  def sig_mismatch4<<todo method>>(p, &<blk>)
+    <emptyTree>
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p, <emptyTree>::<C Integer>).void()
+  end
+
+  def sig_mismatch5<<todo method>>(p = 42, &<blk>)
+    <emptyTree>
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p, <emptyTree>::<C Integer>).void()
+  end
+
+  def sig_mismatch6<<todo method>>(p:, &<blk>)
+    <emptyTree>
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p, <emptyTree>::<C Integer>).void()
+  end
+
+  def sig_mismatch7<<todo method>>(*p, &<blk>)
+    <emptyTree>
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p, <emptyTree>::<C Integer>).void()
+  end
+
+  def sig_mismatch8<<todo method>>(p:, &<blk>)
+    <emptyTree>
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p, <emptyTree>::<C Integer>).void()
+  end
+
+  def sig_mismatch9<<todo method>>(p: = 42, &<blk>)
+    <emptyTree>
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:p, <emptyTree>::<C Integer>).void()
+  end
+
+  def sig_mismatch10<<todo method>>(*p:, &<blk>)
+    <emptyTree>
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:blk, ::<root>::<C T>.proc().void()).void()
+  end
+
+  def sig_mismatch11<<todo method>>(&blk)
+    <emptyTree>
+  end
+
   def method1<<todo method>>(&<blk>)
     <emptyTree>::<C T>.unsafe(nil)
   end
@@ -300,6 +364,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <runtime method definition of sig_mismatch2>
 
   <runtime method definition of sig_mismatch3>
+
+  <runtime method definition of sig_mismatch4>
+
+  <runtime method definition of sig_mismatch5>
+
+  <runtime method definition of sig_mismatch6>
+
+  <runtime method definition of sig_mismatch7>
+
+  <runtime method definition of sig_mismatch8>
+
+  <runtime method definition of sig_mismatch9>
+
+  <runtime method definition of sig_mismatch10>
+
+  <runtime method definition of sig_mismatch11>
 
   <runtime method definition of method1>
 

--- a/test/testdata/rbs/signatures_defs_multiline.rb
+++ b/test/testdata/rbs/signatures_defs_multiline.rb
@@ -145,14 +145,14 @@ end
 #: (
 #|   ?String x
 #| ) -> void
-def method14(x)
+def method14(x = "")
   T.reveal_type(x) # error: Revealed type: `String`
 end
 
 #: (
 #|   String ?x
 #| ) -> void
-def method16(x = nil)
+def method16(x)
   T.reveal_type(x) # error: Revealed type: `T.nilable(String)`
 end
 
@@ -179,7 +179,7 @@ def method20(&block)
 end
 
 class FooProc
-  #: (p: ^() -> Integer)
+  #: (?p: ^() -> Integer)
   #| ?{
   #|   (Integer) [self: FooProc] -> String
   #| } -> void

--- a/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
@@ -140,7 +140,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
-  def method14<<todo method>>(x, &<blk>)
+  def method14<<todo method>>(x = "", &<blk>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
@@ -148,7 +148,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
-  def method16<<todo method>>(x = nil, &<blk>)
+  def method16<<todo method>>(x, &<blk>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 


### PR DESCRIPTION
### Motivation

I found a few cases where the kind of parameter used in the RBS signature was not matching the actual kind expected.

For example, all these cases should error :

```rb
#: (x: String) -> void
def foo(x); end

#: (String) -> void
def bar(x:); end

#: (^() -> void) -> void
def baz(&blk); end
```

but they [do not](https://sorbet.run/?arg=--enable-experimental-rbs-signatures#%23%20typed%3A%20true%0A%0A%0A%23%3A%20%28x%3A%20String%29%20-%3E%20void%0Adef%20foo%28x%29%3B%20end%0A%0A%23%3A%20%28String%29%20-%3E%20void%0Adef%20bar%28x%3A%29%3B%20end%0A%0A%23%3A%20%28%5E%28%29%20-%3E%20void%29%20-%3E%20void%0Adef%20baz%28%26blk%29%3B%20end)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
