### PR TITLE
Stop entering all mangled names

### DIFF
--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -1,47 +1,11 @@
 #include "core/packages/MangledName.h"
-#include "absl/strings/str_join.h"
 #include "core/GlobalState.h"
 #include "core/Names.h"
 
 using namespace std;
 
 namespace sorbet::core::packages {
-MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector<std::string_view> &parts,
-                                              ClassOrModuleRef owner) {
-    // Foo::Bar => Foo_Bar
-    auto mangledName = absl::StrJoin(parts, "_");
-
-    auto utf8Name = gs.enterNameUTF8(mangledName);
-    auto packagerName = gs.freshNameUnique(UniqueNameKind::Packager, utf8Name, 1);
-    gs.enterNameConstant(packagerName);
-    return MangledName(owner);
-}
-
-MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector<NameRef> &parts,
-                                              ClassOrModuleRef owner) {
-    // Foo::Bar => Foo_Bar
-    auto mangledName = absl::StrJoin(parts, "_", NameFormatter(gs));
-
-    auto utf8Name = gs.enterNameUTF8(mangledName);
-    auto packagerName = gs.freshNameUnique(UniqueNameKind::Packager, utf8Name, 1);
-    gs.enterNameConstant(packagerName);
-    return MangledName(owner);
-}
-
 MangledName MangledName::lookupMangledName(const GlobalState &gs, const vector<string> &parts) {
-    // Foo::Bar => Foo_Bar
-    auto mangledName = absl::StrJoin(parts, "_");
-
-    auto utf8Name = gs.lookupNameUTF8(mangledName);
-    if (!utf8Name.exists()) {
-        return MangledName();
-    }
-
-    auto packagerName = gs.lookupNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
-    if (!packagerName.exists()) {
-        return MangledName();
-    }
-
     auto owner = core::Symbols::PackageSpecRegistry();
     for (auto part : parts) {
         auto member = owner.data(gs)->findMember(gs, gs.lookupNameConstant(part));
@@ -56,7 +20,6 @@ MangledName MangledName::lookupMangledName(const GlobalState &gs, const vector<s
         owner = core::Symbols::noClassOrModule();
     }
 
-    gs.lookupNameConstant(packagerName);
     return MangledName(owner);
 }
 

--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -13,7 +13,8 @@ MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
     auto packagerName = gs.freshNameUnique(UniqueNameKind::Packager, utf8Name, 1);
-    return MangledName(gs.enterNameConstant(packagerName), owner);
+    gs.enterNameConstant(packagerName);
+    return MangledName(owner);
 }
 
 MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector<NameRef> &parts,
@@ -23,7 +24,8 @@ MangledName MangledName::mangledNameFromParts(GlobalState &gs, const std::vector
 
     auto utf8Name = gs.enterNameUTF8(mangledName);
     auto packagerName = gs.freshNameUnique(UniqueNameKind::Packager, utf8Name, 1);
-    return MangledName(gs.enterNameConstant(packagerName), owner);
+    gs.enterNameConstant(packagerName);
+    return MangledName(owner);
 }
 
 MangledName MangledName::lookupMangledName(const GlobalState &gs, const vector<string> &parts) {
@@ -54,7 +56,8 @@ MangledName MangledName::lookupMangledName(const GlobalState &gs, const vector<s
         owner = core::Symbols::noClassOrModule();
     }
 
-    return MangledName(gs.lookupNameConstant(packagerName), owner);
+    gs.lookupNameConstant(packagerName);
+    return MangledName(owner);
 }
 
 } // namespace sorbet::core::packages

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -12,9 +12,7 @@ class GlobalState;
 
 namespace sorbet::core::packages {
 class MangledName final {
-    MangledName(NameRef mangledName, ClassOrModuleRef owner) : mangledName(mangledName), owner(owner) {}
-
-    NameRef mangledName;
+    MangledName(ClassOrModuleRef owner) : owner(owner) {}
 
     template <typename H> friend H AbslHashValue(H h, const MangledName &m);
 
@@ -41,7 +39,7 @@ public:
     static MangledName lookupMangledName(const core::GlobalState &gs, const std::vector<std::string> &parts);
 
     bool operator==(const MangledName &rhs) const {
-        return mangledName == rhs.mangledName;
+        return owner == rhs.owner;
     }
 
     bool operator!=(const MangledName &rhs) const {
@@ -49,7 +47,7 @@ public:
     }
 
     bool exists() const {
-        return this->mangledName.exists();
+        return this->owner.exists();
     }
 };
 
@@ -68,7 +66,7 @@ public:
 };
 
 template <typename H> H AbslHashValue(H h, const MangledName &m) {
-    return H::combine(std::move(h), m.mangledName);
+    return H::combine(std::move(h), m.owner);
 }
 } // namespace sorbet::core::packages
 #endif

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -12,10 +12,6 @@ class GlobalState;
 
 namespace sorbet::core::packages {
 class MangledName final {
-    MangledName(ClassOrModuleRef owner) : owner(owner) {}
-
-    template <typename H> friend H AbslHashValue(H h, const MangledName &m);
-
 public:
     // The ClassOrModuleRef that this package is stored in.
     //
@@ -27,6 +23,7 @@ public:
     ClassOrModuleRef owner;
 
     MangledName() = default;
+    explicit MangledName(ClassOrModuleRef owner) : owner(owner) {}
 
     // ["Foo", "Bar"] => :Foo_Bar
     static MangledName mangledNameFromParts(GlobalState &gs, const std::vector<std::string_view> &parts,

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -721,6 +721,9 @@ PackageName getUnresolvedPackageName(core::Context ctx, const ast::UnresolvedCon
     }
 
     if (owner == core::Symbols::PackageSpecRegistry()) {
+        // This is a weird case, because I don't think it's possible to get here, but we can handle it anyways.
+        // This whole function should go away with the switch to PackageRef anyways.
+        ENFORCE(pName.fullName.parts.empty());
         owner = core::Symbols::noClassOrModule();
     }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -723,7 +723,7 @@ PackageName getUnresolvedPackageName(core::Context ctx, const ast::UnresolvedCon
     if (owner == core::Symbols::PackageSpecRegistry()) {
         // This is a weird case, because I don't think it's possible to get here, but we can handle it anyways.
         // This whole function should go away with the switch to PackageRef anyways.
-        ENFORCE(pName.fullName.parts.empty());
+        ENFORCE(fullName.parts.empty());
         owner = core::Symbols::noClassOrModule();
     }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -104,6 +104,9 @@ struct PackageName {
     core::packages::MangledName mangledName;
     FullyQualifiedName fullName;
 
+    PackageName(core::ClassOrModuleRef owner, FullyQualifiedName &&fullName)
+        : mangledName(core::packages::MangledName(owner)), fullName(move(fullName)) {}
+
     // Pretty print the package's (user-observable) name (e.g. Foo::Bar)
     string toString(const core::GlobalState &gs) const {
         return absl::StrJoin(fullName.parts, "::", core::packages::NameFormatter(gs));
@@ -698,24 +701,17 @@ PackageName getPackageName(core::Context ctx, const ast::UnresolvedConstantLit *
                            core::ClassOrModuleRef symbol) {
     ENFORCE(constantLit != nullptr);
 
-    PackageName pName;
-    pName.fullName = getFullyQualifiedName(ctx, constantLit);
-
-    // pname.mangledName will be populated later, when we have a mutable GlobalState
-    pName.mangledName.owner = symbol;
-
-    return pName;
+    return PackageName(symbol, getFullyQualifiedName(ctx, constantLit));
 }
 
 PackageName getUnresolvedPackageName(core::Context ctx, const ast::UnresolvedConstantLit *constantLit) {
     ENFORCE(constantLit != nullptr);
 
-    PackageName pName;
-    pName.fullName = getFullyQualifiedName(ctx, constantLit);
+    auto fullName = getFullyQualifiedName(ctx, constantLit);
 
     // Since packager now runs after namer, we know that these symbols are entered.
     auto owner = core::Symbols::PackageSpecRegistry();
-    for (auto part : pName.fullName.parts) {
+    for (auto part : fullName.parts) {
         auto member = owner.data(ctx)->findMember(ctx, part);
         if (!member.exists() || !member.isClassOrModule()) {
             owner = core::Symbols::noClassOrModule();
@@ -728,9 +724,7 @@ PackageName getUnresolvedPackageName(core::Context ctx, const ast::UnresolvedCon
         owner = core::Symbols::noClassOrModule();
     }
 
-    pName.mangledName.owner = owner;
-
-    return pName;
+    return PackageName(owner, move(fullName));
 }
 
 bool recursiveVerifyConstant(core::Context ctx, core::NameRef fun, const ast::ExpressionPtr &root,
@@ -1599,12 +1593,6 @@ void rewritePackageSpec(const core::GlobalState &gs, ast::ParsedFile &package, P
     bodyWalk.finalize(ctx);
 }
 
-// TODO(jez) Rename this to lookupMangledName, and make it take a const GlobalState
-void populateMangledName(core::GlobalState &gs, PackageName &pName) {
-    pName.mangledName =
-        core::packages::MangledName::mangledNameFromParts(gs, pName.fullName.parts, pName.mangledName.owner);
-}
-
 void populatePackagePathPrefixes(core::GlobalState &gs, ast::ParsedFile &package, PackageInfoImpl &info) {
     auto extraPackageFilesDirectoryUnderscorePrefixes = gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes();
     auto extraPackageFilesDirectorySlashDeprecatedPrefixes =
@@ -1660,13 +1648,6 @@ void populatePackagePathPrefixes(core::GlobalState &gs, ast::ParsedFile &package
 
 void populatePackageEdges(core::GlobalState &gs, ast::ParsedFile &package, PackageInfoImpl &info) {
     rewritePackageSpec(gs, package, info);
-    for (auto &importedPackageName : info.importedPackageNames) {
-        populateMangledName(gs, importedPackageName.name);
-    }
-
-    for (auto &visibleTo : info.visibleTo_) {
-        populateMangledName(gs, visibleTo.name);
-    }
 }
 
 // Metadata for Tarjan's algorithm
@@ -1997,7 +1978,6 @@ void Packager::findPackages(core::GlobalState &gs, absl::Span<ast::ParsedFile> f
                 // surfaced that error to the user. Nothing to do here.
                 continue;
             }
-            populateMangledName(gs, pkg->name);
 
             auto &prevPkg = gs.packageDB().getPackageInfo(pkg->mangledName());
             if (prevPkg.exists() && prevPkg.declLoc() != pkg->declLoc()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This fully identifies packages by their `ClassOrModuleRef` scope, an important
step to being able to migrate packages into the symbol table.

The hairier migration is going to be getting rid of the `FullyQualifiedName`,
but actually maybe that is easy now that we have a `ClassOrModuleRef` in scope?
It's probably a lot easier than the last time I tried.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests