### PR TITLE
Fix a parser crash with empty match vars

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1206,6 +1206,10 @@ public:
                 // Label key is a symbol `sym: val`
                 return match_var_hash(label->loc, key->val.show(gs_));
             } else if (auto *key = parser::cast_node<DSymbol>(pair->key.get())) {
+                if (key->nodes.empty()) {
+                    error_without_recovery(ruby_parser::dclass::InvalidKey, key->loc);
+                    return make_unique<MatchVar>(key->loc, gs_.enterNameUTF8(""));
+                }
                 // Label key is a quoted string `"sym": val`
                 return match_var_hash_from_str(std::move(key->nodes));
             }
@@ -1276,6 +1280,8 @@ public:
     }
 
     unique_ptr<Node> match_var_hash_from_str(sorbet::parser::NodeVec strings) {
+        ENFORCE(!strings.empty());
+
         auto loc = collectionLoc(strings);
         if (strings.size() > 1) {
             error_without_recovery(ruby_parser::dclass::PatternInterpInVarName, loc);

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1208,7 +1208,7 @@ public:
             } else if (auto *key = parser::cast_node<DSymbol>(pair->key.get())) {
                 if (key->nodes.empty()) {
                     error_without_recovery(ruby_parser::dclass::InvalidKey, key->loc);
-                    return make_unique<MatchVar>(key->loc, gs_.enterNameUTF8(""));
+                    return error_node(key->loc.beginPos(), key->loc.endPos());
                 }
                 // Label key is a quoted string `"sym": val`
                 return match_var_hash_from_str(std::move(key->nodes));

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -78,6 +78,7 @@ tuple<string, string> MESSAGES[] = {
     {"NoAnonymousBlockArg", "no anonymous block parameter"},
     {"NoAnonymousRestArg", "no anonymous rest parameter"},
     {"NoAnonymousKwrestArg", "no anonymous keyword rest parameter"},
+    {"InvalidKey", "key must be valid as local variables"},
 
     // Error recovery hints
     {"DedentedEnd", "Hint: this {} token might not be properly closed"},

--- a/test/testdata/parser/crash_case_empty_var.rb
+++ b/test/testdata/parser/crash_case_empty_var.rb
@@ -2,3 +2,4 @@
 
 # Crash with an empty string literal in a case-in expression.
 case T.unsafe(nil); in {"":} then true; end
+                      # ^^^ error: key must be valid as local variables

--- a/test/testdata/parser/crash_case_empty_var.rb
+++ b/test/testdata/parser/crash_case_empty_var.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+# Crash with an empty string literal in a case-in expression.
+case T.unsafe(nil); in {"":} then true; end


### PR DESCRIPTION
Sorbet is crashing when encountering an unterminated string symbol in a match expression. This PR fixes the problem by catching the empty case, and entering it manually.

This introduces a new parser error, with text that mirrors the error from the ruby parser:

```
irb(main):002:0> case nil; in {"":} then true end
/Users/trevor/.rbenv/versions/3.1.2/lib/ruby/3.1.0/irb/workspace.rb:119:in `eval': (irb):2: key must be valid as local variables (SyntaxError)
case nil; in {"":} then true end
              ^~~
(irb):2: identifier  is not valid to set
        from /Users/trevor/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from /Users/trevor/.rbenv/versions/3.1.2/bin/irb:25:in `load'
        from /Users/trevor/.rbenv/versions/3.1.2/bin/irb:25:in `<main>'
```

and from Sorbet after this change:

```
% ./bazel-bin/main/sorbet test/testdata/parser/crash_case_empty_var.rb
👋 Hey there! Heads up that this is not a release build of sorbet.
Release builds are faster and more well-supported by the Sorbet team.
Check out the README to learn how to build Sorbet in release mode.
To forcibly silence this error, either pass --silence-dev-message,
or set SORBET_SILENCE_DEV_MESSAGE=1 in your shell environment.

test/testdata/parser/crash_case_empty_var.rb:4: key must be valid as local variables https://srb.help/2001
     4 |case T.unsafe(nil); in {"":} then true; end
                                ^^^
Errors: 1
```

### Motivation
Fixes #8903

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
