### PR TITLE
Only suggest kwargs that haven't been used

### DIFF
--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "ErrorFlusherLSP.h",
         "ErrorReporter.h",
         "FieldFinder.h",
+        "KwargsFinder.h",
         "LSPFileUpdates.h",
         "LSPIndexer.h",
         "LSPTask.h",

--- a/main/lsp/KwargsFinder.cc
+++ b/main/lsp/KwargsFinder.cc
@@ -1,0 +1,45 @@
+#include "main/lsp/KwargsFinder.h"
+#include "ast/Trees.h"
+#include "ast/treemap/treemap.h"
+#include "core/Context.h"
+#include "core/GlobalState.h"
+#include "core/NameRef.h"
+
+using namespace std;
+
+namespace sorbet::realmain::lsp {
+
+namespace {
+
+struct SendTraversal {
+    core::LocOffsets funLoc;
+    vector<core::NameRef> kwargs;
+
+    SendTraversal(core::LocOffsets funLoc) : funLoc{funLoc} {}
+
+    void preTransformSend(core::Context ctx, const ast::Send &send) {
+        if (!send.funLoc.contains(this->funLoc)) {
+            return;
+        }
+
+        for (const auto &pair : send.kwArgPairs()) {
+            if (auto lit = ast::cast_tree<ast::Literal>(pair.key)) {
+                if (lit->isSymbol()) {
+                    kwargs.emplace_back(lit->asSymbol());
+                }
+            }
+        }
+    }
+};
+
+}; // namespace
+
+vector<core::NameRef> KwargsFinder::findKwargs(const core::GlobalState &gs, const ast::ParsedFile &ast,
+                                               core::LocOffsets funLoc) {
+    core::Context ctx{gs, core::Symbols::root(), ast.file};
+    SendTraversal traversal{funLoc};
+    ast::ConstShallowWalk::apply(ctx, traversal, ast.tree);
+    return move(traversal.kwargs);
+}
+
+} // namespace sorbet::realmain::lsp

--- a/main/lsp/KwargsFinder.h
+++ b/main/lsp/KwargsFinder.h
@@ -1,0 +1,27 @@
+#ifndef RUBY_TYPER_LSP_KWARGSFINDER_H
+#define RUBY_TYPER_LSP_KWARGSFINDER_H
+
+#include "core/Loc.h"
+#include <vector>
+
+namespace sorbet::core {
+class GlobalState;
+class NameRef;
+} // namespace sorbet::core
+
+namespace sorbet::ast {
+struct ParsedFile;
+}
+
+namespace sorbet::realmain::lsp {
+
+class KwargsFinder {
+public:
+    // Find all of the kwargs mentioned by the send whose method name is located at `funLoc`.
+    static std::vector<core::NameRef> findKwargs(const core::GlobalState &gs, const ast::ParsedFile &ast,
+                                                 core::LocOffsets funLoc);
+};
+
+} // namespace sorbet::realmain::lsp
+
+#endif

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -37,6 +37,9 @@ class CompletionTask final : public LSPRequestTask {
         // If not exists(), won't suggest kwargs for the method that this query occurs in the arg list of.
         core::MethodRef kwargsMethod;
 
+        // The location of the method in a send, if applicable.
+        core::LocOffsets funLoc;
+
         // If empty(), won't suggest constants.
         core::lsp::ConstantResponse::Scopes scopes;
     };

--- a/test/testdata/lsp/completion/method_kwargs_extra.rb
+++ b/test/testdata/lsp/completion/method_kwargs_extra.rb
@@ -15,19 +15,19 @@ A.test()
 
 A.test(a: 10, arg: ar, message: "message")
 #                  ^^  error: Method `ar` does not exist
-#                    ^ completion: arg: (keyword argument), argument: (keyword argument), arg, ...
+#                    ^ completion: argument: (keyword argument), arg, ...
 
 A.test(a: 10, ar argument: 20)
 #             ^^  error: Method `ar` does not exist
 #             ^^  error: Unrecognized keyword argument `ar`
 #             ^^  error: positional arg "ar" after keyword arg
-#               ^ completion: arg: (keyword argument), argument: (keyword argument), arg, ...
+#               ^ completion: arg: (keyword argument), arg, ...
 
 A.test(a: 10, ar, argument: 20)
 #           ^     error: unexpected token ","
 #             ^^  error: Method `ar` does not exist
 #             ^^  error: Unrecognized keyword argument `ar`
-#               ^ completion: arg: (keyword argument), argument: (keyword argument), arg, ...
+#               ^ completion: arg: (keyword argument), arg, ...
 
 begin
   A.


### PR DESCRIPTION
Following on from #8938, filter out keyword arguments that are supplied out of the list of completion items.

With the changes in this PR, we won't see kwargs that are already supplied in completion items:
![Screenshot 2025-06-06 at 11 08 12](https://github.com/user-attachments/assets/3c62c981-72ae-4f01-9457-5f2f0079496e)

While on master, we'll see the `a:` kwarg included despite it already being present.
![Screenshot 2025-06-06 at 11 11 02](https://github.com/user-attachments/assets/c5afe1a9-861b-496f-b363-e57736970fbc)


### Motivation
Making completion items more relevant.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
