### PR TITLE
Use the ArgInfo::loc instead of the MethodDef::declLoc for type mismatches

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -139,19 +139,18 @@ void matchPositional(const core::Context ctx, core::TypeConstraint &constr,
     auto maxLen = min(superArgs.size(), methodArgs.size());
 
     while (idx < maxLen) {
-        auto &superArgType = superArgs[idx].get().type;
-        auto &methodArgType = methodArgs[idx].get().type;
+        auto &superArg = superArgs[idx].get();
+        auto &methodArg = methodArgs[idx].get();
 
         core::ErrorSection::Collector errorDetailsCollector;
-        if (!checkSubtype(ctx, constr, methodArgType, method, superArgType, superMethod, core::Polarity::Negative,
+        if (!checkSubtype(ctx, constr, methodArg.type, method, superArg.type, superMethod, core::Polarity::Negative,
                           errorDetailsCollector)) {
-            if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
+            if (auto e = ctx.state.beginError(methodArg.loc, core::errors::Resolver::BadMethodOverride)) {
                 e.setHeader("Parameter `{}` of type `{}` not compatible with type of {} method `{}`",
-                            methodArgs[idx].get().show(ctx), methodArgType.show(ctx), superMethodKind(ctx, superMethod),
-                            superMethod.show(ctx));
-                e.addErrorLine(superMethod.data(ctx)->loc(),
-                               "The super method parameter `{}` was declared here with type `{}`",
-                               superArgs[idx].get().show(ctx), superArgType.show(ctx));
+                            methodArgs[idx].get().show(ctx), methodArg.type.show(ctx),
+                            superMethodKind(ctx, superMethod), superMethod.show(ctx));
+                e.addErrorLine(superArg.loc, "The super method parameter `{}` was declared here with type `{}`",
+                               superArgs[idx].get().show(ctx), superArg.type.show(ctx));
                 e.addErrorNote(
                     "A parameter's type must be a supertype of the same parameter's type on the super method.");
                 e.addErrorSections(move(errorDetailsCollector));
@@ -287,11 +286,12 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
                 core::ErrorSection::Collector errorDetailsCollector;
                 if (!checkSubtype(ctx, *constr, corresponding->get().type, method, req.get().type, superMethod,
                                   core::Polarity::Negative, errorDetailsCollector)) {
-                    if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
+                    if (auto e =
+                            ctx.state.beginError(corresponding->get().loc, core::errors::Resolver::BadMethodOverride)) {
                         e.setHeader("Keyword parameter `{}` of type `{}` not compatible with type of {} method `{}`",
                                     corresponding->get().show(ctx), corresponding->get().type.show(ctx),
                                     superMethodKind(ctx, superMethod), superMethod.show(ctx));
-                        e.addErrorLine(superMethod.data(ctx)->loc(),
+                        e.addErrorLine(req.get().loc,
                                        "The corresponding parameter `{}` was declared here with type `{}`",
                                        req.get().show(ctx), req.get().type.show(ctx));
                         e.addErrorNote(
@@ -318,11 +318,12 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
                 core::ErrorSection::Collector errorDetailsCollector;
                 if (!checkSubtype(ctx, *constr, corresponding->get().type, method, opt.get().type, superMethod,
                                   core::Polarity::Negative, errorDetailsCollector)) {
-                    if (auto e = ctx.beginError(methodDef.declLoc, core::errors::Resolver::BadMethodOverride)) {
+                    if (auto e =
+                            ctx.state.beginError(corresponding->get().loc, core::errors::Resolver::BadMethodOverride)) {
                         e.setHeader("Keyword parameter `{}` of type `{}` not compatible with type of {} method `{}`",
                                     corresponding->get().show(ctx), corresponding->get().type.show(ctx),
                                     superMethodKind(ctx, superMethod), superMethod.show(ctx));
-                        e.addErrorLine(superMethod.data(ctx)->loc(),
+                        e.addErrorLine(opt.get().loc,
                                        "The super method parameter `{}` was declared here with type `{}`",
                                        opt.get().show(ctx), opt.get().type.show(ctx));
                         e.addErrorNote(

--- a/test/cli/detailed-errors-completeness/test.out
+++ b/test/cli/detailed-errors-completeness/test.out
@@ -43,34 +43,34 @@ test.rb:99: The `lower` type bound `[Upper]` is not a subtype of the `upper` typ
   Detailed explanation:
     `Upper` is not a subtype of `Lower` for index `0` of `1`-tuple
 
-test.rb:68: Parameter `x` of type `[String]` not compatible with type of overridable method `A#foo` https://srb.help/5035
-    68 |  def foo(x, y:, z: [''], &blk)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test.rb:50: The super method parameter `x` was declared here with type `[Integer]`
-    50 |  def foo(x, y:, z: [1], &blk)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+test.rb:67: Parameter `x` of type `[String]` not compatible with type of overridable method `A#foo` https://srb.help/5035
+    67 |  sig { override.params(x: [String], y: [String], z: [String], blk: T.proc.returns([String])).returns([String]) }
+                                ^
+    test.rb:49: The super method parameter `x` was declared here with type `[Integer]`
+    49 |  sig { overridable.params(x: [Integer], y: [Integer], z: [Integer], blk: T.proc.returns([Integer])).returns([Integer]) }
+                                   ^
   Note:
     A parameter's type must be a supertype of the same parameter's type on the super method.
   Detailed explanation:
     `Integer` is not a subtype of `String` for index `0` of `1`-tuple
 
-test.rb:68: Keyword parameter `y` of type `[String]` not compatible with type of overridable method `A#foo` https://srb.help/5035
-    68 |  def foo(x, y:, z: [''], &blk)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test.rb:50: The corresponding parameter `y` was declared here with type `[Integer]`
-    50 |  def foo(x, y:, z: [1], &blk)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+test.rb:67: Keyword parameter `y` of type `[String]` not compatible with type of overridable method `A#foo` https://srb.help/5035
+    67 |  sig { override.params(x: [String], y: [String], z: [String], blk: T.proc.returns([String])).returns([String]) }
+                                             ^
+    test.rb:49: The corresponding parameter `y` was declared here with type `[Integer]`
+    49 |  sig { overridable.params(x: [Integer], y: [Integer], z: [Integer], blk: T.proc.returns([Integer])).returns([Integer]) }
+                                                 ^
   Note:
     A parameter's type must be a supertype of the same parameter's type on the super method.
   Detailed explanation:
     `Integer` is not a subtype of `String` for index `0` of `1`-tuple
 
-test.rb:68: Keyword parameter `z` of type `[String]` not compatible with type of overridable method `A#foo` https://srb.help/5035
-    68 |  def foo(x, y:, z: [''], &blk)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test.rb:50: The super method parameter `z` was declared here with type `[Integer]`
-    50 |  def foo(x, y:, z: [1], &blk)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+test.rb:67: Keyword parameter `z` of type `[String]` not compatible with type of overridable method `A#foo` https://srb.help/5035
+    67 |  sig { override.params(x: [String], y: [String], z: [String], blk: T.proc.returns([String])).returns([String]) }
+                                                          ^
+    test.rb:49: The super method parameter `z` was declared here with type `[Integer]`
+    49 |  sig { overridable.params(x: [Integer], y: [Integer], z: [Integer], blk: T.proc.returns([Integer])).returns([Integer]) }
+                                                               ^
   Note:
     A parameter's type must be a supertype of the same parameter's type on the super method.
   Detailed explanation:

--- a/test/testdata/infer/generic_class_overrides.rb
+++ b/test/testdata/infer/generic_class_overrides.rb
@@ -66,17 +66,20 @@ class Child < Parent
   sig {override.params(x: T.nilable(Elem)).void}
   def example_params_1(x); end
   sig {override.params(x: T.all(Elem, Kernel)).void}
-  def example_params_2(x); end # error: Parameter `x` of type `T.all(Kernel, Child::Elem)` not compatible with type of abstract method `Parent#example_params_2`
+  #                    ^ error: Parameter `x` of type `T.all(Kernel, Child::Elem)` not compatible with type of abstract method `Parent#example_params_2`
+  def example_params_2(x); end
 
   sig {override.params(f: T.proc.params(x: T.nilable(Elem)).void).void}
-  def example_proc_1(f); end # error: Parameter `f` of type `T.proc.params(arg0: T.nilable(Child::Elem)).void` not compatible with type of abstract method `Parent#example_proc_1`
+  #                    ^ error: Parameter `f` of type `T.proc.params(arg0: T.nilable(Child::Elem)).void` not compatible with type of abstract method `Parent#example_proc_1`
+  def example_proc_1(f); end
   sig {override.params(f: T.proc.params(x: T.all(Elem, Kernel)).void).void}
   def example_proc_2(f); end
 
   sig {override.params(f: T.proc.returns(T.nilable(Elem))).void}
   def example_proc_returns_1(f); end
   sig {override.params(f: T.proc.returns(T.all(Elem, Kernel))).void}
-  def example_proc_returns_2(f); end # error: Parameter `f` of type `T.proc.returns(T.all(Kernel, Child::Elem))` not compatible with type of abstract method `Parent#example_proc_returns_2`
+  #                    ^ error: Parameter `f` of type `T.proc.returns(T.all(Kernel, Child::Elem))` not compatible with type of abstract method `Parent#example_proc_returns_2`
+  def example_proc_returns_2(f); end
 
   sig {override.params(f: T.proc.params(x: T.nilable(Elem)).void).void}
   def example_block_1(&f); end # error: Block parameter `f` of type `T.proc.params(arg0: T.nilable(Child::Elem)).void` not compatible with type of abstract method `Parent#example_block_1`
@@ -93,17 +96,20 @@ class Child < Parent
   sig {override.params(x: Kernel).void}
   def example_params_all_2(x); end
   sig {override.params(x: Integer).void}
-  def example_params_all_3(x); end # error: Parameter `x` of type `Integer` not compatible with type of abstract method `Parent#example_params_all_3`
+  #                    ^ error: Parameter `x` of type `Integer` not compatible with type of abstract method `Parent#example_params_all_3`
+  def example_params_all_3(x); end
 
   sig {override.type_parameters(:U).params(x: T.any(T.type_parameter(:U), Integer)).void}
   def example_type_param_1(x); end
   sig {override.type_parameters(:U).params(x: Integer).void}
-  def example_type_param_2(x); end # error: Parameter `x` of type `Integer` not compatible with type of abstract method `Parent#example_type_param_2`
+  #                                        ^ error: Parameter `x` of type `Integer` not compatible with type of abstract method `Parent#example_type_param_2`
+  def example_type_param_2(x); end
 
   sig {override.type_parameters(:U).params(x: T.any(Kernel, T.type_parameter(:U))).void}
   def example_type_param_child_1(x); end
   sig {override.type_parameters(:U).params(x: T.all(Kernel, T.type_parameter(:U))).void}
-  def example_type_param_child_2(x); end # error: Parameter `x` of type `T.all(Kernel, T.type_parameter(:U))` not compatible with type of abstract method `Parent#example_type_param_child_2`
+  #                                        ^ error: Parameter `x` of type `T.all(Kernel, T.type_parameter(:U))` not compatible with type of abstract method `Parent#example_type_param_child_2`
+  def example_type_param_child_2(x); end
 end
 
 module Runnable

--- a/test/testdata/infer/generic_method_overrides.rb
+++ b/test/testdata/infer/generic_method_overrides.rb
@@ -64,10 +64,10 @@ class ChildBad < Parent
     override
       .type_parameters(:W)
       .params(x: T.all(T.type_parameter(:W), IFoo))
+  #           ^ error: Parameter `x` of type `T.all(IFoo, T.type_parameter(:W))` not compatible with type of overridable method `Parent#id`
       .returns(T.nilable(T.type_parameter(:W)))
   end
   def id(x); x; end
-# ^^^^^^^^^ error: Parameter `x` of type `T.all(IFoo, T.type_parameter(:W))` not compatible with type of overridable method `Parent#id`
 # ^^^^^^^^^ error: Return type `T.nilable(T.type_parameter(:W))` does not match return type of overridable method `Parent#id`
 
   sig do
@@ -75,13 +75,13 @@ class ChildBad < Parent
       .type_parameters(:W)
       .params(
         x: T.all(T.type_parameter(:W), IFoo),
+  #     ^ error: Parameter `x` of type `T.all(IFoo, T.type_parameter(:W))` not compatible with type of overridable method `Parent#apply_f`
         f: T.proc.params(x: T.nilable(T.type_parameter(:W))).void
+  #     ^ error: Parameter `f` of type `T.proc.params(arg0: T.nilable(T.type_parameter(:W))).void` not compatible with type of overridable method `Parent#apply_f`
       )
       .void
   end
   def apply_f(x, f)
-# ^^^^^^^^^^^^^^^^^ error: Parameter `x` of type `T.all(IFoo, T.type_parameter(:W))` not compatible with type of overridable method `Parent#apply_f`
-# ^^^^^^^^^^^^^^^^^ error: Parameter `f` of type `T.proc.params(arg0: T.nilable(T.type_parameter(:W))).void` not compatible with type of overridable method `Parent#apply_f`
     f.call(x)
   end
 end
@@ -115,12 +115,12 @@ class ChildApplyFWrongOrder < ParentApplyFWrongOrder
       .type_parameters(:U, :V)
       .params(
         x: T.type_parameter(:V),
+  #     ^ error: Parameter `x` of type `T.type_parameter(:V)` not compatible with type of overridable method `ParentApplyFWrongOrder#apply_f`
         f: T.proc.params(x: T.type_parameter(:V)).returns(T.type_parameter(:U)),
+  #     ^ error: Parameter `f` of type `T.proc.params(arg0: T.type_parameter(:V)).returns(T.type_parameter(:U))` not compatible with type of overridable method `ParentApplyFWrongOrder#apply_f`
       )
       .returns(T.type_parameter(:U))
   end
   def apply_f(x, f); f.call(x); end
-# ^^^^^^^^^^^^^^^^^ error: Parameter `x` of type `T.type_parameter(:V)` not compatible with type of overridable method `ParentApplyFWrongOrder#apply_f`
-# ^^^^^^^^^^^^^^^^^ error: Parameter `f` of type `T.proc.params(arg0: T.type_parameter(:V)).returns(T.type_parameter(:U))` not compatible with type of overridable method `ParentApplyFWrongOrder#apply_f`
 # ^^^^^^^^^^^^^^^^^ error: Return type `T.type_parameter(:U)` does not match return type of overridable method `ParentApplyFWrongOrder#apply_f`
 end

--- a/test/testdata/resolver/abstract_types.rb
+++ b/test/testdata/resolver/abstract_types.rb
@@ -17,22 +17,26 @@ module NonMatchingTests
 
   class BadPos < Abstract
     sig { override.params(req: String, opt: Integer, kwreq: Integer, kwopt: Integer).returns(Integer) }
-    def foo(req, opt=1, kwreq:, kwopt: 2); 55; end # error: Parameter `req` of type `String` not compatible with type of abstract method `Abstract#foo`
+    #                     ^^^ error: Parameter `req` of type `String` not compatible with type of abstract method `Abstract#foo`
+    def foo(req, opt=1, kwreq:, kwopt: 2); 55; end
   end
 
   class BadOptPos < Abstract
     sig { override.params(req: Integer, opt: String, kwreq: Integer, kwopt: Integer).returns(Integer) }
-    def foo(req, opt='foo', kwreq:, kwopt: 2); 55; end # error: Parameter `opt` of type `String` not compatible with type of abstract method `Abstract#foo`
+    #                                   ^^^ error: Parameter `opt` of type `String` not compatible with type of abstract method `Abstract#foo`
+    def foo(req, opt='foo', kwreq:, kwopt: 2); 55; end
   end
 
   class BadKw < Abstract
     sig { override.params(req: Integer, opt: Integer, kwreq: String, kwopt: Integer).returns(Integer) }
-    def foo(req, opt=1, kwreq:, kwopt: 2); 55; end # error: Keyword parameter `kwreq` of type `String` not compatible with type of abstract method `Abstract#foo`
+    #                                                 ^^^^^ error: Keyword parameter `kwreq` of type `String` not compatible with type of abstract method `Abstract#foo`
+    def foo(req, opt=1, kwreq:, kwopt: 2); 55; end
   end
 
   class BadKwOpt < Abstract
     sig { override.params(req: Integer, opt: Integer, kwreq: Integer, kwopt: String).returns(Integer) }
-    def foo(req, opt=1, kwreq:, kwopt: 'bar'); 55; end # error: Keyword parameter `kwopt` of type `String` not compatible with type of abstract method `Abstract#foo`
+    #                                                                 ^^^^^ error: Keyword parameter `kwopt` of type `String` not compatible with type of abstract method `Abstract#foo`
+    def foo(req, opt=1, kwreq:, kwopt: 'bar'); 55; end
   end
 
   class BadReturn < Abstract
@@ -71,7 +75,8 @@ module OverrideVarianceTests
   # but an implementation cannot reasonably accept a subtype
   class ArgNarrowing < Abstract
     sig { override.params(arg: C).returns(B) }
-    def bar(arg); B.new; end # error: Parameter `arg` of type `OverrideVarianceTests::C` not compatible with type of overridable method `OverrideVarianceTests::Abstract#bar`
+    #                     ^^^ error: Parameter `arg` of type `OverrideVarianceTests::C` not compatible with type of overridable method `OverrideVarianceTests::Abstract#bar`
+    def bar(arg); B.new; end
   end
 
   # methods are covariant in their return types, so an implementation
@@ -131,7 +136,8 @@ module AbstractVarianceTests
     include IFace
     extend T::Sig
     sig { override.params(arg: C).returns(B) }
-    def bar(arg); B.new; end # error: Parameter `arg` of type `AbstractVarianceTests::C` not compatible with type of abstract method `AbstractVarianceTests::IFace#bar`
+    #                     ^^^ error: Parameter `arg` of type `AbstractVarianceTests::C` not compatible with type of abstract method `AbstractVarianceTests::IFace#bar`
+    def bar(arg); B.new; end
   end
 
   # methods are covariant in their return types, so an implementation


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This shows the errors for override checking in a slightly different spot. Given
that we're talking about the mismatched parameter types, it makes a little more
sense to show the actual definition of the type in the error message.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Some of the tests change, but the error locations all move from the
`MethodDef::declLoc` to where the parameter is defined in the `sig`, like we'd
expect.