### PR TITLE
Add basic debugger config for easy VS Code debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,18 @@
                     "ignoreFailures": false
                 }
             ]
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug Sorbet with test.rb",
+            "program": "${workspaceFolder}/bazel-bin/main/sorbet",
+            "args": ["--enable-experimental-rbs-comments", "test.rb"],
+            "preLaunchTask": "Build",
+            "stopOnEntry": false,
+            "sourceMap": {
+                "": "${workspaceFolder}",
+            },
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "./bazel build //main:sorbet --config=dbg",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### Motivation

This minimal setup will allow devs to debug Sorbet by running typechecking against `test.rb` in VSCode-based editors.

Demo:

https://github.com/user-attachments/assets/a2115833-765c-4b2d-9cac-6f52c151c0c9



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
