### PR TITLE
Add Bundler.original_system sig

### DIFF
--- a/rbi/stdlib/bundler.rbi
+++ b/rbi/stdlib/bundler.rbi
@@ -190,6 +190,9 @@ module Bundler
   sig {returns(T.untyped)}
   def self.original_env(); end
 
+  sig { params(args: T.untyped).returns(T.nilable(T::Boolean)) }
+  def self.original_system(*args); end
+
   sig do
     params(
       file: T.untyped,


### PR DESCRIPTION
See https://docs.ruby-lang.org/en/3.3/Bundler.html#method-c-original_system

This is a wrapper around `Kernel.system`, so it should maybe have the same [sig](https://github.com/sorbet/sorbet/blob/f860e00ee6e35aa527d8e34172770c4512b88e5c/rbi/core/kernel.rbi#L3099-L3107), but I've kept the docs signature of just `*args`.