### PR TITLE
bestEffortCommit the cache after writing the VERSION_KEY

### DIFF
--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -30,7 +30,9 @@ unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::log
     if (opts.cacheDir.empty()) {
         return nullptr;
     }
-    return make_unique<OwnedKeyValueStore>(openCache(std::move(logger), opts.cacheDir, opts));
+    auto ownedKvstore = make_unique<OwnedKeyValueStore>(openCache(logger, opts.cacheDir, opts));
+    auto kvstore = OwnedKeyValueStore::bestEffortCommit(*logger, move(ownedKvstore));
+    return make_unique<OwnedKeyValueStore>(move(kvstore));
 }
 
 namespace {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is just a slight performance optimization. When the cache is cold,
we would write the VERSION_KEY but forget to commit the transaction.
This meant that the first write to the cache when processing files would
defensively abort any previous transaction, causing the VERSION_KEY to
get written again.

It's not clear that this should be user visible, and it's really not a
big performance win, but it looks nicer in the logs because we see
write, commit, write, commit, write, commit, instead of write, drop,
write, commit, write, commit.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not possible to test except by looking in the trace-level logs.