### PR TITLE
Fix a crash in textDocument/implementation

### DIFF
--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -75,11 +75,12 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
         return response;
     }
 
+    vector<unique_ptr<Location>> result;
     if (queryResult.responses.empty()) {
+        response->result = std::move(result);
         return response;
     }
 
-    vector<unique_ptr<Location>> result;
     auto queryResponse = move(queryResult.responses[0]);
     if (auto def = queryResponse->isMethodDef()) {
         // User called "Go to Implementation" from the abstract function definition

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -177,6 +177,13 @@ unique_ptr<LSPMessage> makeDefinitionRequest(int id, string_view uri, int line, 
                                                 make_unique<Position>(line, character))));
 }
 
+unique_ptr<LSPMessage> makeImplementationRequest(int id, string_view uri, int line, int character) {
+    return make_unique<LSPMessage>(
+        make_unique<RequestMessage>("2.0", id, LSPMethod::TextDocumentImplementation,
+                                    make_unique<ImplementationParams>(make_unique<TextDocumentIdentifier>(string(uri)),
+                                                                      make_unique<Position>(line, character))));
+}
+
 unique_ptr<LSPMessage> makeReferenceRequest(int id, string_view uri, int line, int character, bool includeDecl) {
     return make_unique<LSPMessage>(
         make_unique<RequestMessage>("2.0", id, LSPMethod::TextDocumentReferences,

--- a/test/helpers/lsp.h
+++ b/test/helpers/lsp.h
@@ -22,6 +22,9 @@ makeInitializeParams(std::optional<std::variant<std::string, JSONNullObject>> ro
 /** Create an LSPMessage containing a textDocument/definition request. */
 std::unique_ptr<LSPMessage> makeDefinitionRequest(int id, std::string_view uri, int line, int character);
 
+/** Create an LSPMessage containing a textDocument/implementation request. */
+std::unique_ptr<LSPMessage> makeImplementationRequest(int id, std::string_view uri, int line, int character);
+
 /** Create an LSPMessage containing a textDocument/hover request. */
 std::unique_ptr<LSPMessage> makeHover(int id, std::string_view uri, int line, int character);
 

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -123,6 +123,10 @@ unique_ptr<LSPMessage> ProtocolTest::getDefinition(string_view path, int line, i
     return makeDefinitionRequest(nextId++, getUri(path), line, character);
 }
 
+unique_ptr<LSPMessage> ProtocolTest::implementation(string_view path, int line, int character) {
+    return makeImplementationRequest(nextId++, getUri(path), line, character);
+}
+
 unique_ptr<LSPMessage> ProtocolTest::getReference(string_view path, int line, int character) {
     return makeReferenceRequest(nextId++, getUri(path), line, character);
 }

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -69,6 +69,8 @@ protected:
 
     std::unique_ptr<LSPMessage> getDefinition(std::string_view path, int line, int character);
 
+    std::unique_ptr<LSPMessage> implementation(std::string_view path, int line, int character);
+
     std::unique_ptr<LSPMessage> getReference(std::string_view path, int line, int character);
 
     std::unique_ptr<LSPMessage> hover(std::string_view path, int line, int character);

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -1053,4 +1053,13 @@ TEST_CASE_FIXTURE(ProtocolTest, "OpeningExistingFilesTakesTheFastPath") {
     }
 }
 
+TEST_CASE_FIXTURE(ProtocolTest, "ImplementationOnBrokenLambda") {
+    assertErrorDiagnostics(initializeLSP(), {});
+    assertErrorDiagnostics(send(*openFile("foo.rb", "->... {}")), {{"foo.rb", 0, "unexpected token \"...\""}});
+
+    auto responses = send(*implementation("foo.rb", 0, 2));
+    const auto numResponses = absl::c_count_if(responses, [](const auto &m) { return m->isResponse(); });
+    REQUIRE_EQ(1, numResponses);
+}
+
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
We weren't setting any response when there were no locations found for a `textDocument/implementation` request, which would trigger an error in LSPLoop.cc. This PR ensures that we at least return no locations in the response.

### Motivation
Fixes #8906

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
