### PR TITLE
Fix `Time#+` and `Time#-` rbi signatures

### DIFF
--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -336,7 +336,7 @@ class Time < Object
   # ```
   sig do
     params(
-        arg0: BasicObject,
+        arg0: T.any(Integer, Float, Rational),
     )
     .returns(Time)
   end
@@ -361,7 +361,7 @@ class Time < Object
   end
   sig do
     params(
-        arg0: BasicObject,
+        arg0: T.any(Integer, Float, Rational),
     )
     .returns(Time)
   end

--- a/test/testdata/rbi/time.rb
+++ b/test/testdata/rbi/time.rb
@@ -2,3 +2,25 @@
 Time.at(1)
 Time.at(Time.now)
 Time.at(0, 1589855340108, :milliseconds)
+
+Time.now + 1
+Time.now + 1.0
+Time.now + 1.0r
+
+Time.now + nil
+#          ^^^ error: Expected `T.any(Integer, Float, Rational)` but found `NilClass` for argument `arg0`
+Time.now + "foo"
+#          ^^^^^ error: Expected `T.any(Integer, Float, Rational)` but found `String("foo")` for argument `arg0`
+
+Time.now - 1
+Time.now - 1.0
+Time.now - 1.0r
+
+t1 = Time.now
+t2 = t1 - 10
+t1 - t2
+
+Time.now - nil
+#          ^^^ error: Expected `Time` but found `NilClass` for argument `arg0`
+Time.now - "foo"
+#          ^^^^^ error: Expected `Time` but found `String("foo")` for argument `arg0`


### PR DESCRIPTION
### Motivation

Both `Time#+` and `Time#-` (which underneath both depend on the `time_add0` C function) performs the [`num_exact_check`](https://github.com/ruby/ruby/blob/32737f8a1728e2d3841f24cbf17f799abd29251a/time.c#L521-L561) check on the argument. If we look at the implementation of `num_exact_check`, we can see that it only passes if the argument is either:

- `Integer`, `Float`, or `Rational`
  - It doesn't accept `Complex` so we can't use `Numeric`
- Objects with `to_int` methods that return the above types
  - I don't believe this is possible to type atm?

So the current signatures' expected type `BasicObject` is not correct. For example, passing `nil` or `String` will raise a `TypeError`.

```
$ ruby -e 'puts Time.now - nil'
-e:1:in `-': can't convert NilClass into an exact number (TypeError)
        from -e:1:in `<main>'
$ ruby -e 'puts Time.now - "foo"'
-e:1:in `-': can't convert String into an exact number (TypeError)
        from -e:1:in `<main>'
$ ruby -e 'puts Time.now - Object.new'
-e:1:in `-': can't convert Object into an exact number (TypeError)
        from -e:1:in `<main>'
```

This change should make the rbis more correct.


### Test plan

Added new cases to `test/testdata/rbi/time.rb`
