### PR TITLE
rbs: beginError → beginIndexerError

### DIFF
--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -383,7 +383,8 @@ optional<rbs::InlineComment> AssertionsRewriter::commentForNode(unique_ptr<parse
 
 void AssertionsRewriter::checkDanglingCommentWithDecl(uint32_t nodeEnd, uint32_t declEnd, string kind) {
     if (auto assertion = commentForPos(nodeEnd)) {
-        if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc, core::errors::Rewriter::RBSAssertionError)) {
+        if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc,
+                                           core::errors::Rewriter::RBSAssertionError)) {
             e.setHeader("Unexpected RBS assertion comment found after `{}` end", kind);
         }
     }
@@ -393,8 +394,8 @@ void AssertionsRewriter::checkDanglingCommentWithDecl(uint32_t nodeEnd, uint32_t
 
     if ((endLine > decLine)) {
         if (auto assertion = commentForPos(declEnd)) {
-            if (auto e =
-                    ctx.beginIndexerError(assertion.value().comment.commentLoc, core::errors::Rewriter::RBSAssertionError)) {
+            if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc,
+                                               core::errors::Rewriter::RBSAssertionError)) {
                 e.setHeader("Unexpected RBS assertion comment found after `{}` declaration", kind);
             }
         }
@@ -403,7 +404,8 @@ void AssertionsRewriter::checkDanglingCommentWithDecl(uint32_t nodeEnd, uint32_t
 
 void AssertionsRewriter::checkDanglingComment(uint32_t nodeEnd, string kind) {
     if (auto assertion = commentForPos(nodeEnd)) {
-        if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc, core::errors::Rewriter::RBSAssertionError)) {
+        if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc,
+                                           core::errors::Rewriter::RBSAssertionError)) {
             e.setHeader("Unexpected RBS assertion comment found after `{}`", kind);
         }
     }

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -383,7 +383,7 @@ optional<rbs::InlineComment> AssertionsRewriter::commentForNode(unique_ptr<parse
 
 void AssertionsRewriter::checkDanglingCommentWithDecl(uint32_t nodeEnd, uint32_t declEnd, string kind) {
     if (auto assertion = commentForPos(nodeEnd)) {
-        if (auto e = ctx.beginError(assertion.value().comment.commentLoc, core::errors::Rewriter::RBSAssertionError)) {
+        if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc, core::errors::Rewriter::RBSAssertionError)) {
             e.setHeader("Unexpected RBS assertion comment found after `{}` end", kind);
         }
     }
@@ -394,7 +394,7 @@ void AssertionsRewriter::checkDanglingCommentWithDecl(uint32_t nodeEnd, uint32_t
     if ((endLine > decLine)) {
         if (auto assertion = commentForPos(declEnd)) {
             if (auto e =
-                    ctx.beginError(assertion.value().comment.commentLoc, core::errors::Rewriter::RBSAssertionError)) {
+                    ctx.beginIndexerError(assertion.value().comment.commentLoc, core::errors::Rewriter::RBSAssertionError)) {
                 e.setHeader("Unexpected RBS assertion comment found after `{}` declaration", kind);
             }
         }
@@ -403,7 +403,7 @@ void AssertionsRewriter::checkDanglingCommentWithDecl(uint32_t nodeEnd, uint32_t
 
 void AssertionsRewriter::checkDanglingComment(uint32_t nodeEnd, string kind) {
     if (auto assertion = commentForPos(nodeEnd)) {
-        if (auto e = ctx.beginError(assertion.value().comment.commentLoc, core::errors::Rewriter::RBSAssertionError)) {
+        if (auto e = ctx.beginIndexerError(assertion.value().comment.commentLoc, core::errors::Rewriter::RBSAssertionError)) {
             e.setHeader("Unexpected RBS assertion comment found after `{}`", kind);
         }
     }

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -39,7 +39,7 @@ void CommentsAssociator::consumeCommentsUntilLine(int line) {
         if (it->first < line) {
             if (absl::StartsWith(it->second.string, RBS_PREFIX) ||
                 absl::StartsWith(it->second.string, MULTILINE_RBS_PREFIX)) {
-                if (auto e = ctx.beginError(it->second.loc, core::errors::Rewriter::RBSUnusedComment)) {
+                if (auto e = ctx.beginIndexerError(it->second.loc, core::errors::Rewriter::RBSUnusedComment)) {
                     e.setHeader("Unused RBS signature comment. No method definition found after it");
                 }
             }

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -311,7 +311,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
 
     if (node.type->type != RBS_TYPES_FUNCTION) {
         auto errLoc = declaration.typeLocFromRange(node.type->location->rg);
-        if (auto e = ctx.beginError(errLoc, core::errors::Rewriter::RBSUnsupported)) {
+        if (auto e = ctx.beginIndexerError(errLoc, core::errors::Rewriter::RBSUnsupported)) {
             e.setHeader("Unexpected node type `{}` in method signature, expected `{}`", rbs_node_type_name(node.type),
                         "Function");
         }
@@ -398,7 +398,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
         auto type = typeToParserNode.toParserNode(arg.type, declaration);
 
         if (!methodArgs || i >= methodArgs->args.size()) {
-            if (auto e = ctx.beginError(fullTypeLoc, core::errors::Rewriter::RBSParameterMismatch)) {
+            if (auto e = ctx.beginIndexerError(fullTypeLoc, core::errors::Rewriter::RBSParameterMismatch)) {
                 e.setHeader("RBS signature has more parameters than in the method definition");
             }
 
@@ -408,7 +408,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
         auto methodArg = methodArgs->args[i].get();
 
         if (!checkParameterKindMatch(arg, methodArg)) {
-            if (auto e = ctx.beginError(arg.loc, core::errors::Rewriter::RBSIncorrectParameterKind)) {
+            if (auto e = ctx.beginIndexerError(arg.loc, core::errors::Rewriter::RBSIncorrectParameterKind)) {
                 e.setHeader("Argument kind mismatch for `{}`, method declares `{}`, but RBS signature declares `{}`",
                             nodeName(methodArg).show(ctx.state), nodeKindToString(methodArg),
                             argKindToString(arg.kind));
@@ -496,7 +496,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::attrSignature(const parser::Sen
     sigBuilder = handleAnnotations(std::move(sigBuilder), annotations);
 
     if (send->args.size() == 0) {
-        if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::RBSUnsupported)) {
+        if (auto e = ctx.beginIndexerError(send->loc, core::errors::Rewriter::RBSUnsupported)) {
             e.setHeader("RBS signatures do not support accessor without arguments");
         }
 
@@ -508,7 +508,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::attrSignature(const parser::Sen
 
     if (send->method == core::Names::attrWriter()) {
         if (send->args.size() > 1) {
-            if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::RBSUnsupported)) {
+            if (auto e = ctx.beginIndexerError(send->loc, core::errors::Rewriter::RBSUnsupported)) {
                 e.setHeader("RBS signatures for attr_writer do not support multiple arguments");
             }
 

--- a/rbs/SignatureTranslator.cc
+++ b/rbs/SignatureTranslator.cc
@@ -28,7 +28,7 @@ SignatureTranslator::translateAssertionType(vector<std::pair<core::LocOffsets, c
 
     if (parser.hasError()) {
         core::LocOffsets loc = assertion.typeLocFromRange(parser.getError()->token.range);
-        if (auto e = ctx.beginError(loc, core::errors::Rewriter::RBSSyntaxError)) {
+        if (auto e = ctx.beginIndexerError(loc, core::errors::Rewriter::RBSSyntaxError)) {
             e.setHeader("Failed to parse RBS type ({})", parser.getError()->message);
         }
         return nullptr;
@@ -54,11 +54,11 @@ unique_ptr<parser::Node> SignatureTranslator::translateAttrSignature(const parse
         methodParser.parseMethodType();
 
         if (!methodParser.hasError()) {
-            if (auto e = ctx.beginError(offset, core::errors::Rewriter::RBSSyntaxError)) {
+            if (auto e = ctx.beginIndexerError(offset, core::errors::Rewriter::RBSSyntaxError)) {
                 e.setHeader("Using a method signature on an accessor is not allowed, use a bare type instead");
             }
         } else {
-            if (auto e = ctx.beginError(offset, core::errors::Rewriter::RBSSyntaxError)) {
+            if (auto e = ctx.beginIndexerError(offset, core::errors::Rewriter::RBSSyntaxError)) {
                 e.setHeader("Failed to parse RBS type ({})", methodParser.getError()->message);
             }
         }
@@ -83,7 +83,7 @@ unique_ptr<parser::Node> SignatureTranslator::translateMethodSignature(const par
         rbs_range_t tokenRange = parser.getError()->token.range;
         core::LocOffsets offset = declaration.typeLocFromRange(tokenRange);
 
-        if (auto e = ctx.beginError(offset, core::errors::Rewriter::RBSSyntaxError)) {
+        if (auto e = ctx.beginIndexerError(offset, core::errors::Rewriter::RBSSyntaxError)) {
             e.setHeader("Failed to parse RBS signature ({})", parser.getError()->message);
         }
 
@@ -103,7 +103,7 @@ unique_ptr<parser::Node> SignatureTranslator::translateType(const RBSDeclaration
 
     if (parser.hasError()) {
         core::LocOffsets offset = declaration.typeLocFromRange(parser.getError()->token.range);
-        if (auto e = ctx.beginError(offset, core::errors::Rewriter::RBSSyntaxError)) {
+        if (auto e = ctx.beginIndexerError(offset, core::errors::Rewriter::RBSSyntaxError)) {
             e.setHeader("Failed to parse RBS type ({})", parser.getError()->message);
         }
 
@@ -125,7 +125,7 @@ parser::NodeVec SignatureTranslator::translateTypeParams(const RBSDeclaration &d
         rbs_range_t tokenRange = parser.getError()->token.range;
         core::LocOffsets offset = declaration.typeLocFromRange(tokenRange);
 
-        if (auto e = ctx.beginError(offset, core::errors::Rewriter::RBSSyntaxError)) {
+        if (auto e = ctx.beginIndexerError(offset, core::errors::Rewriter::RBSSyntaxError)) {
             e.setHeader("Failed to parse RBS type parameters ({})", parser.getError()->message);
         }
 

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -218,7 +218,7 @@ void SigsRewriter::insertTypeParams(parser::Node *node, unique_ptr<parser::Node>
 
     if (comments.signatures.size() > 1) {
         if (auto e = ctx.beginIndexerError(comments.signatures[0].commentLoc(),
-                                    core::errors::Rewriter::RBSMultipleGenericSignatures)) {
+                                           core::errors::Rewriter::RBSMultipleGenericSignatures)) {
             e.setHeader("Generic classes and modules can only have one RBS generic signature");
             return;
         }
@@ -265,7 +265,8 @@ Comments SigsRewriter::commentsForNode(parser::Node *node) {
             // If the comment starts with `#:`, it's a signature
             if (absl::StartsWith(commentNode.string, "#:")) {
                 if (state == SignatureState::Multiline) {
-                    if (auto e = ctx.beginIndexerError(commentNode.loc, core::errors::Rewriter::RBSMultilineMisformatted)) {
+                    if (auto e =
+                            ctx.beginIndexerError(commentNode.loc, core::errors::Rewriter::RBSMultilineMisformatted)) {
                         e.setHeader("Signature start (\"#:\") cannot appear after a multiline signature (\"#|\")");
                         return comments;
                     }
@@ -293,7 +294,8 @@ Comments SigsRewriter::commentsForNode(parser::Node *node) {
             // If the comment starts with `#|`, it's a multiline signature
             if (absl::StartsWith(commentNode.string, "#|")) {
                 if (state == SignatureState::None) {
-                    if (auto e = ctx.beginIndexerError(commentNode.loc, core::errors::Rewriter::RBSMultilineMisformatted)) {
+                    if (auto e =
+                            ctx.beginIndexerError(commentNode.loc, core::errors::Rewriter::RBSMultilineMisformatted)) {
                         e.setHeader("Multiline signature (\"#|\") must be preceded by a signature start (\"#:\")");
                         return comments;
                     }

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -217,7 +217,7 @@ void SigsRewriter::insertTypeParams(parser::Node *node, unique_ptr<parser::Node>
     }
 
     if (comments.signatures.size() > 1) {
-        if (auto e = ctx.beginError(comments.signatures[0].commentLoc(),
+        if (auto e = ctx.beginIndexerError(comments.signatures[0].commentLoc(),
                                     core::errors::Rewriter::RBSMultipleGenericSignatures)) {
             e.setHeader("Generic classes and modules can only have one RBS generic signature");
             return;
@@ -265,7 +265,7 @@ Comments SigsRewriter::commentsForNode(parser::Node *node) {
             // If the comment starts with `#:`, it's a signature
             if (absl::StartsWith(commentNode.string, "#:")) {
                 if (state == SignatureState::Multiline) {
-                    if (auto e = ctx.beginError(commentNode.loc, core::errors::Rewriter::RBSMultilineMisformatted)) {
+                    if (auto e = ctx.beginIndexerError(commentNode.loc, core::errors::Rewriter::RBSMultilineMisformatted)) {
                         e.setHeader("Signature start (\"#:\") cannot appear after a multiline signature (\"#|\")");
                         return comments;
                     }
@@ -293,7 +293,7 @@ Comments SigsRewriter::commentsForNode(parser::Node *node) {
             // If the comment starts with `#|`, it's a multiline signature
             if (absl::StartsWith(commentNode.string, "#|")) {
                 if (state == SignatureState::None) {
-                    if (auto e = ctx.beginError(commentNode.loc, core::errors::Rewriter::RBSMultilineMisformatted)) {
+                    if (auto e = ctx.beginIndexerError(commentNode.loc, core::errors::Rewriter::RBSMultilineMisformatted)) {
                         e.setHeader("Multiline signature (\"#|\") must be preceded by a signature start (\"#:\")");
                         return comments;
                     }

--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -23,7 +23,7 @@ parser::NodeVec TypeParamsToParserNode::typeParams(const rbs_node_list_t *rbsTyp
         auto loc = declaration.typeLocFromRange(list_node->node->location->rg);
 
         if (rbsTypeParam->unchecked) {
-            if (auto e = ctx.beginError(loc, core::errors::Rewriter::RBSUnsupported)) {
+            if (auto e = ctx.beginIndexerError(loc, core::errors::Rewriter::RBSUnsupported)) {
                 e.setHeader("`{}` type parameters are not supported by Sorbet", "unchecked");
             }
         }

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -165,7 +165,7 @@ unique_ptr<parser::Node> TypeToParserNode::functionType(const rbs_types_function
         unique_ptr<parser::Node> innerType;
 
         if (paramNode->type != RBS_TYPES_FUNCTION_PARAM) {
-            if (auto e = ctx.beginError(loc, core::errors::Internal::InternalError)) {
+            if (auto e = ctx.beginIndexerError(loc, core::errors::Internal::InternalError)) {
                 e.setHeader("Unexpected node type `{}` in function parameter type, expected `{}`",
                             rbs_node_type_name(paramNode), "FunctionParam");
             }
@@ -204,7 +204,7 @@ unique_ptr<parser::Node> TypeToParserNode::procType(const rbs_types_proc_t *node
         }
         default: {
             auto errLoc = declaration.typeLocFromRange(functionTypeNode->location->rg);
-            if (auto e = ctx.beginError(errLoc, core::errors::Internal::InternalError)) {
+            if (auto e = ctx.beginIndexerError(errLoc, core::errors::Internal::InternalError)) {
                 e.setHeader("Unexpected node type `{}` in proc type, expected `{}`",
                             rbs_node_type_name(functionTypeNode), "Function");
             }
@@ -235,7 +235,7 @@ unique_ptr<parser::Node> TypeToParserNode::blockType(const rbs_types_block_t *no
         }
         default: {
             auto errLoc = declaration.typeLocFromRange(functionTypeNode->location->rg);
-            if (auto e = ctx.beginError(errLoc, core::errors::Internal::InternalError)) {
+            if (auto e = ctx.beginIndexerError(errLoc, core::errors::Internal::InternalError)) {
                 e.setHeader("Unexpected node type `{}` in block type, expected `{}`",
                             rbs_node_type_name(functionTypeNode), "Function");
             }
@@ -293,7 +293,7 @@ unique_ptr<parser::Node> TypeToParserNode::recordType(const rbs_types_record_t *
                 break;
             }
             default: {
-                if (auto e = ctx.beginError(loc, core::errors::Internal::InternalError)) {
+                if (auto e = ctx.beginIndexerError(loc, core::errors::Internal::InternalError)) {
                     e.setHeader("Unexpected node type `{}` in record key type, expected `{}`",
                                 rbs_node_type_name(hash_node->key), "Symbol");
                 }
@@ -302,7 +302,7 @@ unique_ptr<parser::Node> TypeToParserNode::recordType(const rbs_types_record_t *
         }
 
         if (hash_node->value->type != RBS_TYPES_RECORD_FIELD_TYPE) {
-            if (auto e = ctx.beginError(loc, core::errors::Internal::InternalError)) {
+            if (auto e = ctx.beginIndexerError(loc, core::errors::Internal::InternalError)) {
                 e.setHeader("Unexpected node type `{}` in record value type, expected `{}`",
                             rbs_node_type_name(hash_node->value), "RecordFieldtype");
             }
@@ -329,7 +329,7 @@ unique_ptr<parser::Node> TypeToParserNode::toParserNode(const rbs_node_t *node, 
     auto nodeLoc = declaration.typeLocFromRange(((rbs_node_t *)node)->location->rg);
     switch (node->type) {
         case RBS_TYPES_ALIAS: {
-            if (auto e = ctx.beginError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
+            if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
                 e.setHeader("RBS aliases are not supported");
             }
             return parser::MK::TUntyped(nodeLoc);
@@ -341,7 +341,7 @@ unique_ptr<parser::Node> TypeToParserNode::toParserNode(const rbs_node_t *node, 
         case RBS_TYPES_BASES_BOTTOM:
             return parser::MK::TNoReturn(nodeLoc);
         case RBS_TYPES_BASES_CLASS: {
-            if (auto e = ctx.beginError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
+            if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
                 e.setHeader("RBS type `{}` is not supported", "class");
             }
             return parser::MK::TUntyped(nodeLoc);
@@ -365,7 +365,7 @@ unique_ptr<parser::Node> TypeToParserNode::toParserNode(const rbs_node_t *node, 
         case RBS_TYPES_FUNCTION:
             return functionType((rbs_types_function_t *)node, nodeLoc, declaration);
         case RBS_TYPES_INTERFACE: {
-            if (auto e = ctx.beginError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
+            if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
                 e.setHeader("RBS interfaces are not supported");
             }
             return parser::MK::TUntyped(nodeLoc);
@@ -373,7 +373,7 @@ unique_ptr<parser::Node> TypeToParserNode::toParserNode(const rbs_node_t *node, 
         case RBS_TYPES_INTERSECTION:
             return intersectionType((rbs_types_intersection_t *)node, nodeLoc, declaration);
         case RBS_TYPES_LITERAL: {
-            if (auto e = ctx.beginError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
+            if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
                 e.setHeader("RBS literal types are not supported");
             }
             return parser::MK::TUntyped(nodeLoc);
@@ -391,7 +391,7 @@ unique_ptr<parser::Node> TypeToParserNode::toParserNode(const rbs_node_t *node, 
         case RBS_TYPES_VARIABLE:
             return variableType((rbs_types_variable_t *)node, nodeLoc);
         default: {
-            if (auto e = ctx.beginError(nodeLoc, core::errors::Internal::InternalError)) {
+            if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Internal::InternalError)) {
                 e.setHeader("Unexpected node type `{}`", rbs_node_type_name((rbs_node_t *)node));
             }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This problems where errors reported by RBS translation would not show up
on hot cache runs with `--cache-dir`.

cc @Morriar


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a If someone wants to test this they're welcome to, we have examples in
`test/cli/`.