### PR TITLE
RBS: add a test case for super

### DIFF
--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -649,8 +649,8 @@ void CommentsAssociator::walkNode(parser::Node *node) {
             consumeCommentsInsideNode(node, "splat");
         },
         [&](parser::Super *super_) {
-            walkNodes(super_->args);
             associateAssertionCommentsToNode(node);
+            walkNodes(super_->args);
             consumeCommentsInsideNode(node, "super");
         },
         [&](parser::Until *until) {

--- a/test/testdata/rbs/assertions_super.rb
+++ b/test/testdata/rbs/assertions_super.rb
@@ -31,3 +31,12 @@ class Baz < Foo
     )
   end
 end
+
+class Qux < Foo
+  # @override
+  #: (Integer, String) -> String
+  def foo(x, y)
+    super(ARGV.first, ARGV.last) #: as Integer
+    #                                  ^^^^^^^ error: Expected `String` but found `Integer` for method result type
+  end
+end

--- a/test/testdata/rbs/assertions_super.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_super.rb.rewrite-tree.exp
@@ -34,4 +34,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of foo>
   end
+
+  class <emptyTree>::<C Qux><<C <todo sym>>> < (<emptyTree>::<C Foo>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.override().params(:x, <emptyTree>::<C Integer>, :y, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+    end
+
+    def foo<<todo method>>(x, y, &<blk>)
+      <cast:cast>(<self>.<super>(<emptyTree>::<C ARGV>.first(), <emptyTree>::<C ARGV>.last()), <todo sym>, <emptyTree>::<C Integer>)
+    end
+
+    <runtime method definition of foo>
+  end
 end


### PR DESCRIPTION
### Motivation

Figured a test case was missing for `super` and it uncovered an edge case that wasn't covered by #8986.

We first need to associate the comment to the `super` call before descending on the arguments.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
