### PR TITLE
Free inputFileNames after initialization

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -541,6 +541,10 @@ int realmain(int argc, char *argv[]) {
 
         inputFiles = pipeline::reserveFiles(*gs, opts.inputFileNames);
 
+        // We explicitly free the input names here, as we won't use them for the remainder of execution, and on large
+        // codebases they take up a non-trivial amount of memory.
+        opts.inputFileNames = vector<string>();
+
         {
             core::UnfreezeFileTable fileTableAccess(*gs);
             if (!opts.inlineInput.empty()) {
@@ -674,7 +678,7 @@ int realmain(int argc, char *argv[]) {
             auto id = 0;
             for (auto &file : gs->getFiles().subspan(1)) {
                 id++;
-                if (file->isStdlib()) {
+                if (file->isPayload()) {
                     continue;
                 }
                 if (file->minErrorLevel() <= core::StrictLevel::Ignore) {


### PR DESCRIPTION
We don't use the `inputFileNames` after initialization, so let's free that memory.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Reducing memory usage.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Should not affect existing behavior.
