### PR TITLE
Remove origSend from ParsedSig

### DIFF
--- a/core/sig_finder/sig_finder.cc
+++ b/core/sig_finder/sig_finder.cc
@@ -114,7 +114,7 @@ void SigFinder::preTransformSend(core::Context ctx, const ast::Send &send) {
             // Found a method defined before the query but later than previous result: overwrite previous result
             auto owner = getEffectiveOwner(ctx);
             auto parsedSig = resolver::TypeSyntax::parseSigTop(ctx.withOwner(owner), send, core::Symbols::untyped());
-            this->result_ = make_optional<resolver::ParsedSig>(move(parsedSig));
+            this->result_ = Result{move(parsedSig), &send};
         } else {
             // We've already found an earlier result, so the current is not the first
         }
@@ -123,12 +123,12 @@ void SigFinder::preTransformSend(core::Context ctx, const ast::Send &send) {
         auto owner = getEffectiveOwner(ctx);
         auto parsedSig = resolver::TypeSyntax::parseSigTop(ctx.withOwner(owner), send, core::Symbols::untyped());
 
-        this->result_ = make_optional<resolver::ParsedSig>(move(parsedSig));
+        this->result_ = Result{move(parsedSig), &send};
     }
 }
 
-optional<resolver::ParsedSig> SigFinder::findSignature(core::Context ctx, const ast::ExpressionPtr &tree,
-                                                       core::Loc queryLoc) {
+optional<SigFinder::Result> SigFinder::findSignature(core::Context ctx, const ast::ExpressionPtr &tree,
+                                                     core::Loc queryLoc) {
     SigFinder sigFinder(queryLoc);
     ast::ConstTreeWalk::apply(ctx, sigFinder, tree);
     return move(sigFinder.result_);

--- a/core/sig_finder/sig_finder.h
+++ b/core/sig_finder/sig_finder.h
@@ -6,6 +6,13 @@
 namespace sorbet::sig_finder {
 
 class SigFinder {
+public:
+    struct Result {
+        resolver::ParsedSig sig;
+        const ast::Send *origSend;
+    };
+
+private:
     const core::Loc queryLoc;
 
     // Track the narrowest location range that still contains the queryLoc.
@@ -17,7 +24,7 @@ class SigFinder {
     // Track whether the current scope has the queryLoc.
     std::vector<bool> scopeContainsQueryLoc;
 
-    std::optional<resolver::ParsedSig> result_;
+    std::optional<Result> result_;
 
 public:
     SigFinder(core::Loc queryLoc)
@@ -30,8 +37,7 @@ public:
     void postTransformRuntimeMethodDefinition(core::Context ctx, const ast::RuntimeMethodDefinition &tree);
     void preTransformSend(core::Context ctx, const ast::Send &tree);
 
-    static std::optional<resolver::ParsedSig> findSignature(core::Context ctx, const ast::ExpressionPtr &tree,
-                                                            core::Loc queryLoc);
+    static std::optional<Result> findSignature(core::Context ctx, const ast::ExpressionPtr &tree, core::Loc queryLoc);
 };
 
 } // namespace sorbet::sig_finder

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -449,7 +449,7 @@ constructOverrideAutocorrect(const core::Context ctx, const ast::ExpressionPtr &
         return nullopt;
     }
 
-    ast::Block *block = parsedSig->origSend->block();
+    auto *block = parsedSig->origSend->block();
     if (!block) {
         return nullopt;
     }

--- a/main/lsp/ConvertToSingletonClassMethod.cc
+++ b/main/lsp/ConvertToSingletonClassMethod.cc
@@ -69,13 +69,13 @@ unique_ptr<TextDocumentEdit> createMethodDefEdit(const core::GlobalState &gs, LS
         auto queryLoc = definition.termLoc.copyWithZeroLength();
         auto parsedSig = sig_finder::SigFinder::findSignature(ctx, rootTree, queryLoc);
         if (parsedSig.has_value()) {
-            if (!parsedSig->argTypes.empty()) {
-                auto firstArgLoc = parsedSig->argTypes[0].nameLoc;
+            if (!parsedSig->sig.argTypes.empty()) {
+                auto firstArgLoc = parsedSig->sig.argTypes[0].nameLoc;
                 auto insertSigParamRange = Range::fromLoc(gs, firstArgLoc.adjustLen(gs, 0, 0));
                 auto sigParamText = fmt::format("this: {}, ", definition.symbol.data(gs)->owner.show(gs));
                 edits.emplace_back(make_unique<TextEdit>(move(insertSigParamRange), move(sigParamText)));
-            } else if (parsedSig->returnsLoc.exists()) {
-                auto insertSigParamsRange = Range::fromLoc(gs, parsedSig->returnsLoc.adjustLen(gs, 0, 0));
+            } else if (parsedSig->sig.returnsLoc.exists()) {
+                auto insertSigParamsRange = Range::fromLoc(gs, parsedSig->sig.returnsLoc.adjustLen(gs, 0, 0));
                 auto sigParamText = fmt::format("params(this: {}).", definition.symbol.data(gs)->owner.show(gs));
                 edits.emplace_back(make_unique<TextEdit>(move(insertSigParamsRange), move(sigParamText)));
             }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -650,7 +650,7 @@ void tryApplyLocalVarSaver(const core::GlobalState &gs, vector<ast::ParsedFile> 
         return;
     }
     for (auto &t : indexedCopies) {
-        optional<resolver::ParsedSig> signature;
+        optional<sig_finder::SigFinder::Result> signature;
         auto ctx = core::Context(gs, core::Symbols::root(), t.file);
         if (t.file == gs.lspQuery.loc.file()) {
             // For a VAR query, gs.lspQuery.loc is the enclosing MethodDef's loc, which we can use
@@ -658,7 +658,7 @@ void tryApplyLocalVarSaver(const core::GlobalState &gs, vector<ast::ParsedFile> 
             auto queryLoc = gs.lspQuery.loc.copyWithZeroLength();
             signature = sig_finder::SigFinder::findSignature(ctx, t.tree, queryLoc);
         }
-        LocalVarSaver localVarSaver(ctx.locAt(t.tree.loc()), move(signature));
+        LocalVarSaver localVarSaver(ctx.locAt(t.tree.loc()), move(signature->sig));
         ast::ConstTreeWalk::apply(ctx, localVarSaver, t.tree);
     }
 }

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -196,7 +196,6 @@ void checkTypeFunArity(core::Context ctx, const ast::Send &send, size_t minArity
 optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend, const ParsedSig *parent,
                                                TypeSyntaxArgs args) {
     ParsedSig sig;
-    sig.origSend = const_cast<ast::Send *>(&sigSend);
 
     const ast::Send *send = nullptr;
     bool isProc = false;

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -28,20 +28,6 @@ struct ParsedSig {
     };
     std::vector<TypeArgSpec> typeArgs;
 
-    // Store the original send that parsed into this structure, so we can modify
-    // it after the sig has been associated with a method.
-    //
-    // The argument for why it is safe to store this runs as follows:
-    //
-    // 1. The phase that parses sigs and associates them with methods doesn't modify
-    //    the AST.
-    // 2. The phase that applies the knowledge from parsing the sigs to the methods
-    //    in the symbol table runs entirely serially and does not modify the AST
-    //    (except for modifying the Send pointed to by this pointer).
-    //
-    // So we don't have to worry about this pointer being dropped from underneath us.
-    ast::Send *origSend;
-
     struct {
         bool sig = false;
         bool proc = false;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This `const_cast` was not great.

I think that a previous version of Sorbet (possibly something related to the
compiler) would use the `origSend` to mutate the tree. That's not happening
anymore: all call sites accessing the `origSend` is not mutating the tree.

Also, the main user of `origSend` used to be resolver, but resolver doesn't use
this anymore. Now, it's only used indirectly by `SigFinder`. To fix that, I'm
going to have `SigFinder` return the send, and also make it return something
that's `const` (because it already takes a `const` tree as an argument).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests