### PR TITLE
Fix RBS assertions in `else` following a `elsif`

### DIFF
--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -326,10 +326,21 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
             consumeCommentsInsideNode(node, "hash");
         },
         [&](parser::If *if_) {
-            associateAssertionCommentsToNode(node);
+            auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
+            auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
+
+            if (beginLine == endLine) {
+                associateAssertionCommentsToNode(node);
+            }
+
             walkNodes(if_->condition.get());
             walkNodes(if_->then_.get());
             walkNodes(if_->else_.get());
+
+            if (beginLine != endLine) {
+                associateAssertionCommentsToNode(node);
+            }
+
             consumeCommentsInsideNode(node, "if");
         },
         [&](parser::InPattern *inPattern) {

--- a/test/testdata/rbs/assertions_if.rb
+++ b/test/testdata/rbs/assertions_if.rb
@@ -48,3 +48,14 @@ T.reveal_type(if8) # error: Revealed type: `Float`
 if9 = if ARGV.empty? #: as Integer
 else
 end
+
+if ARGV.size == 1
+  ARGV.shift #: Integer
+elsif ARGV.size == 2
+  [ARGV.shift, ARGV.shift] #: Array[Integer]
+else
+  ARGV.shift #: NilClass
+end
+
+42 if ARGV.any? #: Integer?
+42 unless ARGV.empty? #: Integer?

--- a/test/testdata/rbs/assertions_if.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_if.rb.rewrite-tree.exp
@@ -66,4 +66,26 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   else
     <emptyTree>
   end
+
+  if <emptyTree>::<C ARGV>.size().==(1)
+    <cast:let>(<emptyTree>::<C ARGV>.shift(), <todo sym>, <emptyTree>::<C Integer>)
+  else
+    if <emptyTree>::<C ARGV>.size().==(2)
+      <cast:let>([<emptyTree>::<C ARGV>.shift(), <emptyTree>::<C ARGV>.shift()], <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
+    else
+      <cast:let>(<emptyTree>::<C ARGV>.shift(), <todo sym>, <emptyTree>::<C NilClass>)
+    end
+  end
+
+  <cast:let>(if <emptyTree>::<C ARGV>.any?()
+    42
+  else
+    <emptyTree>
+  end, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
+
+  <cast:let>(if <emptyTree>::<C ARGV>.empty?()
+    <emptyTree>
+  else
+    42
+  end, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
 end


### PR DESCRIPTION
### Motivation

Correctly associate the `else` assertions from:

```rb
if x
  x #: as Integer
elsif y
  y #: as Integer
else
  z #: as Integer
end
```

So it is rewritten as:

```rb
if x
  T.cast(x, Integer)
elsif y
  T.cast(y, Integer)
else
  T.cast(z, Integer)
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
