### PR TITLE
Defer resolving `--allow-relaxed-packager-checks-for`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2425,19 +2425,9 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &extraPackag
     packageDB_.extraPackageFilesDirectorySlashDeprecatedPrefixes_ = extraPackageFilesDirectorySlashDeprecatedPrefixes;
     packageDB_.extraPackageFilesDirectorySlashPrefixes_ = extraPackageFilesDirectorySlashPrefixes;
     packageDB_.skipRBIExportEnforcementDirs_ = packageSkipRBIExportEnforcementDirs;
+    packageDB_.allowRelaxedPackagerChecksFor_ = allowRelaxedPackagerChecksFor;
     absl::c_transform(packagerLayers, std::back_inserter(packageDB_.layers_),
                       [this](const auto &layer) { return enterNameUTF8(layer); });
-
-    std::vector<core::packages::MangledName> allowRelaxedPackagerChecksFor_;
-    for (const string &pkgName : allowRelaxedPackagerChecksFor) {
-        std::vector<string_view> pkgNameParts = absl::StrSplit(pkgName, "::");
-        // TODO(jez) Figure out how to defer handling these things until we have symbols for
-        // packages, not mangled names.
-        auto mangledName =
-            core::packages::MangledName::mangledNameFromParts(*this, pkgNameParts, core::Symbols::noClassOrModule());
-        allowRelaxedPackagerChecksFor_.emplace_back(mangledName);
-    }
-    packageDB_.allowRelaxedPackagerChecksFor_ = allowRelaxedPackagerChecksFor_;
     packageDB_.errorHint_ = errorHint;
 }
 

--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -9,7 +9,7 @@ namespace sorbet::core::packages {
 MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector<std::string_view> &parts,
                                               ClassOrModuleRef owner) {
     // Foo::Bar => Foo_Bar
-    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_"));
+    auto mangledName = absl::StrJoin(parts, "_");
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
     auto packagerName = gs.freshNameUnique(UniqueNameKind::Packager, utf8Name, 1);
@@ -19,7 +19,7 @@ MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector
 MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector<NameRef> &parts,
                                               ClassOrModuleRef owner) {
     // Foo::Bar => Foo_Bar
-    auto mangledName = absl::StrCat(absl::StrJoin(parts, "_", NameFormatter(gs)));
+    auto mangledName = absl::StrJoin(parts, "_", NameFormatter(gs));
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
     auto packagerName = gs.freshNameUnique(UniqueNameKind::Packager, utf8Name, 1);

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -36,6 +36,10 @@ public:
     // [:Foo, :Bar] => :Foo_Bar
     static MangledName mangledNameFromParts(GlobalState &gs, const std::vector<NameRef> &parts, ClassOrModuleRef owner);
 
+    // [:Foo, :Bar] => :Foo_Bar
+    // (might not exist)
+    static MangledName lookupMangledName(const core::GlobalState &gs, const std::vector<std::string> &parts);
+
     bool operator==(const MangledName &rhs) const {
         return mangledName == rhs.mangledName;
     }

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -72,6 +72,11 @@ public:
     const bool enforceLayering() const;
 
     const std::string_view errorHint() const;
+
+    // Expects to be called after packages have been defined, so that string package names provided
+    // at the command line can be resolved to actual packages.
+    void resolvePackagesWithRelaxedChecks(GlobalState &gs);
+
     bool allowRelaxedPackagerChecksFor(const MangledName mangledName) const;
 
 private:
@@ -81,7 +86,8 @@ private:
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes_;
     std::string errorHint_;
     std::vector<std::string> skipRBIExportEnforcementDirs_;
-    std::vector<MangledName> allowRelaxedPackagerChecksFor_;
+    std::vector<std::string> allowRelaxedPackagerChecksFor_;
+    UnorderedSet<MangledName> packagesWithRelaxedChecks_;
     std::vector<core::NameRef> layers_;
 
     // This vector is kept in sync with the size of the file table in the global state by

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2011,6 +2011,9 @@ void Packager::findPackages(core::GlobalState &gs, absl::Span<ast::ParsedFile> f
                 packages.db.enterPackage(move(pkg));
             }
         }
+
+        // Must be called after any calls to enterPackage (i.e., only here)
+        gs.packageDB().resolvePackagesWithRelaxedChecks(gs);
     }
 
     setPackageNameOnFiles(gs, files);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

We can wait until we have the symbol table populated from namer.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Trying to get away from identifying packages with `MangledName`, so that the
transition to `PackageRef` is seamless.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests