### PR TITLE
delete redundant length checks before calling `absl::StartsWith`

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1204,9 +1204,9 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
         // TODO: for a prefix of just "@", we should provide class variables
         // along with instance variables.
         auto kind = ast::UnresolvedIdent::Kind::Local;
-        if (params.prefix.size() >= 2 && absl::StartsWith(params.prefix, "@@")) {
+        if (absl::StartsWith(params.prefix, "@@")) {
             kind = ast::UnresolvedIdent::Kind::Class;
-        } else if (params.prefix.size() >= 1 && absl::StartsWith(params.prefix, "@")) {
+        } else if (absl::StartsWith(params.prefix, "@")) {
             kind = ast::UnresolvedIdent::Kind::Instance;
         }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`absl::StartsWith` already tests this condition.  It's very possible the compiler optimizes the redundant check away, but the code is more readable this way.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
