### PR TITLE
Fix blank? return types

### DIFF
--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -488,7 +488,7 @@ class Date
   sig {returns(T::Boolean)}
   def saturday?(); end
 
-  sig {returns(T::Boolean)}
+  sig {returns(FalseClass)}
   def blank?(); end
 
   # This method is equivalent to step(min, -1){|date| ...}.

--- a/rbi/stdlib/date.rbi
+++ b/rbi/stdlib/date.rbi
@@ -488,9 +488,6 @@ class Date
   sig {returns(T::Boolean)}
   def saturday?(); end
 
-  sig {returns(FalseClass)}
-  def blank?(); end
-
   # This method is equivalent to step(min, -1){|date| ...}.
   sig {params(arg0: T.untyped).returns(T.untyped)}
   def downto(arg0); end

--- a/rbi/stdlib/date_time.rbi
+++ b/rbi/stdlib/date_time.rbi
@@ -520,9 +520,6 @@ class DateTime < Date
   sig {returns(DateTime)}
   def to_datetime(); end
 
-  sig {returns(FalseClass)}
-  def blank?(); end
-
   sig do
     params(
       locale: T.untyped,

--- a/rbi/stdlib/date_time.rbi
+++ b/rbi/stdlib/date_time.rbi
@@ -520,7 +520,7 @@ class DateTime < Date
   sig {returns(DateTime)}
   def to_datetime(); end
 
-  sig {returns(T.untyped)}
+  sig {returns(FalseClass)}
   def blank?(); end
 
   sig do


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
`blank?` isn't actually defined in the stdlib for these (or any other classes):

https://docs.ruby-lang.org/en/3.4/Date.html
https://docs.ruby-lang.org/en/3.4/DateTime.html

But, presumably these refer to the activesupport monkey-patches:

https://github.com/rails/rails/blob/c1d7d56e831acf0aff5f3e27a6b384f543f358d0/activesupport/lib/active_support/core_ext/date/blank.rb#L6-L13
https://github.com/rails/rails/blob/c1d7d56e831acf0aff5f3e27a6b384f543f358d0/activesupport/lib/active_support/core_ext/date_time/blank.rb#L6-L13

relates to https://github.com/sorbet/sorbet/issues/7494

(I'm also happy deleting these defs from the rbi, since they [exist](https://github.com/Shopify/rbi-central/blob/d5626e66a619dc19ec2f3e4aab49f6b147b15f08/rbi/annotations/activesupport.rbi#L187-L202) as annotations in rbi-central. IMO it would be better for them to live in a shim or a tapioca-generated rbi linked to their actual sources.)