### PR TITLE
Use a `Set` for `T.deprecated_enum`

### DIFF
--- a/gems/sorbet-runtime/.rubocop.yml
+++ b/gems/sorbet-runtime/.rubocop.yml
@@ -37,6 +37,8 @@ Style/SingleLineMethods:
   Enabled: false
 Style/RedundantSelf:
   Enabled: false
+Style/WordArray:
+  Enabled: false
 
 # This doesn't play very well with implementations of Sorbet abstract methods
 Lint/UnusedMethodArgument:

--- a/gems/sorbet-runtime/lib/types/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/enum.rb
@@ -31,7 +31,7 @@ module T::Types
     private def subtype_of_single?(other)
       case other
       when Enum
-        (other.values - @values).empty?
+        (@values - other.values).empty?
       else
         false
       end

--- a/gems/sorbet-runtime/lib/types/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/enum.rb
@@ -9,7 +9,8 @@ module T::Types
     attr_reader :values
 
     def initialize(values)
-      @values = values
+      require "set" unless defined?(Set)
+      @values = values.to_set
     end
 
     def build_type

--- a/gems/sorbet-runtime/lib/types/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/types/enum.rb
@@ -9,8 +9,13 @@ module T::Types
     attr_reader :values
 
     def initialize(values)
-      require "set" unless defined?(Set)
-      @values = values.to_set
+      case values
+      when Hash
+        @values = values
+      else
+        require "set" unless defined?(Set)
+        @values = values.to_set
+      end
     end
 
     def build_type

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1806,7 +1806,7 @@ module Opus::Types::Test
 
       describe 'deprecated_enum' do
         it 'treats the elements as a union of values' do
-          refute_subtype(T.deprecated_enum(["A"]), T.deprecated_enum(["A", "B"]))
+          assert_subtype(T.deprecated_enum(["A"]), T.deprecated_enum(["A", "B"]))
           assert_subtype(T.deprecated_enum(["A", "B"]), T.deprecated_enum(["A", "B"]))
           refute_subtype(T.deprecated_enum(["A", "B"]), T.deprecated_enum(["A"]))
           refute_subtype(T.deprecated_enum(["A", "B"]), T.deprecated_enum(["C"]))

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1803,6 +1803,15 @@ module Opus::Types::Test
           assert_subtype(T::Enumerator[Integer], T::Enumerator[T.untyped])
         end
       end
+
+      describe 'deprecated_enum' do
+        it 'treats the elements as a union of values' do
+          refute_subtype(T.deprecated_enum(["A"]), T.deprecated_enum(["A", "B"]))
+          assert_subtype(T.deprecated_enum(["A", "B"]), T.deprecated_enum(["A", "B"]))
+          refute_subtype(T.deprecated_enum(["A", "B"]), T.deprecated_enum(["A"]))
+          refute_subtype(T.deprecated_enum(["A", "B"]), T.deprecated_enum(["C"]))
+        end
+      end
     end
 
     module TestGeneric1

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -127,7 +127,7 @@ module T
   # Deprecated. Use `T::Enum` instead.
   #
   # For more information, see https://sorbet.org/docs/tenum
-  sig { params(values: T.any(T::Set[T.anything], T::Array[T.anything])).returns(T.untyped) }
+  sig { params(values: T.any(T::Set[T.anything], T::Array[T.anything], T::Hash[T.anything, T.anything])).returns(T.untyped) }
   def self.deprecated_enum(values); end
 
   # Type syntax to opt out of static type checking.

--- a/rbi/sorbet/ttypes.rbi
+++ b/rbi/sorbet/ttypes.rbi
@@ -188,7 +188,7 @@ class T::Types::NoReturn < T::Types::Base
 end
 
 class T::Types::Enum < T::Types::Base
-  sig { params(values: T.any(T::Set[T.anything], T::Array[T.anything])).void }
+  sig { params(values: T.any(T::Set[T.anything], T::Array[T.anything], T::Hash[T.anything, T.anything])).void }
   def initialize(values); end
 
   sig { override.params(obj: Kernel).returns(T::Boolean) }
@@ -199,7 +199,7 @@ class T::Types::Enum < T::Types::Base
 
   def describe_obj(obj); end
 
-  sig { returns(T.any(T::Set[T.anything], T::Array[T.anything])) }
+  sig { returns(T.any(T::Set[T.anything], T::Array[T.anything], T::Hash[T.anything, T.anything])) }
   def values; end
 end
 

--- a/test/cli/autocorrect-t-combinator-kwargs/test.out
+++ b/test/cli/autocorrect-t-combinator-kwargs/test.out
@@ -70,21 +70,6 @@ autocorrect-t-combinator-kwargs.rb:10: Unexpected bare `Symbol(:b)` value found 
     10 |      any: T.any(Integer, String, a: Integer, b: String),
                                                       ^
 
-autocorrect-t-combinator-kwargs.rb:12: Expected `T.any(T::Set[T.anything], T::Array[T.anything])` but found `{a: T.class_of(Integer)}` for argument `values` https://srb.help/7002
-    12 |      enum: T.deprecated_enum(a: Integer),
-                                      ^^^^^^^^^^
-  Expected `T.any(T::Set[T.anything], T::Array[T.anything])` for argument `values` of method `T.deprecated_enum`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L130:
-     130 |  sig { params(values: T.any(T::Set[T.anything], T::Array[T.anything])).returns(T.untyped) }
-                         ^^^^^^
-  Got `{a: T.class_of(Integer)} (shape of T::Hash[T.untyped, T.untyped])` originating from:
-    autocorrect-t-combinator-kwargs.rb:12:
-    12 |      enum: T.deprecated_enum(a: Integer),
-                                      ^^^^^^^^^^
-  Detailed explanation:
-    `Hash` does not derive from `Set`
-    `Hash` does not derive from `Array`
-
 autocorrect-t-combinator-kwargs.rb:14: Method `to_hash` does not exist on `T::Array[T.any(T.class_of(Integer), T.class_of(String))]` https://srb.help/7003
     14 |      splat: T.class_of(**TYPES),
                                 ^^^^^^^
@@ -106,7 +91,7 @@ autocorrect-t-combinator-kwargs.rb:15: Method `to_hash` does not exist on `T::Ar
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L1424: Did you mean: `Array#hash`
     1424 |  def hash; end
             ^^^^^^^^
-Errors: 15
+Errors: 14
 
 --------------------------------------------------------------------------
 

--- a/test/testdata/resolver/sig_bad.rb
+++ b/test/testdata/resolver/sig_bad.rb
@@ -38,10 +38,10 @@ class A
       #          ^^^^^^^^^^^   error: Unsupported type literal
       #    ^^^^                error: Method `enum` does not exist on `T.class_of(T)`
       b1: T.deprecated_enum, # error: Not enough arguments provided for method `T.deprecated_enum`. Expected: `1`, got: `0`
-      c11: T.deprecated_enum(1), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
-      c12: T.deprecated_enum(1.0), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
-      c13: T.deprecated_enum("d"), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
-      c14: T.deprecated_enum(:e), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
+      c11: T.deprecated_enum(1), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything], T::Hash[T.anything, T.anything])`
+      c12: T.deprecated_enum(1.0), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything], T::Hash[T.anything, T.anything])`
+      c13: T.deprecated_enum("d"), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything], T::Hash[T.anything, T.anything])`
+      c14: T.deprecated_enum(:e), # error: Expected `T.any(T::Set[T.anything], T::Array[T.anything], T::Hash[T.anything, T.anything])`
       d1: T.deprecated_enum([]), # error: enum([]) is invalid
       e1: T.deprecated_enum([unsupported]), # error: Unsupported type literal
       f: 0, # error: Unsupported literal in type syntax

--- a/test/testdata/resolver/t_combinator_kwargs.rb
+++ b/test/testdata/resolver/t_combinator_kwargs.rb
@@ -18,7 +18,6 @@ module M
       param: T.type_parameter(a: Integer),
       #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter` does not accept keyword arguments
       enum: T.deprecated_enum(a: Integer),
-      #                       ^^^^^^^^^^ error: Expected `T.any(T::Set[T.anything], T::Array[T.anything])`
       #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.deprecated_enum` does not accept keyword arguments
       klass: T.class_of(a: Integer),
       #      ^^^^^^^^^^^^^^^^^^^^^^ error: `T.class_of` does not accept keyword arguments


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a performance optimization. This is technically a backwards
incompatible change, but this feature is deprecated, so I think that's
reasonable. Most things will stay the same, e.g. if you're only using
`Enumerable` APIs over the `.values` of a `T::Types::Enum` object,
you won't even notice (except performance of some operations).

This leads to a ~20x on certain large T.deprecated_enum's (country codes,
currency codes) in Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Note that all of our sorbet-runtime tests pass without changes.