### PR TITLE
Add AssertNil rewriter

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -311,6 +311,11 @@ NameDef names[] = {
     {"test"},
     {"setup"},
     {"teardown"},
+
+    {"assertNil", "assert_nil"},
+    {"assertNotNil", "assert_not_nil"},
+    {"refuteNil", "refute_nil"},
+
     // end DSL methods
 
     // The next two names are used as keys in SymbolInfo::members to store

--- a/rewriter/AssertNil.cc
+++ b/rewriter/AssertNil.cc
@@ -1,0 +1,61 @@
+#include "rewriter/AssertNil.h"
+#include "ast/Helpers.h"
+#include "ast/ast.h"
+#include "core/core.h"
+
+namespace sorbet::rewriter {
+
+namespace {
+
+bool isAssignable(const ast::ExpressionPtr &expr) {
+    if (auto ident = ast::cast_tree<ast::UnresolvedIdent>(expr)) {
+        // Local, instance, and class variables are assignable
+        return ident->kind == ast::UnresolvedIdent::Kind::Local ||
+               ident->kind == ast::UnresolvedIdent::Kind::Instance ||
+               ident->kind == ast::UnresolvedIdent::Kind::Class;
+    }
+
+    if (ast::isa_tree<ast::Local>(expr)) {
+        // Local variables (after namer pass) are assignable
+        return true;
+    }
+
+    // Constants, method calls, literals, etc. are not assignable
+    return false;
+}
+
+} // namespace
+
+ast::ExpressionPtr AssertNil::run(core::MutableContext ctx, ast::Send *send) {
+    if (send->fun != core::Names::assertNil() &&
+        send->fun != core::Names::assertNotNil() &&
+        send->fun != core::Names::refuteNil()) {
+        return nullptr;
+    }
+
+    if (!send->recv.isSelfReference()) {
+        return nullptr;
+    }
+
+    if (send->numPosArgs() == 0 || send->numPosArgs() > 2) {
+        return nullptr;
+    }
+
+    auto loc = send->loc;
+    auto &arg = send->getPosArg(0);
+
+    if (!isAssignable(arg)) {
+        return nullptr;
+    }
+
+    auto nilCheck = ast::MK::Send0(loc, arg.deepCopy(), core::Names::nil_p(), loc);
+    auto raiseCall = ast::MK::Send0(loc, ast::MK::Self(loc), core::Names::raise(), loc);
+
+    if (send->fun == core::Names::assertNil()) {
+        nilCheck = ast::MK::Send0(loc, std::move(nilCheck), core::Names::bang(), loc);
+    }
+
+    return ast::MK::If(loc, std::move(nilCheck), std::move(raiseCall), ast::MK::EmptyTree());
+}
+
+} // namespace sorbet::rewriter

--- a/rewriter/AssertNil.h
+++ b/rewriter/AssertNil.h
@@ -1,0 +1,33 @@
+#ifndef SORBET_REWRITER_ASSERT_NIL_H
+#define SORBET_REWRITER_ASSERT_NIL_H
+
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * This class converts (assert|assert_not|refute)_nil calls to appropriate T.(cast|must) usage:
+ *
+ * For assignable expressions:
+ *    assert_nil(x)  =>  x = T.cast(x, NilClass)
+ *    assert_not_nil(x)  =>  x = T.must(x)
+ *    refute_nil(x)  =>  x = T.must(x)
+ *
+ * For assignable expressions with a message argument:
+ *    assert_nil(x, "message")  =>  x = T.cast(x, NilClass)
+ *    assert_not_nil(x, "message")  =>  x = T.must(x)
+ *    refute_nil(x, "message")  =>  x = T.must(x)
+ *
+ * For non-assignable expressions it will skip the rewrite.
+ *     assert_nil(x.some_method) # stays as is
+ *
+ */
+class AssertNil final {
+public:
+    static ast::ExpressionPtr run(core::MutableContext ctx, ast::Send *send);
+    AssertNil() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif /* SORBET_REWRITER_ASSERT_NIL_H */

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -3,6 +3,7 @@
 #include "ast/verifier/verifier.h"
 #include "common/typecase.h"
 #include "main/pipeline/semantic_extension/SemanticExtension.h"
+#include "rewriter/AssertNil.h"
 #include "rewriter/AttrReader.h"
 #include "rewriter/ClassNew.h"
 #include "rewriter/Cleanup.h"
@@ -189,6 +190,11 @@ public:
         }
 
         if (auto expr = TypeAssertion::run(ctx, send)) {
+            tree = std::move(expr);
+            return;
+        }
+
+        if (auto expr = AssertNil::run(ctx, send)) {
             tree = std::move(expr);
             return;
         }

--- a/test/testdata/rewriter/assert_nil.rb
+++ b/test/testdata/rewriter/assert_nil.rb
@@ -1,0 +1,139 @@
+# typed: true
+
+$global_var = T.let("string", T.nilable(String))
+
+class TestAssertNil
+  extend T::Sig
+
+  @@class_var = T.let("string", T.nilable(String))
+
+  sig { void }
+  def initialize
+    @instance_var = T.let("string", T.nilable(String))
+  end
+
+  sig { params(value: T.nilable(String)).void }
+  def test_assert_nil_local(value)
+    T.reveal_type(value) # error: Revealed type: `T.nilable(String)`
+    assert_nil(value)
+    T.reveal_type(value) # error: Revealed type: `NilClass`
+  end
+
+  sig { params(value: T.nilable(String)).void }
+  def test_assert_not_nil_local(value)
+    T.reveal_type(value) # error: Revealed type: `T.nilable(String)`
+    assert_not_nil(value)
+    T.reveal_type(value) # error: Revealed type: `String`
+  end
+
+  sig { params(value: T.nilable(String)).void }
+  def test_refute_nil_local(value)
+    T.reveal_type(value) # error: Revealed type: `T.nilable(String)`
+    refute_nil(value)
+    T.reveal_type(value) # error: Revealed type: `String`
+  end
+
+  sig { void }
+  def test_assert_nil_instance_variable
+    T.reveal_type(@instance_var) # error: Revealed type: `T.nilable(String)`
+    assert_nil(@instance_var)
+    T.reveal_type(@instance_var) # error: Revealed type: `NilClass`
+  end
+
+  sig { void }
+  def test_assert_not_nil_instance_variable
+    T.reveal_type(@instance_var) # error: Revealed type: `T.nilable(String)`
+    assert_not_nil(@instance_var)
+    T.reveal_type(@instance_var) # error: Revealed type: `String`
+  end
+
+  sig { void }
+  def test_refute_nil_instance_variable
+    T.reveal_type(@instance_var) # error: Revealed type: `T.nilable(String)`
+    refute_nil(@instance_var)
+    T.reveal_type(@instance_var) # error: Revealed type: `String`
+  end
+
+  sig { void }
+  def test_assert_nil_class_variable
+    T.reveal_type(@@class_var) # error: Revealed type: `T.nilable(String)`
+    assert_nil(@@class_var)
+    T.reveal_type(@@class_var) # error: Revealed type: `NilClass`
+  end
+
+  sig { void }
+  def test_assert_not_nil_class_variable
+    T.reveal_type(@@class_var) # error: Revealed type: `T.nilable(String)`
+    assert_not_nil(@@class_var)
+    T.reveal_type(@@class_var) # error: Revealed type: `String`
+  end
+
+  sig { void }
+  def test_refute_nil_class_variable
+    T.reveal_type(@@class_var) # error: Revealed type: `T.nilable(String)`
+    refute_nil(@@class_var)
+    T.reveal_type(@@class_var) # error: Revealed type: `String`
+  end
+
+  sig { params(value: T.nilable(String)).void }
+  def test_assert_nil_message(value)
+    T.reveal_type(value) # error: Revealed type: `T.nilable(String)`
+    assert_nil(value)
+    T.reveal_type(value) # error: Revealed type: `NilClass`
+  end
+
+  sig { params(value: T.nilable(String)).void }
+  def test_assert_not_nil_message(value)
+    T.reveal_type(value) # error: Revealed type: `T.nilable(String)`
+    assert_not_nil(value)
+    T.reveal_type(value) # error: Revealed type: `String`
+  end
+
+  sig { params(value: T.nilable(String)).void }
+  def test_refute_nil_message(value)
+    T.reveal_type(value) # error: Revealed type: `T.nilable(String)`
+    refute_nil(value)
+    T.reveal_type(value) # error: Revealed type: `String`
+  end
+
+  sig { void }
+  def test_no_args
+    assert_nil()
+    assert_not_nil()
+    refute_nil()
+  end
+
+  sig { params(value: T.nilable(String)).void }
+  def test_too_many_args(value)
+    T.reveal_type(value) # error: Revealed type: `T.nilable(String)`
+    assert_nil(value, "message", "other")
+    assert_not_nil(value, "message", "other")
+    refute_nil(value, "message", "other")
+    T.reveal_type(value) # error: Revealed type: `T.nilable(String)`
+  end
+
+  sig { void }
+  def test_global_variable
+    T.reveal_type($global_var) # error: Revealed type: `T.untyped`
+    assert_nil($global_var)
+    assert_not_nil($global_var)
+    refute_nil($global_var)
+    T.reveal_type($global_var) # error: Revealed type: `T.untyped`
+  end
+
+  sig { void }
+  def test_non_assignable
+    assert_nil("string")
+    assert_not_nil("string")
+    refute_nil("string")
+  end
+
+  sig { params(args: T.anything).void }
+  def assert_nil(*args); end
+
+  sig { params(args: T.anything).void }
+  def assert_not_nil(*args); end
+
+  sig { params(args: T.anything).void }
+  def refute_nil(*args); end
+end

--- a/test/testdata/rewriter/assert_nil.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/assert_nil.rb.rewrite-tree.exp
@@ -1,0 +1,325 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  $global_var = <cast:let>("string", <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+
+  class <emptyTree>::<C TestAssertNil><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def initialize<<todo method>>(&<blk>)
+      @instance_var = <cast:let>("string", <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:value, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).void()
+    end
+
+    def test_assert_nil_local<<todo method>>(value, &<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(value)
+        if value.nil?().!()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(value)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:value, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).void()
+    end
+
+    def test_assert_not_nil_local<<todo method>>(value, &<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(value)
+        if value.nil?()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(value)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:value, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).void()
+    end
+
+    def test_refute_nil_local<<todo method>>(value, &<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(value)
+        if value.nil?()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(value)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def test_assert_nil_instance_variable<<todo method>>(&<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(@instance_var)
+        if @instance_var.nil?().!()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(@instance_var)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def test_assert_not_nil_instance_variable<<todo method>>(&<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(@instance_var)
+        if @instance_var.nil?()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(@instance_var)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def test_refute_nil_instance_variable<<todo method>>(&<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(@instance_var)
+        if @instance_var.nil?()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(@instance_var)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def test_assert_nil_class_variable<<todo method>>(&<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(@@class_var)
+        if @@class_var.nil?().!()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(@@class_var)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def test_assert_not_nil_class_variable<<todo method>>(&<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(@@class_var)
+        if @@class_var.nil?()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(@@class_var)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def test_refute_nil_class_variable<<todo method>>(&<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(@@class_var)
+        if @@class_var.nil?()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(@@class_var)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:value, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).void()
+    end
+
+    def test_assert_nil_message<<todo method>>(value, &<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(value)
+        if value.nil?().!()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(value)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:value, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).void()
+    end
+
+    def test_assert_not_nil_message<<todo method>>(value, &<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(value)
+        if value.nil?()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(value)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:value, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).void()
+    end
+
+    def test_refute_nil_message<<todo method>>(value, &<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(value)
+        if value.nil?()
+          <self>.raise()
+        else
+          <emptyTree>
+        end
+        <emptyTree>::<C T>.reveal_type(value)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def test_no_args<<todo method>>(&<blk>)
+      begin
+        <self>.assert_nil()
+        <self>.assert_not_nil()
+        <self>.refute_nil()
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:value, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).void()
+    end
+
+    def test_too_many_args<<todo method>>(value, &<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type(value)
+        <self>.assert_nil(value, "message", "other")
+        <self>.assert_not_nil(value, "message", "other")
+        <self>.refute_nil(value, "message", "other")
+        <emptyTree>::<C T>.reveal_type(value)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def test_global_variable<<todo method>>(&<blk>)
+      begin
+        <emptyTree>::<C T>.reveal_type($global_var)
+        <self>.assert_nil($global_var)
+        <self>.assert_not_nil($global_var)
+        <self>.refute_nil($global_var)
+        <emptyTree>::<C T>.reveal_type($global_var)
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def test_non_assignable<<todo method>>(&<blk>)
+      begin
+        <self>.assert_nil("string")
+        <self>.assert_not_nil("string")
+        <self>.refute_nil("string")
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:args, <emptyTree>::<C T>.anything()).void()
+    end
+
+    def assert_nil<<todo method>>(*args, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:args, <emptyTree>::<C T>.anything()).void()
+    end
+
+    def assert_not_nil<<todo method>>(*args, &<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:args, <emptyTree>::<C T>.anything()).void()
+    end
+
+    def refute_nil<<todo method>>(*args, &<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    @@class_var = <cast:let>("string", <todo sym>, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+
+    <runtime method definition of initialize>
+
+    <runtime method definition of test_assert_nil_local>
+
+    <runtime method definition of test_assert_not_nil_local>
+
+    <runtime method definition of test_refute_nil_local>
+
+    <runtime method definition of test_assert_nil_instance_variable>
+
+    <runtime method definition of test_assert_not_nil_instance_variable>
+
+    <runtime method definition of test_refute_nil_instance_variable>
+
+    <runtime method definition of test_assert_nil_class_variable>
+
+    <runtime method definition of test_assert_not_nil_class_variable>
+
+    <runtime method definition of test_refute_nil_class_variable>
+
+    <runtime method definition of test_assert_nil_message>
+
+    <runtime method definition of test_assert_not_nil_message>
+
+    <runtime method definition of test_refute_nil_message>
+
+    <runtime method definition of test_no_args>
+
+    <runtime method definition of test_too_many_args>
+
+    <runtime method definition of test_global_variable>
+
+    <runtime method definition of test_non_assignable>
+
+    <runtime method definition of assert_nil>
+
+    <runtime method definition of assert_not_nil>
+
+    <runtime method definition of refute_nil>
+  end
+end


### PR DESCRIPTION
Implemented a simple rewriter to rewrite the calls to `assert_nil`, `assert_not_nil`, and `refute_nil`, if they have a 1 or 2 args. The calls will be converted like so:
```
assert_nil(x) => raise if !x.nil?
assert_not_nil(x) => raise if x.nil?
refute(x) => raise if x.nil?
```

When there is a second argument it will be assumed that this is a message and discarded.

### Motivation

These are very commonly used when using `ActiveSupport::TestCase`. Often this will be used as the first in a series of assertions about some data. 

When that data is nilable to begin with, it can be helpful to utilize knowledge about the behaviour of these methods to give better inference to the types that are being interacted with in the subsequent assertions.

### Test plan

See included automated tests.
