### PR TITLE
RBS: Fix comment association inside setter sends

### DIFF
--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -484,14 +484,8 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
             send->receiver = maybeInsertCast(move(send->receiver));
             send->receiver = rewriteNode(move(send->receiver));
 
-            if (send->method == core::Names::squareBracketsEq()) {
-                // This is a `foo[key]=(y)` method, walk y for chained method calls
+            if (send->method == core::Names::squareBracketsEq() || send->method.isSetter(ctx.state)) {
                 send->args.back() = rewriteNode(move(send->args.back()));
-                result = move(node);
-                return;
-            } else if (send->method.isSetter(ctx.state) && send->args.size() == 1) {
-                // This is a `foo.x=(y)` method, we treat it as a `x = y` assignment
-                send->args[0] = maybeInsertCast(move(send->args[0]));
                 result = move(node);
                 return;
             }

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -568,15 +568,12 @@ void CommentsAssociator::walkNode(parser::Node *node) {
                 auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
                 consumeCommentsBetweenLines(beginLine, endLine, "send");
             } else {
-                if (send->method == core::Names::squareBracketsEq()) {
-                    // This is a `foo[key]=(y)` method, walk y for chained method calls
+                if (send->method == core::Names::squareBracketsEq() || send->method.isSetter(ctx.state)) {
+                    // This is an assign through a send, either: `foo[key]=(y)` or `foo.x=(y)`
+                    // Note: the parser transforms `foo.x = 1, 2` into `foo.x= [1, 2]` so we always have at most one arg
                     walkNode(send->args.back().get());
                     walkNode(send->receiver.get());
-                    return;
-                } else if (send->method.isSetter(ctx.state) && send->args.size() == 1) {
-                    // This is a `foo.x=(y)` method, we treat it as a `x = y` assignment
-                    associateAssertionCommentsToNode(send->args[0].get());
-                    walkNode(send->receiver.get());
+                    consumeCommentsInsideNode(node, "send");
                     return;
                 }
                 associateAssertionCommentsToNode(send);

--- a/test/testdata/rbs/assertions_send_assign.rb
+++ b/test/testdata/rbs/assertions_send_assign.rb
@@ -23,6 +23,18 @@ let3 = Let.new
 let3.foo.foo = "foo", "bar" #: Array[String]
 T.reveal_type(let3.foo) # error: Revealed type: `T.untyped`
 
+let4 = Let.new
+let4.foo = puts(
+  [], #: untyped
+)
+T.reveal_type(let4.foo) # error: Revealed type: `T.untyped`
+
+let5 = Let.new
+let5.foo = puts(
+  *[], #: untyped
+)
+T.reveal_type(let5.foo) # error: Revealed type: `T.untyped`
+
 class BracketsAssign
   #: (*untyped) -> void
   def []=(*args); end
@@ -41,6 +53,15 @@ brackets_assign[:a, :b] = "baz" #: as untyped
 
 brackets_assign[:a, :b, :c] = "qux" #: as untyped
   .unexisting_method
+
+brackets_assign[:a, :b] =
+  "bar",
+  "foo" #: as untyped
+
+brackets_assign[:a, :b] =
+  "bar",
+  "foo" #: as untyped
+    .unexisting_method
 
 self #: as untyped
   .unexisting_method = 42

--- a/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_send_assign.rb.rewrite-tree.exp
@@ -39,6 +39,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <emptyTree>::<C T>.reveal_type(let3.foo())
 
+  let4 = <emptyTree>::<C Let>.new()
+
+  let4.foo=(<self>.puts(<cast:let>([], <todo sym>, ::<root>::<C T>.untyped())))
+
+  <emptyTree>::<C T>.reveal_type(let4.foo())
+
+  let5 = <emptyTree>::<C Let>.new()
+
+  let5.foo=(::<Magic>.<call-with-splat>(<self>, :puts, ::<Magic>.<splat>(<cast:let>([], <todo sym>, ::<root>::<C T>.untyped())), nil))
+
+  <emptyTree>::<C T>.reveal_type(let5.foo())
+
   class <emptyTree>::<C BracketsAssign><<C <todo sym>>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.params(:args, ::<root>::<C T>.untyped()).void()
@@ -60,6 +72,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   brackets_assign.[]=(:a, :b, ::<root>::<C T>.unsafe("baz").unexisting_method())
 
   brackets_assign.[]=(:a, :b, :c, ::<root>::<C T>.unsafe("qux").unexisting_method())
+
+  brackets_assign.[]=(:a, :b, ::<root>::<C T>.unsafe(["bar", "foo"]))
+
+  brackets_assign.[]=(:a, :b, ["bar", ::<root>::<C T>.unsafe("foo").unexisting_method()])
 
   ::<root>::<C T>.unsafe(<self>).unexisting_method=(42)
 end


### PR DESCRIPTION
### Motivation

When passing a send to a setter call, we were not descending inside the send node thus not associating the RBS comment found inside.

This:

```rb
x.foo = puts(
  *[], #: untyped
)
```

Is now properly translated as:

```rb
x.foo = puts(
  *T.unsafe([]),
)
```

We can also simplify the cases for a bracket assign and a setter assign as they are handled the same.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
