### PR TITLE
Intrinsic to turn hash literal into typed hash

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -178,6 +178,7 @@ public:
     static TypePtr arrayOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr rangeOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr hashOf(const GlobalState &gs, const TypePtr &elem);
+    static TypePtr hashOf(const GlobalState &gs, const TypePtr &key, const TypePtr &val);
     static TypePtr setOf(const TypePtr &elem);
     static TypePtr tClass(const TypePtr &attachedClass);
     static TypePtr dropNil(const GlobalState &gs, const TypePtr &from);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3597,17 +3597,8 @@ class Shape_to_h : public IntrinsicMethod {
             return;
         }
 
-        // TODO(jez) Could we use Types::lubAll here? Do we want widen/dropLiteral/something else?
-        auto keyType = Types::bottom();
-        for (const auto &key : shape->keys) {
-            keyType = Types::any(gs, keyType, Types::widen(gs, key));
-        }
-
-        auto valType = Types::bottom();
-        for (const auto &val : shape->values) {
-            valType = Types::any(gs, valType, Types::widen(gs, val));
-        }
-
+        auto keyType = Types::dropLiteral(gs, Types::lubAll(gs, shape->keys));
+        auto valType = Types::dropLiteral(gs, Types::lubAll(gs, shape->values));
         res.returnType = Types::hashOf(gs, keyType, valType);
     }
 } Shape_to_h;

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -347,6 +347,12 @@ TypePtr Types::hashOf(const GlobalState &gs, const TypePtr &elem) {
     return make_type<AppliedType>(Symbols::Hash(), move(targs));
 }
 
+TypePtr Types::hashOf(const GlobalState &gs, const TypePtr &key, const TypePtr &val) {
+    vector<TypePtr> tupleArgs{key, val};
+    vector<TypePtr> targs{key, val, make_type<TupleType>(move(tupleArgs))};
+    return make_type<AppliedType>(Symbols::Hash(), move(targs));
+}
+
 TypePtr Types::setOf(const TypePtr &elem) {
     vector<TypePtr> targs{elem};
     return make_type<AppliedType>(Symbols::Set(), move(targs));

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -326,6 +326,12 @@ TypePtr Types::dropLiteral(const GlobalState &gs, const TypePtr &tp) {
 TypePtr Types::lubAll(const GlobalState &gs, const vector<TypePtr> &elements) {
     TypePtr acc = Types::bottom();
     for (auto &el : elements) {
+        // The only time that `Types::lub` produces a proxy_type is if the two proxy types are
+        // equivalent: `:foo | :foo`. If they're not equivalent, we widen. There are no
+        // `:foo | :bar` types produced by `lub`, so `widen` is unnecessary.
+        //
+        // Which means that to remove all literals, it's sufficient to do a single `dropLiteral`
+        // at the call `lubAll` call site.
         acc = Types::lub(gs, acc, el);
     }
     return acc;

--- a/test/testdata/infer/shape_to_h.rb
+++ b/test/testdata/infer/shape_to_h.rb
@@ -14,7 +14,7 @@ T.reveal_type(opts.to_h) # error: `T::Hash[T.any(Symbol, String), T.any(Integer,
 
 opts = {x: {y: 1}}
 T.reveal_type(opts) # error: `{x: {y: Integer(1)}} (shape of T::Hash[T.untyped, T.untyped])`
-T.reveal_type(opts.to_h) # error: `T::Hash[Symbol, T::Hash[T.untyped, T.untyped]]`
+T.reveal_type(opts.to_h) # error: `T::Hash[Symbol, {y: Integer(1)}]`
 
 opts = {x: {y: 1}.to_h}
 T.reveal_type(opts) # error: `{x: T::Hash[Symbol, Integer]} (shape of T::Hash[T.untyped, T.untyped])`

--- a/test/testdata/infer/shape_to_h.rb
+++ b/test/testdata/infer/shape_to_h.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+opts = {}
+T.reveal_type(opts) # error: `{} (shape of T::Hash[T.untyped, T.untyped])`
+T.reveal_type(opts.to_h) # error: `T::Hash[T.untyped, T.untyped]`
+
+opts = {x: 1}
+T.reveal_type(opts) # error: `{x: Integer(1)} (shape of T::Hash[T.untyped, T.untyped])`
+T.reveal_type(opts.to_h) # error: `T::Hash[Symbol, Integer]`
+
+opts = {x: 1, "y" => 0.0}
+T.reveal_type(opts) # error: `{x: Integer(1), String("y") => Float(0.000000)} (shape of T::Hash[T.untyped, T.untyped])`
+T.reveal_type(opts.to_h) # error: `T::Hash[T.any(Symbol, String), T.any(Integer, Float)]`
+
+opts = {x: {y: 1}}
+T.reveal_type(opts) # error: `{x: {y: Integer(1)}} (shape of T::Hash[T.untyped, T.untyped])`
+T.reveal_type(opts.to_h) # error: `T::Hash[Symbol, T::Hash[T.untyped, T.untyped]]`
+
+opts = {x: {y: 1}.to_h}
+T.reveal_type(opts) # error: `{x: T::Hash[Symbol, Integer]} (shape of T::Hash[T.untyped, T.untyped])`
+T.reveal_type(opts.to_h) # error: `T::Hash[Symbol, T::Hash[Symbol, Integer]]`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet handles hash literals poorly (#11).

Right now it's not even possible for people to opt into better checking if they want to treat hash literals as typed `T::Hash` objects. Even writing `T.let({x: 0}, T::Hash[String, Integer])` will not statically fail, because the hash literal will get upcast to `T::Hash[T.untyped, T.untyped]`.

This `to_h` intrinsic is a stopgap to allow people to opt into better checking while we think of a better long term solution for shape types. After this change, you can call `to_h` to explicitly upcast to a typed hash without having to write the full key+value types.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.