### PR TITLE
Split defining packages apart from imports/exports

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1871,8 +1871,6 @@ void validateVisibility(const core::Context &ctx, const PackageInfoImpl &absPkg,
     }
 }
 
-} // namespace
-
 void validatePackage(core::Context ctx) {
     const auto &packageDB = ctx.state.packageDB();
     auto absPkg = packageDB.getPackageNameForFile(ctx.file);
@@ -1947,6 +1945,8 @@ void validatePackagedFile(core::Context ctx, const ast::ExpressionPtr &tree) {
     EnforcePackagePrefix enforcePrefix(ctx, pkgImpl);
     ast::ConstShallowWalk::apply(ctx, enforcePrefix, tree);
 }
+
+} // namespace
 
 void Packager::findPackages(core::GlobalState &gs, absl::Span<ast::ParsedFile> files) {
     // Ensure files are in canonical order.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1963,8 +1963,7 @@ void Packager::findPackages(core::GlobalState &gs, absl::Span<ast::ParsedFile> f
                 continue;
             }
 
-            core::MutableContext ctx(gs, core::Symbols::root(), file.file);
-            auto pkg = createAndPopulatePackageInfo(ctx, file);
+            auto pkg = createAndPopulatePackageInfo(gs, file);
             if (pkg == nullptr) {
                 // There was an error creating a PackageInfoImpl for this file, and getPackageInfo has already
                 // surfaced that error to the user. Nothing to do here.
@@ -1972,8 +1971,8 @@ void Packager::findPackages(core::GlobalState &gs, absl::Span<ast::ParsedFile> f
             }
             auto &prevPkg = gs.packageDB().getPackageInfo(pkg->mangledName());
             if (prevPkg.exists() && prevPkg.declLoc() != pkg->declLoc()) {
-                if (auto e = ctx.beginError(pkg->loc.offsets(), core::errors::Packager::RedefinitionOfPackage)) {
-                    auto pkgName = pkg->name.toString(ctx);
+                if (auto e = gs.beginError(pkg->loc, core::errors::Packager::RedefinitionOfPackage)) {
+                    auto pkgName = pkg->name.toString(gs);
                     e.setHeader("Redefinition of package `{}`", pkgName);
                     e.addErrorLine(prevPkg.declLoc(), "Package `{}` originally defined here", pkgName);
                 }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1580,31 +1580,6 @@ unique_ptr<PackageInfoImpl> createAndPopulatePackageInfo(core::GlobalState &gs, 
 
     auto &info = *pkg;
 
-    rewritePackageSpec(gs, package, info);
-    for (auto &importedPackageName : info.importedPackageNames) {
-        populateMangledName(gs, importedPackageName.name);
-
-        if (importedPackageName.name.mangledName == info.name.mangledName) {
-            if (auto e = gs.beginError(core::Loc(package.file, importedPackageName.name.fullName.loc),
-                                       core::errors::Packager::NoSelfImport)) {
-                string import_;
-                switch (importedPackageName.type) {
-                    case core::packages::ImportType::Normal:
-                        import_ = "import";
-                        break;
-                    case core::packages::ImportType::Test:
-                        import_ = "test_import";
-                        break;
-                }
-                e.setHeader("Package `{}` cannot {} itself", info.name.toString(gs), import_);
-            }
-        }
-    }
-
-    for (auto &visibleTo : info.visibleTo_) {
-        populateMangledName(gs, visibleTo.name);
-    }
-
     auto extraPackageFilesDirectoryUnderscorePrefixes = gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes();
     auto extraPackageFilesDirectorySlashDeprecatedPrefixes =
         gs.packageDB().extraPackageFilesDirectorySlashDeprecatedPrefixes();
@@ -1654,6 +1629,31 @@ unique_ptr<PackageInfoImpl> createAndPopulatePackageInfo(core::GlobalState &gs, 
     for (const string &prefix : extraPackageFilesDirectorySlashPrefixes) {
         // Project/FooBar -- each constant name is a file or directory name
         info.packagePathPrefixes.emplace_back(absl::StrCat(prefix, slashDirName));
+    }
+
+    rewritePackageSpec(gs, package, info);
+    for (auto &importedPackageName : info.importedPackageNames) {
+        populateMangledName(gs, importedPackageName.name);
+
+        if (importedPackageName.name.mangledName == info.name.mangledName) {
+            if (auto e = gs.beginError(core::Loc(package.file, importedPackageName.name.fullName.loc),
+                                       core::errors::Packager::NoSelfImport)) {
+                string import_;
+                switch (importedPackageName.type) {
+                    case core::packages::ImportType::Normal:
+                        import_ = "import";
+                        break;
+                    case core::packages::ImportType::Test:
+                        import_ = "test_import";
+                        break;
+                }
+                e.setHeader("Package `{}` cannot {} itself", info.name.toString(gs), import_);
+            }
+        }
+    }
+
+    for (auto &visibleTo : info.visibleTo_) {
+        populateMangledName(gs, visibleTo.name);
     }
 
     return pkg;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1983,6 +1983,7 @@ void Packager::findPackages(core::GlobalState &gs, absl::Span<ast::ParsedFile> f
     setPackageNameOnFiles(gs, files);
 
     {
+        core::UnfreezeNameTable unfreeze(gs);
         auto packages = gs.unfreezePackages();
 
         for (auto &file : files) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is more similar to the way that namer is split, with three phases:

1. findSymbols
2. defineSymbols
3. symbolizeTrees

If we're going to use namer to enter packages, we need to model that a bit more closely. In particular, we won't be able to resolve the `imports` of a package until the `symbolizeTrees` phase, which means we need to split defining packages and populating the imports.

This is all the no-op prework to get us closer, but there are more changes coming.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.