### PR TITLE
RBS: introduce support for generics

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -542,6 +542,32 @@ public:
         }
     }
 
+    static bool isSorbetPrivateStatic(const ast::ExpressionPtr &expr) {
+        if (auto recv = cast_tree<ConstantLit>(expr)) {
+            return recv->symbol() == core::Symbols::Sorbet_Private_Static();
+        }
+
+        if (auto recv = cast_tree<UnresolvedConstantLit>(expr)) {
+            if (recv->cnst != core::Names::Constants::Static()) {
+                return false;
+            }
+
+            auto scope = cast_tree<ast::UnresolvedConstantLit>(recv->scope);
+            if (scope == nullptr || scope->cnst != core::Names::Constants::Private()) {
+                return false;
+            }
+
+            scope = cast_tree<ast::UnresolvedConstantLit>(scope->scope);
+            if (scope == nullptr || scope->cnst != core::Names::Constants::Sorbet()) {
+                return false;
+            }
+
+            return scope->scope == nullptr || isRootScope(scope->scope);
+        }
+
+        return false;
+    }
+
     static bool isSelfNew(ast::Send *send) {
         return send->fun == core::Names::new_() && send->recv.isSelfReference();
     }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -934,10 +934,10 @@ void GlobalState::initEmpty() {
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::SyntheticGeneric());
     ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_SyntheticGeneric());
 
-    method = enterMethod(*this, Symbols::Sorbet_Private_Static_SyntheticGeneric(), Names::syntheticSquareBrackets())
-                 .repeatedTopArg(Names::args())
+    method = enterMethod(*this, Symbols::Module(), Names::syntheticSquareBrackets())
+                 .repeatedUntypedArg(Names::arg())
                  .build();
-    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_SyntheticGeneric_syntheticSquareBrackets());
+    ENFORCE_NO_TIMER(method == Symbols::Module_syntheticSquareBrackets());
 
     method = enterMethod(*this, Symbols::Sorbet_Private_Static_SyntheticGeneric(), Names::syntheticTypeMember())
                  .repeatedTopArg(Names::args())

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -931,18 +931,16 @@ void GlobalState::initEmpty() {
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::LoadYieldParams());
     ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_LoadYieldParams());
 
-    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::SyntheticGeneric());
-    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_SyntheticGeneric());
-
     method = enterMethod(*this, Symbols::Module(), Names::syntheticSquareBrackets())
                  .repeatedUntypedArg(Names::arg())
                  .build();
     ENFORCE_NO_TIMER(method == Symbols::Module_syntheticSquareBrackets());
 
-    method = enterMethod(*this, Symbols::Sorbet_Private_Static_SyntheticGeneric(), Names::syntheticTypeMember())
-                 .repeatedTopArg(Names::args())
-                 .build();
-    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_SyntheticGeneric_syntheticTypeMember());
+    method =
+        enterMethod(*this, Symbols::Sorbet_Private_Static().data(*this)->singletonClass(*this), Names::typeMember())
+            .repeatedTopArg(Names::args())
+            .build();
+    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_typeMember());
 
     int reservedCount = 0;
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -931,6 +931,19 @@ void GlobalState::initEmpty() {
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::LoadYieldParams());
     ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_LoadYieldParams());
 
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::GenericWithoutRuntime());
+    ENFORCE_NO_TIMER(klass == Symbols::T_GenericWithoutRuntime());
+
+    method = enterMethod(*this, Symbols::T_GenericWithoutRuntime(), Names::syntheticSquareBrackets())
+                 .repeatedTopArg(Names::args())
+                 .build();
+    ENFORCE_NO_TIMER(method == Symbols::T_GenericWithoutRuntime_syntheticSquareBrackets());
+
+    method = enterMethod(*this, Symbols::T_GenericWithoutRuntime(), Names::syntheticTypeMember())
+                 .repeatedTopArg(Names::args())
+                 .build();
+    ENFORCE_NO_TIMER(method == Symbols::T_GenericWithoutRuntime_syntheticTypeMember());
+
     int reservedCount = 0;
 
     // Set the correct resultTypes for all synthesized classes

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -931,18 +931,18 @@ void GlobalState::initEmpty() {
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::LoadYieldParams());
     ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_LoadYieldParams());
 
-    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::GenericWithoutRuntime());
-    ENFORCE_NO_TIMER(klass == Symbols::T_GenericWithoutRuntime());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::SyntheticGeneric());
+    ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static_SyntheticGeneric());
 
-    method = enterMethod(*this, Symbols::T_GenericWithoutRuntime(), Names::syntheticSquareBrackets())
+    method = enterMethod(*this, Symbols::Sorbet_Private_Static_SyntheticGeneric(), Names::syntheticSquareBrackets())
                  .repeatedTopArg(Names::args())
                  .build();
-    ENFORCE_NO_TIMER(method == Symbols::T_GenericWithoutRuntime_syntheticSquareBrackets());
+    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_SyntheticGeneric_syntheticSquareBrackets());
 
-    method = enterMethod(*this, Symbols::T_GenericWithoutRuntime(), Names::syntheticTypeMember())
+    method = enterMethod(*this, Symbols::Sorbet_Private_Static_SyntheticGeneric(), Names::syntheticTypeMember())
                  .repeatedTopArg(Names::args())
                  .build();
-    ENFORCE_NO_TIMER(method == Symbols::T_GenericWithoutRuntime_syntheticTypeMember());
+    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_SyntheticGeneric_syntheticTypeMember());
 
     int reservedCount = 0;
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1121,12 +1121,12 @@ public:
         return ClassOrModuleRef::fromRaw(96);
     }
 
-    static ClassOrModuleRef Sorbet_Private_Static_SyntheticGeneric() {
-        return ClassOrModuleRef::fromRaw(97);
+    static MethodRef Module_syntheticSquareBrackets() {
+        return MethodRef::fromRaw(57);
     }
 
-    static MethodRef Sorbet_Private_Static_SyntheticGeneric_syntheticSquareBrackets() {
-        return MethodRef::fromRaw(57);
+    static ClassOrModuleRef Sorbet_Private_Static_SyntheticGeneric() {
+        return ClassOrModuleRef::fromRaw(97);
     }
 
     static MethodRef Sorbet_Private_Static_SyntheticGeneric_syntheticTypeMember() {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1125,11 +1125,7 @@ public:
         return MethodRef::fromRaw(57);
     }
 
-    static ClassOrModuleRef Sorbet_Private_Static_SyntheticGeneric() {
-        return ClassOrModuleRef::fromRaw(97);
-    }
-
-    static MethodRef Sorbet_Private_Static_SyntheticGeneric_syntheticTypeMember() {
+    static MethodRef Sorbet_Private_Static_typeMember() {
         return MethodRef::fromRaw(58);
     }
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1121,15 +1121,15 @@ public:
         return ClassOrModuleRef::fromRaw(96);
     }
 
-    static ClassOrModuleRef T_GenericWithoutRuntime() {
+    static ClassOrModuleRef Sorbet_Private_Static_SyntheticGeneric() {
         return ClassOrModuleRef::fromRaw(97);
     }
 
-    static MethodRef T_GenericWithoutRuntime_syntheticSquareBrackets() {
+    static MethodRef Sorbet_Private_Static_SyntheticGeneric_syntheticSquareBrackets() {
         return MethodRef::fromRaw(57);
     }
 
-    static MethodRef T_GenericWithoutRuntime_syntheticTypeMember() {
+    static MethodRef Sorbet_Private_Static_SyntheticGeneric_syntheticTypeMember() {
         return MethodRef::fromRaw(58);
     }
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1121,6 +1121,18 @@ public:
         return ClassOrModuleRef::fromRaw(96);
     }
 
+    static ClassOrModuleRef T_GenericWithoutRuntime() {
+        return ClassOrModuleRef::fromRaw(97);
+    }
+
+    static MethodRef T_GenericWithoutRuntime_syntheticSquareBrackets() {
+        return MethodRef::fromRaw(57);
+    }
+
+    static MethodRef T_GenericWithoutRuntime_syntheticTypeMember() {
+        return MethodRef::fromRaw(58);
+    }
+
     static FieldRef Magic_UntypedSource_super() {
         return FieldRef::fromRaw(4);
     }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -22,8 +22,8 @@ namespace sorbet::core {
 
 using namespace std;
 
-const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 57;
+const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 216;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 59;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 6;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 71;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -22,7 +22,7 @@ namespace sorbet::core {
 
 using namespace std;
 
-const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 216;
+const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
 const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 59;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 6;

--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -20,7 +20,7 @@ constexpr ErrorClass NilableUntyped{3512, StrictLevel::False};
 constexpr ErrorClass ContravariantHasAttachedClass{3514, StrictLevel::False};
 constexpr ErrorClass DuplicateProp{3515, StrictLevel::True};
 
-// Let's reserve 3550-3559 for RBS related errors
+// Let's reserve 3550-3569 for RBS related errors
 constexpr ErrorClass RBSSyntaxError{3550, StrictLevel::False};
 constexpr ErrorClass RBSUnsupported{3551, StrictLevel::False};
 constexpr ErrorClass RBSParameterMismatch{3552, StrictLevel::False};
@@ -28,6 +28,7 @@ constexpr ErrorClass RBSAssertionError{3553, StrictLevel::False};
 constexpr ErrorClass RBSUnusedComment{3554, StrictLevel::False};
 constexpr ErrorClass RBSMultilineMisformatted{3555, StrictLevel::False};
 constexpr ErrorClass RBSIncorrectParameterKind{3556, StrictLevel::False};
+constexpr ErrorClass RBSMultipleGenericSignatures{3557, StrictLevel::False};
 
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -581,7 +581,7 @@ NameDef names[] = {
     {"Merchant", "Merchant", true},
 
     // RBS synthetic generics
-    {"GenericWithoutRuntime", "GenericWithoutRuntime", true},
+    {"SyntheticGeneric", "<SyntheticGeneric>", true},
     {"syntheticSquareBrackets", "<syntheticSquareBrackets>"},
     {"syntheticTypeMember", "<syntheticTypeMember>"},
 

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -580,6 +580,11 @@ NameDef names[] = {
     {"Account", "Account", true},
     {"Merchant", "Merchant", true},
 
+    // RBS synthetic generics
+    {"GenericWithoutRuntime", "GenericWithoutRuntime", true},
+    {"syntheticSquareBrackets", "<syntheticSquareBrackets>"},
+    {"syntheticTypeMember", "<syntheticTypeMember>"},
+
     // Typos
     {"Int", "Int", true},
     {"Timestamp", "Timestamp", true},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -581,9 +581,7 @@ NameDef names[] = {
     {"Merchant", "Merchant", true},
 
     // RBS synthetic generics
-    {"SyntheticGeneric", "<SyntheticGeneric>", true},
     {"syntheticSquareBrackets", "<syntheticSquareBrackets>"},
-    {"syntheticTypeMember", "<syntheticTypeMember>"},
 
     // Typos
     {"Int", "Int", true},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4534,8 +4534,7 @@ const vector<Intrinsic> intrinsics{
     {Symbols::DeclBuilderForProcs(), Intrinsic::Kind::Singleton, Names::bind(), &DeclBuilderForProcs_bind},
 
     {Symbols::T_Generic(), Intrinsic::Kind::Instance, Names::squareBrackets(), &T_Generic_squareBrackets},
-    {Symbols::Sorbet_Private_Static_SyntheticGeneric(), Intrinsic::Kind::Instance, Names::syntheticSquareBrackets(),
-     &T_Generic_squareBrackets},
+    {Symbols::Module(), Intrinsic::Kind::Instance, Names::syntheticSquareBrackets(), &T_Generic_squareBrackets},
 
     {Symbols::T_Array(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},
     {Symbols::T_Hash(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4534,7 +4534,7 @@ const vector<Intrinsic> intrinsics{
     {Symbols::DeclBuilderForProcs(), Intrinsic::Kind::Singleton, Names::bind(), &DeclBuilderForProcs_bind},
 
     {Symbols::T_Generic(), Intrinsic::Kind::Instance, Names::squareBrackets(), &T_Generic_squareBrackets},
-    {Symbols::T_GenericWithoutRuntime(), Intrinsic::Kind::Instance, Names::syntheticSquareBrackets(),
+    {Symbols::Sorbet_Private_Static_SyntheticGeneric(), Intrinsic::Kind::Instance, Names::syntheticSquareBrackets(),
      &T_Generic_squareBrackets},
 
     {Symbols::T_Array(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4534,6 +4534,8 @@ const vector<Intrinsic> intrinsics{
     {Symbols::DeclBuilderForProcs(), Intrinsic::Kind::Singleton, Names::bind(), &DeclBuilderForProcs_bind},
 
     {Symbols::T_Generic(), Intrinsic::Kind::Instance, Names::squareBrackets(), &T_Generic_squareBrackets},
+    {Symbols::T_GenericWithoutRuntime(), Intrinsic::Kind::Instance, Names::syntheticSquareBrackets(),
+     &T_Generic_squareBrackets},
 
     {Symbols::T_Array(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},
     {Symbols::T_Hash(), Intrinsic::Kind::Singleton, Names::squareBrackets(), &T_Generic_squareBrackets},

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -649,13 +649,12 @@ public:
         auto send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send == nullptr) {
             fillAssign(ctx, asgn);
-        } else if (!send->recv.isSelfReference()) {
+        } else if (!send->recv.isSelfReference() && !ast::MK::isSorbetPrivateStatic(send->recv)) {
             handleAssignment(ctx, asgn);
         } else if (!ast::isa_tree<ast::EmptyTree>(lhs->scope)) {
             handleAssignment(ctx, asgn);
         } else {
             switch (send->fun.rawId()) {
-                case core::Names::syntheticTypeMember().rawId():
                 case core::Names::typeTemplate().rawId():
                 case core::Names::typeMember().rawId():
                     handleTypeMemberDefinition(ctx, send, asgn, lhs);
@@ -2064,13 +2063,12 @@ public:
         auto send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send == nullptr) {
             tree = handleAssignment(ctx, std::move(tree));
-        } else if (!send->recv.isSelfReference()) {
+        } else if (!send->recv.isSelfReference() && !ast::MK::isSorbetPrivateStatic(send->recv)) {
             tree = handleAssignment(ctx, std::move(tree));
         } else if (!ast::isa_tree<ast::EmptyTree>(lhs->scope)) {
             tree = handleAssignment(ctx, std::move(tree));
         } else {
             switch (send->fun.rawId()) {
-                case core::Names::syntheticTypeMember().rawId():
                 case core::Names::typeTemplate().rawId():
                 case core::Names::typeMember().rawId(): {
                     tree = handleTypeMemberDefinition(ctx, std::move(tree));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -655,6 +655,7 @@ public:
             handleAssignment(ctx, asgn);
         } else {
             switch (send->fun.rawId()) {
+                case core::Names::syntheticTypeMember().rawId():
                 case core::Names::typeTemplate().rawId():
                 case core::Names::typeMember().rawId():
                     handleTypeMemberDefinition(ctx, send, asgn, lhs);
@@ -2069,6 +2070,7 @@ public:
             tree = handleAssignment(ctx, std::move(tree));
         } else {
             switch (send->fun.rawId()) {
+                case core::Names::syntheticTypeMember().rawId():
                 case core::Names::typeTemplate().rawId():
                 case core::Names::typeMember().rawId(): {
                     tree = handleTypeMemberDefinition(ctx, std::move(tree));

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -182,6 +182,13 @@ public:
     }
 
     /*
+     * Create a `T::GenericWithoutRuntime` constant node.
+     */
+    static std::unique_ptr<parser::Node> T_GenericWithoutRuntime(core::LocOffsets loc) {
+        return Const(loc, T(loc), core::Names::Constants::GenericWithoutRuntime());
+    }
+
+    /*
      * Create a `T::Hash` constant node.
      */
     static std::unique_ptr<parser::Node> T_Hash(core::LocOffsets loc) {
@@ -367,6 +374,10 @@ public:
         }
 
         auto constant = parser::cast_node<parser::Const>(expr.get());
+
+        if (constant == nullptr) {
+            return false;
+        }
 
         if (isT(constant->scope)) {
             return true;

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -182,10 +182,10 @@ public:
     }
 
     /*
-     * Create a `T::GenericWithoutRuntime` constant node.
+     * Create a `Sorbet::Private::Static::SyntheticGeneric` constant node.
      */
-    static std::unique_ptr<parser::Node> T_GenericWithoutRuntime(core::LocOffsets loc) {
-        return Const(loc, T(loc), core::Names::Constants::GenericWithoutRuntime());
+    static std::unique_ptr<parser::Node> SorbetPrivateStaticSyntheticGeneric(core::LocOffsets loc) {
+        return Const(loc, SorbetPrivateStatic(loc), core::Names::Constants::SyntheticGeneric());
     }
 
     /*

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -349,9 +349,30 @@ public:
      * Is `expr` a `T` or `::T` constant node?
      */
     static bool isT(const std::unique_ptr<parser::Node> &expr) {
+        if (expr == nullptr) {
+            return false;
+        }
+
         auto t = parser::cast_node<parser::Const>(expr.get());
         return t != nullptr && t->name == core::Names::Constants::T() &&
                (t->scope == nullptr || isa_node<parser::Cbase>(t->scope.get()));
+    }
+
+    /*
+     * Is `expr` a constant node that is rooted on `::T`?
+     */
+    static bool isTRooted(const std::unique_ptr<parser::Node> &expr) {
+        if (expr == nullptr) {
+            return false;
+        }
+
+        auto constant = parser::cast_node<parser::Const>(expr.get());
+
+        if (isT(constant->scope)) {
+            return true;
+        }
+
+        return isTRooted(constant->scope);
     }
 
     /*

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -182,13 +182,6 @@ public:
     }
 
     /*
-     * Create a `Sorbet::Private::Static::SyntheticGeneric` constant node.
-     */
-    static std::unique_ptr<parser::Node> SorbetPrivateStaticSyntheticGeneric(core::LocOffsets loc) {
-        return Const(loc, SorbetPrivateStatic(loc), core::Names::Constants::SyntheticGeneric());
-    }
-
-    /*
      * Create a `T::Hash` constant node.
      */
     static std::unique_ptr<parser::Node> T_Hash(core::LocOffsets loc) {

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -366,27 +366,6 @@ public:
     }
 
     /*
-     * Is `expr` a constant node that is rooted on `::T`?
-     */
-    static bool isTRooted(const std::unique_ptr<parser::Node> &expr) {
-        if (expr == nullptr) {
-            return false;
-        }
-
-        auto constant = parser::cast_node<parser::Const>(expr.get());
-
-        if (constant == nullptr) {
-            return false;
-        }
-
-        if (isT(constant->scope)) {
-            return true;
-        }
-
-        return isTRooted(constant->scope);
-    }
-
-    /*
      * Is `expr` a `T.untyped()` or `::T.untyped()` send node?
      */
     static bool isTUntyped(const std::unique_ptr<parser::Node> &expr) {

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -220,7 +220,11 @@ module T
   def self.absurd(value); end
 end
 
+module T::GenericWithoutRuntime
+end
+
 module T::Generic
+  include T::GenericWithoutRuntime
   include T::Helpers
 
   # Type syntax for declaring a generic type variable scoped to instances of

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -220,11 +220,7 @@ module T
   def self.absurd(value); end
 end
 
-module T::GenericWithoutRuntime
-end
-
 module T::Generic
-  include T::GenericWithoutRuntime
   include T::Helpers
 
   # Type syntax for declaring a generic type variable scoped to instances of

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -198,8 +198,8 @@ bool sameConstant(core::MutableContext ctx, unique_ptr<parser::Node> &a, unique_
     return (aConst->scope == nullptr && bConst->scope == nullptr) || sameConstant(ctx, aConst->scope, bConst->scope);
 }
 
-void maybeInsertGenericInstantiationCast(core::MutableContext ctx, unique_ptr<parser::Node> *node,
-                                         unique_ptr<parser::Node> *type) {
+void maybeSupplyGenericTypeArguments(core::MutableContext ctx, unique_ptr<parser::Node> *node,
+                                     unique_ptr<parser::Node> *type) {
     // We only rewrite `.new` calls
     auto newSend = parser::cast_node<parser::Send>(node->get());
     if (newSend == nullptr || newSend->method != core::Names::new_()) {
@@ -453,7 +453,7 @@ AssertionsRewriter::insertCast(unique_ptr<parser::Node> node,
     auto type = move(pair->first);
     auto kind = pair->second;
 
-    maybeInsertGenericInstantiationCast(ctx, &node, &type);
+    maybeSupplyGenericTypeArguments(ctx, &node, &type);
 
     if (kind == InlineComment::Kind::LET) {
         return parser::MK::TLet(type->loc, move(node), move(type));

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -178,6 +178,48 @@ vector<pair<core::LocOffsets, core::NameRef>> extractTypeParams(parser::Node *si
     return typeParams;
 }
 
+bool sameConstant(core::MutableContext ctx, unique_ptr<parser::Node> &a, unique_ptr<parser::Node> &b) {
+    auto aConst = parser::cast_node<parser::Const>(a.get());
+    auto bConst = parser::cast_node<parser::Const>(b.get());
+
+    if (aConst == nullptr || bConst == nullptr) {
+        return false;
+    }
+
+    if (aConst->name != bConst->name) {
+        return false;
+    }
+
+    if ((aConst->scope == nullptr && bConst->scope != nullptr) ||
+        (aConst->scope != nullptr && bConst->scope == nullptr)) {
+        return false;
+    }
+
+    return (aConst->scope == nullptr && bConst->scope == nullptr) || sameConstant(ctx, aConst->scope, bConst->scope);
+}
+
+void maybeInsertGenericInstantiationCast(core::MutableContext ctx, unique_ptr<parser::Node> *node,
+                                         unique_ptr<parser::Node> *type) {
+    // We only rewrite `.new` calls
+    auto newSend = parser::cast_node<parser::Send>(node->get());
+    if (newSend == nullptr || newSend->method != core::Names::new_()) {
+        return;
+    }
+
+    // We only rewrite when casted to a generic type
+    auto bracketSend = parser::cast_node<parser::Send>(type->get());
+    if (bracketSend == nullptr || bracketSend->method != core::Names::syntheticSquareBrackets()) {
+        return;
+    }
+
+    // We only rewrite when the generic type is the same as the instantiated one
+    if (!sameConstant(ctx, newSend->receiver, bracketSend->receiver)) {
+        return;
+    }
+
+    newSend->receiver = type->get()->deepCopy();
+}
+
 } // namespace
 
 /**
@@ -410,6 +452,8 @@ AssertionsRewriter::insertCast(unique_ptr<parser::Node> node,
 
     auto type = move(pair->first);
     auto kind = pair->second;
+
+    maybeInsertGenericInstantiationCast(ctx, &node, &type);
 
     if (kind == InlineComment::Kind::LET) {
         return parser::MK::TLet(type->loc, move(node), move(type));

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -30,7 +30,7 @@ private:
     static const std::string_view MULTILINE_RBS_PREFIX;
 
     void walkNodes(parser::Node *node);
-    void associateCommentsToNode(parser::Node *node, absl::Span<const std::string_view> prefixes);
+    void associateCommentsToNode(parser::Node *node);
     void associateInlineCommentToNode(parser::Node *node);
     void consumeCommentsUntilLine(int line);
 };

--- a/rbs/Parser.cc
+++ b/rbs/Parser.cc
@@ -33,6 +33,18 @@ std::string_view Parser::resolveConstant(const rbs_ast_symbol_t *symbol) const {
     return std::string_view(reinterpret_cast<const char *>(constant->start), constant->length);
 }
 
+std::string_view Parser::resolveKeyword(const rbs_keyword_t *keyword) const {
+    auto constant = rbs_constant_pool_id_to_constant(RBS_GLOBAL_CONSTANT_POOL, keyword->constant_id);
+    return std::string_view(reinterpret_cast<const char *>(constant->start), constant->length);
+}
+
+rbs_node_list_t *Parser::parseTypeParams() {
+    rbs_node_list_t *typeParams;
+    auto moduleParams = true;
+    rbs_parse_type_params(parser.get(), moduleParams, &typeParams);
+    return typeParams;
+}
+
 rbs_method_type_t *Parser::parseMethodType() {
     rbs_method_type_t *methodType = nullptr;
     rbs_parse_method_type(parser.get(), &methodType);

--- a/rbs/Parser.h
+++ b/rbs/Parser.h
@@ -14,7 +14,9 @@ public:
     Parser(rbs_string_t rbsString, const rbs_encoding_t *encoding);
 
     std::string_view resolveConstant(const rbs_ast_symbol_t *symbol) const;
+    std::string_view resolveKeyword(const rbs_keyword_t *keyword) const;
 
+    rbs_node_list_t *parseTypeParams();
     rbs_method_type_t *parseMethodType();
     rbs_node_t *parseType();
 

--- a/rbs/SignatureTranslator.h
+++ b/rbs/SignatureTranslator.h
@@ -24,6 +24,8 @@ public:
 
     std::unique_ptr<parser::Node> translateType(const RBSDeclaration &declaration);
 
+    parser::NodeVec translateTypeParams(const RBSDeclaration &declaration);
+
 private:
     core::MutableContext ctx;
 };

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -237,7 +237,7 @@ void SigsRewriter::insertTypeParams(parser::Node *node, unique_ptr<parser::Node>
 
     auto send =
         parser::MK::Send1(signature.commentLoc(), parser::MK::Self(signature.commentLoc()), core::Names::extend(),
-                          signature.commentLoc(), parser::MK::T_GenericWithoutRuntime(signature.commentLoc()));
+                          signature.commentLoc(), parser::MK::SorbetPrivateStaticSyntheticGeneric(signature.commentLoc()));
 
     begin->stmts.emplace_back(move(send));
 

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -235,12 +235,6 @@ void SigsRewriter::insertTypeParams(parser::Node *node, unique_ptr<parser::Node>
     auto begin = parser::cast_node<parser::Begin>(body->get());
     ENFORCE(begin != nullptr);
 
-    auto send =
-        parser::MK::Send1(signature.commentLoc(), parser::MK::Self(signature.commentLoc()), core::Names::extend(),
-                          signature.commentLoc(), parser::MK::SorbetPrivateStaticSyntheticGeneric(signature.commentLoc()));
-
-    begin->stmts.emplace_back(move(send));
-
     for (auto &typeParam : typeParams) {
         begin->stmts.emplace_back(move(typeParam));
     }

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -6,6 +6,7 @@
 #include "core/errors/rewriter.h"
 #include "parser/helper.h"
 #include "rbs/SignatureTranslator.h"
+#include "rbs/TypeParamsToParserNodes.h"
 
 using namespace std;
 
@@ -205,6 +206,46 @@ void insertHelpers(unique_ptr<parser::Node> *body, parser::NodeVec helpers) {
 
 } // namespace
 
+void SigsRewriter::insertTypeParams(parser::Node *node, unique_ptr<parser::Node> *body) {
+    ENFORCE(parser::isa_node<parser::Class>(node) || parser::isa_node<parser::Module>(node) ||
+                parser::isa_node<parser::SClass>(node),
+            "Unimplemented node type: {}", node->nodeName());
+
+    auto comments = commentsForNode(node);
+    if (comments.signatures.empty()) {
+        return;
+    }
+
+    if (comments.signatures.size() > 1) {
+        if (auto e = ctx.beginError(comments.signatures[0].commentLoc(),
+                                    core::errors::Rewriter::RBSMultipleGenericSignatures)) {
+            e.setHeader("Generic classes and modules can only have one RBS generic signature");
+            return;
+        }
+    }
+
+    auto signature = comments.signatures[0];
+    auto typeParamsTranslator = SignatureTranslator(ctx);
+    auto typeParams = typeParamsTranslator.translateTypeParams(signature);
+
+    if (typeParams.empty()) {
+        return;
+    }
+
+    auto begin = parser::cast_node<parser::Begin>(body->get());
+    ENFORCE(begin != nullptr);
+
+    auto send =
+        parser::MK::Send1(signature.commentLoc(), parser::MK::Self(signature.commentLoc()), core::Names::extend(),
+                          signature.commentLoc(), parser::MK::T_GenericWithoutRuntime(signature.commentLoc()));
+
+    begin->stmts.emplace_back(move(send));
+
+    for (auto &typeParam : typeParams) {
+        begin->stmts.emplace_back(move(typeParam));
+    }
+}
+
 Comments SigsRewriter::commentsForNode(parser::Node *node) {
     auto comments = Comments{};
     enum class SignatureState { None, Started, Multiline };
@@ -371,12 +412,9 @@ unique_ptr<parser::Node> SigsRewriter::rewriteClass(unique_ptr<parser::Node> nod
     }
 
     auto comments = commentsForNode(node.get());
-    if (comments.annotations.empty()) {
-        return node;
-    }
-
     auto helpers = extractHelpers(ctx, comments.annotations);
-    if (helpers.empty()) {
+
+    if (helpers.empty() && comments.signatures.empty()) {
         return node;
     }
 
@@ -384,18 +422,27 @@ unique_ptr<parser::Node> SigsRewriter::rewriteClass(unique_ptr<parser::Node> nod
         node.get(),
         [&](parser::Class *klass) {
             klass->body = maybeWrapBody(node, move(klass->body));
-            maybeInsertExtendTHelpers(&klass->body);
-            insertHelpers(&klass->body, move(helpers));
+            if (!helpers.empty()) {
+                maybeInsertExtendTHelpers(&klass->body);
+                insertHelpers(&klass->body, move(helpers));
+            }
+            insertTypeParams(klass, &klass->body);
         },
         [&](parser::Module *module) {
             module->body = maybeWrapBody(node, move(module->body));
-            maybeInsertExtendTHelpers(&module->body);
-            insertHelpers(&module->body, move(helpers));
+            if (!helpers.empty()) {
+                maybeInsertExtendTHelpers(&module->body);
+                insertHelpers(&module->body, move(helpers));
+            }
+            insertTypeParams(module, &module->body);
         },
         [&](parser::SClass *sclass) {
             sclass->body = maybeWrapBody(node, move(sclass->body));
-            maybeInsertExtendTHelpers(&sclass->body);
-            insertHelpers(&sclass->body, move(helpers));
+            if (!helpers.empty()) {
+                maybeInsertExtendTHelpers(&sclass->body);
+                insertHelpers(&sclass->body, move(helpers));
+            }
+            insertTypeParams(sclass, &sclass->body);
         },
         [&](parser::Node *other) { Exception::raise("Unimplemented node type: {}", other->nodeName()); });
 

--- a/rbs/SigsRewriter.h
+++ b/rbs/SigsRewriter.h
@@ -44,6 +44,7 @@ private:
     parser::NodeVec rewriteNodes(parser::NodeVec nodes);
     std::unique_ptr<parser::NodeVec> signaturesForNode(parser::Node *node);
     Comments commentsForNode(parser::Node *node);
+    void insertTypeParams(parser::Node *node, std::unique_ptr<parser::Node> *body);
 };
 
 } // namespace sorbet::rbs

--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -29,8 +29,7 @@ parser::NodeVec TypeParamsToParserNode::typeParams(const rbs_node_list_t *rbsTyp
         }
 
         auto nameStr = parser.resolveConstant(rbsTypeParam->name);
-        auto nameUTF8 = ctx.state.enterNameUTF8(nameStr);
-        auto nameConstant = ctx.state.enterNameConstant(nameUTF8);
+        auto nameConstant = ctx.state.enterNameConstant(nameStr);
 
         auto args = parser::NodeVec();
         if (rbsTypeParam->variance) {

--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -1,0 +1,75 @@
+#include "rbs/TypeParamsToParserNodes.h"
+
+#include "core/errors/rewriter.h"
+#include "parser/helper.h"
+#include "parser/parser.h"
+#include "rbs/TypeToParserNode.h"
+#include "rbs/rbs_common.h"
+
+using namespace std;
+
+namespace sorbet::rbs {
+
+parser::NodeVec TypeParamsToParserNode::typeParams(const rbs_node_list_t *rbsTypeParams,
+                                                   const RBSDeclaration &declaration) {
+    parser::NodeVec result;
+
+    for (rbs_node_list_node_t *list_node = rbsTypeParams->head; list_node != nullptr; list_node = list_node->next) {
+        ENFORCE(list_node->node->type == RBS_AST_TYPE_PARAM,
+                "Unexpected node type `{}` in type parameter list, expected `{}`", rbs_node_type_name(list_node->node),
+                "TypeParam");
+
+        auto rbsTypeParam = (rbs_ast_type_param_t *)list_node->node;
+        auto loc = declaration.typeLocFromRange(list_node->node->location->rg);
+
+        if (rbsTypeParam->unchecked) {
+            if (auto e = ctx.beginError(loc, core::errors::Rewriter::RBSUnsupported)) {
+                e.setHeader("`{}` type parameters are not supported by Sorbet", "unchecked");
+            }
+        }
+
+        auto nameStr = parser.resolveConstant(rbsTypeParam->name);
+        auto nameUTF8 = ctx.state.enterNameUTF8(nameStr);
+        auto nameConstant = ctx.state.enterNameConstant(nameUTF8);
+
+        auto args = parser::NodeVec();
+        if (rbsTypeParam->variance) {
+            auto variance = parser.resolveKeyword(rbsTypeParam->variance);
+            if (variance == "covariant") {
+                args.emplace_back(parser::MK::Symbol(loc, core::Names::covariant()));
+            } else if (variance == "contravariant") {
+                args.emplace_back(parser::MK::Symbol(loc, core::Names::contravariant()));
+            }
+        }
+
+        auto typeConst = parser::MK::Const(loc, nullptr, nameConstant);
+        auto typeSend = parser::MK::Send(loc, parser::MK::Self(loc), core::Names::syntheticTypeMember(), loc, move(args));
+
+        if (rbsTypeParam->default_type || rbsTypeParam->upper_bound) {
+            auto typeTranslator = TypeToParserNode(ctx, vector<pair<core::LocOffsets, core::NameRef>>(), parser);
+            auto pairs = parser::NodeVec();
+
+            if (rbsTypeParam->default_type) {
+                pairs.emplace_back(
+                    make_unique<parser::Pair>(loc, parser::MK::Symbol(loc, core::Names::fixed()),
+                                              typeTranslator.toParserNode(rbsTypeParam->default_type, declaration)));
+            }
+
+            if (rbsTypeParam->upper_bound) {
+                pairs.emplace_back(
+                    make_unique<parser::Pair>(loc, parser::MK::Symbol(loc, core::Names::upper()),
+                                              typeTranslator.toParserNode(rbsTypeParam->upper_bound, declaration)));
+            }
+
+            auto body = parser::MK::Hash(loc, false, move(pairs));
+            typeSend = make_unique<parser::Block>(loc, move(typeSend), nullptr, move(body));
+        }
+
+        auto assign = make_unique<parser::Assign>(loc, move(typeConst), move(typeSend));
+        result.emplace_back(move(assign));
+    }
+
+    return result;
+}
+
+} // namespace sorbet::rbs

--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -42,7 +42,8 @@ parser::NodeVec TypeParamsToParserNode::typeParams(const rbs_node_list_t *rbsTyp
         }
 
         auto typeConst = parser::MK::Const(loc, nullptr, nameConstant);
-        auto typeSend = parser::MK::Send(loc, parser::MK::Self(loc), core::Names::syntheticTypeMember(), loc, move(args));
+        auto typeSend =
+            parser::MK::Send(loc, parser::MK::SorbetPrivateStatic(loc), core::Names::typeMember(), loc, move(args));
 
         if (rbsTypeParam->default_type || rbsTypeParam->upper_bound) {
             auto typeTranslator = TypeToParserNode(ctx, vector<pair<core::LocOffsets, core::NameRef>>(), parser);

--- a/rbs/TypeParamsToParserNodes.h
+++ b/rbs/TypeParamsToParserNodes.h
@@ -1,0 +1,21 @@
+#ifndef RBS_TYPE_PARAMS_TO_PARSER_NODE_H
+#define RBS_TYPE_PARAMS_TO_PARSER_NODE_H
+
+#include "parser/parser.h"
+#include "rbs/rbs_common.h"
+
+namespace sorbet::rbs {
+
+class TypeParamsToParserNode {
+    core::MutableContext ctx;
+    Parser parser;
+
+public:
+    TypeParamsToParserNode(core::MutableContext ctx, Parser parser) : ctx(ctx), parser(parser) {}
+
+    parser::NodeVec typeParams(const rbs_node_list_t *rbsTypeParams, const RBSDeclaration &declaration);
+};
+
+} // namespace sorbet::rbs
+
+#endif // RBS_METHOD_TYPE_TO_PARSER_NODE_H

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -101,7 +101,12 @@ unique_ptr<parser::Node> TypeToParserNode::classInstanceType(const rbs_types_cla
             args.emplace_back(move(argType));
         }
 
-        return parser::MK::Send(loc, move(typeConstant), core::Names::squareBrackets(), loc, move(args));
+        auto method = core::Names::syntheticSquareBrackets();
+        if (parser::MK::isTRooted(typeConstant)) {
+            method = core::Names::squareBrackets();
+        }
+
+        return parser::MK::Send(loc, move(typeConstant), method, loc, move(args));
     }
 
     return typeConstant;

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -101,12 +101,7 @@ unique_ptr<parser::Node> TypeToParserNode::classInstanceType(const rbs_types_cla
             args.emplace_back(move(argType));
         }
 
-        auto method = core::Names::syntheticSquareBrackets();
-        if (parser::MK::isTRooted(typeConstant)) {
-            method = core::Names::squareBrackets();
-        }
-
-        return parser::MK::Send(loc, move(typeConstant), method, loc, move(args));
+        return parser::MK::Send(loc, move(typeConstant), core::Names::syntheticSquareBrackets(), loc, move(args));
     }
 
     return typeConstant;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2692,7 +2692,6 @@ public:
             case core::Names::typeAlias().rawId():
             case core::Names::typeMember().rawId():
             case core::Names::typeTemplate().rawId():
-            case core::Names::syntheticTypeMember().rawId():
                 break;
 
             default:
@@ -2798,7 +2797,6 @@ public:
             case core::Names::typeMember().rawId():
             case core::Names::typeTemplate().rawId():
             case core::Names::typeAlias().rawId():
-            case core::Names::syntheticTypeMember().rawId():
                 trackDependencies_ = false;
                 break;
 
@@ -2920,11 +2918,12 @@ public:
         auto sym = id->symbol();
         auto send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send && (sym.isTypeAlias(ctx) || sym.isTypeMember())) {
-            ENFORCE(!sym.isTypeMember() || send->recv.isSelfReference());
+            ENFORCE(!sym.isTypeMember() ||
+                    (send->recv.isSelfReference() || ast::MK::isSorbetPrivateStatic(send->recv)));
 
             if ((sym.isTypeAlias(ctx) && send->fun != core::Names::typeAlias()) ||
                 (sym.isTypeMember() && send->fun != core::Names::typeMember() &&
-                 send->fun != core::Names::typeTemplate() && send->fun != core::Names::syntheticTypeMember())) {
+                 send->fun != core::Names::typeTemplate())) {
                 // This is a reassignment of a constant that was declared as a type member or a type alias.
                 // The redefinition error is reported elsewhere.
                 return;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2692,6 +2692,7 @@ public:
             case core::Names::typeAlias().rawId():
             case core::Names::typeMember().rawId():
             case core::Names::typeTemplate().rawId():
+            case core::Names::syntheticTypeMember().rawId():
                 break;
 
             default:
@@ -2797,6 +2798,7 @@ public:
             case core::Names::typeMember().rawId():
             case core::Names::typeTemplate().rawId():
             case core::Names::typeAlias().rawId():
+            case core::Names::syntheticTypeMember().rawId():
                 trackDependencies_ = false;
                 break;
 
@@ -2922,7 +2924,7 @@ public:
 
             if ((sym.isTypeAlias(ctx) && send->fun != core::Names::typeAlias()) ||
                 (sym.isTypeMember() && send->fun != core::Names::typeMember() &&
-                 send->fun != core::Names::typeTemplate())) {
+                 send->fun != core::Names::typeTemplate() && send->fun != core::Names::syntheticTypeMember())) {
                 // This is a reassignment of a constant that was declared as a type member or a type alias.
                 // The redefinition error is reported elsewhere.
                 return;

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1347,7 +1347,8 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
 
             appliedKlass = recvi->symbol();
         } else if (auto recvi = ast::cast_tree<ast::Send>(s.recv)) {
-            if (recvi->fun != core::Names::classOf() || s.fun != core::Names::squareBrackets()) {
+            if (recvi->fun != core::Names::classOf() ||
+                (s.fun != core::Names::squareBrackets() && s.fun != core::Names::syntheticSquareBrackets())) {
                 return reportUnknownTypeSyntaxError(ctx, s, move(result));
             }
 
@@ -1366,7 +1367,7 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
             return reportUnknownTypeSyntaxError(ctx, s, move(result));
         }
 
-        if (s.fun != core::Names::squareBrackets()) {
+        if (s.fun != core::Names::squareBrackets() && s.fun != core::Names::syntheticSquareBrackets()) {
             return reportUnknownTypeSyntaxError(ctx, s, move(result));
         }
 

--- a/rewriter/TypeMembers.cc
+++ b/rewriter/TypeMembers.cc
@@ -21,8 +21,7 @@ void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
 
         auto rhs = ast::cast_tree<ast::Send>(assn->rhs);
         if (!rhs || !rhs->recv.isSelfReference() ||
-            (rhs->fun != core::Names::typeMember() && rhs->fun != core::Names::typeTemplate() &&
-             rhs->fun != core::Names::syntheticTypeMember())) {
+            (rhs->fun != core::Names::typeMember() && rhs->fun != core::Names::typeTemplate())) {
             continue;
         }
 
@@ -34,7 +33,7 @@ void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
         auto it = typeMembers.find(lhs->cnst);
         if (it != typeMembers.end()) {
             if (auto e = ctx.beginIndexerError(lhs->loc, core::errors::Namer::InvalidTypeDefinition)) {
-                auto memTem = rhs->fun == core::Names::typeTemplate() ? "template" : "member";
+                auto memTem = rhs->fun == core::Names::typeMember() ? "member" : "template";
                 e.setHeader("Duplicate type {} `{}`", memTem, lhs->cnst.show(ctx));
                 e.addErrorLine(ctx.locAt(it->second), "Previous definition");
                 e.replaceWith(fmt::format("Delete duplicate type {}", memTem), ctx.locAt(expr.loc()), "");

--- a/rewriter/TypeMembers.cc
+++ b/rewriter/TypeMembers.cc
@@ -21,7 +21,8 @@ void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
 
         auto rhs = ast::cast_tree<ast::Send>(assn->rhs);
         if (!rhs || !rhs->recv.isSelfReference() ||
-            (rhs->fun != core::Names::typeMember() && rhs->fun != core::Names::typeTemplate())) {
+            (rhs->fun != core::Names::typeMember() && rhs->fun != core::Names::typeTemplate() &&
+             rhs->fun != core::Names::syntheticTypeMember())) {
             continue;
         }
 
@@ -33,7 +34,7 @@ void TypeMembers::run(core::MutableContext ctx, ast::ClassDef *cdef) {
         auto it = typeMembers.find(lhs->cnst);
         if (it != typeMembers.end()) {
             if (auto e = ctx.beginIndexerError(lhs->loc, core::errors::Namer::InvalidTypeDefinition)) {
-                auto memTem = rhs->fun == core::Names::typeMember() ? "member" : "template";
+                auto memTem = rhs->fun == core::Names::typeTemplate() ? "template" : "member";
                 e.setHeader("Duplicate type {} `{}`", memTem, lhs->cnst.show(ctx));
                 e.addErrorLine(ctx.locAt(it->second), "Previous definition");
                 e.replaceWith(fmt::format("Delete duplicate type {}", memTem), ctx.locAt(expr.loc()), "");

--- a/test/testdata/rbs/assertions_array.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_array.rb.rewrite-tree.exp
@@ -1,30 +1,30 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  arr1 = [<cast:cast>(1, <todo sym>, <emptyTree>::<C String>), <cast:cast>(2, <todo sym>, <emptyTree>::<C String>), <cast:cast>([<cast:cast>(3, <todo sym>, <emptyTree>::<C String>)], <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C Integer>))]
+  arr1 = [<cast:cast>(1, <todo sym>, <emptyTree>::<C String>), <cast:cast>(2, <todo sym>, <emptyTree>::<C String>), <cast:cast>([<cast:cast>(3, <todo sym>, <emptyTree>::<C String>)], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))]
 
   <emptyTree>::<C T>.reveal_type(arr1)
 
-  <cast:let>([1, 2], <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C Integer>))
+  <cast:let>([1, 2], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
 
-  arr2 = <cast:let>([], <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C Integer>))
+  arr2 = <cast:let>([], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
 
   <emptyTree>::<C T>.reveal_type(arr2)
 
-  arr3 = <cast:let>(::<Magic>.<splat>(arr2), <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C Integer>))
+  arr3 = <cast:let>(::<Magic>.<splat>(arr2), <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
 
   <emptyTree>::<C T>.reveal_type(arr3)
 
-  arr4 = ::<Magic>.<splat>(<cast:cast>(arr2, <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
+  arr4 = ::<Magic>.<splat>(<cast:cast>(arr2, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)))
 
   <emptyTree>::<C T>.reveal_type(arr4)
 
   arr5 = <cast:let>([begin
       <hashTemp>$2 = ::<Magic>.<to-hash-dup>({:a => 1})
       <hashTemp>$2
-    end], <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>)))
+    end], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>)))
 
   <emptyTree>::<C T>.reveal_type(arr5)
 
-  arr_nil = <cast:let>({}, <todo sym>, ::<root>::<C T>.nilable(::<root>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>)))
+  arr_nil = <cast:let>({}, <todo sym>, ::<root>::<C T>.nilable(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>)))
 
   arr6 = [begin
       <hashTemp>$5 = ::<Magic>.<to-hash-dup>(::<root>::<C T>.must(arr_nil))

--- a/test/testdata/rbs/assertions_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_assign.rb.rewrite-tree.exp
@@ -58,7 +58,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     else
       []
     end
-  end, <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+  end, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
 
   <emptyTree>::<C T>.reveal_type(@let2)
 

--- a/test/testdata/rbs/assertions_break.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_break.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   while <emptyTree>::<C ARGV>.any?()
-    break(<cast:let>([<emptyTree>::<C ARGV>.shift(), "foo"], <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
+    break(<cast:let>([<emptyTree>::<C ARGV>.shift(), "foo"], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)))
   end
 
   while <emptyTree>::<C ARGV>.shift()

--- a/test/testdata/rbs/assertions_csend_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_csend_assign.rb.rewrite-tree.exp
@@ -64,7 +64,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     if ::NilClass.===(<assignTemp>$5)
       ::<Magic>.<nil-for-safe-navigation>(<assignTemp>$5)
     else
-      <assignTemp>$5.foo=(<cast:let>(["foo", "bar"], <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
+      <assignTemp>$5.foo=(<cast:let>(["foo", "bar"], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)))
     end
   end
 end

--- a/test/testdata/rbs/assertions_for.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_for.rb.rewrite-tree.exp
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>)).each() do |x|
+  <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)).each() do |x|
     <emptyTree>
   end
 

--- a/test/testdata/rbs/assertions_hash.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_hash.rb.rewrite-tree.exp
@@ -3,28 +3,28 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <emptyTree>::<C T>.reveal_type(hash1)
 
-  <cast:let>({:a => 1, :b => 2}, <todo sym>, ::<root>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>))
+  <cast:let>({:a => 1, :b => 2}, <todo sym>, ::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>))
 
-  hash2 = <cast:let>({}, <todo sym>, ::<root>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>))
+  hash2 = <cast:let>({}, <todo sym>, ::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>))
 
   <emptyTree>::<C T>.reveal_type(hash2)
 
   hash3 = <cast:let>(begin
     <hashTemp>$6 = ::<Magic>.<to-hash-dup>(hash2)
     <hashTemp>$6
-  end, <todo sym>, ::<root>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>))
+  end, <todo sym>, ::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, <emptyTree>::<C Integer>))
 
   <emptyTree>::<C T>.reveal_type(hash3)
 
   hash4 = begin
-    <hashTemp>$7 = ::<Magic>.<to-hash-dup>(<cast:cast>(hash2, <todo sym>, ::<root>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>)))
+    <hashTemp>$7 = ::<Magic>.<to-hash-dup>(<cast:cast>(hash2, <todo sym>, ::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, <emptyTree>::<C String>)))
     <hashTemp>$7
   end
 
   <emptyTree>::<C T>.reveal_type(hash4)
 
   hash5 = begin
-    <hashTemp>$8 = ::<Magic>.<to-hash-dup>(<cast:cast>(hash2, <todo sym>, ::<root>::<C T>::<C Hash>.[](<emptyTree>::<C Symbol>, <emptyTree>::<C String>)))
+    <hashTemp>$8 = ::<Magic>.<to-hash-dup>(<cast:cast>(hash2, <todo sym>, ::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, <emptyTree>::<C String>)))
     <hashTemp>$8
   end
 

--- a/test/testdata/rbs/assertions_massign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_massign.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   begin
-    <assignTemp>$2 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+    <assignTemp>$2 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
     <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 1, 0)
     let1 = <assignTemp>$3.[](0)
     let2 = <assignTemp>$3.to_ary()
@@ -12,7 +12,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(let2)
 
   begin
-    <assignTemp>$4 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+    <assignTemp>$4 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
     <assignTemp>$5 = ::<Magic>.<expand-splat>(<assignTemp>$4, 1, 0)
     let3 = <assignTemp>$5.[](0)
     let4 = <assignTemp>$5.to_ary()
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(let4)
 
   begin
-    <assignTemp>$6 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+    <assignTemp>$6 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
     <assignTemp>$7 = ::<Magic>.<expand-splat>(<assignTemp>$6, 1, 0)
     let5 = <assignTemp>$7.[](0)
     let6 = <assignTemp>$7.to_ary()
@@ -41,7 +41,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     let7 = <assignTemp>$9.[](0)
     let8 = <assignTemp>$9.to_ary()
     <assignTemp>$8
-  end, <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>))
+  end, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
 
   <emptyTree>::<C T>.reveal_type(let7)
 

--- a/test/testdata/rbs/assertions_next.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_next.rb.rewrite-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   while <emptyTree>::<C ARGV>.any?()
-    next(<cast:let>([<emptyTree>::<C ARGV>.shift(), "foo"], <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
+    next(<cast:let>([<emptyTree>::<C ARGV>.shift(), "foo"], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)))
   end
 
   while <emptyTree>::<C ARGV>.shift()

--- a/test/testdata/rbs/assertions_send.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_send.rb.rewrite-tree.exp
@@ -11,11 +11,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <self>.puts(<cast:cast>(42, <todo sym>, <emptyTree>::<C String>), <cast:cast>(42, <todo sym>, <emptyTree>::<C String>))
 
-  arr_nil = <cast:let>(nil, <todo sym>, ::<root>::<C T>.nilable(::<root>::<C T>::<C Array>.[](::<root>::<C T>.untyped())))
+  arr_nil = <cast:let>(nil, <todo sym>, ::<root>::<C T>.nilable(::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(::<root>::<C T>.untyped())))
 
   ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :puts, ::<Magic>.<splat>(::<root>::<C T>.must(arr_nil)).concat(::<Magic>.<splat>(::<root>::<C T>.must(arr_nil))), nil)
 
-  hash_nil = <cast:let>(nil, <todo sym>, ::<root>::<C T>.nilable(::<root>::<C T>::<C Hash>.[](::<root>::<C T>.untyped(), ::<root>::<C T>.untyped())))
+  hash_nil = <cast:let>(nil, <todo sym>, ::<root>::<C T>.nilable(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(::<root>::<C T>.untyped(), ::<root>::<C T>.untyped())))
 
   <self>.puts(begin
       <hashTemp>$2 = ::<Magic>.<to-hash-dup>(::<root>::<C T>.must(hash_nil))

--- a/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
@@ -35,7 +35,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   let3 = <emptyTree>::<C Let>.new()
 
-  let3.foo().foo=(<cast:let>(["foo", "bar"], <todo sym>, ::<root>::<C T>::<C Array>.[](<emptyTree>::<C String>)))
+  let3.foo().foo=(<cast:let>(["foo", "bar"], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)))
 
   <emptyTree>::<C T>.reveal_type(let3.foo())
 end

--- a/test/testdata/rbs/assertions_type_params.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_type_params.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     begin
       x = <cast:let>(a, <todo sym>, ::<root>::<C T>.type_parameter(:A))
       <emptyTree>::<C T>.reveal_type(x)
-      y = <cast:let>([], <todo sym>, ::<root>::<C T>::<C Array>.[](::<root>::<C T>.type_parameter(:B)))
+      y = <cast:let>([], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(::<root>::<C T>.type_parameter(:B)))
       <emptyTree>::<C T>.reveal_type(y)
       z = <cast:let>(nil, <todo sym>, ::<root>::<C T>.nilable(::<root>::<C T>.type_parameter(:C)))
       <emptyTree>::<C T>.reveal_type(z)

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -250,7 +250,6 @@ def method24(x)
 end
 
 class UnusedTypeAnnotation
-  #: -> void # error: Unused RBS signature comment. No method definition found after it
   class Inner
     def foo; end # error: The method `foo` does not have a `sig`
   end

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -266,7 +266,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.[](::<root>::<C T>.type_parameter(:X)))
+    <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(::<root>::<C T>.type_parameter(:X)))
   end
 
   def method19<<todo method>>(x, &<blk>)

--- a/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
@@ -72,7 +72,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.[](<emptyTree>::<C Y>))
+    <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Y>))
   end
 
   def method_with_missing_type_2<<todo method>>(x, &<blk>)
@@ -161,7 +161,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.[](::<root>::<C T>.type_parameter(:X)))
+    <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(::<root>::<C T>.type_parameter(:X)))
   end
 
   def method19<<todo method>>(x, &<blk>)

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -76,6 +76,16 @@ T.reveal_type(g2_1) # error: Revealed type: `G2[Integer, String]`
 
 g2_1.v = 2 # error: Assigning a value to `v` that does not match expected type `String`
 
+g2_2 = G2 #: Class[G2[Integer, String]]
+   .new(1, 2) #: G2[Numeric, String]
+#          ^ error: Expected `String` but found `Integer(2)` for argument `v`
+T.reveal_type(g2_2) # error: Revealed type: `G2[Numeric, String]`
+
+g2_3 = G2 #: Class[G2[Integer, String]]
+   .new(1, 2) #: G2[Integer, String]?
+#          ^ error: Expected `String` but found `Integer(2)` for argument `v`
+T.reveal_type(g2_3) # error: Revealed type: `T.nilable(G2[Integer, String])`
+
 #: [in U, out V]
 class G3
   #: U

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -103,7 +103,6 @@ T.reveal_type(g4) # error: Revealed type: `G4[T.untyped]`
 #     ^ error: Failed to parse RBS type parameters (expected a token `tUIDENT`)
 class G5; end
 
-
 #: [U]
 class G6; end
 

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -1,0 +1,154 @@
+# typed: strict
+# enable-experimental-rbs-signatures: true
+# enable-experimental-rbs-assertions: true
+
+module Errors
+  #:
+  # ^ error: Failed to parse RBS type parameters (expected a token `pLBRACKET`)
+  class ParseError1; end
+
+  #: -> void
+  #  ^^ error: Failed to parse RBS type parameters (expected a token `pLBRACKET`)
+  class ParseError2; end
+
+  #: [
+  # ^^ error: Failed to parse RBS type parameters (expected a token `tUIDENT`)
+  class ParseError3; end
+
+  #: [T
+  # ^^^ error: Failed to parse RBS type parameters (expected a token `tUIDENT`)
+  class ParseError4; end
+
+  #: [unchecked T]
+  #   ^^^^^^^^^^^ error: `unchecked` type parameters are not supported by Sorbet
+  class UnsupportedError1; end
+end
+
+#: [U]
+class G1; end
+
+g1_1 = G1.new
+T.reveal_type(g1_1) # error: Revealed type: `G1[T.untyped]`
+
+g1_2 = G1.new #: G1[Integer]
+T.reveal_type(g1_2) # error: Revealed type: `G1[Integer]`
+
+g1_3 = G1.new #: G1[String]
+T.reveal_type(g1_3) # error: Revealed type: `G1[String]`
+
+#: (G1) -> void
+#   ^^ error: Malformed type declaration. Generic class without type arguments `G1`
+def take_g1_1(g1)
+  T.reveal_type(g1) # error: Revealed type: `G1[T.untyped]`
+end
+
+#: (G1[Integer]) -> void
+def take_g1_2(g1)
+  T.reveal_type(g1) # error: Revealed type: `G1[Integer]`
+end
+
+take_g1_2(g1_1)
+take_g1_2(g1_2)
+take_g1_2(g1_3) # error: Expected `G1[Integer]` but found `G1[String]` for argument `g1`
+
+#: [U, V]
+class G2
+  #: U
+  attr_accessor :u
+
+  #: V
+  attr_accessor :v
+
+  #: (U, V) -> void
+  def initialize(u, v)
+    @u = u
+    @v = v
+  end
+end
+
+g2_1 = G2.new(1, 2) #: G2[Integer, String]
+#                ^ error: Expected `String` but found `Integer(2)` for argument `v`
+T.reveal_type(g2_1) # error: Revealed type: `G2[Integer, String]`
+
+g2_1.v = 2 # error: Assigning a value to `v` that does not match expected type `String`
+
+#: [in U, out V]
+class G3
+  #: U
+  attr_reader :u # error: `type_member` `U` was defined as `:in` but is used in an `:out` context
+
+  #: V
+  attr_writer :v # error: `type_member` `V` was defined as `:out` but is used in an `:in` context
+
+  #: (U, V) -> void
+  def initialize(u, v)
+    @u = u
+    @v = v
+  end
+end
+
+#: [U < String]
+class G4; end
+
+g4 = G4.new #: G4[Integer]
+#                 ^^^^^^^ error-with-dupes: `Integer` is not a subtype of upper bound of type member `::G4::U`
+T.reveal_type(g4) # error: Revealed type: `G4[T.untyped]`
+
+# TODO: unsupported yet, working on it
+#: [U > String]
+#     ^ error: Failed to parse RBS type parameters (expected a token `tUIDENT`)
+class G5; end
+
+
+#: [U]
+class G6; end
+
+g6 = G6[Integer].new # error: Method `[]` does not exist on `T.class_of(G6)`
+T.reveal_type(g6) # error: Revealed type: `T.untyped`
+
+arr1 = Array.new #: T::Array[Integer]
+T.reveal_type(arr1) # error: Revealed type: `T::Array[Integer]`
+
+arr2 = T::Array[Integer].new(1)
+T.reveal_type(arr2) # error: Revealed type: `T::Array[Integer]`
+
+#: [U < Numeric]
+class G7; end
+
+#: [out E]
+class G8; end
+g8_1 = G8.new #: G8[Numeric]
+T.reveal_type(g8_1) # error: Revealed type: `G8[Numeric]`
+
+g8_2 = g8_1 #: G8[Object]
+T.reveal_type(g8_2) # error: Revealed type: `G8[Object]`
+
+g8_3 = g8_1 #: G8[Integer]
+#              ^^^^^^^^^^^ error: Argument does not have asserted type `G8[Integer]`
+T.reveal_type(g8_3) # error: Revealed type: `G8[Integer]`
+
+#: [in E]
+class G9; end
+g9_1 = G9.new #: G9[Numeric]
+T.reveal_type(g9_1) # error: Revealed type: `G9[Numeric]`
+
+g9_2 = g9_1 #: G9[Object]
+#              ^^^^^^^^^^ error: Argument does not have asserted type `G9[Object]`
+T.reveal_type(g9_2) # error: Revealed type: `G9[Object]`
+
+g9_3 = g9_1 #: G9[Integer]
+T.reveal_type(g9_3) # error: Revealed type: `G9[Integer]`
+
+#: [U]
+class G10
+  extend T::Generic
+
+  V = type_member
+end
+
+g10 = G10[Integer, String].new #: G10[Integer, String]
+T.reveal_type(g10) # error: Revealed type: `G10[Integer, String]`
+
+#: [U < Numeric = Integer]
+#   ^^^^^^^^^^^^^^^^^^^^^ error: Type member is defined with bounds and `fixed`
+class G11; end

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -152,3 +152,10 @@ T.reveal_type(g10) # error: Revealed type: `G10[Integer, String]`
 #: [U < Numeric = Integer]
 #   ^^^^^^^^^^^^^^^^^^^^^ error: Type member is defined with bounds and `fixed`
 class G11; end
+
+#: [in U < Numeric]
+class G12; end
+
+#: (G12[Object]) -> void
+#       ^^^^^^ error-with-dupes: `Object` is not a subtype of upper bound of type member `::G12::U`
+def take_g12(g12); end

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -22,6 +22,10 @@ module Errors
   #: [unchecked T]
   #   ^^^^^^^^^^^ error: `unchecked` type parameters are not supported by Sorbet
   class UnsupportedError1; end
+
+  class UselessSignature1 #: [U]
+  #                       ^^^^^^ error: Unexpected RBS assertion comment found after `class` declaration
+  end
 end
 
 #: [U]

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C UnsupportedError1><<C <todo sym>>> < (::<todo sym>)
-      <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+      <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
       <emptyTree>::<C T> = <self>.<syntheticTypeMember>()
     end
@@ -47,7 +47,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G1><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
   end
@@ -128,7 +128,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of initialize>
 
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
 
@@ -175,7 +175,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of initialize>
 
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>(:in)
 
@@ -183,7 +183,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G4><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>() do ||
       {:upper => <emptyTree>::<C String>}
@@ -198,7 +198,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G6><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
   end
@@ -216,7 +216,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(arr2)
 
   class <emptyTree>::<C G7><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>() do ||
       {:upper => <emptyTree>::<C Numeric>}
@@ -224,7 +224,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G8><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C E> = <self>.<syntheticTypeMember>(:out)
   end
@@ -242,7 +242,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g8_3)
 
   class <emptyTree>::<C G9><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C E> = <self>.<syntheticTypeMember>(:in)
   end
@@ -264,7 +264,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <emptyTree>::<C V> = <self>.type_member()
 
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
   end
@@ -274,7 +274,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g10)
 
   class <emptyTree>::<C G11><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>() do ||
       {:fixed => <emptyTree>::<C Integer>, :upper => <emptyTree>::<C Numeric>}
@@ -282,7 +282,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G12><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>(:in) do ||
       {:upper => <emptyTree>::<C Numeric>}

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -207,7 +207,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <emptyTree>::<C T>.reveal_type(g6)
 
-  arr1 = <cast:let>(<emptyTree>::<C Array>.new(), <todo sym>, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C Integer>))
+  arr1 = <cast:let>(<emptyTree>::<C Array>.new(), <todo sym>, <emptyTree>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
 
   <emptyTree>::<C T>.reveal_type(arr1)
 

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -37,9 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C UnsupportedError1><<C <todo sym>>> < (::<todo sym>)
-      <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-      <emptyTree>::<C T> = <self>.<syntheticTypeMember>()
+      <emptyTree>::<C T> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
     end
 
     class <emptyTree>::<C UselessSignature1><<C <todo sym>>> < (::<todo sym>)
@@ -47,9 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G1><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
   end
 
   g1_1 = <emptyTree>::<C G1>.new()
@@ -128,11 +124,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of initialize>
 
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
 
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
-
-    <emptyTree>::<C V> = <self>.<syntheticTypeMember>()
+    <emptyTree>::<C V> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
   end
 
   g2_1 = <cast:let>(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>).new(1, 2), <todo sym>, <emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))
@@ -175,17 +169,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of initialize>
 
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:in)
 
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>(:in)
-
-    <emptyTree>::<C V> = <self>.<syntheticTypeMember>(:out)
+    <emptyTree>::<C V> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:out)
   end
 
   class <emptyTree>::<C G4><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>() do ||
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member() do ||
       {:upper => <emptyTree>::<C String>}
     end
   end
@@ -198,9 +188,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G6><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
   end
 
   g6 = <emptyTree>::<C G6>.[](<emptyTree>::<C Integer>).new()
@@ -216,17 +204,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(arr2)
 
   class <emptyTree>::<C G7><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>() do ||
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member() do ||
       {:upper => <emptyTree>::<C Numeric>}
     end
   end
 
   class <emptyTree>::<C G8><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C E> = <self>.<syntheticTypeMember>(:out)
+    <emptyTree>::<C E> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:out)
   end
 
   g8_1 = <cast:let>(<emptyTree>::<C G8>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>).new(), <todo sym>, <emptyTree>::<C G8>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>))
@@ -242,9 +226,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g8_3)
 
   class <emptyTree>::<C G9><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C E> = <self>.<syntheticTypeMember>(:in)
+    <emptyTree>::<C E> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:in)
   end
 
   g9_1 = <cast:let>(<emptyTree>::<C G9>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>).new(), <todo sym>, <emptyTree>::<C G9>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>))
@@ -264,9 +246,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <emptyTree>::<C V> = <self>.type_member()
 
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
   end
 
   g10 = <cast:let>(<emptyTree>::<C G10>.[](<emptyTree>::<C Integer>, <emptyTree>::<C String>).new(), <todo sym>, <emptyTree>::<C G10>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))
@@ -274,17 +254,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g10)
 
   class <emptyTree>::<C G11><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>() do ||
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member() do ||
       {:fixed => <emptyTree>::<C Integer>, :upper => <emptyTree>::<C Numeric>}
     end
   end
 
   class <emptyTree>::<C G12><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>(:in) do ||
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:in) do ||
       {:upper => <emptyTree>::<C Numeric>}
     end
   end

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -15,6 +15,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(g1)
   end
 
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:g12, <emptyTree>::<C G12>.<syntheticSquareBrackets>(<emptyTree>::<C Object>)).void()
+  end
+
+  def take_g12<<todo method>>(g12, &<blk>)
+    <emptyTree>
+  end
+
   module <emptyTree>::<C Errors><<C <todo sym>>> < ()
     class <emptyTree>::<C ParseError1><<C <todo sym>>> < (::<todo sym>)
     end
@@ -269,4 +277,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       {:fixed => <emptyTree>::<C Integer>, :upper => <emptyTree>::<C Numeric>}
     end
   end
+
+  class <emptyTree>::<C G12><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>(:in) do ||
+      {:upper => <emptyTree>::<C Numeric>}
+    end
+  end
+
+  <runtime method definition of take_g12>
 end

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -41,6 +41,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       <emptyTree>::<C T> = <self>.<syntheticTypeMember>()
     end
+
+    class <emptyTree>::<C UselessSignature1><<C <todo sym>>> < (::<todo sym>)
+    end
   end
 
   class <emptyTree>::<C G1><<C <todo sym>>> < (::<todo sym>)

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -135,6 +135,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   g2_1.v=(2)
 
+  g2_2 = <cast:let>(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>, <emptyTree>::<C String>).new(1, 2), <todo sym>, <emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>, <emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(g2_2)
+
+  g2_3 = <cast:let>(<cast:let>(<emptyTree>::<C G2>, <todo sym>, ::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))).new(1, 2), <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>)))
+
+  <emptyTree>::<C T>.reveal_type(g2_3)
+
   class <emptyTree>::<C G3><<C <todo sym>>> < (::<todo sym>)
     ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C U>)

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -1,0 +1,272 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:g1, <emptyTree>::<C G1>).void()
+  end
+
+  def take_g1_1<<todo method>>(g1, &<blk>)
+    <emptyTree>::<C T>.reveal_type(g1)
+  end
+
+  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    <self>.params(:g1, <emptyTree>::<C G1>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>)).void()
+  end
+
+  def take_g1_2<<todo method>>(g1, &<blk>)
+    <emptyTree>::<C T>.reveal_type(g1)
+  end
+
+  module <emptyTree>::<C Errors><<C <todo sym>>> < ()
+    class <emptyTree>::<C ParseError1><<C <todo sym>>> < (::<todo sym>)
+    end
+
+    class <emptyTree>::<C ParseError2><<C <todo sym>>> < (::<todo sym>)
+    end
+
+    class <emptyTree>::<C ParseError3><<C <todo sym>>> < (::<todo sym>)
+    end
+
+    class <emptyTree>::<C ParseError4><<C <todo sym>>> < (::<todo sym>)
+    end
+
+    class <emptyTree>::<C UnsupportedError1><<C <todo sym>>> < (::<todo sym>)
+      <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+      <emptyTree>::<C T> = <self>.<syntheticTypeMember>()
+    end
+  end
+
+  class <emptyTree>::<C G1><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
+  end
+
+  g1_1 = <emptyTree>::<C G1>.new()
+
+  <emptyTree>::<C T>.reveal_type(g1_1)
+
+  g1_2 = <cast:let>(<emptyTree>::<C G1>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>).new(), <todo sym>, <emptyTree>::<C G1>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
+
+  <emptyTree>::<C T>.reveal_type(g1_2)
+
+  g1_3 = <cast:let>(<emptyTree>::<C G1>.<syntheticSquareBrackets>(<emptyTree>::<C String>).new(), <todo sym>, <emptyTree>::<C G1>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(g1_3)
+
+  <runtime method definition of take_g1_1>
+
+  <runtime method definition of take_g1_2>
+
+  <self>.take_g1_2(g1_1)
+
+  <self>.take_g1_2(g1_2)
+
+  <self>.take_g1_2(g1_3)
+
+  class <emptyTree>::<C G2><<C <todo sym>>> < (::<todo sym>)
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.returns(<emptyTree>::<C U>)
+    end
+
+    def u<<todo method>>(&<blk>)
+      @u
+    end
+
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.params(:u, <emptyTree>::<C U>).returns(<emptyTree>::<C U>)
+    end
+
+    def u=<<todo method>>(u, &<blk>)
+      @u = u
+    end
+
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.returns(<emptyTree>::<C V>)
+    end
+
+    def v<<todo method>>(&<blk>)
+      @v
+    end
+
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.params(:v, <emptyTree>::<C V>).returns(<emptyTree>::<C V>)
+    end
+
+    def v=<<todo method>>(v, &<blk>)
+      @v = v
+    end
+
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.params(:u, <emptyTree>::<C U>, :v, <emptyTree>::<C V>).void()
+    end
+
+    def initialize<<todo method>>(u, v, &<blk>)
+      begin
+        @u = <cast:let>(u, <todo sym>, <emptyTree>::<C U>)
+        @v = <cast:let>(v, <todo sym>, <emptyTree>::<C V>)
+      end
+    end
+
+    <runtime method definition of u>
+
+    <runtime method definition of u=>
+
+    <runtime method definition of v>
+
+    <runtime method definition of v=>
+
+    <runtime method definition of initialize>
+
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
+
+    <emptyTree>::<C V> = <self>.<syntheticTypeMember>()
+  end
+
+  g2_1 = <cast:let>(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>).new(1, 2), <todo sym>, <emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(g2_1)
+
+  g2_1.v=(2)
+
+  class <emptyTree>::<C G3><<C <todo sym>>> < (::<todo sym>)
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.returns(<emptyTree>::<C U>)
+    end
+
+    def u<<todo method>>(&<blk>)
+      @u
+    end
+
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.params(:v, <emptyTree>::<C V>).returns(<emptyTree>::<C V>)
+    end
+
+    def v=<<todo method>>(v, &<blk>)
+      @v = v
+    end
+
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.params(:u, <emptyTree>::<C U>, :v, <emptyTree>::<C V>).void()
+    end
+
+    def initialize<<todo method>>(u, v, &<blk>)
+      begin
+        @u = <cast:let>(u, <todo sym>, <emptyTree>::<C U>)
+        @v = <cast:let>(v, <todo sym>, <emptyTree>::<C V>)
+      end
+    end
+
+    <runtime method definition of u>
+
+    <runtime method definition of v=>
+
+    <runtime method definition of initialize>
+
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>(:in)
+
+    <emptyTree>::<C V> = <self>.<syntheticTypeMember>(:out)
+  end
+
+  class <emptyTree>::<C G4><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>() do ||
+      {:upper => <emptyTree>::<C String>}
+    end
+  end
+
+  g4 = <cast:let>(<emptyTree>::<C G4>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>).new(), <todo sym>, <emptyTree>::<C G4>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
+
+  <emptyTree>::<C T>.reveal_type(g4)
+
+  class <emptyTree>::<C G5><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C G6><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
+  end
+
+  g6 = <emptyTree>::<C G6>.[](<emptyTree>::<C Integer>).new()
+
+  <emptyTree>::<C T>.reveal_type(g6)
+
+  arr1 = <cast:let>(<emptyTree>::<C Array>.new(), <todo sym>, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C Integer>))
+
+  <emptyTree>::<C T>.reveal_type(arr1)
+
+  arr2 = <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C Integer>).new(1)
+
+  <emptyTree>::<C T>.reveal_type(arr2)
+
+  class <emptyTree>::<C G7><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>() do ||
+      {:upper => <emptyTree>::<C Numeric>}
+    end
+  end
+
+  class <emptyTree>::<C G8><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C E> = <self>.<syntheticTypeMember>(:out)
+  end
+
+  g8_1 = <cast:let>(<emptyTree>::<C G8>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>).new(), <todo sym>, <emptyTree>::<C G8>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>))
+
+  <emptyTree>::<C T>.reveal_type(g8_1)
+
+  g8_2 = <cast:let>(g8_1, <todo sym>, <emptyTree>::<C G8>.<syntheticSquareBrackets>(<emptyTree>::<C Object>))
+
+  <emptyTree>::<C T>.reveal_type(g8_2)
+
+  g8_3 = <cast:let>(g8_1, <todo sym>, <emptyTree>::<C G8>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
+
+  <emptyTree>::<C T>.reveal_type(g8_3)
+
+  class <emptyTree>::<C G9><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C E> = <self>.<syntheticTypeMember>(:in)
+  end
+
+  g9_1 = <cast:let>(<emptyTree>::<C G9>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>).new(), <todo sym>, <emptyTree>::<C G9>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>))
+
+  <emptyTree>::<C T>.reveal_type(g9_1)
+
+  g9_2 = <cast:let>(g9_1, <todo sym>, <emptyTree>::<C G9>.<syntheticSquareBrackets>(<emptyTree>::<C Object>))
+
+  <emptyTree>::<C T>.reveal_type(g9_2)
+
+  g9_3 = <cast:let>(g9_1, <todo sym>, <emptyTree>::<C G9>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
+
+  <emptyTree>::<C T>.reveal_type(g9_3)
+
+  class <emptyTree>::<C G10><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(<emptyTree>::<C T>::<C Generic>)
+
+    <emptyTree>::<C V> = <self>.type_member()
+
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
+  end
+
+  g10 = <cast:let>(<emptyTree>::<C G10>.[](<emptyTree>::<C Integer>, <emptyTree>::<C String>).new(), <todo sym>, <emptyTree>::<C G10>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(g10)
+
+  class <emptyTree>::<C G11><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>() do ||
+      {:fixed => <emptyTree>::<C Integer>, :upper => <emptyTree>::<C Numeric>}
+    end
+  end
+end

--- a/test/testdata/rbs/signatures_generics_without_assertions.rb
+++ b/test/testdata/rbs/signatures_generics_without_assertions.rb
@@ -1,0 +1,11 @@
+# typed: strict
+# enable-experimental-rbs-signatures: true
+
+#: [U]
+class G1; end
+
+g1_1 = G1.new
+T.reveal_type(g1_1) # error: Revealed type: `G1[T.untyped]`
+
+g1_2 = G1.new #: G1[Integer]
+T.reveal_type(g1_2) # error: Revealed type: `G1[T.untyped]`

--- a/test/testdata/rbs/signatures_generics_without_assertions.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics_without_assertions.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C G1><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
 
     <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
   end

--- a/test/testdata/rbs/signatures_generics_without_assertions.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics_without_assertions.rb.rewrite-tree.exp
@@ -1,0 +1,15 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C G1><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(::<root>::<C T>::<C GenericWithoutRuntime>)
+
+    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
+  end
+
+  g1_1 = <emptyTree>::<C G1>.new()
+
+  <emptyTree>::<C T>.reveal_type(g1_1)
+
+  g1_2 = <emptyTree>::<C G1>.new()
+
+  <emptyTree>::<C T>.reveal_type(g1_2)
+end

--- a/test/testdata/rbs/signatures_generics_without_assertions.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics_without_assertions.rb.rewrite-tree.exp
@@ -1,8 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C G1><<C <todo sym>>> < (::<todo sym>)
-    <self>.extend(::<root>::<C Sorbet>::<C Private>::<C Static>::<C <SyntheticGeneric>>)
-
-    <emptyTree>::<C U> = <self>.<syntheticTypeMember>()
+    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
   end
 
   g1_1 = <emptyTree>::<C G1>.new()

--- a/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
@@ -320,7 +320,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(<emptyTree>::<C GenericType1>.[](<emptyTree>::<C Integer>))
+    <self>.returns(<emptyTree>::<C GenericType1>.<genericSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type5<<todo method>>(&<blk>)
@@ -328,7 +328,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(<emptyTree>::<C GenericType2>.[](<emptyTree>::<C GenericType1>.[](::<root>::<C T>.untyped()), <emptyTree>::<C GenericType3>.[](<emptyTree>::<C Integer>, <emptyTree>::<C String>, ::<root>::<C T>.untyped())))
+    <self>.returns(<emptyTree>::<C GenericType2>.<genericSquareBrackets>(<emptyTree>::<C GenericType1>.<genericSquareBrackets>(::<root>::<C T>.untyped()), <emptyTree>::<C GenericType3>.<genericSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>, ::<root>::<C T>.untyped())))
   end
 
   def generic_type6<<todo method>>(&<blk>)

--- a/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
@@ -160,7 +160,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Array>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_array<<todo method>>(&<blk>)
@@ -168,7 +168,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Array>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_array_root<<todo method>>(&<blk>)
@@ -176,7 +176,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Class>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_class<<todo method>>(&<blk>)
@@ -184,7 +184,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Class>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_class_root<<todo method>>(&<blk>)
@@ -192,7 +192,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Enumerable>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Enumerable>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_enumerable<<todo method>>(&<blk>)
@@ -200,7 +200,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Enumerable>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Enumerable>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_enumerable_root<<todo method>>(&<blk>)
@@ -208,7 +208,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Enumerator>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Enumerator>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_enumerator<<todo method>>(&<blk>)
@@ -216,7 +216,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Enumerator>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Enumerator>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_enumerator_root<<todo method>>(&<blk>)
@@ -224,7 +224,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Enumerator>::<C Lazy>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Enumerator>::<C Lazy>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_enumerator_lazy<<todo method>>(&<blk>)
@@ -232,7 +232,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Enumerator>::<C Lazy>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Enumerator>::<C Lazy>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_enumerator_lazy_root<<todo method>>(&<blk>)
@@ -240,7 +240,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Enumerator>::<C Chain>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Enumerator>::<C Chain>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_enumerator_chain<<todo method>>(&<blk>)
@@ -248,7 +248,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Enumerator>::<C Chain>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Enumerator>::<C Chain>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_enumerator_chain_root<<todo method>>(&<blk>)
@@ -256,7 +256,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Hash>.[](<emptyTree>::<C String>, <emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C String>, <emptyTree>::<C Integer>))
   end
 
   def generic_type_hash<<todo method>>(&<blk>)
@@ -264,7 +264,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Hash>.[](<emptyTree>::<C String>, <emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C String>, <emptyTree>::<C Integer>))
   end
 
   def generic_type_hash_root<<todo method>>(&<blk>)
@@ -272,7 +272,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Set>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Set>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_set<<todo method>>(&<blk>)
@@ -280,7 +280,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Set>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Set>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_set_root<<todo method>>(&<blk>)
@@ -288,7 +288,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Range>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Range>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_range<<todo method>>(&<blk>)
@@ -296,7 +296,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(::<root>::<C T>::<C Range>.[](<emptyTree>::<C Integer>))
+    <self>.returns(::<root>::<C T>::<C Range>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_range_root<<todo method>>(&<blk>)
@@ -304,7 +304,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(<emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C Integer>))
+    <self>.returns(<emptyTree>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type_t_array<<todo method>>(&<blk>)
@@ -312,7 +312,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(<emptyTree>::<C T>::<C Hash>.[](<emptyTree>::<C String>, <emptyTree>::<C Integer>))
+    <self>.returns(<emptyTree>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C String>, <emptyTree>::<C Integer>))
   end
 
   def generic_type_t_hash<<todo method>>(&<blk>)

--- a/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
@@ -320,7 +320,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(<emptyTree>::<C GenericType1>.<genericSquareBrackets>(<emptyTree>::<C Integer>))
+    <self>.returns(<emptyTree>::<C GenericType1>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
   def generic_type5<<todo method>>(&<blk>)
@@ -328,7 +328,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
-    <self>.returns(<emptyTree>::<C GenericType2>.<genericSquareBrackets>(<emptyTree>::<C GenericType1>.<genericSquareBrackets>(::<root>::<C T>.untyped()), <emptyTree>::<C GenericType3>.<genericSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>, ::<root>::<C T>.untyped())))
+    <self>.returns(<emptyTree>::<C GenericType2>.<syntheticSquareBrackets>(<emptyTree>::<C GenericType1>.<syntheticSquareBrackets>(::<root>::<C T>.untyped()), <emptyTree>::<C GenericType3>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>, ::<root>::<C T>.untyped())))
   end
 
   def generic_type6<<todo method>>(&<blk>)

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -317,8 +317,9 @@ def register_sorbet_dependencies():
     # while we're upstreaming their changes.
     http_archive(
         name = "rbs_parser",
-        url = "https://github.com/shopify/rbs/archive/91dfbbda3cc43cdc4f47048abb9de597a15c1ada.zip",
-        sha256 = "1166b6d7dc1268213fb8a936125b7a28da89c881802946e11f87a4560263c107",
-        strip_prefix = "rbs-91dfbbda3cc43cdc4f47048abb9de597a15c1ada",
+        url = "https://github.com/shopify/rbs/archive/f8d9d5186c39eebffcd350b5452c6041f7ca6e6c.zip",
+        sha256 = "7fc542180adbeb653f0ce95b1cda9630286b6d1e4edb6ede2b61cf1cf7a3758c",
+        strip_prefix = "rbs-f8d9d5186c39eebffcd350b5452c6041f7ca6e6c",
         build_file = "@com_stripe_ruby_typer//third_party:rbs_parser.BUILD",
     )
+

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -322,4 +322,3 @@ def register_sorbet_dependencies():
         strip_prefix = "rbs-f8d9d5186c39eebffcd350b5452c6041f7ca6e6c",
         build_file = "@com_stripe_ruby_typer//third_party:rbs_parser.BUILD",
     )
-

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -670,6 +670,20 @@ parameter, while the RBS signature declares it as a positional parameter:
 def method(param:); end
 ```
 
+## 3557
+
+This error is raised when a class or module is annotated with multiple RBS
+generic signature comments:
+
+```ruby
+#: [T]
+#: [U]
+class A
+end
+```
+
+Only one is allowed.
+
 ## 3702
 
 > This error is specific to Stripe's custom `--stripe-packages` mode. If you are

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -672,8 +672,11 @@ def method(param:); end
 
 ## 3557
 
+> This error is specific to RBS support when using the
+> `--enable-experimental-rbs-signatures` flag.
+
 This error is raised when a class or module is annotated with multiple RBS
-generic signature comments:
+generic type parameters comments:
 
 ```ruby
 #: [U]

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -676,13 +676,19 @@ This error is raised when a class or module is annotated with multiple RBS
 generic signature comments:
 
 ```ruby
-#: [T]
 #: [U]
+#: [V]
 class A
 end
 ```
 
-Only one is allowed.
+Only one signature is allowed:
+
+```ruby
+#: [U, V]
+class A
+end
+```
 
 ## 3702
 

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -703,6 +703,8 @@ end
 
 RBS supports generic classes and modules.
 
+### Type members
+
 [Type members](generics#type_member--type_template) can be specified using a
 `#:` comment on the class or module:
 
@@ -731,6 +733,43 @@ runtime and Sorbet will report an error if you try to use it:
 Box[Integer].new
    ^^^^^^^^^ error: Method `[]` does not exist on `T.class_of(Box)`
 ```
+
+Because of this, Sorbet will use the RBS comment type as the type of the class
+being instantiated:
+
+```ruby
+box = Box.new #: Box[Integer]
+T.reveal_type(box) # Revealed type: `Box[Integer]`
+```
+
+To change the type of the class being instantiated, the expression can be broken
+into multiple lines:
+
+```ruby
+nilable_box = Box #: Class[Box[Integer]]
+   .new #: Box[Integer]?
+T.reveal_type(nilable_box) # => `T.nilable(Box[Integer])`
+
+1.times do
+  nilable_box = nil
+end
+```
+
+You can also use an intermediate variable to change the type of the class being
+instantiated:
+
+```ruby
+box_of_integer = Box.new("foo") #: Box[Integer]
+T.reveal_type(box_of_integer) # => `Box[Integer]`
+nilable_box = box_of_integer #: as Box[Integer]?
+T.reveal_type(nilable_box) # => `T.nilable(Box[Integer])`
+
+1.times do
+  nilable_box = nil
+end
+```
+
+### Type templates
 
 There is no equivalent to `type_template` in RBS. Instead, you can define type
 members on the singleton class. So this:
@@ -762,6 +801,8 @@ end
 Note: there is no RBS equivalent to the generic `T.class_of()[]` syntax just
 yet.
 
+### Variance
+
 [Variance](generics.md#in-out-and-variance) can be specified using the `in` and
 `out` keywords:
 
@@ -773,6 +814,8 @@ end
 box = Box.new #: Box[Integer]
 box #: Box[Numeric]
 ```
+
+### Bounds
 
 By default, type parameters do not have
 [bounds](generics.md#bounds-on-type_members-and-type_templates-fixed-upper-lower):

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -732,7 +732,22 @@ Box[Integer].new
    ^^^^^^^^^ error: Method `[]` does not exist on `T.class_of(Box)`
 ```
 
-To define a type template, use the `#:` comment on a `class << self`:
+There is no equivalent to `type_template` in RBS. Instead, you can define type
+members on the singleton class. So this:
+
+```ruby
+module Factory
+  extend T::Sig
+  extend T::Generic
+
+  InstanceType = type_template
+
+  sig { returns(InstanceType) }
+  def self.make; end
+end
+```
+
+Can be written as:
 
 ```ruby
 module Factory
@@ -743,6 +758,9 @@ module Factory
   end
 end
 ```
+
+Note: there is no RBS equivalent to the generic `T.class_of()[]` syntax just
+yet.
 
 [Variance](generics.md#in-out-and-variance) can be specified using the `in` and
 `out` keywords:

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -766,7 +766,7 @@ class Box; end
 box = Box.new #: Box[Integer]
 ```
 
-Upper bounds can be specified using `>`:
+Upper bounds can be specified using `<`:
 
 ```ruby
 #: [E < Numeric]

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -699,6 +699,93 @@ class Foo
 end
 ```
 
+## Generic classes and modules
+
+RBS supports generic classes and modules.
+
+[Type members](generics#type_member--type_template) can be specified using a
+`#:` comment on the class or module:
+
+```ruby
+#: [E]
+class Box
+  #: -> void
+  def initialize
+    @elems = [] #: T::Array[E]
+  end
+
+  #: (E) -> void
+  def <<(e)
+    @elems << e
+  end
+end
+
+box = Box.new #: Box[Integer]
+box << 42
+```
+
+RBS generics do not use `T::Generic`, thus the `[]` method doesn't exist at
+runtime and Sorbet will report an error if you try to use it:
+
+```ruby
+Box[Integer].new
+   ^^^^^^^^^ error: Method `[]` does not exist on `T.class_of(Box)`
+```
+
+To define a type template, use the `#:` comment on a `class << self`:
+
+```ruby
+module Factory
+  #: [InstanceType]
+  class << self
+    #: -> InstanceType
+    def make; end
+  end
+end
+```
+
+[Variance](generics.md#in-out-and-variance) can be specified using the `in` and
+`out` keywords:
+
+```ruby
+#: [out E]
+class Box
+end
+
+box = Box.new #: Box[Integer]
+box #: Box[Numeric]
+```
+
+By default, type parameters do not have
+[bounds](generics.md#bounds-on-type_members-and-type_templates-fixed-upper-lower):
+
+```ruby
+#: [E]
+class Box; end
+
+box = Box.new #: Box[Integer]
+```
+
+Upper bounds can be specified using `>`:
+
+```ruby
+#: [E < Numeric]
+class Box; end
+
+Box.new #: Box[Integer]
+Box.new #: Box[String]
+               ^^^^^^ error: `String` is not a subtype of upper bound of type member `::Box::E`
+```
+
+Fixed bounds can be specified using `=`:
+
+```ruby
+#: [E = Integer]
+class Box; end
+```
+
+Note: the lower bound `>` syntax is not supported in RBS yet.
+
 ## Special behaviors
 
 The `#:` comment must come **immediately** before the following method
@@ -775,6 +862,17 @@ to use the literal's underlying type instead:
 - `nil` is `NilClass`
 
 You can also consider using [`T::Enum`](tenum.md).
+
+### Unchecked generics
+
+RBS `unchecked` generics are not supported by Sorbet, use `untyped` instead:
+
+```ruby
+#: [E]
+class Box; end
+
+box = Box.new #: Box[untyped]
+```
 
 ## Type assertions comments
 


### PR DESCRIPTION
### Motivation

Allow Sorbet generics to be used through RBS comments:

```ruby
#: [E]
class Box
  #: -> void
  def initialize
    @elems = [] #: T::Array[E]
  end

  #: (E) -> void
  def <<(e)
    @elems << e
  end
end

box = Box.new #: Box[Integer]
box << 42
```

### Implementation

The main piece of the implementation is located inside the RBS pre-desugar rewriter: we associate the comment to the class/module then rewrite it into the corresponding Sorbet constructs.

I want to discuss three changes that "leaked" outside of this rewriter: `T::GenericWithoutRuntime`, `<syntheticTypeMember>` and `<syntheticSquareBrackets>`.

The main reason for these changes is so we can error when the user tries to refer to methods that would normally come from `sorbet-runtime`:

```ruby
#: [E]
class Box
  type_member
  ^^^^^^^^^^^  we need to disallow this if `T::Generic` is not explicitly extended
end

box = Box[Integer].new
         ^^^^^^^^^ we need to disallow this, `[]` won't be defined at runtime
```

To do so, we first added an ancestor to `T::Generic`: `T::GenericWithoutRuntime`. It's methods are all synthetic and added through GlobalState: `<syntheticSquareBraquets>` and `<syntheticTypeMember>`. Then we made them behave like their real counterpart: `squareBracket` and `typeMember`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
