### PR TITLE
Remove `initialGS` terminology from comments, and the indexer

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -144,11 +144,10 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
             continue;
         }
 
-        // When run from the indexer, the old file will actually have been evicted from the initialGS
-        // so that the initialGS containing the new file can be given to the pipeline to be indexed
-        // (and thus have the new hashes computed), so that the `updatedFile` and
-        // `fref.data(gs)` actually are the same File object. For this case, we have to find the
-        // old File's hashes in `evictedFiles`.
+        // When run from the indexer, the old file will actually have been evicted from the GlobalState so that the new
+        // file can be given to the pipeline to be indexed (and thus have the new hashes computed), so that the
+        // `updatedFile` and `fref.data(gs)` actually are the same File object. For this case, we have to find the old
+        // File's hashes in `evictedFiles`.
         //
         // When run from the typechecker, the old file will not yet have been evicted before
         // fastPathFilesToTypecheck is called (it will be evicted later on that thread, right

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -52,10 +52,9 @@ void clearAndReplaceTimers(vector<unique_ptr<Timer>> &timers, const vector<uniqu
 }
 } // namespace
 
-LSPIndexer::LSPIndexer(shared_ptr<const LSPConfiguration> config, unique_ptr<core::GlobalState> initialGS,
+LSPIndexer::LSPIndexer(shared_ptr<const LSPConfiguration> config, unique_ptr<core::GlobalState> gs,
                        unique_ptr<KeyValueStore> kvstore)
-    : config(config), initialGS(move(initialGS)), kvstore(move(kvstore)),
-      emptyWorkers(WorkerPool::create(0, *config->logger)) {}
+    : config(config), gs(move(gs)), kvstore(move(kvstore)), emptyWorkers(WorkerPool::create(0, *config->logger)) {}
 
 LSPIndexer::~LSPIndexer() {
     for (auto &timer : pendingTypecheckDiagnosticLatencyTimers) {
@@ -103,7 +102,7 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
     }
 
     for (auto &f : changedFiles) {
-        auto fref = initialGS->findFileByPath(f->path());
+        auto fref = gs->findFileByPath(f->path());
         if (!fref.exists()) {
             logger.debug("Taking slow path because {} is a new file", f->path());
             prodCategoryCounterInc("lsp.slow_path_reason", "new_file");
@@ -111,7 +110,7 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
             return result;
         }
 
-        const auto &oldFile = getOldFile(fref, *initialGS, evictedFiles);
+        const auto &oldFile = getOldFile(fref, *gs, evictedFiles);
         // We don't yet have a content hash that works for package files yet. Instead, we check if the package file
         // source text has changed at all. If it does, we take the slow path.
         // Only relevant in `--stripe-packages` mode. This prevents LSP editing features like autocomplete from
@@ -201,7 +200,7 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
     // foreground..." operation, we also compute how many downstream files (outside of the changed
     // files) would need to be typechecked on the fast path so we can compare that number against
     // `lspMaxFilesOnFastPath` as well.
-    result.files = LSPFileUpdates::fastPathFilesToTypecheck(*initialGS, *config, changedFiles, evictedFiles);
+    result.files = LSPFileUpdates::fastPathFilesToTypecheck(*gs, *config, changedFiles, evictedFiles);
     if (result.files.totalChanged > config->opts.lspMaxFilesOnFastPath) {
         logger.debug(
             "Taking slow path because too many extra files would be typechecked on the fast path ({} files > {} files)",
@@ -275,13 +274,12 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
     // indexer and typechecker's file tables will almost immediately diverge, but that's not an issue as we don't share
     // `core::FileRef` values between the two.
     auto typecheckerGS = std::exchange(
-        this->initialGS,
-        this->initialGS->copyForIndex(this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
-                                      this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                                      this->config->opts.extraPackageFilesDirectorySlashPrefixes,
-                                      this->config->opts.packageSkipRBIExportEnforcementDirs,
-                                      this->config->opts.allowRelaxedPackagerChecksFor,
-                                      this->config->opts.packagerLayers, this->config->opts.stripePackagesHint));
+        this->gs, this->gs->copyForIndex(this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                                         this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                                         this->config->opts.extraPackageFilesDirectorySlashPrefixes,
+                                         this->config->opts.packageSkipRBIExportEnforcementDirs,
+                                         this->config->opts.allowRelaxedPackagerChecksFor,
+                                         this->config->opts.packagerLayers, this->config->opts.stripePackagesHint));
 
     task.setGlobalState(std::move(typecheckerGS));
     task.setKeyValueStore(std::move(this->kvstore));
@@ -293,14 +291,14 @@ void LSPIndexer::initialize(IndexerInitializationTask &task, std::vector<std::sh
     }
 
     {
-        core::UnfreezeFileTable unfreezeFiles{*this->initialGS};
+        core::UnfreezeFileTable unfreezeFiles{*this->gs};
 
         for (auto &file : files) {
-            auto fref = this->initialGS->findFileByPath(file->path());
+            auto fref = this->gs->findFileByPath(file->path());
             if (fref.exists()) {
-                this->initialGS->replaceFile(fref, std::move(file));
+                this->gs->replaceFile(fref, std::move(file));
             } else {
-                this->initialGS->enterFile(std::move(file));
+                this->gs->enterFile(std::move(file));
             }
         }
     }
@@ -323,23 +321,23 @@ std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams
     // Update globalStateHashes. Keep track of file IDs for these files, along with old hashes for these files.
     vector<core::FileRef> frefs;
     {
-        core::UnfreezeFileTable fileTableAccess(*initialGS);
+        core::UnfreezeFileTable fileTableAccess(*gs);
         for (auto &file : update.updatedFiles) {
-            auto fref = initialGS->findFileByPath(file->path());
+            auto fref = gs->findFileByPath(file->path());
             if (fref.exists()) {
-                newlyEvictedFiles[fref] = initialGS->getFiles()[fref.id()];
-                initialGS->replaceFile(fref, file);
+                newlyEvictedFiles[fref] = gs->getFiles()[fref.id()];
+                gs->replaceFile(fref, file);
             } else {
                 // This file update adds a new file to GlobalState.
                 update.hasNewFiles = true;
-                fref = initialGS->enterFile(file);
-                fref.data(*initialGS).strictLevel = pipeline::decideStrictLevel(*initialGS, fref, config->opts);
+                fref = gs->enterFile(file);
+                fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config->opts);
             }
             frefs.emplace_back(fref);
         }
     }
 
-    // Index changes in initialGS. pipeline::index sorts output by file id, but we need to reorder to match the order of
+    // Index changes in gs. pipeline::index sorts output by file id, but we need to reorder to match the order of
     // other fields.
     UnorderedMap<core::FileRef, int> fileToPos;
     {
@@ -357,9 +355,9 @@ std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams
         unique_ptr<const OwnedKeyValueStore> kvstore;
         // Create a throwaway error queue. commitEdit may be called on two different threads, and we can't anticipate
         // which one it will be.
-        initialGS->errorQueue = make_shared<core::ErrorQueue>(
-            initialGS->errorQueue->logger, initialGS->errorQueue->tracer, make_shared<core::NullFlusher>());
-        auto trees = hashing::Hashing::indexAndComputeFileHashes(*initialGS, config->opts, *config->logger,
+        gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer,
+                                                       make_shared<core::NullFlusher>());
+        auto trees = hashing::Hashing::indexAndComputeFileHashes(*gs, config->opts, *config->logger,
                                                                  absl::Span<core::FileRef>(frefs), workers, kvstore);
         ENFORCE(trees.hasResult(), "The indexer thread doesn't support cancellation");
     }
@@ -367,7 +365,7 @@ std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams
     // _Now_ that we've computed file hashes, we can make a fast path determination.
     update.typecheckingPath = getTypecheckingPath(update, newlyEvictedFiles);
 
-    auto runningSlowPath = initialGS->epochManager->getStatus();
+    auto runningSlowPath = gs->epochManager->getStatus();
     if (runningSlowPath.slowPathRunning) {
         // A cancelable slow path is currently running. Check if we can cancel.
         // Invariant: `pendingTypecheckUpdates` should contain the edits currently being typechecked on the slow path.
@@ -377,8 +375,7 @@ std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams
         ENFORCE(runningSlowPath.epoch > (pendingTypecheckUpdates.epoch - pendingTypecheckUpdates.editCount));
 
         // Cancel if the new update will take the slow path anyway.
-        if (update.typecheckingPath != TypecheckingPath::Fast &&
-            initialGS->epochManager->tryCancelSlowPath(update.epoch)) {
+        if (update.typecheckingPath != TypecheckingPath::Fast && gs->epochManager->tryCancelSlowPath(update.epoch)) {
             // Cancelation succeeded! Merge the updates from the cancelled run into the current update.
             update.mergeOlder(pendingTypecheckUpdates);
             mergeEvictedFiles(evictedFiles, newlyEvictedFiles);
@@ -435,17 +432,16 @@ std::unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams
 }
 
 core::FileRef LSPIndexer::uri2FileRef(string_view uri) const {
-    return config->uri2FileRef(*initialGS, uri);
+    return config->uri2FileRef(*gs, uri);
 }
 
 const core::File &LSPIndexer::getFile(core::FileRef fref) const {
     ENFORCE(fref.exists());
-    return fref.data(*initialGS);
+    return fref.data(*gs);
 }
 
 void LSPIndexer::updateGsFromOptions(const DidChangeConfigurationParams &options) const {
-    initialGS->trackUntyped =
-        LSPClientConfiguration::parseEnableHighlightUntyped(*options.settings, initialGS->trackUntyped);
+    gs->trackUntyped = LSPClientConfiguration::parseEnableHighlightUntyped(*options.settings, gs->trackUntyped);
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -29,9 +29,9 @@ class LSPIndexer final {
     bool initialized = false;
     /** Encapsulates the active configuration for the language server. */
     const std::shared_ptr<const LSPConfiguration> config;
-    /** Global state that we keep up-to-date with file edits. We do _not_ typecheck using this global state! We clone
-     * this global state every time we need to perform a slow path typechecking operation. */
-    std::unique_ptr<core::GlobalState> initialGS;
+    /** Global state that we keep up-to-date with file edits. We do _not_ typecheck using this global state, as it will
+     * never have a populated symbol table. */
+    std::unique_ptr<core::GlobalState> gs;
     /** Key-value store used during initialization. */
     std::unique_ptr<KeyValueStore> kvstore;
     /** Contains a copy of the last edit committed on the slow path. Used in slow path cancelation logic. */
@@ -48,7 +48,7 @@ class LSPIndexer final {
 
     /**
      * Determines if the given edit can take the fast path relative to the most recently committed edit.
-     * It compares the file hashes in the files in `edit` to those in `evictedFiles` and `initialGS` (in that order).
+     * It compares the file hashes in the files in `edit` to those in `evictedFiles` and `gs` (in that order).
      */
     TypecheckingPath
     getTypecheckingPath(LSPFileUpdates &edit,
@@ -67,7 +67,7 @@ class LSPIndexer final {
                                 const UnorderedMap<core::FileRef, std::shared_ptr<core::File>> &evictedFiles) const;
 
 public:
-    LSPIndexer(std::shared_ptr<const LSPConfiguration> config, std::unique_ptr<core::GlobalState> initialGS,
+    LSPIndexer(std::shared_ptr<const LSPConfiguration> config, std::unique_ptr<core::GlobalState> gs,
                std::unique_ptr<KeyValueStore> kvstore);
     ~LSPIndexer();
 
@@ -87,7 +87,7 @@ public:
     void initialize(IndexerInitializationTask &task, std::vector<std::shared_ptr<core::File>> &&files);
 
     /**
-     * Commits the given edit to `initialGS`, and returns a canonical LSPFileUpdates object containing indexed trees
+     * Commits the given edit to `gs`, and returns a canonical LSPFileUpdates object containing indexed trees
      * and file hashes. Also handles canceling the running slow path.
      */
     std::unique_ptr<LSPFileUpdates> commitEdit(SorbetWorkspaceEditParams &edit, WorkerPool &workers);

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -60,9 +60,7 @@ public:
 /**
  * The LSP preprocessor typically runs on an independent thread and performs the following tasks:
  * - Preprocesses and merges contiguous file updates before they are sent to the typechecking thread.
- * - Determines if edits should take the fast or slow path.
  * - Is the source-of-truth for the latest file updates.
- * - Clones initialGS so that the typechecking thread can perform typechecking on the clone.
  * - Early rejects messages that are sent prior to initialization completion.
  * - Determines if a running slow path should be canceled, and undertakes canceling if so.
  */

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -149,7 +149,7 @@ TEST_CASE("IgnoresWatchmanUpdatesFromOpenFiles") {
     CHECK_EQ(updates->updates[0]->source(), fileContents);
 }
 
-// When deepCopying initialGS for typechecking, it should always have all previous updates applied to it.
+// it.
 TEST_CASE("ClonesTypecheckingGSAtCorrectLogicalTime") {
     string fileV1 = "# typed: true";
     // V1 => V2: Slow path
@@ -292,7 +292,7 @@ TEST_CASE("MergesFileUpdatesProperlyAfterCancelation") {
         CHECK_EQ(contents, updates->updates[0]->source());
     }
 
-    // Cancel hover requests, and ensure that initialGS has the proper value of foo.rb
+    // Cancel hover requests, and ensure that the typechecker's GlobalState has the proper value of foo.rb
     vector<pair<int, string>> entries = {
         {0, fileV2},
         {1, fileV3},

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -149,7 +149,6 @@ TEST_CASE("IgnoresWatchmanUpdatesFromOpenFiles") {
     CHECK_EQ(updates->updates[0]->source(), fileContents);
 }
 
-// it.
 TEST_CASE("ClonesTypecheckingGSAtCorrectLogicalTime") {
     string fileV1 = "# typed: true";
     // V1 => V2: Slow path

--- a/test/lsp/watchman_test_corpus.cc
+++ b/test/lsp/watchman_test_corpus.cc
@@ -110,8 +110,8 @@ TEST_CASE_FIXTURE(ProtocolTest, "MergesMultipleWatchmanUpdates") {
                                                      {"baz.rb", 3, "Expected `Integer`"},
                                                  });
 
-    // getTypecheckCount tracks the number of times typechecking has run on the same clone from LSPLoop's
-    // initialGS. It's reset to 1 after each slow path run, and incremented after every fast path.
+    // getTypecheckCount tracks the number of times typechecking has run on the same version of the typechecker's
+    // GlobalState. It's reset to 1 after each slow path run, and incremented after every fast path.
     // We expect the merged case to run 1 slow path (where typecheck count would be 1), and the unmerged case to run
     // 3 slow paths and 2 fast paths (where typecheck count would be 3).
     INFO(fmt::format("Expected Sorbet to apply multiple Watchman updates in one typechecking run, but Sorbet ran "


### PR DESCRIPTION
Since we've switched to deriving a new `GlobalState` from the typechecker's current `GlobalState`, the terminology of `initialGS` that was used throughout the indexer has lost its relevance. Additionally, we no longer have any references to `finalGS` anywhere, so it seems like a good time to remove as much of this as possible. This PR:

1. removes all references to `initialGS` from comments, and
2. renames the indexer's `initialGS` instance variable to `gs`.

### Motivation
Keeping comments up to date.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
