### PR TITLE
Make conditionals that test emscripten_build constexpr

### DIFF
--- a/common/Subprocess.cc
+++ b/common/Subprocess.cc
@@ -58,7 +58,7 @@ private:
 // and returns the child's stdout and status code
 optional<sorbet::Subprocess::Result> sorbet::Subprocess::spawn(string executable, vector<string> arguments,
                                                                optional<string_view> stdinContents) {
-    if (emscripten_build) {
+    if constexpr (emscripten_build) {
         return nullopt;
     }
     int stdinPipe[2];

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -61,7 +61,7 @@ public:
     inline DequeueResult wait_pop_timed(Elem &elem, std::chrono::duration<Rep, Period> const &timeout,
                                         spdlog::logger &log, bool silent = false) noexcept {
         DequeueResult ret;
-        if (!sorbet::emscripten_build) {
+        if constexpr (!sorbet::emscripten_build) {
             ret.shouldRetry = elementsLeftToPush.load(std::memory_order_acquire) != 0;
             if (ret.shouldRetry) {
                 std::unique_ptr<sorbet::Timer> time;

--- a/common/concurrency/WorkerPoolImpl.cc
+++ b/common/concurrency/WorkerPoolImpl.cc
@@ -17,7 +17,7 @@ WorkerPool::~WorkerPool() {
 
 WorkerPoolImpl::WorkerPoolImpl(int size, spdlog::logger &logger) : _size(size), logger(logger) {
     logger.trace("Creating {} worker threads", _size);
-    if (sorbet::emscripten_build) {
+    if constexpr (sorbet::emscripten_build) {
         ENFORCE_NO_TIMER(size == 0);
         this->_size = 0;
     } else {


### PR DESCRIPTION
As `sorbet::emscripten_build` is defined as a `constexpr` constant, we can make all conditionals that test it into `constexpr` conditionals. There aren't many, but it feels worth doing to ensure that we're not accidentally keeping those conditionals in a build.

### Motivation
Build config hygiene.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests
