### PR TITLE
Change callsites to use `maybeAddAutocorrect`

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -633,10 +633,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
                             method.show(ctx), overriddenMethod.show(ctx), "override.");
                 e.addErrorLine(overriddenMethod.data(ctx)->loc(), "defined here");
 
-                auto potentialAutocorrect = constructOverrideAutocorrect(ctx, tree, methodDef);
-                if (potentialAutocorrect.has_value()) {
-                    e.addAutocorrect(std::move(*potentialAutocorrect));
-                }
+                e.maybeAddAutocorrect(constructOverrideAutocorrect(ctx, tree, methodDef));
             }
         }
         if (!method.data(ctx)->flags.isOverride && !method.data(ctx)->flags.isAbstract && method.data(ctx)->hasSig() &&
@@ -647,10 +644,7 @@ void validateOverriding(const core::Context ctx, const ast::ExpressionPtr &tree,
                             method.show(ctx), overriddenMethod.show(ctx), "override.");
                 e.addErrorLine(overriddenMethod.data(ctx)->loc(), "defined here");
 
-                auto potentialAutocorrect = constructOverrideAutocorrect(ctx, tree, methodDef);
-                if (potentialAutocorrect.has_value()) {
-                    e.addAutocorrect(std::move(*potentialAutocorrect));
-                }
+                e.maybeAddAutocorrect(constructOverrideAutocorrect(ctx, tree, methodDef));
             }
         }
         if ((overriddenMethod.data(ctx)->flags.isAbstract || overriddenMethod.data(ctx)->flags.isOverridable ||

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -482,9 +482,7 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
                             nodeName(methodArg).show(ctx.state), nodeKindToString(methodArg),
                             argKindToString(arg.kind));
 
-                if (auto autocorrect = autocorrectArg(ctx, methodArg, arg, type->deepCopy())) {
-                    e.addAutocorrect(move(autocorrect.value()));
-                }
+                e.maybeAddAutocorrect(autocorrectArg(ctx, methodArg, arg, type->deepCopy()));
             }
         }
 


### PR DESCRIPTION
### Motivation
This was split out from #9017 to change a few other callsites to use `maybeAddAutocorrect`.

There are fewer places where this is useful than I thought; a lot of places where we have a `std::optional<AutocorrectSuggestion>` we end up doing more than "unwrap and add if present". Still a minor boilerplate win, though.

### Test plan

Existing automated tests pass.