### PR TITLE
Introduce parser::ResolvedConst

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -547,24 +547,6 @@ public:
             return recv->symbol() == core::Symbols::Sorbet_Private_Static();
         }
 
-        if (auto recv = cast_tree<UnresolvedConstantLit>(expr)) {
-            if (recv->cnst != core::Names::Constants::Static()) {
-                return false;
-            }
-
-            auto scope = cast_tree<ast::UnresolvedConstantLit>(recv->scope);
-            if (scope == nullptr || scope->cnst != core::Names::Constants::Private()) {
-                return false;
-            }
-
-            scope = cast_tree<ast::UnresolvedConstantLit>(scope->scope);
-            if (scope == nullptr || scope->cnst != core::Names::Constants::Sorbet()) {
-                return false;
-            }
-
-            return scope->scope == nullptr || isRootScope(scope->scope);
-        }
-
         return false;
     }
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2447,6 +2447,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = std::move(res);
             },
             [&](parser::EmptyElse *else_) { result = MK::EmptyTree(); },
+            [&](parser::ResolvedConst *resolvedConst) {
+                result = make_expression<ConstantLit>(resolvedConst->loc, std::move(resolvedConst->symbol));
+            },
 
             [&](parser::BlockPass *blockPass) { Exception::raise("Send should have already handled the BlockPass"); },
             [&](parser::Node *node) { Exception::raise("Unimplemented Parser Node: {}", node->nodeName()); });

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -118,11 +118,7 @@ public:
      * Create a `Sorbet::Private::Static` constant node.
      */
     static std::unique_ptr<parser::Node> SorbetPrivateStatic(core::LocOffsets loc) {
-        auto cSorbet = parser::MK::Const(loc, parser::MK::Cbase(loc), core::Names::Constants::Sorbet());
-        auto cPrivate = parser::MK::Const(loc, move(cSorbet), core::Names::Constants::Private());
-        auto cStatic = parser::MK::Const(loc, move(cPrivate), core::Names::Constants::Static());
-
-        return cStatic;
+        return std::make_unique<parser::ResolvedConst>(loc, core::Symbols::Sorbet_Private_Static());
     }
 
     /*

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -199,6 +199,13 @@ public:
     }
 
     /*
+     * Create a `T::Sig::WithoutRuntime` resolved constant node.
+     */
+    static std::unique_ptr<parser::Node> T_Sig_WithoutRuntime(core::LocOffsets loc) {
+        return std::make_unique<parser::ResolvedConst>(loc, core::Symbols::T_Sig_WithoutRuntime());
+    }
+
+    /*
      * Create a `T::Range` constant node.
      */
     static std::unique_ptr<parser::Node> T_Range(core::LocOffsets loc) {

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -281,13 +281,6 @@ void collectKeywords(const RBSDeclaration &declaration, rbs_hash_t *field, vecto
     }
 }
 
-unique_ptr<parser::Node> assembleTSigWithoutRuntime(const core::LocOffsets &loc) {
-    auto t = parser::MK::T(loc);
-    auto t_sig = parser::MK::Const(loc, move(t), core::Names::Constants::Sig());
-    auto t_sig_withoutRuntime = parser::MK::Const(loc, move(t_sig), core::Names::Constants::WithoutRuntime());
-    return t_sig_withoutRuntime;
-}
-
 } // namespace
 
 unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::Node *methodDef,
@@ -470,7 +463,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
     }
 
     auto sigArgs = parser::NodeVec();
-    sigArgs.emplace_back(assembleTSigWithoutRuntime(firstLineTypeLoc));
+    sigArgs.emplace_back(parser::MK::T_Sig_WithoutRuntime(firstLineTypeLoc));
 
     auto final = absl::c_find_if(annotations, [](const Comment &annotation) { return annotation.string == "final"; });
     if (final != annotations.end()) {
@@ -537,7 +530,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::attrSignature(const parser::Sen
         parser::MK::Send1(fullTypeLoc, move(sigBuilder), core::Names::returns(), returnType->loc, move(returnType));
 
     auto sigArgs = parser::NodeVec();
-    sigArgs.emplace_back(assembleTSigWithoutRuntime(firstLineTypeLoc));
+    sigArgs.emplace_back(parser::MK::T_Sig_WithoutRuntime(firstLineTypeLoc));
 
     auto final = absl::c_find_if(annotations, [](const Comment &annotation) { return annotation.string == "final"; });
     if (final != annotations.end()) {

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -349,7 +349,7 @@ unique_ptr<parser::Node> TypeToParserNode::toParserNode(const rbs_node_t *node, 
         case RBS_TYPES_BASES_INSTANCE:
             return parser::MK::TAttachedClass(nodeLoc);
         case RBS_TYPES_BASES_NIL:
-            return parser::MK::Const(nodeLoc, parser::MK::Cbase(nodeLoc), core::Names::Constants::NilClass());
+            return make_unique<parser::ResolvedConst>(nodeLoc, core::Symbols::NilClass());
         case RBS_TYPES_BASES_SELF:
             return parser::MK::TSelfType(nodeLoc);
         case RBS_TYPES_BASES_TOP:

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -149,7 +149,7 @@ unique_ptr<parser::Node> TypeToParserNode::optionalType(const rbs_types_optional
 }
 
 unique_ptr<parser::Node> TypeToParserNode::voidType(const rbs_types_bases_void_t *node, core::LocOffsets loc) {
-    return parser::MK::Const(loc, parser::MK::SorbetPrivateStatic(loc), core::Names::Constants::Void());
+    return make_unique<parser::ResolvedConst>(loc, core::Symbols::void_());
 }
 
 unique_ptr<parser::Node> TypeToParserNode::functionType(const rbs_types_function_t *node, core::LocOffsets loc,

--- a/test/cli/rbs-cache-dir/test.out
+++ b/test/cli/rbs-cache-dir/test.out
@@ -1,7 +1,7 @@
 No errors! Great job.
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C Integer>)
     end
 

--- a/test/cli/rbs-print-rewrite-tree/test.out
+++ b/test/cli/rbs-print-rewrite-tree/test.out
@@ -16,29 +16,15 @@ Begin {
     }
     Block {
       send = Send {
-        receiver = Const {
-          scope = Const {
-            scope = Const {
-              scope = Cbase {
-              }
-              name = <C <U Sorbet>>
-            }
-            name = <C <U Private>>
-          }
-          name = <C <U Static>>
+        receiver = ResolvedConst {
+          symbol = module <C <U Sorbet>>::<C <U Private>>::<C <U Static>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/sorbet.rbi start=2:1 end=2:31}
+
         }
         method = <U sig>
         args = [
-          Const {
-            scope = Const {
-              scope = Const {
-                scope = Cbase {
-                }
-                name = <C <U T>>
-              }
-              name = <C <U Sig>>
-            }
-            name = <C <U WithoutRuntime>>
+          ResolvedConst {
+            symbol = module <C <U T>>::<C <U Sig>>::<C <U WithoutRuntime>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi start=9:1 end=9:30}
+
           }
         ]
       }

--- a/test/testdata/rbs/assertions_block.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_block.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:args, ::<root>::<C T>.untyped(), :&, ::<root>::<C T>.proc().params(:arg0, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)).returns(::<root>::<C T>.untyped())
   end
 

--- a/test/testdata/rbs/assertions_block.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_block.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:args, ::<root>::<C T>.untyped(), :&, ::<root>::<C T>.proc().params(:arg0, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)).returns(::<root>::<C T>.untyped())
   end
 

--- a/test/testdata/rbs/assertions_csend_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_csend_assign.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Let><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:args, ::<root>::<C T>.untyped()).void()
     end
 
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(::<root>::<C T>.untyped())
     end
 

--- a/test/testdata/rbs/assertions_csend_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_csend_assign.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Let><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:args, ::<root>::<C T>.untyped()).void()
     end
 
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(::<root>::<C T>.untyped())
     end
 

--- a/test/testdata/rbs/assertions_def.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_def.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:let>(42, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -42,7 +42,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -50,7 +50,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -61,7 +61,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -69,7 +69,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     return <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -77,7 +77,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     return <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -85,7 +85,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     return <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>), :y, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -96,7 +96,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 

--- a/test/testdata/rbs/assertions_def.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_def.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:let>(42, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -42,7 +42,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -50,7 +50,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -61,7 +61,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -69,7 +69,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     return <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -77,7 +77,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     return <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -85,7 +85,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     return <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>), :y, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -96,7 +96,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 

--- a/test/testdata/rbs/assertions_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_defs.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:let>(42, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -42,7 +42,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -50,7 +50,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -61,7 +61,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -69,7 +69,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     return <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 

--- a/test/testdata/rbs/assertions_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_defs.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:let>(42, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -42,7 +42,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -50,7 +50,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -61,7 +61,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)
   end
 
@@ -69,7 +69,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     return <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 

--- a/test/testdata/rbs/assertions_or_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_or_assign.rb.rewrite-tree.exp
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(let3)
 
   class <emptyTree>::<C DesugaredLetNilable><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.void()
     end
 
@@ -69,7 +69,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.void()
     end
 

--- a/test/testdata/rbs/assertions_or_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_or_assign.rb.rewrite-tree.exp
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(let3)
 
   class <emptyTree>::<C DesugaredLetNilable><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.void()
     end
 
@@ -69,7 +69,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.void()
     end
 

--- a/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Let><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:args, ::<root>::<C T>.untyped()).void()
     end
 
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(::<root>::<C T>.untyped())
     end
 

--- a/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Let><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:args, ::<root>::<C T>.untyped()).void()
     end
 
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(::<root>::<C T>.untyped())
     end
 

--- a/test/testdata/rbs/assertions_type_params.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_type_params.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.type_parameters(:A, :B, :C).params(:a, ::<root>::<C T>.type_parameter(:A), :b, ::<root>::<C T>.nilable(::<root>::<C T>.type_parameter(:B)), :c, ::<root>::<C T>.type_parameter(:C)).void()
   end
 
@@ -14,7 +14,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.type_parameters(:A).params(:a, ::<root>::<C T>.nilable(::<root>::<C T>.type_parameter(:A))).returns(::<root>::<C T>.type_parameter(:A))
   end
 
@@ -22,7 +22,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:cast>(a, <todo sym>, ::<root>::<C T>.type_parameter(:A))
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.type_parameters(:A).params(:a, ::<root>::<C T>.nilable(::<root>::<C T>.type_parameter(:A))).returns(::<root>::<C T>.type_parameter(:A))
   end
 

--- a/test/testdata/rbs/assertions_type_params.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_type_params.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.type_parameters(:A, :B, :C).params(:a, ::<root>::<C T>.type_parameter(:A), :b, ::<root>::<C T>.nilable(::<root>::<C T>.type_parameter(:B)), :c, ::<root>::<C T>.type_parameter(:C)).void()
   end
 
@@ -14,7 +14,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.type_parameters(:A).params(:a, ::<root>::<C T>.nilable(::<root>::<C T>.type_parameter(:A))).returns(::<root>::<C T>.type_parameter(:A))
   end
 
@@ -22,7 +22,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:cast>(a, <todo sym>, ::<root>::<C T>.type_parameter(:A))
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.type_parameters(:A).params(:a, ::<root>::<C T>.nilable(::<root>::<C T>.type_parameter(:A))).returns(::<root>::<C T>.type_parameter(:A))
   end
 

--- a/test/testdata/rbs/signatures_attrs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_attrs.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @foo
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @bar
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @baz
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:bar, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @bar = <cast:let>(bar, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:baz, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @baz = <cast:let>(baz, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:qux, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @quux3
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.void()
     end
 
@@ -114,7 +114,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   x.qux=("")
 
   class <emptyTree>::<C AttrRewriter><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -122,7 +122,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @a
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:a, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -130,7 +130,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @a = <cast:let>(a, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.void()
     end
 
@@ -149,7 +149,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C AttrAnnotations><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C Base><<C <todo sym>>> < (::<todo sym>)
-      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
         <self>.overridable().returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
       end
 
@@ -157,7 +157,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         @foo
       end
 
-      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
         <self>.params(:foo, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).void()
       end
 
@@ -173,7 +173,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C Sub><<C <todo sym>>> < (<emptyTree>::<C Base>)
-      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
         <self>.override().returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
       end
 
@@ -194,7 +194,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @foo
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.void()
     end
 

--- a/test/testdata/rbs/signatures_attrs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_attrs.rb.rewrite-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C Integer>)
     end
 
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @foo
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @bar
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -24,7 +24,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @baz
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:bar, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @bar = <cast:let>(bar, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:baz, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -40,7 +40,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @baz = <cast:let>(baz, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:qux, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -60,7 +60,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @quux3
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.void()
     end
 
@@ -114,7 +114,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   x.qux=("")
 
   class <emptyTree>::<C AttrRewriter><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -122,7 +122,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @a
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:a, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
@@ -130,7 +130,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @a = <cast:let>(a, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.void()
     end
 
@@ -149,7 +149,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C AttrAnnotations><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C Base><<C <todo sym>>> < (::<todo sym>)
-      ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
         <self>.overridable().returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
       end
 
@@ -157,7 +157,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         @foo
       end
 
-      ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
         <self>.params(:foo, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>)).void()
       end
 
@@ -173,7 +173,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C Sub><<C <todo sym>>> < (<emptyTree>::<C Base>)
-      ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
         <self>.override().returns(::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
       end
 
@@ -194,7 +194,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @foo
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.void()
     end
 

--- a/test/testdata/rbs/signatures_blocks.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_blocks.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -39,7 +39,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -47,7 +47,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -55,7 +55,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -63,7 +63,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -71,7 +71,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -79,7 +79,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -87,7 +87,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -95,7 +95,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -111,7 +111,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -119,7 +119,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C Symbol>)
   end
 
@@ -127,7 +127,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of def20>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -135,7 +135,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C Symbol>)
   end
 
@@ -143,7 +143,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of def22>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -151,7 +151,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -159,7 +159,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -167,7 +167,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -175,7 +175,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -183,7 +183,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -191,7 +191,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -199,7 +199,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -207,7 +207,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -215,7 +215,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -223,7 +223,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -250,7 +250,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Const1><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C String>)
     end
 
@@ -262,7 +262,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Const2><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C String>)
     end
 
@@ -270,7 +270,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       nil
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C String>)
     end
 
@@ -395,7 +395,7 @@ ensure
 
   class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
     class <singleton class><<C <todo sym>>> < ()
-      ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
         <self>.returns(<emptyTree>::<C String>)
       end
 

--- a/test/testdata/rbs/signatures_blocks.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_blocks.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -39,7 +39,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -47,7 +47,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -55,7 +55,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -63,7 +63,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -71,7 +71,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -79,7 +79,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -87,7 +87,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -95,7 +95,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -111,7 +111,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -119,7 +119,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C Symbol>)
   end
 
@@ -127,7 +127,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of def20>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -135,7 +135,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C Symbol>)
   end
 
@@ -143,7 +143,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of def22>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -151,7 +151,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -159,7 +159,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -167,7 +167,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -175,7 +175,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -183,7 +183,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -191,7 +191,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -199,7 +199,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -207,7 +207,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -215,7 +215,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -223,7 +223,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     nil
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -250,7 +250,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Const1><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C String>)
     end
 
@@ -262,7 +262,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Const2><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C String>)
     end
 
@@ -270,7 +270,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       nil
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C String>)
     end
 
@@ -395,7 +395,7 @@ ensure
 
   class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
     class <singleton class><<C <todo sym>>> < ()
-      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
         <self>.returns(<emptyTree>::<C String>)
       end
 

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C P1>).void()
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:foo, <emptyTree>::<C P1>).void()
   end
 
@@ -27,7 +27,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -35,7 +35,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -51,7 +51,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -59,7 +59,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -67,7 +67,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -75,7 +75,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -83,7 +83,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:blk, ::<root>::<C T>.proc().void()).void()
   end
 
@@ -91,7 +91,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p, ::<root>::<C T>.proc().void()).void()
   end
 
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -111,7 +111,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -119,7 +119,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -127,7 +127,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -135,11 +135,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -147,7 +147,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C P1>).void()
   end
 
@@ -155,7 +155,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, <emptyTree>::<C P2>).void()
   end
 
@@ -166,7 +166,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C Integer>).void()
   end
 
@@ -174,7 +174,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, ::<root>::<C T>.nilable(<emptyTree>::<C P2>)).void()
   end
 
@@ -185,7 +185,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -193,7 +193,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -201,7 +201,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(y)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:foo, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -209,7 +209,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(y)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -217,7 +217,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -225,7 +225,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -233,7 +233,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -241,7 +241,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, ::<root>::<C T>.nilable(<emptyTree>::<C P2>), :p3, <emptyTree>::<C P3>, :p4, <emptyTree>::<C P4>, :p5, ::<root>::<C T>.nilable(<emptyTree>::<C P5>), :p6, <emptyTree>::<C P6>, :block, ::<root>::<C T>.proc().void()).void()
   end
 
@@ -257,7 +257,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().void())).void()
   end
 
@@ -265,7 +265,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(block)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(::<root>::<C T>.type_parameter(:X)))
   end
 
@@ -276,7 +276,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:block, ::<root>::<C T>.untyped()).void()
   end
 
@@ -284,7 +284,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(block)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -308,7 +308,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -319,7 +319,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C Integer>).void()
   end
 
@@ -508,7 +508,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C FooProc><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:p, ::<root>::<C T>.proc().returns(<emptyTree>::<C Integer>), :block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>).bind(<emptyTree>::<C FooProc>))).void()
     end
 
@@ -542,7 +542,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C Annotations><<C <todo sym>>> < ()
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.abstract().returns(<emptyTree>::<C Integer>)
     end
 
@@ -550,7 +550,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.override().returns(<emptyTree>::<C Integer>)
     end
 
@@ -563,7 +563,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of method2>
 
     class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
-      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
         <self>.params(:x, <emptyTree>::<C Integer>).void()
       end
 
@@ -575,7 +575,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C OverrideIncompatible><<C <todo sym>>> < (<emptyTree>::<C Parent>)
-      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
         <self>.override().params(:x, <emptyTree>::<C String>).void()
       end
 
@@ -587,7 +587,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C OverrideAllowIncompatible><<C <todo sym>>> < (<emptyTree>::<C Parent>)
-      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
         <self>.override(:allow_incompatible, true).params(:x, <emptyTree>::<C String>).void()
       end
 
@@ -599,7 +599,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C Final><<C <todo sym>>> < (::<todo sym>)
-      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>, :final) do ||
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime, :final) do ||
         <self>.void()
       end
 
@@ -616,7 +616,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Visibility><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:x, <emptyTree>::<C Integer>).void()
     end
 
@@ -624,7 +624,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C T>.reveal_type(x)
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:x, <emptyTree>::<C Integer>).void()
     end
 
@@ -632,7 +632,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C T>.reveal_type(x)
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:x, <emptyTree>::<C Integer>).void()
     end
 

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C P1>).void()
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:foo, <emptyTree>::<C P1>).void()
   end
 
@@ -27,7 +27,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -35,7 +35,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -51,7 +51,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -59,7 +59,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -67,7 +67,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -75,7 +75,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
@@ -83,7 +83,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:blk, ::<root>::<C T>.proc().void()).void()
   end
 
@@ -91,7 +91,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p, ::<root>::<C T>.proc().void()).void()
   end
 
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -111,7 +111,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -119,7 +119,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -127,7 +127,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -135,11 +135,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -147,7 +147,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C P1>).void()
   end
 
@@ -155,7 +155,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, <emptyTree>::<C P2>).void()
   end
 
@@ -166,7 +166,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C Integer>).void()
   end
 
@@ -174,7 +174,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, ::<root>::<C T>.nilable(<emptyTree>::<C P2>)).void()
   end
 
@@ -185,7 +185,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -193,7 +193,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -201,7 +201,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(y)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:foo, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -209,7 +209,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(y)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -217,7 +217,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -225,7 +225,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -233,7 +233,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -241,7 +241,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, ::<root>::<C T>.nilable(<emptyTree>::<C P2>), :p3, <emptyTree>::<C P3>, :p4, <emptyTree>::<C P4>, :p5, ::<root>::<C T>.nilable(<emptyTree>::<C P5>), :p6, <emptyTree>::<C P6>, :block, ::<root>::<C T>.proc().void()).void()
   end
 
@@ -257,7 +257,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().void())).void()
   end
 
@@ -265,7 +265,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(block)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(::<root>::<C T>.type_parameter(:X)))
   end
 
@@ -276,7 +276,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:block, ::<root>::<C T>.untyped()).void()
   end
 
@@ -284,7 +284,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(block)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -308,7 +308,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -319,7 +319,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C Integer>).void()
   end
 
@@ -508,7 +508,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C FooProc><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:p, ::<root>::<C T>.proc().returns(<emptyTree>::<C Integer>), :block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>).bind(<emptyTree>::<C FooProc>))).void()
     end
 
@@ -542,7 +542,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C Annotations><<C <todo sym>>> < ()
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.abstract().returns(<emptyTree>::<C Integer>)
     end
 
@@ -550,7 +550,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.override().returns(<emptyTree>::<C Integer>)
     end
 
@@ -563,7 +563,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of method2>
 
     class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
-      ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
         <self>.params(:x, <emptyTree>::<C Integer>).void()
       end
 
@@ -575,7 +575,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C OverrideIncompatible><<C <todo sym>>> < (<emptyTree>::<C Parent>)
-      ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
         <self>.override().params(:x, <emptyTree>::<C String>).void()
       end
 
@@ -587,7 +587,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C OverrideAllowIncompatible><<C <todo sym>>> < (<emptyTree>::<C Parent>)
-      ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
         <self>.override(:allow_incompatible, true).params(:x, <emptyTree>::<C String>).void()
       end
 
@@ -599,7 +599,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C Final><<C <todo sym>>> < (::<todo sym>)
-      ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>, :final) do ||
+      ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>, :final) do ||
         <self>.void()
       end
 
@@ -616,7 +616,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Visibility><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:x, <emptyTree>::<C Integer>).void()
     end
 
@@ -624,7 +624,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C T>.reveal_type(x)
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:x, <emptyTree>::<C Integer>).void()
     end
 
@@ -632,7 +632,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::<C T>.reveal_type(x)
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:x, <emptyTree>::<C Integer>).void()
     end
 

--- a/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
@@ -11,7 +11,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -19,7 +19,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(y)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -27,7 +27,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(y)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -35,7 +35,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -51,11 +51,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -63,7 +63,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C P1>).returns(<emptyTree>::<C P10>)
   end
 
@@ -71,7 +71,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Y>))
   end
 
@@ -82,7 +82,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C P1>).void()
   end
 
@@ -90,7 +90,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, <emptyTree>::<C P2>).void()
   end
 
@@ -101,7 +101,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C Integer>).void()
   end
 
@@ -109,7 +109,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, ::<root>::<C T>.nilable(<emptyTree>::<C P2>)).void()
   end
 
@@ -120,7 +120,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -128,7 +128,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -136,7 +136,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -144,7 +144,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -152,7 +152,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().void())).void()
   end
 
@@ -160,7 +160,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(block)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(::<root>::<C T>.type_parameter(:X)))
   end
 
@@ -171,7 +171,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:block, ::<root>::<C T>.untyped()).void()
   end
 
@@ -179,7 +179,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(block)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:x, <emptyTree>::<C P1>, :y, <emptyTree>::<C P2>).returns(<emptyTree>::<C P10>)
   end
 
@@ -288,7 +288,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <runtime method definition of method20>
 
   class <emptyTree>::<C FooProc><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:p, ::<root>::<C T>.proc().returns(<emptyTree>::<C Integer>), :block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>).bind(<emptyTree>::<C FooProc>))).void()
     end
 

--- a/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs_multiline.rb.rewrite-tree.exp
@@ -11,7 +11,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -19,7 +19,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(y)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -27,7 +27,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(y)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -35,7 +35,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -43,7 +43,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
@@ -51,11 +51,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C String>)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -63,7 +63,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C P1>).returns(<emptyTree>::<C P10>)
   end
 
@@ -71,7 +71,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Y>))
   end
 
@@ -82,7 +82,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C P1>).void()
   end
 
@@ -90,7 +90,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, <emptyTree>::<C P2>).void()
   end
 
@@ -101,7 +101,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C Integer>).void()
   end
 
@@ -109,7 +109,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(p1)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, ::<root>::<C T>.nilable(<emptyTree>::<C P2>)).void()
   end
 
@@ -120,7 +120,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
   end
 
@@ -128,7 +128,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -136,7 +136,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C String>).void()
   end
 
@@ -144,7 +144,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).void()
   end
 
@@ -152,7 +152,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(x)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().void())).void()
   end
 
@@ -160,7 +160,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(block)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.type_parameters(:X).params(:x, ::<root>::<C T>.all(::<root>::<C T>.type_parameter(:X), <emptyTree>::<C Object>)).returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(::<root>::<C T>.type_parameter(:X)))
   end
 
@@ -171,7 +171,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:block, ::<root>::<C T>.untyped()).void()
   end
 
@@ -179,7 +179,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(block)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:x, <emptyTree>::<C P1>, :y, <emptyTree>::<C P2>).returns(<emptyTree>::<C P10>)
   end
 
@@ -288,7 +288,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <runtime method definition of method20>
 
   class <emptyTree>::<C FooProc><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:p, ::<root>::<C T>.proc().returns(<emptyTree>::<C Integer>), :block, ::<root>::<C T>.nilable(::<root>::<C T>.proc().params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>).bind(<emptyTree>::<C FooProc>))).void()
     end
 

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:g1, <emptyTree>::<C G1>).void()
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(g1)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:g1, <emptyTree>::<C G1>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>)).void()
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(g1)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.params(:g12, <emptyTree>::<C G12>.<syntheticSquareBrackets>(<emptyTree>::<C Object>)).void()
   end
 
@@ -71,7 +71,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <self>.take_g1_2(g1_3)
 
   class <emptyTree>::<C G2><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C U>)
     end
 
@@ -79,7 +79,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @u
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:u, <emptyTree>::<C U>).returns(<emptyTree>::<C U>)
     end
 
@@ -87,7 +87,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @u = u
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C V>)
     end
 
@@ -95,7 +95,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @v
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:v, <emptyTree>::<C V>).returns(<emptyTree>::<C V>)
     end
 
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @v = v
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:u, <emptyTree>::<C U>, :v, <emptyTree>::<C V>).void()
     end
 
@@ -144,7 +144,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g2_3)
 
   class <emptyTree>::<C G3><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(<emptyTree>::<C U>)
     end
 
@@ -152,7 +152,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @u
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:v, <emptyTree>::<C V>).returns(<emptyTree>::<C V>)
     end
 
@@ -160,7 +160,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @v = v
     end
 
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:u, <emptyTree>::<C U>, :v, <emptyTree>::<C V>).void()
     end
 

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:g1, <emptyTree>::<C G1>).void()
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(g1)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:g1, <emptyTree>::<C G1>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>)).void()
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.reveal_type(g1)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.params(:g12, <emptyTree>::<C G12>.<syntheticSquareBrackets>(<emptyTree>::<C Object>)).void()
   end
 
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C UnsupportedError1><<C <todo sym>>> < (::<todo sym>)
-      <emptyTree>::<C T> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
+      <emptyTree>::<C T> = ::Sorbet::Private::Static.type_member()
     end
 
     class <emptyTree>::<C UselessSignature1><<C <todo sym>>> < (::<todo sym>)
@@ -45,7 +45,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G1><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member()
   end
 
   g1_1 = <emptyTree>::<C G1>.new()
@@ -71,7 +71,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <self>.take_g1_2(g1_3)
 
   class <emptyTree>::<C G2><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C U>)
     end
 
@@ -79,7 +79,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @u
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:u, <emptyTree>::<C U>).returns(<emptyTree>::<C U>)
     end
 
@@ -87,7 +87,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @u = u
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C V>)
     end
 
@@ -95,7 +95,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @v
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:v, <emptyTree>::<C V>).returns(<emptyTree>::<C V>)
     end
 
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @v = v
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:u, <emptyTree>::<C U>, :v, <emptyTree>::<C V>).void()
     end
 
@@ -124,9 +124,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of initialize>
 
-    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member()
 
-    <emptyTree>::<C V> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
+    <emptyTree>::<C V> = ::Sorbet::Private::Static.type_member()
   end
 
   g2_1 = <cast:let>(<emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>).new(1, 2), <todo sym>, <emptyTree>::<C G2>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))
@@ -144,7 +144,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g2_3)
 
   class <emptyTree>::<C G3><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(<emptyTree>::<C U>)
     end
 
@@ -152,7 +152,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @u
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:v, <emptyTree>::<C V>).returns(<emptyTree>::<C V>)
     end
 
@@ -160,7 +160,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @v = v
     end
 
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.params(:u, <emptyTree>::<C U>, :v, <emptyTree>::<C V>).void()
     end
 
@@ -177,13 +177,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of initialize>
 
-    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:in)
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member(:in)
 
-    <emptyTree>::<C V> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:out)
+    <emptyTree>::<C V> = ::Sorbet::Private::Static.type_member(:out)
   end
 
   class <emptyTree>::<C G4><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member() do ||
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member() do ||
       {:upper => <emptyTree>::<C String>}
     end
   end
@@ -196,7 +196,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C G6><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member()
   end
 
   g6 = <emptyTree>::<C G6>.[](<emptyTree>::<C Integer>).new()
@@ -212,13 +212,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(arr2)
 
   class <emptyTree>::<C G7><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member() do ||
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member() do ||
       {:upper => <emptyTree>::<C Numeric>}
     end
   end
 
   class <emptyTree>::<C G8><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C E> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:out)
+    <emptyTree>::<C E> = ::Sorbet::Private::Static.type_member(:out)
   end
 
   g8_1 = <cast:let>(<emptyTree>::<C G8>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>).new(), <todo sym>, <emptyTree>::<C G8>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>))
@@ -234,7 +234,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g8_3)
 
   class <emptyTree>::<C G9><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C E> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:in)
+    <emptyTree>::<C E> = ::Sorbet::Private::Static.type_member(:in)
   end
 
   g9_1 = <cast:let>(<emptyTree>::<C G9>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>).new(), <todo sym>, <emptyTree>::<C G9>.<syntheticSquareBrackets>(<emptyTree>::<C Numeric>))
@@ -254,7 +254,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <emptyTree>::<C V> = <self>.type_member()
 
-    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member()
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member()
   end
 
   g10 = <cast:let>(<emptyTree>::<C G10>.[](<emptyTree>::<C Integer>, <emptyTree>::<C String>).new(), <todo sym>, <emptyTree>::<C G10>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>))
@@ -262,13 +262,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g10)
 
   class <emptyTree>::<C G11><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member() do ||
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member() do ||
       {:fixed => <emptyTree>::<C Integer>, :upper => <emptyTree>::<C Numeric>}
     end
   end
 
   class <emptyTree>::<C G12><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C U> = ::<root>::<C Sorbet>::<C Private>::<C Static>.type_member(:in) do ||
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member(:in) do ||
       {:upper => <emptyTree>::<C Numeric>}
     end
   end

--- a/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C Foo>)
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C Foo>)
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C Foo>::<C Bar>)
   end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C Foo>::<C Bar>::<C Baz>)
   end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C Foo>::<C Bar>)
   end
 
@@ -39,7 +39,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.class_of(<emptyTree>::<C Foo>))
   end
 
@@ -47,7 +47,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.class_of(::<root>::<C Foo>))
   end
 
@@ -55,7 +55,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.class_of(<emptyTree>::<C Foo>::<C Bar>))
   end
 
@@ -63,7 +63,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.class_of(<emptyTree>::<C Foo>::<C Bar>::<C Baz>))
   end
 
@@ -71,7 +71,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.class_of(::<root>::<C Foo>::<C Bar>))
   end
 
@@ -79,7 +79,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.any(<emptyTree>::<C Foo>, <emptyTree>::<C Foo>::<C Bar>))
   end
 
@@ -87,7 +87,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.any(<emptyTree>::<C Foo>, <emptyTree>::<C Foo>::<C Bar>, ::<root>::<C Foo>::<C Bar>::<C Baz>))
   end
 
@@ -95,7 +95,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.all(<emptyTree>::<C A>, <emptyTree>::<C B>, <emptyTree>::<C C>))
   end
 
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.nilable(<emptyTree>::<C Foo>))
   end
 
@@ -111,7 +111,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.self_type())
   end
 
@@ -119,7 +119,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -127,7 +127,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Boolean>)
   end
 
@@ -135,7 +135,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C NilClass>)
   end
 
@@ -143,7 +143,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.anything())
   end
 
@@ -151,7 +151,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.void()
   end
 
@@ -159,7 +159,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -167,7 +167,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -175,7 +175,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -183,7 +183,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -191,7 +191,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Enumerable>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -199,7 +199,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Enumerable>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -207,7 +207,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -215,7 +215,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -223,7 +223,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>::<C Lazy>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -231,7 +231,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>::<C Lazy>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -239,7 +239,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>::<C Chain>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -247,7 +247,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>::<C Chain>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -255,7 +255,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C String>, <emptyTree>::<C Integer>))
   end
 
@@ -263,7 +263,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C String>, <emptyTree>::<C Integer>))
   end
 
@@ -271,7 +271,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Set>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -279,7 +279,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Set>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -287,7 +287,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Range>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -295,7 +295,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>::<C Range>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -303,7 +303,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -311,7 +311,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C String>, <emptyTree>::<C Integer>))
   end
 
@@ -319,7 +319,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C GenericType1>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -327,7 +327,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(<emptyTree>::<C GenericType2>.<syntheticSquareBrackets>(<emptyTree>::<C GenericType1>.<syntheticSquareBrackets>(::<root>::<C T>.untyped()), <emptyTree>::<C GenericType3>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>, ::<root>::<C T>.untyped())))
   end
 
@@ -335,7 +335,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns([<emptyTree>::<C Integer>])
   end
 
@@ -343,7 +343,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns([<emptyTree>::<C Integer>, <emptyTree>::<C String>, ::<root>::<C T>.untyped()])
   end
 
@@ -351,7 +351,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns({:id => <emptyTree>::<C String>, :name => <emptyTree>::<C String>})
   end
 
@@ -359,7 +359,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns({"a" => <emptyTree>::<C String>, "b" => <emptyTree>::<C Integer>})
   end
 
@@ -367,7 +367,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns({:a => <emptyTree>::<C String>, :b => <emptyTree>::<C Integer>})
   end
 
@@ -375,7 +375,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns({"a" => <emptyTree>::<C String>, :b => <emptyTree>::<C Integer>})
   end
 
@@ -383,7 +383,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.proc().params(:arg0, <emptyTree>::<C Integer>, :arg1, <emptyTree>::<C String>).returns(<emptyTree>::<C String>))
   end
 
@@ -391,7 +391,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.proc().void().bind(<emptyTree>::<C Foo>))
   end
 
@@ -399,7 +399,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -407,7 +407,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -415,7 +415,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.noreturn())
   end
 
@@ -423,7 +423,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -431,7 +431,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -439,7 +439,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -530,7 +530,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(<self>.base_type1())
 
   class <emptyTree>::<C BaseType2><<C <todo sym>>> < (::<todo sym>)
-    ::<root>::<C Sorbet>::<C Private>::<C Static>.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
       <self>.returns(::<root>::<C T>.attached_class())
     end
 

--- a/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
@@ -136,7 +136,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-    <self>.returns(::<root>::<C NilClass>)
+    <self>.returns(::NilClass)
   end
 
   def base_type5<<todo method>>(&<blk>)

--- a/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C Foo>)
   end
 
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C Foo>)
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C Foo>::<C Bar>)
   end
 
@@ -23,7 +23,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C Foo>::<C Bar>::<C Baz>)
   end
 
@@ -31,7 +31,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C Foo>::<C Bar>)
   end
 
@@ -39,7 +39,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.class_of(<emptyTree>::<C Foo>))
   end
 
@@ -47,7 +47,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.class_of(::<root>::<C Foo>))
   end
 
@@ -55,7 +55,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.class_of(<emptyTree>::<C Foo>::<C Bar>))
   end
 
@@ -63,7 +63,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.class_of(<emptyTree>::<C Foo>::<C Bar>::<C Baz>))
   end
 
@@ -71,7 +71,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.class_of(::<root>::<C Foo>::<C Bar>))
   end
 
@@ -79,7 +79,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.any(<emptyTree>::<C Foo>, <emptyTree>::<C Foo>::<C Bar>))
   end
 
@@ -87,7 +87,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.any(<emptyTree>::<C Foo>, <emptyTree>::<C Foo>::<C Bar>, ::<root>::<C Foo>::<C Bar>::<C Baz>))
   end
 
@@ -95,7 +95,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.all(<emptyTree>::<C A>, <emptyTree>::<C B>, <emptyTree>::<C C>))
   end
 
@@ -103,7 +103,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.nilable(<emptyTree>::<C Foo>))
   end
 
@@ -111,7 +111,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.self_type())
   end
 
@@ -119,7 +119,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -127,7 +127,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Boolean>)
   end
 
@@ -135,7 +135,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C NilClass>)
   end
 
@@ -143,7 +143,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.anything())
   end
 
@@ -151,7 +151,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.void()
   end
 
@@ -159,7 +159,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -167,7 +167,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -175,7 +175,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -183,7 +183,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -191,7 +191,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Enumerable>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -199,7 +199,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Enumerable>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -207,7 +207,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -215,7 +215,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -223,7 +223,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>::<C Lazy>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -231,7 +231,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>::<C Lazy>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -239,7 +239,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>::<C Chain>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -247,7 +247,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Enumerator>::<C Chain>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -255,7 +255,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C String>, <emptyTree>::<C Integer>))
   end
 
@@ -263,7 +263,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C String>, <emptyTree>::<C Integer>))
   end
 
@@ -271,7 +271,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Set>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -279,7 +279,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Set>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -287,7 +287,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Range>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -295,7 +295,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>::<C Range>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -303,7 +303,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -311,7 +311,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C String>, <emptyTree>::<C Integer>))
   end
 
@@ -319,7 +319,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C GenericType1>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -327,7 +327,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(<emptyTree>::<C GenericType2>.<syntheticSquareBrackets>(<emptyTree>::<C GenericType1>.<syntheticSquareBrackets>(::<root>::<C T>.untyped()), <emptyTree>::<C GenericType3>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>, <emptyTree>::<C String>, ::<root>::<C T>.untyped())))
   end
 
@@ -335,7 +335,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns([<emptyTree>::<C Integer>])
   end
 
@@ -343,7 +343,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns([<emptyTree>::<C Integer>, <emptyTree>::<C String>, ::<root>::<C T>.untyped()])
   end
 
@@ -351,7 +351,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns({:id => <emptyTree>::<C String>, :name => <emptyTree>::<C String>})
   end
 
@@ -359,7 +359,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns({"a" => <emptyTree>::<C String>, "b" => <emptyTree>::<C Integer>})
   end
 
@@ -367,7 +367,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns({:a => <emptyTree>::<C String>, :b => <emptyTree>::<C Integer>})
   end
 
@@ -375,7 +375,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns({"a" => <emptyTree>::<C String>, :b => <emptyTree>::<C Integer>})
   end
 
@@ -383,7 +383,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.proc().params(:arg0, <emptyTree>::<C Integer>, :arg1, <emptyTree>::<C String>).returns(<emptyTree>::<C String>))
   end
 
@@ -391,7 +391,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.proc().void().bind(<emptyTree>::<C Foo>))
   end
 
@@ -399,7 +399,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -407,7 +407,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -415,7 +415,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.noreturn())
   end
 
@@ -423,7 +423,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -431,7 +431,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -439,7 +439,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
-  ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+  ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
     <self>.returns(::<root>::<C T>.untyped())
   end
 
@@ -530,7 +530,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(<self>.base_type1())
 
   class <emptyTree>::<C BaseType2><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::<root>::<C T>::<C Sig>::<C WithoutRuntime>) do ||
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.returns(::<root>::<C T>.attached_class())
     end
 


### PR DESCRIPTION
### Motivation

If we already know the symbol a constant refers to, we can pre-resolve it to speed up subsequent phases.

Suggested by @jez in https://github.com/sorbet/sorbet/pull/8845#discussion_r2080448553.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
