### PR TITLE
add a test for and-and + singleton method conversion

### DIFF
--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/and_and.A.rbedited
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/and_and.A.rbedited
@@ -1,0 +1,19 @@
+# typed: true
+# selective-apply-code-action: refactor.rewrite
+extend T::Sig
+
+class A
+  extend T::Sig
+
+  sig {params(this: A).returns(T.nilable(String))}
+  def self.returns_nilable(this)
+    # | apply-code-action: [A] Convert to singleton class method (best effort)
+  end
+end
+
+# Our <Magic> methods are hard.
+if A.returns_nilable(A.new) && A.returns_nilable(A.new).start_with?("prefix") # error: assumes result type doesn't change
+  puts "yup"
+else
+  puts "nope"
+end

--- a/test/testdata/lsp/code_actions/convert_to_singleton_method/and_and.rb
+++ b/test/testdata/lsp/code_actions/convert_to_singleton_method/and_and.rb
@@ -1,0 +1,19 @@
+# typed: true
+# selective-apply-code-action: refactor.rewrite
+extend T::Sig
+
+class A
+  extend T::Sig
+
+  sig {returns(T.nilable(String))}
+  def returns_nilable
+    # | apply-code-action: [A] Convert to singleton class method (best effort)
+  end
+end
+
+# Our <Magic> methods are hard.
+if A.new.returns_nilable && A.new.returns_nilable.start_with?("prefix") # error: assumes result type doesn't change
+  puts "yup"
+else
+  puts "nope"
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I thought we should add a check for `<check-and-and>` in `ConvertToSingletonMethod.cc` where we already check for our magic call methods...but apparently that's not the case.  Might as well add a test that captures this behavior.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
