### PR TITLE
Clarify a comment in LSPTypecheckerCoordinator

### DIFF
--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -40,9 +40,12 @@ class LSPTypecheckerCoordinator final {
     // the global state for the first time.
     std::shared_ptr<TaskQueue> taskQueue;
 
-    // The worker pool used specifically for preemption tasks. This pool has the same number of threads as `workers`,
-    // because running preemption tasks implies that `workers` pool is suspended waiting for the preemption task to
-    // finish.
+    // The worker pool used specifically for preemption tasks. This pool has the same number of
+    // threads as `workers` so that running preemption tasks can use as many threads as a slowpath
+    // task would.
+    //
+    // (When running preemption tasks, every thread in the main `workers` pool is suspended, which
+    // is why we have a second pool.)
     std::unique_ptr<WorkerPool> preemptionWorkers;
 
     /**


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The "because" was confusing me. It made it sound to me like there was a
correctness invariant where the number of threads must be the same.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

comment-only