### PR TITLE
Fix the kwargs finder, and add some extra tests

### DIFF
--- a/main/lsp/KwargsFinder.cc
+++ b/main/lsp/KwargsFinder.cc
@@ -38,7 +38,7 @@ vector<core::NameRef> KwargsFinder::findKwargs(const core::GlobalState &gs, cons
                                                core::LocOffsets funLoc) {
     core::Context ctx{gs, core::Symbols::root(), ast.file};
     SendTraversal traversal{funLoc};
-    ast::ConstShallowWalk::apply(ctx, traversal, ast.tree);
+    ast::ConstTreeWalk::apply(ctx, traversal, ast.tree);
     return move(traversal.kwargs);
 }
 

--- a/test/testdata/lsp/completion/method_kwargs_extra.rb
+++ b/test/testdata/lsp/completion/method_kwargs_extra.rb
@@ -66,13 +66,23 @@ def other(message:, mes:)
   #               ^^^  error: Method `mes` does not exist
   #               ^^^  error: Unrecognized keyword argument `mes`
   #               ^^^  error: positional arg "mes" after keyword arg
-  #                  ^ completion: message: (keyword argument), mes, message, ...
+  #                  ^ completion: mes, message, ...
+
+  A.test(arg: 10, a message: "")
+  #               ^  error: Method `a` does not exist
+  #               ^  error: positional arg "a" after keyword arg
+  #                ^ completion: alias, and, argument: (keyword argument), message, ...
 
   A.test(arg: 10, mes, message: "")
   #               ^^^  error: Method `mes` does not exist
   #               ^^^  error: Unrecognized keyword argument `mes`
   #             ^      error: unexpected token ","
-  #                  ^ completion: message: (keyword argument), mes, message, ...
+  #                  ^ completion: mes, message, ...
+
+  A.test(arg: 10, a, message: "")
+  #               ^  error: Method `a` does not exist
+  #             ^    error: unexpected token ","
+  #                ^ completion: alias, and, argument: (keyword argument), message, ...
 end
 
 class B
@@ -86,7 +96,7 @@ class B
     # This would be nice to fix in the future, as `bar_arg:` is already
     # supplied.
     self.bar(bar_arg: foo_arg, &blk)
-    #                         ^ completion: bar_arg: (keyword argument), blk, foo_arg, ...
+    #                         ^ completion: blk, foo_arg, ...
   end
 
   def self.bar(bar_arg: nil, &blk)


### PR DESCRIPTION
I used the `ConstShallowWalk` instead of `ConstTreeWalk` when implementing the `KwargsFinder`, as I had a previous version that would find methods first and then traverse into them that didn't work out.

### Motivation
Fixing bugs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
