### PR TITLE
Sorbet support deprecated keyword.

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1375,6 +1375,9 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
     if (sym->flags.isIncompatibleOverride) {
         methodFlags.emplace_back("allow_incompatible");
     }
+    if (sym->flags.isDeprecated) {
+        methodFlags.emplace_back("deprecated");
+    }
     if (sym->flags.isFinal) {
         methodFlags.emplace_back("final");
     }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -79,13 +79,14 @@ public:
         bool isOverride : 1;
         bool isIncompatibleOverride : 1;
         bool isPackagePrivate : 1;
+        bool isDeprecated : 1;
 
-        constexpr static uint16_t NUMBER_OF_FLAGS = 11;
+        constexpr static uint16_t NUMBER_OF_FLAGS = 12;
         constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
         Flags() noexcept
             : isRewriterSynthesized(false), isProtected(false), isPrivate(false), isOverloaded(false),
               isAbstract(false), isGenericMethod(false), isOverridable(false), isFinal(false), isOverride(false),
-              isIncompatibleOverride(false), isPackagePrivate(false) {}
+              isIncompatibleOverride(false), isPackagePrivate(false), isDeprecated(false) {}
 
         uint16_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint16_t));

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -55,6 +55,7 @@ constexpr ErrorClass UnknownSuperMethod{7048, StrictLevel::True};
 constexpr ErrorClass TypecheckOverloadBody{7049, StrictLevel::True};
 constexpr ErrorClass RedundantMust{7050, StrictLevel::Strict};
 constexpr ErrorClass BranchOnVoid{7051, StrictLevel::True};
+constexpr ErrorClass DeprecatedMethodUsage{7052, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 
 ErrorClass errorClassForUntyped(const GlobalState &gs, FileRef file, const TypePtr &ptr);

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -85,6 +85,7 @@ constexpr ErrorClass TNilableArity{5076, StrictLevel::False};
 constexpr ErrorClass UnsupportedLiteralType{5077, StrictLevel::False};
 constexpr ErrorClass GenericArgumentCountMismatch{5078, StrictLevel::True};
 constexpr ErrorClass GenericArgumentKeywordArgs{5079, StrictLevel::False};
+constexpr ErrorClass OverrideMustBeDeprecated{5080, StrictLevel::True};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/source_generator/source_generator.cc
+++ b/core/source_generator/source_generator.cc
@@ -48,6 +48,9 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
     if (sym->flags.isFinal) {
         sigCall = "sig(:final)";
     }
+	if (sym->flags.isDeprecated) {
+		flags.emplace_back("deprecated");
+	}
     if (sym->flags.isAbstract && options.concretizeIfAbstract) {
         flags.emplace_back("override");
     } else if (sym->flags.isAbstract) {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -113,6 +113,7 @@ NameDef names[] = {
     {"abstract"},
     {"implementation"},
     {"override_", "override"},
+    {"deprecated"},
     {"overridable"},
     {"allowIncompatible", "allow_incompatible"},
     {"sigForMethod"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -938,6 +938,13 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         }
     }
 
+    if (methodData->flags.isDeprecated && !args.suppressErrors) {
+        if (auto e = gs.beginError(args.errLoc(), core::errors::Infer::DeprecatedMethodUsage)) {
+			e.setHeader("Method `{}` is deprecated", method.show(gs));
+            e.addErrorLine(methodData->loc(), "Defined in `{}` here", methodData->owner.show(gs));
+        }
+    }
+
     DispatchResult result;
     auto &component = result.main;
     component.receiver = args.selfType;

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -150,13 +150,19 @@ void ErrorReporter::pushDiagnostics(uint32_t epoch, core::FileRef file, const ve
 
         auto diagnostic = make_unique<Diagnostic>(std::move(range), error->header);
         diagnostic->code = error->what.code;
+        
         if (error->what.code == sorbet::core::errors::Infer::DeadBranchInferencer.code) {
             vector<DiagnosticTag> tags;
             tags.push_back(DiagnosticTag::Unnecessary);
             diagnostic->tags = move(tags);
         }
-
-        diagnostic->severity = DiagnosticSeverity::Error;
+		diagnostic->severity = DiagnosticSeverity::Error;
+        if (error->what.code == sorbet::core::errors::Infer::DeprecatedMethodUsage.code) {
+            vector<DiagnosticTag> tags;
+            tags.push_back(DiagnosticTag::Deprecated);
+            diagnostic->tags = move(tags);
+            diagnostic->severity = DiagnosticSeverity::Warning;
+        }
         if (error->what == sorbet::core::errors::Infer::UntypedValueInformation) {
             diagnostic->severity = DiagnosticSeverity::Information;
         }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1061,6 +1061,10 @@ CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker, 
     if (documentation != nullopt && documentation->find("@deprecated") != documentation->npos) {
         item->deprecated = true;
     }
+    
+    if (what.data(gs)->flags.isDeprecated) {
+        item->deprecated = true;
+    }
 
     return item;
 }

--- a/rbi/sorbet/builder.rbi
+++ b/rbi/sorbet/builder.rbi
@@ -18,6 +18,9 @@ class T::Private::Methods::DeclBuilder
   sig {returns(T::Private::Methods::DeclBuilder)}
   def overridable; end
 
+  sig {returns(T::Private::Methods::DeclBuilder)}
+  def deprecated; end
+
   sig {params(klass: T.untyped).returns(T::Private::Methods::DeclBuilder)}
   def bind(klass); end
 

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -65,6 +65,9 @@ unique_ptr<parser::Node> handleAnnotations(unique_ptr<parser::Node> sigBuilder, 
         } else if (annotation.string == "override") {
             sigBuilder =
                 parser::MK::Send0(annotation.typeLoc, move(sigBuilder), core::Names::override_(), annotation.typeLoc);
+        } else if (annotation.string == "deprecated") {
+            sigBuilder =
+                parser::MK::Send0(annotation.typeLoc, move(sigBuilder), core::Names::deprecated(), annotation.typeLoc);
         } else if (annotation.string == "override(allow_incompatible: true)") {
             auto pairs = parser::NodeVec();
             auto key = parser::MK::Symbol(annotation.typeLoc, core::Names::allowIncompatible());

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3327,31 +3327,6 @@ private:
             method.data(ctx)->flags.isFinal = true;
         }
         
-        // Inherit deprecated flag from parent methods if this method overrides and isn't explicitly deprecated
-        if (sig.seen.override_ && !sig.seen.deprecated_) {
-            auto owner = method.data(ctx)->owner;
-            auto name = method.data(ctx)->name;
-            
-            // Check superclass
-            if (owner.data(ctx)->superClass().exists()) {
-                auto parentMethod = owner.data(ctx)->superClass().data(ctx)->findMethodTransitive(ctx, name);
-                if (parentMethod.exists() && parentMethod != method && parentMethod.data(ctx)->flags.isDeprecated) {
-                    sig.seen.deprecated_ = true;
-                    method.data(ctx)->flags.isDeprecated = true;
-                }
-            }
-            
-            // Check mixins if not already inherited
-			for (const auto &mixin : owner.data(ctx)->mixins()) {
-				auto mixinMethod = mixin.data(ctx)->findMethod(ctx, name);
-				if (mixinMethod.exists() && mixinMethod != method && mixinMethod.data(ctx)->flags.isDeprecated) {
-					sig.seen.deprecated_ = true;
-					method.data(ctx)->flags.isDeprecated = true;
-					break;
-				}
-            }
-        }
-        
         if (sig.seen.bind) {
             if (sig.bind == core::Symbols::MagicBindToAttachedClass()) {
                 if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::BindNonBlockParameter)) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -483,6 +483,9 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                 }
                 sig.seen.overridable = true;
                 break;
+            case core::Names::deprecated().rawId():
+                sig.seen.deprecated_ = true;
+                break;
             case core::Names::returns().rawId(): {
                 sig.seen.returns = true;
                 if (send->hasKwArgs()) {

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -49,6 +49,7 @@ struct ParsedSig {
         bool params = false;
         bool abstract = false;
         bool override_ = false;
+        bool deprecated_ = false;
         bool overridable = false;
         bool returns = false;
         bool void_ = false;

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -68,22 +68,34 @@ void reportMissingError(const string &filename, const T &assertion, string_view 
 
 void reportUnexpectedError(const string &filename, const Diagnostic &diagnostic, string_view sourceLine,
                            string_view errorPrefix) {
-    auto diagnosticMessage = (diagnostic.severity == DiagnosticSeverity::Information)
-                                 ? fmt::format("untyped: {}", diagnostic.message)
-                                 : fmt::format("error: {}", diagnostic.message);
-    ADD_FAIL_CHECK_AT(
-        filename.c_str(), diagnostic.range->start->line + 1,
-        fmt::format(
-            "{}Found unexpected error:\n{}\nNote: If there is already an assertion for this error, then this is a "
-            "duplicate error. Change the assertion to `# error-with-dupes: <error message>` if the duplicate is "
-            "expected.",
-            errorPrefix, prettyPrintRangeComment(sourceLine, *diagnostic.range, diagnosticMessage)));
+    std::string messageType;
+	if (diagnostic.severity == DiagnosticSeverity::Error) {
+		messageType = "error";
+	} else if (diagnostic.severity == DiagnosticSeverity::Warning) {
+		messageType = "warning";
+	} else if (diagnostic.severity == DiagnosticSeverity::Information) {
+		messageType = "untyped";
+	} else if (diagnostic.severity == DiagnosticSeverity::Hint) {
+		messageType = "hint";
+	} else {
+		messageType = "unknown";
+	}
+
+	std::string diagnosticMessage = fmt::format("{}: {}", messageType, diagnostic.message);
+
+	ADD_FAIL_CHECK_AT(
+		filename.c_str(), diagnostic.range->start->line + 1,
+		fmt::format(
+			"{}Found unexpected error:\n{}\nNote: If there is already an assertion for this error, then this is a "
+			"duplicate error. Change the assertion to `# error-with-dupes: <error message>` if the duplicate is "
+			"expected.",
+			errorPrefix, prettyPrintRangeComment(sourceLine, *diagnostic.range, diagnosticMessage)));
 }
 string getSourceLine(const UnorderedMap<string, shared_ptr<core::File>> &sourceFileContents, const string &filename,
-                     int line) {
-    if (absl::StartsWith(filename, core::File::URL_PREFIX)) {
-        return "";
-    }
+					 int line) {
+	if (absl::StartsWith(filename, core::File::URL_PREFIX)) {
+		return "";
+	}
 
     auto it = sourceFileContents.find(filename);
     if (it == sourceFileContents.end()) {
@@ -242,6 +254,7 @@ const UnorderedMap<
         {"untyped", UntypedAssertion::make},
         {"error", ErrorAssertion::make},
         {"error-with-dupes", ErrorAssertion::make},
+        {"warning", WarningAssertion::make},
         {"usage", UsageAssertion::make},
         {"import", ImportAssertion::make},
         {"importusage", ImportUsageAssertion::make},
@@ -478,6 +491,12 @@ shared_ptr<ErrorAssertion> ErrorAssertion::make(string_view filename, unique_ptr
                                        assertionType == "error-with-dupes");
 }
 
+shared_ptr<WarningAssertion> WarningAssertion::make(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                                   string_view assertionContents, string_view assertionType) {
+    return make_shared<WarningAssertion>(filename, range, assertionLine, assertionContents,
+                                        assertionType == "warning-with-dupes");
+}
+
 string ErrorAssertion::toString() const {
     return fmt::format("{}: {}", (matchesDuplicateErrors ? "error-with-dupes" : "error"), message);
 }
@@ -493,6 +512,35 @@ bool ErrorAssertion::check(const Diagnostic &diagnostic, string_view sourceLine,
         return false;
     }
     return true;
+}
+
+WarningAssertion::WarningAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                 string_view message, bool matchesDuplicateWarnings)
+    : RangeAssertion(filename, range, assertionLine), message(message), matchesDuplicateErrors(matchesDuplicateWarnings) {
+}
+
+string WarningAssertion::toString() const {
+    return fmt::format("{}: {}", (matchesDuplicateErrors ? "warning-with-dupes" : "warning"), message);
+}
+
+bool WarningAssertion::check(const Diagnostic &diagnostic, string_view sourceLine, string_view errorPrefix) {
+    // The warning message must contain `message`.
+    if (diagnostic.message.find(message) == string::npos) {
+        ADD_FAIL_CHECK_AT(filename.c_str(), range->start->line + 1,
+                          fmt::format("{}Expected warning of form:\n{}\nFound warning:\n{}", errorPrefix,
+                                      prettyPrintRangeComment(sourceLine, *range, toString()),
+                                      prettyPrintRangeComment(sourceLine, *diagnostic.range,
+                                                              fmt::format("warning: {}", diagnostic.message))));
+        return false;
+    }
+    return true;
+}
+
+bool WarningAssertion::checkAll(const UnorderedMap<string, shared_ptr<core::File>> &files,
+                               vector<shared_ptr<WarningAssertion>> warningAssertions,
+                               map<string, vector<unique_ptr<Diagnostic>>> &filenamesAndDiagnostics,
+                               string warningPrefix) {
+    return checkAllInner<WarningAssertion>(files, warningAssertions, filenamesAndDiagnostics, warningPrefix);
 }
 
 UntypedAssertion::UntypedAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -11,6 +11,7 @@ namespace sorbet::test {
 using namespace sorbet::realmain::lsp;
 
 class ErrorAssertion;
+class WarningAssertion;
 class UntypedAssertion;
 
 /**
@@ -94,6 +95,32 @@ public:
 
     ErrorAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
                    std::string_view message, bool matchesDuplicateErrors);
+
+    std::string toString() const override;
+
+    bool check(const Diagnostic &diagnostic, std::string_view sourceLine, std::string_view errorPrefix);
+};
+
+class WarningAssertion final : public RangeAssertion {
+public:
+    static std::shared_ptr<WarningAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                int assertionLine, std::string_view assertionContents,
+                                                std::string_view assertionType);
+
+    /**
+     * Given a set of position-based assertions and Sorbet-generated diagnostics, check that the assertions pass.
+     */
+    static bool checkAll(const UnorderedMap<std::string, std::shared_ptr<core::File>> &files,
+                         std::vector<std::shared_ptr<WarningAssertion>> warningAssertions,
+                         std::map<std::string, std::vector<std::unique_ptr<Diagnostic>>> &filenamesAndDiagnostics,
+                         std::string warningPrefix = "");
+
+    const std::string message;
+    const bool matchesDuplicateErrors;  // Template compatibility - same as matchesDuplicateWarnings
+    static constexpr DiagnosticSeverity severity = DiagnosticSeverity::Warning;
+
+    WarningAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                   std::string_view message, bool matchesDuplicateWarnings);
 
     std::string toString() const override;
 

--- a/test/testdata/lsp/deprecated_method_diagnostics.rb
+++ b/test/testdata/lsp/deprecated_method_diagnostics.rb
@@ -1,0 +1,25 @@
+# typed: true
+
+class TestClass
+  extend T::Sig
+
+  sig { deprecated.returns(String) }
+  def old_method
+    "legacy"
+  end
+
+  sig { returns(String) }
+  def new_method
+    "current"  
+  end
+end
+
+# This should generate a diagnostic with deprecated tag
+obj = TestClass.new
+result = obj.old_method
+#            ^^^^^^^^^^ warning: Method `TestClass#old_method` is deprecated
+puts result
+
+# This should not generate any diagnostic
+result2 = obj.new_method
+puts result2

--- a/test/testdata/lsp/hover.rb
+++ b/test/testdata/lsp/hover.rb
@@ -169,3 +169,24 @@ def main
   # ^ hover-line: 11 # result type:
   # ^ hover-line: 12 T.noreturn
 end
+
+# Test deprecated method hover
+class DeprecatedTestClass
+  extend T::Sig
+  
+  sig { deprecated.returns(String) }
+  def deprecated_method
+    "old way"
+  end
+  
+  sig { returns(String) }
+  def normal_method
+    "new way"
+  end
+end
+
+deprecated_obj = DeprecatedTestClass.new
+deprecated_obj.deprecated_method
+#              ^^^^^^^^^^^^^^^^^ hover: sig { deprecated.returns(String) }
+deprecated_obj.normal_method
+#              ^^^^^^^^^^^^^ hover: sig { returns(String) }

--- a/test/testdata/resolver/deprecated.rb
+++ b/test/testdata/resolver/deprecated.rb
@@ -1,0 +1,141 @@
+# typed: true
+
+# Basic deprecated method
+class BasicDeprecated
+  extend T::Sig
+  
+  sig { deprecated.returns(String) }
+  def old_method
+    "legacy"
+  end
+  
+  sig { returns(String) }
+  def new_method
+    "current"
+  end
+end
+
+BasicDeprecated.new.old_method # error: Method `BasicDeprecated#old_method` is deprecated
+BasicDeprecated.new.new_method
+
+class DeprecatedVoid
+  extend T::Sig
+  
+  sig { deprecated.void }
+  def old_method
+  end
+end
+
+DeprecatedVoid.new.old_method # error: Method `DeprecatedVoid#old_method` is deprecated
+
+# Deprecated with parameters
+class DeprecatedWithParams
+  extend T::Sig
+  
+  sig { deprecated.params(x: String, y: Integer).returns(String) }
+  def old_method(x, y)
+    "#{x}#{y}"
+  end
+end
+
+DeprecatedWithParams.new.old_method("test", 42) # error: Method `DeprecatedWithParams#old_method` is deprecated
+
+# Deprecated class method
+class DeprecatedClassMethod
+  extend T::Sig
+  
+  sig { deprecated.returns(String) }
+  def self.old_method
+    "legacy class method"
+  end
+end
+
+DeprecatedClassMethod.old_method # error: Method `DeprecatedClassMethod.old_method` is deprecated
+
+# Deprecated with inheritance - deprecated method in parent
+class ParentWithDeprecated
+  extend T::Sig
+  
+  sig { deprecated.returns(String) }
+  def inherited_deprecated
+    "parent deprecated"
+  end
+  
+  sig { overridable.deprecated.returns(String) }
+  def overridable_deprecated
+    "parent overridable deprecated"
+  end
+end
+
+class ChildInheritsDeprecated < ParentWithDeprecated
+  extend T::Sig
+  
+  # Child overrides deprecated method - should still be deprecated
+  sig { override.deprecated.returns(String) }
+  def overridable_deprecated
+    "child overrides deprecated"
+  end
+end
+
+ChildInheritsDeprecated.new.inherited_deprecated # error: Method `ParentWithDeprecated#inherited_deprecated` is deprecated
+ChildInheritsDeprecated.new.overridable_deprecated # error: Method `ChildInheritsDeprecated#overridable_deprecated` is deprecated
+
+class ChildMissingInheritedDeprecated < ParentWithDeprecated
+  extend T::Sig
+  
+  # Child overrides deprecated method - should still be deprecated
+  sig { override.returns(String) }
+  def overridable_deprecated
+    "child overrides deprecated"
+  end
+end
+
+ChildMissingInheritedDeprecated.new.inherited_deprecated # error: Method `ParentWithDeprecated#inherited_deprecated` is deprecated
+ChildMissingInheritedDeprecated.new.overridable_deprecated
+
+# Deprecated with other annotations
+class DeprecatedCombinations
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+  
+  sig { deprecated.overridable.returns(String) }
+  def deprecated_and_overridable
+    "deprecated but overridable"
+  end
+  
+  # Can be both deprecated and abstract
+  sig { deprecated.abstract.void }
+  def deprecated_abstract; end
+  
+  # Can't be both deprecated and final (if we add validation)
+  sig(:final) { deprecated.void }
+  def deprecated_final; end
+end
+
+class ConcreteDeprecatedCombinations < DeprecatedCombinations
+  extend T::Sig
+  
+  sig { override.returns(String) }
+  def deprecated_abstract
+    "concrete implementation"
+  end
+end
+
+ConcreteDeprecatedCombinations.new.deprecated_and_overridable # warning: Method `DeprecatedCombinations#deprecated_and_overridable` is deprecated
+ConcreteDeprecatedCombinations.new.deprecated_abstract # warning: Method `ConcreteDeprecatedCombinations#deprecated_abstract` is deprecated
+ConcreteDeprecatedCombinations.new.deprecated_final # warning: Method `DeprecatedCombinations#deprecated_final` is deprecated
+
+# Test deprecated with attr_accessor-style methods
+class DeprecatedAccessors
+  extend T::Sig
+  
+  sig { deprecated.returns(T.nilable(String)) }
+  attr_reader :old_attr
+  
+  sig { deprecated.params(old_attr: String).returns(String) }
+  attr_writer :old_attr
+end
+accessor_instance = DeprecatedAccessors.new
+accessor_instance.old_attr # error: Method `DeprecatedAccessors#old_attr` is deprecated
+accessor_instance.old_attr = "test" # error: Method `DeprecatedAccessors#old_attr=` is deprecated

--- a/test/testdata/resolver/deprecated.rb
+++ b/test/testdata/resolver/deprecated.rb
@@ -85,7 +85,7 @@ class ChildMissingInheritedDeprecated < ParentWithDeprecated
   
   # Child overrides deprecated method - should still be deprecated
   sig { override.returns(String) }
-  def overridable_deprecated
+  def overridable_deprecated # error: Method `ChildMissingInheritedDeprecated#overridable_deprecated` overrides deprecated method but is not marked deprecated
     "child overrides deprecated"
   end
 end
@@ -117,14 +117,14 @@ class ConcreteDeprecatedCombinations < DeprecatedCombinations
   extend T::Sig
   
   sig { override.returns(String) }
-  def deprecated_abstract
+  def deprecated_abstract # error: Method `ConcreteDeprecatedCombinations#deprecated_abstract` overrides deprecated method but is not marked deprecated
     "concrete implementation"
   end
 end
 
-ConcreteDeprecatedCombinations.new.deprecated_and_overridable # warning: Method `DeprecatedCombinations#deprecated_and_overridable` is deprecated
-ConcreteDeprecatedCombinations.new.deprecated_abstract # warning: Method `ConcreteDeprecatedCombinations#deprecated_abstract` is deprecated
-ConcreteDeprecatedCombinations.new.deprecated_final # warning: Method `DeprecatedCombinations#deprecated_final` is deprecated
+ConcreteDeprecatedCombinations.new.deprecated_and_overridable # error: Method `DeprecatedCombinations#deprecated_and_overridable` is deprecated
+ConcreteDeprecatedCombinations.new.deprecated_abstract
+ConcreteDeprecatedCombinations.new.deprecated_final # error: Method `DeprecatedCombinations#deprecated_final` is deprecated
 
 # Test deprecated with attr_accessor-style methods
 class DeprecatedAccessors


### PR DESCRIPTION
Closes: https://github.com/sorbet/sorbet/issues/4481

Sorbet now supports `# @deprecated` and the `deprecated` keyword in method signatures. On hover, we show `deprecated` in the signature. Method calls now are marked as deprecated. Autocomplete items are also marked as deprecated. We have validation logic that child classes that override methods must mark their methods as deprecated if the parent is marked as deprecated. 


### Motivation
We don't currently support deprecation at the lsp level. It's difficult to know if code is deprecated at a glance.


### Test plan

See included automated tests.
