### PR TITLE
Add `CSV::Coverters` types

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -247,6 +247,8 @@ class CSV < Object
   DEFAULT_OPTIONS = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
   # The version of the installed library.
   VERSION = T.let(T.unsafe(nil), String)
+  # A Hash containing the built-in CSV converters
+  Converters = T.let(T.unsafe(nil), T::Hash[Symbol, T.any(Proc, T::Array[Symbol])])
 
   # This method is intended as the primary interface for reading
   # [`CSV`](https://docs.ruby-lang.org/en/2.7.0/CSV.html) files. You pass a

--- a/test/testdata/rbi/csv.rb
+++ b/test/testdata/rbi/csv.rb
@@ -1,6 +1,9 @@
 # typed: true
 require 'csv'
 
+# Test the `CSV::Converters` constant type
+T.assert_type!(CSV::Converters, T::Hash[Symbol, T.any(Proc, T::Array[Symbol])])
+
 T.assert_type!(CSV.foreach('source.csv', headers: true), T.nilable(T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)]))
 T.assert_type!(CSV.foreach('source.csv', 'r:bom|utf-8'), T.nilable(T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)]))
 T.assert_type!(CSV.foreach('source.csv', headers: true, col_sep: ','), T.nilable(T::Enumerator[T.any(T::Array[T.nilable(BasicObject)], CSV::Row)]))


### PR DESCRIPTION
This adds typing for the `CSV::Converters` hash so we may add converters as [described in the documentation](https://ruby.github.io/csv/CSV.html#class-CSV-label-Custom+Field+Converters).

### Motivation
My team was attempting to add the `strip` converter almost exactly as shown in the documentation as our input files have an enormous amount of unnecessary whitespace and this would enable us to avoid countless `row[:some_header].strip` calls. Once added Sorbet and its integration into git hooks and CI would not allow it in. We fixed it locally with a similar change and believe this will benefit others.

### Test plan
Added a passing test that confirms the type is as expected.