### PR TITLE
Sync the file table between the typechecker and indexer after init

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -292,12 +292,16 @@ void LSPIndexer::initialize(IndexerInitializationTask &task, std::vector<std::sh
         Exception::raise("Indexer is already initialized; cannot initialize a second time.");
     }
 
-    for (auto &file : files) {
-        auto fref = this->initialGS->findFileByPath(file->path());
-        if (fref.exists()) {
-            this->initialGS->replaceFile(fref, std::move(file));
-        } else {
-            this->initialGS->enterFile(std::move(file));
+    {
+        core::UnfreezeFileTable unfreezeFiles{*this->initialGS};
+
+        for (auto &file : files) {
+            auto fref = this->initialGS->findFileByPath(file->path());
+            if (fref.exists()) {
+                this->initialGS->replaceFile(fref, std::move(file));
+            } else {
+                this->initialGS->enterFile(std::move(file));
+            }
         }
     }
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -287,7 +287,7 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
     task.setKeyValueStore(std::move(this->kvstore));
 }
 
-void LSPIndexer::initialize(IndexerInitializationTask &task, std::vector<std::shared_ptr<core::File>> files) {
+void LSPIndexer::initialize(IndexerInitializationTask &task, std::vector<std::shared_ptr<core::File>> &&files) {
     if (initialized) {
         Exception::raise("Indexer is already initialized; cannot initialize a second time.");
     }

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -287,10 +287,20 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
     task.setKeyValueStore(std::move(this->kvstore));
 }
 
-void LSPIndexer::initialize(IndexerInitializationTask &task) {
+void LSPIndexer::initialize(IndexerInitializationTask &task, std::vector<std::shared_ptr<core::File>> files) {
     if (initialized) {
         Exception::raise("Indexer is already initialized; cannot initialize a second time.");
     }
+
+    for (auto &file : files) {
+        auto fref = this->initialGS->findFileByPath(file->path());
+        if (fref.exists()) {
+            this->initialGS->replaceFile(fref, std::move(file));
+        } else {
+            this->initialGS->enterFile(std::move(file));
+        }
+    }
+
     initialized = true;
 }
 

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -84,7 +84,7 @@ public:
     /**
      * Finalizes indexer initialization.
      */
-    void initialize(IndexerInitializationTask &task, std::vector<std::shared_ptr<core::File>> files);
+    void initialize(IndexerInitializationTask &task, std::vector<std::shared_ptr<core::File>> &&files);
 
     /**
      * Commits the given edit to `initialGS`, and returns a canonical LSPFileUpdates object containing indexed trees

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -84,7 +84,7 @@ public:
     /**
      * Finalizes indexer initialization.
      */
-    void initialize(IndexerInitializationTask &task);
+    void initialize(IndexerInitializationTask &task, std::vector<std::shared_ptr<core::File>> files);
 
     /**
      * Commits the given edit to `initialGS`, and returns a canonical LSPFileUpdates object containing indexed trees

--- a/main/lsp/notifications/indexer_initialization.cc
+++ b/main/lsp/notifications/indexer_initialization.cc
@@ -3,15 +3,16 @@
 
 namespace sorbet::realmain::lsp {
 
-IndexerInitializationTask::IndexerInitializationTask(const LSPConfiguration &config)
-    : LSPTask(config, LSPMethod::SorbetIndexerInitialization) {}
+IndexerInitializationTask::IndexerInitializationTask(const LSPConfiguration &config,
+                                                     std::vector<std::shared_ptr<core::File>> files)
+    : LSPTask(config, LSPMethod::SorbetIndexerInitialization), files{std::move(files)} {}
 
 LSPTask::Phase IndexerInitializationTask::finalPhase() const {
     return LSPTask::Phase::INDEX;
 }
 
 void IndexerInitializationTask::index(LSPIndexer &indexer) {
-    indexer.initialize(*this);
+    indexer.initialize(*this, std::move(this->files));
 }
 
 void IndexerInitializationTask::run(LSPTypecheckerDelegate &typechecker) {}

--- a/main/lsp/notifications/indexer_initialization.cc
+++ b/main/lsp/notifications/indexer_initialization.cc
@@ -4,7 +4,7 @@
 namespace sorbet::realmain::lsp {
 
 IndexerInitializationTask::IndexerInitializationTask(const LSPConfiguration &config,
-                                                     std::vector<std::shared_ptr<core::File>> files)
+                                                     std::vector<std::shared_ptr<core::File>> &&files)
     : LSPTask(config, LSPMethod::SorbetIndexerInitialization), files{std::move(files)} {}
 
 LSPTask::Phase IndexerInitializationTask::finalPhase() const {

--- a/main/lsp/notifications/indexer_initialization.h
+++ b/main/lsp/notifications/indexer_initialization.h
@@ -6,8 +6,10 @@
 namespace sorbet::realmain::lsp {
 
 class IndexerInitializationTask final : public LSPTask {
+    std::vector<std::shared_ptr<core::File>> files;
+
 public:
-    IndexerInitializationTask(const LSPConfiguration &config);
+    IndexerInitializationTask(const LSPConfiguration &config, std::vector<std::shared_ptr<core::File>> files);
 
     Phase finalPhase() const override;
 

--- a/main/lsp/notifications/indexer_initialization.h
+++ b/main/lsp/notifications/indexer_initialization.h
@@ -9,7 +9,7 @@ class IndexerInitializationTask final : public LSPTask {
     std::vector<std::shared_ptr<core::File>> files;
 
 public:
-    IndexerInitializationTask(const LSPConfiguration &config, std::vector<std::shared_ptr<core::File>> files);
+    IndexerInitializationTask(const LSPConfiguration &config, std::vector<std::shared_ptr<core::File>> &&files);
 
     Phase finalPhase() const override;
 


### PR DESCRIPTION
In #8807 we broke the connection between the typechecker and indexer, removing the copy of the global state from the `IndexerInitializationTask` message. This introduced a bug: the indexer uses presence in the file table to determine if a file is new, and now that the file tables don't agree opening a file forces the slow path.

This PR fixes the bug by syncing the file tables of the typechecker and indexer at the end of initialization.

### Motivation
Fixing a fast path decision regression.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included tests.

I verified this experimentally by opening an existing file after initialization had finished, and seeing it not kick off another slow path.
