### PR TITLE
Change beginLoc for single line heredocs to include the marker

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1550,7 +1550,8 @@ public:
                 }
             } else {
                 auto *s = parser::cast_node<String>(firstPart);
-                return make_unique<String>(s->loc, s->val);
+                auto loc = tokLoc(begin).join(tokLoc(end));
+                return make_unique<String>(loc, s->val);
             }
         } else {
             core::LocOffsets loc = collectionLoc(begin, parts, end);

--- a/test/testdata/infer/heredoc_loc.rb
+++ b/test/testdata/infer/heredoc_loc.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+extend T::Sig
+
+sig { params(x: Integer).void }
+def foo(x); end
+
+foo(<<~MSG) # error: Expected `Integer` but found `String("foo\n")` for argument `x`
+  foo
+MSG


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Before:
```ruby
test.rb:9: Expected Integer but found String("foo\n") for argument x https://srb.help/7002
     9 |  foo
    10 |MSG
```

After:
```ruby
test.rb:8: Expected Integer but found String("foo\n") for argument x https://srb.help/7002
     8 |foo(<<~MSG)
     9 |  foo
    10 |MSG
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This results in better error messages and squiggly line locations as it points to the start
of the heredoc. It also gets Sorbet closer to Prism which assigns the
heredoc location to the marker.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
