### PR TITLE
don't indirect through `ref` in `LSPQuery::bySymbol`

### DIFF
--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -109,6 +109,10 @@ LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypechecker
     for (auto &file : typechecker.state().getFiles().subspan(1)) {
         i++;
 
+        if (file->sourceType != core::File::Type::Normal) {
+            continue;
+        }
+
         auto ref = core::FileRef(i);
         if (pkgName.exists() && gs.packageDB().getPackageNameForFile(ref) != pkgName) {
             continue;
@@ -118,8 +122,7 @@ LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypechecker
         const auto &hash = *file->getFileHash();
         const auto &usedSymbolNameHashes = hash.usages.nameHashes;
 
-        const bool fileIsValid = ref.exists() && ref.data(gs).sourceType == core::File::Type::Normal;
-        if (fileIsValid && absl::c_contains(usedSymbolNameHashes, symShortNameHash)) {
+        if (absl::c_contains(usedSymbolNameHashes, symShortNameHash)) {
             frefs.emplace_back(ref);
         }
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Now that we're operating with the `File` objects themselves here, we don't need to construct `ref`, check that it exists (of course it does), and indirect through the global file table to determine whether this is a file we can handle.

The function here is probably dominated by the search through the name hashes for each file (can we binary search this list?), but this change probably helps a bit?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
