### PR TITLE
consistence-ify access to the URI in LSP queries

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -432,7 +432,7 @@ LSPPreprocessor::canonicalizeEdits(uint32_t v, unique_ptr<DidChangeTextDocumentP
     edit->epoch = v;
     edit->sorbetCancellationExpected = changeParams->sorbetCancellationExpected.value_or(false);
     edit->sorbetPreemptionsExpected = changeParams->sorbetPreemptionsExpected.value_or(0);
-    string_view uri = changeParams->textDocument->uri;
+    const auto &uri = changeParams->textDocument->uri;
     if (config->isUriInWorkspace(uri)) {
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath) && config->hasAllowedExtension(localPath)) {
@@ -452,7 +452,7 @@ unique_ptr<SorbetWorkspaceEditParams>
 LSPPreprocessor::canonicalizeEdits(uint32_t v, unique_ptr<DidOpenTextDocumentParams> openParams) {
     auto edit = make_unique<SorbetWorkspaceEditParams>();
     edit->epoch = v;
-    string_view uri = openParams->textDocument->uri;
+    const auto &uri = openParams->textDocument->uri;
     if (config->isUriInWorkspace(uri)) {
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath) && config->hasAllowedExtension(localPath)) {
@@ -471,7 +471,7 @@ unique_ptr<SorbetWorkspaceEditParams>
 LSPPreprocessor::canonicalizeEdits(uint32_t v, unique_ptr<DidCloseTextDocumentParams> closeParams) {
     auto edit = make_unique<SorbetWorkspaceEditParams>();
     edit->epoch = v;
-    string_view uri = closeParams->textDocument->uri;
+    const auto &uri = closeParams->textDocument->uri;
     if (config->isUriInWorkspace(uri)) {
         string localPath = config->remoteName2Local(uri);
         if (!config->isFileIgnored(localPath) && config->hasAllowedExtension(localPath)) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1350,7 +1350,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
     auto emptyResult = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});
 
     const auto &gs = typechecker.state();
-    auto uri = params->textDocument->uri;
+    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     if (!fref.exists()) {
         response->result = std::move(emptyResult);

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -52,8 +52,8 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDefinition);
     const core::GlobalState &gs = typechecker.state();
     const auto &uri = params->textDocument->uri;
-    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
-                                  LSPMethod::TextDocumentDefinition, false);
+    auto result =
+        LSPQuery::byLoc(config, typechecker, uri, *params->position, LSPMethod::TextDocumentDefinition, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -51,7 +51,8 @@ DefinitionTask::DefinitionTask(const LSPConfiguration &config, MessageId id,
 unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDefinition);
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    const auto &uri = params->textDocument->uri;
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
                                   LSPMethod::TextDocumentDefinition, false);
     if (result.error) {
         // An error happened while setting up the query.
@@ -59,7 +60,6 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
         return response;
     }
 
-    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     // LSPQuery::byLoc reports an error if the file or loc don't exist
     auto queryLoc = params->position->toLoc(gs, fref).value();

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -59,7 +59,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
         return response;
     }
 
-    auto uri = params->textDocument->uri;
+    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     // LSPQuery::byLoc reports an error if the file or loc don't exist
     auto queryLoc = params->position->toLoc(gs, fref).value();

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -38,7 +38,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
 
     const core::GlobalState &gs = typechecker.state();
     const auto &uri = params->textDocument->uri;
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
                                   LSPMethod::TextDocumentDocumentHighlight, false);
     if (result.error) {
         // An error happened while setting up the query.

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -38,8 +38,8 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
 
     const core::GlobalState &gs = typechecker.state();
     const auto &uri = params->textDocument->uri;
-    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
-                                  LSPMethod::TextDocumentDocumentHighlight, false);
+    auto result =
+        LSPQuery::byLoc(config, typechecker, uri, *params->position, LSPMethod::TextDocumentDocumentHighlight, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -37,7 +37,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
     }
 
     const core::GlobalState &gs = typechecker.state();
-    auto uri = params->textDocument->uri;
+    const auto &uri = params->textDocument->uri;
     auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
                                   LSPMethod::TextDocumentDocumentHighlight, false);
     if (result.error) {

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -193,7 +193,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
 
     const core::GlobalState &gs = typechecker.state();
     vector<unique_ptr<DocumentSymbol>> result;
-    string_view uri = params->textDocument->uri;
+    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     if (!fref.exists()) {
         response->result = move(result);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -51,7 +51,8 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentHover);
 
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    const auto &uri = params->textDocument->uri;
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
                                   LSPMethod::TextDocumentHover, false);
     if (result.error) {
         // An error happened while setting up the query.
@@ -59,7 +60,6 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         return response;
     }
 
-    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     // LSPQuery::byLoc reports an error if the file or loc don't exist
     auto queryLoc = params->position->toLoc(gs, fref).value();

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -52,8 +52,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
 
     const core::GlobalState &gs = typechecker.state();
     const auto &uri = params->textDocument->uri;
-    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
-                                  LSPMethod::TextDocumentHover, false);
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position, LSPMethod::TextDocumentHover, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -59,7 +59,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         return response;
     }
 
-    auto uri = params->textDocument->uri;
+    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     // LSPQuery::byLoc reports an error if the file or loc don't exist
     auto queryLoc = params->position->toLoc(gs, fref).value();

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -70,7 +70,8 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
     ShowOperation op(config, ShowOperation::Kind::References);
 
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    const auto &uri = params->textDocument->uri;
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
                                   LSPMethod::TextDocumentReferences, false);
     if (result.error) {
         // An error happened while setting up the query.
@@ -83,7 +84,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
     response->result = variant<JSONNullObject, vector<unique_ptr<Location>>>(JSONNullObject());
     auto &queryResponses = result.responses;
     bool notifyAboutUntypedFile = false;
-    core::FileRef fref = config.uri2FileRef(gs, params->textDocument->uri);
+    core::FileRef fref = config.uri2FileRef(gs, uri);
     bool fileIsTyped = false;
     if (fref.exists()) {
         fileIsTyped = fref.data(gs).strictLevel >= core::StrictLevel::True;

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -71,8 +71,8 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
 
     const core::GlobalState &gs = typechecker.state();
     const auto &uri = params->textDocument->uri;
-    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
-                                  LSPMethod::TextDocumentReferences, false);
+    auto result =
+        LSPQuery::byLoc(config, typechecker, uri, *params->position, LSPMethod::TextDocumentReferences, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -73,8 +73,7 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
 
     const core::GlobalState &gs = typechecker.state();
     const auto &uri = params->textDocument->uri;
-    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
-                                  LSPMethod::TextDocumentSignatureHelp);
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position, LSPMethod::TextDocumentSignatureHelp);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);
@@ -98,8 +97,8 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
 
             auto fref = config.uri2FileRef(gs, uri);
             if (!fref.exists()) {
-                response->error = make_unique<ResponseError>(
-                    (int)LSPErrorCodes::InvalidRequest, fmt::format("Unknown file: `{}`", uri));
+                response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
+                                                             fmt::format("Unknown file: `{}`", uri));
                 return response;
             }
             auto src = fref.data(gs).source();

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -72,7 +72,8 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
     }
 
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    const auto &uri = params->textDocument->uri;
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
                                   LSPMethod::TextDocumentSignatureHelp);
     if (result.error) {
         // An error happened while setting up the query.
@@ -95,10 +96,10 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
             }
             auto sendLocIndex = sendResp->termLoc().beginPos();
 
-            auto fref = config.uri2FileRef(gs, params->textDocument->uri);
+            auto fref = config.uri2FileRef(gs, uri);
             if (!fref.exists()) {
                 response->error = make_unique<ResponseError>(
-                    (int)LSPErrorCodes::InvalidRequest, fmt::format("Unknown file: `{}`", params->textDocument->uri));
+                    (int)LSPErrorCodes::InvalidRequest, fmt::format("Unknown file: `{}`", uri));
                 return response;
             }
             auto src = fref.data(gs).source();

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -18,7 +18,8 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
     // To match the behavior of Go To Definition, we don't error in an untyped file, but instead
     // be okay with returning an empty result for certain queries.
     auto emptyResultIfFileIsUntyped = false;
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    const auto &uri = params->textDocument->uri;
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
                                   LSPMethod::SorbetShowSymbol, emptyResultIfFileIsUntyped);
     if (result.error) {
         // An error happened while setting up the query.
@@ -26,7 +27,6 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
         return response;
     }
 
-    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     // LSPQuery::byLoc reports an error if the file or loc don't exist
     auto queryLoc = params->position->toLoc(gs, fref).value();

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -19,8 +19,8 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
     // be okay with returning an empty result for certain queries.
     auto emptyResultIfFileIsUntyped = false;
     const auto &uri = params->textDocument->uri;
-    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
-                                  LSPMethod::SorbetShowSymbol, emptyResultIfFileIsUntyped);
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position, LSPMethod::SorbetShowSymbol,
+                                  emptyResultIfFileIsUntyped);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -26,7 +26,7 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
         return response;
     }
 
-    auto uri = params->textDocument->uri;
+    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     // LSPQuery::byLoc reports an error if the file or loc don't exist
     auto queryLoc = params->position->toLoc(gs, fref).value();

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -101,7 +101,7 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
         return response;
     }
 
-    auto uri = params->textDocument->uri;
+    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     // LSPQuery::byLoc reports an error if the file or loc don't exist
     auto queryLoc = params->position->toLoc(gs, fref).value();

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -94,8 +94,8 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentTypeDefinition);
     const core::GlobalState &gs = typechecker.state();
     const auto &uri = params->textDocument->uri;
-    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
-                                  LSPMethod::TextDocumentTypeDefinition, false);
+    auto result =
+        LSPQuery::byLoc(config, typechecker, uri, *params->position, LSPMethod::TextDocumentTypeDefinition, false);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -93,7 +93,8 @@ TypeDefinitionTask::TypeDefinitionTask(const LSPConfiguration &config, MessageId
 unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentTypeDefinition);
     const core::GlobalState &gs = typechecker.state();
-    auto result = LSPQuery::byLoc(config, typechecker, params->textDocument->uri, *params->position,
+    const auto &uri = params->textDocument->uri;
+    auto result = LSPQuery::byLoc(config, typechecker, uri, *params->position,
                                   LSPMethod::TextDocumentTypeDefinition, false);
     if (result.error) {
         // An error happened while setting up the query.
@@ -101,7 +102,6 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
         return response;
     }
 
-    const auto &uri = params->textDocument->uri;
     auto fref = config.uri2FileRef(gs, uri);
     // LSPQuery::byLoc reports an error if the file or loc don't exist
     auto queryLoc = params->position->toLoc(gs, fref).value();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This bugged me -- we sometimes access this field as a `string_view` named variable, sometimes as a `auto` named variable (which copies, bleh).  It'd be nice to be consistent and be ever-so-slightly more efficient.  I went with `const auto &`, but `string_view` can work too.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
