### PR TITLE
Compute the SCCs of tests as well

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -86,6 +86,11 @@ public:
         return nullopt;
     }
 
+    optional<int> testSccID() const {
+        notImplemented();
+        return nullopt;
+    }
+
     bool causesLayeringViolation(const core::packages::PackageDB &packageDB, const PackageInfo &otherPkg) const {
         notImplemented();
         return false;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -60,6 +60,7 @@ public:
     strictDependenciesLevel() const = 0;
     virtual std::optional<std::pair<core::NameRef, core::LocOffsets>> layer() const = 0;
     virtual std::optional<int> sccID() const = 0;
+    virtual std::optional<int> testSccID() const = 0;
     virtual core::Loc fullLoc() const = 0;
     virtual core::Loc declLoc() const = 0;
     virtual bool exists() const final;


### PR DESCRIPTION
Currently, we ignore test dependencies when computing SCCs for packages. This is fine for our current needs, as we don't enforce strict dependencies or layering for test code, but this will change soon when we start refactoring the pipeline to operate on SCCs of packages.

This PR adds a second scc id to each package, `testSccID`. The new ID is the result of a separate run of Tarjan's algorithm over just test dependencies. While it's not used for anything currently, it will soon be used to emit a possible traversal order for packages when typechecking by SCC.

### Motivation
Prework for typechecking by package SCC.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
