### PR TITLE
don't indirect through `ref` in `fastPathFilesToTypecheck`

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -206,7 +206,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
             continue;
         }
 
-        result.extraFiles.emplace_back(ref.data(gs).path());
+        result.extraFiles.emplace_back(oldFile->path());
         result.totalChanged += 1;
 
         if (result.totalChanged > (2 * config.opts.lspMaxFilesOnFastPath)) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is the same sort of logic as #9036, just in a different place -- we shouldn't have to indirect through `gs` to find the file that we're looking for, because we're already iterating over the files!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
