### PR TITLE
make constant completion more efficient

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2663,12 +2663,11 @@ void ClassOrModule::removeLocsForFile(core::FileRef file) {
 }
 
 vector<pair<NameRef, SymbolRef>> ClassOrModule::membersStableOrderSlow(const GlobalState &gs) const {
-    vector<pair<NameRef, SymbolRef>> result;
-    result.reserve(members().size());
-    for (const auto &e : members()) {
-        result.emplace_back(e);
-    }
-    fast_sort(result, [&](auto const &lhs, auto const &rhs) -> bool {
+    return membersStableOrderSlowPredicate(gs, [](const auto _name, const auto _sym) -> bool { return true; });
+}
+
+void ClassOrModule::sortMembersStableOrder(const GlobalState &gs, std::vector<std::pair<NameRef, SymbolRef>> &out) {
+    fast_sort(out, [&](auto const &lhs, auto const &rhs) -> bool {
         auto lhsShort = lhs.first.shortName(gs);
         auto rhsShort = rhs.first.shortName(gs);
         auto compareShort = lhsShort.compare(rhsShort);
@@ -2702,7 +2701,6 @@ vector<pair<NameRef, SymbolRef>> ClassOrModule::membersStableOrderSlow(const Glo
         ENFORCE(false, "no stable sort");
         return false;
     });
-    return result;
 }
 
 ClassOrModuleData::ClassOrModuleData(ClassOrModule &ref, GlobalState &gs) : DebugOnlyCheck(gs), symbol(ref) {}

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -617,12 +617,30 @@ public:
         return members_;
     };
 
+    template <typename P>
+    std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlowPredicate(const GlobalState &gs,
+                                                                               P predicate) const {
+        std::vector<std::pair<NameRef, SymbolRef>> result;
+
+        for (const auto &e : this->members()) {
+            if (predicate(e.first, e.second)) {
+                result.emplace_back(e);
+            }
+        }
+
+        sortMembersStableOrder(gs, result);
+
+        return result;
+    }
+
     std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
 
     ClassOrModule deepCopy(const GlobalState &to, bool keepGsId = false) const;
     void sanityCheck(const GlobalState &gs) const;
 
 private:
+    static void sortMembersStableOrder(const GlobalState &gs, std::vector<std::pair<NameRef, SymbolRef>> &out);
+
     friend class serialize::SerializerImpl;
     friend class GlobalState;
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -882,13 +882,12 @@ vector<unique_ptr<CompletionItem>> allSimilarConstantItems(const core::GlobalSta
             continue;
         }
 
-        // TODO(jez) This membersStableOrderSlow is the only ordering we have on constant items right now.
-        // We should probably at least sort by whether the prefix of the suggested constant matches.
-        for (auto [_name, sym] : scope.asClassOrModuleRef().data(gs)->membersStableOrderSlow(gs)) {
-            if (isSimilarConstant(gs, prefix, sym)) {
-                items.push_back(
-                    getCompletionItemForConstant(gs, config, sym, queryLoc, prefix, initialSortIdx + items.size()));
-            }
+        for (auto [_name, sym] : scope.asClassOrModuleRef().data(gs)->membersStableOrderSlowPredicate(
+                 gs, [&gs, prefix](const auto _name, const auto sym) -> bool {
+                     return isSimilarConstant(gs, prefix, sym);
+                 })) {
+            items.push_back(
+                getCompletionItemForConstant(gs, config, sym, queryLoc, prefix, initialSortIdx + items.size()));
         }
     }
 
@@ -908,11 +907,12 @@ vector<unique_ptr<CompletionItem>> allSimilarConstantItems(const core::GlobalSta
             continue;
         }
 
-        for (auto [_name, sym] : ancestor.data(gs)->membersStableOrderSlow(gs)) {
-            if (isSimilarConstant(gs, prefix, sym)) {
-                items.push_back(
-                    getCompletionItemForConstant(gs, config, sym, queryLoc, prefix, initialSortIdx + items.size()));
-            }
+        for (auto [_name, sym] : ancestor.data(gs)->membersStableOrderSlowPredicate(
+                 gs, [&gs, prefix](const auto _name, const auto sym) -> bool {
+                     return isSimilarConstant(gs, prefix, sym);
+                 })) {
+            items.push_back(
+                getCompletionItemForConstant(gs, config, sym, queryLoc, prefix, initialSortIdx + items.size()));
         }
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This addresses a long-standing `TODO` in the completion code, and feels like it ought to be faster: rather than repeatedly:

1. Allocate vectors for members in scope;
2. Sort those vectors;
3. Throw away most of the information in those vectors; and
4. Repeat until done.

We can allocate everything into one big vector and do the filtering _prior_ to sorting at each step.

I don't know whether it's more efficient to accumulate into one big vector and then convert into completion items, as is done here, or to reuse the storage in `MembersStableOrder` and convert into completion items along the way as the previous code did.  Either way is compatible with the new filtering scheme proposed here.

Some of the code gymnastics are done to prevent needing to move the entirety of the sorting algorithm into `core/Symbols.h`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
