### PR TITLE
stop moving things that don't need to be

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -72,7 +72,7 @@ class AutogenWalk {
 
                     // append the name in reverse order to the hitherto-built name vector,
                     // then break out of the loop.
-                    out.insert(out.end(), std::move(resolvedScopeName).rbegin(), std::move(resolvedScopeName).rend());
+                    out.insert(out.end(), resolvedScopeName.rbegin(), resolvedScopeName.rend());
                     break;
                 }
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's bad form to use a variable after applying `std::move` to it -- even if, in this case, I don't think it actually gets moved.

We could use `make_move_iterator`, but since the vector elements here are `NameRef`s, which are cheap to move, we can just do the ordinary thing and everything will work out.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
