### PR TITLE
Desugar integer complement (~ operator) to a Send

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -42,6 +42,7 @@ NameDef names[] = {
     {"intern"},
     {"call"},
     {"bang", "!"},
+    {"tilde", "~"},
     {"squareBrackets", "[]"},
     {"squareBracketsEq", "[]="},
     {"unaryPlus", "+@"},

--- a/test/testdata/parser/complement_literal.rb
+++ b/test/testdata/parser/complement_literal.rb
@@ -4,3 +4,4 @@
 x = 10
 ~x
 ~1.0 # error: Method `~` does not exist on `Float`
+~-10

--- a/test/testdata/parser/complement_literal.rb.desugar-tree.exp
+++ b/test/testdata/parser/complement_literal.rb.desugar-tree.exp
@@ -1,9 +1,11 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  -11
+  10.~()
 
   x = 10
 
   x.~()
 
   1.000000.~()
+
+  -10.~()
 end

--- a/test/testdata/parser/complement_literal.rb.parse-tree.exp
+++ b/test/testdata/parser/complement_literal.rb.parse-tree.exp
@@ -27,5 +27,8 @@ Begin {
       args = [
       ]
     }
+    Integer {
+      val = "~-10"
+    }
   ]
 }

--- a/test/testdata/parser/error_recovery/missing_operator.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/missing_operator.rb.desugar-tree.exp
@@ -363,7 +363,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  <self>.puts(-20)
+  <self>.puts(19.~())
 
   <self>.puts(<emptyTree>::<C <ErrorNode>>.~())
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When a literal integer was desugared with the complement operator (eg `~42`) it was replaced with an Integer node with the calculated complement. Instead this replaces it with a call to `.~`.

Related to: https://github.com/Shopify/sorbet/pull/577

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No new tests but tests were changed to validate the new behavior.