### PR TITLE
 Remove use of SIGINT when terminating Sorbet.

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version history
 
+## 0.3.43
+- Remove use of SIGINT when terminating Sorbet.
+
 ## 0.3.42
 - Use VS Code's standard `$(sync)` icon on status bar.
 

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/src/connections.ts
+++ b/vscode_extension/src/connections.ts
@@ -2,33 +2,30 @@ import { ChildProcess } from "child_process";
 import { Log } from "./log";
 
 /**
- * Attempts to stop the given child process. Tries a SIGINT, then a SIGTERM, then a SIGKILL.
+ * Attempts to stop the given child process. Tries a SIGTERM, then a SIGKILL.
  */
 export async function stopProcess(p: ChildProcess, log: Log): Promise<void> {
-  return new Promise<void>((res) => {
+  return new Promise<void>((resolve) => {
     let hasExited = false;
     log.debug("Stopping process", p.pid);
     function onExit() {
       if (!hasExited) {
         hasExited = true;
-        res();
+        resolve();
       }
     }
     p.on("exit", onExit);
     p.on("error", onExit);
-    p.kill("SIGINT");
+    p.kill("SIGTERM");
     setTimeout(() => {
       if (!hasExited) {
-        log.debug("Process did not respond to SIGINT. Sending a SIGTERM.");
+        log.debug(
+          "Process did not respond to SIGTERM with 1s. Sending a SIGKILL.",
+          p.pid,
+        );
+        p.kill("SIGKILL");
+        setTimeout(resolve, 100);
       }
-      p.kill("SIGTERM");
-      setTimeout(() => {
-        if (!hasExited) {
-          log.debug("Process did not respond to SIGTERM. Sending a SIGKILL.");
-          p.kill("SIGKILL");
-          setTimeout(res, 100);
-        }
-      }, 1000);
     }, 1000);
   });
 }


### PR DESCRIPTION
Sorbet termination logic tries to go over `SIGINT`, `SIGTERM` and finally `SIGKILL` to allow for graceful termination but  there is no known handler of `SIGINT` signal. This change removes the `SIGINT` attempt.

- Release 0.3.43 with change to detect issues early, if any (testing showed no issues).

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
