### PR TITLE
Support keyword arguments with autocomplete

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1010,6 +1010,11 @@ core::MethodRef findEnclosingSend(const core::GlobalState &gs,
     core::MethodRef result;
 
     for (auto &resp : responses) {
+        // Walking past a method definition means we're out of the context of a send.
+        if (resp->isMethodDef()) {
+            break;
+        }
+
         if (auto *enclosingSend = resp->isSend()) {
             result = enclosingSend->dispatchResult->main.method;
             break;

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1172,7 +1172,7 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
         vector<core::NameRef> kwargs;
         kwargs.reserve(params.sendMethod.data(gs)->arguments.size());
         for (auto &param : params.sendMethod.data(gs)->arguments) {
-            if (param.flags.isKeyword && hasSimilarName(gs, param.name, params.prefix)) {
+            if (param.flags.isKeyword && !param.flags.isRepeated && hasSimilarName(gs, param.name, params.prefix)) {
                 similarKwargs.emplace_back(param.name);
             }
         }

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -35,7 +35,7 @@ class CompletionTask final : public LSPRequestTask {
         core::MethodRef enclosingMethod;
 
         // If not exists(), won't suggest kwargs for the method that this query occurs in the arg list of.
-        core::MethodRef sendMethod;
+        core::MethodRef kwargsMethod;
 
         // If empty(), won't suggest constants.
         core::lsp::ConstantResponse::Scopes scopes;

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -34,6 +34,9 @@ class CompletionTask final : public LSPRequestTask {
         // If not exists(), won't suggest locals for the enclosing method.
         core::MethodRef enclosingMethod;
 
+        // If not exists(), won't suggest kwargs for the method that this query occurs in the arg list of.
+        core::MethodRef sendMethod;
+
         // If empty(), won't suggest constants.
         core::lsp::ConstantResponse::Scopes scopes;
     };

--- a/test/testdata/lsp/completion/method_kwargs.A.rbedited
+++ b/test/testdata/lsp/completion/method_kwargs.A.rbedited
@@ -1,0 +1,33 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig { params(arg1: Integer, arg2: String, message: String).void }
+  def self.test(arg1:, arg2: "", message: "")
+  end
+end
+
+A.test(a) # error: Method `a` does not exist
+      # ^ completion: alias, and, arg1: (keyword argument), arg2: (keyword argument), ...
+
+A.test(mess)
+#          ^ completion: message: (keyword argument)
+#      ^^^^  error: Method `mess` does not exist
+
+A.test(arg1: 10, mess)
+#                    ^ completion: message: (keyword argument)
+#                ^^^^  error: Method `mess` does not exist
+#                ^^^^  error: Unrecognized keyword argument
+#                ^^^^  error: positional arg
+
+A.test(message: $1)
+#      ^^^^  error: Method `mess` does not exist
+#          ^ apply-completion: [A] item: 0
+
+A.test(message: "hi", ar)
+#                       ^ apply-completion: [B] item: 0
+#                     ^^  error: Method `ar` does not exist
+#      ^^^^^^^^^^^^^^^^^  error: Missing required keyword argument
+#                     ^^  error: Unrecognized keyword argument
+#                     ^^  error: positional arg

--- a/test/testdata/lsp/completion/method_kwargs.A.rbedited
+++ b/test/testdata/lsp/completion/method_kwargs.A.rbedited
@@ -21,7 +21,7 @@ A.test(arg1: 10, mess)
 #                ^^^^  error: Unrecognized keyword argument
 #                ^^^^  error: positional arg
 
-A.test(message: $1)
+A.test(message:)
 #      ^^^^  error: Method `mess` does not exist
 #          ^ apply-completion: [A] item: 0
 

--- a/test/testdata/lsp/completion/method_kwargs.B.rbedited
+++ b/test/testdata/lsp/completion/method_kwargs.B.rbedited
@@ -1,0 +1,33 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig { params(arg1: Integer, arg2: String, message: String).void }
+  def self.test(arg1:, arg2: "", message: "")
+  end
+end
+
+A.test(a) # error: Method `a` does not exist
+      # ^ completion: alias, and, arg1: (keyword argument), arg2: (keyword argument), ...
+
+A.test(mess)
+#          ^ completion: message: (keyword argument)
+#      ^^^^  error: Method `mess` does not exist
+
+A.test(arg1: 10, mess)
+#                    ^ completion: message: (keyword argument)
+#                ^^^^  error: Method `mess` does not exist
+#                ^^^^  error: Unrecognized keyword argument
+#                ^^^^  error: positional arg
+
+A.test(mess)
+#      ^^^^  error: Method `mess` does not exist
+#          ^ apply-completion: [A] item: 0
+
+A.test(message: "hi", arg1: $1)
+#                       ^ apply-completion: [B] item: 0
+#                     ^^  error: Method `ar` does not exist
+#      ^^^^^^^^^^^^^^^^^  error: Missing required keyword argument
+#                     ^^  error: Unrecognized keyword argument
+#                     ^^  error: positional arg

--- a/test/testdata/lsp/completion/method_kwargs.B.rbedited
+++ b/test/testdata/lsp/completion/method_kwargs.B.rbedited
@@ -25,7 +25,7 @@ A.test(mess)
 #      ^^^^  error: Method `mess` does not exist
 #          ^ apply-completion: [A] item: 0
 
-A.test(message: "hi", arg1: $1)
+A.test(message: "hi", arg1:)
 #                       ^ apply-completion: [B] item: 0
 #                     ^^  error: Method `ar` does not exist
 #      ^^^^^^^^^^^^^^^^^  error: Missing required keyword argument

--- a/test/testdata/lsp/completion/method_kwargs.rb
+++ b/test/testdata/lsp/completion/method_kwargs.rb
@@ -1,0 +1,33 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig { params(arg1: Integer, arg2: String, message: String).void }
+  def self.test(arg1:, arg2: "", message: "")
+  end
+end
+
+A.test(a) # error: Method `a` does not exist
+      # ^ completion: alias, and, arg1: (keyword argument), arg2: (keyword argument), ...
+
+A.test(mess)
+#          ^ completion: message: (keyword argument)
+#      ^^^^  error: Method `mess` does not exist
+
+A.test(arg1: 10, mess)
+#                    ^ completion: message: (keyword argument)
+#                ^^^^  error: Method `mess` does not exist
+#                ^^^^  error: Unrecognized keyword argument
+#                ^^^^  error: positional arg
+
+A.test(mess)
+#      ^^^^  error: Method `mess` does not exist
+#          ^ apply-completion: [A] item: 0
+
+A.test(message: "hi", ar)
+#                       ^ apply-completion: [B] item: 0
+#                     ^^  error: Method `ar` does not exist
+#      ^^^^^^^^^^^^^^^^^  error: Missing required keyword argument
+#                     ^^  error: Unrecognized keyword argument
+#                     ^^  error: positional arg

--- a/test/testdata/lsp/completion/method_kwargs_extra.rb
+++ b/test/testdata/lsp/completion/method_kwargs_extra.rb
@@ -1,0 +1,68 @@
+# typed: true
+
+class A
+  def self.test(a: nil, arg: nil, argument: nil, message: nil)
+  end
+end
+
+arg = 10
+A.test(ar)
+#      ^^  error: Method `ar` does not exist
+#        ^ completion: arg: (keyword argument), argument: (keyword argument), arg, ...
+
+A.test()
+#      ^ completion: a: (keyword argument), arg: (keyword argument), argument: (keyword argument), message: (keyword argument), ...
+
+A.test(a: 10, arg: ar, message: "message")
+#                  ^^  error: Method `ar` does not exist
+#                    ^ completion: arg: (keyword argument), argument: (keyword argument), arg, ...
+
+A.test(a: 10, ar argument: 20)
+#             ^^  error: Method `ar` does not exist
+#             ^^  error: Unrecognized keyword argument `ar`
+#             ^^  error: positional arg "ar" after keyword arg
+#               ^ completion: arg: (keyword argument), argument: (keyword argument), arg, ...
+
+A.test(a: 10, ar, argument: 20)
+#           ^     error: unexpected token ","
+#             ^^  error: Method `ar` does not exist
+#             ^^  error: Unrecognized keyword argument `ar`
+#               ^ completion: arg: (keyword argument), argument: (keyword argument), arg, ...
+
+begin
+  A.
+#   ^ completion: test, allocate, ...
+end # error: unexpected token
+
+def bar(other: nil)
+end
+
+A.test(arg: def foo(x = bar()); end)
+#                           ^ completion: other: (keyword argument), ...
+
+def other(message:, mes:)
+  A.test(mess)
+  #      ^^^^  error: Method `mess` does not exist
+  #          ^ completion: message: (keyword argument), message, ...
+
+  A.test(mes)
+  #         ^ completion: message: (keyword argument), mes, message, ...
+
+  A.test(arg: 10, mes)
+  #               ^^^  error: Method `mes` does not exist
+  #               ^^^  error: Unrecognized keyword argument `mes`
+  #               ^^^  error: positional arg "mes" after keyword arg
+  #                  ^ completion: message: (keyword argument), mes, message, ...
+
+  A.test(arg: 10, mes message: "")
+  #               ^^^  error: Method `mes` does not exist
+  #               ^^^  error: Unrecognized keyword argument `mes`
+  #               ^^^  error: positional arg "mes" after keyword arg
+  #                  ^ completion: message: (keyword argument), mes, message, ...
+
+  A.test(arg: 10, mes, message: "")
+  #               ^^^  error: Method `mes` does not exist
+  #               ^^^  error: Unrecognized keyword argument `mes`
+  #             ^      error: unexpected token ","
+  #                  ^ completion: message: (keyword argument), mes, message, ...
+end


### PR DESCRIPTION
This PR adds support for keyword arguments when requesting autocompletion inside of a method send.

This screenshot shows what happens when requesting autocompletion with no prefix:
![Screenshot 2025-06-02 at 09 27 35](https://github.com/user-attachments/assets/ea252418-2686-4624-8aa8-92c908e699b7)

While this screenshot shows the behavior with `arg` as a prefix:
![Screenshot 2025-06-02 at 09 30 49](https://github.com/user-attachments/assets/f82f119b-3f4a-41dc-8df3-0fd6cc8e13b3)

### Motivation
Adding more features to autocompletion.
Fixes #5436 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
