### PR TITLE
Fix RBS assertions inside `super`

### DIFF
--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -732,6 +732,12 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
             splat->var = rewriteNode(move(splat->var));
             result = move(node);
         },
+        [&](parser::Super *super_) {
+            for (auto &expr : super_->args) {
+                expr = rewriteNode(move(expr));
+            }
+            result = maybeInsertCast(move(node));
+        },
         [&](parser::Kwsplat *splat) {
             splat->expr = rewriteNode(move(splat->expr));
             result = move(node);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -590,6 +590,11 @@ void CommentsAssociator::walkNode(parser::Node *node) {
             walkNode(splat->var.get());
             consumeCommentsInsideNode(node, "splat");
         },
+        [&](parser::Super *super_) {
+            walkNodes(super_->args);
+            associateAssertionCommentsToNode(node);
+            consumeCommentsInsideNode(node, "super");
+        },
         [&](parser::Until *until) {
             associateAssertionCommentsToNode(node);
             walkNode(until->cond.get());

--- a/test/testdata/rbs/assertions_super.rb
+++ b/test/testdata/rbs/assertions_super.rb
@@ -1,0 +1,20 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+class Foo
+  #: (Integer, String) -> String
+  def foo(x, y)
+    y * x
+  end
+end
+
+class Bar < Foo
+  # @override
+  #: (Integer, String) -> String
+  def foo(x, y)
+    super(
+      ARGV.first, #: as String # error: Expected `Integer` but found `String` for argument `x
+      ARGV.last #: as Integer # error: Expected `String` but found `Integer` for argument `y`
+    ) #: as Integer # error: Expected `String` but found `Integer` for method result type
+  end
+end

--- a/test/testdata/rbs/assertions_super.rb
+++ b/test/testdata/rbs/assertions_super.rb
@@ -18,3 +18,16 @@ class Bar < Foo
     ) #: as Integer # error: Expected `String` but found `Integer` for method result type
   end
 end
+
+class Baz < Foo
+  # @override
+  #: (Integer, String) -> String
+  def foo(x, y)
+    super(
+      *[
+        ARGV.first, #: as Integer
+        ARGV.last #: as String
+      ]
+    )
+  end
+end

--- a/test/testdata/rbs/assertions_super.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_super.rb.rewrite-tree.exp
@@ -22,4 +22,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of foo>
   end
+
+  class <emptyTree>::<C Baz><<C <todo sym>>> < (<emptyTree>::<C Foo>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.override().params(:x, <emptyTree>::<C Integer>, :y, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+    end
+
+    def foo<<todo method>>(x, y, &<blk>)
+      ::<Magic>.<call-with-splat>(<self>, :<super>, ::<Magic>.<splat>([<cast:cast>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C Integer>), <cast:cast>(<emptyTree>::<C ARGV>.last(), <todo sym>, <emptyTree>::<C String>)]), nil)
+    end
+
+    <runtime method definition of foo>
+  end
 end

--- a/test/testdata/rbs/assertions_super.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_super.rb.rewrite-tree.exp
@@ -1,0 +1,25 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:x, <emptyTree>::<C Integer>, :y, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+    end
+
+    def foo<<todo method>>(x, y, &<blk>)
+      y.*(x)
+    end
+
+    <runtime method definition of foo>
+  end
+
+  class <emptyTree>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C Foo>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.override().params(:x, <emptyTree>::<C Integer>, :y, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+    end
+
+    def foo<<todo method>>(x, y, &<blk>)
+      <cast:cast>(<self>.<super>(<cast:cast>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C String>), <cast:cast>(<emptyTree>::<C ARGV>.last(), <todo sym>, <emptyTree>::<C Integer>)), <todo sym>, <emptyTree>::<C Integer>)
+    end
+
+    <runtime method definition of foo>
+  end
+end


### PR DESCRIPTION
### Motivation

Support cases like this one:

```rb
super(
  x, #: as String
  y #: as Integer
) #: as Integer
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
