### PR TITLE
Only track the modified state of the name table

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1213,7 +1213,6 @@ ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, 
     data->owner = owner;
     data->addLoc(*this, loc);
     DEBUG_ONLY(categoryCounterInc("symbols", "class"));
-    wasModified_ = true;
 
     return ret;
 }
@@ -1253,7 +1252,6 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
     data->owner = owner;
     data->addLoc(*this, loc);
     DEBUG_ONLY(categoryCounterInc("symbols", "type_member"));
-    wasModified_ = true;
 
     auto &members = owner.dataAllowingNone(*this)->getOrCreateTypeMembers();
     if (!absl::c_linear_search(members, result)) {
@@ -1304,7 +1302,6 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     data->owner = owner;
     data->addLoc(*this, loc);
     DEBUG_ONLY(categoryCounterInc("symbols", "type_argument"));
-    wasModified_ = true;
 
     owner.dataAllowingNone(*this)->getOrCreateTypeArguments().emplace_back(result);
     return result;
@@ -1330,7 +1327,6 @@ MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRe
     data->owner = owner;
     data->addLoc(*this, loc);
     DEBUG_ONLY(categoryCounterInc("symbols", "method"));
-    wasModified_ = true;
 
     return result;
 }
@@ -1397,7 +1393,6 @@ FieldRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef 
     data->addLoc(*this, loc);
 
     DEBUG_ONLY(categoryCounterInc("symbols", "field"));
-    wasModified_ = true;
 
     return result;
 }
@@ -1436,7 +1431,6 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
     data->addLoc(*this, loc);
 
     DEBUG_ONLY(categoryCounterInc("symbols", "static_field"));
-    wasModified_ = true;
 
     return ret;
 }
@@ -1459,7 +1453,6 @@ ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRe
     store.loc = loc;
     DEBUG_ONLY(categoryCounterInc("symbols", "argument"););
 
-    wasModified_ = true;
     return store;
 }
 
@@ -1539,7 +1532,7 @@ NameRef GlobalState::enterNameUTF8(string_view nm) {
     ENFORCE(hashNameRef(*this, name) == hs);
     categoryCounterInc("names", "utf8");
 
-    wasModified_ = true;
+    wasNameTableModified_ = true;
     return name;
 }
 
@@ -1589,7 +1582,7 @@ NameRef GlobalState::enterNameConstant(NameRef original) {
 
     constantNames.emplace_back(ConstantName{original});
     ENFORCE(hashNameRef(*this, name) == hs);
-    wasModified_ = true;
+    wasNameTableModified_ = true;
     categoryCounterInc("names", "constant");
     return name;
 }
@@ -1735,7 +1728,7 @@ NameRef GlobalState::freshNameUnique(UniqueNameKind uniqueNameKind, NameRef orig
 
     uniqueNames.emplace_back(UniqueName{original, num, uniqueNameKind});
     ENFORCE(hashNameRef(*this, name) == hs);
-    wasModified_ = true;
+    wasNameTableModified_ = true;
     categoryCounterInc("names", "unique");
     return name;
 }
@@ -2370,8 +2363,8 @@ bool GlobalState::shouldReportErrorOn(FileRef file, ErrorClass what) const {
     return level >= what.minLevel;
 }
 
-bool GlobalState::wasModified() const {
-    return wasModified_;
+bool GlobalState::wasNameTableModified() const {
+    return wasNameTableModified_;
 }
 
 void GlobalState::trace(string_view msg) const {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -234,7 +234,7 @@ public:
     ErrorBuilder beginIndexerError(Loc loc, ErrorClass what);
 
     int totalErrors() const;
-    bool wasModified() const;
+    bool wasNameTableModified() const;
 
     int globalStateId;
     bool silenceErrors = false;
@@ -386,7 +386,7 @@ private:
     UnorderedSet<int> ignoredForSuggestTypedErrorClasses;
     UnorderedSet<int> suppressedErrorClasses;
     UnorderedSet<int> onlyErrorClasses;
-    bool wasModified_ = false;
+    bool wasNameTableModified_ = false;
 
     core::packages::PackageDB packageDB_;
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -88,6 +88,7 @@ bool retainGlobalState(core::GlobalState &gs, const unique_ptr<OwnedKeyValueStor
     // It would be valid to always generate a new UUID and write it to the cache, but as an
     // optimization we can skip that when nothing has been modified.
     if (gs.wasModified()) {
+        Timer timeit(gs.tracer(), "retainGlobalState.writeNameTable");
         gs.kvstoreUuid = Random::uniformU4();
         kvstore->write(core::serialize::Serializer::NAME_TABLE_KEY, core::serialize::Serializer::storeNameTable(gs));
     }

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -87,7 +87,7 @@ bool retainGlobalState(core::GlobalState &gs, const unique_ptr<OwnedKeyValueStor
     //
     // It would be valid to always generate a new UUID and write it to the cache, but as an
     // optimization we can skip that when nothing has been modified.
-    if (gs.wasModified()) {
+    if (gs.wasNameTableModified()) {
         Timer timeit(gs.tracer(), "retainGlobalState.writeNameTable");
         gs.kvstoreUuid = Random::uniformU4();
         kvstore->write(core::serialize::Serializer::NAME_TABLE_KEY, core::serialize::Serializer::storeNameTable(gs));

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -95,7 +95,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         payload::createInitialGlobalState(*gs, *opts, kvstore);
 
         // If caching fails, gs gets modified during payload creation.
-        CHECK_FALSE(gs->wasModified());
+        CHECK_FALSE(gs->wasNameTableModified());
 
         core::File file{string(filePath), string(fileContents), core::File::Type::Normal};
         auto tree = core::serialize::Serializer::loadTree(*gs, file, contents.data);
@@ -195,7 +195,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPDoesNotUseCacheIfModified") {
         payload::createInitialGlobalState(*gs, *opts, kvstore);
 
         // If caching fails, gs gets modified during payload creation.
-        CHECK_FALSE(gs->wasModified());
+        CHECK_FALSE(gs->wasNameTableModified());
 
         core::File file{string(filePath), string(fileContents), core::File::Type::Normal};
         auto tree = core::serialize::Serializer::loadTree(*gs, file, contents.data);
@@ -306,7 +306,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "ReindexingUsesTheCache") {
     payload::createInitialGlobalState(*gs, *opts, kvstore);
 
     // If caching fails, gs gets modified during payload creation.
-    CHECK_FALSE(gs->wasModified());
+    CHECK_FALSE(gs->wasNameTableModified());
 
     core::FileRef fref;
     {


### PR DESCRIPTION
For a while now we've only written the name table to the cache, but have continued considering modifications to all other parts of the symbol table as requiring the global state to be re-written. This means that if we have files that we couldn't cache due to indexer errors, subsequent runs on the same set of files will still write the name table to the cache, even if there have been no changes to the name table.

This PR switches us to only considering changes to the name table when determining if we need to write the name table to the cache, which should reduce writes on successive invocations of sorbet.

### Motivation
Avoiding unnecessary writes to the cache.

### Test plan
This shouldn't affect existing behavior, as we would have been writing out the exact same name table.
