### PR TITLE
Add kwargs and block support to BasicObject#__send__

### DIFF
--- a/rbi/core/basic_object.rbi
+++ b/rbi/core/basic_object.rbi
@@ -172,10 +172,12 @@ class BasicObject
     params(
         arg0: Symbol,
         arg1: BasicObject,
+        kwargs: T.nilable(T::Hash[Symbol, BasicObject]),
+        blk: T.nilable(T.proc.returns(T.untyped)),
     )
     .returns(T.untyped)
   end
-  def __send__(arg0, *arg1); end
+  def __send__(arg0, *arg1, **kwargs, &blk); end
 
   # Equality --- At the
   # [`Object`](https://docs.ruby-lang.org/en/2.7.0/Object.html) level, #==


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
In Ruby, `BasicObject#__send__` can optionally take kwargs and a block, but this is not reflected in Sorbet right now.

[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20A%0A%20%20extend%20T%3A%3ASig%0A%20%20%0A%20%20sig%20%7B%20params%28method%3A%20T.any%28String%2C%20Symbol%29%2C%20path%3A%20String%2C%20idempotency_key%3A%20T.nilable%28String%29%2C%20body%3A%20T.nilable%28T%3A%3AHash%5BString%2C%20T.untyped%5D%29%29.returns%28Net%3A%3AHTTPResponse%29%20%7D%0A%20%20%20%20def%20curl!%28method%2C%20path%2C%20idempotency_key%3A%20nil%2C%20body%3A%20nil%29%0A%20%20%20%20%20%20body_str%20%3D%20body%26.to_json%0A%20%20%20%20%20%20Net%3A%3AHTTP.__send__%28method.to_sym%2C%20path%29%20do%20%7Creq%7C%0A%20%20%20%20%20%20%20%20req%20%3D%20T.cast%28req%2C%20Net%3A%3AHTTPRequest%29%0A%0A%20%20%20%20%20%20%20%20req.add_field%20%22Content-Type%22%2C%20%22application%2Fjson%22%0A%20%20%20%20%20%20%20%20req.add_field%20%22Api-Key%22%20%2C%20'mock-api-key'%0A%20%20%20%20%20%20%20%20req.add_field%20%22Idempotency-Key%22%2C%20idempotency_key%20unless%20idempotency_key.nil%3F%0A%20%20%20%20%20%20%20%20req.body%20%3D%20body_str%20unless%20body_str.nil%3F%0A%20%20%20%20%20%20end%0A%20%20end%0Aend)

```ruby
# typed: true
class A
  extend T::Sig
  
  sig { params(method: T.any(String, Symbol), path: String, idempotency_key: T.nilable(String), body: T.nilable(T::Hash[String, T.untyped])).returns(Net::HTTPResponse) }
    def curl!(method, path, idempotency_key: nil, body: nil)
      body_str = body&.to_json
      Net::HTTP.__send__(method.to_sym, path) do |req|
        req = T.cast(req, Net::HTTPRequest)

        req.add_field "Content-Type", "application/json"
        req.add_field "Api-Key" , 'mock-api-key'
        req.add_field "Idempotency-Key", idempotency_key unless idempotency_key.nil?
        req.body = body_str unless body_str.nil?
      end
  end
end
```

#### Observed output

```
editor.rb:8: Method BasicObject#__send__ does not take a block https://srb.help/7035
     8 |      Net::HTTP.__send__(method.to_sym, path) do |req|
     9 |        req = T.cast(req, Net::HTTPRequest)
    10 |
    11 |        req.add_field "Content-Type", "application/json"
    12 |        req.add_field "Api-Key" , 'mock-api-key'
    13 |        req.add_field "Idempotency-Key", idempotency_key unless idempotency_key.nil?
    14 |        req.body = body_str unless body_str.nil?
    15 |      end
    https://github.com/sorbet/sorbet/tree/master/rbi/core/basic_object.rbi#L178: BasicObject#__send__ defined here
     178 |  def __send__(arg0, *arg1); end
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  Autocorrect: Use -a to autocorrect
    editor.rb:8: Delete
     8 |      Net::HTTP.__send__(method.to_sym, path) do |req|
     9 |        req = T.cast(req, Net::HTTPRequest)
    10 |
    11 |        req.add_field "Content-Type", "application/json"
    12 |        req.add_field "Api-Key" , 'mock-api-key'
    13 |        req.add_field "Idempotency-Key", idempotency_key unless idempotency_key.nil?
    14 |        req.body = body_str unless body_str.nil?
    15 |      end
Errors: 1
```

<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
