### PR TITLE
Bump the size of the DB on the kvstore test

### DIFF
--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -20,7 +20,7 @@ TEST_CASE("kvstore") {
     const auto logger = make_shared<spdlog::logger>("test", sink);
     // Uncomment this for debugging (or copy it into the test case you care about)
     // logger->set_level(spdlog::level::trace);
-    auto maxSize = 4096 * 20;
+    auto maxSize = 4096 * 50;
 
     SUBCASE("CommitsChangesToDisk") {
         {


### PR DESCRIPTION
This test fails on newer osx releases without a larger DB.

### Motivation
Fixing tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
