### PR TITLE
Introduce RBS alternative to `T.absurd`

### DIFF
--- a/parser/helper.h
+++ b/parser/helper.h
@@ -215,6 +215,13 @@ public:
     /* T methods */
 
     /*
+     * Create a `T.absurd()` send node.
+     */
+    static std::unique_ptr<parser::Node> TAbsurd(core::LocOffsets loc, std::unique_ptr<parser::Node> node) {
+        return Send1(loc, T(loc), core::Names::absurd(), loc, move(node));
+    }
+
+    /*
      * Create a `T.all(args...)` send node.
      */
     static std::unique_ptr<parser::Node> TAll(core::LocOffsets loc, parser::NodeVec args) {

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -10,8 +10,9 @@ namespace sorbet::rbs {
 
 struct InlineComment {
     enum class Kind {
-        LET,
+        ABSURD,
         CAST,
+        LET,
         MUST,
         UNSAFE,
     };

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -512,7 +512,10 @@ void CommentsAssociator::walkNodes(parser::Node *node) {
         },
         [&](parser::When *when) {
             walkNodes(when->body.get());
-            consumeCommentsInsideNode(node, "when");
+
+            if (auto body = when->body.get()) {
+                consumeCommentsInsideNode(body, "when");
+            }
         },
         [&](parser::While *while_) {
             associateAssertionCommentsToNode(node);

--- a/test/testdata/rbs/assertions_absurd.rb
+++ b/test/testdata/rbs/assertions_absurd.rb
@@ -1,0 +1,260 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+#: (Integer | String) -> void
+def normal_usage(x)
+  case x
+  when Integer
+    puts x
+  when String
+    puts x
+  else
+    x #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def forgotten_case(x)
+  case x
+  when Integer
+    puts x
+  else
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+#: (Integer | String) -> void
+def got_all_cases_but_untyped(x)
+  y = T.unsafe(x)
+  case y
+  when Integer
+    puts y
+  when String
+    puts y
+  else
+    y #: absurd # error: Control flow could reach `T.absurd` because argument was `T.untyped`
+  end
+end
+
+#: (Integer | String | Array[Integer]) -> void
+def forgotten_two_cases(x)
+  case x
+  when Integer
+    puts x
+  else
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `T.any(String, T::Array[Integer])` wasn't handled
+  end
+end
+
+#: (String | Array[Integer]) -> void
+def missing_case_with_generic(x)
+  case x
+  when Array
+    puts x
+  else
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+#: (Array[String] | Array[Integer]) -> void
+def ok_when_generic_cases_overlap(x)
+  case x
+  when Array
+    puts x
+  else
+    x #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def dead_code_before(x)
+  case x
+  when Integer
+    puts x
+  when String
+    puts x
+  else
+    puts 1 # error: This code is unreachable
+    x #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def dead_code_after(x)
+  case x
+  when Integer
+    puts x
+  when String
+    puts x
+  else
+    x #: absurd
+    puts 1 # error: This code is unreachable
+  end
+end
+
+#: (Integer | String) -> void
+def cant_alias_local_variables(x)
+  case x
+  when Integer
+    puts x
+  when String
+    puts x
+  else
+    # Hello future Sorbet contributor.
+    # It's not that we MUST have an error here, but rather that we were fine
+    # with it, and couldn't see a simple solution that avoided emitting one.
+    y = x
+    #   ^ error: This code is unreachable
+    y #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def normal_usage_with_isa(x)
+  if x.is_a?(Integer)
+    puts x
+  elsif x.is_a?(String)
+    puts x
+  else
+    x #: absurd
+  end
+end
+
+#: (Integer | String) -> void
+def missing_case_with_isa(x)
+  if x.is_a?(Integer)
+    puts x
+  else
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+#: (Integer) -> void
+def enforce_something_is_always_non_nil(x)
+  if !x.nil?
+    puts x
+  else
+    x #: absurd
+  end
+end
+
+#: (Integer) -> void
+def error_when_predicate_always_true(x)
+  if !x.nil?
+    puts 1 # not a dead code error, because it's always true!
+    # This is a strange error message given the test case.
+    x #: absurd # error: Control flow could reach `T.absurd` because the type `Integer` wasn't handled
+  end
+end
+
+# --- trying to subvert normal usage ------------------------------------------
+
+def only_absurd
+  temp1 = T.let(T.unsafe(nil), T.noreturn)
+  temp1 #: absurd
+end
+
+#: (bot) -> void
+def allows_arg_noreturn(x)
+  x #: absurd
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+#: (bot, bot) -> void
+def allows_args_noreturn(x, y)
+  x #: absurd
+  y #: absurd
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+#: (Integer & String) -> void
+def intersects_to_bottom(x)
+  x #: absurd
+  puts(x)
+# ^^^^^^^ error: This code is unreachable
+end
+
+# --- reasonable usage on global, class, instance, and local variables --------
+$some_global = true #: bool
+
+#: -> void
+def absurd_not_reached_on_global_var
+  case $some_global
+  when TrueClass
+  when FalseClass
+  else $some_global #: absurd # error: Control flow could reach `T.absurd` because argument was `T.untyped`
+  end
+end
+
+#: -> void
+def absurd_reached_on_global_var
+  if !$some_global
+    $some_global #: absurd # error: Control flow could reach `T.absurd` because the type `T.nilable(FalseClass)` wasn't handled
+  end
+end
+
+class SomeClass
+  @@some_class_var = true #: bool
+
+  #: -> void
+  def initialize
+    @some_instance_var = true #: bool
+  end
+
+  #: -> void
+  def absurd_not_reached_on_class_var
+    case @@some_class_var
+    when TrueClass
+    when FalseClass
+    else
+      @@some_class_var #: absurd
+    end
+  end
+
+  #: -> void
+  def absurd_reached_on_class_var
+    if !@@some_class_var
+      @@some_class_var #: absurd # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+    end
+  end
+
+  #: -> void
+  def absurd_not_reached_on_instance_var
+    case @some_instance_var
+    when TrueClass
+    when FalseClass
+    else
+      @some_instance_var #: absurd
+    end
+  end
+
+  #: -> void
+  def absurd_reached_on_instance_var
+    if !@some_instance_var
+      @some_instance_var #: absurd # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+    end
+  end
+end
+
+#: (bool) -> void
+def absurd_reached_on_local_var(some_local_var)
+  if !some_local_var
+    some_local_var #: absurd # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+  end
+end
+
+# --- incorrect usage ---------------------------------------------------------
+
+#: (Integer) -> void
+def not_enough_args(x)
+  #: absurd # error: Unexpected RBS assertion comment found in `method`
+end
+
+#: (Integer) -> void
+def too_many_args(x)
+  if x.nil?
+    nil #: absurd # error: `T.absurd` expects to be called on a variable
+  end
+end

--- a/test/testdata/rbs/assertions_case.rb
+++ b/test/testdata/rbs/assertions_case.rb
@@ -35,3 +35,8 @@ T.reveal_type(c1) # error: Revealed type: `Integer`
 case ARGV.shift #: as String
 when "foo"
 end
+
+case ARGV.shift
+when "foo"
+else ARGV.shift #: as String
+end

--- a/test/testdata/rbs/assertions_case.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_case.rb.rewrite-tree.exp
@@ -62,4 +62,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
   end
+
+  begin
+    <assignTemp>$7 = <emptyTree>::<C ARGV>.shift()
+    if "foo".===(<assignTemp>$7)
+      <emptyTree>
+    else
+      <cast:cast>(<emptyTree>::<C ARGV>.shift(), <todo sym>, <emptyTree>::<C String>)
+    end
+  end
 end

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -1084,6 +1084,28 @@ x = T.unsafe(42)
 x.undefined_method
 ```
 
+### `T.absurd`
+
+[`T.absurd`](exhaustiveness.md) can be expressed using RBS comments:
+
+```ruby
+#: (Integer | String) -> void
+def foo(x)
+  case x
+  when Integer
+  when String
+  else
+    x #: absurd
+  end
+end
+```
+
+This is equivalent to:
+
+```ruby
+T.absurd(x)
+```
+
 [Class instance type]:
   https://github.com/ruby/rbs/blob/master/docs/syntax.md#class-instance-type
 [Class singleton type]:


### PR DESCRIPTION
### Motivation

So `T.absurd` can be expressed using RBS comments:

```ruby
#: (Integer | String) -> void
def foo(x)
  case x
  when Integer
  when String
  else
    x #: absurd
  end
end
```

This is equivalent to:

```ruby
T.absurd(x)
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
