### PR TITLE
class_eval: Attempt to use `T.self_type`, not `T.untyped`

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -390,7 +390,7 @@ class Module < Object
   sig do
     type_parameters(:U).params(
         blk: T.proc
-              .bind(T.untyped)
+              .bind(T.self_type)
               .params(m: T.untyped)
               .returns(T.type_parameter(:U))
     )
@@ -1211,7 +1211,7 @@ class Module < Object
   sig do
     type_parameters(:U).params(
         blk: T.proc
-              .bind(T.untyped)
+              .bind(T.self_type)
               .params(m: T.untyped)
               .returns(T.type_parameter(:U))
     )


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

It only causes 5 type errors on Stripe's codebase, but there are only ~45 usages of `{class,module}_eval` in Stripe's codebase, and almost all of those are in `# typed: false` files anyways.

Spot checking the errors, most of the errors look like this

```
mod.module_eval do
  define_method("foo") do
    some_method # :boom:
  end
end
```

which suggests that maybe we want to move the `.bind(T.untyped)` to `define_method`. In the past I tried making `define_method` use `T.proc.bind(T.attached_class)`:

https://github.com/sorbet/sorbet/pull/6181

it looks like I didn't document the problems I ran into (or if no problems, not sure why I closed the PR)

I'm down to try changing it, but in general for super metaprogrammy APIs like this my default is just to leave them untyped, usually the only people using these APIs are the sort of people who want Sorbet to get out of their way in the first place, otherwise they'd go to greater effort to restructure their code to type it.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Requested by a user

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.