### PR TITLE
Don't populate MangledName if it doesn't exist

### DIFF
--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -1,6 +1,5 @@
 #include "core/packages/MangledName.h"
 #include "absl/strings/str_join.h"
-#include "absl/strings/str_replace.h"
 #include "core/GlobalState.h"
 #include "core/Names.h"
 
@@ -23,6 +22,23 @@ MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::
     auto utf8Name = gs.enterNameUTF8(mangledName);
     auto packagerName = gs.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
     return MangledName(gs.enterNameConstant(packagerName));
+}
+
+MangledName MangledName::lookupMangledName(const core::GlobalState &gs, const std::vector<core::NameRef> &parts) {
+    // Foo::Bar => Foo_Bar
+    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(gs)));
+
+    auto utf8Name = gs.lookupNameUTF8(mangledName);
+    if (!utf8Name.exists()) {
+        return MangledName();
+    }
+
+    auto packagerName = gs.lookupNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
+    if (!packagerName.exists()) {
+        return MangledName();
+    }
+
+    return MangledName(gs.lookupNameConstant(packagerName));
 }
 
 } // namespace sorbet::core::packages

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -23,6 +23,10 @@ public:
     // [:Foo, :Bar] => :Foo_Bar
     static MangledName mangledNameFromParts(core::GlobalState &gs, const std::vector<core::NameRef> &parts);
 
+    // [:Foo, :Bar] => :Foo_Bar
+    // (might not exist)
+    static MangledName lookupMangledName(const core::GlobalState &gs, const std::vector<core::NameRef> &parts);
+
     bool operator==(const MangledName &rhs) const {
         return mangledName == rhs.mangledName;
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't have to create new MangledNames for packages that don't actually exist (making the semantics of `MangledName` closer to the semantics of a future `PackageRef` type).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests