### PR TITLE
Fix an out-of-bounds source access in constant completion

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1346,8 +1346,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
             auto prefix = name == core::Names::Constants::ConstantNameMissing() ? "" : name.shortName(gs);
             if (prefix != "") {
                 auto behindCursor = queryLoc.adjust(gs, -1 * static_cast<int32_t>(prefix.size()), 0);
-                auto precedingChar = queryLoc.adjust(gs, -1, 0);
-                if (behindCursor.source(gs) != prefix && precedingChar.source(gs) == ":") {
+                if (!behindCursor.exists() || behindCursor.source(gs) != prefix) {
                     // Probably a case like this:
                     //   A::|
                     //   B::C

--- a/test/testdata/lsp/completion/test.rb
+++ b/test/testdata/lsp/completion/test.rb
@@ -1,0 +1,7 @@
+MyAlias = T.type_alias { Integer }
+# ^      completion: ARGF, ...
+#      ^ completion: MyAlias
+
+# We keep the typed sigil down here to ensure that it's possible to accidentally
+# calculate a negative offset into the file.
+# typed: true


### PR DESCRIPTION
When requesting completion with the cursor in the middle of a constant, we compute a loc that includes the space before the cursor, of that constant's length. If we happen to be close to the beginning of the file, there is a possibiliity that this new location does not exist. This PR fixes the problem by checking that we don't produce an invalid location, and then also requires that the cursor be at the end of the constant's name to be used in completion.

### Motivation
Fixes #8930

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
