### PR TITLE
Stop using -Oz when building sorbet.run wasm

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -282,7 +282,7 @@ build:fuzz --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 ##
 ## Webasm config. Please use either of those depending on your platform
 ##
-build:webasm --copt=-Oz --linkopt=-Oz --copt=-DMDB_USE_ROBUST=0
+build:webasm --copt=-DMDB_USE_ROBUST=0
 build:webasm --define release=true
 build:webasm --compilation_mode=opt
 # https://emscripten.org/docs/porting/exceptions.html#webassembly-exception-handling-based-support


### PR DESCRIPTION
Stop using `-Oz` when compiling sorbet.run, as in [emscripten](https://github.com/emscripten-core/emscripten/issues/21215) that option is mutually exclusive with `--stack-first`. This increases the size of the sorbet.run wasm from 7.6M to 10M, but the use of `--stack-first` does resolve some weird crashes that we've been seeing.

As an alternative I tried increasing the stack size to 1M, but that didn't seem to have any effect.

### Motivation
Resolving strange sorbet.run behavior.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
