### PR TITLE
Update Kernel.Integer() return type to be nilable

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -978,7 +978,7 @@ module Kernel
         base: Integer,
         exception: T::Boolean
     )
-    .returns(Integer)
+    .returns(T.nilable(Integer))
   end
   def Integer(arg, base=T.unsafe(nil), exception: true); end
   ### As of 2.6, all these numeric conversion methods *can* return `nil` iff given the kwarg `exception: false`, which


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The method `Kernel.Integer()` can actually return `nil` if `exception: false` is passed.  The existing RBI file assumes the method always returns `Integer` which causes false-positive typechecking errors when passing `exception: false`

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Looks like this functionality to be able to return `nil` from `Kernel.Integer()` has been in Ruby since v2.6: https://github.com/ruby/ruby/commit/2cfc5b03dac80a92de2dc7a17be4b3cfff92adf7

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I validated this fixes the typechecking red herring I see as well as doesn't add any additional errors in our code base
