### PR TITLE
Fix a crash when renaming a method at a send

### DIFF
--- a/test/testdata/lsp/rename/rename_overload.A.rbedited
+++ b/test/testdata/lsp/rename/rename_overload.A.rbedited
@@ -1,0 +1,11 @@
+# typed: true
+
+class Main
+    extend T::Sig
+
+    sig {params(val: T::Set[String]).returns(T.nilable(String))}
+    def set(val)
+        val.second
+          # ^ apply-rename: [A] newName: second placeholderText: first
+    end
+end

--- a/test/testdata/lsp/rename/rename_overload.rb
+++ b/test/testdata/lsp/rename/rename_overload.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class Main
+    extend T::Sig
+
+    sig {params(val: T::Set[String]).returns(T.nilable(String))}
+    def set(val)
+        val.first
+          # ^ apply-rename: [A] newName: second placeholderText: first
+    end
+end


### PR DESCRIPTION
When renaming methods, we weren't handling the case where we might be renaming an overloaed method. This was leading to the assumption that the original name for the method looked something like `"foo (overload.1)"` instead of just `"foo"`, which in turn led to a crash when calculating a substring of the original send to replace. This PR fixes the issue by detecting overloads when constructing the renamer, and then using the name of the original definition instead.

This does raise a question though: should we support renaming methods anywhere other than the definition site? I think another reasonable change here would be to say that we don't support renaming methods at sends, but that would be a change in existing behavior.

### Motivation
Fixing a crash during method renaming.

### Test plan
See included automated tests.
