### PR TITLE
Fix a vector overrun when printing applied types

### DIFF
--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -463,6 +463,8 @@ string AppliedType::show(const GlobalState &gs, ShowOptions options) const {
     auto targs = this->targs;
     auto typeMembers = this->klass.data(gs)->typeMembers();
     if (typeMembers.size() < targs.size()) {
+        // We have too many arguments at the application site, let's truncate them to match the number of type members
+        // that are defined for this generic.
         targs.erase(targs.begin() + typeMembers.size());
     }
 
@@ -483,6 +485,12 @@ string AppliedType::show(const GlobalState &gs, ShowOptions options) const {
 
     auto it = targs.begin();
     for (auto typeMember : typeMembers) {
+        // We can have fewer arguments than the generic has type members, which might cause our type args list to empty
+        // before we've iterated all the type members.
+        if (targs.empty()) {
+            break;
+        }
+
         auto tm = typeMember;
         if (tm.data(gs)->flags.isFixed) {
             it = targs.erase(it);

--- a/test/testdata/lsp/completion/constant_fuzz_crash.rb
+++ b/test/testdata/lsp/completion/constant_fuzz_crash.rb
@@ -1,0 +1,7 @@
+
+# It's important that the name in the class decl be an existing module name
+class Enumerable # error: `Enumerable` was previously defined as a `module`
+  extend T::Generic
+        # ^ completion: DATA, ...
+  X = type_member
+end

--- a/test/testdata/lsp/completion/constant_fuzz_crash.rb
+++ b/test/testdata/lsp/completion/constant_fuzz_crash.rb
@@ -1,7 +1,0 @@
-
-# It's important that the name in the class decl be an existing module name
-class Enumerable # error: `Enumerable` was previously defined as a `module`
-  extend T::Generic
-        # ^ completion: DATA, ...
-  X = type_member
-end


### PR DESCRIPTION
When printing an `AppliedType` that was given no arguments (like in the case for the type of the top-level constant `::DATA`), we would overrun our copy of the type arguments list if there were more type parameters than arguments. This would lead to undefined behavior in the best case, and a crash otherwise. This PR fixes the issue by exiting the loop that edits the copy of the type arguments list if it becomes empty.

### Motivation
Fixes #8928

### Test plan
See included automated tests.
