### PR TITLE
Introduce RBS alternative to `T.bind`

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -581,6 +581,9 @@ NameDef names[] = {
     {"Account", "Account", true},
     {"Merchant", "Merchant", true},
 
+    // RBS
+    {"RBSBind", "<RBSBind>", true},
+
     // RBS synthetic generics
     {"syntheticSquareBrackets", "<syntheticSquareBrackets>"},
 

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -249,6 +249,10 @@ public:
         return Send0(loc, T(loc), core::Names::attachedClass(), loc);
     }
 
+    static std::unique_ptr<parser::Node> TBind(core::LocOffsets loc, std::unique_ptr<parser::Node> type) {
+        return Send2(loc, T(loc), core::Names::bind(), loc, MK::Self(loc), move(type));
+    }
+
     /*
      * Create a `T.cast(value, type)` send node.
      */

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -249,7 +249,7 @@ public:
         return Send0(loc, T(loc), core::Names::attachedClass(), loc);
     }
 
-    static std::unique_ptr<parser::Node> TBind(core::LocOffsets loc, std::unique_ptr<parser::Node> type) {
+    static std::unique_ptr<parser::Node> TBindSelf(core::LocOffsets loc, std::unique_ptr<parser::Node> type) {
         return Send2(loc, T(loc), core::Names::bind(), loc, MK::Self(loc), move(type));
     }
 

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -621,6 +621,12 @@ NodeDef nodes[] = {
         "rational",
         vector<FieldDef>({{"val", FieldType::String}}),
     },
+    // RBS placeholder for a bind comment
+    {
+        "RBSPlaceholder",
+        "rbs_placeholder",
+        vector<FieldDef>({{"kind", FieldType::Name}}),
+    },
     // `redo` keyword
     {
         "Redo",

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -318,7 +318,7 @@ unique_ptr<parser::Node> AssertionsRewriter::replaceSyntheticBind(unique_ptr<par
 
     if (!pair) {
         // We already raised an error while parsing the comment, so we just bind to `T.untyped`
-        return parser::MK::TBind(node->loc, parser::MK::TUntyped(node->loc));
+        return parser::MK::TBindSelf(node->loc, parser::MK::TUntyped(node->loc));
     }
 
     auto kind = pair->second;
@@ -330,7 +330,7 @@ unique_ptr<parser::Node> AssertionsRewriter::replaceSyntheticBind(unique_ptr<par
 
     auto type = move(pair->first);
 
-    return parser::MK::TBind(type->loc, move(type));
+    return parser::MK::TBindSelf(type->loc, move(type));
 }
 
 /**

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -626,6 +626,7 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
             result = move(node);
         },
         [&](parser::Ensure *ensure) {
+            ensure->ensure = rewriteBody(move(ensure->ensure));
             ensure->body = rewriteBody(move(ensure->body));
             result = move(node);
         },

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -11,6 +11,7 @@ namespace sorbet::rbs {
 struct InlineComment {
     enum class Kind {
         ABSURD,
+        BIND,
         CAST,
         LET,
         MUST,
@@ -45,6 +46,7 @@ private:
 
     bool saveTypeParams(parser::Block *block);
     std::unique_ptr<parser::Node> maybeInsertCast(std::unique_ptr<parser::Node> node);
+    std::unique_ptr<parser::Node> replaceSyntheticBind(std::unique_ptr<parser::Node> node);
     std::unique_ptr<parser::Node>
     insertCast(std::unique_ptr<parser::Node> node,
                std::optional<std::pair<std::unique_ptr<parser::Node>, InlineComment::Kind>> pair);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -177,7 +177,7 @@ void CommentsAssociator::associateSignatureCommentsToNode(parser::Node *node) {
     commentsByNode[node] = move(comments);
 }
 
-void CommentsAssociator::walkNodes(parser::Node *node) {
+void CommentsAssociator::walkNode(parser::Node *node) {
     if (node == nullptr) {
         return;
     }
@@ -187,25 +187,25 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
 
         [&](parser::And *and_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(and_->right.get());
-            walkNodes(and_->left.get());
+            walkNode(and_->right.get());
+            walkNode(and_->left.get());
             consumeCommentsInsideNode(node, "and");
         },
         [&](parser::AndAsgn *andAsgn) {
             associateAssertionCommentsToNode(andAsgn->right.get(), true);
-            walkNodes(andAsgn->right.get());
+            walkNode(andAsgn->right.get());
             consumeCommentsInsideNode(node, "and_asgn");
         },
         [&](parser::Array *array) {
             associateAssertionCommentsToNode(node);
             for (auto &elem : array->elts) {
-                walkNodes(elem.get());
+                walkNode(elem.get());
             }
             consumeCommentsInsideNode(node, "array");
         },
         [&](parser::Assign *assign) {
             associateAssertionCommentsToNode(assign->rhs.get(), true);
-            walkNodes(assign->rhs.get());
+            walkNode(assign->rhs.get());
             consumeCommentsInsideNode(node, "assign");
         },
         [&](parser::Begin *begin) {
@@ -222,7 +222,7 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 associateAssertionCommentsToNode(node);
             }
             for (auto &stmt : begin->stmts) {
-                walkNodes(stmt.get());
+                walkNode(stmt.get());
             }
             consumeCommentsInsideNode(node, "begin");
         },
@@ -231,8 +231,8 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             consumeCommentsUntilLine(beginLine);
 
             associateAssertionCommentsToNode(node);
-            walkNodes(block->send.get());
-            walkNodes(block->body.get());
+            walkNode(block->send.get());
+            walkNode(block->body.get());
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "block");
         },
@@ -248,33 +248,33 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             }
 
             for (auto it = break_->exprs.rbegin(); it != break_->exprs.rend(); ++it) {
-                walkNodes(it->get());
+                walkNode(it->get());
             }
             consumeCommentsInsideNode(node, "break");
         },
         [&](parser::Case *case_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(case_->condition.get());
+            walkNode(case_->condition.get());
             for (auto &when : case_->whens) {
-                walkNodes(when.get());
+                walkNode(when.get());
             }
-            walkNodes(case_->else_.get());
+            walkNode(case_->else_.get());
             consumeCommentsInsideNode(node, "case");
         },
         [&](parser::CaseMatch *case_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(case_->expr.get());
+            walkNode(case_->expr.get());
             for (auto &inBody : case_->inBodies) {
-                walkNodes(inBody.get());
+                walkNode(inBody.get());
             }
-            walkNodes(case_->elseBody.get());
+            walkNode(case_->elseBody.get());
             consumeCommentsInsideNode(node, "case");
         },
         [&](parser::Class *cls) {
             associateSignatureCommentsToNode(node);
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
-            walkNodes(cls->body.get());
+            walkNode(cls->body.get());
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "class");
         },
@@ -285,32 +285,32 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 return;
             }
             associateAssertionCommentsToNode(node);
-            walkNodes(csend->receiver.get());
+            walkNode(csend->receiver.get());
             for (auto &arg : csend->args) {
-                walkNodes(arg.get());
+                walkNode(arg.get());
             }
             consumeCommentsInsideNode(node, "csend");
         },
         [&](parser::DefMethod *def) {
             associateSignatureCommentsToNode(node);
-            walkNodes(def->body.get());
+            walkNode(def->body.get());
             consumeCommentsInsideNode(node, "method");
         },
         [&](parser::DefS *def) {
             associateSignatureCommentsToNode(node);
-            walkNodes(def->body.get());
+            walkNode(def->body.get());
             consumeCommentsInsideNode(node, "method");
         },
         [&](parser::Ensure *ensure) {
-            walkNodes(ensure->body.get());
-            walkNodes(ensure->ensure.get());
+            walkNode(ensure->body.get());
+            walkNode(ensure->ensure.get());
             consumeCommentsInsideNode(node, "ensure");
         },
         [&](parser::For *for_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(for_->expr.get());
-            walkNodes(for_->vars.get());
-            walkNodes(for_->body.get());
+            walkNode(for_->expr.get());
+            walkNode(for_->vars.get());
+            walkNode(for_->body.get());
             consumeCommentsInsideNode(node, "for");
         },
         [&](parser::Hash *hash) {
@@ -318,7 +318,7 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 associateAssertionCommentsToNode(node);
             }
             for (auto &elem : hash->pairs) {
-                walkNodes(elem.get());
+                walkNode(elem.get());
             }
             consumeCommentsInsideNode(node, "hash");
         },
@@ -330,9 +330,9 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
                 associateAssertionCommentsToNode(node);
             }
 
-            walkNodes(if_->condition.get());
-            walkNodes(if_->then_.get());
-            walkNodes(if_->else_.get());
+            walkNode(if_->condition.get());
+            walkNode(if_->then_.get());
+            walkNode(if_->else_.get());
 
             if (beginLine != endLine) {
                 associateAssertionCommentsToNode(node);
@@ -341,32 +341,32 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             consumeCommentsInsideNode(node, "if");
         },
         [&](parser::InPattern *inPattern) {
-            walkNodes(inPattern->pattern.get());
-            walkNodes(inPattern->guard.get());
-            walkNodes(inPattern->body.get());
+            walkNode(inPattern->pattern.get());
+            walkNode(inPattern->guard.get());
+            walkNode(inPattern->body.get());
             consumeCommentsInsideNode(node, "in_pattern");
         },
         [&](parser::Kwsplat *kwsplat) {
-            walkNodes(kwsplat->expr.get());
+            walkNode(kwsplat->expr.get());
             consumeCommentsInsideNode(node, "kwsplat");
         },
         [&](parser::Kwbegin *kwbegin) {
             associateAssertionCommentsToNode(node);
             for (auto &stmt : kwbegin->stmts) {
-                walkNodes(stmt.get());
+                walkNode(stmt.get());
             }
             consumeCommentsInsideNode(node, "begin");
         },
         [&](parser::Masgn *masgn) {
             associateAssertionCommentsToNode(masgn->rhs.get(), true);
-            walkNodes(masgn->rhs.get());
+            walkNode(masgn->rhs.get());
             consumeCommentsInsideNode(node, "masgn");
         },
         [&](parser::Module *mod) {
             associateSignatureCommentsToNode(node);
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
-            walkNodes(mod->body.get());
+            walkNode(mod->body.get());
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "module");
         },
@@ -381,33 +381,33 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             }
 
             for (auto &expr : next->exprs) {
-                walkNodes(expr.get());
+                walkNode(expr.get());
             }
             consumeCommentsInsideNode(node, "next");
         },
         [&](parser::OpAsgn *opAsgn) {
             associateAssertionCommentsToNode(opAsgn->right.get(), true);
-            walkNodes(opAsgn->right.get());
+            walkNode(opAsgn->right.get());
             consumeCommentsInsideNode(node, "op_asgn");
         },
         [&](parser::Or *or_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(or_->right.get());
-            walkNodes(or_->left.get());
+            walkNode(or_->right.get());
+            walkNode(or_->left.get());
             consumeCommentsInsideNode(node, "or");
         },
         [&](parser::OrAsgn *orAsgn) {
             associateAssertionCommentsToNode(orAsgn->right.get(), true);
-            walkNodes(orAsgn->right.get());
+            walkNode(orAsgn->right.get());
             consumeCommentsInsideNode(node, "or_asgn");
         },
         [&](parser::Pair *pair) {
-            walkNodes(pair->value.get());
-            walkNodes(pair->key.get());
+            walkNode(pair->value.get());
+            walkNode(pair->key.get());
             consumeCommentsInsideNode(node, "pair");
         },
         [&](parser::Resbody *resbody) {
-            walkNodes(resbody->body.get());
+            walkNode(resbody->body.get());
             consumeCommentsInsideNode(node, "rescue");
         },
         [&](parser::Rescue *rescue) {
@@ -416,17 +416,17 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
 
             if (beginLine == endLine) {
                 // Single line rescue that may have an assertion comment so we need to start from the else node
-                walkNodes(rescue->else_.get());
+                walkNode(rescue->else_.get());
                 for (auto &rescued : rescue->rescue) {
-                    walkNodes(rescued.get());
+                    walkNode(rescued.get());
                 }
-                walkNodes(rescue->body.get());
+                walkNode(rescue->body.get());
             } else {
-                walkNodes(rescue->body.get());
+                walkNode(rescue->body.get());
                 for (auto &rescued : rescue->rescue) {
-                    walkNodes(rescued.get());
+                    walkNode(rescued.get());
                 }
-                walkNodes(rescue->else_.get());
+                walkNode(rescue->else_.get());
             }
             consumeCommentsBetweenLines(beginLine, endLine, "rescue");
         },
@@ -441,7 +441,7 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             }
 
             for (auto &expr : ret->exprs) {
-                walkNodes(expr.get());
+                walkNode(expr.get());
             }
             consumeCommentsInsideNode(node, "return");
         },
@@ -449,7 +449,7 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             associateSignatureCommentsToNode(node);
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
-            walkNodes(sclass->body.get());
+            walkNode(sclass->body.get());
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "sclass");
         },
@@ -467,42 +467,42 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             } else {
                 if (send->method == core::Names::squareBracketsEq()) {
                     // This is a `foo[key]=(y)` method, walk y for chained method calls
-                    walkNodes(send->args.back().get());
-                    walkNodes(send->receiver.get());
+                    walkNode(send->args.back().get());
+                    walkNode(send->receiver.get());
                     return;
                 } else if (send->method.isSetter(ctx.state) && send->args.size() == 1) {
                     // This is a `foo.x=(y)` method, we treat it as a `x = y` assignment
                     associateAssertionCommentsToNode(send->args[0].get());
-                    walkNodes(send->receiver.get());
+                    walkNode(send->receiver.get());
                     return;
                 }
                 associateAssertionCommentsToNode(send);
 
-                walkNodes(send->receiver.get());
+                walkNode(send->receiver.get());
 
                 for (auto &arg : send->args) {
-                    walkNodes(arg.get());
+                    walkNode(arg.get());
                 }
                 consumeCommentsInsideNode(node, "send");
             }
         },
         [&](parser::Splat *splat) {
-            walkNodes(splat->var.get());
+            walkNode(splat->var.get());
             consumeCommentsInsideNode(node, "splat");
         },
         [&](parser::Until *until) {
             associateAssertionCommentsToNode(node);
-            walkNodes(until->cond.get());
-            walkNodes(until->body.get());
+            walkNode(until->cond.get());
+            walkNode(until->body.get());
             consumeCommentsInsideNode(node, "until");
         },
         [&](parser::UntilPost *untilPost) {
-            walkNodes(untilPost->cond.get());
-            walkNodes(untilPost->body.get());
+            walkNode(untilPost->cond.get());
+            walkNode(untilPost->body.get());
             consumeCommentsInsideNode(node, "until");
         },
         [&](parser::When *when) {
-            walkNodes(when->body.get());
+            walkNode(when->body.get());
 
             if (auto body = when->body.get()) {
                 consumeCommentsInsideNode(body, "when");
@@ -510,13 +510,13 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
         },
         [&](parser::While *while_) {
             associateAssertionCommentsToNode(node);
-            walkNodes(while_->cond.get());
-            walkNodes(while_->body.get());
+            walkNode(while_->cond.get());
+            walkNode(while_->body.get());
             consumeCommentsInsideNode(node, "while");
         },
         [&](parser::WhilePost *whilePost) {
-            walkNodes(whilePost->cond.get());
-            walkNodes(whilePost->body.get());
+            walkNode(whilePost->cond.get());
+            walkNode(whilePost->body.get());
             consumeCommentsInsideNode(node, "while");
         },
         [&](parser::Node *other) {
@@ -537,7 +537,7 @@ map<parser::Node *, vector<CommentNode>> CommentsAssociator::run(unique_ptr<pars
         }
     }
 
-    walkNodes(node.get());
+    walkNode(node.get());
 
     // Check for any remaining comments
     for (const auto &[line, comment] : commentByLine) {

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -274,10 +274,7 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             associateSignatureCommentsToNode(node);
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
-
-            if (auto body = cls->body.get()) {
-                walkNodes(body);
-            }
+            walkNodes(cls->body.get());
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "class");
         },
@@ -369,10 +366,7 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             associateSignatureCommentsToNode(node);
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
-
-            if (auto body = mod->body.get()) {
-                walkNodes(body);
-            }
+            walkNodes(mod->body.get());
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "module");
         },
@@ -455,10 +449,7 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             associateSignatureCommentsToNode(node);
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
-
-            if (auto body = sclass->body.get()) {
-                walkNodes(body);
-            }
+            walkNodes(sclass->body.get());
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "sclass");
         },

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -177,6 +177,12 @@ void CommentsAssociator::associateSignatureCommentsToNode(parser::Node *node) {
     commentsByNode[node] = move(comments);
 }
 
+void CommentsAssociator::walkNodes(parser::NodeVec &nodes) {
+    for (auto &node : nodes) {
+        walkNode(node.get());
+    }
+}
+
 void CommentsAssociator::walkNode(parser::Node *node) {
     if (node == nullptr) {
         return;
@@ -198,9 +204,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
         },
         [&](parser::Array *array) {
             associateAssertionCommentsToNode(node);
-            for (auto &elem : array->elts) {
-                walkNode(elem.get());
-            }
+            walkNodes(array->elts);
             consumeCommentsInsideNode(node, "array");
         },
         [&](parser::Assign *assign) {
@@ -221,9 +225,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
             if (begin->stmts.size() > 0 && begin->stmts[0]->loc.endPos() + 1 == node->loc.endPos()) {
                 associateAssertionCommentsToNode(node);
             }
-            for (auto &stmt : begin->stmts) {
-                walkNode(stmt.get());
-            }
+            walkNodes(begin->stmts);
             consumeCommentsInsideNode(node, "begin");
         },
         [&](parser::Block *block) {
@@ -247,26 +249,20 @@ void CommentsAssociator::walkNode(parser::Node *node) {
                 }
             }
 
-            for (auto it = break_->exprs.rbegin(); it != break_->exprs.rend(); ++it) {
-                walkNode(it->get());
-            }
+            walkNodes(break_->exprs);
             consumeCommentsInsideNode(node, "break");
         },
         [&](parser::Case *case_) {
             associateAssertionCommentsToNode(node);
             walkNode(case_->condition.get());
-            for (auto &when : case_->whens) {
-                walkNode(when.get());
-            }
+            walkNodes(case_->whens);
             walkNode(case_->else_.get());
             consumeCommentsInsideNode(node, "case");
         },
         [&](parser::CaseMatch *case_) {
             associateAssertionCommentsToNode(node);
             walkNode(case_->expr.get());
-            for (auto &inBody : case_->inBodies) {
-                walkNode(inBody.get());
-            }
+            walkNodes(case_->inBodies);
             walkNode(case_->elseBody.get());
             consumeCommentsInsideNode(node, "case");
         },
@@ -286,9 +282,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
             }
             associateAssertionCommentsToNode(node);
             walkNode(csend->receiver.get());
-            for (auto &arg : csend->args) {
-                walkNode(arg.get());
-            }
+            walkNodes(csend->args);
             consumeCommentsInsideNode(node, "csend");
         },
         [&](parser::DefMethod *def) {
@@ -317,9 +311,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
             if (!hash->kwargs) {
                 associateAssertionCommentsToNode(node);
             }
-            for (auto &elem : hash->pairs) {
-                walkNode(elem.get());
-            }
+            walkNodes(hash->pairs);
             consumeCommentsInsideNode(node, "hash");
         },
         [&](parser::If *if_) {
@@ -352,9 +344,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
         },
         [&](parser::Kwbegin *kwbegin) {
             associateAssertionCommentsToNode(node);
-            for (auto &stmt : kwbegin->stmts) {
-                walkNode(stmt.get());
-            }
+            walkNodes(kwbegin->stmts);
             consumeCommentsInsideNode(node, "begin");
         },
         [&](parser::Masgn *masgn) {
@@ -380,9 +370,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
                 }
             }
 
-            for (auto &expr : next->exprs) {
-                walkNode(expr.get());
-            }
+            walkNodes(next->exprs);
             consumeCommentsInsideNode(node, "next");
         },
         [&](parser::OpAsgn *opAsgn) {
@@ -417,17 +405,14 @@ void CommentsAssociator::walkNode(parser::Node *node) {
             if (beginLine == endLine) {
                 // Single line rescue that may have an assertion comment so we need to start from the else node
                 walkNode(rescue->else_.get());
-                for (auto &rescued : rescue->rescue) {
-                    walkNode(rescued.get());
-                }
+                walkNodes(rescue->rescue);
                 walkNode(rescue->body.get());
             } else {
                 walkNode(rescue->body.get());
-                for (auto &rescued : rescue->rescue) {
-                    walkNode(rescued.get());
-                }
+                walkNodes(rescue->rescue);
                 walkNode(rescue->else_.get());
             }
+
             consumeCommentsBetweenLines(beginLine, endLine, "rescue");
         },
         [&](parser::Return *ret) {
@@ -440,9 +425,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
                 }
             }
 
-            for (auto &expr : ret->exprs) {
-                walkNode(expr.get());
-            }
+            walkNodes(ret->exprs);
             consumeCommentsInsideNode(node, "return");
         },
         [&](parser::SClass *sclass) {
@@ -479,10 +462,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
                 associateAssertionCommentsToNode(send);
 
                 walkNode(send->receiver.get());
-
-                for (auto &arg : send->args) {
-                    walkNode(arg.get());
-                }
+                walkNodes(send->args);
                 consumeCommentsInsideNode(node, "send");
             }
         },

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -23,20 +23,26 @@ public:
 private:
     static const std::string_view ANNOTATION_PREFIX;
     static const std::string_view MULTILINE_RBS_PREFIX;
+    static const std::string_view BIND_PREFIX;
 
     core::MutableContext ctx;
     std::vector<core::LocOffsets> commentLocations;
     std::map<int, CommentNode> commentByLine;
     std::map<parser::Node *, std::vector<CommentNode>> commentsByNode;
+    int lastLine;
 
     void walkNode(parser::Node *node);
     void walkNodes(parser::NodeVec &nodes);
+    void walkStatements(parser::NodeVec &nodes);
+    std::unique_ptr<parser::Node> walkBody(parser::Node *node, std::unique_ptr<parser::Node> body);
     void associateAssertionCommentsToNode(parser::Node *node, bool adjustLocForHeredoc);
     void associateSignatureCommentsToNode(parser::Node *node);
     void consumeCommentsInsideNode(parser::Node *node, std::string kind);
     void consumeCommentsBetweenLines(int startLine, int endLine, std::string kind);
     void consumeCommentsUntilLine(int line);
     std::optional<uint32_t> locateTargetLine(parser::Node *node);
+
+    int maybeInsertStandalonePlaceholders(parser::NodeVec &nodes, int index, int lastLine, int currentLine);
 };
 
 } // namespace sorbet::rbs

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -29,7 +29,7 @@ private:
     std::map<int, CommentNode> commentByLine;
     std::map<parser::Node *, std::vector<CommentNode>> commentsByNode;
 
-    void walkNodes(parser::Node *node);
+    void walkNode(parser::Node *node);
     void associateAssertionCommentsToNode(parser::Node *node, bool adjustLocForHeredoc);
     void associateSignatureCommentsToNode(parser::Node *node);
     void consumeCommentsInsideNode(parser::Node *node, std::string kind);

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -30,6 +30,7 @@ private:
     std::map<parser::Node *, std::vector<CommentNode>> commentsByNode;
 
     void walkNode(parser::Node *node);
+    void walkNodes(parser::NodeVec &nodes);
     void associateAssertionCommentsToNode(parser::Node *node, bool adjustLocForHeredoc);
     void associateSignatureCommentsToNode(parser::Node *node);
     void consumeCommentsInsideNode(parser::Node *node, std::string kind);

--- a/test/testdata/rbs/assertions_bind.rb
+++ b/test/testdata/rbs/assertions_bind.rb
@@ -1,0 +1,130 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+#: self as Foo
+T.reveal_type(self) # error: Revealed type: `Foo`
+
+class Foo
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+module Bar
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+
+  class << self
+    #: self as Foo
+    T.reveal_type(self) # error: Revealed type: `Foo`
+  end
+end
+
+class Baz; end
+
+def foo
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+def bar
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+def self.baz
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+[].each do
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+case ARGV.first
+when "foo"
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+else
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+case ARGV.first
+in "foo"
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+else
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+for _i in 0..10
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+end
+
+if ARGV.first == "foo"
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+elsif ARGV.first == "bar"
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+else
+  #: self as untyped
+  T.reveal_type(self) # error: Revealed type: `T.untyped`
+end
+
+begin
+  #: self as Foo
+  T.reveal_type(self) # error: Revealed type: `Foo`
+rescue
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+else
+  #: self as Baz
+  T.reveal_type(self) # error: Revealed type: `Baz`
+ensure
+  #: self as untyped
+  T.reveal_type(self) # error: Revealed type: `T.untyped`
+end
+
+until ARGV.first == "foo"
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+begin
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end until ARGV.first == "foo"
+
+while ARGV.first == "foo"
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end
+
+begin
+  #: self as Bar
+  T.reveal_type(self) # error: Revealed type: `Bar`
+end while ARGV.first == "foo"
+
+module Errors
+  #: self as foo
+  #          ^^^ error: RBS aliases are not supported
+
+  #: self as (
+  #          ^ error: Failed to parse RBS type (unexpected token for simple type)
+
+  T.reveal_type(self) # error: Revealed type: `T.untyped`
+
+  self #: self as String
+  #               ^^^^^^ error: `self` binding can't be used as a trailing comment
+end
+
+#: self as Bar
+T.reveal_type(self) # error: Revealed type: `Bar`

--- a/test/testdata/rbs/assertions_bind.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_bind.rb.rewrite-tree.exp
@@ -1,0 +1,198 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def foo<<todo method>>(&<blk>)
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  def bar<<todo method>>(&<blk>)
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  def self.baz<<todo method>>(&<blk>)
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+
+  <emptyTree>::<C T>.reveal_type(<self>)
+
+  class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+
+  module <emptyTree>::<C Bar><<C <todo sym>>> < ()
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+
+    <emptyTree>::<C T>.reveal_type(<self>)
+
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+
+    <emptyTree>::<C T>.reveal_type(<self>)
+
+    class <singleton class><<C <todo sym>>> < ()
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  class <emptyTree>::<C Baz><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  <runtime method definition of foo>
+
+  <runtime method definition of bar>
+
+  <runtime method definition of self.baz>
+
+  [].each() do ||
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  begin
+    <assignTemp>$2 = <emptyTree>::<C ARGV>.first()
+    if "foo".===(<assignTemp>$2)
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    else
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    end
+  end
+
+  begin
+    <assignTemp>$3 = <emptyTree>::<C ARGV>.first()
+    if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    else
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    end
+  end
+
+  ::<Magic>.<build-range>(0, 10, false).each() do |_i|
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  if <emptyTree>::<C ARGV>.first().==("foo")
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  else
+    if <emptyTree>::<C ARGV>.first().==("bar")
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    else
+      begin
+        <cast:bind>(<self>, <todo sym>, ::<root>::<C T>.untyped())
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+    end
+  end
+
+  begin
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+rescue => <rescueTemp>$4
+  begin
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+else
+  begin
+    <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Baz>)
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+ensure
+  begin
+    <cast:bind>(<self>, <todo sym>, ::<root>::<C T>.untyped())
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+
+  while <emptyTree>::<C ARGV>.first().==("foo").!()
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  while true
+    begin
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+      if <emptyTree>::<C ARGV>.first().==("foo")
+        break(<emptyTree>)
+      else
+        <emptyTree>
+      end
+    end
+  end
+
+  while <emptyTree>::<C ARGV>.first().==("foo")
+    begin
+      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  while true
+    begin
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
+      if <emptyTree>::<C ARGV>.first().==("foo").!()
+        break(<emptyTree>)
+      else
+        <emptyTree>
+      end
+    end
+  end
+
+  module <emptyTree>::<C Errors><<C <todo sym>>> < ()
+    <cast:bind>(<self>, <todo sym>, ::<root>::<C T>.untyped())
+
+    <cast:bind>(<self>, <todo sym>, ::<root>::<C T>.untyped())
+
+    <emptyTree>::<C T>.reveal_type(<self>)
+
+    <self>
+  end
+
+  <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
+
+  <emptyTree>::<C T>.reveal_type(<self>)
+end

--- a/test/testdata/rbs/assertions_ensure.rb
+++ b/test/testdata/rbs/assertions_ensure.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+begin
+  ARGV.first #: as Integer
+ensure
+  ARGV.first #: as String
+end

--- a/test/testdata/rbs/assertions_ensure.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_ensure.rb.rewrite-tree.exp
@@ -1,0 +1,5 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <cast:cast>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C Integer>)
+ensure
+  <cast:cast>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C String>)
+end

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -1106,6 +1106,33 @@ This is equivalent to:
 T.absurd(x)
 ```
 
+### `T.bind`
+
+[`T.bind`](type-assertions.md#tbind) can be expressed using RBS comments with
+the special `self as` construct:
+
+```ruby
+class Foo
+  def foo; end
+end
+
+def bar
+  #: self as Foo
+
+  foo
+end
+```
+
+This is equivalent to:
+
+```ruby
+def bar
+  T.bind(self, Foo)
+
+  foo
+end
+```
+
 [Class instance type]:
   https://github.com/ruby/rbs/blob/master/docs/syntax.md#class-instance-type
 [Class singleton type]:


### PR DESCRIPTION
### Motivation

Allow binding `self` with an RBS comment:

```rb
class Foo
  def foo; end
end

def bar
  #: self as Foo

  T.reveal_type(self) # => Foo
  foo # ok
end
```

The implementation to support this comment is slightly different from the other ones since the comment is standalone and not attached to any existing parser node.

During the comment association, we inject a synthetic `rbs_placeholder` in the AST so we can attach the comment to it, the node then gets replaced by the assertions rewriter into a proper `T.bind` call.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
