### PR TITLE
Remove MangleName functions on `string_view`

### DIFF
--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -25,23 +25,4 @@ MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::
     return MangledName(gs.enterNameConstant(packagerName));
 }
 
-MangledName MangledName::mangledNameFromHuman(const core::GlobalState &gs, string_view nameStr) {
-    auto mangled = absl::StrCat(absl::StrReplaceAll(nameStr, {{"::", "_"}}));
-    auto utf8Name = gs.lookupNameUTF8(mangled);
-    if (!utf8Name.exists()) {
-        return MangledName();
-    }
-
-    auto packagerName = gs.lookupNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-    if (!packagerName.exists()) {
-        return MangledName();
-    }
-
-    auto cnst = gs.lookupNameConstant(packagerName);
-    if (!cnst.exists()) {
-        return MangledName();
-    }
-
-    return MangledName(cnst);
-}
 } // namespace sorbet::core::packages

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -22,8 +22,6 @@ public:
     static MangledName mangledNameFromParts(core::GlobalState &gs, const std::vector<std::string_view> &parts);
     // [:Foo, :Bar] => :Foo_Bar
     static MangledName mangledNameFromParts(core::GlobalState &gs, const std::vector<core::NameRef> &parts);
-    // "Foo::Bar" -> :Foo_Bar
-    static MangledName mangledNameFromHuman(const core::GlobalState &gs, std::string_view human);
 
     bool operator==(const MangledName &rhs) const {
         return mangledName == rhs.mangledName;

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -199,14 +199,6 @@ MangledName PackageDB::findPackageByPath(const core::GlobalState &gs, core::File
     return MangledName();
 }
 
-const PackageInfo &PackageDB::getPackageInfo(const core::GlobalState &gs, std::string_view nameStr) const {
-    auto cnst = core::packages::MangledName::mangledNameFromHuman(gs, nameStr);
-    if (!cnst.exists()) {
-        return NONE_PKG;
-    }
-    return getPackageInfo(cnst);
-}
-
 const PackageInfo &PackageDB::getPackageInfo(MangledName mangledName) const {
     auto it = packages_.find(mangledName);
     if (it == packages_.end()) {

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -39,9 +39,6 @@ public:
     const PackageInfo &getPackageInfo(MangledName mangledName) const;
     PackageInfo *getPackageInfoNonConst(MangledName mangledName);
 
-    // Lookup `PackageInfo` from the string representation of the un-mangled package name.
-    const PackageInfo &getPackageInfo(const core::GlobalState &gs, std::string_view str) const;
-
     // Get mangled names for all packages.
     // Packages are ordered lexicographically with respect to the NameRef's that make up their
     // namespaces.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was probably getting used for some part of single package RBI mode (maybe?)
In any case it's not used anymore, and we shouldn't have APIs like that that are
using `string_view` instead of `NameRef`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CI