### PR TITLE
Introduce flag for setting default strictness level

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -466,6 +466,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                  "Ensure that every class and module only defines 'behavior' in one file. Ensures "
                                  "that every class or module can be autoloaded by loading exactly one file.",
                                  cxxopts::value<bool>());
+    options.add_options(section)("default-strictness-level",
+                                 "Set the default strictness level for files without a `# typed:` sigil.",
+                                 cxxopts::value<string>()->default_value("false"), "[ignore|false|true|strict|strong]");
     fmt::memory_buffer all_stop_after;
     fmt::format_to(
         std::back_inserter(all_stop_after),
@@ -938,6 +941,9 @@ void readOptions(Options &opts,
         }
 
         opts.cacheSensitiveOptions.requiresAncestorEnabled = raw["enable-experimental-requires-ancestor"].as<bool>();
+
+        opts.cacheSensitiveOptions.defaultStrictnessLevel =
+            text2StrictLevel(raw["default-strictness-level"].as<string>(), logger);
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();
         opts.lspAllBetaFeaturesEnabled = enableAllLSPFeatures || raw["enable-all-beta-lsp-features"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -196,20 +196,22 @@ struct Options {
 
         bool stripePackages : 1;
 
+        core::StrictLevel defaultStrictnessLevel : 3;
+
         // HELLO! adding/removing MUST also change this number!!
-        constexpr static uint8_t NUMBER_OF_FLAGS = 6;
+        constexpr static uint8_t NUMBER_OF_BITS = 9;
 
         // In C++20 we can replace this with bit field initializers
         CacheSensitiveOptions()
             : noStdlib(false), typedSuper(true), rbsEnabled(false), requiresAncestorEnabled(false),
-              runningUnderAutogen(false), stripePackages(false) {}
+              runningUnderAutogen(false), stripePackages(false), defaultStrictnessLevel(core::StrictLevel::False) {}
 
-        constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
+        constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_BITS) - 1;
 
-        uint8_t serialize() const {
-            static_assert(sizeof(CacheSensitiveOptions) == sizeof(uint8_t));
+        uint16_t serialize() const {
+            static_assert(sizeof(CacheSensitiveOptions) == sizeof(uint16_t));
             // Can replace this with std::bit_cast in C++20
-            auto rawBits = *reinterpret_cast<const uint8_t *>(this);
+            auto rawBits = *reinterpret_cast<const uint16_t *>(this);
             // Mask the valid bits since uninitialized bits can be any value.
             return rawBits & VALID_BITS_MASK;
         }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -159,7 +159,7 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
     core::StrictLevel level;
 
     if (fileData.originalSigil == core::StrictLevel::None) {
-        level = core::StrictLevel::False;
+        level = opts.cacheSensitiveOptions.defaultStrictnessLevel;
     } else {
         level = fileData.originalSigil;
     }

--- a/test/cli/default-strictness-level/default-strictness-level.rb
+++ b/test/cli/default-strictness-level/default-strictness-level.rb
@@ -1,0 +1,4 @@
+class Foo
+end
+
+Foo.new.bar

--- a/test/cli/default-strictness-level/test.out
+++ b/test/cli/default-strictness-level/test.out
@@ -1,0 +1,8 @@
+test/cli/default-strictness-level/default-strictness-level.rb:4: Method `bar` does not exist on `Foo` https://srb.help/7003
+     4 |Foo.new.bar
+                ^^^
+  Got `Foo` originating from:
+    test/cli/default-strictness-level/default-strictness-level.rb:4:
+     4 |Foo.new.bar
+        ^^^^^^^
+Errors: 1

--- a/test/cli/default-strictness-level/test.sh
+++ b/test/cli/default-strictness-level/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+main/sorbet --silence-dev-message --default-strictness-level=true test/cli/default-strictness-level/default-strictness-level.rb 2>&1

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -163,6 +163,9 @@ Usage:
                                 Ensure that every class and module only defines
                                 'behavior' in one file. Ensures that every class or
                                 module can be autoloaded by loading exactly one file.
+      --default-strictness-level [ignore|false|true|strict|strong]
+                                Set the default strictness level for files without a `#
+                                typed:` sigil. (default: false)
       --stop-after <phase>      Stop after completing <phase>. Can be useful for
                                 debugging. Also useful when overwhelmed with errors,
                                 because errors from earlier phases (like resolver) can


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Introduces a new CLI option to set the strictness level of files that don't specify a `# typed: ` sigil.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We'd like to increase type safety requirements by setting the default level be `true` instead of `false`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
