### PR TITLE
Add `override(allow_incompatible: :visibility)`

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1372,7 +1372,9 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
     if (sym->flags.isOverride) {
         methodFlags.emplace_back("override");
     }
-    if (sym->flags.allowIncompatibleOverrideAll) {
+    if (sym->flags.allowIncompatibleOverrideVisibility) {
+        methodFlags.emplace_back("allow_incompatible(:visibility)");
+    } else if (sym->flags.allowIncompatibleOverrideAll) {
         methodFlags.emplace_back("allow_incompatible");
     }
     if (sym->flags.isFinal) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1372,7 +1372,7 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
     if (sym->flags.isOverride) {
         methodFlags.emplace_back("override");
     }
-    if (sym->flags.isIncompatibleOverride) {
+    if (sym->flags.allowIncompatibleOverrideAll) {
         methodFlags.emplace_back("allow_incompatible");
     }
     if (sym->flags.isFinal) {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -81,14 +81,16 @@ public:
         // This boolean silences all override-related errors, which includes arity mismatch, type
         // param arity mismatch, and param/return type mismatch.
         bool allowIncompatibleOverrideAll : 1;
+        bool allowIncompatibleOverrideVisibility : 1;
         bool isPackagePrivate : 1;
 
-        constexpr static uint16_t NUMBER_OF_FLAGS = 11;
+        constexpr static uint16_t NUMBER_OF_FLAGS = 12;
         constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
         Flags() noexcept
             : isRewriterSynthesized(false), isProtected(false), isPrivate(false), isOverloaded(false),
               isAbstract(false), isGenericMethod(false), isOverridable(false), isFinal(false), isOverride(false),
-              allowIncompatibleOverrideAll(false), isPackagePrivate(false) {}
+              allowIncompatibleOverrideAll(false), allowIncompatibleOverrideVisibility(false), isPackagePrivate(false) {
+        }
 
         uint16_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint16_t));

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -77,7 +77,7 @@ public:
         bool isOverridable : 1;
         bool isFinal : 1;
         bool isOverride : 1;
-        bool isIncompatibleOverride : 1;
+        bool allowIncompatibleOverrideAll : 1;
         bool isPackagePrivate : 1;
 
         constexpr static uint16_t NUMBER_OF_FLAGS = 11;
@@ -85,7 +85,7 @@ public:
         Flags() noexcept
             : isRewriterSynthesized(false), isProtected(false), isPrivate(false), isOverloaded(false),
               isAbstract(false), isGenericMethod(false), isOverridable(false), isFinal(false), isOverride(false),
-              isIncompatibleOverride(false), isPackagePrivate(false) {}
+              allowIncompatibleOverrideAll(false), isPackagePrivate(false) {}
 
         uint16_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint16_t));

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -77,6 +77,9 @@ public:
         bool isOverridable : 1;
         bool isFinal : 1;
         bool isOverride : 1;
+        // It might have been nice to be able to separate out the kinds of incompatible overrides.
+        // This boolean silences all override-related errors, which includes arity mismatch, type
+        // param arity mismatch, and param/return type mismatch.
         bool allowIncompatibleOverrideAll : 1;
         bool isPackagePrivate : 1;
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -78,8 +78,8 @@ public:
         bool isFinal : 1;
         bool isOverride : 1;
         // It might have been nice to be able to separate out the kinds of incompatible overrides.
-        // This boolean silences all override-related errors, which includes arity mismatch, type
-        // param arity mismatch, and param/return type mismatch.
+        // This boolean silences all override-related errors, which includes arity mismatch,
+        // type_parameters arity mismatch, param/return type mismatch, etc.
         bool allowIncompatibleOverrideAll : 1;
         bool allowIncompatibleOverrideVisibility : 1;
         bool isPackagePrivate : 1;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -115,6 +115,7 @@ NameDef names[] = {
     {"override_", "override"},
     {"overridable"},
     {"allowIncompatible", "allow_incompatible"},
+    {"visibility"},
     {"sigForMethod"},
 
     // Sig builders

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -605,7 +605,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
     }
 
     if (overriddenMethods.size() == 0 && method.data(ctx)->flags.isOverride &&
-        !method.data(ctx)->flags.isIncompatibleOverride) {
+        !method.data(ctx)->flags.allowIncompatibleOverrideAll) {
         if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
             e.setHeader("Method `{}` is marked `{}` but does not override anything", method.show(ctx), "override");
             e.maybeAddAutocorrect(constructAllowIncompatibleAutocorrect(ctx, tree, methodDef));
@@ -655,7 +655,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
         }
         if ((overriddenMethod.data(ctx)->flags.isAbstract || overriddenMethod.data(ctx)->flags.isOverridable ||
              (overriddenMethod.data(ctx)->hasSig() && method.data(ctx)->flags.isOverride)) &&
-            !method.data(ctx)->flags.isIncompatibleOverride && !isRBI &&
+            !method.data(ctx)->flags.allowIncompatibleOverrideAll && !isRBI &&
             !method.data(ctx)->flags.isRewriterSynthesized &&
             overriddenMethod != core::Symbols::BasicObject_initialize()) {
             // We only ignore BasicObject#initialize for backwards compatibility.

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -662,6 +662,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
             // One day, we may want to build something like overridable(allow_incompatible: true)
             // and mark certain methods in the standard library as possible to be overridden incompatibly,
             // without needing to write `override(allow_incompatible: true)`.
+            // Further context: https://blog.jez.io/constructor-override-checking/
             validateCompatibleOverride(ctx, tree, overriddenMethod, methodDef);
         }
     }

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -155,7 +155,7 @@ module T::Private::Methods
       when Modes.standard
         decl.mode = Modes.override
         case allow_incompatible
-        when true, false
+        when true, false, :visibility
           decl.override_allow_incompatible = allow_incompatible
         else
           raise BuilderError.new(".override(allow_incompatible: ...) only accepts `true` or `false`, got: #{allow_incompatible.inspect}")

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -154,7 +154,12 @@ module T::Private::Methods
       case decl.mode
       when Modes.standard
         decl.mode = Modes.override
-        decl.override_allow_incompatible = allow_incompatible
+        case allow_incompatible
+        when true, false
+          decl.override_allow_incompatible = allow_incompatible
+        else
+          raise BuilderError.new(".override(allow_incompatible: ...) only accepts `true` or `false`, got: #{allow_incompatible.inspect}")
+        end
       when Modes.override, Modes.overridable_override
         raise BuilderError.new(".override cannot be repeated in a single signature")
       when Modes.overridable

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -158,7 +158,7 @@ module T::Private::Methods
         when true, false, :visibility
           decl.override_allow_incompatible = allow_incompatible
         else
-          raise BuilderError.new(".override(allow_incompatible: ...) only accepts `true` or `false`, got: #{allow_incompatible.inspect}")
+          raise BuilderError.new(".override(allow_incompatible: ...) only accepts `true`, `false`, or `:visibility`, got: #{allow_incompatible.inspect}")
         end
       when Modes.override, Modes.overridable_override
         raise BuilderError.new(".override cannot be repeated in a single signature")

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -175,7 +175,7 @@ module T::Private::Methods::SignatureValidation
   end
 
   def self.validate_override_shape(signature, super_signature)
-    return if signature.override_allow_incompatible
+    return if signature.override_allow_incompatible == true
     return if super_signature.mode == Modes.untyped
 
     method_name = signature.method_name
@@ -231,7 +231,7 @@ module T::Private::Methods::SignatureValidation
   end
 
   def self.validate_override_types(signature, super_signature)
-    return if signature.override_allow_incompatible
+    return if signature.override_allow_incompatible == true
     return if super_signature.mode == Modes.untyped
     return unless [signature, super_signature].all? do |sig|
       sig.check_level == :always || (sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -506,7 +506,7 @@ module Opus::Types::Test
         assert_includes(e.message, "You can't call .returns after calling .void.")
       end
 
-      it 'disallows override(allow_incompatible: ...) except true/false' do
+      it 'disallows override(allow_incompatible: ...) except true/false/:visibility' do
         parent = Class.new do
           extend T::Sig
           sig { overridable.returns(Integer) }
@@ -540,6 +540,12 @@ module Opus::Types::Test
           end
         end
         assert_includes(e.message, "only accepts `true` or `false`")
+
+        Class.new(parent) do
+          sig { override(allow_incompatible: :visibility).returns(Integer) }
+          def self.foo; 0; end
+          raise unless foo == 0
+        end
       end
     end
 

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -505,6 +505,42 @@ module Opus::Types::Test
         end
         assert_includes(e.message, "You can't call .returns after calling .void.")
       end
+
+      it 'disallows override(allow_incompatible: ...) except true/false' do
+        parent = Class.new do
+          extend T::Sig
+          sig { overridable.returns(Integer) }
+          def self.foo; 0; end
+          foo
+        end
+
+        e = assert_raises(ArgumentError) do
+          Class.new(parent) do
+            sig { override(allow_incompatible: nil).returns(Integer) }
+            def self.foo; 0; end
+            foo
+          end
+        end
+        assert_includes(e.message, "only accepts `true` or `false`")
+
+        e = assert_raises(ArgumentError) do
+          Class.new(parent) do
+            sig { override(allow_incompatible: 0).returns(Integer) }
+            def self.foo; 0; end
+            foo
+          end
+        end
+        assert_includes(e.message, "only accepts `true` or `false`")
+
+        e = assert_raises(ArgumentError) do
+          Class.new(parent) do
+            sig { override(allow_incompatible: :bad).returns(Integer) }
+            def self.foo; 0; end
+            foo
+          end
+        end
+        assert_includes(e.message, "only accepts `true` or `false`")
+      end
     end
 
     describe 'type_parameters' do

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -544,7 +544,7 @@ module Opus::Types::Test
         Class.new(parent) do
           sig { override(allow_incompatible: :visibility).returns(Integer) }
           def self.foo; 0; end
-          raise unless foo == 0
+          raise unless foo.zero?
         end
       end
     end

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -521,7 +521,7 @@ module Opus::Types::Test
             foo
           end
         end
-        assert_includes(e.message, "only accepts `true` or `false`")
+        assert_includes(e.message, "only accepts `true`, `false`, or `:visibility`")
 
         e = assert_raises(ArgumentError) do
           Class.new(parent) do
@@ -530,7 +530,7 @@ module Opus::Types::Test
             foo
           end
         end
-        assert_includes(e.message, "only accepts `true` or `false`")
+        assert_includes(e.message, "only accepts `true`, `false`, or `:visibility`")
 
         e = assert_raises(ArgumentError) do
           Class.new(parent) do
@@ -539,7 +539,7 @@ module Opus::Types::Test
             foo
           end
         end
-        assert_includes(e.message, "only accepts `true` or `false`")
+        assert_includes(e.message, "only accepts `true`, `false`, or `:visibility`")
 
         Class.new(parent) do
           sig { override(allow_incompatible: :visibility).returns(Integer) }

--- a/rbi/sorbet/builder.rbi
+++ b/rbi/sorbet/builder.rbi
@@ -12,7 +12,7 @@ class T::Private::Methods::DeclBuilder
   sig {returns(T::Private::Methods::DeclBuilder)}
   def implementation; end
 
-  sig {params(allow_incompatible: T::Boolean).returns(T::Private::Methods::DeclBuilder)}
+  sig {params(allow_incompatible: T.any(T::Boolean, Symbol)).returns(T::Private::Methods::DeclBuilder)}
   def override(allow_incompatible: false); end
 
   sig {returns(T::Private::Methods::DeclBuilder)}

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3303,8 +3303,16 @@ private:
         if (sig.seen.abstract.exists()) {
             method.data(ctx)->flags.isAbstract = true;
         }
-        if (sig.seen.incompatibleOverride.exists()) {
+        if (sig.seen.incompatibleOverride.exists() && sig.seen.incompatibleOverrideVisibility.exists()) {
+            if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
+                e.setHeader("Malformed `{}`: Don't use both `{}` and `{}", "sig", "override(allow_incompatible: true)",
+                            "override(allow_incompatible: :visibility)");
+            }
             method.data(ctx)->flags.allowIncompatibleOverrideAll = true;
+        } else if (sig.seen.incompatibleOverride.exists()) {
+            method.data(ctx)->flags.allowIncompatibleOverrideAll = true;
+        } else if (sig.seen.incompatibleOverrideVisibility.exists()) {
+            method.data(ctx)->flags.allowIncompatibleOverrideVisibility = true;
         }
         if (!sig.typeArgs.empty()) {
             method.data(ctx)->flags.isGenericMethod = true;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3304,7 +3304,7 @@ private:
             method.data(ctx)->flags.isAbstract = true;
         }
         if (sig.seen.incompatibleOverride.exists()) {
-            method.data(ctx)->flags.isIncompatibleOverride = true;
+            method.data(ctx)->flags.allowIncompatibleOverrideAll = true;
         }
         if (!sig.typeArgs.empty()) {
             method.data(ctx)->flags.isGenericMethod = true;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3304,9 +3304,16 @@ private:
             method.data(ctx)->flags.isAbstract = true;
         }
         if (sig.seen.incompatibleOverride.exists() && sig.seen.incompatibleOverrideVisibility.exists()) {
-            if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
+            ENFORCE(sig.seen.override_.exists());
+            if (auto e = ctx.beginError(sig.seen.override_, core::errors::Resolver::InvalidMethodSignature)) {
                 e.setHeader("Malformed `{}`: Don't use both `{}` and `{}", "sig", "override(allow_incompatible: true)",
                             "override(allow_incompatible: :visibility)");
+                auto deleteLoc = ctx.locAt(sig.seen.override_);
+                auto dotAfterLoc = deleteLoc.copyEndWithZeroLength().adjust(ctx, 0, 1);
+                if (dotAfterLoc.source(ctx) == ".") {
+                    deleteLoc = deleteLoc.join(dotAfterLoc);
+                }
+                e.replaceWith("Remove this override", deleteLoc, "");
             }
             method.data(ctx)->flags.allowIncompatibleOverrideAll = true;
         } else if (sig.seen.incompatibleOverride.exists()) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -459,6 +459,20 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                                 if (val && val->isTrue(ctx)) {
                                     sig.seen.incompatibleOverride = key.loc().join(value.loc());
                                 }
+                                if (val && val->isSymbol()) {
+                                    if (val->asSymbol() == core::Names::visibility()) {
+                                        sig.seen.incompatibleOverrideVisibility = key.loc().join(value.loc());
+                                    } else {
+                                        if (auto e = ctx.beginError(val->loc,
+                                                                    core::errors::Resolver::InvalidMethodSignature)) {
+                                            e.setHeader("`{}` expects one of `{}`, `{}`, or `{}`",
+                                                        "override(allow_incompatible: ...)", "true", "false",
+                                                        ":visibility");
+                                        }
+                                    }
+                                }
+                                // Other errors are caught with type checking, but since the sig says
+                                // `T.any(Symbol, ...)` we have to explicitly check the allowed symbol literals.
                             }
                         }
                     }

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -441,7 +441,7 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                         e.setHeader("`{}` cannot be combined with `{}`", "override", "abstract");
                     }
                 }
-                sig.seen.override_ = send->funLoc.join(send->loc);
+                sig.seen.override_ = send->funLoc.join(send->loc.copyEndWithZeroLength());
 
                 if (send->hasPosArgs()) {
                     if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -41,6 +41,7 @@ struct ParsedSig {
         core::LocOffsets checked = core::LocOffsets::none();
         core::LocOffsets final = core::LocOffsets::none();
         core::LocOffsets incompatibleOverride = core::LocOffsets::none();
+        core::LocOffsets incompatibleOverrideVisibility = core::LocOffsets::none();
     } seen;
 
     TypeArgSpec &enterTypeArgByName(core::NameRef name);

--- a/test/testdata/resolver/allow_incompatible_visibility.rb
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb
@@ -13,18 +13,18 @@ class ChildBad < Parent
 end
 
 class ChildOkay < Parent
-  sig {override(allow_incompatible: :visibility).returns(Integer)} # error: Expected `T::Boolean` but found `Symbol(:visibility)`
+  sig {override(allow_incompatible: :visibility).returns(Integer)}
   private def some_public_api; 1; end
 end
 
 class ChildBadTypes < Parent
-  sig {override(allow_incompatible: :visibility).returns(String)} # error: Expected `T::Boolean` but found `Symbol(:visibility)`
+  sig {override(allow_incompatible: :visibility).returns(String)}
   private def some_public_api; ''; end
   #       ^^^^^^^^^^^^^^^^^^^ error: Return type `String` does not match return type of overridable method `Parent#some_public_api`
 end
 
 class ChildBadSymbol < Parent
   sig {override(allow_incompatible: :bad).returns(Integer)}
-  #                                 ^^^^ error: Expected `T::Boolean` but found `Symbol(:bad)`
+  #                                 ^^^^ error: `override(allow_incompatible: ...)` expects one of `true`, `false`, or `:visibility
   private def some_public_api; 0; end
 end

--- a/test/testdata/resolver/allow_incompatible_visibility.rb
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb
@@ -1,0 +1,30 @@
+# typed: true
+
+class Parent
+  extend T::Sig
+
+  sig {overridable.returns(Integer)}
+  def some_public_api; 0; end
+end
+
+class ChildBad < Parent
+  sig {override.returns(Integer)}
+  private def some_public_api; 1; end
+end
+
+class ChildOkay < Parent
+  sig {override(allow_incompatible: :visibility).returns(Integer)} # error: Expected `T::Boolean` but found `Symbol(:visibility)`
+  private def some_public_api; 1; end
+end
+
+class ChildBadTypes < Parent
+  sig {override(allow_incompatible: :visibility).returns(String)} # error: Expected `T::Boolean` but found `Symbol(:visibility)`
+  private def some_public_api; ''; end
+  #       ^^^^^^^^^^^^^^^^^^^ error: Return type `String` does not match return type of overridable method `Parent#some_public_api`
+end
+
+class ChildBadSymbol < Parent
+  sig {override(allow_incompatible: :bad).returns(Integer)}
+  #                                 ^^^^ error: Expected `T::Boolean` but found `Symbol(:bad)`
+  private def some_public_api; 0; end
+end

--- a/test/testdata/resolver/allow_incompatible_visibility.rb
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb
@@ -28,3 +28,13 @@ class ChildBadSymbol < Parent
   #                                 ^^^^ error: `override(allow_incompatible: ...)` expects one of `true`, `false`, or `:visibility
   private def some_public_api; 0; end
 end
+
+class ChildBoth1 < Parent
+  sig { override(allow_incompatible: true).override(allow_incompatible: :visibility).returns(Integer) }
+  private def some_public_api; 0; end
+end
+
+class ChildBoth2 < Parent
+  sig { override(allow_incompatible: :visibility).override(allow_incompatible: true).returns(Integer) }
+  private def some_public_api; 0; end
+end

--- a/test/testdata/resolver/allow_incompatible_visibility.rb
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb
@@ -31,15 +31,18 @@ end
 
 class ChildBoth1 < Parent
   sig { override(allow_incompatible: true).override(allow_incompatible: :visibility).returns(Integer) }
+  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
   private def some_public_api; 0; end
 end
 
 class ChildBoth2 < Parent
   sig { override(allow_incompatible: :visibility).override(allow_incompatible: true).returns(Integer) }
+  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
   private def some_public_api; 0; end
 end
 
 class ChildBoth3 < Parent
   sig { returns(Integer).override(allow_incompatible: :visibility).override(allow_incompatible: true) }
+  #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
   private def some_public_api; 0; end
 end

--- a/test/testdata/resolver/allow_incompatible_visibility.rb.autocorrects.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb.autocorrects.exp
@@ -1,3 +1,4 @@
+# -- test/testdata/resolver/allow_incompatible_visibility.rb --
 # typed: true
 
 class Parent
@@ -30,16 +31,17 @@ class ChildBadSymbol < Parent
 end
 
 class ChildBoth1 < Parent
-  sig { override(allow_incompatible: true).override(allow_incompatible: :visibility).returns(Integer) }
+  sig { override(allow_incompatible: :visibility).returns(Integer) }
   private def some_public_api; 0; end
 end
 
 class ChildBoth2 < Parent
-  sig { override(allow_incompatible: :visibility).override(allow_incompatible: true).returns(Integer) }
+  sig { override(allow_incompatible: true).returns(Integer) }
   private def some_public_api; 0; end
 end
 
 class ChildBoth3 < Parent
-  sig { returns(Integer).override(allow_incompatible: :visibility).override(allow_incompatible: true) }
+  sig { override(allow_incompatible: true) }
   private def some_public_api; 0; end
 end
+# ------------------------------

--- a/test/testdata/resolver/allow_incompatible_visibility.rb.autocorrects.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb.autocorrects.exp
@@ -32,16 +32,19 @@ end
 
 class ChildBoth1 < Parent
   sig { override(allow_incompatible: :visibility).returns(Integer) }
+  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
   private def some_public_api; 0; end
 end
 
 class ChildBoth2 < Parent
   sig { override(allow_incompatible: true).returns(Integer) }
+  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
   private def some_public_api; 0; end
 end
 
 class ChildBoth3 < Parent
-  sig { override(allow_incompatible: true) }
+  sig { returns(Integer).override(allow_incompatible: true) }
+  #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: Don't use both `override(allow_incompatible: true)` and `override(allow_incompatible: :visibility)
   private def some_public_api; 0; end
 end
 # ------------------------------

--- a/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
@@ -1,0 +1,40 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::ChildBad < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:10
+    method ::ChildBad#some_public_api : private|override (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:12
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::<Class:ChildBad>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:10
+    type-member(+) ::<Class:ChildBad>::<AttachedClass> -> T.attached_class (of ChildBad) @ test/testdata/resolver/allow_incompatible_visibility.rb:10
+    method ::<Class:ChildBad>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:10
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::ChildBadSymbol < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:26
+    method ::ChildBadSymbol#some_public_api : private|override (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:29
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::<Class:ChildBadSymbol>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:26
+    type-member(+) ::<Class:ChildBadSymbol>::<AttachedClass> -> T.attached_class (of ChildBadSymbol) @ test/testdata/resolver/allow_incompatible_visibility.rb:26
+    method ::<Class:ChildBadSymbol>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:26
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::ChildBadTypes < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:20
+    method ::ChildBadTypes#some_public_api : private|override (<blk>) -> String @ test/testdata/resolver/allow_incompatible_visibility.rb:22
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::<Class:ChildBadTypes>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:20
+    type-member(+) ::<Class:ChildBadTypes>::<AttachedClass> -> T.attached_class (of ChildBadTypes) @ test/testdata/resolver/allow_incompatible_visibility.rb:20
+    method ::<Class:ChildBadTypes>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:20
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::ChildOkay < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:15
+    method ::ChildOkay#some_public_api : private|override (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:17
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::<Class:ChildOkay>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:15
+    type-member(+) ::<Class:ChildOkay>::<AttachedClass> -> T.attached_class (of ChildOkay) @ test/testdata/resolver/allow_incompatible_visibility.rb:15
+    method ::<Class:ChildOkay>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:15
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::Parent < ::Object () @ test/testdata/resolver/allow_incompatible_visibility.rb:3
+    method ::Parent#some_public_api : overridable (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:7
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::<Class:Parent>[<AttachedClass>] < ::<Class:Object> (Sig) @ test/testdata/resolver/allow_incompatible_visibility.rb:3
+    type-member(+) ::<Class:Parent>::<AttachedClass> -> T.attached_class (of Parent) @ test/testdata/resolver/allow_incompatible_visibility.rb:3
+    method ::<Class:Parent>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+

--- a/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
@@ -17,14 +17,14 @@ class ::<root> < ::Object ()
     method ::<Class:ChildBadSymbol>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:26
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
   class ::ChildBadTypes < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:20
-    method ::ChildBadTypes#some_public_api : private|override (<blk>) -> String @ test/testdata/resolver/allow_incompatible_visibility.rb:22
+    method ::ChildBadTypes#some_public_api : private|override|allow_incompatible(:visibility) (<blk>) -> String @ test/testdata/resolver/allow_incompatible_visibility.rb:22
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
   class ::<Class:ChildBadTypes>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:20
     type-member(+) ::<Class:ChildBadTypes>::<AttachedClass> -> T.attached_class (of ChildBadTypes) @ test/testdata/resolver/allow_incompatible_visibility.rb:20
     method ::<Class:ChildBadTypes>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:20
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
   class ::ChildOkay < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:15
-    method ::ChildOkay#some_public_api : private|override (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:17
+    method ::ChildOkay#some_public_api : private|override|allow_incompatible(:visibility) (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:17
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
   class ::<Class:ChildOkay>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:15
     type-member(+) ::<Class:ChildOkay>::<AttachedClass> -> T.attached_class (of ChildOkay) @ test/testdata/resolver/allow_incompatible_visibility.rb:15

--- a/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
@@ -23,6 +23,27 @@ class ::<root> < ::Object ()
     type-member(+) ::<Class:ChildBadTypes>::<AttachedClass> -> T.attached_class (of ChildBadTypes) @ test/testdata/resolver/allow_incompatible_visibility.rb:20
     method ::<Class:ChildBadTypes>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:20
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::ChildBoth1 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:32
+    method ::ChildBoth1#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:34
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::<Class:ChildBoth1>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:32
+    type-member(+) ::<Class:ChildBoth1>::<AttachedClass> -> T.attached_class (of ChildBoth1) @ test/testdata/resolver/allow_incompatible_visibility.rb:32
+    method ::<Class:ChildBoth1>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:32
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::ChildBoth2 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:37
+    method ::ChildBoth2#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:39
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::<Class:ChildBoth2>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:37
+    type-member(+) ::<Class:ChildBoth2>::<AttachedClass> -> T.attached_class (of ChildBoth2) @ test/testdata/resolver/allow_incompatible_visibility.rb:37
+    method ::<Class:ChildBoth2>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:37
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::ChildBoth3 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:42
+    method ::ChildBoth3#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:44
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
+  class ::<Class:ChildBoth3>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:42
+    type-member(+) ::<Class:ChildBoth3>::<AttachedClass> -> T.attached_class (of ChildBoth3) @ test/testdata/resolver/allow_incompatible_visibility.rb:42
+    method ::<Class:ChildBoth3>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:42
+      argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
   class ::ChildOkay < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:15
     method ::ChildOkay#some_public_api : private|override|allow_incompatible(:visibility) (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:17
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}

--- a/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility.rb.symbol-table.exp
@@ -24,25 +24,25 @@ class ::<root> < ::Object ()
     method ::<Class:ChildBadTypes>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:20
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
   class ::ChildBoth1 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:32
-    method ::ChildBoth1#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:34
+    method ::ChildBoth1#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:35
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
   class ::<Class:ChildBoth1>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:32
     type-member(+) ::<Class:ChildBoth1>::<AttachedClass> -> T.attached_class (of ChildBoth1) @ test/testdata/resolver/allow_incompatible_visibility.rb:32
     method ::<Class:ChildBoth1>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:32
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::ChildBoth2 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:37
-    method ::ChildBoth2#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:39
+  class ::ChildBoth2 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:38
+    method ::ChildBoth2#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:41
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::<Class:ChildBoth2>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:37
-    type-member(+) ::<Class:ChildBoth2>::<AttachedClass> -> T.attached_class (of ChildBoth2) @ test/testdata/resolver/allow_incompatible_visibility.rb:37
-    method ::<Class:ChildBoth2>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:37
+  class ::<Class:ChildBoth2>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:38
+    type-member(+) ::<Class:ChildBoth2>::<AttachedClass> -> T.attached_class (of ChildBoth2) @ test/testdata/resolver/allow_incompatible_visibility.rb:38
+    method ::<Class:ChildBoth2>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:38
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::ChildBoth3 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:42
-    method ::ChildBoth3#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:44
+  class ::ChildBoth3 < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:44
+    method ::ChildBoth3#some_public_api : private|override|allow_incompatible (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:47
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
-  class ::<Class:ChildBoth3>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:42
-    type-member(+) ::<Class:ChildBoth3>::<AttachedClass> -> T.attached_class (of ChildBoth3) @ test/testdata/resolver/allow_incompatible_visibility.rb:42
-    method ::<Class:ChildBoth3>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:42
+  class ::<Class:ChildBoth3>[<AttachedClass>] < ::<Class:Parent> () @ test/testdata/resolver/allow_incompatible_visibility.rb:44
+    type-member(+) ::<Class:ChildBoth3>::<AttachedClass> -> T.attached_class (of ChildBoth3) @ test/testdata/resolver/allow_incompatible_visibility.rb:44
+    method ::<Class:ChildBoth3>#<static-init> (<blk>) @ test/testdata/resolver/allow_incompatible_visibility.rb:44
       argument <blk><block> @ Loc {file=test/testdata/resolver/allow_incompatible_visibility.rb start=??? end=???}
   class ::ChildOkay < ::Parent () @ test/testdata/resolver/allow_incompatible_visibility.rb:15
     method ::ChildOkay#some_public_api : private|override|allow_incompatible(:visibility) (<blk>) -> Integer @ test/testdata/resolver/allow_incompatible_visibility.rb:17

--- a/website/docs/override-checking.md
+++ b/website/docs/override-checking.md
@@ -274,6 +274,31 @@ end
 
 **Again**, reach for this escape hatch sparingly. Every location where override checking has been silenced is a place where Sorbet could fail to catch an error that it might otherwise have been able to catch.
 
+### Use `override(allow_incompatible: :visibility)`
+
+To silence errors about incompatible overrides _specifically_ for mismatches of visibility (for example: a method is `public` in a parent class or interface, but `private` in a child class or implementation), there is a more precise alternative:
+
+```ruby
+class Parent
+  extend T::Sig
+
+  sig { overridable.returns(Integer) }
+  def some_public_api; 0; end
+end
+
+class ChildBad < Parent
+  sig { override.returns(Integer) }
+  private def some_public_api; 1; end # error: `some_public_api` must be public
+end
+
+class ChildOkay < Parent
+  sig { override(allow_incompatible: :visibility).returns(Integer) }
+  private def some_public_api; 1; end # error is silenced (underlying problem remains!)
+end
+```
+
+Compared to `override(allow_incompatible: true)`, this version will still check things like when the parent and child methods have mismatched arities or types—it only silences visibility-related mismatches.
+
 ## What's next?
 
 - [Final Methods, Classes, and Modules](final.md)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #8959

This unblocks #8381. That PR extends Sorbet's override checking to whether an override has a Liskov-substitution-compatible visibility compared to the method it overrides. It exposes about a thousand errors on Stripe's codebase. Some of those errors can be fixed, but the rest must be silenced (because people are depending on the incompatible overrides).

Technically, these errors can be silenced with `override(allow_incompatible: true)`, but that is a pretty large pill to swallow, because it opts out of _all_ the remaining override checks. For example, it opts the method out of all param/return type compatibility checking.

There is already a more granular way to opt out of individual type compatibility checking: mark individual parameters as `T.untyped`. There is no way to opt out of arity checking without opting out the whole method, but that somewhat makes sense because if the arities are different, it's not clear which parameters in the parent/child should be compared for equality. But if the only thing mismatched is the visibility, it could reasonably be that the arity and types are still compatible with the parent, and in fact this could still result in valid code:

```ruby
class Parent
  sig { overridable.returns(Integer) }
  def callback = 0
  
  sig(:final) { returns(Integer) }
  def main = example
end

class Child < Parent
  sig { override.returns(Integer) }
  private def callback = 1
end

p(Child.new.main)
```

This example runs fine—as written, despite the fact that the override is incompatible, it doesn't actually cause problems in practice.

We _could_ fix this by marking `Parent#callback` as a `private` method, but in general that's not going to be able to automatically fix all sorts of violations like this. Having a less punishing way to silence these kinds of errors is good.

**How do other languages solve this?**

Sorbet is somewhat unique in that [Sorbet Does Not Have FixMe Comments](https://blog.jez.io/sorbet-fixme-comment/) which can silence individual errors by code or by identifier at the point of the error. This is intentional, and there is motivation in the blog post.

Usually, errors can be silenced by relying on Sorbet as a gradual type system, e.g. using `T.untyped`. However, for certain classes of errors, the error does not relate specifically to a type mismatch, which necessitates building one-off suppression mechanisms, like this.

So: other languages solve this problem differently, and Sorbet's approach takes a somewhat fundamentally different stance.

**Did we consider anything else?**

We could just use `override(allow_incompatible: true)`, but that has problems (see above).

We could choose a different syntax entirely (new top-level builder method? new type sigil? command line flag?) but those all deviate substantially more from what an idiomatic Sorbet design would look like, especially given that `override(allow_incompatible: true)` already exists.

**Is this backwards compatible?**

Yes.

We're landing this PR **before** #8381 so that there will be a published version of Sorbet that parses this syntax in advance of #8381 introducing the new error.

Users will be able to upgrade to this PR, which is completely backwards compatible, so that people can pre-emptively add calls to `override(allow_incompatible: :visibility)` in advance of upgrading to #8381.

That's not _100%_ accurate: technically this change could introduce new runtime errors if people are passing something other than `true` or `false` at runtime to `override(allow_incompatible: true)` but arguably that's undefined behavior. The declared `sig` in the `rbi/sorbet/builder.rbi` file already checked that people are only passing `T::Boolean` for this keyword arg.

And in any case, if there are _those_ kinds of runtime errors, they can be fixed on any current version of Sorbet before upgrading to this one (e.g., the same strategy for the errors that #8381 introduces, shifted up by one PR).

So while this and the next PR will introduce new errors, it will be possible for users to incrementally migrate to the versions of Sorbet that start reporting them.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. All new tests have a before+after commit so that you can see the tests evolve in response to the changes in this PR.