### PR TITLE
Always compile with --stack-first when building wasm

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -289,6 +289,9 @@ build:webasm --compilation_mode=opt
 build:webasm --features=exceptions --cxxopt=-fwasm-exceptions --linkopt=-fwasm-exceptions
 # Blocked on https://github.com/emscripten-core/emscripten/issues/9780
 build:webasm --copt=-fno-stack-protector
+# We put the stack first, so that an argument stack overflow doesn't clobber
+# global data, and traps instead.
+build:webasm --linkopt=--stack-first
 
 ##
 ## Stripe's ci passes --config=ci, we need it to exist


### PR DESCRIPTION
When compiling c/c++ for wasm, you need to include an argument stack in memory to hold arguments to functions that don't fit into one of the wasm primitive types. This stack is just a regular buffer of fixed size that's reserved in memory, and as such is succeptable to overflows, which as the stack grows down means that arbitrary memory will be overwritten if this happens.

Using `--stack-first` means that the argument stack is the very first thing allocated in the memory, so a stack overflow will trap as an out-of-bounds access by trying to write an address that's less than zero. This behavior is preferable to overwriting random memory, as that puts the wasm into a non-functional state.

Oddly, emscripten will add `--stack-first` only when producing debug builds, and will leave it out when producing optimized builds. This doesn't really make much sense to me, as I don't think there's a performance benefit for putting the stack later in memory, and the possibility of overwriting arbitrary globals is really unacceptable.

### Motivation
Fixing odd crashes in sorbet.run.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not applicable
