### PR TITLE
Offer an autocorrect that both adds the import and export when both are missing

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -532,6 +532,22 @@ public:
                         }
                         addPackagedFalseNote(ctx, e);
                     }
+                } else if (!isExported && testImportInProd) {
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
+                        e.setHeader("`{}` resolves but is not exported from `{}` and `{}` is `{}`ed",
+                                    litSymbol.show(ctx), pkg.show(ctx), pkg.show(ctx), "test_import");
+                        addExportInfo(ctx, e, litSymbol);
+                        if (importAutocorrect.has_value() && exportAutocorrect.has_value()) {
+                            core::AutocorrectSuggestion combinedAutocorrect =
+                                combineImportExportAutocorrect(importAutocorrect.value(), exportAutocorrect.value());
+                            e.addAutocorrect(std::move(combinedAutocorrect));
+                            if (!db.errorHint().empty()) {
+                                e.addErrorNote("{}", db.errorHint());
+                            }
+                        } else {
+                            ENFORCE(false);
+                        }
+                    }
                 } else if (!isExported) {
                     if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
                         e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -548,6 +548,25 @@ public:
                             ENFORCE(false);
                         }
                     }
+                } else if (!isExported && testUnitImportInHelper) {
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
+                        e.setHeader("`{}` resolves but is not exported from `{}` and `{}` is `{}`ed for only {} files",
+                                    litSymbol.show(ctx), pkg.show(ctx), pkg.show(ctx), "test_import", ".test.rb");
+                        e.addErrorNote("This is because this `{}` is declared with `{}`, which means the constant can "
+                                       "only be used in `{}` files.",
+                                       "test_import", "only: 'test_rb'", ".test.rb");
+                        addExportInfo(ctx, e, litSymbol);
+                        if (importAutocorrect.has_value() && exportAutocorrect.has_value()) {
+                            core::AutocorrectSuggestion combinedAutocorrect =
+                                combineImportExportAutocorrect(importAutocorrect.value(), exportAutocorrect.value());
+                            e.addAutocorrect(std::move(combinedAutocorrect));
+                            if (!db.errorHint().empty()) {
+                                e.addErrorNote("{}", db.errorHint());
+                            }
+                        } else {
+                            ENFORCE(false);
+                        }
+                    }
                 } else if (!isExported) {
                     if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
                         e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));

--- a/test/cli/package-error-missing-export-import/imported_as_test/__package.rb
+++ b/test/cli/package-error-missing-export-import/imported_as_test/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Foo::MissingImport < PackageSpec
+  test_import Other
+end

--- a/test/cli/package-error-missing-export-import/imported_as_test/foo_class.rb
+++ b/test/cli/package-error-missing-export-import/imported_as_test/foo_class.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Foo::MissingImport
+  class FooClass
+    Other::OtherClass
+  end
+end

--- a/test/cli/package-error-missing-export-import/imported_as_test_unit/__package.rb
+++ b/test/cli/package-error-missing-export-import/imported_as_test_unit/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Foo::MissingImport < PackageSpec
+  test_import Other, only: "test_rb"
+end

--- a/test/cli/package-error-missing-export-import/imported_as_test_unit/test/foo_class.rb
+++ b/test/cli/package-error-missing-export-import/imported_as_test_unit/test/foo_class.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Test::Foo::MissingImport
+  class FooClass
+    Other::OtherClass
+  end
+end

--- a/test/cli/package-error-missing-export-import/missing_import/__package.rb
+++ b/test/cli/package-error-missing-export-import/missing_import/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::MissingImport < PackageSpec
+end

--- a/test/cli/package-error-missing-export-import/missing_import/foo_class.rb
+++ b/test/cli/package-error-missing-export-import/missing_import/foo_class.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Foo::MissingImport
+  class FooClass
+    Other::OtherClass
+  end
+end

--- a/test/cli/package-error-missing-export-import/other/__package.rb
+++ b/test/cli/package-error-missing-export-import/other/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Other < PackageSpec
+end

--- a/test/cli/package-error-missing-export-import/other/other_class.rb
+++ b/test/cli/package-error-missing-export-import/other/other_class.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module Other
+  class OtherClass
+  end
+end

--- a/test/cli/package-error-missing-export-import/test.out
+++ b/test/cli/package-error-missing-export-import/test.out
@@ -1,0 +1,56 @@
+missing_import/foo_class.rb:5: `Other::OtherClass` resolves but is not exported from `Other` and `Other` is not imported https://srb.help/3718
+     5 |    Other::OtherClass
+            ^^^^^^^^^^^^^^^^^
+    other/other_class.rb:4: Defined here
+     4 |  class OtherClass
+          ^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    missing_import/__package.rb:3: Insert `import Other`
+     3 |class Foo::MissingImport < PackageSpec
+                                              ^
+    other/__package.rb:3: Insert `export Other::OtherClass`
+     3 |class Other < PackageSpec
+                                 ^
+  Note:
+    Try running generate-packages.sh
+Errors: 1
+imported_as_test/foo_class.rb:5: `Other::OtherClass` resolves but is not exported from `Other` and `Other` is `test_import`ed https://srb.help/3720
+     5 |    Other::OtherClass
+            ^^^^^^^^^^^^^^^^^
+    other/other_class.rb:4: Defined here
+     4 |  class OtherClass
+          ^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    imported_as_test/__package.rb:3: Insert `import Other`
+     3 |class Foo::MissingImport < PackageSpec
+                                              ^
+    imported_as_test/__package.rb:4: Delete
+     4 |  test_import Other
+        ^^^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Insert `export Other::OtherClass`
+     3 |class Other < PackageSpec
+                                 ^
+  Note:
+    Try running generate-packages.sh
+Errors: 1
+imported_as_test_unit/test/foo_class.rb:5: `Other::OtherClass` resolves but is not exported from `Other` and `Other` is `test_import`ed for only .test.rb files https://srb.help/3720
+     5 |    Other::OtherClass
+            ^^^^^^^^^^^^^^^^^
+  Note:
+    This is because this `test_import` is declared with `only: 'test_rb'`, which means the constant can only be used in `.test.rb` files.
+    other/other_class.rb:4: Defined here
+     4 |  class OtherClass
+          ^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    imported_as_test_unit/__package.rb:3: Insert `test_import Other`
+     3 |class Foo::MissingImport < PackageSpec
+                                              ^
+    imported_as_test_unit/__package.rb:4: Delete
+     4 |  test_import Other, only: "test_rb"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Insert `export Other::OtherClass`
+     3 |class Other < PackageSpec
+                                 ^
+  Note:
+    Try running generate-packages.sh
+Errors: 1

--- a/test/cli/package-error-missing-export-import/test.sh
+++ b/test/cli/package-error-missing-export-import/test.sh
@@ -1,0 +1,13 @@
+cd test/cli/package-error-missing-export-import || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages \
+  --stripe-packages-hint-message="Try running generate-packages.sh" \
+  --max-threads=0 other missing_import 2>&1
+
+../../../main/sorbet --silence-dev-message --stripe-packages \
+  --stripe-packages-hint-message="Try running generate-packages.sh" \
+  --max-threads=0 other imported_as_test 2>&1
+
+../../../main/sorbet --silence-dev-message --stripe-packages \
+  --stripe-packages-hint-message="Try running generate-packages.sh" \
+  --max-threads=0 other imported_as_test_unit 2>&1

--- a/test/cli/packager_suggest_nested_crash/test.out
+++ b/test/cli/packager_suggest_nested_crash/test.out
@@ -1,10 +1,13 @@
-consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierType` resolves but is not exported from `Project::ConsumerAuth` https://srb.help/3717
+consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierType` resolves but is not exported from `Project::ConsumerAuth` and `Project::ConsumerAuth` is not imported https://srb.help/3718
      6 |    puts(Project::ConsumerAuth::IdentifierType)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     consumer_auth/identity_type.rb:5: Defined here
      5 |  class IdentifierType
           ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
+    consumer_auth/data/__package.rb:4: Insert `import Project::ConsumerAuth`
+     4 |class Project::ConsumerAuth::Data < PackageSpec
+                                                       ^
     consumer_auth/__package.rb:6: Insert `export Project::ConsumerAuth::IdentifierType`
      6 |  import Project::ConsumerAuth::Data
                                             ^


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

If you have both a missing export and missing import, we'll now suggest a single autocorrect that adds both the export and import.

Review commit-by-commit.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Before this change, we would suggest an autocorrect that would add the missing export. Then, after accepting it, you'd have to wait for the slow path to run again, after which we'd suggest another autocorrect to add the import. The second wait is unnecessary.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
