### PR TITLE
Associate packages with files during buildPackageDB

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -490,12 +490,11 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                         pipeline::name(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers, foundHashes);
                     if (cancelled) {
                         ast::ParsedFilesOrCancelled::cancel(move(indexed), workers);
-                        ast::ParsedFilesOrCancelled::cancel(move(nonPackagedIndexed), workers);
                         return;
                     }
 
-                    pipeline::buildPackageDB(*this->gs, absl::MakeSpan(indexed), workspaceFilesSpan, this->config->opts,
-                                             workers);
+                    pipeline::buildPackageDB(*this->gs, absl::MakeSpan(indexed), this->config->opts, workers);
+                    pipeline::setPackageForSourceFiles(*this->gs, workspaceFilesSpan, this->config->opts);
                 }
 
                 {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -776,17 +776,18 @@ void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const opti
 }
 
 // packager intentionally runs outside of rewriter so that its output does not get cached.
-void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
-                    WorkerPool &workers) {
+void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> packageFiles,
+                    absl::Span<core::FileRef> sourceFiles, const options::Options &opts, WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
     if (!opts.cacheSensitiveOptions.stripePackages) {
         return;
     }
 
     try {
-        packager::Packager::buildPackageDB(gs, workers, what);
+        packager::Packager::buildPackageDB(gs, workers, packageFiles);
+        packager::Packager::setPackageNameOnFiles(gs, sourceFiles);
         if (opts.print.Packager.enabled) {
-            for (auto &f : what) {
+            for (auto &f : packageFiles) {
                 opts.print.Packager.fmt("# -- {} --\n", f.file.data(gs).path());
                 opts.print.Packager.fmt("{}\n", f.tree.toStringWithTabs(gs, 0));
             }
@@ -801,7 +802,7 @@ void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, con
 }
 
 // packager intentionally runs outside of rewriter so that its output does not get cached.
-void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
+void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> sourceFiles, const options::Options &opts,
                            WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
     if (!opts.cacheSensitiveOptions.stripePackages) {
@@ -809,9 +810,9 @@ void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> wh
     }
 
     try {
-        packager::Packager::validatePackagedFiles(gs, workers, what);
+        packager::Packager::validatePackagedFiles(gs, workers, sourceFiles);
         if (opts.print.Packager.enabled) {
-            for (auto &f : what) {
+            for (auto &f : sourceFiles) {
                 opts.print.Packager.fmt("# -- {} --\n", f.file.data(gs).path());
                 opts.print.Packager.fmt("{}\n", f.tree.toStringWithTabs(gs, 0));
             }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -784,8 +784,7 @@ void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> packageFi
     }
 
     try {
-        packager::Packager::buildPackageDB(gs, workers, packageFiles);
-        packager::Packager::setPackageNameOnFiles(gs, sourceFiles);
+        packager::Packager::buildPackageDB(gs, workers, packageFiles, sourceFiles);
         if (opts.print.Packager.enabled) {
             for (auto &f : packageFiles) {
                 opts.print.Packager.fmt("# -- {} --\n", f.file.data(gs).path());

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -51,10 +51,10 @@ void unpartitionPackageFiles(std::vector<ast::ParsedFile> &packageFiles,
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers);
 
-void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
-                    WorkerPool &workers);
+void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, absl::Span<core::FileRef> sourceFiles,
+                    const options::Options &opts, WorkerPool &workers);
 
-void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
+void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> sourceFiles, const options::Options &opts,
                            WorkerPool &workers);
 
 // ----- namer + resolver -----------------------------------------------------

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -51,10 +51,14 @@ void unpartitionPackageFiles(std::vector<ast::ParsedFile> &packageFiles,
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers);
 
-void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, absl::Span<core::FileRef> sourceFiles,
-                    const options::Options &opts, WorkerPool &workers);
+void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
+                    WorkerPool &workers);
 
-void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> sourceFiles, const options::Options &opts,
+// Associates source files with their package in the package DB. This can only be called after `buildPackageDB`.
+void setPackageForSourceFiles(core::GlobalState &gs, absl::Span<core::FileRef> sourceFiles,
+                              const options::Options &opts);
+
+void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
                            WorkerPool &workers);
 
 // ----- namer + resolver -----------------------------------------------------

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -587,7 +587,8 @@ int realmain(int argc, char *argv[]) {
                 auto foundHashes = nullptr;
                 auto canceled = pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers, foundHashes);
                 ENFORCE(!canceled, "There's no cancellation in batch mode");
-                pipeline::buildPackageDB(*gs, absl::MakeSpan(indexed), inputFilesSpan, opts, *workers);
+                pipeline::buildPackageDB(*gs, absl::MakeSpan(indexed), opts, *workers);
+                pipeline::setPackageForSourceFiles(*gs, inputFilesSpan, opts);
             }
 
             auto nonPackageIndexedResult =

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -587,7 +587,7 @@ int realmain(int argc, char *argv[]) {
                 auto foundHashes = nullptr;
                 auto canceled = pipeline::name(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers, foundHashes);
                 ENFORCE(!canceled, "There's no cancellation in batch mode");
-                pipeline::buildPackageDB(*gs, absl::Span<ast::ParsedFile>(indexed), opts, *workers);
+                pipeline::buildPackageDB(*gs, absl::MakeSpan(indexed), inputFilesSpan, opts, *workers);
             }
 
             auto nonPackageIndexedResult =

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2287,10 +2287,8 @@ vector<ast::ParsedFile> Packager::runIncremental(const core::GlobalState &gs, ve
     return files;
 }
 
-void Packager::buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> packageFiles,
-                              absl::Span<core::FileRef> sourceFiles) {
+void Packager::buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> packageFiles) {
     packageRunCore<PackagerMode::PackagesOnly>(gs, workers, packageFiles);
-    setPackageNameOnFiles(gs, sourceFiles);
 }
 
 void Packager::validatePackagedFiles(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2227,9 +2227,6 @@ void packageRunCore(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::
 
     if constexpr (buildPackageDB) {
         Packager::findPackages(gs, files);
-    } else {
-        // findPackages already called this
-        Packager::setPackageNameOnFiles(gs, files);
     }
 
     {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2290,8 +2290,10 @@ vector<ast::ParsedFile> Packager::runIncremental(const core::GlobalState &gs, ve
     return files;
 }
 
-void Packager::buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files) {
-    packageRunCore<PackagerMode::PackagesOnly>(gs, workers, files);
+void Packager::buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> packageFiles,
+                              absl::Span<core::FileRef> sourceFiles) {
+    packageRunCore<PackagerMode::PackagesOnly>(gs, workers, packageFiles);
+    setPackageNameOnFiles(gs, sourceFiles);
 }
 
 void Packager::validatePackagedFiles(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files) {

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -48,8 +48,12 @@ public:
     static std::vector<ast::ParsedFile> runIncremental(const core::GlobalState &gs, std::vector<ast::ParsedFile> files,
                                                        WorkerPool &workers);
 
-    // Build the packageDB only. This requires that the `files` span only contains `__package.rb` files.
-    static void buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);
+    // Build the packageDB only. This requires that the `packageFiles` span only contains `__package.rb` files that have
+    // been through the indexer and namer, and that the `sourceFiles` span contains the rest of the non-package files
+    // from the workspace. The files in the `sourceFiles` span will get their package associated after the package DB
+    // has been built.
+    static void buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> packageFiles,
+                               absl::Span<core::FileRef> sourceFiles);
 
     // Validate packaged files. This requires that hte `files` span does not contain any `__package.rb` files.
     static void validatePackagedFiles(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -57,6 +57,9 @@ public:
     // For each file, set its package name.
     static void setPackageNameOnFiles(core::GlobalState &gs, absl::Span<const ast::ParsedFile> files);
 
+    // For each file, set its package name.
+    static void setPackageNameOnFiles(core::GlobalState &gs, absl::Span<const core::FileRef> files);
+
     static core::SymbolRef getEnumClassForEnumValue(const core::GlobalState &gs, core::SymbolRef sym);
 
     Packager() = delete;

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -48,12 +48,9 @@ public:
     static std::vector<ast::ParsedFile> runIncremental(const core::GlobalState &gs, std::vector<ast::ParsedFile> files,
                                                        WorkerPool &workers);
 
-    // Build the packageDB only. This requires that the `packageFiles` span only contains `__package.rb` files that have
-    // been through the indexer and namer, and that the `sourceFiles` span contains the rest of the non-package files
-    // from the workspace. The files in the `sourceFiles` span will get their package associated after the package DB
-    // has been built.
-    static void buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> packageFiles,
-                               absl::Span<core::FileRef> sourceFiles);
+    // Build the packageDB only. This requires that the `files` span only contains `__package.rb` files that have been
+    // through the indexer and namer.
+    static void buildPackageDB(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);
 
     // Validate packaged files. This requires that hte `files` span does not contain any `__package.rb` files.
     static void validatePackagedFiles(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::ParsedFile> files);


### PR DESCRIPTION
It's helpful to have packages associated with sources files before those files are parsed in #9005. This PR moves the call to `setPackageNameOnFiles` for those files directly after the call to `Packager::buildPackageDB` in realmain.cc, making the connection between files and packages more explicit.

The main complexity with this change was in `LSPTypechecker.cc`, where we need to reorder things slightly to allow us to call the namer on package files before indexing source files.

### Motivation
Making more use of the package graph before source files have been processed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Shouldn't change functionality.
