### PR TITLE
Add and populate new `owner` field on `PackageName`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2420,7 +2420,10 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &extraPackag
     std::vector<core::packages::MangledName> allowRelaxedPackagerChecksFor_;
     for (const string &pkgName : allowRelaxedPackagerChecksFor) {
         std::vector<string_view> pkgNameParts = absl::StrSplit(pkgName, "::");
-        auto mangledName = core::packages::MangledName::mangledNameFromParts(*this, pkgNameParts);
+        // TODO(jez) Figure out how to defer handling these things until we have symbols for
+        // packages, not mangled names.
+        auto mangledName =
+            core::packages::MangledName::mangledNameFromParts(*this, pkgNameParts, core::Symbols::noClassOrModule());
         allowRelaxedPackagerChecksFor_.emplace_back(mangledName);
     }
     packageDB_.allowRelaxedPackagerChecksFor_ = allowRelaxedPackagerChecksFor_;

--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -1,28 +1,29 @@
 #include "core/packages/MangledName.h"
 #include "absl/strings/str_join.h"
-#include "absl/strings/str_replace.h"
 #include "core/GlobalState.h"
 #include "core/Names.h"
 
 using namespace std;
 
 namespace sorbet::core::packages {
-MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::vector<std::string_view> &parts) {
+MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector<std::string_view> &parts,
+                                              ClassOrModuleRef owner) {
     // Foo::Bar => Foo_Bar
     auto mangledName = absl::StrCat(absl::StrJoin(parts, "_"));
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
-    auto packagerName = gs.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-    return MangledName(gs.enterNameConstant(packagerName));
+    auto packagerName = gs.freshNameUnique(UniqueNameKind::Packager, utf8Name, 1);
+    return MangledName(gs.enterNameConstant(packagerName), owner);
 }
 
-MangledName MangledName::mangledNameFromParts(core::GlobalState &gs, const std::vector<core::NameRef> &parts) {
+MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector<NameRef> &parts,
+                                              ClassOrModuleRef owner) {
     // Foo::Bar => Foo_Bar
     auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(gs)));
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
-    auto packagerName = gs.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-    return MangledName(gs.enterNameConstant(packagerName));
+    auto packagerName = gs.freshNameUnique(UniqueNameKind::Packager, utf8Name, 1);
+    return MangledName(gs.enterNameConstant(packagerName), owner);
 }
 
 } // namespace sorbet::core::packages

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -14,9 +14,11 @@ namespace sorbet::core::packages {
 class MangledName final {
     MangledName(NameRef mangledName, ClassOrModuleRef owner) : mangledName(mangledName), owner(owner) {}
 
-public:
     NameRef mangledName;
 
+    template <typename H> friend H AbslHashValue(H h, const MangledName &m);
+
+public:
     // The ClassOrModuleRef that this package is stored in.
     //
     // This is only to ease the transition to storing packages in the symbol table--eventually,

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -690,14 +690,41 @@ FullyQualifiedName getFullyQualifiedName(core::Context ctx, const ast::Unresolve
     return fqn;
 }
 
-// Gets the package name in `tree` if applicable.
-PackageName getPackageName(core::Context ctx, const ast::UnresolvedConstantLit *constantLit) {
+PackageName getPackageName(core::Context ctx, const ast::UnresolvedConstantLit *constantLit,
+                           core::ClassOrModuleRef symbol) {
     ENFORCE(constantLit != nullptr);
 
     PackageName pName;
     pName.fullName = getFullyQualifiedName(ctx, constantLit);
 
     // pname.mangledName will be populated later, when we have a mutable GlobalState
+    pName.mangledName.owner = symbol;
+
+    return pName;
+}
+
+PackageName getUnresolvedPackageName(core::Context ctx, const ast::UnresolvedConstantLit *constantLit) {
+    ENFORCE(constantLit != nullptr);
+
+    PackageName pName;
+    pName.fullName = getFullyQualifiedName(ctx, constantLit);
+
+    // Since packager now runs after namer, we know that these symbols are entered.
+    auto owner = core::Symbols::PackageSpecRegistry();
+    for (auto part : pName.fullName.parts) {
+        auto member = owner.data(ctx)->findMember(ctx, part);
+        if (!member.exists() || !member.isClassOrModule()) {
+            owner = core::Symbols::noClassOrModule();
+            break;
+        }
+        owner = member.asClassOrModuleRef();
+    }
+
+    if (owner == core::Symbols::PackageSpecRegistry()) {
+        owner = core::Symbols::noClassOrModule();
+    }
+
+    pName.mangledName.owner = owner;
 
     return pName;
 }
@@ -1231,7 +1258,7 @@ struct PackageSpecBodyWalk {
                 auto importArg = move(posArg);
                 posArg = ast::packager::prependRegistry(move(importArg));
 
-                info.importedPackageNames.emplace_back(getPackageName(ctx, target), method2ImportType(send));
+                info.importedPackageNames.emplace_back(getUnresolvedPackageName(ctx, target), method2ImportType(send));
             }
         }
 
@@ -1273,7 +1300,8 @@ struct PackageSpecBodyWalk {
                     auto &posArg = send.getPosArg(0);
                     auto importArg = move(target->recv);
                     posArg = ast::packager::prependRegistry(move(importArg));
-                    info.visibleTo_.emplace_back(getPackageName(ctx, recv), core::packages::VisibleToType::Wildcard);
+                    info.visibleTo_.emplace_back(getUnresolvedPackageName(ctx, recv),
+                                                 core::packages::VisibleToType::Wildcard);
                 } else {
                     if (auto e = ctx.beginError(target->loc, core::errors::Packager::InvalidConfiguration)) {
                         e.setHeader("Argument to `{}` must be a constant or the string literal `{}`",
@@ -1286,7 +1314,8 @@ struct PackageSpecBodyWalk {
                 auto importArg = move(posArg);
                 posArg = ast::packager::prependRegistry(move(importArg));
 
-                info.visibleTo_.emplace_back(getPackageName(ctx, target), core::packages::VisibleToType::Normal);
+                info.visibleTo_.emplace_back(getUnresolvedPackageName(ctx, target),
+                                             core::packages::VisibleToType::Normal);
             }
         }
 
@@ -1540,8 +1569,8 @@ unique_ptr<PackageInfoImpl> definePackage(const core::GlobalState &gs, ast::Pars
         auto nameTree = ast::cast_tree<ast::ConstantLit>(packageSpecClass->name);
         ENFORCE(nameTree != nullptr, "Invariant from rewriter");
 
-        return make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree->original()), ctx.locAt(packageSpecClass->loc),
-                                            ctx.locAt(packageSpecClass->declLoc));
+        return make_unique<PackageInfoImpl>(getPackageName(ctx, nameTree->original(), packageSpecClass->symbol),
+                                            ctx.locAt(packageSpecClass->loc), ctx.locAt(packageSpecClass->declLoc));
     }
 
     return nullptr;
@@ -1568,7 +1597,8 @@ void rewritePackageSpec(const core::GlobalState &gs, ast::ParsedFile &package, P
 
 // TODO(jez) Rename this to lookupMangledName, and make it take a const GlobalState
 void populateMangledName(core::GlobalState &gs, PackageName &pName) {
-    pName.mangledName = core::packages::MangledName::mangledNameFromParts(gs, pName.fullName.parts);
+    pName.mangledName =
+        core::packages::MangledName::mangledNameFromParts(gs, pName.fullName.parts, pName.mangledName.owner);
 }
 
 void populatePackagePathPrefixes(core::GlobalState &gs, ast::ParsedFile &package, PackageInfoImpl &info) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes a `ClassOrModuleRef` available on `PackageInfoImpl`, `Import`, and
`VisibleTo` (but not `export`, which deals with constants and not package
names).

Due to a fortuitous quirk: the `PackageName` struct was storing the
`MangledName` (4 bytes) in front of the `FullyQualifiedName` which has 8 byte
alignment, so there was already 4 spare bytes.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests