### PR TITLE
add ranged-for iterators for `DispatchResult`

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -1105,14 +1105,6 @@ struct DispatchResult {
 
         explicit Iterator(PtrT *it) : it(it) {}
 
-        Iterator begin() const {
-            return *this;
-        }
-
-        Iterator end() const {
-            return Iterator(nullptr);
-        }
-
         PtrT *operator*() const {
             return it;
         }
@@ -1135,17 +1127,57 @@ struct DispatchResult {
         }
     };
 
-    Iterator<DispatchResult> iterator() {
-        return Iterator(this);
-    }
-
-    Iterator<const DispatchResult> iterator() const {
-        return Iterator(this);
-    }
-
     // Combine two dispatch results, preferring the left as the `main`.
     static DispatchResult merge(const GlobalState &gs, Combinator kind, DispatchResult &&left, DispatchResult &&right);
 };
+
+inline DispatchResult::Iterator<DispatchResult> begin(DispatchResult *dr) {
+    return DispatchResult::Iterator<DispatchResult>(dr);
+}
+
+inline DispatchResult::Iterator<DispatchResult> end(DispatchResult *dr) {
+    return DispatchResult::Iterator<DispatchResult>(nullptr);
+}
+
+inline DispatchResult::Iterator<DispatchResult> begin(DispatchResult &dr) {
+    return DispatchResult::Iterator<DispatchResult>(&dr);
+}
+
+inline DispatchResult::Iterator<DispatchResult> end(DispatchResult &dr) {
+    return DispatchResult::Iterator<DispatchResult>(nullptr);
+}
+
+inline DispatchResult::Iterator<DispatchResult> begin(const std::shared_ptr<DispatchResult> &dr) {
+    return DispatchResult::Iterator<DispatchResult>(dr.get());
+}
+
+inline DispatchResult::Iterator<DispatchResult> end(const std::shared_ptr<DispatchResult> &dr) {
+    return DispatchResult::Iterator<DispatchResult>(nullptr);
+}
+
+inline DispatchResult::Iterator<DispatchResult> begin(const std::unique_ptr<DispatchResult> &dr) {
+    return DispatchResult::Iterator<DispatchResult>(dr.get());
+}
+
+inline DispatchResult::Iterator<DispatchResult> end(const std::unique_ptr<DispatchResult> &dr) {
+    return DispatchResult::Iterator<DispatchResult>(nullptr);
+}
+
+inline DispatchResult::Iterator<const DispatchResult> begin(const DispatchResult *dr) {
+    return DispatchResult::Iterator<const DispatchResult>(dr);
+}
+
+inline DispatchResult::Iterator<const DispatchResult> end(const DispatchResult *dr) {
+    return DispatchResult::Iterator<const DispatchResult>(nullptr);
+}
+
+inline DispatchResult::Iterator<const DispatchResult> begin(const DispatchResult &dr) {
+    return DispatchResult::Iterator<const DispatchResult>(&dr);
+}
+
+inline DispatchResult::Iterator<const DispatchResult> end(const DispatchResult &dr) {
+    return DispatchResult::Iterator<const DispatchResult>(nullptr);
+}
 
 TYPE_INLINED(BlamedUntyped) final : public ClassType {
 public:

--- a/core/Types.h
+++ b/core/Types.h
@@ -1100,6 +1100,49 @@ struct DispatchResult {
         : returnType(std::move(returnType)), main(std::move(comp)), secondary(std::move(secondary)),
           secondaryKind(secondaryKind){};
 
+    template <typename PtrT> struct Iterator {
+        PtrT *it;
+
+        explicit Iterator(PtrT *it) : it(it) {}
+
+        Iterator begin() const {
+            return *this;
+        }
+
+        Iterator end() const {
+            return Iterator(nullptr);
+        }
+
+        PtrT *operator*() const {
+            return it;
+        }
+
+        Iterator &operator++() {
+            it = it->secondary.get();
+            return *this;
+        }
+
+        Iterator operator++(int) {
+            return Iterator(it->secondary.get());
+        }
+
+        bool operator==(const Iterator &other) const {
+            return this->it == other.it;
+        }
+
+        bool operator!=(const Iterator &other) const {
+            return this->it != other.it;
+        }
+    };
+
+    Iterator<DispatchResult> iterator() {
+        return Iterator(this);
+    }
+
+    Iterator<const DispatchResult> iterator() const {
+        return Iterator(this);
+    }
+
     // Combine two dispatch results, preferring the left as the `main`.
     static DispatchResult merge(const GlobalState &gs, Combinator kind, DispatchResult &&left, DispatchResult &&right);
 };

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2672,7 +2672,7 @@ private:
         {
             auto nonNilPassedInBlockType = Types::dropNil(gs, passedInBlockType);
             auto passedInBlockReturnType = Types::getProcReturnType(gs, nonNilPassedInBlockType);
-            for (auto it : dispatched.iterator()) {
+            for (auto it : dispatched) {
                 if (it->main.method.exists()) {
                     // TODO(jez) This only looks at the main component!
                     const auto &blockReturnType = it->main.blockReturnType;
@@ -3088,7 +3088,7 @@ public:
         auto multipleComponents = dispatched.secondary != nullptr;
         if (multipleComponents) {
             int unknownMethodOnNilClassErrors = 0;
-            for (auto it : dispatched.iterator()) {
+            for (auto it : dispatched) {
                 for (auto &err : it->main.errors) {
                     if (err->what == core::errors::Infer::UnknownMethod && it->main.receiver.isNilClass()) {
                         unknownMethodOnNilClassErrors++;
@@ -3115,12 +3115,12 @@ public:
                 auto retried = selfTyAndAnd.type.dispatchCall(gs, newInnerArgs);
 
                 auto foundErrorOnRetry = false;
-                for (auto it : retried.iterator()) {
+                for (auto it : retried) {
                     foundErrorOnRetry |= !it->main.errors.empty();
                 }
 
                 if (!foundErrorOnRetry) {
-                    for (auto it : dispatched.iterator()) {
+                    for (auto it : dispatched) {
                         for (auto &err : it->main.errors) {
                             if (err->what == core::errors::Infer::UnknownMethod && it->main.receiver.isNilClass()) {
                                 if (auto newErr = gs.beginError(err->loc, core::errors::Infer::CallAfterAndAnd)) {
@@ -3906,7 +3906,7 @@ void digImplementation(const GlobalState &gs, const DispatchArgs &args, Dispatch
 
     auto recursiveDispatch = newSelfType.dispatchCall(gs, digArgs);
 
-    for (auto it : recursiveDispatch.iterator()) {
+    for (auto it : recursiveDispatch) {
         for (auto &err : it->main.errors) {
             res.main.errors.emplace_back(std::move(err));
         }
@@ -4342,7 +4342,7 @@ public:
         };
         auto dispatched = classArg->type.dispatchCall(gs, newArgs);
 
-        for (auto it : dispatched.iterator()) {
+        for (auto it : dispatched) {
             for (auto &err : it->main.errors) {
                 res.main.errors.emplace_back(std::move(err));
             }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2672,8 +2672,7 @@ private:
         {
             auto nonNilPassedInBlockType = Types::dropNil(gs, passedInBlockType);
             auto passedInBlockReturnType = Types::getProcReturnType(gs, nonNilPassedInBlockType);
-            auto it = &dispatched;
-            while (it != nullptr) {
+            for (auto it : dispatched.iterator()) {
                 if (it->main.method.exists()) {
                     // TODO(jez) This only looks at the main component!
                     const auto &blockReturnType = it->main.blockReturnType;
@@ -2684,7 +2683,6 @@ private:
                                                         UntypedMode::AlwaysCompatible, ErrorSection::Collector::NO_OP);
                     }
                 }
-                it = it->secondary.get();
             }
         }
         if (constr) {
@@ -3090,7 +3088,7 @@ public:
         auto multipleComponents = dispatched.secondary != nullptr;
         if (multipleComponents) {
             int unknownMethodOnNilClassErrors = 0;
-            for (auto it = &dispatched; it != nullptr; it = it->secondary.get()) {
+            for (auto it : dispatched.iterator()) {
                 for (auto &err : it->main.errors) {
                     if (err->what == core::errors::Infer::UnknownMethod && it->main.receiver.isNilClass()) {
                         unknownMethodOnNilClassErrors++;
@@ -3117,12 +3115,12 @@ public:
                 auto retried = selfTyAndAnd.type.dispatchCall(gs, newInnerArgs);
 
                 auto foundErrorOnRetry = false;
-                for (auto it = &retried; it != nullptr; it = it->secondary.get()) {
+                for (auto it : retried.iterator()) {
                     foundErrorOnRetry |= !it->main.errors.empty();
                 }
 
                 if (!foundErrorOnRetry) {
-                    for (auto it = &dispatched; it != nullptr; it = it->secondary.get()) {
+                    for (auto it : dispatched.iterator()) {
                         for (auto &err : it->main.errors) {
                             if (err->what == core::errors::Infer::UnknownMethod && it->main.receiver.isNilClass()) {
                                 if (auto newErr = gs.beginError(err->loc, core::errors::Infer::CallAfterAndAnd)) {
@@ -3908,7 +3906,7 @@ void digImplementation(const GlobalState &gs, const DispatchArgs &args, Dispatch
 
     auto recursiveDispatch = newSelfType.dispatchCall(gs, digArgs);
 
-    for (auto it = &recursiveDispatch; it != nullptr; it = it->secondary.get()) {
+    for (auto it : recursiveDispatch.iterator()) {
         for (auto &err : it->main.errors) {
             res.main.errors.emplace_back(std::move(err));
         }
@@ -4344,7 +4342,7 @@ public:
         };
         auto dispatched = classArg->type.dispatchCall(gs, newArgs);
 
-        for (auto it = &dispatched; it != nullptr; it = it->secondary.get()) {
+        for (auto it : dispatched.iterator()) {
             for (auto &err : it->main.errors) {
                 res.main.errors.emplace_back(std::move(err));
             }

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -122,8 +122,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
         }
 
         core::TypePtr thisType;
-        auto iter = &dispatchInfo;
-        while (iter != nullptr) {
+        for (auto iter : dispatchInfo.iterator()) {
             if (iter->main.method.exists()) {
                 auto argType = extractArgType(ctx, *snd, iter->main, keyword, argIdx);
                 if (argType && !argType.isUntyped()) {
@@ -135,8 +134,6 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
                     }
                 }
             }
-
-            iter = iter->secondary.get();
         }
         if (!thisType) {
             continue;

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -122,7 +122,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
         }
 
         core::TypePtr thisType;
-        for (auto iter : dispatchInfo.iterator()) {
+        for (auto iter : dispatchInfo) {
             if (iter->main.method.exists()) {
                 auto argType = extractArgType(ctx, *snd, iter->main, keyword, argIdx);
                 if (argType && !argType.isUntyped()) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1053,8 +1053,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                                 suppressErrors,  inWhat.symbol.data(ctx)->name};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
 
-                auto it = &dispatched;
-                while (it != nullptr) {
+                for (auto it : dispatched.iterator()) {
                     for (auto &err : it->main.errors) {
                         if (err->what != core::errors::Infer::UnknownMethod ||
                             !parentUpdateKnowledgeReceiver.has_value()) {
@@ -1140,7 +1139,6 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     }
 
                     lspQueryMatch = lspQueryMatch || lspQuery.matchesSymbol(it->main.method);
-                    it = it->secondary.get();
                 }
                 shared_ptr<core::DispatchResult> retainedResult;
                 if (send.link) {
@@ -1360,8 +1358,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
 
                 auto &procType = insn.link->result->main.blockPreType;
                 auto params = procType.getCallArguments(ctx, core::Names::call());
-                auto it = insn.link->result->secondary.get();
-                while (it != nullptr) {
+                for (auto it : insn.link->result->secondary->iterator()) {
                     auto &secondaryProcType = it->main.blockPreType;
                     if (secondaryProcType != nullptr) {
                         auto secondaryParams = secondaryProcType.getCallArguments(ctx, core::Names::call());
@@ -1382,8 +1379,6 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         // nicer to let it be whatever it would have been. This way they'll get
                         // completion results as if the previous type error was fixed. So do nothing.
                     }
-
-                    it = it->secondary.get();
                 }
 
                 // A multi-arg proc, if provided a single arg which is an array,
@@ -1594,8 +1589,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
             [&](cfg::LoadSelf &l) {
                 ENFORCE(l.link);
                 auto tpo = getTypeFromRebind(ctx, l.link->result->main, l.fallback);
-                auto it = l.link->result->secondary.get();
-                while (it != nullptr) {
+                for (auto it : l.link->result->secondary->iterator()) {
                     auto secondaryTpo = getTypeFromRebind(ctx, it->main, l.fallback);
                     switch (l.link->result->secondaryKind) {
                         case core::DispatchResult::Combinator::OR:
@@ -1607,8 +1601,6 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     }
                     tpo.origins.insert(tpo.origins.begin(), make_move_iterator(secondaryTpo.origins.begin()),
                                        make_move_iterator(secondaryTpo.origins.end()));
-
-                    it = it->secondary.get();
                 }
 
                 tp = tpo;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1053,7 +1053,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                                 suppressErrors,  inWhat.symbol.data(ctx)->name};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
 
-                for (auto it : dispatched.iterator()) {
+                for (auto it : dispatched) {
                     for (auto &err : it->main.errors) {
                         if (err->what != core::errors::Infer::UnknownMethod ||
                             !parentUpdateKnowledgeReceiver.has_value()) {
@@ -1358,7 +1358,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
 
                 auto &procType = insn.link->result->main.blockPreType;
                 auto params = procType.getCallArguments(ctx, core::Names::call());
-                for (auto it : insn.link->result->secondary->iterator()) {
+                for (auto it : insn.link->result->secondary) {
                     auto &secondaryProcType = it->main.blockPreType;
                     if (secondaryProcType != nullptr) {
                         auto secondaryParams = secondaryProcType.getCallArguments(ctx, core::Names::call());
@@ -1589,7 +1589,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
             [&](cfg::LoadSelf &l) {
                 ENFORCE(l.link);
                 auto tpo = getTypeFromRebind(ctx, l.link->result->main, l.fallback);
-                for (auto it : l.link->result->secondary->iterator()) {
+                for (auto it : l.link->result->secondary) {
                     auto secondaryTpo = getTypeFromRebind(ctx, it->main, l.fallback);
                     switch (l.link->result->secondaryKind) {
                         case core::DispatchResult::Combinator::OR:

--- a/main/lsp/AbstractRewriter.cc
+++ b/main/lsp/AbstractRewriter.cc
@@ -124,7 +124,7 @@ void AbstractRewriter::addSubclassRelatedMethods(const core::GlobalState &gs, co
 void AbstractRewriter::addDispatchRelatedMethods(const core::GlobalState &gs,
                                                  const core::DispatchResult *dispatchResult,
                                                  shared_ptr<UniqueSymbolQueue> methods) {
-    for (const core::DispatchResult *dr = dispatchResult; dr != nullptr; dr = dr->secondary.get()) {
+    for (const auto *dr : dispatchResult->iterator()) {
         auto method = dr->main.method;
         ENFORCE(method.exists());
         auto isNew = methods->tryEnqueue(method);

--- a/main/lsp/AbstractRewriter.cc
+++ b/main/lsp/AbstractRewriter.cc
@@ -124,7 +124,7 @@ void AbstractRewriter::addSubclassRelatedMethods(const core::GlobalState &gs, co
 void AbstractRewriter::addDispatchRelatedMethods(const core::GlobalState &gs,
                                                  const core::DispatchResult *dispatchResult,
                                                  shared_ptr<UniqueSymbolQueue> methods) {
-    for (const auto *dr : dispatchResult->iterator()) {
+    for (const auto *dr : dispatchResult) {
         auto method = dr->main.method;
         ENFORCE(method.exists());
         auto isNew = methods->tryEnqueue(method);

--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -141,7 +141,7 @@ public:
         if (auto sendResp = response->isSend()) {
             // if the call site is not trivial, don't attempt to rename
             // the typecheck error will guide user how to fix it
-            for (auto dr : sendResp->dispatchResult->iterator()) {
+            for (auto dr : sendResp->dispatchResult) {
                 if (dr->main.method != originalSymbol.asMethodRef()) {
                     return;
                 }

--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -141,7 +141,7 @@ public:
         if (auto sendResp = response->isSend()) {
             // if the call site is not trivial, don't attempt to rename
             // the typecheck error will guide user how to fix it
-            for (auto dr = sendResp->dispatchResult.get(); dr != nullptr; dr = dr->secondary.get()) {
+            for (auto dr : sendResp->dispatchResult->iterator()) {
                 if (dr->main.method != originalSymbol.asMethodRef()) {
                     return;
                 }

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -107,7 +107,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
             auto sendResp = resp->isSend();
             // Don't want to show hover results if we're hovering over, e.g., the arguments, and there's nothing there.
             if (sendResp->funLoc().exists() && sendResp->funLoc().contains(queryLoc)) {
-                for (auto start : sendResp->dispatchResult->iterator()) {
+                for (auto start : sendResp->dispatchResult) {
                     if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                         auto loc = start->main.method.data(gs)->loc();
                         if (start->main.method == core::Symbols::T_Private_Methods_DeclBuilder_override()) {

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -107,8 +107,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
             auto sendResp = resp->isSend();
             // Don't want to show hover results if we're hovering over, e.g., the arguments, and there's nothing there.
             if (sendResp->funLoc().exists() && sendResp->funLoc().contains(queryLoc)) {
-                auto start = sendResp->dispatchResult.get();
-                while (start != nullptr) {
+                for (auto start : sendResp->dispatchResult->iterator()) {
                     if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                         auto loc = start->main.method.data(gs)->loc();
                         if (start->main.method == core::Symbols::T_Private_Methods_DeclBuilder_override()) {
@@ -125,7 +124,6 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
 
                         addLocIfExists(gs, locations, loc);
                     }
-                    start = start->secondary.get();
                 }
             }
         }

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -95,7 +95,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
         } else if (fileIsTyped && resp->isSend()) {
             auto sendResp = resp->isSend();
             vector<unique_ptr<core::lsp::QueryResponse>> references;
-            for (auto start : sendResp->dispatchResult->iterator()) {
+            for (auto start : sendResp->dispatchResult) {
                 if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                     // This could be a `prop` or `attr_*`, which have multiple associated symbols.
                     references = getReferencesToAccessorInFile(typechecker, fref,

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -94,16 +94,14 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
             }
         } else if (fileIsTyped && resp->isSend()) {
             auto sendResp = resp->isSend();
-            auto start = sendResp->dispatchResult.get();
             vector<unique_ptr<core::lsp::QueryResponse>> references;
-            while (start != nullptr) {
+            for (auto start : sendResp->dispatchResult->iterator()) {
                 if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                     // This could be a `prop` or `attr_*`, which have multiple associated symbols.
                     references = getReferencesToAccessorInFile(typechecker, fref,
                                                                getAccessorInfo(typechecker.state(), start->main.method),
                                                                start->main.method, move(references));
                 }
-                start = start->secondary.get();
             }
             response->result = getHighlights(typechecker, references);
         }

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -15,9 +15,7 @@ namespace sorbet::realmain::lsp {
 string methodInfoString(const core::GlobalState &gs, const core::DispatchResult &dispatchResult,
                         const core::ShowOptions options) {
     string contents;
-    auto start = &dispatchResult;
-
-    while (start != nullptr) {
+    for (auto start : dispatchResult.iterator()) {
         auto &component = start->main;
         if (component.method.exists()) {
             if (!contents.empty()) {
@@ -27,7 +25,6 @@ string methodInfoString(const core::GlobalState &gs, const core::DispatchResult 
                 move(contents), "# ", component.method.show(gs), ":\n",
                 core::source_generator::prettyTypeForMethod(gs, component.method, component.receiver, options));
         }
-        start = start->secondary.get();
     }
 
     // contents being empty implies that there were no components that existed, which means that
@@ -89,15 +86,13 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
     if (auto s = resp->isSend()) {
         // Don't want to show hover results if we're hovering over, e.g., the arguments, and there's nothing there.
         if (s->funLoc().exists() && s->funLoc().contains(queryLoc)) {
-            auto start = s->dispatchResult.get();
-            while (start != nullptr) {
+            for (auto start : s->dispatchResult->iterator()) {
                 if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                     auto loc = start->main.method.data(gs)->loc();
                     if (loc.exists()) {
                         documentationLocations.emplace_back(loc);
                     }
                 }
-                start = start->secondary.get();
             }
 
             if (s->dispatchResult->main.method.exists() &&

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -15,7 +15,7 @@ namespace sorbet::realmain::lsp {
 string methodInfoString(const core::GlobalState &gs, const core::DispatchResult &dispatchResult,
                         const core::ShowOptions options) {
     string contents;
-    for (auto start : dispatchResult.iterator()) {
+    for (auto start : dispatchResult) {
         auto &component = start->main;
         if (component.method.exists()) {
             if (!contents.empty()) {
@@ -86,7 +86,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
     if (auto s = resp->isSend()) {
         // Don't want to show hover results if we're hovering over, e.g., the arguments, and there's nothing there.
         if (s->funLoc().exists() && s->funLoc().contains(queryLoc)) {
-            for (auto start : s->dispatchResult->iterator()) {
+            for (auto start : s->dispatchResult) {
                 if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                     auto loc = start->main.method.data(gs)->loc();
                     if (loc.exists()) {

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -178,7 +178,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
         } else if (auto sendResp = resp->isSend()) {
             if (fileIsTyped) {
                 vector<unique_ptr<core::lsp::QueryResponse>> responses;
-                for (auto start : sendResp->dispatchResult->iterator()) {
+                for (auto start : sendResp->dispatchResult) {
                     if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                         // This could be a `prop` or `attr_*`, which has multiple associated symbols.
                         responses = getReferencesToAccessor(typechecker,

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -177,16 +177,14 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
             }
         } else if (auto sendResp = resp->isSend()) {
             if (fileIsTyped) {
-                auto start = sendResp->dispatchResult.get();
                 vector<unique_ptr<core::lsp::QueryResponse>> responses;
-                while (start != nullptr) {
+                for (auto start : sendResp->dispatchResult->iterator()) {
                     if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
                         // This could be a `prop` or `attr_*`, which has multiple associated symbols.
                         responses = getReferencesToAccessor(typechecker,
                                                             getAccessorInfo(typechecker.state(), start->main.method),
                                                             start->main.method, move(responses));
                     }
-                    start = start->secondary.get();
                 }
                 response->result = extractLocations(typechecker.state(), responses);
             } else {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

I'm not the biggest fan of how this implementation turned out.  We can't have `begin()` and `end()` methods on `DispatchResult` because in some places we would wind up calling those on `nullptr`, which ASan complains about (even though we never access anything through `this`).

So we need `begin()` and `end()` free functions, but a billion versions of those to handle all the different flavors of `DispatchResult` we pass around.  I guess we could reduce them down to just the pointer overloads if we were willing to change the callsites.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes the loops over `DispatchResult`s less boiler-platey.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
