### PR TITLE
Replace `Class#subclasses` intrinsic with `T.attached_class` RBI

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2247,13 +2247,6 @@ public:
     }
 } Class_new;
 
-class Class_subclasses : public IntrinsicMethod {
-public:
-    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
-        res.returnType = Types::arrayOf(gs, args.thisType);
-    }
-} Class_subclasses;
-
 class T_Generic_squareBrackets : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
@@ -4550,7 +4543,6 @@ const vector<Intrinsic> intrinsics{
     {Symbols::Object(), Intrinsic::Kind::Instance, Names::singletonClass(), &Object_class},
 
     {Symbols::Class(), Intrinsic::Kind::Instance, Names::new_(), &Class_new},
-    {Symbols::Class(), Intrinsic::Kind::Instance, Names::subclasses(), &Class_subclasses},
 
     {Symbols::Sorbet_Private_Static(), Intrinsic::Kind::Singleton, Names::sig(), &SorbetPrivateStatic_sig},
 

--- a/rbi/core/class.rbi
+++ b/rbi/core/class.rbi
@@ -196,7 +196,7 @@ class Class < Module
   # B.subclasses        #=> [C]
   # C.subclasses        #=> []
   # ```
-  sig { returns(T::Array[T::Class[T.anything]]) }
+  sig { returns(T::Array[T::Class[T.attached_class]]) }
   def subclasses(); end
 
   # Returns the superclass of *class*, or `nil`.


### PR DESCRIPTION
It looks like this was the history:

- A Rails monkey patch defined `Class#subclasses`. Since it was a gem
  monkey patch, most people using it were relying on it being untyped
  because the monkey patch method would have a generated, not
  hand-written, RBI.
- `Class#subclasses` got upstreamed into the Ruby stdlib.
- At the same time, Sorbet gained an RBI for the stdlib method, with a
  `sig` that did not use untyped (like most things in Sorbet's
  hand-written RBIs)
- Someone complained that Sorbet was flagging more errors, because it
  was not untyped anymore.

  option 1: push back, say that sometimes adding types causes errors
  option 2: fix this specific case with an intrinsic, because the type
  system machinery to do it in the RBI didn't exist yet

- Later, we made `Class` be generic (`T::Class[...]`). When that landed,
  I didn't realize that `subclasses` had an intrinsic that could be
  removed now and replaced with a simple RBI


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Someone asked why the RBI type didn't seem to match the sorbet.run behavior,
which revealed the existence of an intrinsic.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Stripe's codebase and the existing tests in

test/testdata/rbi/subclasses.rb