### PR TITLE
Utilize `CommentsAssociator` in `AssertionsRewriter` for faster RBS type checking

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -262,7 +262,7 @@ unique_ptr<parser::Node> runRBSRewrite(core::GlobalState &gs, core::FileRef file
         auto sigsRewriter = rbs::SigsRewriter(ctx, commentsByNode);
         node = sigsRewriter.run(move(node));
 
-        auto assertionsRewriter = rbs::AssertionsRewriter(ctx);
+        auto assertionsRewriter = rbs::AssertionsRewriter(ctx, commentsByNode);
         node = assertionsRewriter.run(move(node));
 
         if (print.RBSRewriteTree.enabled) {

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -368,6 +368,28 @@ public:
         auto send = parser::cast_node<parser::Send>(expr.get());
         return send != nullptr && send->method == core::Names::untyped() && isT(send->receiver);
     }
+
+    /**
+     * Is `send` a visibility modifier (private, protected, public, etc.)?
+     */
+    static bool isVisibilitySend(const parser::Send *send) {
+        return send->receiver == nullptr && send->args.size() == 1 &&
+               (parser::isa_node<parser::DefMethod>(send->args[0].get()) ||
+                parser::isa_node<parser::DefS>(send->args[0].get())) &&
+               (send->method == core::Names::private_() || send->method == core::Names::protected_() ||
+                send->method == core::Names::public_() || send->method == core::Names::privateClassMethod() ||
+                send->method == core::Names::publicClassMethod() || send->method == core::Names::packagePrivate() ||
+                send->method == core::Names::packagePrivateClassMethod());
+    }
+
+    /**
+     * Is `send` an attribute accessor (attr_reader, attr_writer, attr_accessor)?
+     */
+    static bool isAttrAccessorSend(const parser::Send *send) {
+        return (send->receiver == nullptr || parser::isa_node<parser::Self>(send->receiver.get())) &&
+               (send->method == core::Names::attrReader() || send->method == core::Names::attrWriter() ||
+                send->method == core::Names::attrAccessor());
+    }
 };
 
 } // namespace sorbet::parser

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -271,26 +271,9 @@ int lexer::arg_or_cmdarg(int cmd_state) {
 
 void lexer::emit_comment(const char* s, const char* e) {
   if (collect_comments) {
-    // Find the start of the line manually. `newline_s` was incorrect for HEREDOCs
-
-    const char* line_start = source_buffer.data();
-    for (const char* p = s - 1; p >= source_buffer.data(); --p) {
-      if (*p == '\n') {
-        line_start = p + 1;
-        break;
-      }
-    }
-    // `line_start` will either point to beginning of the file or the first `\n` character found
-
-    // Ensure the comment is the first character in line (Temporary until assertions support)
-    bool is_first_in_line = absl::c_all_of(absl::string_view(line_start, s - line_start), [](auto c) { return isspace(c); } );
-
-    // Save the comment for RBS processing
-    if (is_first_in_line) {
-      size_t offset_start = (size_t)(s - source_buffer.data());
-      size_t offset_end = (size_t)(e - source_buffer.data());
-      comment_locations.emplace_back(offset_start, offset_end);
-    }
+    size_t offset_start = (size_t)(s - source_buffer.data());
+    size_t offset_end = (size_t)(e - source_buffer.data());
+    comment_locations.emplace_back(offset_start, offset_end);
   }
   if (*e == '\n') { // might also be \0
     newline_s = e;

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -168,7 +168,7 @@ bool AssertionsRewriter::hasConsumedComment(core::LocOffsets loc) {
  *
  * Returns `nullopt` if no comment is found or if the comment was already consumed.
  */
-optional<rbs::InlineComment> AssertionsRewriter::commentForNode(unique_ptr<parser::Node> &node) {
+optional<rbs::InlineComment> AssertionsRewriter::commentForNode(const unique_ptr<parser::Node> &node) {
     if (auto it = commentsByNode.find(node.get()); it != commentsByNode.end()) {
         for (const auto &commentNode : it->second) {
             if (absl::StartsWith(commentNode.string, RBS_PREFIX)) {
@@ -294,7 +294,7 @@ unique_ptr<parser::Node> AssertionsRewriter::maybeInsertCast(unique_ptr<parser::
 /**
  * Rewrite a collection of nodes, wrap them in an array and cast the array.
  */
-parser::NodeVec AssertionsRewriter::rewriteNodesAsArray(unique_ptr<parser::Node> &node, parser::NodeVec nodes) {
+parser::NodeVec AssertionsRewriter::rewriteNodesAsArray(const unique_ptr<parser::Node> &node, parser::NodeVec nodes) {
     auto inlineComment = commentForNode(node);
 
     if (inlineComment) {

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -179,8 +179,8 @@ optional<rbs::InlineComment> AssertionsRewriter::commentForNode(const unique_ptr
             continue;
         }
 
-        auto contentStart = commentNode.loc.beginPos() + 2;
-        auto content = commentNode.string.substr(2);
+        auto contentStart = commentNode.loc.beginPos() + 2; // +2 for the #: prefix
+        auto content = commentNode.string.substr(2);        // skip the #: prefix
 
         // Skip whitespace after the #:
         while (contentStart < commentNode.loc.endPos() && content[0] == ' ') {

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -183,7 +183,7 @@ optional<rbs::InlineComment> AssertionsRewriter::commentForNode(const unique_ptr
         auto content = commentNode.string.substr(2);        // skip the #: prefix
 
         // Skip whitespace after the #:
-        while (contentStart < commentNode.loc.endPos() && content[0] == ' ') {
+        while (contentStart < commentNode.loc.endPos() && std::isspace(content[0])) {
             contentStart++;
             content = content.substr(1);
         }

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -13,85 +13,12 @@ using namespace std;
 
 namespace sorbet::rbs {
 
+const string_view AssertionsRewriter::RBS_PREFIX = "#:";
+
 namespace {
 
 const regex not_nil_pattern("^\\s*!nil\\s*(#.*)?$");
 const regex untyped_pattern("^\\s*untyped\\s*(#.*)?$");
-
-/**
- * Check if the given range is the start of a heredoc assignment `= <<~FOO` and return the position of the end of the
- * heredoc marker.
- *
- * Returns -1 if no heredoc marker is found.
- */
-uint32_t hasHeredocMarker(core::Context ctx, const uint32_t fromPos, const uint32_t toPos) {
-    string source(ctx.file.data(ctx).source().substr(fromPos, toPos - fromPos));
-    regex heredoc_pattern("\\s*=?\\s*<<(-|~)[^,\\s\\n#]+(,\\s*<<(-|~)[^,\\s\\n#]+)*");
-    smatch match;
-    if (regex_search(source, match, heredoc_pattern)) {
-        return fromPos + match.length();
-    }
-    return UINT32_MAX;
-}
-
-/**
- * Check if the given expression is a heredoc
- */
-uint32_t heredocPos(core::Context ctx, core::LocOffsets assignLoc, const unique_ptr<parser::Node> &node) {
-    if (node == nullptr) {
-        return UINT32_MAX;
-    }
-
-    uint32_t result = UINT32_MAX;
-    typecase(
-        node.get(),
-        [&](parser::String *lit) {
-            // For some reason, heredoc strings are parser differently if they contain a single line or more.
-            //
-            // Single line heredocs do not contain the `<<-` or `<<~` markers inside their location.
-            //
-            // For example, this heredoc:
-            //
-            //     <<~MSG
-            //       foo
-            //     MSG
-
-            // has the `<<-` or `<<~` markers **outside** its location.
-            //
-            // While this heredoc:
-            //
-            //     <<~MSG
-            //       foo
-            //     MSG
-            //
-            // has the `<<-` or `<<~` markers **inside** its location.
-
-            auto lineStart = core::Loc::pos2Detail(ctx.file.data(ctx), lit->loc.beginLoc).line;
-            auto lineEnd = core::Loc::pos2Detail(ctx.file.data(ctx), lit->loc.endLoc).line;
-
-            if (lineEnd - lineStart <= 1) {
-                // Single line heredoc, we look for the heredoc marker outside, ie. between the assign `=` sign
-                // and the begining of the string.
-                result = hasHeredocMarker(ctx, assignLoc.endPos(), lit->loc.beginPos());
-            } else {
-                // Multi-line heredoc, we look for the heredoc marker inside the string itself.
-                result = hasHeredocMarker(ctx, lit->loc.beginPos(), lit->loc.endPos());
-            }
-        },
-        [&](parser::DString *lit) { result = hasHeredocMarker(ctx, lit->loc.beginPos(), lit->loc.endPos()); },
-        [&](parser::Array *arr) {
-            for (auto &elem : arr->elts) {
-                result = heredocPos(ctx, assignLoc, elem);
-                if (result != UINT32_MAX) {
-                    break;
-                }
-            }
-        },
-        [&](parser::Send *send) { result = heredocPos(ctx, assignLoc, send->receiver); },
-        [&](parser::Node *expr) { result = false; });
-
-    return result;
-}
 
 /*
  * Parse the comment and return the type as a `parser::Node` and the kind of assertion we need to apply (let, cast,
@@ -237,178 +164,54 @@ bool AssertionsRewriter::hasConsumedComment(core::LocOffsets loc) {
 }
 
 /*
- * Get the RBS comment for the given position.
- *
- * This function looks up for a comment starting at the given position until the end of the line.
- *
- * Returns `nullopt` if no comment is found.
- *
- * This function will mark the comment location as consumed so it won't be picked up by subsequent calls to this
- * function. This is to avoid applying the same comment multiple times:
- *
- *     foo x #: as !nil
- *
- * We only want to apply the `as !nil` comment on the `foo` call and not on the `x` argument.
- */
-optional<rbs::InlineComment> AssertionsRewriter::commentForPos(uint32_t fromPos, vector<char> allowedTokens = {}) {
-    auto source = ctx.file.data(ctx).source();
-
-    // Get the position of the end of the line from the startingLoc
-    auto endPos = source.find('\n', fromPos);
-    if (endPos == string::npos) {
-        // If we don't find a newline, we just use the rest of the file
-        endPos = source.size();
-    }
-
-    if (fromPos == endPos) {
-        // We reached the end of the line, we don't have a comment
-        return nullopt;
-    }
-
-    auto commentStart = fromPos;
-    while (commentStart < endPos) {
-        char c = source[commentStart];
-        if (c == ' ') {
-            // Skip whitespace until we find a `#:`
-            commentStart++;
-            continue;
-        } else if (find(allowedTokens.begin(), allowedTokens.end(), c) != allowedTokens.end()) {
-            // Skip allowed tokens like `,` or `.` depending on the callsite
-            commentStart++;
-            continue;
-        } else if (c == '#' && commentStart + 1 < endPos && source[commentStart + 1] == ':') {
-            // We found a `#:`
-            break;
-        } else {
-            // We found a character that is not a space or a `#`, so we don't have a comment
-            return nullopt;
-        }
-    }
-
-    if (commentStart == endPos) {
-        // We didn't find a `#:`
-        return nullopt;
-    }
-
-    // Consume the spaces after the `#:`
-    auto contentStart = commentStart + 2;
-    char c = source[contentStart];
-    while (c == ' ' && contentStart < endPos) {
-        contentStart++;
-        c = source[contentStart];
-    }
-
-    auto content = source.substr(contentStart, endPos - contentStart);
-    auto kind = InlineComment::Kind::LET;
-
-    if (absl::StartsWith(content, "as ")) {
-        // We found a `as` keyword, this is a `T.cast` comment
-        kind = InlineComment::Kind::CAST;
-        contentStart += 3;
-        content = content.substr(3);
-
-        if (regex_match(content.begin(), content.end(), not_nil_pattern)) {
-            // We found a `as !nil`, so a `T.must` comment
-            kind = InlineComment::Kind::MUST;
-        } else if (regex_match(content.begin(), content.end(), untyped_pattern)) {
-            // We found a `as untyped`, so a `T.unsafe` comment
-            kind = InlineComment::Kind::UNSAFE;
-        }
-    }
-
-    auto commentLoc = core::LocOffsets{(uint32_t)commentStart, static_cast<uint32_t>(endPos)};
-
-    // If we already consumed this comment, we don't return it since it's been "consumed" already
-    if (hasConsumedComment(commentLoc)) {
-        return nullopt;
-    }
-
-    // We consume the comment so it won't be picked up by subsequent calls to this function
-    consumeComment(commentLoc);
-
-    return InlineComment{
-        rbs::Comment{
-            commentLoc,
-            core::LocOffsets{(uint32_t)contentStart, static_cast<uint32_t>(endPos)},
-            content,
-        },
-        kind,
-    };
-}
-
-/*
  * Get the RBS comment for the given node.
  *
  * Returns `nullopt` if no comment is found or if the comment was already consumed.
- *
- * The `fromLoc` param is used to detect heredocs if any. Consider this example:
- *
- *     foo = <<~MSG
- *       bar
- *     MSG
- *
- * Since heredocs are parsed differently, we need to special case them. Using `fromLoc` as the end of the `foo` lhs
- * location, we can detect the heredoc between the `=` sign and the end of the line.
- *
- * This hack won't be necessary once we migrate the parsing to Prism.
  */
-optional<rbs::InlineComment> AssertionsRewriter::commentForNode(unique_ptr<parser::Node> &node,
-                                                                core::LocOffsets fromLoc,
-                                                                vector<char> allowedTokens = {}) {
-    // We want to find the comment right after the end of the assign
-    auto fromPos = node->loc.endPos();
+optional<rbs::InlineComment> AssertionsRewriter::commentForNode(unique_ptr<parser::Node> &node) {
+    if (auto it = commentsByNode.find(node.get()); it != commentsByNode.end()) {
+        for (const auto &commentNode : it->second) {
+            if (absl::StartsWith(commentNode.string, RBS_PREFIX)) {
+                auto contentStart = commentNode.loc.beginPos() + 2;
+                auto content = commentNode.string.substr(2);
 
-    // On heredocs, adding the comment at the end of the assign won't work because this is invalid Ruby syntax:
-    // ```
-    // <<~MSG
-    //   foo
-    // MSG #: String
-    // ```
-    // We add a special case for heredocs to allow adding the comment at the end of the assign:
-    // ```
-    // <<~MSG #: String
-    //   foo
-    // MSG
-    // ```
-    if (fromLoc.exists()) {
-        if (auto pos = heredocPos(ctx, fromLoc, node)) {
-            if (pos != -1) {
-                fromPos = pos;
+                // Skip whitespace after the #:
+                while (contentStart < commentNode.loc.endPos() && content[0] == ' ') {
+                    contentStart++;
+                    content = content.substr(1);
+                }
+
+                auto kind = InlineComment::Kind::LET;
+                if (absl::StartsWith(content, "as ")) {
+                    kind = InlineComment::Kind::CAST;
+                    contentStart += 3;
+                    content = content.substr(3);
+
+                    if (regex_match(content.begin(), content.end(), not_nil_pattern)) {
+                        kind = InlineComment::Kind::MUST;
+                    } else if (regex_match(content.begin(), content.end(), untyped_pattern)) {
+                        kind = InlineComment::Kind::UNSAFE;
+                    }
+                }
+
+                if (hasConsumedComment(commentNode.loc)) {
+                    continue;
+                }
+                consumeComment(commentNode.loc);
+
+                return InlineComment{
+                    rbs::Comment{
+                        commentNode.loc,
+                        core::LocOffsets{contentStart, commentNode.loc.endPos()},
+                        content,
+                    },
+                    kind,
+                };
             }
         }
     }
 
-    return commentForPos(fromPos, allowedTokens);
-}
-
-void AssertionsRewriter::checkDanglingCommentWithDecl(uint32_t nodeEnd, uint32_t declEnd, string kind) {
-    if (auto assertion = commentForPos(nodeEnd)) {
-        if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc,
-                                           core::errors::Rewriter::RBSAssertionError)) {
-            e.setHeader("Unexpected RBS assertion comment found after `{}` end", kind);
-        }
-    }
-
-    auto decLine = core::Loc::pos2Detail(ctx.file.data(ctx), declEnd).line;
-    auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), nodeEnd).line;
-
-    if ((endLine > decLine)) {
-        if (auto assertion = commentForPos(declEnd)) {
-            if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc,
-                                               core::errors::Rewriter::RBSAssertionError)) {
-                e.setHeader("Unexpected RBS assertion comment found after `{}` declaration", kind);
-            }
-        }
-    }
-}
-
-void AssertionsRewriter::checkDanglingComment(uint32_t nodeEnd, string kind) {
-    if (auto assertion = commentForPos(nodeEnd)) {
-        if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc,
-                                           core::errors::Rewriter::RBSAssertionError)) {
-            e.setHeader("Unexpected RBS assertion comment found after `{}`", kind);
-        }
-    }
+    return nullopt;
 }
 
 /**
@@ -472,15 +275,14 @@ AssertionsRewriter::insertCast(unique_ptr<parser::Node> node,
 
 /**
  * Insert a cast into the given node if there is an not yet consumed RBS assertion comment after the node.
+ * Optionally accepts another node to associate its comments instead.
  */
-unique_ptr<parser::Node> AssertionsRewriter::maybeInsertCast(unique_ptr<parser::Node> node,
-                                                             core::LocOffsets assignLoc = core::LocOffsets::none(),
-                                                             vector<char> allowedTokens = {}) {
+unique_ptr<parser::Node> AssertionsRewriter::maybeInsertCast(unique_ptr<parser::Node> node) {
     if (node == nullptr) {
         return node;
     }
 
-    if (auto inlineComment = commentForNode(node, assignLoc, allowedTokens)) {
+    if (auto inlineComment = commentForNode(node)) {
         if (auto type = parseComment(ctx, inlineComment.value(), typeParams)) {
             return insertCast(move(node), move(type));
         }
@@ -492,22 +294,26 @@ unique_ptr<parser::Node> AssertionsRewriter::maybeInsertCast(unique_ptr<parser::
 /**
  * Rewrite a collection of nodes, wrap them in an array and cast the array.
  */
-parser::NodeVec AssertionsRewriter::rewriteNodesAsArray(parser::NodeVec nodes) {
-    if (nodes.size() == 1) {
-        rewriteNodes(&nodes);
-        return nodes;
+parser::NodeVec AssertionsRewriter::rewriteNodesAsArray(unique_ptr<parser::Node> &node, parser::NodeVec nodes) {
+    auto inlineComment = commentForNode(node);
+
+    if (inlineComment) {
+        if (nodes.size() > 1) {
+            auto loc = nodes.front()->loc.join(nodes.back()->loc);
+            auto arr = parser::MK::Array(loc, move(nodes));
+            arr = rewriteNode(move(arr));
+
+            auto vector = parser::NodeVec();
+            vector.emplace_back(move(arr));
+            nodes = move(vector);
+        }
+        if (auto type = parseComment(ctx, inlineComment.value(), typeParams)) {
+            nodes.front() = insertCast(move(nodes.front()), move(type));
+        }
     }
 
-    auto loc = core::LocOffsets{
-        nodes.front()->loc.beginPos(),
-        nodes.back()->loc.endPos(),
-    };
-    auto arr = parser::MK::Array(loc, move(nodes));
-    arr = rewriteNode(move(arr));
-
-    auto vector = parser::NodeVec();
-    vector.emplace_back(move(arr));
-    return vector;
+    rewriteNodes(&nodes);
+    return nodes;
 }
 
 /**
@@ -552,35 +358,30 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
 
         [&](parser::Module *module) {
             module->body = rewriteBody(move(module->body));
-            checkDanglingCommentWithDecl(module->loc.endPos(), module->declLoc.endPos(), "module");
             result = move(node);
 
             typeParams.clear();
         },
         [&](parser::Class *klass) {
             klass->body = rewriteBody(move(klass->body));
-            checkDanglingCommentWithDecl(klass->loc.endPos(), klass->declLoc.endPos(), "class");
             result = move(node);
 
             typeParams.clear();
         },
         [&](parser::SClass *sclass) {
             sclass->body = rewriteBody(move(sclass->body));
-            checkDanglingCommentWithDecl(sclass->loc.endPos(), sclass->declLoc.endPos() + 8, "sclass");
             result = move(node);
 
             typeParams.clear();
         },
         [&](parser::DefMethod *method) {
             method->body = rewriteBody(move(method->body));
-            checkDanglingCommentWithDecl(method->loc.endPos(), method->declLoc.endPos(), "method");
             result = move(node);
 
             typeParams.clear();
         },
         [&](parser::DefS *method) {
             method->body = rewriteBody(move(method->body));
-            checkDanglingCommentWithDecl(method->loc.endPos(), method->declLoc.endPos(), "method");
             result = move(node);
 
             typeParams.clear();
@@ -603,25 +404,24 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
 
         [&](parser::Assign *asgn) {
             asgn->lhs = rewriteNode(move(asgn->lhs));
-            asgn->rhs = maybeInsertCast(move(asgn->rhs), asgn->lhs->loc);
             asgn->rhs = rewriteNode(move(asgn->rhs));
             result = move(node);
         },
         [&](parser::AndAsgn *andAsgn) {
             andAsgn->left = rewriteNode(move(andAsgn->left));
-            andAsgn->right = maybeInsertCast(move(andAsgn->right), andAsgn->left->loc);
+            andAsgn->right = maybeInsertCast(move(andAsgn->right));
             andAsgn->right = rewriteNode(move(andAsgn->right));
             result = move(node);
         },
         [&](parser::OpAsgn *opAsgn) {
             opAsgn->left = rewriteNode(move(opAsgn->left));
-            opAsgn->right = maybeInsertCast(move(opAsgn->right), opAsgn->left->loc);
+            opAsgn->right = maybeInsertCast(move(opAsgn->right));
             opAsgn->right = rewriteNode(move(opAsgn->right));
             result = move(node);
         },
         [&](parser::OrAsgn *orAsgn) {
             orAsgn->left = rewriteNode(move(orAsgn->left));
-            orAsgn->right = maybeInsertCast(move(orAsgn->right), orAsgn->left->loc);
+            orAsgn->right = maybeInsertCast(move(orAsgn->right));
             orAsgn->right = rewriteNode(move(orAsgn->right));
             result = move(node);
         },
@@ -635,10 +435,21 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
         // Sends
 
         [&](parser::Send *send) {
-            send->receiver = maybeInsertCast(move(send->receiver), core::LocOffsets::none(), {'.'});
+            // Skip visibility sends and attr_accessor sends as their comments are not assertions
+            if (parser::MK::isVisibilitySend(send) || parser::MK::isAttrAccessorSend(send)) {
+                result = move(node);
+                return;
+            }
+
+            send->receiver = maybeInsertCast(move(send->receiver));
             send->receiver = rewriteNode(move(send->receiver));
 
-            if (send->method.isSetter(ctx.state) && send->args.size() == 1) {
+            if (send->method == core::Names::squareBracketsEq()) {
+                // This is a `foo[key]=(y)` method, walk y for chained method calls
+                send->args.back() = rewriteNode(move(send->args.back()));
+                result = move(node);
+                return;
+            } else if (send->method.isSetter(ctx.state) && send->args.size() == 1) {
                 // This is a `foo.x=(y)` method, we treat it as a `x = y` assignment
                 send->args[0] = maybeInsertCast(move(send->args[0]));
                 result = move(node);
@@ -651,26 +462,19 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
                 arg = rewriteNode(move(arg));
 
                 if (auto splat = parser::cast_node<parser::Splat>(arg.get())) {
-                    splat->var = maybeInsertCast(move(splat->var), core::LocOffsets::none(), {','});
+                    splat->var = maybeInsertCast(move(splat->var));
                 } else if (auto kwsplat = parser::cast_node<parser::Kwsplat>(arg.get())) {
-                    kwsplat->expr = maybeInsertCast(move(kwsplat->expr), core::LocOffsets::none(), {','});
+                    kwsplat->expr = maybeInsertCast(move(kwsplat->expr));
                 } else {
-                    arg = maybeInsertCast(move(arg), core::LocOffsets::none(), {','});
+                    arg = maybeInsertCast(move(arg));
                 }
             }
 
             result = move(node);
         },
         [&](parser::CSend *csend) {
-            csend->receiver = maybeInsertCast(move(csend->receiver), core::LocOffsets::none(), {'&', '.'});
+            csend->receiver = maybeInsertCast(move(csend->receiver));
             csend->receiver = rewriteNode(move(csend->receiver));
-
-            if (csend->method.isSetter(ctx.state) && csend->args.size() == 1) {
-                // This is a `foo&.x=(y)` method, we treat it as a `x = y` assignment
-                csend->args[0] = maybeInsertCast(move(csend->args[0]));
-                result = move(node);
-                return;
-            }
 
             node = maybeInsertCast(move(node));
 
@@ -678,11 +482,11 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
                 arg = rewriteNode(move(arg));
 
                 if (auto splat = parser::cast_node<parser::Splat>(arg.get())) {
-                    splat->var = maybeInsertCast(move(splat->var), core::LocOffsets::none(), {','});
+                    splat->var = maybeInsertCast(move(splat->var));
                 } else if (auto kwsplat = parser::cast_node<parser::Kwsplat>(arg.get())) {
-                    kwsplat->expr = maybeInsertCast(move(kwsplat->expr), core::LocOffsets::none(), {','});
+                    kwsplat->expr = maybeInsertCast(move(kwsplat->expr));
                 } else {
-                    arg = maybeInsertCast(move(arg), core::LocOffsets::none(), {','});
+                    arg = maybeInsertCast(move(arg));
                 }
             }
 
@@ -736,32 +540,41 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
 
         [&](parser::Break *break_) {
             if (break_->exprs.empty()) {
-                checkDanglingComment(break_->loc.endPos(), "break");
                 result = move(node);
                 return;
             }
 
-            break_->exprs = rewriteNodesAsArray(move(break_->exprs));
+            for (auto &expr : break_->exprs) {
+                expr = rewriteNode(move(expr));
+            }
+
+            break_->exprs = rewriteNodesAsArray(node, move(break_->exprs));
             result = move(node);
         },
         [&](parser::Next *next) {
             if (next->exprs.empty()) {
-                checkDanglingComment(next->loc.endPos(), "next");
                 result = move(node);
                 return;
             }
 
-            next->exprs = rewriteNodesAsArray(move(next->exprs));
+            for (auto &expr : next->exprs) {
+                expr = rewriteNode(move(expr));
+            }
+
+            next->exprs = rewriteNodesAsArray(node, move(next->exprs));
             result = move(node);
         },
         [&](parser::Return *ret) {
             if (ret->exprs.empty()) {
-                checkDanglingComment(ret->loc.endPos(), "return");
                 result = move(node);
                 return;
             }
 
-            ret->exprs = rewriteNodesAsArray(move(ret->exprs));
+            for (auto &expr : ret->exprs) {
+                expr = rewriteNode(move(expr));
+            }
+
+            ret->exprs = rewriteNodesAsArray(node, move(ret->exprs));
             result = move(node);
         },
 
@@ -795,13 +608,6 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
             result = move(node);
         },
         [&](parser::Resbody *resbody) {
-            if (resbody->var) {
-                checkDanglingComment(resbody->var->loc.endPos(), "rescue");
-            } else if (resbody->exception) {
-                checkDanglingComment(resbody->exception->loc.endPos(), "rescue");
-            } else {
-                checkDanglingComment(resbody->loc.beginPos() + 6, "rescue");
-            }
             resbody->body = rewriteBody(move(resbody->body));
             result = move(node);
         },
@@ -813,11 +619,13 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
         // Others
 
         [&](parser::And *and_) {
+            node = maybeInsertCast(move(node));
             and_->left = rewriteNode(move(and_->left));
             and_->right = rewriteNode(move(and_->right));
             result = move(node);
         },
         [&](parser::Or *or_) {
+            node = maybeInsertCast(move(node));
             or_->left = rewriteNode(move(or_->left));
             or_->right = rewriteNode(move(or_->right));
             result = move(node);
@@ -830,11 +638,11 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
                 elem = rewriteNode(move(elem));
 
                 if (auto pair = parser::cast_node<parser::Pair>(elem.get())) {
-                    pair->value = maybeInsertCast(move(pair->value), core::LocOffsets::none(), {','});
+                    pair->value = maybeInsertCast(move(pair->value));
                 } else if (auto splat = parser::cast_node<parser::Splat>(elem.get())) {
-                    splat->var = maybeInsertCast(move(splat->var), core::LocOffsets::none(), {','});
+                    splat->var = maybeInsertCast(move(splat->var));
                 } else if (auto kwsplat = parser::cast_node<parser::Kwsplat>(elem.get())) {
-                    kwsplat->expr = maybeInsertCast(move(kwsplat->expr), core::LocOffsets::none(), {','});
+                    kwsplat->expr = maybeInsertCast(move(kwsplat->expr));
                 } else {
                     continue;
                 }
@@ -855,11 +663,11 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
                 elem = rewriteNode(move(elem));
 
                 if (auto splat = parser::cast_node<parser::Splat>(elem.get())) {
-                    splat->var = maybeInsertCast(move(splat->var), core::LocOffsets::none(), {','});
+                    splat->var = maybeInsertCast(move(splat->var));
                 } else if (auto kwsplat = parser::cast_node<parser::Kwsplat>(elem.get())) {
-                    kwsplat->expr = maybeInsertCast(move(kwsplat->expr), core::LocOffsets::none(), {','});
+                    kwsplat->expr = maybeInsertCast(move(kwsplat->expr));
                 } else {
-                    elem = maybeInsertCast(move(elem), core::LocOffsets::none(), {','});
+                    elem = maybeInsertCast(move(elem));
                 }
             }
 

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -300,9 +300,7 @@ unique_ptr<parser::Node> AssertionsRewriter::maybeInsertCast(unique_ptr<parser::
  * Rewrite a collection of nodes, wrap them in an array and cast the array.
  */
 parser::NodeVec AssertionsRewriter::rewriteNodesAsArray(const unique_ptr<parser::Node> &node, parser::NodeVec nodes) {
-    auto inlineComment = commentForNode(node);
-
-    if (inlineComment) {
+    if (auto inlineComment = commentForNode(node)) {
         if (nodes.size() > 1) {
             auto loc = nodes.front()->loc.join(nodes.back()->loc);
             auto arr = parser::MK::Array(loc, move(nodes));

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -169,7 +169,7 @@ bool AssertionsRewriter::hasConsumedComment(core::LocOffsets loc) {
 optional<rbs::InlineComment> AssertionsRewriter::commentForNode(const unique_ptr<parser::Node> &node) {
     auto it = commentsByNode.find(node.get());
     if (it == commentsByNode.end()) {
-        return std::nullopt;
+        return nullopt;
     }
 
     for (const auto &commentNode : it->second) {
@@ -181,7 +181,7 @@ optional<rbs::InlineComment> AssertionsRewriter::commentForNode(const unique_ptr
         auto content = commentNode.string.substr(2);        // skip the #: prefix
 
         // Skip whitespace after the #:
-        while (contentStart < commentNode.loc.endPos() && std::isspace(content[0])) {
+        while (contentStart < commentNode.loc.endPos() && isspace(content[0])) {
             contentStart++;
             content = content.substr(1);
         }

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -13,8 +13,6 @@ using namespace std;
 
 namespace sorbet::rbs {
 
-const string_view AssertionsRewriter::RBS_PREFIX = "#:";
-
 namespace {
 
 const regex not_nil_pattern("^\\s*!nil\\s*(#.*)?$");
@@ -175,7 +173,7 @@ optional<rbs::InlineComment> AssertionsRewriter::commentForNode(const unique_ptr
     }
 
     for (const auto &commentNode : it->second) {
-        if (!absl::StartsWith(commentNode.string, RBS_PREFIX)) {
+        if (!absl::StartsWith(commentNode.string, CommentsAssociator::RBS_PREFIX)) {
             continue;
         }
 

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -22,7 +22,7 @@ struct InlineComment {
 
 class AssertionsRewriter {
 public:
-    AssertionsRewriter(core::MutableContext ctx, std::map<parser::Node *, std::vector<CommentNode>> commentsByNode)
+    AssertionsRewriter(core::MutableContext ctx, std::map<parser::Node *, std::vector<CommentNode>> &commentsByNode)
         : ctx(ctx), commentsByNode(commentsByNode){};
     std::unique_ptr<parser::Node> run(std::unique_ptr<parser::Node> tree);
 
@@ -30,7 +30,7 @@ private:
     static const std::string_view RBS_PREFIX;
 
     core::MutableContext ctx;
-    std::map<parser::Node *, std::vector<CommentNode>> commentsByNode;
+    std::map<parser::Node *, std::vector<CommentNode>> &commentsByNode;
     std::vector<std::pair<core::LocOffsets, core::NameRef>> typeParams = {};
     std::set<std::pair<uint32_t, uint32_t>> consumedComments = {};
 

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -2,6 +2,7 @@
 #define SORBET_RBS_ASSERTIONS_REWRITER_H
 
 #include "parser/parser.h"
+#include "rbs/CommentsAssociator.h"
 #include "rbs/rbs_common.h"
 #include <memory>
 
@@ -21,28 +22,30 @@ struct InlineComment {
 
 class AssertionsRewriter {
 public:
-    AssertionsRewriter(core::MutableContext ctx) : ctx(ctx){};
+    AssertionsRewriter(core::MutableContext ctx, std::map<parser::Node *, std::vector<CommentNode>> commentsByNode)
+        : ctx(ctx), commentsByNode(commentsByNode){};
     std::unique_ptr<parser::Node> run(std::unique_ptr<parser::Node> tree);
 
 private:
+    static const std::string_view RBS_PREFIX;
+
     core::MutableContext ctx;
+    std::map<parser::Node *, std::vector<CommentNode>> commentsByNode;
     std::vector<std::pair<core::LocOffsets, core::NameRef>> typeParams = {};
     std::set<std::pair<uint32_t, uint32_t>> consumedComments = {};
 
     void consumeComment(core::LocOffsets loc);
     bool hasConsumedComment(core::LocOffsets loc);
     std::optional<InlineComment> commentForPos(uint32_t fromPos, std::vector<char> allowedTokens);
-    std::optional<InlineComment> commentForNode(std::unique_ptr<parser::Node> &node, core::LocOffsets fromLoc,
-                                                std::vector<char> allowedTokens);
+    std::optional<InlineComment> commentForNode(std::unique_ptr<parser::Node> &node);
 
     std::unique_ptr<parser::Node> rewriteBody(std::unique_ptr<parser::Node> tree);
     std::unique_ptr<parser::Node> rewriteNode(std::unique_ptr<parser::Node> tree);
-    parser::NodeVec rewriteNodesAsArray(parser::NodeVec nodes);
+    parser::NodeVec rewriteNodesAsArray(std::unique_ptr<parser::Node> &node, parser::NodeVec nodes);
     void rewriteNodes(parser::NodeVec *nodes);
 
     bool saveTypeParams(parser::Block *block);
-    std::unique_ptr<parser::Node> maybeInsertCast(std::unique_ptr<parser::Node> node, core::LocOffsets assignLoc,
-                                                  std::vector<char> allowedTokens);
+    std::unique_ptr<parser::Node> maybeInsertCast(std::unique_ptr<parser::Node> node);
     std::unique_ptr<parser::Node>
     insertCast(std::unique_ptr<parser::Node> node,
                std::optional<std::pair<std::unique_ptr<parser::Node>, InlineComment::Kind>> pair);

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -27,8 +27,6 @@ public:
     std::unique_ptr<parser::Node> run(std::unique_ptr<parser::Node> tree);
 
 private:
-    static const std::string_view RBS_PREFIX;
-
     core::MutableContext ctx;
     std::map<parser::Node *, std::vector<CommentNode>> &commentsByNode;
     std::vector<std::pair<core::LocOffsets, core::NameRef>> typeParams = {};

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -37,11 +37,11 @@ private:
     void consumeComment(core::LocOffsets loc);
     bool hasConsumedComment(core::LocOffsets loc);
     std::optional<InlineComment> commentForPos(uint32_t fromPos, std::vector<char> allowedTokens);
-    std::optional<InlineComment> commentForNode(std::unique_ptr<parser::Node> &node);
+    std::optional<InlineComment> commentForNode(const std::unique_ptr<parser::Node> &node);
 
     std::unique_ptr<parser::Node> rewriteBody(std::unique_ptr<parser::Node> tree);
     std::unique_ptr<parser::Node> rewriteNode(std::unique_ptr<parser::Node> tree);
-    parser::NodeVec rewriteNodesAsArray(std::unique_ptr<parser::Node> &node, parser::NodeVec nodes);
+    parser::NodeVec rewriteNodesAsArray(const std::unique_ptr<parser::Node> &node, parser::NodeVec nodes);
     void rewriteNodes(parser::NodeVec *nodes);
 
     bool saveTypeParams(parser::Block *block);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -17,7 +17,7 @@ const string_view CommentsAssociator::ANNOTATION_PREFIX = "# @";
 const string_view CommentsAssociator::MULTILINE_RBS_PREFIX = "#|";
 
 // Static regex pattern to avoid recompilation
-static const std::regex HEREDOC_PATTERN("\\s*=?\\s*<<(-|~)[^,\\s\\n#]+(,\\s*<<(-|~)[^,\\s\\n#]+)*");
+static const regex HEREDOC_PATTERN("\\s*=?\\s*<<(-|~)[^,\\s\\n#]+(,\\s*<<(-|~)[^,\\s\\n#]+)*");
 
 /**
  * Check if the given range is the start of a heredoc assignment `= <<~FOO` and return the position of the end of the
@@ -26,11 +26,11 @@ static const std::regex HEREDOC_PATTERN("\\s*=?\\s*<<(-|~)[^,\\s\\n#]+(,\\s*<<(-
  * Returns -1 if no heredoc marker is found.
  */
 uint32_t hasHeredocMarker(core::Context ctx, const uint32_t fromPos, const uint32_t toPos) {
-    std::string_view source(ctx.file.data(ctx).source().substr(fromPos, toPos - fromPos));
+    string_view source(ctx.file.data(ctx).source().substr(fromPos, toPos - fromPos));
 
-    std::string source_str(source);
-    std::smatch match;
-    if (std::regex_search(source_str, HEREDOC_PATTERN)) {
+    string source_str(source);
+    smatch match;
+    if (regex_search(source_str, HEREDOC_PATTERN)) {
         return fromPos + source_str.length();
     }
     return UINT32_MAX;
@@ -561,7 +561,7 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
         });
 }
 
-std::map<parser::Node *, vector<CommentNode>> CommentsAssociator::run(unique_ptr<parser::Node> &node) {
+map<parser::Node *, vector<CommentNode>> CommentsAssociator::run(unique_ptr<parser::Node> &node) {
     // Remove any comments that don't start with RBS prefixes
     for (auto it = commentByLine.begin(); it != commentByLine.end();) {
         if (!absl::StartsWith(it->second.string, RBS_PREFIX) &&

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -493,10 +493,12 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 if (send->method == core::Names::squareBracketsEq()) {
                     // This is a `foo[key]=(y)` method, walk y for chained method calls
                     walkNodes(send->args.back().get());
+                    walkNodes(send->receiver.get());
                     return;
                 } else if (send->method.isSetter(ctx.state) && send->args.size() == 1) {
                     // This is a `foo.x=(y)` method, we treat it as a `x = y` assignment
                     associateAssertionCommentsToNode(send->args[0].get());
+                    walkNodes(send->receiver.get());
                     return;
                 }
                 associateAssertionCommentsToNode(send);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -25,7 +25,7 @@ static const regex HEREDOC_PATTERN("\\s*=?\\s*<<(-|~)[^,\\s\\n#]+(,\\s*<<(-|~)[^
  *
  * Returns -1 if no heredoc marker is found.
  */
-uint32_t hasHeredocMarker(core::Context ctx, const uint32_t fromPos, const uint32_t toPos) {
+optional<uint32_t> hasHeredocMarker(core::Context ctx, const uint32_t fromPos, const uint32_t toPos) {
     string_view source(ctx.file.data(ctx).source().substr(fromPos, toPos - fromPos));
 
     string source_str(source);
@@ -33,7 +33,8 @@ uint32_t hasHeredocMarker(core::Context ctx, const uint32_t fromPos, const uint3
     if (regex_search(source_str, HEREDOC_PATTERN)) {
         return fromPos + source_str.length();
     }
-    return UINT32_MAX;
+
+    return nullopt;
 }
 
 uint32_t CommentsAssociator::locateTargetLine(parser::Node *node) {
@@ -45,12 +46,12 @@ uint32_t CommentsAssociator::locateTargetLine(parser::Node *node) {
     typecase(
         node,
         [&](parser::String *lit) {
-            if (hasHeredocMarker(ctx, lit->loc.beginPos(), lit->loc.endPos()) != UINT32_MAX) {
+            if (hasHeredocMarker(ctx, lit->loc.beginPos(), lit->loc.endPos())) {
                 result = core::Loc::pos2Detail(ctx.file.data(ctx), lit->loc.beginPos()).line;
             }
         },
         [&](parser::DString *lit) {
-            if (hasHeredocMarker(ctx, lit->loc.beginPos(), lit->loc.endPos()) != UINT32_MAX) {
+            if (hasHeredocMarker(ctx, lit->loc.beginPos(), lit->loc.endPos())) {
                 result = core::Loc::pos2Detail(ctx.file.data(ctx), lit->loc.beginPos()).line;
             }
         },

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -34,7 +34,7 @@ private:
     void associateSignatureCommentsToNode(parser::Node *node);
     void consumeCommentsBetweenLines(int startLine, int endLine, std::string kind);
     void consumeCommentsUntilLine(int line);
-    uint32_t locateTargetLine(parser::Node *node);
+    std::optional<uint32_t> locateTargetLine(parser::Node *node);
 };
 
 } // namespace sorbet::rbs

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -19,20 +19,21 @@ public:
     std::map<parser::Node *, std::vector<CommentNode>> run(std::unique_ptr<parser::Node> &tree);
 
 private:
-    core::MutableContext ctx;
-    std::vector<core::LocOffsets> commentLocations;
-
-    std::map<int, CommentNode> commentByLine;
-    std::map<parser::Node *, std::vector<CommentNode>> commentsByNode;
-
     static const std::string_view RBS_PREFIX;
     static const std::string_view ANNOTATION_PREFIX;
     static const std::string_view MULTILINE_RBS_PREFIX;
 
+    core::MutableContext ctx;
+    std::vector<core::LocOffsets> commentLocations;
+    std::map<int, CommentNode> commentByLine;
+    std::map<parser::Node *, std::vector<CommentNode>> commentsByNode;
+
     void walkNodes(parser::Node *node);
-    void associateCommentsToNode(parser::Node *node);
-    void associateInlineCommentToNode(parser::Node *node);
+    void associateAssertionCommentsToNode(parser::Node *node, bool adjustLocForHeredoc);
+    void associateSignatureCommentsToNode(parser::Node *node);
+    void consumeCommentsBetweenLines(int startLine, int endLine, std::string kind);
     void consumeCommentsUntilLine(int line);
+    uint32_t locateTargetLine(parser::Node *node);
 };
 
 } // namespace sorbet::rbs

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -15,11 +15,12 @@ struct CommentNode {
 
 class CommentsAssociator {
 public:
+    static const std::string_view RBS_PREFIX;
+
     CommentsAssociator(core::MutableContext ctx, std::vector<core::LocOffsets> commentLocations);
     std::map<parser::Node *, std::vector<CommentNode>> run(std::unique_ptr<parser::Node> &tree);
 
 private:
-    static const std::string_view RBS_PREFIX;
     static const std::string_view ANNOTATION_PREFIX;
     static const std::string_view MULTILINE_RBS_PREFIX;
 

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -431,7 +431,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
     // Build the sig
 
     auto sigBuilder = parser::MK::Self(fullTypeLoc);
-    sigBuilder = handleAnnotations(std::move(sigBuilder), annotations);
+    sigBuilder = handleAnnotations(move(sigBuilder), annotations);
 
     if (typeParams.size() > 0) {
         auto typeParamsVector = parser::NodeVec();
@@ -486,7 +486,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::attrSignature(const parser::Sen
     auto commentLoc = declaration.commentLoc();
 
     auto sigBuilder = parser::MK::Self(fullTypeLoc.copyWithZeroLength());
-    sigBuilder = handleAnnotations(std::move(sigBuilder), annotations);
+    sigBuilder = handleAnnotations(move(sigBuilder), annotations);
 
     if (send->args.size() == 0) {
         if (auto e = ctx.beginIndexerError(send->loc, core::errors::Rewriter::RBSUnsupported)) {

--- a/rbs/Parser.cc
+++ b/rbs/Parser.cc
@@ -35,9 +35,9 @@ string_view Parser::resolveConstant(const rbs_ast_symbol_t *symbol) const {
     return string_view(reinterpret_cast<const char *>(constant->start), constant->length);
 }
 
-std::string_view Parser::resolveKeyword(const rbs_keyword_t *keyword) const {
+string_view Parser::resolveKeyword(const rbs_keyword_t *keyword) const {
     auto constant = rbs_constant_pool_id_to_constant(RBS_GLOBAL_CONSTANT_POOL, keyword->constant_id);
-    return std::string_view(reinterpret_cast<const char *>(constant->start), constant->length);
+    return string_view(reinterpret_cast<const char *>(constant->start), constant->length);
 }
 
 rbs_node_list_t *Parser::parseTypeParams() {

--- a/rbs/SignatureTranslator.cc
+++ b/rbs/SignatureTranslator.cc
@@ -34,7 +34,7 @@ SignatureTranslator::translateAssertionType(vector<pair<core::LocOffsets, core::
         return nullptr;
     }
 
-    auto typeToParserNode = TypeToParserNode(ctx, typeParams, std::move(parser));
+    auto typeToParserNode = TypeToParserNode(ctx, typeParams, move(parser));
     return typeToParserNode.toParserNode(rbsType, assertion);
 }
 
@@ -66,7 +66,7 @@ unique_ptr<parser::Node> SignatureTranslator::translateAttrSignature(const parse
         return nullptr;
     }
 
-    auto methodTypeToParserNode = MethodTypeToParserNode(ctx, std::move(parser));
+    auto methodTypeToParserNode = MethodTypeToParserNode(ctx, move(parser));
     return methodTypeToParserNode.attrSignature(send, rbsType, declaration, annotations);
 }
 
@@ -90,7 +90,7 @@ unique_ptr<parser::Node> SignatureTranslator::translateMethodSignature(const par
         return nullptr;
     }
 
-    auto methodTypeToParserNode = MethodTypeToParserNode(ctx, std::move(parser));
+    auto methodTypeToParserNode = MethodTypeToParserNode(ctx, move(parser));
     return methodTypeToParserNode.methodSignature(methodDef, rbsMethodType, declaration, annotations);
 }
 
@@ -132,7 +132,7 @@ parser::NodeVec SignatureTranslator::translateTypeParams(const RBSDeclaration &d
         return parser::NodeVec();
     }
 
-    auto typeParamsToParserNode = TypeParamsToParserNode(ctx, std::move(parser));
+    auto typeParamsToParserNode = TypeParamsToParserNode(ctx, move(parser));
     return typeParamsToParserNode.typeParams(rbsTypeParams, declaration);
 }
 

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -14,31 +14,15 @@ namespace sorbet::rbs {
 
 namespace {
 
-bool isVisibilitySend(const parser::Send *send) {
-    return send->receiver == nullptr && send->args.size() == 1 &&
-           (parser::isa_node<parser::DefMethod>(send->args[0].get()) ||
-            parser::isa_node<parser::DefS>(send->args[0].get())) &&
-           (send->method == core::Names::private_() || send->method == core::Names::protected_() ||
-            send->method == core::Names::public_() || send->method == core::Names::privateClassMethod() ||
-            send->method == core::Names::publicClassMethod() || send->method == core::Names::packagePrivate() ||
-            send->method == core::Names::packagePrivateClassMethod());
-}
-
-bool isAttrAccessorSend(const parser::Send *send) {
-    return (send->receiver == nullptr || parser::isa_node<parser::Self>(send->receiver.get())) &&
-           (send->method == core::Names::attrReader() || send->method == core::Names::attrWriter() ||
-            send->method == core::Names::attrAccessor());
-}
-
 parser::Node *signaturesTarget(parser::Node *node) {
     if (parser::isa_node<parser::DefMethod>(node) || parser::cast_node<parser::DefS>(node)) {
         return node;
     }
 
     if (auto send = parser::cast_node<parser::Send>(node)) {
-        if (isVisibilitySend(send)) {
+        if (parser::MK::isVisibilitySend(send)) {
             return send->args[0].get();
-        } else if (isAttrAccessorSend(send)) {
+        } else if (parser::MK::isAttrAccessorSend(send)) {
             return node;
         }
     }

--- a/rbs/SigsRewriter.h
+++ b/rbs/SigsRewriter.h
@@ -29,13 +29,13 @@ struct Comments {
 
 class SigsRewriter {
 public:
-    SigsRewriter(core::MutableContext ctx, std::map<parser::Node *, std::vector<rbs::CommentNode>> commentsByNode)
+    SigsRewriter(core::MutableContext ctx, std::map<parser::Node *, std::vector<rbs::CommentNode>> &commentsByNode)
         : ctx(ctx), commentsByNode(commentsByNode){};
     std::unique_ptr<parser::Node> run(std::unique_ptr<parser::Node> tree);
 
 private:
     core::MutableContext ctx;
-    std::map<parser::Node *, std::vector<rbs::CommentNode>> commentsByNode;
+    std::map<parser::Node *, std::vector<rbs::CommentNode>> &commentsByNode;
 
     std::unique_ptr<parser::Node> rewriteBegin(std::unique_ptr<parser::Node> tree);
     std::unique_ptr<parser::Node> rewriteBody(std::unique_ptr<parser::Node> tree);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -247,7 +247,7 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
                 auto rbsSignatures = rbs::SigsRewriter(ctx, commentsByNode);
                 nodes = rbsSignatures.run(std::move(nodes));
 
-                auto rbsAssertions = rbs::AssertionsRewriter(ctx);
+                auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentsByNode);
                 nodes = rbsAssertions.run(std::move(nodes));
             }
 
@@ -691,7 +691,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             auto rbsSignatures = rbs::SigsRewriter(ctx, commentsByNode);
             parseResult.tree = rbsSignatures.run(std::move(parseResult.tree));
 
-            auto rbsAssertions = rbs::AssertionsRewriter(ctx);
+            auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentsByNode);
             parseResult.tree = rbsAssertions.run(std::move(parseResult.tree));
         }
         auto nodes = move(parseResult.tree);

--- a/test/testdata/rbs/assertions_and_or.rb
+++ b/test/testdata/rbs/assertions_and_or.rb
@@ -34,3 +34,17 @@ ARGV.first || ARGV.last #: as String
 y = ARGV.first && ARGV.last #: as String
 
 ARGV.first && ARGV.last #: as String
+
+(
+  ARGV.first #: as String?
+) || (
+  ARGV.last #: as String
+)
+
+ARGV.first || ( #: as String? # error: Unexpected RBS assertion comment found after `begin`
+  ARGV.last #: as String
+)
+
+ARGV.first && ( #: as String # error: Unexpected RBS assertion comment found after `begin`
+  ARGV.last #: as String
+)

--- a/test/testdata/rbs/assertions_and_or.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_and_or.rb.rewrite-tree.exp
@@ -50,14 +50,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end, <todo sym>, <emptyTree>::<C String>)
 
-  begin
+  <cast:cast>(begin
     ||$7 = <emptyTree>::<C ARGV>.first()
     if ||$7
       ||$7
     else
-      <cast:cast>(<emptyTree>::<C ARGV>.last(), <todo sym>, <emptyTree>::<C String>)
+      <emptyTree>::<C ARGV>.last()
     end
-  end
+  end, <todo sym>, <emptyTree>::<C String>)
 
   y = <cast:cast>(begin
     &&$8 = <emptyTree>::<C ARGV>.first()
@@ -68,12 +68,39 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end, <todo sym>, <emptyTree>::<C String>)
 
-  begin
+  <cast:cast>(begin
     &&$9 = <emptyTree>::<C ARGV>.first()
     if &&$9
-      <cast:cast>(<emptyTree>::<C ARGV>.last(), <todo sym>, <emptyTree>::<C String>)
+      <emptyTree>::<C ARGV>.last()
     else
       &&$9
+    end
+  end, <todo sym>, <emptyTree>::<C String>)
+
+  begin
+    ||$10 = <cast:cast>(<emptyTree>::<C ARGV>.first(), <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C String>))
+    if ||$10
+      ||$10
+    else
+      <cast:cast>(<emptyTree>::<C ARGV>.last(), <todo sym>, <emptyTree>::<C String>)
+    end
+  end
+
+  begin
+    ||$11 = <emptyTree>::<C ARGV>.first()
+    if ||$11
+      ||$11
+    else
+      <cast:cast>(<emptyTree>::<C ARGV>.last(), <todo sym>, <emptyTree>::<C String>)
+    end
+  end
+
+  begin
+    &&$12 = <emptyTree>::<C ARGV>.first()
+    if &&$12
+      <cast:cast>(<emptyTree>::<C ARGV>.last(), <todo sym>, <emptyTree>::<C String>)
+    else
+      &&$12
     end
   end
 end

--- a/test/testdata/rbs/assertions_assign.rb
+++ b/test/testdata/rbs/assertions_assign.rb
@@ -80,6 +80,9 @@ T.reveal_type(cast6) # error: Revealed type: `String`
 cast7 = ARGV.first#:as String # some comment
 T.reveal_type(cast7) # error: Revealed type: `String`
 
+cast8 = "a" #: as untyped
+  .random_method_name
+
 # must
 
 must_x = ARGV.first #:as String?
@@ -99,7 +102,7 @@ T.reveal_type(must4) # error: Revealed type: `String`
 must5 = must_x#: as !nil # some comment
 T.reveal_type(must5) # error: Revealed type: `String`
 
-# unsage
+# unsafe
 
 unsafe_x = ARGV.first #:as String?
 

--- a/test/testdata/rbs/assertions_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_assign.rb.rewrite-tree.exp
@@ -109,6 +109,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <emptyTree>::<C T>.reveal_type(cast7)
 
+  cast8 = ::<root>::<C T>.unsafe("a").random_method_name()
+
   must_x = <cast:cast>(<emptyTree>::<C ARGV>.first(), <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C String>))
 
   must1 = ::<root>::<C T>.must(must_x)

--- a/test/testdata/rbs/assertions_break.rb
+++ b/test/testdata/rbs/assertions_break.rb
@@ -6,7 +6,18 @@ while ARGV.any?
 end
 
 while ARGV.any?
+  break(
+    ARGV.shift #: as String
+  )
+end
+
+while ARGV.any?
   break ARGV.shift, "foo" #: Array[String]
+end
+
+while ARGV.any?
+  break ARGV.shift, #: as String
+   "foo" #: String
 end
 
 while ARGV.shift

--- a/test/testdata/rbs/assertions_break.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_break.rb.rewrite-tree.exp
@@ -4,7 +4,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   while <emptyTree>::<C ARGV>.any?()
+    break(<cast:cast>(<emptyTree>::<C ARGV>.shift(), <todo sym>, <emptyTree>::<C String>))
+  end
+
+  while <emptyTree>::<C ARGV>.any?()
     break(<cast:let>([<emptyTree>::<C ARGV>.shift(), "foo"], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)))
+  end
+
+  while <emptyTree>::<C ARGV>.any?()
+    break([<cast:cast>(<emptyTree>::<C ARGV>.shift(), <todo sym>, <emptyTree>::<C String>), <cast:let>("foo", <todo sym>, <emptyTree>::<C String>)])
   end
 
   while <emptyTree>::<C ARGV>.shift()

--- a/test/testdata/rbs/assertions_kwbegin.rb
+++ b/test/testdata/rbs/assertions_kwbegin.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # enable-experimental-rbs-comments: true
 
-begin #: as String # error Unexpected RBS assertion comment found after `begin` declaration
+begin #: as String # error: Unexpected RBS assertion comment found after `begin` declaration
 end
 
 x = begin

--- a/test/testdata/rbs/assertions_next.rb
+++ b/test/testdata/rbs/assertions_next.rb
@@ -9,6 +9,11 @@ while ARGV.any?
   next ARGV.shift, "foo" #: Array[String]
 end
 
+while ARGV.any?
+  next ARGV.shift, #: as String
+   "foo" #: String
+end
+
 while ARGV.shift
   next #: as String
   #    ^^^^^^^^^^^^ error: Unexpected RBS assertion comment found after `next`

--- a/test/testdata/rbs/assertions_next.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_next.rb.rewrite-tree.exp
@@ -7,6 +7,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     next(<cast:let>([<emptyTree>::<C ARGV>.shift(), "foo"], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)))
   end
 
+  while <emptyTree>::<C ARGV>.any?()
+    next([<cast:cast>(<emptyTree>::<C ARGV>.shift(), <todo sym>, <emptyTree>::<C String>), <cast:let>("foo", <todo sym>, <emptyTree>::<C String>)])
+  end
+
   while <emptyTree>::<C ARGV>.shift()
     next(<emptyTree>)
   end

--- a/test/testdata/rbs/assertions_send.rb
+++ b/test/testdata/rbs/assertions_send.rb
@@ -36,7 +36,6 @@ puts(
   )
 )
 
-
 ARGV.
   first #: as Integer
 

--- a/test/testdata/rbs/assertions_send_assign.rb
+++ b/test/testdata/rbs/assertions_send_assign.rb
@@ -41,3 +41,6 @@ brackets_assign[:a, :b] = "baz" #: as untyped
 
 brackets_assign[:a, :b, :c] = "qux" #: as untyped
   .unexisting_method
+
+self #: as untyped
+  .unexisting_method = 42

--- a/test/testdata/rbs/assertions_send_assign.rb
+++ b/test/testdata/rbs/assertions_send_assign.rb
@@ -22,3 +22,22 @@ T.reveal_type(let2.foo) # error: Revealed type: `T.untyped`
 let3 = Let.new
 let3.foo.foo = "foo", "bar" #: Array[String]
 T.reveal_type(let3.foo) # error: Revealed type: `T.untyped`
+
+class BracketsAssign
+  #: (*untyped) -> void
+  def []=(*args); end
+end
+
+brackets_assign = BracketsAssign.new
+
+brackets_assign[] = "foo" #: as untyped
+  .unexisting_method
+
+brackets_assign[:a] = "bar" #: as untyped
+  .unexisting_method
+
+brackets_assign[:a, :b] = "baz" #: as untyped
+  .unexisting_method
+
+brackets_assign[:a, :b, :c] = "qux" #: as untyped
+  .unexisting_method

--- a/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
@@ -60,4 +60,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   brackets_assign.[]=(:a, :b, ::<root>::<C T>.unsafe("baz").unexisting_method())
 
   brackets_assign.[]=(:a, :b, :c, ::<root>::<C T>.unsafe("qux").unexisting_method())
+
+  ::<root>::<C T>.unsafe(<self>).unexisting_method=(42)
 end

--- a/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
@@ -38,4 +38,26 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   let3.foo().foo=(<cast:let>(["foo", "bar"], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)))
 
   <emptyTree>::<C T>.reveal_type(let3.foo())
+
+  class <emptyTree>::<C BracketsAssign><<C <todo sym>>> < (::<todo sym>)
+    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      <self>.params(:args, ::<root>::<C T>.untyped()).void()
+    end
+
+    def []=<<todo method>>(*args, &<blk>)
+      <emptyTree>
+    end
+
+    <runtime method definition of []=>
+  end
+
+  brackets_assign = <emptyTree>::<C BracketsAssign>.new()
+
+  brackets_assign.[]=(::<root>::<C T>.unsafe("foo").unexisting_method())
+
+  brackets_assign.[]=(:a, ::<root>::<C T>.unsafe("bar").unexisting_method())
+
+  brackets_assign.[]=(:a, :b, ::<root>::<C T>.unsafe("baz").unexisting_method())
+
+  brackets_assign.[]=(:a, :b, :c, ::<root>::<C T>.unsafe("qux").unexisting_method())
 end

--- a/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(let3.foo())
 
   class <emptyTree>::<C BracketsAssign><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:args, ::<root>::<C T>.untyped()).void()
     end
 

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -255,7 +255,7 @@ class UnusedTypeAnnotation
   end
 
   def foo # error: The method `foo` does not have a `sig`
-    #: -> void # error: Unused RBS signature comment. No method definition found after it
+    #: -> void # error: Unexpected RBS assertion comment found in `method`
   end
   def bar; end # error: The method `bar` does not have a `sig`
 end

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -54,10 +54,10 @@ take_g1_2(g1_1)
 take_g1_2(g1_2)
 take_g1_2(g1_3) # error: Expected `G1[Integer]` but found `G1[String]` for argument `g1`
 
-#: [U, V]
+#: [out U, V]
 class G2
   #: U
-  attr_accessor :u
+  attr_reader :u
 
   #: V
   attr_accessor :v
@@ -75,12 +75,13 @@ T.reveal_type(g2_1) # error: Revealed type: `G2[Integer, String]`
 
 g2_1.v = 2 # error: Assigning a value to `v` that does not match expected type `String`
 
-g2_2 = G2 #: Class[G2[Integer, String]]
-   .new(1, 2) #: G2[Numeric, String]
-#          ^ error: Expected `String` but found `Integer(2)` for argument `v`
+g2_2 = G2 #: as Class[G2[Integer, String]]
+   .new("a", 2) #: G2[Numeric, String]
+#       ^^^ error: Expected `Integer` but found `String("a")` for argument `u`
+#            ^ error: Expected `String` but found `Integer(2)` for argument `v`
 T.reveal_type(g2_2) # error: Revealed type: `G2[Numeric, String]`
 
-g2_3 = G2 #: Class[G2[Integer, String]]
+g2_3 = G2 #: as Class[G2[Integer, String]]
    .new(1, 2) #: G2[Integer, String]?
 #          ^ error: Expected `String` but found `Integer(2)` for argument `v`
 T.reveal_type(g2_3) # error: Revealed type: `T.nilable(G2[Integer, String])`

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -79,15 +79,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @u
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.params(:u, <emptyTree>::<C U>).returns(<emptyTree>::<C U>)
-    end
-
-    def u=<<todo method>>(u, &<blk>)
-      @u = u
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C V>)
     end
 
@@ -116,15 +108,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of u>
 
-    <runtime method definition of u=>
-
     <runtime method definition of v>
 
     <runtime method definition of v=>
 
     <runtime method definition of initialize>
 
-    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member()
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member(:out)
 
     <emptyTree>::<C V> = ::Sorbet::Private::Static.type_member()
   end
@@ -135,11 +125,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   g2_1.v=(2)
 
-  g2_2 = <cast:let>(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>, <emptyTree>::<C String>).new(1, 2), <todo sym>, <emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>, <emptyTree>::<C String>))
+  g2_2 = <cast:let>(<cast:cast>(<emptyTree>::<C G2>, <todo sym>, ::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))).new("a", 2), <todo sym>, <emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>, <emptyTree>::<C String>))
 
   <emptyTree>::<C T>.reveal_type(g2_2)
 
-  g2_3 = <cast:let>(<cast:let>(<emptyTree>::<C G2>, <todo sym>, ::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))).new(1, 2), <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>)))
+  g2_3 = <cast:let>(<cast:cast>(<emptyTree>::<C G2>, <todo sym>, ::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))).new(1, 2), <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>)))
 
   <emptyTree>::<C T>.reveal_type(g2_3)
 

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -79,7 +79,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @u
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C V>)
     end
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -642,8 +642,8 @@ end
 > This error is specific to RBS support when using the
 > `--enable-experimental-rbs-comments` flag.
 
-This error is raised when Sorbet couldn't match a RBS signature comment with a
-method definition. Ensure your comment is followed by a method definition.
+This error is raised when Sorbet couldn't match a RBS comment with a method
+definition or a type assertion.
 
 ## 3555
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
`AssertionsRewriter` currently parses the source code to extract RBS comments before translating them into sorbet assertions. This is inefficient and doesn't utilize the `CommentsAssociator` which relies on the lexer to parse the comments and associates them to a specific node.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
