### PR TITLE
Add an rbi definition for Enumerator::Lazy#compact

### DIFF
--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -676,6 +676,13 @@ class Enumerator::Lazy < Enumerator
   end
   def collect_concat(&blk); end
 
+  # Like [`Enumerable#compact`](https://docs.ruby-lang.org/en/3.1/Enumerable.html#method-i-compact),
+  # but chains operation to be lazy-evaluated.
+  sig do
+    returns(T::Enumerator::Lazy[Elem])
+  end 
+  def compact; end
+
   # Like
   # [`Enumerable#drop`](https://docs.ruby-lang.org/en/2.7.0/Enumerable.html#method-i-drop),
   # but chains operation to be lazy-evaluated.


### PR DESCRIPTION
### Motivation

Enumerator::Lazy#compact was introduced in Ruby 3.1.

References:
- https://rubyreferences.github.io/rubychanges/3.1.html#enumerablecompact-and-enumeratorlazycompact
- https://docs.ruby-lang.org/en/3.1/Enumerator/Lazy.html#method-i-compact

### Test plan

I'm happy to validate anything in addition to existing tests if needed.