### PR TITLE
Use the loc from the current file for override autocorrect

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -471,7 +471,8 @@ constructOverrideAutocorrect(const core::Context ctx, const ast::ExpressionPtr &
     };
 }
 
-void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree, core::MethodRef method) {
+void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree, const ast::MethodDef &methodDef) {
+    auto method = methodDef.symbol;
     auto klass = method.data(ctx)->owner;
     auto name = method.data(ctx)->name;
     auto klassData = klass.data(ctx);
@@ -1186,7 +1187,7 @@ public:
         // See the comment in `VarianceValidator::validateMethod` for an explanation of why we don't
         // need to check types on instance variables.
 
-        validateOverriding(ctx, this->tree, methodDef.symbol);
+        validateOverriding(ctx, this->tree, methodDef);
     }
 
     void postTransformSend(core::Context ctx, const ast::ExpressionPtr &tree) {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -443,8 +443,13 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
 
 optional<core::AutocorrectSuggestion>
 constructOverrideAutocorrect(const core::Context ctx, const ast::ExpressionPtr &tree, core::MethodRef method) {
-    auto methodLoc = method.data(ctx)->loc();
-    auto parsedSig = sig_finder::SigFinder::findSignature(ctx, tree, methodLoc.copyWithZeroLength());
+    auto methodLocs = method.data(ctx)->locs();
+    auto methodLoc = absl::c_find_if(methodLocs, [&](auto &loc) { return loc.file() == ctx.file; });
+    if (methodLoc == methodLocs.end() || !methodLoc->exists()) {
+        return nullopt;
+    }
+
+    auto parsedSig = sig_finder::SigFinder::findSignature(ctx, tree, methodLoc->copyWithZeroLength());
     if (!parsedSig.has_value()) {
         return nullopt;
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -133,7 +133,8 @@ void matchPositional(const core::Context ctx, core::TypeConstraint &constr,
                      absl::InlinedVector<reference_wrapper<const core::ArgInfo>, 4> &superArgs,
                      core::MethodRef superMethod,
                      absl::InlinedVector<reference_wrapper<const core::ArgInfo>, 4> &methodArgs,
-                     core::MethodRef method) {
+                     const ast::MethodDef &methodDef) {
+    auto method = methodDef.symbol;
     auto idx = 0;
     auto maxLen = min(superArgs.size(), methodArgs.size());
 
@@ -144,7 +145,7 @@ void matchPositional(const core::Context ctx, core::TypeConstraint &constr,
         core::ErrorSection::Collector errorDetailsCollector;
         if (!checkSubtype(ctx, constr, methodArgType, method, superArgType, superMethod, core::Polarity::Negative,
                           errorDetailsCollector)) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("Parameter `{}` of type `{}` not compatible with type of {} method `{}`",
                             methodArgs[idx].get().show(ctx), methodArgType.show(ctx), superMethodKind(ctx, superMethod),
                             superMethod.show(ctx));
@@ -161,7 +162,8 @@ void matchPositional(const core::Context ctx, core::TypeConstraint &constr,
 }
 
 // Ensure that two argument lists are compatible in shape and type
-void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMethod, core::MethodRef method) {
+void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMethod, const ast::MethodDef &methodDef) {
+    auto method = methodDef.symbol;
     if (method.data(ctx)->flags.isOverloaded) {
         // Don't try to check overloaded methods; It's not immediately clear how
         // to match overloads against their superclass definitions. Since we
@@ -171,7 +173,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
 
     if (superMethod.data(ctx)->flags.isGenericMethod != method.data(ctx)->flags.isGenericMethod &&
         method.data(ctx)->hasSig()) {
-        if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+        if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
             if (superMethod.data(ctx)->flags.isGenericMethod) {
                 e.setHeader("{} method `{}` must declare the same number of type parameters as the base method",
                             implementationOf(ctx, superMethod), superMethod.show(ctx));
@@ -191,7 +193,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
         const auto &methodTypeArguments = method.data(ctx)->typeArguments();
         const auto &superMethodTypeArguments = superMethod.data(ctx)->typeArguments();
         if (methodTypeArguments.size() != superMethodTypeArguments.size()) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("{} method `{}` must declare the same number of type parameters as the base method",
                             implementationOf(ctx, superMethod), superMethod.show(ctx));
                 e.addErrorLine(superMethod.data(ctx)->loc(), "Base method defined here");
@@ -236,7 +238,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
         auto leftPos = left.pos.required.size() + left.pos.optional.size();
         auto rightPos = right.pos.required.size() + right.pos.optional.size();
         if (leftPos > rightPos) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("{} method `{}` must accept at least `{}` positional arguments",
                             implementationOf(ctx, superMethod), superMethod.show(ctx), leftPos);
                 e.addErrorLine(superMethod.data(ctx)->loc(), "Base method defined here");
@@ -246,7 +248,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
 
     if (auto leftRest = left.pos.rest) {
         if (!right.pos.rest) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("{} method `{}` must accept *`{}`", implementationOf(ctx, superMethod),
                             superMethod.show(ctx), leftRest->get().show(ctx));
                 e.addErrorLine(superMethod.data(ctx)->loc(), "Base method defined here");
@@ -255,7 +257,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
     }
 
     if (right.pos.required.size() > left.pos.required.size()) {
-        if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+        if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
             e.setHeader("{} method `{}` must accept no more than `{}` required argument(s)",
                         implementationOf(ctx, superMethod), superMethod.show(ctx), left.pos.required.size());
             e.addErrorLine(superMethod.data(ctx)->loc(), "Base method defined here");
@@ -263,9 +265,9 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
     }
 
     // match types of required positional arguments
-    matchPositional(ctx, *constr, left.pos.required, superMethod, right.pos.required, method);
+    matchPositional(ctx, *constr, left.pos.required, superMethod, right.pos.required, methodDef);
     // match types of optional positional arguments
-    matchPositional(ctx, *constr, left.pos.optional, superMethod, right.pos.optional, method);
+    matchPositional(ctx, *constr, left.pos.optional, superMethod, right.pos.optional, methodDef);
 
     if (!right.kw.rest) {
         for (auto req : left.kw.required) {
@@ -285,8 +287,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
                 core::ErrorSection::Collector errorDetailsCollector;
                 if (!checkSubtype(ctx, *constr, corresponding->get().type, method, req.get().type, superMethod,
                                   core::Polarity::Negative, errorDetailsCollector)) {
-                    if (auto e =
-                            ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+                    if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                         e.setHeader("Keyword parameter `{}` of type `{}` not compatible with type of {} method `{}`",
                                     corresponding->get().show(ctx), corresponding->get().type.show(ctx),
                                     superMethodKind(ctx, superMethod), superMethod.show(ctx));
@@ -299,7 +300,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
                     }
                 }
             } else {
-                if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+                if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                     e.setHeader("{} method `{}` is missing required keyword argument `{}`",
                                 implementationOf(ctx, superMethod), superMethod.show(ctx), req.get().name.show(ctx));
                     e.addErrorLine(superMethod.data(ctx)->loc(), "Base method defined here");
@@ -317,8 +318,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
                 core::ErrorSection::Collector errorDetailsCollector;
                 if (!checkSubtype(ctx, *constr, corresponding->get().type, method, opt.get().type, superMethod,
                                   core::Polarity::Negative, errorDetailsCollector)) {
-                    if (auto e =
-                            ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+                    if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                         e.setHeader("Keyword parameter `{}` of type `{}` not compatible with type of {} method `{}`",
                                     corresponding->get().show(ctx), corresponding->get().type.show(ctx),
                                     superMethodKind(ctx, superMethod), superMethod.show(ctx));
@@ -332,7 +332,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
                 }
             } else if (absl::c_any_of(right.kw.required,
                                       [&](const auto &r) { return r.get().name == opt.get().name; })) {
-                if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+                if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                     e.setHeader("{} method `{}` must redeclare keyword parameter `{}` as optional",
                                 implementationOf(ctx, superMethod), superMethod.show(ctx), opt.get().name.show(ctx));
                     // Show the superMethod loc (declLoc) so the error message includes the default value
@@ -341,7 +341,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
                                    opt.get().name.show(ctx));
                 }
             } else {
-                if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+                if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                     e.setHeader("{} method `{}` must accept optional keyword parameter `{}`",
                                 implementationOf(ctx, superMethod), superMethod.show(ctx), opt.get().name.show(ctx));
                     // Show the superMethod loc (declLoc) so the error message includes the default value
@@ -356,14 +356,14 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
     if (auto leftRest = left.kw.rest) {
         core::ErrorSection::Collector errorDetailsCollector;
         if (!right.kw.rest) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("{} method `{}` must accept **`{}`", implementationOf(ctx, superMethod),
                             superMethod.show(ctx), leftRest->get().show(ctx));
                 e.addErrorLine(superMethod.data(ctx)->loc(), "Base method defined here");
             }
         } else if (!checkSubtype(ctx, *constr, right.kw.rest->get().type, method, leftRest->get().type, superMethod,
                                  core::Polarity::Negative, errorDetailsCollector)) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("Parameter **`{}` of type `{}` not compatible with type of {} method `{}`",
                             right.kw.rest->get().show(ctx), right.kw.rest->get().type.show(ctx),
                             superMethodKind(ctx, superMethod), superMethod.show(ctx));
@@ -385,7 +385,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
             // We would have already reported a more informative error above.
             continue;
         }
-        if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+        if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
             e.setHeader("{} method `{}` contains extra required keyword argument `{}`",
                         implementationOf(ctx, superMethod), superMethod.show(ctx), extra.get().name.toString(ctx));
             e.addErrorLine(superMethod.data(ctx)->loc(), "Base method defined here");
@@ -393,7 +393,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
     }
 
     if (!left.syntheticBlk && right.syntheticBlk) {
-        if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+        if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
             e.setHeader("{} method `{}` must explicitly name a block argument", implementationOf(ctx, superMethod),
                         superMethod.show(ctx));
             e.addErrorLine(superMethod.data(ctx)->loc(), "Base method defined here");
@@ -405,7 +405,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
         core::ErrorSection::Collector errorDetailsCollector;
         if (!checkSubtype(ctx, *constr, methodBlkArg.type, method, superMethodBlkArg.type, superMethod,
                           core::Polarity::Negative, errorDetailsCollector)) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("Block parameter `{}` of type `{}` not compatible with type of {} method `{}`",
                             methodBlkArg.argumentName(ctx), methodBlkArg.type.show(ctx),
                             superMethodKind(ctx, superMethod), superMethod.show(ctx));
@@ -428,7 +428,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
         core::ErrorSection::Collector errorDetailsCollector;
         if (!checkSubtype(ctx, *constr, methodReturn, method, superReturn, superMethod, core::Polarity::Positive,
                           errorDetailsCollector)) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
                 auto methodReturnShow = methodReturn == core::Types::void_() ? "void" : methodReturn.show(ctx);
                 e.setHeader("Return type `{}` does not match return type of {} method `{}`", methodReturnShow,
                             superMethodKind(ctx, superMethod), superMethod.show(ctx));
@@ -478,7 +478,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
     // NOTE(jez): I don't think this check makes all that much sense, but I haven't thought about it.
     // We already deleted the corresponding check for `private`, and may want to revisit this, too.
     if (klassData->flags.isInterface && method.data(ctx)->flags.isProtected) {
-        if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::NonPublicAbstract)) {
+        if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::NonPublicAbstract)) {
             e.setHeader("Interface method `{}` cannot be protected", method.show(ctx));
         }
     }
@@ -486,8 +486,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
     if (method.data(ctx)->flags.isAbstract && klassData->isSingletonClass(ctx)) {
         auto attached = klassData->attachedClass(ctx);
         if (attached.exists() && attached.data(ctx)->isModule()) {
-            if (auto e =
-                    ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::StaticAbstractModuleMethod)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::StaticAbstractModuleMethod)) {
                 e.setHeader("Static methods in a module cannot be abstract");
             }
         }
@@ -522,7 +521,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
 
     if (overriddenMethods.size() == 0 && method.data(ctx)->flags.isOverride &&
         !method.data(ctx)->flags.isIncompatibleOverride) {
-        if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::BadMethodOverride)) {
+        if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
             e.setHeader("Method `{}` is marked `{}` but does not override anything", method.show(ctx), "override");
         }
     }
@@ -532,7 +531,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
     auto anyIsInterface = absl::c_any_of(overriddenMethods, [&](auto &m) { return m.data(ctx)->flags.isAbstract; });
     for (const auto &overriddenMethod : overriddenMethods) {
         if (overriddenMethod.data(ctx)->flags.isFinal) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::OverridesFinal)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::OverridesFinal)) {
                 e.setHeader("`{}` was declared as final and cannot be overridden by `{}`", overriddenMethod.show(ctx),
                             method.show(ctx));
                 e.addErrorLine(overriddenMethod.data(ctx)->loc(), "original method defined here");
@@ -543,9 +542,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
             (overriddenMethod.data(ctx)->flags.isOverridable || overriddenMethod.data(ctx)->flags.isOverride) &&
             !anyIsInterface && overriddenMethod.data(ctx)->hasSig() && !method.data(ctx)->flags.isRewriterSynthesized &&
             !isRBI) {
-            auto methodLoc = method.data(ctx)->loc();
-
-            if (auto e = ctx.state.beginError(methodLoc, core::errors::Resolver::UndeclaredOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` overrides an overridable method `{}` but is not declared with `{}`",
                             method.show(ctx), overriddenMethod.show(ctx), "override.");
                 e.addErrorLine(overriddenMethod.data(ctx)->loc(), "defined here");
@@ -559,7 +556,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
         if (!method.data(ctx)->flags.isOverride && !method.data(ctx)->flags.isAbstract && method.data(ctx)->hasSig() &&
             overriddenMethod.data(ctx)->flags.isAbstract && overriddenMethod.data(ctx)->hasSig() &&
             !method.data(ctx)->flags.isRewriterSynthesized && !isRBI) {
-            if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::UndeclaredOverride)) {
+            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::UndeclaredOverride)) {
                 e.setHeader("Method `{}` implements an abstract method `{}` but is not declared with `{}`",
                             method.show(ctx), overriddenMethod.show(ctx), "override.");
                 e.addErrorLine(overriddenMethod.data(ctx)->loc(), "defined here");
@@ -579,7 +576,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
             // One day, we may want to build something like overridable(allow_incompatible: true)
             // and mark certain methods in the standard library as possible to be overridden incompatibly,
             // without needing to write `override(allow_incompatible: true)`.
-            validateCompatibleOverride(ctx, overriddenMethod, method);
+            validateCompatibleOverride(ctx, overriddenMethod, methodDef);
         }
     }
 }

--- a/test/testdata/definition_validator/insert_override_multi.autocorrects.exp
+++ b/test/testdata/definition_validator/insert_override_multi.autocorrects.exp
@@ -1,0 +1,34 @@
+# -- test/testdata/definition_validator/insert_override_multi__1.rb --
+# typed: true
+
+class Parent
+  sig { overridable.void }
+  def example; end
+end
+
+class Child < Parent
+  sig { void }
+  def example; end
+end
+
+class Module
+  include T::Sig
+end
+# ------------------------------
+# -- test/testdata/definition_validator/insert_override_multi__2.rb --
+# typed: true
+
+class Parent
+  sig { overridable.void }
+  def example; end
+end
+
+class Child < Parent
+  sig { override.void }
+  def example; end # error: Method `Child#example` overrides an overridable method `Parent#example` but is not declared with `override.`
+end
+
+class Module
+  include T::Sig
+end
+# ------------------------------

--- a/test/testdata/definition_validator/insert_override_multi.autocorrects.exp
+++ b/test/testdata/definition_validator/insert_override_multi.autocorrects.exp
@@ -7,8 +7,8 @@ class Parent
 end
 
 class Child < Parent
-  sig { void }
-  def example; end
+  sig { override.void }
+  def example; end # error: Method `Child#example` overrides an overridable method `Parent#example` but is not declared with `override.`
 end
 
 class Module

--- a/test/testdata/definition_validator/insert_override_multi__1.rb
+++ b/test/testdata/definition_validator/insert_override_multi__1.rb
@@ -7,7 +7,7 @@ end
 
 class Child < Parent
   sig { void }
-  def example; end
+  def example; end # error: Method `Child#example` overrides an overridable method `Parent#example` but is not declared with `override.`
 end
 
 class Module

--- a/test/testdata/definition_validator/insert_override_multi__1.rb
+++ b/test/testdata/definition_validator/insert_override_multi__1.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class Parent
+  sig { overridable.void }
+  def example; end
+end
+
+class Child < Parent
+  sig { void }
+  def example; end
+end
+
+class Module
+  include T::Sig
+end

--- a/test/testdata/definition_validator/insert_override_multi__2.rb
+++ b/test/testdata/definition_validator/insert_override_multi__2.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class Parent
+  sig { overridable.void }
+  def example; end
+end
+
+class Child < Parent
+  sig { void }
+  def example; end # error: Method `Child#example` overrides an overridable method `Parent#example` but is not declared with `override.`
+end
+
+class Module
+  include T::Sig
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were running `findSignature` using the method definition's canonical loc. If
there were multiple locs for the method definition, it would fail to find one of
the sigs when the next `findSignature` call happened.

This didn't _really_ matter, because as long as it's added to one sig, it's
fine--the `override` doesn't actually have to be added to all `sig`. That's
probably weird, we should probably require that it's added to all the sigs, but
that's a problem for another day, as this is particularly rare.

In any case, we can search over the list of locs and find the relevant sig.

It also means that we can introduce an `ENFORCE` for `findSignature`, but we
will have to audit all the other uses of `findSignature` too.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests for before+after changes.