### PR TITLE
Drop threads back to 16MB stack

### DIFF
--- a/common/os/os.cc
+++ b/common/os/os.cc
@@ -9,8 +9,8 @@
 using namespace std;
 
 // When changing this, you should also update the -stack-size flag in main/BUILD.
-// 64 Megabytes
-constexpr int REQUIRED_STACK_SIZE = 64 * 1024 * 1024;
+// 16 Megabytes
+constexpr int REQUIRED_STACK_SIZE = 16 * 1024 * 1024;
 
 void *Joinable::trampoline(void *ptr) {
     Joinable &self = *static_cast<Joinable *>(ptr);

--- a/main/BUILD
+++ b/main/BUILD
@@ -21,14 +21,6 @@ cc_binary(
     srcs = [
         "main.cc",
     ],
-    # When changing this, you should also update the REQUIRED_STACK_SIZE variable in common/os/os.cc.
-    linkopts = select({
-        "//tools/config:darwindbg": [
-            "-Wl,-stack_size",
-            "-Wl,0x4000000",
-        ],
-        "//conditions:default": [],
-    }),
     linkstatic = select({
         "//tools/config:linkshared": 0,
         "//conditions:default": 1,

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -57,16 +57,6 @@ config_setting(
 )
 
 config_setting(
-    name = "darwindbg",
-    constraint_values = [
-        "@platforms//os:osx",
-    ],
-    values = {
-        "compilation_mode": "dbg",
-    },
-)
-
-config_setting(
     name = "release",
     values = {
         "define": "release=true",


### PR DESCRIPTION
Also remove the darwindbg config_setting, and the associated build configuration that depended on it and would set the main thread's stack size.

I think this could probably be smaller than 16MB: running on Stripe's codebase indicated that we're well within that limit.

### Motivation
Tightening up resource limits a bit in anticipation of adding a second worker pool.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
