### PR TITLE
Run publish.sh from elastic queue

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -115,8 +115,7 @@ steps:
 # Deploy Phase - Send the artifacts to the world
   - label: ":linux: publish.sh"
     command: '.buildkite/publish.sh'
-    agents:
-      os: linux
+    <<: *elastic
   - wait: ~
 
 # Success Phase - Allow the PR to be merged


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already run publish-ruby-gems.sh from elastic.

I believe that elastic already has

- GitHub access to `sorbet` org (push, releases)
- `VSCE_PAT` for VS marketplace
- RubyGems API key

This keeps the credentials on arbiter small: it only has access to
GitHub, but not VS or RubyGems.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

`pipeline.sh` is a dry-run job except for `master` builds, so I plan to test by
merging.