### PR TITLE
Add a preemption thread pool

### DIFF
--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -120,7 +120,8 @@ LSPTypecheckerCoordinator::LSPTypecheckerCoordinator(const shared_ptr<const LSPC
                                                      WorkerPool &workers, std::shared_ptr<TaskQueue> taskQueue)
     : preemptionTaskManager(preemptionTaskManager), shouldTerminate(false),
       typechecker(config, move(preemptionTaskManager)), config(config), hasDedicatedThread(false),
-      workers(workers), taskQueue{std::move(taskQueue)}, emptyWorkers(WorkerPool::create(0, *config->logger)) {}
+      workers(workers), taskQueue{std::move(taskQueue)},
+      preemptionWorkers(WorkerPool::create(config->opts.threads, *config->logger)) {}
 
 void LSPTypecheckerCoordinator::asyncRunInternal(shared_ptr<core::lsp::Task> task) {
     if (hasDedicatedThread) {
@@ -141,7 +142,7 @@ void LSPTypecheckerCoordinator::syncRun(unique_ptr<LSPTask> task) {
 shared_ptr<core::lsp::Task>
 LSPTypecheckerCoordinator::trySchedulePreemption(std::unique_ptr<LSPQueuePreemptionTask> preemptTask) {
     auto wrappedTask = make_shared<TypecheckerTask>(
-        *config, move(preemptTask), make_unique<LSPTypecheckerDelegate>(*taskQueue, *emptyWorkers, typechecker),
+        *config, move(preemptTask), make_unique<LSPTypecheckerDelegate>(*taskQueue, *preemptionWorkers, typechecker),
         /* collectCounters */ false);
     // Plant this timer before scheduling task to preempt, as task could run before we plant the timer!
     wrappedTask->timeLatencyUntilRun(make_unique<Timer>(*config->logger, "latency.preempt_slow_path"));

--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -40,8 +40,10 @@ class LSPTypecheckerCoordinator final {
     // the global state for the first time.
     std::shared_ptr<TaskQueue> taskQueue;
 
-    // An empty workerpool with 0 threads. Runs all work on the thread using it.
-    std::unique_ptr<WorkerPool> emptyWorkers;
+    // The worker pool used specifically for preemption tasks. This pool has the same number of threads as `workers`,
+    // because running preemption tasks implies that `workers` pool is suspended waiting for the preemption task to
+    // finish.
+    std::unique_ptr<WorkerPool> preemptionWorkers;
 
     /**
      * Runs the provided task on the typechecker thread.


### PR DESCRIPTION
We currently run preemption tasks with an empty thread pool, which means that if they are made up of multiple files, or have many functions defined, they'll take longer to run than on the non-preemption fast path.

As running preemption tasks necessarily requires parking all threads currently typechecking files, we could keep a second thread pool around for running the fast path during preemption. The threads in the alternate pool would schedule well as the others would be blocked on a mutex, and having the extra threads available during preemption would give a more consistent fast-path experience.

### Motivation
More consistent fast-path editing experience.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
