### PR TITLE
Update json.rbi to make pretty_generate return String

### DIFF
--- a/rbi/stdlib/json.rbi
+++ b/rbi/stdlib/json.rbi
@@ -328,7 +328,7 @@ module JSON
       obj: ::T.untyped,
       opts: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .returns(::String)
   end
   def self.pretty_generate(obj, opts=T.unsafe(nil)); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`JSON.pretty_generate` is typed to only return `T.untyped` but it can only ever return `String`. This PR updates the type annotation to say so.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Correctness

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
