### PR TITLE
Correctly resolve namespace for RBS type aliases

### DIFF
--- a/rbs/TypeToParserNode.h
+++ b/rbs/TypeToParserNode.h
@@ -26,6 +26,8 @@ public:
     std::unique_ptr<parser::Node> toParserNode(const rbs_node_t *node, const RBSDeclaration &declaration);
 
 private:
+    std::unique_ptr<parser::Node> namespaceConst(const rbs_namespace_t *rbsNamespace,
+                                                 const RBSDeclaration &declaration);
     std::unique_ptr<parser::Node> typeNameType(const rbs_type_name_t *typeName, bool isGeneric,
                                                const RBSDeclaration &declaration);
     std::unique_ptr<parser::Node> aliasType(const rbs_types_alias_t *node, core::LocOffsets loc,

--- a/test/testdata/rbs/signatures_type_aliases.rb
+++ b/test/testdata/rbs/signatures_type_aliases.rb
@@ -135,3 +135,19 @@ module TypeAliasMultiline
     T.reveal_type(x) # error: Revealed type: `T.any(Integer, String)`
   end
 end
+
+module TypeAliasWithNamespace
+  module Foo
+    #: type a = Integer | String
+
+    #: (a) -> void
+    def foo(x)
+      T.reveal_type(x) # error: Revealed type: `T.any(Integer, String)`
+    end
+  end
+
+  #: (Foo::a) -> void
+  def bar(x)
+    T.reveal_type(x) # error: Revealed type: `T.any(Integer, String)`
+  end
+end

--- a/test/testdata/rbs/signatures_type_aliases.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_type_aliases.rb.rewrite-tree.exp
@@ -210,4 +210,32 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of method3>
   end
+
+  module <emptyTree>::<C TypeAliasWithNamespace><<C <todo sym>>> < ()
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:x, <emptyTree>::<C Foo>::<C type a>).void()
+    end
+
+    def bar<<todo method>>(x, &<blk>)
+      <emptyTree>::<C T>.reveal_type(x)
+    end
+
+    module <emptyTree>::<C Foo><<C <todo sym>>> < ()
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.params(:x, <emptyTree>::<C type a>).void()
+      end
+
+      def foo<<todo method>>(x, &<blk>)
+        <emptyTree>::<C T>.reveal_type(x)
+      end
+
+      <emptyTree>::<C type a> = ::<root>::<C T>.type_alias() do ||
+        ::<root>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>)
+      end
+
+      <runtime method definition of foo>
+    end
+
+    <runtime method definition of bar>
+  end
 end


### PR DESCRIPTION
### Motivation

In RBS, type aliases can have namespaces, but we currently don't take it into account when processing type aliases. This causes aliasing types can only be resolved inside the same namespace.

This change fixes the issue by generating namespace constants for type aliases.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
