### PR TITLE
provide completion on calls passing blocks or splats

### DIFF
--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -11,16 +11,21 @@ class TypeConstraint;
 class SendResponse final {
 public:
     SendResponse(std::shared_ptr<core::DispatchResult> dispatchResult, InlinedVector<core::LocOffsets, 2> argLocOffsets,
-                 core::NameRef callerSideName, core::MethodRef enclosingMethod, bool isPrivateOk, core::FileRef file,
+                 core::NameRef callerSideName, core::NameRef originalName, core::MethodRef enclosingMethod, bool isPrivateOk, core::FileRef file,
                  core::LocOffsets termLocOffsets, core::LocOffsets receiverLocOffsets, core::LocOffsets funLocOffsets,
                  core::LocOffsets locOffsetsWithoutBlock)
         : dispatchResult(std::move(dispatchResult)), argLocOffsets(std::move(argLocOffsets)),
-          callerSideName(callerSideName), enclosingMethod(enclosingMethod), isPrivateOk(isPrivateOk), file(file),
+          callerSideName(callerSideName), originalName(originalName), enclosingMethod(enclosingMethod), isPrivateOk(isPrivateOk), file(file),
           termLocOffsets(termLocOffsets), receiverLocOffsets(receiverLocOffsets), funLocOffsets(funLocOffsets),
           locOffsetsWithoutBlock(locOffsetsWithoutBlock){};
     const std::shared_ptr<core::DispatchResult> dispatchResult;
     const InlinedVector<core::LocOffsets, 2> argLocOffsets;
+    // The actual name we wind up invoking; in the case of `<Magic>` methods
+    // like `<call-with-splat>`, this is the name that would be invoked.
     const core::NameRef callerSideName;
+    // The method name from the send with none of the filtering involved in
+    // `callerSideName`.
+    const core::NameRef originalName;
     const core::MethodRef enclosingMethod;
     const bool isPrivateOk;
     const core::FileRef file;
@@ -44,7 +49,7 @@ public:
 
     const std::optional<core::Loc> getMethodNameLoc(const core::GlobalState &gs) const;
 };
-CheckSize(SendResponse, 88, 8);
+CheckSize(SendResponse, 96, 8);
 
 class IdentResponse final {
 public:

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -11,13 +11,14 @@ class TypeConstraint;
 class SendResponse final {
 public:
     SendResponse(std::shared_ptr<core::DispatchResult> dispatchResult, InlinedVector<core::LocOffsets, 2> argLocOffsets,
-                 core::NameRef callerSideName, core::NameRef originalName, core::MethodRef enclosingMethod, bool isPrivateOk, core::FileRef file,
-                 core::LocOffsets termLocOffsets, core::LocOffsets receiverLocOffsets, core::LocOffsets funLocOffsets,
+                 core::NameRef callerSideName, core::NameRef originalName, core::MethodRef enclosingMethod,
+                 bool isPrivateOk, core::FileRef file, core::LocOffsets termLocOffsets,
+                 core::LocOffsets receiverLocOffsets, core::LocOffsets funLocOffsets,
                  core::LocOffsets locOffsetsWithoutBlock)
         : dispatchResult(std::move(dispatchResult)), argLocOffsets(std::move(argLocOffsets)),
-          callerSideName(callerSideName), originalName(originalName), enclosingMethod(enclosingMethod), isPrivateOk(isPrivateOk), file(file),
-          termLocOffsets(termLocOffsets), receiverLocOffsets(receiverLocOffsets), funLocOffsets(funLocOffsets),
-          locOffsetsWithoutBlock(locOffsetsWithoutBlock){};
+          callerSideName(callerSideName), originalName(originalName), enclosingMethod(enclosingMethod),
+          isPrivateOk(isPrivateOk), file(file), termLocOffsets(termLocOffsets), receiverLocOffsets(receiverLocOffsets),
+          funLocOffsets(funLocOffsets), locOffsetsWithoutBlock(locOffsetsWithoutBlock){};
     const std::shared_ptr<core::DispatchResult> dispatchResult;
     const InlinedVector<core::LocOffsets, 2> argLocOffsets;
     // The actual name we wind up invoking; in the case of `<Magic>` methods

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1181,11 +1181,11 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 const bool ignoreSendForLSPQuery = isDesugarTripleEqSend || isSuggestConstantType;
                 if (lspQueryMatch && !ignoreSendForLSPQuery) {
                     auto fun = send.fun;
-                    if ((fun == core::Names::checkAndAnd() || fun == core::Names::callWithSplat()) && core::isa_type<core::NamedLiteralType>(args[1]->type)) {
+                    if (fun == core::Names::checkAndAnd() || fun == core::Names::callWithSplat()) {
+                        ENFORCE(send.numPosArgs > 2, "Desugar invariant");
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[1]->type);
-                        if (lit.derivesFrom(ctx, core::Symbols::Symbol())) {
-                            fun = lit.asName();
-                        }
+                        ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);
+                        fun = lit.asName();
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
                         ctx, core::lsp::SendResponse(retainedResult, send.argLocs, fun, ctx.owner.asMethodRef(),

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1181,16 +1181,17 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 const bool ignoreSendForLSPQuery = isDesugarTripleEqSend || isSuggestConstantType;
                 if (lspQueryMatch && !ignoreSendForLSPQuery) {
                     auto fun = send.fun;
-                    if (fun == core::Names::checkAndAnd() || fun == core::Names::callWithSplat() || fun == core::Names::callWithBlock() || fun == core::Names::callWithSplatAndBlock()) {
+                    if (fun == core::Names::checkAndAnd() || fun == core::Names::callWithSplat() ||
+                        fun == core::Names::callWithBlock() || fun == core::Names::callWithSplatAndBlock()) {
                         ENFORCE(send.numPosArgs > 2, "Desugar invariant");
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[1]->type);
                         ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);
                         fun = lit.asName();
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::SendResponse(retainedResult, send.argLocs, fun, send.fun, ctx.owner.asMethodRef(),
-                                                     send.isPrivateOk, ctx.file, bind.loc, send.receiverLoc,
-                                                     send.funLoc, locWithoutBlock));
+                        ctx, core::lsp::SendResponse(retainedResult, send.argLocs, fun, send.fun,
+                                                     ctx.owner.asMethodRef(), send.isPrivateOk, ctx.file, bind.loc,
+                                                     send.receiverLoc, send.funLoc, locWithoutBlock));
                 }
                 if (send.link) {
                     send.link->result = move(retainedResult);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1181,7 +1181,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 const bool ignoreSendForLSPQuery = isDesugarTripleEqSend || isSuggestConstantType;
                 if (lspQueryMatch && !ignoreSendForLSPQuery) {
                     auto fun = send.fun;
-                    if (fun == core::Names::checkAndAnd() || fun == core::Names::callWithSplat()) {
+                    if (fun == core::Names::checkAndAnd() || fun == core::Names::callWithSplat() || fun == core::Names::callWithBlock() || fun == core::Names::callWithSplatAndBlock()) {
                         ENFORCE(send.numPosArgs > 2, "Desugar invariant");
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[1]->type);
                         ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1188,7 +1188,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         fun = lit.asName();
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::SendResponse(retainedResult, send.argLocs, fun, ctx.owner.asMethodRef(),
+                        ctx, core::lsp::SendResponse(retainedResult, send.argLocs, fun, send.fun, ctx.owner.asMethodRef(),
                                                      send.isPrivateOk, ctx.file, bind.loc, send.receiverLoc,
                                                      send.funLoc, locWithoutBlock));
                 }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1181,13 +1181,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 const bool ignoreSendForLSPQuery = isDesugarTripleEqSend || isSuggestConstantType;
                 if (lspQueryMatch && !ignoreSendForLSPQuery) {
                     auto fun = send.fun;
-                    if (fun == core::Names::checkAndAnd() && core::isa_type<core::NamedLiteralType>(args[1]->type)) {
-                        auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[1]->type);
-                        if (lit.derivesFrom(ctx, core::Symbols::Symbol())) {
-                            fun = lit.asName();
-                        }
-                    }
-                    if (fun == core::Names::callWithSplat() && core::isa_type<core::NamedLiteralType>(args[1]->type)) {
+                    if ((fun == core::Names::checkAndAnd() || fun == core::Names::callWithSplat()) && core::isa_type<core::NamedLiteralType>(args[1]->type)) {
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[1]->type);
                         if (lit.derivesFrom(ctx, core::Symbols::Symbol())) {
                             fun = lit.asName();

--- a/main/lsp/ConvertToSingletonClassMethod.cc
+++ b/main/lsp/ConvertToSingletonClassMethod.cc
@@ -104,9 +104,9 @@ public:
             return;
         }
 
-        if (sendResp->callerSideName == core::Names::callWithSplat() ||
-            sendResp->callerSideName == core::Names::callWithBlock() ||
-            sendResp->callerSideName == core::Names::callWithSplatAndBlock()) {
+        if (sendResp->originalName == core::Names::callWithSplat() ||
+            sendResp->originalName == core::Names::callWithBlock() ||
+            sendResp->originalName == core::Names::callWithSplatAndBlock()) {
             // These are too hard... skipping for the time being.
             return;
         }

--- a/test/testdata/lsp/completion/splat_call.rb
+++ b/test/testdata/lsp/completion/splat_call.rb
@@ -1,0 +1,42 @@
+# typed: true
+
+class A
+  def value
+    5
+  end
+end
+
+extend T::Sig
+
+sig { params(as: A).returns(T.untyped) }
+def sumup_splat(*as)
+  sumup(as)
+end
+
+sig { params(avec: T::Array[A], blk: T.proc.params(a0: A).returns(T.untyped)).returns(T.untyped) }
+def call_with_block(avec, &blk)
+  avec.su(&blk) # error: does not exist
+#        ^ completion: sum
+end
+
+sig { params(as: A, blk: T.proc.params(a0: A).returns(T.untyped)).returns(T.untyped) }
+def sumup_splat_with_block(*as, &blk)
+  as.su(&blk) # error: does not exist
+#      ^ completion: sum
+end
+
+sig { params(avec: T::Array[A]).returns(T.untyped) }
+def sumup(avec)
+end
+
+def f
+  as = [A.new]
+  sumup_(*as) # error: does not exist
+#       ^ completion: sumup_splat
+end
+
+def g(&blk)
+  as = [A.new]
+  sumup_(*as, &blk) # error: does not exist
+#       ^ completion: sumup_splat
+end

--- a/test/testdata/lsp/completion/splat_call.rb
+++ b/test/testdata/lsp/completion/splat_call.rb
@@ -16,13 +16,13 @@ end
 sig { params(avec: T::Array[A], blk: T.proc.params(a0: A).returns(T.untyped)).returns(T.untyped) }
 def call_with_block(avec, &blk)
   avec.su(&blk) # error: does not exist
-#        ^ completion: sum
+#        ^ completion: sum, sum, sum, sum
 end
 
 sig { params(as: A, blk: T.proc.params(a0: A).returns(T.untyped)).returns(T.untyped) }
 def sumup_splat_with_block(*as, &blk)
   as.su(&blk) # error: does not exist
-#      ^ completion: sum
+#      ^ completion: sum, sum, sum, sum
 end
 
 sig { params(avec: T::Array[A]).returns(T.untyped) }
@@ -32,11 +32,11 @@ end
 def f
   as = [A.new]
   sumup_(*as) # error: does not exist
-#       ^ completion: sumup_splat
+#       ^ completion: sumup_splat, sumup_splat_with_block
 end
 
 def g(&blk)
   as = [A.new]
   sumup_(*as, &blk) # error: does not exist
-#       ^ completion: sumup_splat
+#       ^ completion: sumup_splat, sumup_splat_with_block
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Similar to #8946, but for `<call-with-block>` and `<call-with-splat-and-block>`.

You should be able to review commit-by-commit.  It's unfortunate that `SendResponse` had to have even more information, but I don't see a different way to handle it, and this change would be fixing a regression from #8946 anyway.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
