### PR TITLE
Force RBS abstract methods to raise

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -29,6 +29,7 @@ constexpr ErrorClass RBSUnusedComment{3554, StrictLevel::False};
 constexpr ErrorClass RBSMultilineMisformatted{3555, StrictLevel::False};
 constexpr ErrorClass RBSIncorrectParameterKind{3556, StrictLevel::False};
 constexpr ErrorClass RBSMultipleGenericSignatures{3557, StrictLevel::False};
+constexpr ErrorClass RBSAbstractMethodNoRaises{3558, StrictLevel::False};
 
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -52,13 +52,66 @@ core::LocOffsets adjustNameLoc(const RBSDeclaration &declaration, rbs_node_t *no
     return declaration.typeLocFromRange(range);
 }
 
-unique_ptr<parser::Node> handleAnnotations(unique_ptr<parser::Node> sigBuilder, const vector<Comment> &annotations) {
+bool isSelfOrKernel(parser::Node *node) {
+    if (auto self = parser::cast_node<parser::Self>(node)) {
+        return true;
+    }
+
+    if (auto constant = parser::cast_node<parser::Const>(node)) {
+        return constant->name == core::Names::Constants::Kernel() &&
+               (constant->scope == nullptr || parser::isa_node<parser::Cbase>(constant->scope.get()));
+    }
+
+    return false;
+}
+
+bool isRaise(parser::Node *node) {
+    auto raise = parser::cast_node<parser::Send>(node);
+
+    if (!raise) {
+        return false;
+    }
+
+    if (raise->method != core::Names::raise()) {
+        return false;
+    }
+
+    return raise->receiver == nullptr || isSelfOrKernel(raise->receiver.get());
+}
+
+void ensureAbstractMethodRaises(core::MutableContext ctx, const parser::Node *node) {
+    if (auto method = parser::cast_node<parser::DefMethod>((parser::Node *)node)) {
+        if (isRaise(method->body.get())) {
+            // If the method raises properly, we remove the body the body to not error later (see error 5019)
+            method->body = nullptr;
+            return;
+        }
+    } else if (auto method = parser::cast_node<parser::DefS>((parser::Node *)node)) {
+        if (isRaise(method->body.get())) {
+            // If the method raises properly, we remove the body the body to not error later (see error 5019)
+            method->body = nullptr;
+            return;
+        }
+    } else {
+        // Not a case we care about right now, will error later down the pipeline
+        return;
+    }
+
+    if (auto e = ctx.beginIndexerError(node->loc, core::errors::Rewriter::RBSAbstractMethodNoRaises)) {
+        e.setHeader("Methods declared @abstract with an RBS comment must always raise");
+    }
+}
+
+unique_ptr<parser::Node> handleAnnotations(core::MutableContext ctx, const parser::Node *node,
+                                           unique_ptr<parser::Node> sigBuilder, const vector<Comment> &annotations) {
     for (auto &annotation : annotations) {
         if (annotation.string == "final") {
             // no-op, `final` is handled in the `sig()` call later
         } else if (annotation.string == "abstract") {
             sigBuilder =
                 parser::MK::Send0(annotation.typeLoc, move(sigBuilder), core::Names::abstract(), annotation.typeLoc);
+
+            ensureAbstractMethodRaises(ctx, node);
         } else if (annotation.string == "overridable") {
             sigBuilder =
                 parser::MK::Send0(annotation.typeLoc, move(sigBuilder), core::Names::overridable(), annotation.typeLoc);
@@ -428,7 +481,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
     // Build the sig
 
     auto sigBuilder = parser::MK::Self(fullTypeLoc);
-    sigBuilder = handleAnnotations(move(sigBuilder), annotations);
+    sigBuilder = handleAnnotations(ctx, methodDef, move(sigBuilder), annotations);
 
     if (typeParams.size() > 0) {
         auto typeParamsVector = parser::NodeVec();
@@ -483,7 +536,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::attrSignature(const parser::Sen
     auto commentLoc = declaration.commentLoc();
 
     auto sigBuilder = parser::MK::Self(fullTypeLoc.copyWithZeroLength());
-    sigBuilder = handleAnnotations(move(sigBuilder), annotations);
+    sigBuilder = handleAnnotations(ctx, send, move(sigBuilder), annotations);
 
     if (send->args.size() == 0) {
         if (auto e = ctx.beginIndexerError(send->loc, core::errors::Rewriter::RBSUnsupported)) {

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -53,7 +53,7 @@ core::LocOffsets adjustNameLoc(const RBSDeclaration &declaration, rbs_node_t *no
 }
 
 bool isSelfOrKernel(parser::Node *node) {
-    if (auto self = parser::cast_node<parser::Self>(node)) {
+    if (parser::isa_node<parser::Self>(node)) {
         return true;
     }
 

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -277,13 +277,9 @@ FooProc.new do |foo|
 end
 
 module Annotations
-  # @abstract
-  #: -> Integer
-  def method1; end # error: Before declaring an abstract method, you must mark your class/module as abstract using `abstract!` or `interface!`
-
   # @override
   #: -> Integer
-  def method2; T.unsafe(nil); end # error: Method `Annotations#method2` is marked `override` but does not override anything
+  def method1; T.unsafe(nil); end # error: Method `Annotations#method1` is marked `override` but does not override anything
 
   class Parent
     #: (Integer) -> void
@@ -306,6 +302,81 @@ module Annotations
     def method(x)
       T.reveal_type(x) # error: Revealed type: `String`
     end
+  end
+
+  # @abstract
+  class Abstract
+    # @abstract
+    #: -> Integer
+    def method_abstract1; end # error: Methods declared @abstract with an RBS comment must always raise
+
+    # @abstract
+    #: -> Integer
+    def method_abstract2
+      raise
+    end
+
+    # @abstract
+    #: -> Integer
+    def method_abstract3
+      raise "foo"
+    end
+
+    # @abstract
+    #: -> Integer
+    def method_abstract4
+      Kernel.raise "foo"
+    end
+
+    # @abstract
+    #: -> Integer
+    def method_abstract5 # error: Methods declared @abstract with an RBS comment must always raise
+      puts "foo" # error: Abstract methods must not contain any code in their body
+    end
+
+    # @abstract
+    #: -> Integer
+    def method_abstract6 # error: Methods declared @abstract with an RBS comment must always raise
+      puts "foo" # error: Abstract methods must not contain any code in their body
+      raise "foo"
+    end
+
+    # @abstract
+    #: -> Integer
+    def method_abstract7
+      raise StandardError
+    end
+
+    # @abstract
+    #: -> Integer
+    def method_abstract8
+      raise StandardError, "error"
+    end
+
+    # @abstract
+    #: -> Integer
+    def method_abstract8
+      raise ::Abstract::Error, "error"
+    end
+
+    # @abstract
+    #: -> Integer
+    def method_abstract9 # error: Methods declared @abstract with an RBS comment must always raise
+      Abstract.raise # error: Abstract methods must not contain any code in their body
+    end
+
+    # @abstract
+    #: -> Integer
+    def method_abstract10
+      self.raise
+    end
+
+    #: -> bot
+    def self.raise
+      raise
+    end
+
+    class Error < StandardError; end
   end
 
   class Final

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -543,24 +543,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   module <emptyTree>::<C Annotations><<C <todo sym>>> < ()
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.abstract().returns(<emptyTree>::<C Integer>)
-    end
-
-    def method1<<todo method>>(&<blk>)
-      <emptyTree>
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.override().returns(<emptyTree>::<C Integer>)
     end
 
-    def method2<<todo method>>(&<blk>)
+    def method1<<todo method>>(&<blk>)
       <emptyTree>::<C T>.unsafe(nil)
     end
 
     <runtime method definition of method1>
-
-    <runtime method definition of method2>
 
     class <emptyTree>::<C Parent><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
@@ -596,6 +586,138 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       <runtime method definition of method>
+    end
+
+    class <emptyTree>::<C Abstract><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract1<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract2<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract3<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract4<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract5<<todo method>>(&<blk>)
+        <self>.puts("foo")
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract6<<todo method>>(&<blk>)
+        begin
+          <self>.puts("foo")
+          <self>.raise("foo")
+        end
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract7<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract8<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract8<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract9<<todo method>>(&<blk>)
+        <emptyTree>::<C Abstract>.raise()
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.abstract().returns(<emptyTree>::<C Integer>)
+      end
+
+      def method_abstract10<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.returns(::<root>::<C T>.noreturn())
+      end
+
+      def self.raise<<todo method>>(&<blk>)
+        <self>.raise()
+      end
+
+      <runtime method definition of method_abstract1>
+
+      <runtime method definition of method_abstract2>
+
+      <runtime method definition of method_abstract3>
+
+      <runtime method definition of method_abstract4>
+
+      <runtime method definition of method_abstract5>
+
+      <runtime method definition of method_abstract6>
+
+      <runtime method definition of method_abstract7>
+
+      <runtime method definition of method_abstract8>
+
+      <runtime method definition of method_abstract8>
+
+      <runtime method definition of method_abstract9>
+
+      <runtime method definition of method_abstract10>
+
+      <runtime method definition of self.raise>
+
+      class <emptyTree>::<C Error><<C <todo sym>>> < (<emptyTree>::<C StandardError>)
+      end
+
+      <self>.extend(::<root>::<C T>::<C Helpers>)
+
+      <self>.abstract!()
     end
 
     class <emptyTree>::<C Final><<C <todo sym>>> < (::<todo sym>)

--- a/test/testdata/rbs/signatures_defs_abstract_autocorrect.autocorrects.exp
+++ b/test/testdata/rbs/signatures_defs_abstract_autocorrect.autocorrects.exp
@@ -1,0 +1,51 @@
+# -- test/testdata/rbs/signatures_defs_abstract_autocorrect.rb --
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+# @abstract
+class Abstract
+  # @abstract
+  #: -> void
+  def foo; raise "abstract method called"; end # error: Methods declared @abstract with an RBS comment must always raise
+
+  # @abstract
+  #: -> void
+  def bar
+    raise "abstract method called" # error: Methods declared @abstract with an RBS comment must always raise
+  end
+
+  # @abstract
+  #: -> void
+  def baz # error: Methods declared @abstract with an RBS comment must always raise
+    raise "abstract method called" # error: Abstract methods must not contain any code in their body
+  end
+
+  # @abstract
+  #: -> void
+  def qux # error: Methods declared @abstract with an RBS comment must always raise
+    raise "abstract method called"
+  end
+
+    # @abstract
+  #: -> void
+  def self.foo; raise "abstract method called"; end # error: Methods declared @abstract with an RBS comment must always raise
+
+  # @abstract
+  #: -> void
+  def self.bar
+    raise "abstract method called" # error: Methods declared @abstract with an RBS comment must always raise
+  end
+
+  # @abstract
+  #: -> void
+  def self.baz # error: Methods declared @abstract with an RBS comment must always raise
+    raise "abstract method called" # error: Abstract methods must not contain any code in their body
+  end
+
+  # @abstract
+  #: -> void
+  def self.qux # error: Methods declared @abstract with an RBS comment must always raise
+    raise "abstract method called"
+  end
+end
+# ------------------------------

--- a/test/testdata/rbs/signatures_defs_abstract_autocorrect.rb
+++ b/test/testdata/rbs/signatures_defs_abstract_autocorrect.rb
@@ -1,0 +1,49 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+# @abstract
+class Abstract
+  # @abstract
+  #: -> void
+  def foo; end # error: Methods declared @abstract with an RBS comment must always raise
+
+  # @abstract
+  #: -> void
+  def bar # error: Methods declared @abstract with an RBS comment must always raise
+  end
+
+  # @abstract
+  #: -> void
+  def baz # error: Methods declared @abstract with an RBS comment must always raise
+    puts # error: Abstract methods must not contain any code in their body
+  end
+
+  # @abstract
+  #: -> void
+  def qux # error: Methods declared @abstract with an RBS comment must always raise
+    puts # error: Abstract methods must not contain any code in their body
+    puts
+  end
+
+    # @abstract
+  #: -> void
+  def self.foo; end # error: Methods declared @abstract with an RBS comment must always raise
+
+  # @abstract
+  #: -> void
+  def self.bar # error: Methods declared @abstract with an RBS comment must always raise
+  end
+
+  # @abstract
+  #: -> void
+  def self.baz # error: Methods declared @abstract with an RBS comment must always raise
+    puts # error: Abstract methods must not contain any code in their body
+  end
+
+  # @abstract
+  #: -> void
+  def self.qux # error: Methods declared @abstract with an RBS comment must always raise
+    puts # error: Abstract methods must not contain any code in their body
+    puts
+  end
+end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -560,6 +560,20 @@ class A
 end
 ```
 
+## 3558
+
+> This error is specific to RBS support when using the `--enable-experimental-rbs-comments` flag.
+
+Methods annotated with `@abstract` must always raise an error:
+
+```ruby
+# @abstract
+#: -> void
+def baz
+  raise "not implemented"
+end
+```
+
 ## 3702
 
 > This error is specific to Stripe's custom `--stripe-packages` mode. If you are at Stripe, please see [go/modularity](http://go/modularity) for more.


### PR DESCRIPTION
### Motivation

When declaring a method abstract in a sig, we expect `sorbet-runtime` to undef the method and avoid `super` calls.

This makes sure cases like this one raise at runtime:

```rb
class Foo
  sig { abstract.returns(Integer) }
  def foo; end
end

class Bar < Foo
  sig { override.returns(Integer) }
  def foo
    super
  end
end
```

But also insure that more complex cases like this one behave properly:

```rb
module FooInterface
  # @abstract
  #: -> Integer
  def foo; end
end

module Bar
  #: -> Integer
  def foo = 42
end

class Baz
  include Bar
  include FooInterface
end

Baz.new.foo # => nil :(
```

When using the RBS `@abstract` annotation, `sorbet-runtime` won't remove the abstract method and both behaviors can still occur.

This PR proposes to for RBS abstract methods to always have a body that raises so at least the cases shown before can be detected early.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
