### PR TITLE
Mark `Opus::Command` instance methods as private

### DIFF
--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -42,76 +42,72 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         if (mdef == nullptr) {
             continue;
         }
-        if (mdef->name != core::Names::call()) {
-            if (!mdef->flags.isSelfMethod) {
-                instanceMethods.push_back(pair(mdef->name, mdef->loc.copyWithZeroLength()));
-            }
-            continue;
+        if (mdef->name == core::Names::call()) {
+            i = &stat - &klass->rhs.front();
+            call = mdef;
+            callptr = &stat;
+        } else if (!mdef->flags.isSelfMethod) {
+            instanceMethods.push_back(pair(mdef->name, mdef->loc.copyWithZeroLength()));
         }
-
-        i = &stat - &klass->rhs.front();
-        call = mdef;
-        callptr = &stat;
-        break;
     }
+
     // If we didn't find a `call` method, or if it was the first statement (and
     // thus couldn't have a `sig`)
-    if (call == nullptr || i == 0) {
-        return;
+    if (call != nullptr && i != 0) {
+        // Heuristic: Does the previous node look like a `sig`? Check that it's a
+        // Send node and so is its receiver.
+        //
+        // This could in principle be `resolver::TypeSyntax::isSig`, but we don't
+        // want to depend on the internals of the resolver, or accidentally rely on
+        // passes that happen between here and the resolver.
+        auto sig = ast::cast_tree<ast::Send>(klass->rhs[i - 1]);
+        if (sig == nullptr || sig->fun != core::Names::sig()) {
+            return;
+        }
+
+        ast::MethodDef::ARGS_store newArgs;
+        newArgs.reserve(call->args.size());
+        for (auto &arg : call->args) {
+            newArgs.emplace_back(arg.deepCopy());
+        }
+
+        // This method is only for type checking. It doesn't actually exist at runtime, and instead all
+        // Opus::Command subclasses inherit the `self.call` method from `Opus::Command` directly.
+        ast::MethodDef::Flags flags;
+        flags.isSelfMethod = true;
+        flags.discardDef = true;
+        auto selfCall = ast::MK::SyntheticMethod(call->loc, call->declLoc, call->name, std::move(newArgs),
+                                                 ast::MK::RaiseTypedUnimplemented(call->declLoc), flags);
+
+        // We are now in the weird situation where we have an actual method that
+        // the user has written, but we have a synthetic method that lives at the
+        // same location.  If we try to find all references from the actual
+        // method, there are no calls to it, which will frustrate the user.  Erase
+        // the location(s) on the non-synthetic method so that LSP only sees the
+        // synthetic method.
+        auto hiddenCall = ast::MK::Method(call->loc.copyWithZeroLength(), call->declLoc.copyWithZeroLength(),
+                                          call->name, std::move(call->args), std::move(call->rhs), call->flags);
+
+        // We need to make sure we assign into `callptr` prior to inserting into
+        // `klass->rhs`, otherwise our pointer might not be live anymore.
+        *callptr = std::move(hiddenCall);
+
+        klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());
+        klass->rhs.insert(klass->rhs.begin() + i + 2, std::move(selfCall));
     }
-
-    // Heuristic: Does the previous node look like a `sig`? Check that it's a
-    // Send node and so is its receiver.
-    //
-    // This could in principle be `resolver::TypeSyntax::isSig`, but we don't
-    // want to depend on the internals of the resolver, or accidentally rely on
-    // passes that happen between here and the resolver.
-    auto sig = ast::cast_tree<ast::Send>(klass->rhs[i - 1]);
-    if (sig == nullptr || sig->fun != core::Names::sig()) {
-        return;
-    }
-
-    ast::MethodDef::ARGS_store newArgs;
-    newArgs.reserve(call->args.size());
-    for (auto &arg : call->args) {
-        newArgs.emplace_back(arg.deepCopy());
-    }
-
-    // This method is only for type checking. It doesn't actually exist at runtime, and instead all
-    // Opus::Command subclasses inherit the `self.call` method from `Opus::Command` directly.
-    ast::MethodDef::Flags flags;
-    flags.isSelfMethod = true;
-    flags.discardDef = true;
-    auto selfCall = ast::MK::SyntheticMethod(call->loc, call->declLoc, call->name, std::move(newArgs),
-                                             ast::MK::RaiseTypedUnimplemented(call->declLoc), flags);
-
-    // We are now in the weird situation where we have an actual method that
-    // the user has written, but we have a synthetic method that lives at the
-    // same location.  If we try to find all references from the actual
-    // method, there are no calls to it, which will frustrate the user.  Erase
-    // the location(s) on the non-synthetic method so that LSP only sees the
-    // synthetic method.
-    auto hiddenCall = ast::MK::Method(call->loc.copyWithZeroLength(), call->declLoc.copyWithZeroLength(), call->name,
-                                      std::move(call->args), std::move(call->rhs), call->flags);
-
-    // We need to make sure we assign into `callptr` prior to inserting into
-    // `klass->rhs`, otherwise our pointer might not be live anymore.
-    *callptr = std::move(hiddenCall);
-
-    klass->rhs.insert(klass->rhs.begin() + i + 1, sig->deepCopy());
-    klass->rhs.insert(klass->rhs.begin() + i + 2, std::move(selfCall));
 
     if (!instanceMethods.empty()) {
-        ast::Send::ARGS_store args = InlinedVector<ast::ExpressionPtr, ast::Send::EXPECTED_ARGS_COUNT>();
+        ast::Send::ARGS_store args;
+        args.reserve(instanceMethods.size());
         for (auto [name, loc] : instanceMethods) {
             args.push_back(ast::MK::Symbol(loc, name));
         }
 
         auto hiddenPrivate =
             ast::MK::Send(klass->loc.copyWithZeroLength(), ast::MK::Self(klass->loc), core::Names::private_(),
-                          klass->loc.copyWithZeroLength(), 0, std::move(args));
+                          klass->loc.copyWithZeroLength(), instanceMethods.size(), std::move(args));
 
-        klass->rhs.insert(klass->rhs.begin() + i + 3, std::move(hiddenPrivate));
+        klass->rhs.push_back(std::move(hiddenPrivate));
     }
 }
 

--- a/test/testdata/rewriter/command.rb
+++ b/test/testdata/rewriter/command.rb
@@ -39,3 +39,39 @@ class CallNoSig < Opus::Command
 end
 
 CallNoSig.call # error: Method `call` does not exist
+
+module AbstractMixin
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig { abstract.params(z: Integer).returns(Integer) }
+  def foo(z); end
+end
+
+class ConcreteCommand < Opus::Command
+  include AbstractMixin
+
+  # This secretly becomes a private method and so should error.
+  sig { override.params(z: Integer).returns(Integer) }
+  def foo(z); z; end # error: Method `foo` is private in `ConcreteCommand` but not in `AbstractMixin`
+end
+
+module AbstractMixin
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig { abstract.params(z: Integer).returns(Integer) }
+  def foo(z); end
+end
+
+class ConcreteCommand < Opus::Command
+  include AbstractMixin
+
+  # This secretly becomes a private method and so should error.
+  sig { override.params(z: Integer).returns(Integer) }
+  def foo(z); z; end # error: Method `foo` is private in `ConcreteCommand` but not in `AbstractMixin`
+end

--- a/test/testdata/rewriter/command.rb
+++ b/test/testdata/rewriter/command.rb
@@ -75,3 +75,11 @@ class ConcreteCommand < Opus::Command
   sig { override.params(z: Integer).returns(Integer) }
   def foo(z); z; end # error: Method `foo` is private in `ConcreteCommand` but not in `AbstractMixin`
 end
+
+# This isn't a command and should still work
+class NotACommand
+  include AbstractMixin
+
+  sig { override.params(z: Integer).returns(Integer) }
+  def foo(z); 0; end
+end

--- a/test/testdata/rewriter/command.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/command.rb.rewrite-tree.exp
@@ -72,4 +72,86 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   <emptyTree>::<C CallNoSig>.call()
+
+  module <emptyTree>::<C AbstractMixin><<C <todo sym>>> < ()
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.abstract().params(:z, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<<todo method>>(z, &<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <self>.extend(<emptyTree>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+
+    <runtime method definition of foo>
+  end
+
+  class <emptyTree>::<C ConcreteCommand><<C <todo sym>>> < (<emptyTree>::<C Opus>::<C Command>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.override().params(:z, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<<todo method>>(z, &<blk>)
+      z
+    end
+
+    <self>.include(<emptyTree>::<C AbstractMixin>)
+
+    <runtime method definition of foo>
+
+    <self>.private(:foo)
+  end
+
+  module <emptyTree>::<C AbstractMixin><<C <todo sym>>> < ()
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.abstract().params(:z, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<<todo method>>(z, &<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <self>.extend(<emptyTree>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+
+    <runtime method definition of foo>
+  end
+
+  class <emptyTree>::<C ConcreteCommand><<C <todo sym>>> < (<emptyTree>::<C Opus>::<C Command>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.override().params(:z, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<<todo method>>(z, &<blk>)
+      z
+    end
+
+    <self>.include(<emptyTree>::<C AbstractMixin>)
+
+    <runtime method definition of foo>
+
+    <self>.private(:foo)
+  end
+
+  class <emptyTree>::<C NotACommand><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.override().params(:z, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
+    end
+
+    def foo<<todo method>>(z, &<blk>)
+      0
+    end
+
+    <self>.include(<emptyTree>::<C AbstractMixin>)
+
+    <runtime method definition of foo>
+  end
 end


### PR DESCRIPTION
### Motivation
Stripe-internal API details.


### Test plan

See included automated tests.
