### PR TITLE
remove unused `constr` field

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -126,7 +126,6 @@ struct SimilarMethod final {
 
     // Populated later
     core::TypePtr receiverType = nullptr;
-    shared_ptr<core::TypeConstraint> constr = nullptr;
 };
 
 bool hasAngleBrackets(string_view haystack) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The use of this was removed in #8205.  Should make method completion a little more efficient by allocating less, less code, etc.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
