### PR TITLE
Added `CGI::Util.escapeURIComponent` and `unescapeURIComponent`

### DIFF
--- a/rbi/stdlib/cgi.rbi
+++ b/rbi/stdlib/cgi.rbi
@@ -1263,6 +1263,35 @@ module CGI::Util
     .returns(::T.untyped)
   end
   def unescape_html(_); end
+
+  # URL-encode a string following RFC 3986 Space characters (+“ ”+) are encoded with (+“%20”+)
+  #
+  # ```ruby
+  # url_encoded_string = CGI.escape("'Stop!' said Fred")
+  #    # => "%27Stop%21%27%20said%20Fred"
+  # ```
+  sig do
+    params(
+      string: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def escapeURIComponent(string); end
+
+  # URL-decode a string following RFC 3986 with encoding(optional).
+  #
+  # ```ruby
+  # string = CGI.unescape("%27Stop%21%27+said%20Fred")
+  #    # => "'Stop!'+said Fred"
+  # ```
+  sig do
+    params(
+      string: ::T.untyped,
+      encoding: ::T.untyped
+    )
+    .returns(::String)
+  end
+  def unescapeURIComponent(string, encoding = T.unsafe(nil)); end
 end
 
 module CGI::Escape

--- a/test/testdata/rbi/cgi.rb
+++ b/test/testdata/rbi/cgi.rb
@@ -1,0 +1,6 @@
+# typed: true
+require 'cgi'
+
+T.assert_type!(CGI.escapeURIComponent("'Stop!' said Fred"), String)
+T.assert_type!(CGI.unescapeURIComponent("%27Stop%21%27+said%20Fred"), String)
+T.assert_type!(CGI.unescapeURIComponent("%27Stop%21%27+said%20Fred", "ISO-8859-1"), String)


### PR DESCRIPTION
In Nov 2021, CGI gained `escapeURIComponent` and `unescapeURIComponent` which were missing from the signatures.

### Motivation
This Sorbet playground example fails because the `CGI.escapeURIComponent` signature does not exist at all: https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Arequire%20%22cgi%22%0ACGI.escapeURIComponent%28%22tada%26%22%29

```ruby
# typed: true
extend T::Sig

require "cgi"
CGI.escapeURIComponent("tada&")
```

```
editor.rb:5: Method escapeURIComponent does not exist on T.class_of(CGI) https://srb.help/7003
     5 |CGI.escapeURIComponent("tada&")
            ^^^^^^^^^^^^^^^^^^
  Got T.class_of(CGI) originating from:
    editor.rb:5:
     5 |CGI.escapeURIComponent("tada&")
        ^^^
  Did you mean escapeElement? Use -a to autocorrect
    editor.rb:5: Replace with escapeElement
     5 |CGI.escapeURIComponent("tada&")
            ^^^^^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/cgi.rbi#L1082: Defined here
    1082 |  def escapeElement(string, *elements); end
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Errors: 1
```

### Test plan
A new `cgi.rb` file was added to assert a minimum of type checking for only these two methods.

Most of `CGI::Util` is defined as taking untyped values and returning untyped values. A separate PR will be made to address that.