### PR TITLE
rbi: Require `Array#concat` args to have same type as receiver

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -914,9 +914,9 @@ class Array < Object
   # [`Array#+`](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-2B).
   sig do
     type_parameters(:T).params(
-        arrays: T::Array[T.type_parameter(:T)],
+        arrays: T::Array[Elem],
     )
-    .returns(T::Array[T.any(Elem, T.type_parameter(:T))])
+    .returns(T::Array[Elem])
   end
   def concat(*arrays); end
 

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -1,4 +1,5 @@
 # typed: strict
+extend T::Sig
 
 # initializing with array
 T.assert_type!(T::Array[String].new(['a', 'b', 'c']), T::Array[String])
@@ -79,3 +80,15 @@ x = [[3.4], [1, "a"]]
 T.reveal_type(x.transpose) # error: Revealed type: `T::Array[T::Array[T.untyped]]`
 x = [[3.4, "a"], [:a, 5]]
 T.reveal_type(x.transpose) # error: Revealed type: `[T::Array[T.any(Float, Symbol)], T::Array[T.any(Integer, String)]] (2-tuple)`
+
+# concat
+sig {params(x: T::Array[Integer], y: T::Array[String]).void}
+def concat_test(x, y)
+  T.reveal_type(x + y) # error: `T::Array[T.any(Integer, String)]`
+
+  # mutates receiver type:
+  x.concat(y) # error: Expected `T::Array[Integer]` but found `T::Array[String]` for argument `arrays`
+
+  T.reveal_type(x) # error: `T::Array[Integer]`
+end
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet does not have a way to track mutable updates to a variable's type unless
there is some sort of explicit control flow branch—it assumes that within a
given, branchless basic block, the type of a variable is constant. Given:

```ruby
x.concat(y)
```

Sorbet will think that `x` has the same type before, during, and after that
line.

As such, for methods like this it's dangerous to allow calls that would change
the type of the array.

Alternatives and workarounds:

```ruby
# creates a new Array instead of mutating `x` in place, but assigns the result
# back into `x`, and evaluates to the same thing as `Array#concat` (both
# evaluate to the new value of `x`)
x += y

# Relies on the fact that Sorbet treats Arrays as covariant (unsound, but it's
# the way it works in Sorbet, and is extremely unlike to change).
x = T.let(x, T::Array[T.any(Integer, String)])
x.concat(y)

# Silences the error
x.concat(T.unsafe(y))
# ^ it's better this way vs `T.unsafe(x).concat(y)` because at least Sorbet can
# check that `.concat` exists (vs `x` might be made `nil` in the future).
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.