### PR TITLE
`requires` is a C++20 keyword, so we can't use it

### DIFF
--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -208,8 +208,7 @@ string MsgpackWriterFull::pack(core::Context ctx, ParsedFile &pf, const AutogenC
 
         // requires
         {
-            MsgpackArray
-                requires(&writer, pf.requireStatements.size());
+            MsgpackArray requires_(&writer, pf.requireStatements.size());
             for (auto nm : pf.requireStatements) {
                 packString(&writer, nm.show(ctx));
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

(Eventual) C++ compatibility.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
