### PR TITLE
RBS: Switch to the upstream (`ruby/rbs`) RBS parser

### DIFF
--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -373,9 +373,6 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
     auto *block = node.block;
     if (block) {
         auto loc = declaration.typeLocFromRange(block->base.location->rg);
-        // TODO: fix block location in RBS parser
-        loc.beginLoc = loc.beginLoc + 1;
-        loc.endLoc = loc.endLoc + 2;
         auto arg = RBSArg{loc, loc, nullptr, (rbs_node_t *)block, RBSArg::Kind::Block};
         args.emplace_back(arg);
     }

--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -45,20 +45,27 @@ parser::NodeVec TypeParamsToParserNode::typeParams(const rbs_node_list_t *rbsTyp
         auto typeSend =
             parser::MK::Send(loc, parser::MK::SorbetPrivateStatic(loc), core::Names::typeMember(), loc, move(args));
 
-        if (rbsTypeParam->default_type || rbsTypeParam->upper_bound) {
+        auto defaultType = rbsTypeParam->default_type;
+        auto upperBound = rbsTypeParam->upper_bound;
+        auto lowerBound = rbsTypeParam->lower_bound;
+
+        if (defaultType || upperBound || lowerBound) {
             auto typeTranslator = TypeToParserNode(ctx, vector<pair<core::LocOffsets, core::NameRef>>(), parser);
             auto pairs = parser::NodeVec();
 
-            if (rbsTypeParam->default_type) {
-                pairs.emplace_back(
-                    make_unique<parser::Pair>(loc, parser::MK::Symbol(loc, core::Names::fixed()),
-                                              typeTranslator.toParserNode(rbsTypeParam->default_type, declaration)));
+            if (defaultType) {
+                pairs.emplace_back(make_unique<parser::Pair>(loc, parser::MK::Symbol(loc, core::Names::fixed()),
+                                                             typeTranslator.toParserNode(defaultType, declaration)));
             }
 
-            if (rbsTypeParam->upper_bound) {
-                pairs.emplace_back(
-                    make_unique<parser::Pair>(loc, parser::MK::Symbol(loc, core::Names::upper()),
-                                              typeTranslator.toParserNode(rbsTypeParam->upper_bound, declaration)));
+            if (upperBound) {
+                pairs.emplace_back(make_unique<parser::Pair>(loc, parser::MK::Symbol(loc, core::Names::upper()),
+                                                             typeTranslator.toParserNode(upperBound, declaration)));
+            }
+
+            if (lowerBound) {
+                pairs.emplace_back(make_unique<parser::Pair>(loc, parser::MK::Symbol(loc, core::Names::lower()),
+                                                             typeTranslator.toParserNode(lowerBound, declaration)));
             }
 
             auto body = parser::MK::Hash(loc, false, move(pairs));

--- a/test/testdata/rbs/signatures_attrs_multiline.rb
+++ b/test/testdata/rbs/signatures_attrs_multiline.rb
@@ -26,7 +26,7 @@ class AttrsMultiline
   #| P1,
   #|  P2
   #| -> void
-  #  ^^ error: Failed to parse RBS type (expected a token `tUIDENT`)
+  #  ^^ error: Failed to parse RBS type (expected ',' or ']' after type parameter, got pARROW)
   attr_reader :parse_error3 # error: The method `parse_error3` does not have a `sig`
 
   #:

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -15,7 +15,7 @@ module Errors
   class ParseError3; end
 
   #: [T
-  # ^^^ error: Failed to parse RBS type parameters (expected a token `tUIDENT`)
+  # ^^^ error: Failed to parse RBS type parameters (expected ',' or ']' after type parameter, got pEOF)
   class ParseError4; end
 
   #: [unchecked T]

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -108,10 +108,12 @@ g4 = G4.new #: G4[Integer]
 #                 ^^^^^^^ error-with-dupes: `Integer` is not a subtype of upper bound of type member `::G4::U`
 T.reveal_type(g4) # error: Revealed type: `G4[T.untyped]`
 
-# TODO: unsupported yet, working on it
-#: [U > String]
-#     ^ error: Failed to parse RBS type parameters (expected a token `tUIDENT`)
+#: [U > BasicObject]
 class G5; end
+
+g5 = G5.new #: G5[String]
+#                 ^^^^^^ error-with-dupes: `String` is not a supertype of lower bound of type member `::G5::U`
+T.reveal_type(g5) # error: Revealed type: `G5[T.untyped]`
 
 #: [U]
 class G6; end

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -183,7 +183,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g4)
 
   class <emptyTree>::<C G5><<C <todo sym>>> < (::<todo sym>)
+    <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member() do ||
+      {:lower => <emptyTree>::<C BasicObject>}
+    end
   end
+
+  g5 = <cast:let>(<emptyTree>::<C G5>.<syntheticSquareBrackets>(<emptyTree>::<C String>).new(), <todo sym>, <emptyTree>::<C G5>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
+
+  <emptyTree>::<C T>.reveal_type(g5)
 
   class <emptyTree>::<C G6><<C <todo sym>>> < (::<todo sym>)
     <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member()

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -317,8 +317,8 @@ def register_sorbet_dependencies():
     # while we're upstreaming their changes.
     http_archive(
         name = "rbs_parser",
-        url = "https://github.com/shopify/rbs/archive/f8d9d5186c39eebffcd350b5452c6041f7ca6e6c.zip",
-        sha256 = "7fc542180adbeb653f0ce95b1cda9630286b6d1e4edb6ede2b61cf1cf7a3758c",
-        strip_prefix = "rbs-f8d9d5186c39eebffcd350b5452c6041f7ca6e6c",
+        url = "https://github.com/ruby/rbs/archive/ee566f83bb11c1b6e4acc13f1910ccc54ad53af4.zip",
+        sha256 = "d0a2a4077f4849566b6a93d874fd13465deef26630024e9d928e9e23ef90b186",
+        strip_prefix = "rbs-ee566f83bb11c1b6e4acc13f1910ccc54ad53af4",
         build_file = "@com_stripe_ruby_typer//third_party:rbs_parser.BUILD",
     )


### PR DESCRIPTION
### Motivation

Since Shopify has upstreamed all RBS improvements from `Shopify/rbs` to `ruby/rbs` and even contributed a bit more there, we should switch to use `ruby/rbs` as the source of Sorbet's RBS parser.

Some related changes are:
- Generics in RBS now supports lower bound too thanks to https://github.com/ruby/rbs/pull/2490
- A location calculation workaround is not needed anymore thanks to https://github.com/ruby/rbs/pull/2456
- A few parsing error message updates


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
