### PR TITLE
Add shim for Kernel#pretty_inspect

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1968,6 +1968,14 @@ module Kernel
   # [`pp`](https://docs.ruby-lang.org/en/2.7.0/Kernel.html#method-i-pp)
   def pp(obj, out = nil, width = nil); end
 
+  # Returns a pretty printed object as a string.
+  #
+  # See the PP module for more information.
+  sig do
+    returns(String)
+  end
+  def pretty_inspect; end
+
   # If called without an argument, or if `max.to_i.abs == 0`, rand returns a
   # pseudo-random floating point number between 0.0 and 1.0, including 0.0 and
   # excluding 1.0.


### PR DESCRIPTION
`pp` is present, but not `pretty_inspect`, which is found here: https://github.com/ruby/ruby/blob/master/lib/pp.rb#L722

### Motivation
Type checking errors when using the built-in to Ruby `#pretty_inspect`.

### Test plan
See the link to the Ruby repo; the method definition is copied from there. I assume we don't add tests for all of the shims, but if not, I'd be happy to add one.
