### PR TITLE
avoid deleting abstract method bodies

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3777,8 +3777,6 @@ public:
                     e.setHeader("Abstract methods must not contain any code in their body");
                     e.replaceWith("Delete the body", ctx.locAt(mdef.rhs.loc()), "");
                 }
-
-                mdef.rhs = ast::MK::EmptyTree();
             }
             if (!mdef.symbol.enclosingClass(ctx).data(ctx)->flags.isAbstract) {
                 if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::AbstractMethodOutsideAbstract)) {

--- a/test/testdata/resolver/cast_in_abstract_crash.rb
+++ b/test/testdata/resolver/cast_in_abstract_crash.rb
@@ -2,7 +2,7 @@
 class A
   extend T::Sig
 
-  sig {abstract.params(blk: T.proc.returns(Out)).void}
+  sig {abstract.void}
   def foo
     @z ||= T.let(nil, T.nilable(T.type_parameter(:U)))
   end

--- a/test/testdata/resolver/cast_in_abstract_crash.rb
+++ b/test/testdata/resolver/cast_in_abstract_crash.rb
@@ -1,9 +1,15 @@
 # typed: true
 class A
   extend T::Sig
+  extend T::Helpers
+
+  abstract!
 
   sig {abstract.void}
   def foo
     @z ||= T.let(nil, T.nilable(T.type_parameter(:U)))
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Abstract methods must not contain any code in their body
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve declared type for `@z`
+#                                                ^^ error: Unspecified type parameter
   end
 end

--- a/test/testdata/resolver/cast_in_abstract_crash.rb
+++ b/test/testdata/resolver/cast_in_abstract_crash.rb
@@ -1,34 +1,9 @@
-class HasPrivate
-  private def my_private; end
-end
-
+# typed: true
 class A
   extend T::Sig
 
   sig {abstract.params(blk: T.proc.returns(Out)).void}
   def foo
-    T.reveal_type(@y1)
-    T.reveal_type(@y2)
-
-    @z = T.let(nil, T.nilable(T.type_parameter(:U)))
-  end
-
-  sig {returns(T.nilable(HasPrivate))}
-  def ;end; end
-
-  def bar
-    a = A.new
-
-    if a.foo && a.foo.even?
-      puts a.foo
-    end
-
-    if foo && foo.even?
-      puts a.foo
-    end
-
-    if a.get_private && a.get_private.my_private
-      puts a.foo
-    end
+    @z ||= T.let(nil, T.nilable(T.type_parameter(:U)))
   end
 end

--- a/test/testdata/resolver/cast_in_abstract_crash.rb
+++ b/test/testdata/resolver/cast_in_abstract_crash.rb
@@ -1,0 +1,34 @@
+class HasPrivate
+  private def my_private; end
+end
+
+class A
+  extend T::Sig
+
+  sig {abstract.params(blk: T.proc.returns(Out)).void}
+  def foo
+    T.reveal_type(@y1)
+    T.reveal_type(@y2)
+
+    @z = T.let(nil, T.nilable(T.type_parameter(:U)))
+  end
+
+  sig {returns(T.nilable(HasPrivate))}
+  def ;end; end
+
+  def bar
+    a = A.new
+
+    if a.foo && a.foo.even?
+      puts a.foo
+    end
+
+    if foo && foo.even?
+      puts a.foo
+    end
+
+    if a.get_private && a.get_private.my_private
+      puts a.foo
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

When we come upon an abstract method with expressions/statements in it, we issue an error (good!) and replace the method's body with an empty tree.  Unfortunately, there may be other parts of resolver holding on to trees within the body -- #8918 is about cast items that have yet to be processed, but it is entirely possible there are other cases.

Since we refuse to typecheck the bodies of abstract methods (see `infer::Inference::willRun`), we can just leave the method body as-is and rely on the user to remove it.  This is a small memory hit, but it is better than crashing.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #8918 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
