### PR TITLE
Avoid absl::BlockingCounter use for the single-threaded WorkerPool

### DIFF
--- a/common/concurrency/BUILD
+++ b/common/concurrency/BUILD
@@ -26,6 +26,7 @@ cc_library(
         "//common/enforce_no_timer",
         "//common/exception",
         "//common/os",
+        "@com_google_absl//absl/synchronization",
         "@concurrentqueue",
         "@spdlog",
     ],

--- a/common/concurrency/WorkerPool.h
+++ b/common/concurrency/WorkerPool.h
@@ -14,6 +14,11 @@ public:
     using Task = std::function<void()>;
     static std::unique_ptr<WorkerPool> create(int size, spdlog::logger &logger);
     virtual void multiplexJob(std::string_view taskName, Task t) = 0;
+
+    // A version of multiplexJob that can be used when the caller is only interested in blocking until the workers have
+    // finished.
+    virtual void multiplexJobWait(std::string_view taskName, Task t) = 0;
+
     virtual ~WorkerPool() = 0;
     virtual int size() = 0;
     WorkerPool() = default;

--- a/common/concurrency/WorkerPool.h
+++ b/common/concurrency/WorkerPool.h
@@ -13,6 +13,9 @@ public:
     }
     using Task = std::function<void()>;
     static std::unique_ptr<WorkerPool> create(int size, spdlog::logger &logger);
+
+    // Run a job on each of the workers in the pool. This method returns after queueing the work on the pool, under the
+    // expectation that the caller will coordinate reading results and waiting for jobs to finish.
     virtual void multiplexJob(std::string_view taskName, Task t) = 0;
 
     // A version of multiplexJob that can be used when the caller is only interested in blocking until the workers have

--- a/common/concurrency/WorkerPoolImpl.cc
+++ b/common/concurrency/WorkerPoolImpl.cc
@@ -1,5 +1,6 @@
 #include "common/concurrency/WorkerPoolImpl.h"
 #include "absl/strings/str_cat.h"
+#include "absl/synchronization/blocking_counter.h"
 #include "common/concurrency/WorkerPool.h"
 #include "common/enforce_no_timer/EnforceNoTimer.h"
 #include "common/os/os.h"
@@ -55,6 +56,22 @@ WorkerPoolImpl::~WorkerPoolImpl() {
         return false;
     });
     // join will be called when destructing joinable;
+}
+
+void WorkerPoolImpl::multiplexJobWait(string_view taskName, WorkerPool::Task t) {
+    if (_size > 0) {
+        absl::BlockingCounter barrier(_size);
+        multiplexJob_([&barrier, t{move(t)}, taskName] {
+            setCurrentThreadName(taskName);
+            t();
+            barrier.DecrementCount();
+            return true;
+        });
+        barrier.Wait();
+    } else {
+        // main thread is the worker.
+        t();
+    }
 }
 
 void WorkerPoolImpl::multiplexJob(string_view taskName, WorkerPool::Task t) {

--- a/common/concurrency/WorkerPoolImpl.h
+++ b/common/concurrency/WorkerPoolImpl.h
@@ -88,6 +88,7 @@ public:
     ~WorkerPoolImpl();
 
     void multiplexJob(std::string_view taskName, Task t) override;
+    void multiplexJobWait(std::string_view taskName, Task t) override;
     int size() override;
 };
 };     // namespace sorbet

--- a/core/BUILD
+++ b/core/BUILD
@@ -38,7 +38,6 @@ cc_library(
         "//core/hashing",
         "//main/pipeline/semantic_extension:interface",
         "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
         "@rang",
     ],

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -587,13 +587,11 @@ public:
                                             std::vector<ast::ParsedFile> files) {
         Timer timeit(gs.tracer(), "visibility_checker.check_visibility");
         auto taskq = std::make_shared<ConcurrentBoundedQueue<size_t>>(files.size());
-        absl::BlockingCounter barrier(std::max(workers.size(), 1));
-
         for (size_t i = 0; i < files.size(); ++i) {
             taskq->push(i, 1);
         }
 
-        workers.multiplexJob("VisibilityChecker", [&gs, &files, &barrier, taskq]() {
+        workers.multiplexJobWait("VisibilityChecker", [&gs, &files, taskq]() {
             size_t idx;
             for (auto result = taskq->try_pop(idx); !result.done(); result = taskq->try_pop(idx)) {
                 ast::ParsedFile &f = files[idx];
@@ -606,11 +604,7 @@ public:
                     }
                 }
             }
-
-            barrier.DecrementCount();
         });
-
-        barrier.Wait();
 
         return files;
     }


### PR DESCRIPTION
In some uses of `WorkerPool::multiplexJob` we allocate an `absl::BlockingCounter` and wait on it after the call to `multiplexJob` to ensure that all workers finished processing our job. This is a fine pattern, but in the case of a worker pool created with `0` workers, the blocking counter is totally unneeded as `multiplexJob` will execute our task directly.

We can avoid the `absl::BlockingCounter` use entirely if we add a specialization of `multiplexJob` for this case specifically, and that's what this PR does. `WorkerPool::multiplexJobWait` manages the allocation and use of the counter in the multi-threaded case, and avoids it all when we're running single-threaded.

### Motivation
Performance improvements when we're running with an empty worker pool, which happens frequently during slow path preemption in LSP.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
