### PR TITLE
Small autogen memory improvements

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -422,7 +422,7 @@ ParsedFile Autogen::generate(core::Context ctx, ast::ParsedFile tree, const Auto
     pf.path = string(tree.file.data(ctx).path());
     auto src = tree.file.data(ctx).source();
     pf.cksum = crcBuilder.crc32(src);
-    pf.tree = move(tree);
+    pf.file = tree.file;
     return pf;
 }
 

--- a/main/autogen/data/definitions.cc
+++ b/main/autogen/data/definitions.cc
@@ -137,7 +137,7 @@ string ParsedFile::toString(const core::GlobalState &gs, int version) const {
                        ref.id.id(), fmt::map_join(refFullName, " ", nameToString),
                        fmt::map_join(ref.name.nameParts, " ", nameToString), fmt::join(nestingStrings, " "),
                        fmt::map_join(ref.resolved.nameParts, " ", nameToString),
-                       core::Loc(tree.file, ref.loc).filePosToString(gs), (int)ref.is_defining_ref);
+                       core::Loc(file, ref.loc).filePosToString(gs), (int)ref.is_defining_ref);
 
         if (ref.parent_of.exists()) {
             auto parentOfFullName = showFullName(gs, ref.parent_of);

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -126,10 +126,12 @@ struct Reference {
     // In which class or module was this reference used?
     DefinitionRef scope;
 
-    // its full qualified name
-    QualifiedName name;
     // the nesting ID of this constant
     uint32_t nestingId;
+
+    // its full qualified name
+    QualifiedName name;
+
     // the resolved name iff we have it from Sorbet
     QualifiedName resolved;
 
@@ -137,16 +139,16 @@ struct Reference {
     core::LocOffsets loc;
     core::LocOffsets definitionLoc;
 
+    // If this is a ref used in an `include` or `extend`, then this will point to the definition of the class in which
+    // this is being `include`d or `extend`ed
+    DefinitionRef parent_of;
+
     // `true` if this is the appearance of the constant name associated with a definition: i.e. the name of a class or
     // module or the LHS of a casgn
     bool is_defining_ref;
 
     // Iff this is a class, then this will be `ClassKind::Class`, otherwise `ClassKind::Module`
     ClassKind parentKind = ClassKind::Module;
-
-    // If this is a ref used in an `include` or `extend`, then this will point to the definition of the class in which
-    // this is being `include`d or `extend`ed
-    DefinitionRef parent_of;
 };
 
 struct AutogenConfig {

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -2,6 +2,7 @@
 #define AUTOGEN_DEFINITIONS_H
 
 #include "ast/ast.h"
+#include "common/common.h"
 
 namespace sorbet::autogen {
 
@@ -111,6 +112,7 @@ struct Definition {
     // once `AutogenWalk` has completed; please update this comment if that ever turns out to be false
     ReferenceRef defining_ref;
 };
+CheckSize(Definition, 24, 4);
 
 // A `Reference` corresponds to a simple use of a constant name in a file. After a `ParsedFile` has been created, every
 // constant use should have a `Reference` corresponding to it
@@ -150,6 +152,7 @@ struct Reference {
     // Iff this is a class, then this will be `ClassKind::Class`, otherwise `ClassKind::Module`
     ClassKind parentKind = ClassKind::Module;
 };
+CheckSize(Reference, 96, 8);
 
 struct AutogenConfig {
     const std::vector<std::string> behaviorAllowedInRBIsPaths;

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -158,8 +158,8 @@ struct AutogenConfig {
 struct ParsedFile {
     friend class MsgpackWriter;
 
-    // the original file AST from Sorbet
-    ast::ParsedFile tree;
+    // the file that was parsed
+    core::FileRef file;
     // the checksum of this file
     uint32_t cksum;
     // the path on disk to this file

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -268,7 +268,7 @@ string MsgpackWriterFull::pack(core::Context ctx, ParsedFile &pf, const AutogenC
     {
         MsgpackArray headerArray(&writer, pfAttrs.size());
 
-        uint32_t value = strictLevelToInt(pf.tree.file.data(ctx).strictLevel);
+        uint32_t value = strictLevelToInt(pf.file.data(ctx).strictLevel);
         mpack_write_u32(&writer, value);
 
         mpack_write_u32(&writer, pf.refs.size());

--- a/main/autogen/data/msgpack_lite.cc
+++ b/main/autogen/data/msgpack_lite.cc
@@ -139,7 +139,7 @@ string MsgpackWriterLite::pack(core::Context ctx, ParsedFile &pf, const AutogenC
         MsgpackArray attributes(&writer, pfAttrs.size());
 
         if (version >= 7) {
-            uint32_t value = strictLevelToInt(pf.tree.file.data(ctx).strictLevel);
+            uint32_t value = strictLevelToInt(pf.file.data(ctx).strictLevel);
             mpack_write_u32(&writer, value);
         }
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -260,7 +260,7 @@ void runAutogen(core::GlobalState &gs, options::Options &opts, WorkerPool &worke
 
                     core::Context ctx(gs, core::Symbols::root(), tree.file);
                     auto pf = autogen::Autogen::generate(ctx, move(tree), autogenCfg, *crcBuilder);
-                    tree = move(pf.tree);
+                    auto file = pf.file;
 
                     AutogenResult::Serialized serialized;
 
@@ -273,7 +273,7 @@ void runAutogen(core::GlobalState &gs, options::Options &opts, WorkerPool &worke
                         serialized.msgpack = pf.toMsgpack(ctx, autogenVersion, autogenCfg);
                     }
 
-                    if (!tree.file.data(gs).isRBI()) {
+                    if (!file.data(gs).isRBI()) {
                         // Exclude RBI files because they are not loadable and should not appear in
                         // auto-loader related output.
                         if (opts.print.AutogenSubclasses.enabled) {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -421,7 +421,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 for (auto &tree : trees) {
                     core::Context ctx(*gs, core::Symbols::root(), tree.file);
                     auto pf = autogen::Autogen::generate(ctx, move(tree), autogen::AutogenConfig{{}}, *crcBuilder);
-                    tree = move(pf.tree);
                     payload << pf.toString(ctx, autogen::AutogenVersion::MAX_VERSION);
                 }
                 return payload.str();


### PR DESCRIPTION
We can free the trees given to autogen as soon as they're walked, which will make room for the string/msgpack allocations to follow.

We can also cut out 8 bytes from the `Reference` type by reorganizing fields to pack a bit better.

### Motivation
Improving autogen memory usage.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Shouldn't change existing behavior.
