### PR TITLE
RBS: Better autocorrect for abstract methods

### DIFF
--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -77,7 +77,7 @@ bool isRaise(parser::Node *node) {
 core::AutocorrectSuggestion autocorrectAbstractBody(core::MutableContext ctx, parser::Node *method,
                                                     core::LocOffsets method_declLoc, parser::Node *method_body) {
     core::LocOffsets editLoc;
-    string corrected = "raise \"abstract method called\"";
+    string corrected = "raise \"Abstract method called\"";
 
     auto lineStart = core::Loc::pos2Detail(ctx.file.data(ctx), method_declLoc.endPos()).line;
     auto lineEnd = core::Loc::pos2Detail(ctx.file.data(ctx), method->loc.endPos()).line;

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -77,21 +77,22 @@ bool isRaise(parser::Node *node) {
 core::AutocorrectSuggestion autocorrectAbstractBody(core::MutableContext ctx, parser::Node *method,
                                                     core::LocOffsets method_declLoc, parser::Node *method_body) {
     core::LocOffsets editLoc;
-    string corrected = "raise \"Abstract method called\"";
+    string corrected;
 
     auto lineStart = core::Loc::pos2Detail(ctx.file.data(ctx), method_declLoc.endPos()).line;
     auto lineEnd = core::Loc::pos2Detail(ctx.file.data(ctx), method->loc.endPos()).line;
 
     if (method_body) {
         editLoc = method_body->loc;
+        corrected = "raise \"Abstract method called\"";
     } else if (lineStart == lineEnd) {
-        editLoc = method_declLoc.copyEndWithZeroLength();
-        corrected = "; " + corrected;
+        editLoc = method_declLoc.copyEndWithZeroLength().join(method->loc.copyEndWithZeroLength());
+        corrected = " = raise(\"Abstract method called\")";
     } else {
         editLoc = method_declLoc.copyEndWithZeroLength();
         auto [_endLoc, indentLength] = ctx.locAt(method->loc).findStartOfIndentation(ctx);
         string indent(indentLength + 2, ' ');
-        corrected = "\n" + indent + corrected;
+        corrected = "\n" + indent + "raise \"Abstract method called\"";
     }
 
     return core::AutocorrectSuggestion{fmt::format("Add `raise` to the method body"),

--- a/test/testdata/rbs/signatures_defs_abstract_autocorrect.autocorrects.exp
+++ b/test/testdata/rbs/signatures_defs_abstract_autocorrect.autocorrects.exp
@@ -6,7 +6,7 @@
 class Abstract
   # @abstract
   #: -> void
-  def foo; raise "Abstract method called"; end # error: Methods declared @abstract with an RBS comment must always raise
+  def foo = raise("Abstract method called") # error: Methods declared @abstract with an RBS comment must always raise
 
   # @abstract
   #: -> void
@@ -26,9 +26,9 @@ class Abstract
     raise "Abstract method called"
   end
 
-    # @abstract
+  # @abstract
   #: -> void
-  def self.foo; raise "Abstract method called"; end # error: Methods declared @abstract with an RBS comment must always raise
+  def self.foo = raise("Abstract method called") # error: Methods declared @abstract with an RBS comment must always raise
 
   # @abstract
   #: -> void

--- a/test/testdata/rbs/signatures_defs_abstract_autocorrect.autocorrects.exp
+++ b/test/testdata/rbs/signatures_defs_abstract_autocorrect.autocorrects.exp
@@ -6,46 +6,46 @@
 class Abstract
   # @abstract
   #: -> void
-  def foo; raise "abstract method called"; end # error: Methods declared @abstract with an RBS comment must always raise
+  def foo; raise "Abstract method called"; end # error: Methods declared @abstract with an RBS comment must always raise
 
   # @abstract
   #: -> void
   def bar
-    raise "abstract method called" # error: Methods declared @abstract with an RBS comment must always raise
+    raise "Abstract method called" # error: Methods declared @abstract with an RBS comment must always raise
   end
 
   # @abstract
   #: -> void
   def baz # error: Methods declared @abstract with an RBS comment must always raise
-    raise "abstract method called" # error: Abstract methods must not contain any code in their body
+    raise "Abstract method called" # error: Abstract methods must not contain any code in their body
   end
 
   # @abstract
   #: -> void
   def qux # error: Methods declared @abstract with an RBS comment must always raise
-    raise "abstract method called"
+    raise "Abstract method called"
   end
 
     # @abstract
   #: -> void
-  def self.foo; raise "abstract method called"; end # error: Methods declared @abstract with an RBS comment must always raise
+  def self.foo; raise "Abstract method called"; end # error: Methods declared @abstract with an RBS comment must always raise
 
   # @abstract
   #: -> void
   def self.bar
-    raise "abstract method called" # error: Methods declared @abstract with an RBS comment must always raise
+    raise "Abstract method called" # error: Methods declared @abstract with an RBS comment must always raise
   end
 
   # @abstract
   #: -> void
   def self.baz # error: Methods declared @abstract with an RBS comment must always raise
-    raise "abstract method called" # error: Abstract methods must not contain any code in their body
+    raise "Abstract method called" # error: Abstract methods must not contain any code in their body
   end
 
   # @abstract
   #: -> void
   def self.qux # error: Methods declared @abstract with an RBS comment must always raise
-    raise "abstract method called"
+    raise "Abstract method called"
   end
 end
 # ------------------------------

--- a/test/testdata/rbs/signatures_defs_abstract_autocorrect.rb
+++ b/test/testdata/rbs/signatures_defs_abstract_autocorrect.rb
@@ -25,7 +25,7 @@ class Abstract
     puts
   end
 
-    # @abstract
+  # @abstract
   #: -> void
   def self.foo; end # error: Methods declared @abstract with an RBS comment must always raise
 


### PR DESCRIPTION
### Motivation

Follow up to https://github.com/sorbet/sorbet/pull/8982.

We can provide a better syntax when the method had no body.

Original code
```rb
  # @abstract
  #: -> void
  def bar; end # error: Methods declared @abstract with an RBS comment must always raise
```

Autocorrect before:
```rb
  # @abstract
  #: -> void
  def bar; raise "Abstract method called"; end
```

Autocorrect after:
```rb
  # @abstract
  #: -> void
  def bar = raise("Abstract method called")
```

Also addressed https://github.com/sorbet/sorbet/pull/8982#discussion_r2143832004.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
