### PR TITLE
Fix a crash when suggesting a change to a generic

### DIFF
--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1045,7 +1045,7 @@ TypeSyntax::ResultType reportUnknownTypeSyntaxError(core::Context ctx, const ast
                                                     TypeSyntax::ResultType &&result) {
     if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
         auto klass = sendLooksLikeBadTypeApplication(ctx, s);
-        if (klass.exists()) {
+        if (klass.exists() && s.hasPosArgs()) {
             auto scope =
                 s.recv.isSelfReference() ? "" : fmt::format("{}::", ctx.locAt(s.recv.loc()).source(ctx).value());
             auto replacement =

--- a/test/testdata/resolver/generic_missing_args_in_sig.rb
+++ b/test/testdata/resolver/generic_missing_args_in_sig.rb
@@ -4,5 +4,7 @@ class A
   extend T::Sig, T::Generic
   Elem = type_member
   sig { params(x: self.A).void }
+                # ^^^^^^ error: Malformed type declaration
+                #      ^ error: Method `A` does not exist
   def test(x); end
 end

--- a/test/testdata/resolver/generic_missing_args_in_sig.rb
+++ b/test/testdata/resolver/generic_missing_args_in_sig.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  extend T::Sig, T::Generic
+  Elem = type_member
+  sig { params(x: self.A).void }
+  def test(x); end
+end


### PR DESCRIPTION
We were assuming that seeing a send to a generic meant that it always had arguments present, but `self.A` is an example of a case where that's not true. This PR fixes the autocorrect by requiring that there are positional args to suggest changing parens to brackets.

### Motivation
Fixing a crash.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
