### PR TITLE
Sort operators later in completion results

### DIFF
--- a/test/testdata/lsp/completion/operators.rb
+++ b/test/testdata/lsp/completion/operators.rb
@@ -17,7 +17,7 @@ def test(x)
   # We should see the completion item for `%` sorted later, as users are for the
   # most part not looking for operator completions.
   x.
-  # ^ completion: test, %, class, ...
+  # ^ completion: test, class, ...
 end # error: unexpected token
 
 

--- a/test/testdata/lsp/completion/operators.rb
+++ b/test/testdata/lsp/completion/operators.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+extend T::Sig
+
+class A
+  def %(other)
+    self
+  end
+
+  def test
+    "hi"
+  end
+end
+
+sig { params(x: A).void }
+def test(x)
+  # We should see the completion item for `%` sorted later, as users are for the
+  # most part not looking for operator completions.
+  x.
+  # ^ completion: test, %, class, ...
+end # error: unexpected token
+
+


### PR DESCRIPTION
Sort method operators later in completion results, as users are usually looking for named methods instead. This change moves all operators after all textual method names, but preserves the existing depth heuristic ordering for each group.

After this change, operators will no longer be the first thing in the completion results list:
![Screenshot 2025-06-02 at 17 32 44](https://github.com/user-attachments/assets/545b75ed-3d56-4c83-ab2a-4e23af436029)

Whereas before, you would see methods like `%` always bubble to the top.
![Screenshot 2025-06-02 at 11 31 01](https://github.com/user-attachments/assets/7a647318-49c3-447f-9dcf-8a9fe7338a03)

### Motivation
Fixes #5148

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
