### PR TITLE
Use `WorkspaceFolder` rather than deprecated `workspace.rootFolder` property

### DIFF
--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -1,3 +1,4 @@
+import { WorkspaceFolder } from "vscode";
 import { ErrorHandler, RevealOutputChannelOn } from "vscode-languageclient";
 import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
 import { backwardsCompatibleTrackUntyped } from "./config";
@@ -8,6 +9,7 @@ import { SorbetExtensionContext } from "./sorbetExtensionContext";
  */
 export function createClient(
   context: SorbetExtensionContext,
+  workspaceFolder: WorkspaceFolder | undefined,
   serverOptions: ServerOptions,
   errorHandler: ErrorHandler,
 ): LanguageClient {
@@ -45,6 +47,7 @@ export function createClient(
       return false;
     },
     outputChannel: context.logOutputChannel,
+    workspaceFolder,
     revealOutputChannelOn: context.configuration.revealOutputOnError
       ? RevealOutputChannelOn.Error
       : RevealOutputChannelOn.Never,


### PR DESCRIPTION
Use `WorkspaceFolder` rather than deprecated `workspace.rootFolder` property. 
- This wires the selected `WorkspaceFolder` all the way into the `LanguageClient` for consistency.
- This does not change any assumption made by `workspace.rootFolder`: there might be or not any `workspace` open (which explains the `WorkspaceFolder | undefined`)  and when there are multiple, only and always `workspace.workspaceFolders[0]` is used.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
