### PR TITLE
Allow customizing the untyped code highlight diagnostic severity

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2089,6 +2089,7 @@ void GlobalState::copyOptions(const core::GlobalState &other) {
     this->ruby3KeywordArgs = other.ruby3KeywordArgs;
     this->suppressPayloadSuperclassRedefinitionFor = other.suppressPayloadSuperclassRedefinitionFor;
     this->trackUntyped = other.trackUntyped;
+    this->highlightUntypedDiagnosticSeverity = other.highlightUntypedDiagnosticSeverity;
     this->printingFileTable = other.printingFileTable;
     this->errorUrlBase = other.errorUrlBase;
     this->includeErrorSections = other.includeErrorSections;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -9,6 +9,7 @@
 #include "core/Names.h"
 #include "core/Symbols.h"
 #include "core/TrackUntyped.h"
+#include "core/lsp/DiagnosticSeverity.h"
 #include "core/lsp/Query.h"
 #include "core/packages/PackageDB.h"
 #include "core/packages/PackageInfo.h"
@@ -241,6 +242,25 @@ public:
     bool autocorrect = false;
     bool didYouMean = true;
     TrackUntyped trackUntyped = TrackUntyped::Nowhere;
+
+    /**
+     * The severity to use when reporting untyped highlights.
+     *
+     * Must be stored on GlobalState (vs LSPClientConfiguration) because LSPClientConfiguration is
+     * immutable after initialization.
+     *
+     * The fact that we report untyped code as "diagnostic" is mostly a limitation of the LSP spec.
+     * There's no real way to communicate passive information about individual regions of code
+     * except by either defining "semantic tokens" (for syntax highlighting) or diagnostics.
+     *
+     * VS Code is special (like it always is) and makes it hard to customize how diagnostics are
+     * presented. In particular, marking a diagnostic as "Information" will make it show up in the
+     * Problems view, while "Hint" diagnostics will not show up there. (Hint diagnostics have their
+     * own problems: it's hard to customize the style of them in the editor). But in any case, we
+     * can let users choose which side of these tradeoffs they want to come down on.
+     */
+    lsp::DiagnosticSeverity highlightUntypedDiagnosticSeverity = lsp::DiagnosticSeverity::Information;
+
     bool printingFileTable = false;
 
     // We have a lot of internal names of form `<something>` that's chosen with `<` and `>` as you can't make

--- a/core/lsp/DiagnosticSeverity.h
+++ b/core/lsp/DiagnosticSeverity.h
@@ -1,0 +1,19 @@
+#ifndef SORBET_CORE_LSP_DIAGNOSTIC_SEVERITY_H
+#define SORBET_CORE_LSP_DIAGNOSTIC_SEVERITY_H
+
+#include <stdint.h>
+
+namespace sorbet::core::lsp {
+
+// Identical to realmain::lsp::DiagnosticSeverity.
+// Needs to be here so that we can store this in GlobalState without depending on all of realmain::lsp
+enum class DiagnosticSeverity {
+    Error = 1,
+    Warning = 2,
+    Information = 3,
+    Hint = 4,
+};
+
+} // namespace sorbet::core::lsp
+
+#endif

--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -32,6 +32,7 @@ cc_library(
     ],
     hdrs = [
         "ConvertToSingletonClassMethod.h",
+        "DiagnosticSeverity.h",
         "ExtractVariable.h",
         "LSPConfiguration.h",
         "LSPInput.h",

--- a/main/lsp/DiagnosticSeverity.cc
+++ b/main/lsp/DiagnosticSeverity.cc
@@ -1,0 +1,31 @@
+#include "main/lsp/DiagnosticSeverity.h"
+
+namespace sorbet::realmain::lsp {
+
+DiagnosticSeverity convertDiagnosticSeverity(core::lsp::DiagnosticSeverity severity) {
+    switch (severity) {
+        case core::lsp::DiagnosticSeverity::Error:
+            return DiagnosticSeverity::Error;
+        case core::lsp::DiagnosticSeverity::Warning:
+            return DiagnosticSeverity::Warning;
+        case core::lsp::DiagnosticSeverity::Information:
+            return DiagnosticSeverity::Information;
+        case core::lsp::DiagnosticSeverity::Hint:
+            return DiagnosticSeverity::Hint;
+    }
+}
+
+core::lsp::DiagnosticSeverity convertDiagnosticSeverity(DiagnosticSeverity severity) {
+    switch (severity) {
+        case DiagnosticSeverity::Error:
+            return core::lsp::DiagnosticSeverity::Error;
+        case DiagnosticSeverity::Warning:
+            return core::lsp::DiagnosticSeverity::Warning;
+        case DiagnosticSeverity::Information:
+            return core::lsp::DiagnosticSeverity::Information;
+        case DiagnosticSeverity::Hint:
+            return core::lsp::DiagnosticSeverity::Hint;
+    }
+}
+
+} // namespace sorbet::realmain::lsp

--- a/main/lsp/DiagnosticSeverity.h
+++ b/main/lsp/DiagnosticSeverity.h
@@ -1,0 +1,15 @@
+#ifndef SORBET_MAIN_LSP_DIAGNOSTIC_SEVERITY_H
+#define SORBET_MAIN_LSP_DIAGNOSTIC_SEVERITY_H
+
+#include "core/lsp/DiagnosticSeverity.h"
+#include "main/lsp/json_enums.h"
+
+namespace sorbet::realmain::lsp {
+
+DiagnosticSeverity convertDiagnosticSeverity(core::lsp::DiagnosticSeverity severity);
+
+core::lsp::DiagnosticSeverity convertDiagnosticSeverity(DiagnosticSeverity severity);
+
+} // namespace sorbet::realmain::lsp
+
+#endif

--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -2,6 +2,7 @@
 #include "core/errors/infer.h"
 #include "core/errors/internal.h"
 #include "core/lsp/TypecheckEpochManager.h"
+#include "main/lsp/DiagnosticSeverity.h"
 #include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/LSPMessage.h"
 #include "main/lsp/LSPOutput.h"
@@ -158,7 +159,7 @@ void ErrorReporter::pushDiagnostics(uint32_t epoch, core::FileRef file, const ve
 
         diagnostic->severity = DiagnosticSeverity::Error;
         if (error->what == sorbet::core::errors::Infer::UntypedValueInformation) {
-            diagnostic->severity = DiagnosticSeverity::Information;
+            diagnostic->severity = convertDiagnosticSeverity(gs.highlightUntypedDiagnosticSeverity);
         }
 
         if (!error->autocorrects.empty()) {

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -126,6 +126,8 @@ LSPClientConfiguration::LSPClientConfiguration(const InitializeParams &params) {
         enableSorbetURIs = initOptions->supportsSorbetURIs.value_or(false);
         initialEnableHighlightUntyped = parseEnableHighlightUntyped(*initOptions, core::TrackUntyped::Nowhere);
         enableTypedFalseCompletionNudges = initOptions->enableTypedFalseCompletionNudges.value_or(true);
+        initialHighlightUntypedDiagnosticSeverity =
+            initOptions->highlightUntypedDiagnosticSeverity.value_or(DiagnosticSeverity::Information);
     }
 }
 

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -45,6 +45,13 @@ public:
     bool enableTypedFalseCompletionNudges = true;
 
     /**
+     * Initial value for which DiagnosticSeverity level to use when reporting untyped values.
+     *
+     * See `GlobalState::highlightUntypedDiagnosticSeverity` for more.
+     */
+    DiagnosticSeverity initialHighlightUntypedDiagnosticSeverity = DiagnosticSeverity::Information;
+
+    /**
      * Whether or not the active client has support for snippets in CompletionItems.
      * Note: There is a generated ClientCapabilities class, but it is cumbersome to work with as most fields are
      * optional.

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -8,6 +8,7 @@
 #include "core/lsp/TypecheckEpochManager.h"
 #include "hashing/hashing.h"
 #include "main/cache/cache.h"
+#include "main/lsp/DiagnosticSeverity.h"
 #include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/ShowOperation.h"
 #include "main/lsp/json_types.h"
@@ -440,8 +441,15 @@ const core::File &LSPIndexer::getFile(core::FileRef fref) const {
     return fref.data(*gs);
 }
 
-void LSPIndexer::updateGsFromOptions(const DidChangeConfigurationParams &options) const {
+void LSPIndexer::updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const {
     gs->trackUntyped = LSPClientConfiguration::parseEnableHighlightUntyped(*options.settings, gs->trackUntyped);
+
+    // Errors are flushed from the typechecker thread, so this should not matter, but we may as well
+    // set it just in case.
+    if (options.settings->highlightUntypedDiagnosticSeverity.has_value()) {
+        gs->highlightUntypedDiagnosticSeverity =
+            convertDiagnosticSeverity(options.settings->highlightUntypedDiagnosticSeverity.value());
+    }
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -110,7 +110,7 @@ public:
      */
     void transferInitializeState(InitializedTask &task);
 
-    void updateGsFromOptions(const DidChangeConfigurationParams &options) const;
+    void updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -13,6 +13,7 @@
 #include "local_vars/local_vars.h"
 #include "main/cache/cache.h"
 #include "main/lsp/DefLocSaver.h"
+#include "main/lsp/DiagnosticSeverity.h"
 #include "main/lsp/ErrorFlusherLSP.h"
 #include "main/lsp/ErrorReporter.h"
 #include "main/lsp/LSPMessage.h"
@@ -75,6 +76,9 @@ void LSPTypechecker::initialize(TaskQueue &queue, unique_ptr<core::GlobalState> 
 
     // Initialize settings that come through from the client.
     this->gs->trackUntyped = currentConfig.getClientConfig().initialEnableHighlightUntyped;
+
+    this->gs->highlightUntypedDiagnosticSeverity =
+        convertDiagnosticSeverity(currentConfig.getClientConfig().initialHighlightUntypedDiagnosticSeverity);
 
     // Initialization typecheck is not cancelable.
     // TODO(jvilk): Make it preemptible.
@@ -833,9 +837,14 @@ void LSPTypechecker::setSlowPathBlocked(bool blocked) {
     slowPathBlocked = blocked;
 }
 
-void LSPTypechecker::updateGsFromOptions(const DidChangeConfigurationParams &options) const {
+void LSPTypechecker::updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const {
     this->gs->trackUntyped =
         LSPClientConfiguration::parseEnableHighlightUntyped(*options.settings, this->gs->trackUntyped);
+
+    if (options.settings->highlightUntypedDiagnosticSeverity.has_value()) {
+        this->gs->highlightUntypedDiagnosticSeverity =
+            convertDiagnosticSeverity(options.settings->highlightUntypedDiagnosticSeverity.value());
+    }
 
     if (options.settings->enableTypecheckInfo.has_value() ||
         options.settings->enableTypedFalseCompletionNudges.has_value() ||
@@ -898,8 +907,8 @@ ast::ExpressionPtr LSPTypecheckerDelegate::getLocalVarTrees(core::FileRef fref) 
 const core::GlobalState &LSPTypecheckerDelegate::state() const {
     return typechecker.state();
 }
-void LSPTypecheckerDelegate::updateGsFromOptions(const DidChangeConfigurationParams &options) const {
-    typechecker.updateGsFromOptions(options);
+void LSPTypecheckerDelegate::updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const {
+    typechecker.updateConfigAndGsFromOptions(options);
 }
 
 unique_ptr<LSPFileUpdates> LSPTypecheckerDelegate::getNoopUpdate(absl::Span<const core::FileRef> frefs) const {

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -196,7 +196,7 @@ public:
      * Exposes very limited mutability to typechecker's global state in order to support the client changing
      * options (such as highlighting untyped code) without doing a full restart of Sorbet.
      */
-    void updateGsFromOptions(const DidChangeConfigurationParams &options) const;
+    void updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const;
 
     /**
      * Get an LSPFileUpdates containing the latest versions of the given files. It's a "no-op" file update because it
@@ -246,7 +246,7 @@ public:
 
     const core::GlobalState &state() const;
 
-    void updateGsFromOptions(const DidChangeConfigurationParams &options) const;
+    void updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const;
     std::unique_ptr<LSPFileUpdates> getNoopUpdate(absl::Span<const core::FileRef> frefs) const;
 };
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/notifications/did_change_configuration.cc
+++ b/main/lsp/notifications/did_change_configuration.cc
@@ -18,11 +18,11 @@ LSPTask::Phase DidChangeConfigurationTask::finalPhase() const {
 }
 
 void DidChangeConfigurationTask::index(LSPIndexer &indexer) {
-    indexer.updateGsFromOptions(*params);
+    indexer.updateConfigAndGsFromOptions(*params);
 }
 
 void DidChangeConfigurationTask::run(LSPTypecheckerDelegate &tc) {
-    tc.updateGsFromOptions(*params);
+    tc.updateConfigAndGsFromOptions(*params);
     vector<core::FileRef> openFileRefs;
     for (auto const &path : openFilePaths) {
         openFileRefs.push_back(tc.state().findFileByPath(path));

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1265,6 +1265,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        makeField("enableTypecheckInfo", makeOptional(JSONBool)),
                        makeField("highlightUntyped", makeOptional(makeVariant({JSONBool, JSONString}))),
                        makeField("enableTypedFalseCompletionNudges", makeOptional(JSONBool)),
+                       makeField("highlightUntypedDiagnosticSeverity", makeOptional(DiagnosticSeverity)),
                    },
                    classTypes);
     auto InitializeParams =

--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version history
 
+## 0.3.44
+- Allow configuring the diagnostic severity used to highlight untyped code. See [the docs](https://sorbet.org/docs/highlight-untyped) for more.
+
 ## 0.3.43
 - Remove use of SIGINT when terminating Sorbet.
 

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {
@@ -25,6 +25,7 @@
   "activationEvents": [
     "onCommand:sorbet.configure",
     "onCommand:sorbet.configureHighlightUntyped",
+    "onCommand:sorbet.configureHighlightUntypedDiagnosticSeverity",
     "onCommand:sorbet.disable",
     "onCommand:sorbet.enable",
     "onCommand:sorbet.restart",
@@ -59,6 +60,12 @@
       {
         "command": "sorbet.configureHighlightUntyped",
         "title": "Configure untyped code highlighting",
+        "category": "Sorbet",
+        "enablement": "workbenchState != empty"
+      },
+      {
+        "command": "sorbet.configureHighlightUntypedDiagnosticSeverity",
+        "title": "Configure untyped code highlighting diagnostic severity",
         "category": "Sorbet",
         "enablement": "workbenchState != empty"
       },
@@ -279,6 +286,28 @@
           ],
           "description": "Shows warning for untyped values.",
           "default": "nowhere"
+        },
+        "sorbet.highlightUntypedDiagnosticSeverity": {
+          "enum": [
+            1,
+            2,
+            3,
+            4
+          ],
+          "enumItemLabels": [
+            "Error",
+            "Warning",
+            "Information",
+            "Hint"
+          ],
+          "markdownEnumDescriptions": [
+            "Error",
+            "Warning",
+            "Information",
+            "Hint"
+          ],
+          "description": "Which severity to use to highlight untyped usages with (controls the squiggle colors)",
+          "default": 3
         },
         "sorbet.typedFalseCompletionNudges": {
           "type": "boolean",

--- a/vscode_extension/src/commandIds.ts
+++ b/vscode_extension/src/commandIds.ts
@@ -5,6 +5,12 @@ export const CONFIGURE_HIGHLIGHT_UNTYPED_COMMAND_ID =
   "sorbet.configureHighlightUntyped";
 
 /**
+ * Configure highlighting of untyped code.
+ */
+export const CONFIGURE_HIGHLIGHT_UNTYPED_DIAGNOSTIC_SEVERITY_COMMAND_ID =
+  "sorbet.configureHighlightUntypedDiagnosticSeverity";
+
+/**
  * Copy Symbol to Clipboard.
  */
 export const COPY_SYMBOL_COMMAND_ID = "sorbet.copySymbolToClipboard";
@@ -54,6 +60,7 @@ export const SORBET_SAVE_PACKAGE_FILES = "sorbet.savePackageFiles";
  */
 export const TOGGLE_HIGHLIGHT_UNTYPED_COMMAND_ID =
   "sorbet.toggleHighlightUntyped";
+
 /**
  * Toggle the auto-complete nudge in `typed: false` files.
  */

--- a/vscode_extension/src/commands/configureUntypedCodeHighlightingDiagnosticSeverity.ts
+++ b/vscode_extension/src/commands/configureUntypedCodeHighlightingDiagnosticSeverity.ts
@@ -1,0 +1,77 @@
+import { QuickPickItem, window, DiagnosticSeverity } from "vscode";
+import { ALL_DIAGNOSTIC_SEVERITY } from "../config";
+import { SorbetExtensionContext } from "../sorbetExtensionContext";
+
+export interface DiagnosticSeverityQuickPickItem extends QuickPickItem {
+  severity: DiagnosticSeverity;
+}
+
+async function cycleStates(
+  context: SorbetExtensionContext,
+  targetState: DiagnosticSeverity,
+  forCommand: string,
+) {
+  const oldHighlightUntyped = context.configuration.highlightUntyped;
+  context.configuration.oldHighlightUntyped = oldHighlightUntyped;
+
+  await context.configuration.setHighlightUntypedDiagnosticSeverity(
+    targetState,
+  );
+  context.log.info(
+    forCommand,
+    "Untyped code highlighting diagnostic severity",
+    targetState,
+  );
+}
+
+/**
+ * Set highlighting of untyped code to specific setting.
+ * @param context Sorbet extension context.
+ */
+export async function configureUntypedCodeHighlightingDiagnosticSeverity(
+  context: SorbetExtensionContext,
+): Promise<DiagnosticSeverity | null> {
+  const items: DiagnosticSeverityQuickPickItem[] = ALL_DIAGNOSTIC_SEVERITY.map(
+    (severity) => {
+      return {
+        label: severity,
+        // vscode.DiagnosticSeverity is 0-indexed, LSP spec is 1-indexed 🤦‍♂️
+        //
+        // - <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticSeverity>
+        // - <https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity>
+        severity: DiagnosticSeverity[severity] + 1,
+      };
+    },
+  );
+
+  const selectedItem = await window.showQuickPick(items, {
+    placeHolder:
+      "Select which diagnostic level to use when highlighting untyped",
+  });
+
+  if (selectedItem) {
+    const targetState = selectedItem.severity;
+    await cycleStates(
+      context,
+      targetState,
+      "ConfigureUntypedDiagnosticSeverity",
+    );
+
+    const { activeLanguageClient: client } = context.statusProvider;
+    if (client) {
+      client.sendNotification("workspace/didChangeConfiguration", {
+        settings: {
+          highlightUntypedDiagnosticSeverity: targetState,
+        },
+      });
+    } else {
+      context.log.debug(
+        "ConfigureUntypedDiagnosticSeverity: No active Sorbet LSP to notify.",
+      );
+    }
+
+    return targetState;
+  }
+
+  return null;
+}

--- a/vscode_extension/src/config.ts
+++ b/vscode_extension/src/config.ts
@@ -1,6 +1,7 @@
 import {
   ConfigurationChangeEvent,
   Disposable,
+  DiagnosticSeverity,
   Event,
   EventEmitter,
   ExtensionContext,
@@ -19,6 +20,19 @@ export const ALL_TRACK_UNTYPED: TrackUntyped[] = [
   "nowhere",
   "everywhere-but-tests",
   "everywhere",
+];
+
+export type DiagnosticSeverityStr =
+  | "Error"
+  | "Warning"
+  | "Information"
+  | "Hint";
+
+export const ALL_DIAGNOSTIC_SEVERITY: DiagnosticSeverityStr[] = [
+  "Error",
+  "Warning",
+  "Information",
+  "Hint",
 ];
 
 function coerceTrackUntypedSetting(value: boolean | string): TrackUntyped {
@@ -216,6 +230,7 @@ export class SorbetExtensionConfig implements Disposable {
   private userLspConfigs: ReadonlyArray<SorbetLspConfig>;
   private wrappedEnabled: boolean;
   private wrappedHighlightUntyped: TrackUntyped;
+  private wrappedHighlightUntypedDiagnosticSeverity: DiagnosticSeverity;
   private wrappedTypedFalseCompletionNudges: boolean;
   private wrappedRevealOutputOnError: boolean;
 
@@ -229,6 +244,8 @@ export class SorbetExtensionConfig implements Disposable {
     this.standardLspConfigs = [];
     this.userLspConfigs = [];
     this.wrappedHighlightUntyped = "nowhere";
+    this.wrappedHighlightUntypedDiagnosticSeverity =
+      DiagnosticSeverity.Information;
     this.wrappedTypedFalseCompletionNudges = true;
     this.wrappedRevealOutputOnError = false;
 
@@ -291,6 +308,10 @@ export class SorbetExtensionConfig implements Disposable {
     this.wrappedTypedFalseCompletionNudges = this.sorbetWorkspaceContext.get(
       "typedFalseCompletionNudges",
       this.typedFalseCompletionNudges,
+    );
+    this.wrappedHighlightUntypedDiagnosticSeverity = this.sorbetWorkspaceContext.get(
+      "highlightUntypedDiagnosticSeverity",
+      this.highlightUntypedDiagnosticSeverity,
     );
 
     Disposable.from(...this.configFileWatchers).dispose();
@@ -363,6 +384,10 @@ export class SorbetExtensionConfig implements Disposable {
     return this.wrappedHighlightUntyped;
   }
 
+  public get highlightUntypedDiagnosticSeverity(): DiagnosticSeverity {
+    return this.wrappedHighlightUntypedDiagnosticSeverity;
+  }
+
   public oldHighlightUntyped: TrackUntyped | undefined = undefined;
 
   /**
@@ -428,6 +453,16 @@ export class SorbetExtensionConfig implements Disposable {
 
   public async setHighlightUntyped(trackWhere: TrackUntyped): Promise<void> {
     await this.sorbetWorkspaceContext.update("highlightUntyped", trackWhere);
+    this.refresh();
+  }
+
+  public async setHighlightUntypedDiagnosticSeverity(
+    severity: DiagnosticSeverity,
+  ): Promise<void> {
+    await this.sorbetWorkspaceContext.update(
+      "highlightUntypedDiagnosticSeverity",
+      severity,
+    );
     this.refresh();
   }
 

--- a/vscode_extension/src/extension.ts
+++ b/vscode_extension/src/extension.ts
@@ -9,6 +9,7 @@ import {
   toggleUntypedCodeHighlighting,
   configureUntypedCodeHighlighting,
 } from "./commands/toggleUntypedCodeHighlighting";
+import { configureUntypedCodeHighlightingDiagnosticSeverity } from "./commands/configureUntypedCodeHighlightingDiagnosticSeverity";
 import { toggleTypedFalseCompletionNudges } from "./commands/toggleTypedFalseCompletionNudges";
 import { getLogLevelFromEnvironment, LogLevel } from "./log";
 import { SorbetContentProvider, SORBET_SCHEME } from "./sorbetContentProvider";
@@ -90,6 +91,13 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand(
       cmdIds.CONFIGURE_HIGHLIGHT_UNTYPED_COMMAND_ID,
       () => configureUntypedCodeHighlighting(sorbetExtensionContext),
+    ),
+    commands.registerCommand(
+      cmdIds.CONFIGURE_HIGHLIGHT_UNTYPED_DIAGNOSTIC_SEVERITY_COMMAND_ID,
+      () =>
+        configureUntypedCodeHighlightingDiagnosticSeverity(
+          sorbetExtensionContext,
+        ),
     ),
     commands.registerCommand(
       cmdIds.TOGGLE_TYPED_FALSE_COMPLETION_NUDGES_COMMAND_ID,

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -22,6 +22,8 @@ export function createClient(
     ),
     enableTypedFalseCompletionNudges:
       context.configuration.typedFalseCompletionNudges,
+    highlightUntypedDiagnosticSeverity:
+      context.configuration.highlightUntypedDiagnosticSeverity,
   };
 
   context.log.debug(

--- a/vscode_extension/src/test/commands/configureUntypedCodeHighlightingDiagnosticSeverity.test.ts
+++ b/vscode_extension/src/test/commands/configureUntypedCodeHighlightingDiagnosticSeverity.test.ts
@@ -1,0 +1,76 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as path from "path";
+import * as sinon from "sinon";
+
+import { createLogStub } from "../testUtils";
+import {
+  configureUntypedCodeHighlightingDiagnosticSeverity,
+  DiagnosticSeverityQuickPickItem,
+} from "../../commands/configureUntypedCodeHighlightingDiagnosticSeverity";
+import { SorbetExtensionConfig } from "../../config";
+import { SorbetExtensionContext } from "../../sorbetExtensionContext";
+import { SorbetStatusProvider } from "../../sorbetStatusProvider";
+import { RestartReason } from "../../types";
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  let testRestorables: { restore: () => void }[];
+
+  setup(() => {
+    testRestorables = [];
+  });
+
+  teardown(() => {
+    testRestorables.forEach((r) => r.restore());
+  });
+
+  test("configureUntypedCodeHighlightingDiagnosticSeverity", async () => {
+    const initialState = vscode.DiagnosticSeverity.Information;
+    let currentState = initialState;
+
+    const log = createLogStub();
+
+    const setHighlightUntypedDiagnosticSeveritySpy = sinon.spy(
+      (value: vscode.DiagnosticSeverity) => {
+        currentState = value;
+      },
+    );
+    const configuration = <SorbetExtensionConfig>(<unknown>{
+      get highlightUntypedDiagnosticSeverity() {
+        return currentState;
+      },
+      setHighlightUntypedDiagnosticSeverity: setHighlightUntypedDiagnosticSeveritySpy,
+    });
+
+    const restartSorbetSpy = sinon.spy((_reason: RestartReason) => {});
+    const statusProvider = <SorbetStatusProvider>(<unknown>{
+      restartSorbet: restartSorbetSpy,
+    });
+
+    const context = <SorbetExtensionContext>{
+      log,
+      configuration,
+      statusProvider,
+    };
+
+    const expectedSeverityStr = "Warning";
+    const expectedSeverity = vscode.DiagnosticSeverity[expectedSeverityStr] + 1;
+    const showQuickPickSingleStub = sinon
+      .stub(vscode.window, "showQuickPick")
+      .resolves(<DiagnosticSeverityQuickPickItem>{
+        label: expectedSeverityStr,
+        severity: expectedSeverity,
+      });
+    testRestorables.push(showQuickPickSingleStub);
+
+    assert.strictEqual(
+      await configureUntypedCodeHighlightingDiagnosticSeverity(context),
+      expectedSeverity,
+    );
+    sinon.assert.calledOnce(setHighlightUntypedDiagnosticSeveritySpy);
+    sinon.assert.calledWithExactly(
+      setHighlightUntypedDiagnosticSeveritySpy,
+      expectedSeverity,
+    );
+  });
+});

--- a/website/docs/highlight-untyped.md
+++ b/website/docs/highlight-untyped.md
@@ -90,6 +90,60 @@ For example, in Neovim, this `highlightUntyped` setting can be provided via the 
 
 [`init_options` argument]: https://neovim.io/doc/user/lsp.html#:~:text=initializationOptions
 
+## Customizing the presentation of untyped highlights
+
+Due to limitations in the LSP spec, Sorbet reports untyped highlights as diagnostics. By default Sorbet reports untyped highlights using a [`DiagnosticSeverity`] of `Information`, which does not specify how it should be visualized.
+
+[`DiagnosticSeverity`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticSeverity
+
+Instead, presentation is the responsibility of the client. For example, Neovim's uses highlight groups (`:help diagnostic-highlights`) to specify how diagnostics look, and VS Code allows customizing diagnostics with [various settings](https://code.visualstudio.com/api/references/theme-color#:~:text=editorInfo.foreground) like `editorInfo.foreground`.
+
+Because certain language clients like VS Code make it hard to customize how diagnostics are presented in the editor, Sorbet allows specifying which diagnostic severity to report untyped highlights with.
+
+### In VS Code
+
+There are two methods:
+
+- Open a Ruby file, and run the `Sorbet: Configure highlight untyped diagnostic severity` command from the command palette (accessed via ⇧⌘P on macOS, or ⌃⇧P on Windows and Linux).
+
+  You will be able to choose the severity
+
+  - 1 – `Error` (red squiggles)
+
+  - 2 – `Warning` (yellow squiggles)
+
+  - 3 – `Information` (blue squiggles)
+
+  - 4 – `Hint` (gray `...`, no squiggles)
+
+- Set the `"sorbet.highlightUntypedDiagnosticSeverity": ...` setting in the VS Code preferences. This changes the _default_ setting--values chosen with the Configure command above will not change this value.
+
+  For example, to have a workspace default to reporting untyped code as warnings, add this to the project's `.vscode/settings.json` file:
+
+  ```json
+    "sorbet.highlightUntypedDiagnosticSeverity": 2
+  ```
+
+### In other LSP clients
+
+This feature relies on two LSP features:
+
+- The `initializationOptions` parameter in the `initialize` request that starts [every language server protocol session](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize).
+
+- The `settings` parameter in the `workspace/didChangeConfiguration` notification.
+
+For both the `initializationOptions` and `settings` parameters, Sorbet allows passing a JSON object containing
+
+```json
+  "highlightUntypedDiagnosticSeverity": ...,
+```
+
+Where `...` is one of the [`DiagnosticSeverity`] integers from the LSP spec (1, 2, 3, 4).
+
+For example, in Neovim, this `highlightUntypedDiagnosticSeverity` setting can be provided via the [`init_options` argument] to the `vim.lsp.start_client()` function, which then passes it to the underlying `initialize` request.
+
+[`init_options` argument]: https://neovim.io/doc/user/lsp.html#:~:text=initializationOptions
+
 ## Notes
 
 - This feature is not enabled in `# typed: false` files. A `# typed: false` file is essentially a file where the entire contents would need to be underlined. Sorbet does not actually underline the entire content of such a file, as it would be too noisy.

--- a/website/docs/lsp.md
+++ b/website/docs/lsp.md
@@ -179,6 +179,8 @@ export interface SorbetInitializationOptions {
   enableTypedFalseCompletionNudges?: boolean;
   supportsOperationNotifications?: boolean;
   supportsSorbetURIs?: boolean;
+  supportsSorbetURIs?: boolean;
+  highlightUntypedDiagnosticSeverity?: DiagnosticSeverity;
 }
 ```
 
@@ -199,6 +201,12 @@ export interface SorbetInitializationOptions {
 - `supportsSorbetURIs`
 
   See [Working with Synthetic or Missing Files](sorbet-uris.md)
+
+- `highlightUntypedDiagnosticSeverity`
+
+  What "severity" to report usages of untyped in the client. This is to workaround limitations in the LSP specification and VS Code. See [the relevant section](highlight-untyped.md#customizing-the-presentation-of-untyped-highlights) for more information.
+
+  **Note** that [`DiagnosticSeverity`] is an `integer`-valued enum, as per the LSP specification.
 
 ### `workspace/didChangeConfiguration` notification
 
@@ -360,3 +368,4 @@ Thus, to use Sorbet with watchman in a project that does not use Git, create an 
 [`SymbolInformation`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolInformation
 [`TextDocumentIdentifier`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentIdentifier
 [`TextDocumentItem`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+[`DiagnosticSeverity`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticSeverity

--- a/website/docs/vscode.md
+++ b/website/docs/vscode.md
@@ -314,6 +314,12 @@ Whether to highlight untyped, and where. Defaults to `"nowhere"`.
 
 See [Highlighting untyped code](highlight-untyped.md)
 
+### `sorbet.highlightUntypedDiagnosticSeverity`
+
+What diagnostic severity to use when reporting usages of untyped.
+
+See [Highlighting untyped code](highlight-untyped.md)
+
 ### `sorbet.typedFalseCompletionNudges`
 
 Whether to enable `# typed: false` completion nudges. Defaults to `true`.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have been getting complaints that using information diagnostics to highlight untyped code is too noisy sometimes especially because it pollutes the `Problems` tab.

VS Code treats the `Hint` diagnostic level as something that never shows up in the problems tab, and this might be a better option for some users.

It would be nice if VS Code made it possible to easily style hint diagnostics to have the same squiggle underline that other diagnostics have, but that does not seem to be something VS Code allows (we might build custom, opt-in logic in the VS Code extension to allow styling the untyped code hint diagnostics, but that can be a future change).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I opted to test this manually instead of with CLI tests, because I think that testing this mostly indicates whether the new test framework I've written is correct (and I don't think it would have actually caught the ways that this failed when trying it out for real).

I tested that this works in both Neovim and VS Code (and specifically that both `.vscode/settings.json` and `>Sorbet: Configure [...]` are valid ways of getting this setting to pick up.