### PR TITLE
Use `LocOffset` instead of `bool` throughout `ParsedSig`

### DIFF
--- a/main/lsp/ConvertToSingletonClassMethod.cc
+++ b/main/lsp/ConvertToSingletonClassMethod.cc
@@ -71,11 +71,12 @@ unique_ptr<TextDocumentEdit> createMethodDefEdit(const core::GlobalState &gs, LS
         if (parsedSig.has_value()) {
             if (!parsedSig->sig.argTypes.empty()) {
                 auto firstArgLoc = parsedSig->sig.argTypes[0].nameLoc;
-                auto insertSigParamRange = Range::fromLoc(gs, firstArgLoc.adjustLen(gs, 0, 0));
+                auto insertSigParamRange = Range::fromLoc(gs, ctx.locAt(firstArgLoc).adjustLen(gs, 0, 0));
                 auto sigParamText = fmt::format("this: {}, ", definition.symbol.data(gs)->owner.show(gs));
                 edits.emplace_back(make_unique<TextEdit>(move(insertSigParamRange), move(sigParamText)));
             } else if (parsedSig->sig.returnsLoc.exists()) {
-                auto insertSigParamsRange = Range::fromLoc(gs, parsedSig->sig.returnsLoc.adjustLen(gs, 0, 0));
+                auto insertSigParamsRange =
+                    Range::fromLoc(gs, ctx.locAt(parsedSig->sig.returnsLoc).adjustLen(gs, 0, 0));
                 auto sigParamText = fmt::format("params(this: {}).", definition.symbol.data(gs)->owner.show(gs));
                 edits.emplace_back(make_unique<TextEdit>(move(insertSigParamsRange), move(sigParamText)));
             }

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -76,8 +76,8 @@ void LocalVarSaver::postTransformMethodDef(core::Context ctx, const ast::MethodD
                     });
                     if (it != this->signature->argTypes.end()) {
                         core::lsp::QueryResponse::pushQueryResponse(
-                            ctx, core::lsp::IdentResponse(it->nameLoc, localExp->localVariable, tp, methodDef.symbol,
-                                                          methodDefLoc));
+                            ctx, core::lsp::IdentResponse(ctx.locAt(it->nameLoc), localExp->localVariable, tp,
+                                                          methodDef.symbol, methodDefLoc));
                     }
                 }
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1897,7 +1897,12 @@ class ResolveTypeMembersAndFieldsWalk {
             for (const auto &typeArg : job.owner.asMethodRef().data(gs)->typeArguments()) {
                 const auto &data = typeArg.data(gs);
                 auto name = data->name.dataUnique(gs)->original; // unwrap UniqueNameKind::TypeVarName
-                emptySig.typeArgs.emplace_back(ParsedSig::TypeArgSpec{data->loc(), name, data->resultType});
+                auto typeArgLoc = data->loc();
+                // TypeParameter might be defined in an RBI file, and thus not be in the same file
+                // as the `T.cast` is listed in.
+                auto typeArgLocOffsets = typeArgLoc.file() == job.file ? typeArgLoc.offsets()
+                                                                       : job.cast->typeExpr.loc().copyWithZeroLength();
+                emptySig.typeArgs.emplace_back(ParsedSig::TypeArgSpec{typeArgLocOffsets, name, data->resultType});
             }
         }
         auto allowSelfType = true;
@@ -3306,7 +3311,8 @@ private:
             for (auto &typeSpec : sig.typeArgs) {
                 if (typeSpec.type) {
                     auto name = ctx.state.freshNameUnique(core::UniqueNameKind::TypeVarName, typeSpec.name, 1);
-                    auto sym = ctx.state.enterTypeArgument(typeSpec.loc, method, name, core::Variance::CoVariant);
+                    auto sym =
+                        ctx.state.enterTypeArgument(ctx.locAt(typeSpec.loc), method, name, core::Variance::CoVariant);
                     auto asTypeVar = core::cast_type<core::TypeVar>(typeSpec.type);
                     ENFORCE(asTypeVar != nullptr);
                     asTypeVar->sym = sym;
@@ -3388,7 +3394,7 @@ private:
                 ENFORCE(spec->type != nullptr);
 
                 if (!isBlkArg && spec->rebind.exists()) {
-                    if (auto e = ctx.state.beginError(spec->nameLoc, core::errors::Resolver::BindNonBlockParameter)) {
+                    if (auto e = ctx.beginError(spec->nameLoc, core::errors::Resolver::BindNonBlockParameter)) {
                         e.setHeader("Using `{}` is not permitted here", "bind");
                         e.addErrorNote("Only block arguments can use `{}`", "bind");
                     }
@@ -3398,7 +3404,7 @@ private:
                 // Passing in a noOp collector even though this call is used for error reporting,
                 // because it's unlikely we'll add more details to a subtype check for T.nilable(Proc)
                 if (isBlkArg && !core::Types::isSubType(ctx, arg.type, core::Types::nilableProcClass())) {
-                    if (auto e = ctx.state.beginError(spec->nameLoc, core::errors::Resolver::InvalidMethodSignature)) {
+                    if (auto e = ctx.beginError(spec->nameLoc, core::errors::Resolver::InvalidMethodSignature)) {
                         e.setHeader("Block argument type must be either `{}` or a `{}` type (and possibly nilable)",
                                     "Proc", "T.proc");
                         e.addErrorNote(
@@ -3406,11 +3412,12 @@ private:
                             "    `{}` objects, but even those methods must return `{}` objects.",
                             "to_proc", "&blk", "Proc", "Proc");
 
-                        e.replaceWith("Change block type to `T.nilable(Proc)`", spec->typeLoc, "T.nilable(Proc)");
+                        e.replaceWith("Change block type to `T.nilable(Proc)`", ctx.locAt(spec->typeLoc),
+                                      "T.nilable(Proc)");
                     }
                     arg.type = core::Types::untypedUntracked();
                 }
-                arg.loc = spec->nameLoc;
+                arg.loc = ctx.locAt(spec->nameLoc);
                 arg.rebind = spec->rebind;
                 sig.argTypes.erase(spec);
                 // Since methods always have (synthesized if necessary) block arguments,
@@ -3457,7 +3464,7 @@ private:
 
         for (const auto &spec : sig.argTypes) {
             info.allArgsMatched = false;
-            if (auto e = ctx.state.beginError(spec.nameLoc, core::errors::Resolver::InvalidMethodSignature)) {
+            if (auto e = ctx.beginError(spec.nameLoc, core::errors::Resolver::InvalidMethodSignature)) {
                 e.setHeader("Unknown argument name `{}`", spec.name.show(ctx));
             }
         }
@@ -3475,7 +3482,7 @@ private:
                     if (auto e = ctx.beginError(param->loc, core::errors::Resolver::BadParameterOrdering)) {
                         e.setHeader("Bad parameter ordering for `{}`, expected `{}` instead", dname.show(ctx),
                                     sname.show(ctx));
-                        e.addErrorLine(spec.nameLoc, "Expected index in signature:");
+                        e.addErrorLine(ctx.locAt(spec.nameLoc), "Expected index in signature:");
                     }
                 }
                 j++;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3289,21 +3289,21 @@ private:
         ENFORCE(isOverloaded || mdef.symbol == method);
         ENFORCE(isOverloaded || method.data(ctx)->arguments.size() == mdef.args.size());
 
-        if (!sig.seen.returns && !sig.seen.void_) {
+        if (!sig.seen.returns.exists() && !sig.seen.void_.exists()) {
             if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
                 e.setHeader("Malformed `{}`: No return type specified. Specify one with .returns()", "sig");
             }
         }
-        if (sig.seen.returns && sig.seen.void_) {
+        if (sig.seen.returns.exists() && sig.seen.void_.exists()) {
             if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
                 e.setHeader("Malformed `{}`: Don't use both .returns() and .void", "sig");
             }
         }
 
-        if (sig.seen.abstract) {
+        if (sig.seen.abstract.exists()) {
             method.data(ctx)->flags.isAbstract = true;
         }
-        if (sig.seen.incompatibleOverride) {
+        if (sig.seen.incompatibleOverride.exists()) {
             method.data(ctx)->flags.isIncompatibleOverride = true;
         }
         if (!sig.typeArgs.empty()) {
@@ -3320,16 +3320,16 @@ private:
                 }
             }
         }
-        if (sig.seen.overridable) {
+        if (sig.seen.overridable.exists()) {
             method.data(ctx)->flags.isOverridable = true;
         }
-        if (sig.seen.override_) {
+        if (sig.seen.override_.exists()) {
             method.data(ctx)->flags.isOverride = true;
         }
-        if (sig.seen.final) {
+        if (sig.seen.final.exists()) {
             method.data(ctx)->flags.isFinal = true;
         }
-        if (sig.seen.bind) {
+        if (sig.seen.bind.exists()) {
             if (sig.bind == core::Symbols::MagicBindToAttachedClass()) {
                 if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::BindNonBlockParameter)) {
                     e.setHeader("Using `{}` is not permitted here", "bind");
@@ -3440,7 +3440,8 @@ private:
                 }
 
                 // We silence the "type not specified" error when a sig does not mention the synthesized block arg.
-                if (!isOverloaded && !isSyntheticBlkArg && (sig.seen.params || sig.seen.returns || sig.seen.void_)) {
+                if (!isOverloaded && !isSyntheticBlkArg &&
+                    (sig.seen.params.exists() || sig.seen.returns.exists() || sig.seen.void_.exists())) {
                     // Only error if we have any types
                     if (auto e = ctx.state.beginError(arg.loc, core::errors::Resolver::InvalidMethodSignature)) {
                         e.setHeader("Malformed `{}`. Type not specified for argument `{}`", "sig",

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -3,7 +3,6 @@
 #include "core/Names.h"
 #include "core/Symbols.h"
 #include "core/TypeErrorDiagnostics.h"
-#include "core/core.h"
 #include "core/errors/resolver.h"
 
 using namespace std;
@@ -262,7 +261,7 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                     }
                 }
                 typeArgSpec.type = core::make_type<core::TypeVar>(core::Symbols::todoTypeArgument());
-                typeArgSpec.loc = ctx.locAt(arg.loc());
+                typeArgSpec.loc = arg.loc();
             }
 
             for (auto [key, _value] : tsend->kwArgPairs()) {
@@ -414,8 +413,8 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                         }
                         auto resultAndBind = move(maybeResultAndBind.value());
 
-                        sig.argTypes.emplace_back(ParsedSig::ArgSpec{ctx.locAt(key.loc()), name, ctx.locAt(value.loc()),
-                                                                     resultAndBind.rebind, resultAndBind.type});
+                        sig.argTypes.emplace_back(
+                            ParsedSig::ArgSpec{key.loc(), name, value.loc(), resultAndBind.rebind, resultAndBind.type});
                     }
                 }
                 break;
@@ -514,7 +513,7 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                     return nullopt;
                 }
                 sig.returns = move(maybeReturns.value());
-                sig.returnsLoc = ctx.locAt(send->loc);
+                sig.returnsLoc = send->loc;
 
                 break;
             }
@@ -522,7 +521,7 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                 checkTypeFunArity(ctx, *send, 0, 0);
                 sig.seen.void_ = true;
                 sig.returns = core::Types::void_();
-                sig.returnsLoc = ctx.locAt(send->loc);
+                sig.returnsLoc = send->loc;
                 break;
             }
             case core::Names::checked().rawId(): {

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -10,19 +10,19 @@ namespace sorbet::resolver {
 
 struct ParsedSig {
     struct ArgSpec {
-        core::Loc nameLoc;
+        core::LocOffsets nameLoc;
         core::NameRef name;
-        core::Loc typeLoc;
+        core::LocOffsets typeLoc;
         core::ClassOrModuleRef rebind;
         core::TypePtr type;
     };
     core::ClassOrModuleRef bind;
     std::vector<ArgSpec> argTypes;
     core::TypePtr returns;
-    core::Loc returnsLoc;
+    core::LocOffsets returnsLoc;
 
     struct TypeArgSpec {
-        core::Loc loc;
+        core::LocOffsets loc;
         core::NameRef name;
         core::TypePtr type;
     };

--- a/resolver/type_syntax/type_syntax.h
+++ b/resolver/type_syntax/type_syntax.h
@@ -29,18 +29,18 @@ struct ParsedSig {
     std::vector<TypeArgSpec> typeArgs;
 
     struct {
-        bool sig = false;
-        bool proc = false;
-        bool bind = false;
-        bool params = false;
-        bool abstract = false;
-        bool override_ = false;
-        bool overridable = false;
-        bool returns = false;
-        bool void_ = false;
-        bool checked = false;
-        bool final = false;
-        bool incompatibleOverride = false;
+        core::LocOffsets sig = core::LocOffsets::none();
+        core::LocOffsets proc = core::LocOffsets::none();
+        core::LocOffsets bind = core::LocOffsets::none();
+        core::LocOffsets params = core::LocOffsets::none();
+        core::LocOffsets abstract = core::LocOffsets::none();
+        core::LocOffsets override_ = core::LocOffsets::none();
+        core::LocOffsets overridable = core::LocOffsets::none();
+        core::LocOffsets returns = core::LocOffsets::none();
+        core::LocOffsets void_ = core::LocOffsets::none();
+        core::LocOffsets checked = core::LocOffsets::none();
+        core::LocOffsets final = core::LocOffsets::none();
+        core::LocOffsets incompatibleOverride = core::LocOffsets::none();
     } seen;
 
     TypeArgSpec &enterTypeArgByName(core::NameRef name);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Right now we only track whether we've seen various builder methods, not where
we've seen them.

There are a handful of things that I want to build (better errors for the
existing "duplicate builder method", better autocorrect for removing duplicates,
new autocorrect for inserting `allow_incompatible: true`) and that all gets
easier if we can track location information for these things.

While this is more memory, I think this should be mostly fine, because we don't
keep more than a file's worth of `ParsedSig` in memory at a time. As in, we're
not persisting these `ParsedSig` for the entirety of Sorbet's pipeline.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests; shouldn't have a real visible change yet until the follow up
changes that depend on this.