### PR TITLE
Free the session cache when destroying the typechecker

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -640,6 +640,7 @@ void LSPTypechecker::cacheUpdatedFiles(absl::Span<const ast::ParsedFile> indexed
 }
 
 unique_ptr<core::GlobalState> LSPTypechecker::destroy() {
+    this->sessionCache.reset();
     return move(gs);
 }
 


### PR DESCRIPTION
When the `ShutdownTask` is run inside of the typecheck coordinator, the `destroy` method is called on the typechecker. This moves its `GlobalState` out, but otherwise leaves its internals alone. If for some reason the typechecker is never fully destroyed, the session cache will not be properly cleaned up, leaving a copy on disk.

This PR frees the session cache in the `destroy` method, ensuring that the session cache is released when the shutdown request is received.

### Motivation
Avoiding situations where the session cache might accidentally persist beyond the end of an LSP session.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.

cc @technicalpickles, @dduugg 