### PR TITLE
RBS: Handle assertions inside attribute accessor sends 

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -257,12 +257,12 @@ unique_ptr<parser::Node> runRBSRewrite(core::GlobalState &gs, core::FileRef file
         core::UnfreezeNameTable nameTableAccess(gs);
 
         auto associator = rbs::CommentsAssociator(ctx, commentLocations);
-        auto commentsByNode = associator.run(node);
+        auto commentMap = associator.run(node);
 
-        auto sigsRewriter = rbs::SigsRewriter(ctx, commentsByNode);
+        auto sigsRewriter = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
         node = sigsRewriter.run(move(node));
 
-        auto assertionsRewriter = rbs::AssertionsRewriter(ctx, commentsByNode);
+        auto assertionsRewriter = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
         node = assertionsRewriter.run(move(node));
 
         if (print.RBSRewriteTree.enabled) {

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -540,10 +540,7 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
                 return;
             }
 
-            for (auto &expr : break_->exprs) {
-                expr = rewriteNode(move(expr));
-            }
-
+            rewriteNodes(&break_->exprs);
             break_->exprs = rewriteNodesAsArray(node, move(break_->exprs));
             result = move(node);
         },
@@ -553,10 +550,7 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
                 return;
             }
 
-            for (auto &expr : next->exprs) {
-                expr = rewriteNode(move(expr));
-            }
-
+            rewriteNodes(&next->exprs);
             next->exprs = rewriteNodesAsArray(node, move(next->exprs));
             result = move(node);
         },
@@ -566,10 +560,7 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
                 return;
             }
 
-            for (auto &expr : ret->exprs) {
-                expr = rewriteNode(move(expr));
-            }
-
+            rewriteNodes(&ret->exprs);
             ret->exprs = rewriteNodesAsArray(node, move(ret->exprs));
             result = move(node);
         },
@@ -663,9 +654,7 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
             result = move(node);
         },
         [&](parser::Super *super_) {
-            for (auto &expr : super_->args) {
-                expr = rewriteNode(move(expr));
-            }
+            rewriteNodes(&super_->args);
             result = maybeInsertCast(move(node));
         },
         [&](parser::Kwsplat *splat) {

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -475,20 +475,7 @@ unique_ptr<parser::Node> AssertionsRewriter::rewriteNode(unique_ptr<parser::Node
         // Sends
 
         [&](parser::Send *send) {
-            // Skip visibility sends and attr_accessor sends as their comments are not assertions
-            if (parser::MK::isVisibilitySend(send) || parser::MK::isAttrAccessorSend(send)) {
-                result = move(node);
-                return;
-            }
-
             send->receiver = rewriteNode(move(send->receiver));
-
-            if (send->method == core::Names::squareBracketsEq() || send->method.isSetter(ctx.state)) {
-                rewriteNodes(&send->args);
-                result = move(node);
-                return;
-            }
-
             node = maybeInsertCast(move(node));
             rewriteNodes(&send->args);
             result = move(node);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -620,11 +620,12 @@ void CommentsAssociator::walkNode(parser::Node *node) {
         [&](parser::Send *send) {
             if (parser::MK::isVisibilitySend(send)) {
                 associateSignatureCommentsToNode(send->args[0].get());
-                auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
-                auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
-                consumeCommentsBetweenLines(beginLine, endLine, "send");
+                consumeCommentsInsideNode(node, "send");
             } else if (parser::MK::isAttrAccessorSend(send)) {
                 associateSignatureCommentsToNode(send);
+                associateAssertionCommentsToNode(send);
+                walkNode(send->receiver.get());
+                walkNodes(send->args);
                 auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
                 auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
                 consumeCommentsBetweenLines(beginLine, endLine, "send");

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -14,12 +14,17 @@ struct CommentNode {
     std::string_view string;
 };
 
+struct CommentMap {
+    std::map<parser::Node *, std::vector<CommentNode>> signaturesForNode;
+    std::map<parser::Node *, std::vector<CommentNode>> assertionsForNode;
+};
+
 class CommentsAssociator {
 public:
     static const std::string_view RBS_PREFIX;
 
     CommentsAssociator(core::MutableContext ctx, std::vector<core::LocOffsets> commentLocations);
-    std::map<parser::Node *, std::vector<CommentNode>> run(std::unique_ptr<parser::Node> &tree);
+    CommentMap run(std::unique_ptr<parser::Node> &tree);
 
 private:
     static const std::string_view ANNOTATION_PREFIX;
@@ -29,7 +34,8 @@ private:
     core::MutableContext ctx;
     std::vector<core::LocOffsets> commentLocations;
     std::map<int, CommentNode> commentByLine;
-    std::map<parser::Node *, std::vector<CommentNode>> commentsByNode;
+    std::map<parser::Node *, std::vector<CommentNode>> signaturesForNode;
+    std::map<parser::Node *, std::vector<CommentNode>> assertionsForNode;
     std::vector<std::pair<bool, core::LocOffsets>> contextAllowingTypeAlias;
     int lastLine;
 

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -347,9 +347,6 @@ unique_ptr<parser::Node> SigsRewriter::replaceSyntheticTypeAlias(unique_ptr<pars
         Exception::raise("Multiple signatures found for synthetic type alias");
     }
 
-    // Consume the comments
-    commentsByNode.erase(commentsByNode.find(node.get()));
-
     auto aliasDeclaration = comments.signatures[0];
     auto typeBeginLoc = (uint32_t)aliasDeclaration.string.find("=");
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -242,12 +242,12 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
                 core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
                 core::MutableContext ctx(gs, core::Symbols::root(), file);
                 auto associator = rbs::CommentsAssociator(ctx, parseResult.commentLocations);
-                auto commentsByNode = associator.run(nodes);
+                auto commentMap = associator.run(nodes);
 
-                auto rbsSignatures = rbs::SigsRewriter(ctx, commentsByNode);
+                auto rbsSignatures = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
                 nodes = rbsSignatures.run(std::move(nodes));
 
-                auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentsByNode);
+                auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
                 nodes = rbsAssertions.run(std::move(nodes));
             }
 
@@ -685,12 +685,12 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
         if (gs->cacheSensitiveOptions.rbsEnabled) {
             auto associator = rbs::CommentsAssociator(ctx, parseResult.commentLocations);
-            auto commentsByNode = associator.run(parseResult.tree);
+            auto commentMap = associator.run(parseResult.tree);
 
-            auto rbsSignatures = rbs::SigsRewriter(ctx, commentsByNode);
+            auto rbsSignatures = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
             parseResult.tree = rbsSignatures.run(std::move(parseResult.tree));
 
-            auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentsByNode);
+            auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
             parseResult.tree = rbsAssertions.run(std::move(parseResult.tree));
         }
         auto nodes = move(parseResult.tree);

--- a/test/testdata/rbs/assertions_send.rb
+++ b/test/testdata/rbs/assertions_send.rb
@@ -46,3 +46,12 @@ ARGV. #: as Integer
 ARGV #: as Integer
  .first #: as String # error: Method `first` does not exist on `Integer`
  .last # error: Method `last` does not exist on `String`
+
+self. #: as untyped
+ attr_writer(
+   ARGV.first, #: as String # error: Argument to `attr_writer` must be a Symbol or String
+   ARGV.last, #: as Integer
+ )
+
+self #: as untyped
+  .attr_writer #: as String

--- a/test/testdata/rbs/assertions_send.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_send.rb.rewrite-tree.exp
@@ -28,4 +28,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <cast:cast>(<cast:cast>(<emptyTree>::<C ARGV>, <todo sym>, <emptyTree>::<C Integer>).first(), <todo sym>, <emptyTree>::<C Integer>)
 
   <cast:cast>(<cast:cast>(<emptyTree>::<C ARGV>, <todo sym>, <emptyTree>::<C Integer>).first(), <todo sym>, <emptyTree>::<C String>).last()
+
+  ::<root>::<C T>.unsafe(<self>).attr_writer(<cast:cast>(<emptyTree>::<C ARGV>.first(), <todo sym>, <emptyTree>::<C String>), <cast:cast>(<emptyTree>::<C ARGV>.last(), <todo sym>, <emptyTree>::<C Integer>))
+
+  <cast:cast>(::<root>::<C T>.unsafe(<self>).attr_writer(), <todo sym>, <emptyTree>::<C String>)
 end


### PR DESCRIPTION
### Motivation

So this:

```rb
self. #: as untyped
 attr_writer(
   ARGV.first, #: as String
   ARGV.last, #: as Integer
 ) #: as String
```

Is properly rewritten as this:

```rb
T.cast(
  T.unsafe(self).
    attr_writer(
     T.cast(ARGV.first, String),
     T.cast(ARGV.last, Integer),
   ), String)
```

I also split the association maps for signatures and assertions comments. Since we were associating both to the same node it was becoming increasingly difficult to differentiate in the rewriter passes. Consider this:

```
# signature:
#: String
attr_reader(:foo)

# vs.

# assertion:
attr_reader(:foo) #: String
```

This also simplifies the assertions rewriter code as we do not have to consider comments that may have been used during the signatures pass.

### Test plan

See included automated tests.
