### PR TITLE
Add Psych Object#to_yaml core extension

### DIFF
--- a/rbi/stdlib/psych.rbi
+++ b/rbi/stdlib/psych.rbi
@@ -635,6 +635,16 @@ module Psych
   def self.safe_load_file(filename, **kwargs); end
 end
 
+class Object
+  ###
+  # call-seq: to_yaml(options = {})
+  #
+  # Convert an object to YAML.  See Psych.dump for more information on the
+  # available +options+.
+  sig { params(options: T::Hash[Symbol, T.untyped]).returns(String) }
+  def to_yaml(options = {}); end
+end
+
 class Psych::Exception < RuntimeError
 end
 

--- a/test/testdata/cfg/singleton_lazy.rb.symbol-table-raw.exp
+++ b/test/testdata/cfg/singleton_lazy.rb.symbol-table-raw.exp
@@ -7,7 +7,7 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=2:1 end=2:8}
     method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=2:1 end=3:4}
       argument <blk><block> @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=4:1 end=4:9}
       argument <blk><block> @ Loc {file=test/testdata/cfg/singleton_lazy.rb start=??? end=???}
 

--- a/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/sclass.rb.symbol-table-raw.exp
@@ -92,7 +92,7 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <S <C <U H>> $1> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U H>> $1> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <S <C <U H>> $1>   targs = [     <C <U <AttachedClass>>> = H   ] }) @ Loc {file=test/testdata/desugar/sclass.rb start=75:5 end=75:10}
     method <S <S <C <U H>> $1> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=75:5 end=81:8}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/desugar/sclass.rb start=84:1 end=84:9}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass.rb start=??? end=???}
 

--- a/test/testdata/desugar/sclass_inheritance.rb.symbol-table-raw.exp
+++ b/test/testdata/desugar/sclass_inheritance.rb.symbol-table-raw.exp
@@ -35,7 +35,7 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U MM>> $1> < <C <U Module>> () @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=2:1 end=2:10}
     method <S <C <U MM>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=2:1 end=2:15}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=30:1 end=30:9}
       argument <blk><block> @ Loc {file=test/testdata/desugar/sclass_inheritance.rb start=??? end=???}
 

--- a/test/testdata/infer/infer1.rb.symbol-table-raw.exp
+++ b/test/testdata/infer/infer1.rb.symbol-table-raw.exp
@@ -2,7 +2,7 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=2:1 end=50:4}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U baz1> : private (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=2:1 end=2:9}
       argument <blk><block> @ Loc {file=test/testdata/infer/infer1.rb start=??? end=???}
     method <C <U Object>>#<U baz2> : private (<blk>) @ Loc {file=test/testdata/infer/infer1.rb start=7:1 end=7:9}

--- a/test/testdata/infer/private_class_methods.rb.symbol-table.exp
+++ b/test/testdata/infer/private_class_methods.rb.symbol-table.exp
@@ -2,7 +2,7 @@ class ::<root> < ::Object ()
   class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/infer/private_class_methods.rb:4
       argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
-  class ::<Class:Object>[<AttachedClass>] < ::<Class:BasicObject> () @ (https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED)
+  class ::<Class:Object>[<AttachedClass>] < ::<Class:BasicObject> () @ (https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED)
     method ::<Class:Object>#bar : private (<blk>) @ test/testdata/infer/private_class_methods.rb:4
       argument <blk><block> @ Loc {file=test/testdata/infer/private_class_methods.rb start=??? end=???}
   class ::Test < ::Object () @ test/testdata/infer/private_class_methods.rb:6

--- a/test/testdata/infer/private_constant.rb.symbol-table.exp
+++ b/test/testdata/infer/private_constant.rb.symbol-table.exp
@@ -52,7 +52,7 @@ class ::<root> < ::Object ()
     method ::<Class:Foo>#using_private_module (x, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant.rb:64
       argument x<> -> T.class_of(Foo::PrivateModule) @ Loc {file=test/testdata/infer/private_constant.rb start=63:16 end=63:17}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}
-  class ::Object < ::BasicObject (Object, Kernel) @ (https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED)
+  class ::Object < ::BasicObject (Object, Kernel) @ (https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED)
     method ::Object#foo : private (x, <blk>) -> Sorbet::Private::Static::Void @ test/testdata/infer/private_constant.rb:100
       argument x<> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=98:13 end=98:14}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/infer/private_constant.rb start=??? end=???}

--- a/test/testdata/infer/private_methods.rb.symbol-table.exp
+++ b/test/testdata/infer/private_methods.rb.symbol-table.exp
@@ -2,7 +2,7 @@ class ::<root> < ::Object ()
   class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/infer/private_methods.rb:3
       argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
-  class ::Object < ::BasicObject (Object, Kernel) @ (https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED)
+  class ::Object < ::BasicObject (Object, Kernel) @ (https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED)
     method ::Object#foo : private (<blk>) @ test/testdata/infer/private_methods.rb:3
       argument <blk><block> @ Loc {file=test/testdata/infer/private_methods.rb start=??? end=???}
   class ::Test < ::Object () @ test/testdata/infer/private_methods.rb:5

--- a/test/testdata/lsp/completion/self_receiver.rb
+++ b/test/testdata/lsp/completion/self_receiver.rb
@@ -10,6 +10,6 @@ end
 class A
   def foo
     self.y # error: does not exist
-    #     ^ completion: yield_self, ...
+    #     ^ completion: to_yaml, yield_self, Array, Array, display, initialize_copy, pretty_inspect, syscall, system
   end
 end

--- a/test/testdata/namer/defs_in_blocks.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/defs_in_blocks.rb.symbol-table-raw.exp
@@ -2,7 +2,7 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=2:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U a_method> : private (<blk>) @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=5:3 end=5:15}
       argument <blk><block> @ Loc {file=test/testdata/namer/defs_in_blocks.rb start=??? end=???}
 

--- a/test/testdata/namer/parameter_names.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/parameter_names.rb.symbol-table-raw.exp
@@ -2,7 +2,7 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>)
     method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/parameter_names.rb start=2:1 end=32:23}
       argument <blk><block> @ Loc {file=test/testdata/namer/parameter_names.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U m1> : private (argX, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/namer/parameter_names.rb start=8:1 end=8:13}
       argument argX<> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=7:14 end=7:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=??? end=???}

--- a/test/testdata/namer/root_private.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/root_private.rb.symbol-table-raw.exp
@@ -11,7 +11,7 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/root_private.rb start=10:1 end=10:8}
     method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/root_private.rb start=10:1 end=14:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/root_private.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U foo_method_root> : private (<blk>) @ Loc {file=test/testdata/namer/root_private.rb start=5:1 end=5:20}
       argument <blk><block> @ Loc {file=test/testdata/namer/root_private.rb start=??? end=???}
 

--- a/test/testdata/namer/singleton_class.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/singleton_class.rb.symbol-table-raw.exp
@@ -11,7 +11,7 @@ class <C <U <root>>> < <C <U Object>> ()
           argument <blk><block> @ Loc {file=test/testdata/namer/singleton_class.rb start=??? end=???}
     class <C <U A>>::<S <C <U B>> $1> < <C <U Module>> () @ Loc {file=test/testdata/namer/singleton_class.rb start=2:7 end=2:11}
   class <S <C <U A>> $1> < <C <U Module>> () @ Loc {file=test/testdata/namer/singleton_class.rb start=2:7 end=2:8}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/namer/singleton_class.rb start=5:1 end=5:9}
       argument <blk><block> @ Loc {file=test/testdata/namer/singleton_class.rb start=??? end=???}
 

--- a/test/testdata/namer/toplevel_attr_writer.rb.symbol-table.exp
+++ b/test/testdata/namer/toplevel_attr_writer.rb.symbol-table.exp
@@ -2,7 +2,7 @@ class ::<root> < ::Object ()
   class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> (Sig)
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/namer/toplevel_attr_writer.rb:3
       argument <blk><block> @ Loc {file=test/testdata/namer/toplevel_attr_writer.rb start=??? end=???}
-  class ::Object < ::BasicObject (Object, Kernel) @ (https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED)
+  class ::Object < ::BasicObject (Object, Kernel) @ (https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi#LCENSORED, https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#LCENSORED)
     field ::Object#@foo -> T.untyped @ test/testdata/namer/toplevel_attr_writer.rb:6
     method ::Object#foo= : private (foo, <blk>) -> T.untyped @ test/testdata/namer/toplevel_attr_writer.rb:6
       argument foo<> -> T.untyped @ Loc {file=test/testdata/namer/toplevel_attr_writer.rb start=6:14 end=6:17}

--- a/test/testdata/rbi/psych.rb
+++ b/test/testdata/rbi/psych.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+T.assert_type!([].to_yaml, String)

--- a/test/testdata/resolver/invalid_alias.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/invalid_alias.rb.symbol-table-raw.exp
@@ -13,7 +13,7 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <S <C <U BadAliasingClassMethod1>> $1> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <S <C <U BadAliasingClassMethod1>> $1> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AppliedType {   klass = <S <C <U BadAliasingClassMethod1>> $1>   targs = [     <C <U <AttachedClass>>> = BadAliasingClassMethod1   ] }) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=4:3 end=4:8}
     method <S <S <C <U BadAliasingClassMethod1>> $1> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=4:3 end=10:6}
       argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/resolver/invalid_alias.rb start=13:1 end=13:9}
       argument <blk><block> @ Loc {file=test/testdata/resolver/invalid_alias.rb start=??? end=???}
 

--- a/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/recover_from_bad_superclass.rb.symbol-table-raw.exp
@@ -34,7 +34,7 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U G>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U G>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=G) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=29:1 end=29:12}
     method <S <C <U G>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=29:1 end=30:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U make_a_class> : private (<blk>) @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=3:1 end=3:17}
       argument <blk><block> @ Loc {file=test/testdata/resolver/recover_from_bad_superclass.rb start=??? end=???}
 

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -149,7 +149,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <S <C <U NotAODM>> $1>#<U prop> (args, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=3:5 end=3:25}
       argument args<repeated> @ Loc {file=test/testdata/rewriter/prop.rb start=3:20 end=3:24}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
     method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=94:1 end=94:9}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   module <C <U Opus>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/prop.rb start=84:7 end=84:11}


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This is unfortunately a part of the `psych` gem, defined here: https://github.com/ruby/psych/blob/3f24df27377a068fd799f4b549aa4ca0dd6b3acd/lib/psych/core_ext.rb#L12

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
