### PR TITLE
add missing hash substitution signature for `String#gsub!`

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -1405,6 +1405,13 @@ class String < Object
   sig do
     params(
         arg0: T.any(Regexp, String),
+        arg1: T::Hash[T.untyped, T.untyped],
+    )
+    .returns(String)
+  end
+  sig do
+    params(
+        arg0: T.any(Regexp, String),
         blk: T.proc.params(arg0: String).returns(BasicObject),
     )
     .returns(T.nilable(String))


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Noticed this when trying to make some changes in Stripe's codebase.

Yes, I know the sigils here are reversed, but proof that Ruby supports this:

```
irb(main):001> ec = {">" => "lt", "<" => "gt"}
=> {">"=>"lt", "<"=>"gt"}
irb(main):002> s = "<>"
=> "<>"
irb(main):003> s.gsub!(/[<>]/, ec)
=> "gtlt"
irb(main):004> s
=> "gtlt"
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
