### PR TITLE
Handle proxy types in type_definition.cc

### DIFF
--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -53,9 +53,6 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, const core::TypePtr &
                 result.emplace_back(loc);
             }
         },
-        [&](const core::NamedLiteralType &_) {
-            // nothing
-        },
         [&](const core::ShapeType &_) {
             // nothing
         },
@@ -78,6 +75,11 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, const core::TypePtr &
             ENFORCE(false, "Please add a test case for this test, and delete this enforce.");
         },
         [&](const core::TypePtr &t) {
+            if (core::is_proxy_type(type)) {
+                auto type = t.underlying(gs);
+                result = locsForType(gs, type);
+                return;
+            }
             Exception::raise("Unhandled case in textDocument/typeDefinition: {}", core::TypePtr::tagToString(t.tag()));
         });
     return result;

--- a/test/testdata/lsp/type_def_edge.rb
+++ b/test/testdata/lsp/type_def_edge.rb
@@ -32,9 +32,6 @@ class Wrapper
 
     sig {void}
     def test_nothings
-      puts(:foo)
-      #      ^ type: (nothing)
-
       shape = {foo: 0}
       puts(shape)
       #    ^ type: (nothing)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes a crash in production.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I only tested this in my editor.

Getting an automated test for it was hard, because our `type-def`/`type`
assertions don't have a way to assert that the place you get jumped to
is someplace in the standard library, but I confirmed that's what
happens in the editor.