### PR TITLE
Avoid synthesized sends when computing a method completion prefix

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1395,9 +1395,11 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
 
     if (auto sendResp = resp->isSend()) {
         auto callerSideName = sendResp->callerSideName;
-        auto prefix = (callerSideName == core::Names::methodNameMissing() || !sendResp->funLoc().contains(queryLoc))
-                          ? ""
-                          : callerSideName.shortName(gs);
+        auto funLoc = sendResp->funLoc();
+        auto prefix =
+            (callerSideName == core::Names::methodNameMissing() || (funLoc.exists() && !funLoc.contains(queryLoc)))
+                ? ""
+                : callerSideName.shortName(gs);
         if (prefix == "" && queryLoc.adjust(gs, -2, 0).source(gs) == "::") {
             // Probably a case like this:
             //   A::|

--- a/test/testdata/lsp/completion/magic_hash.rb
+++ b/test/testdata/lsp/completion/magic_hash.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+xs = {
+  :key => '',
+  #          ^ completion: (nothing)
+}


### PR DESCRIPTION
We weren't checking for a valid function location when checking send query responses, which meant that we would sometimes include internal intrinsics in the list of completion items. This PR fixes that by guarding prefix construction with a check that the function's loc is valid.

### Motivation
Fixes #6944

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
