### PR TITLE
[runtime] Allow props to override regular methods

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -112,6 +112,10 @@ module T::Private::Methods
     signature_for_key(method_to_key(method))
   end
 
+  def self.signature_for_method_by_owner_and_name(owner, name)
+    signature_for_key(method_owner_and_name_to_key(owner, name))
+  end
+
   private_class_method def self.signature_for_key(key)
     maybe_run_sig_block_for_key(key)
 

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -638,7 +638,7 @@ class T::Props::Decorator
 
     props.each do |name, rules|
       copied_rules = rules.dup
-      # NB: Calling `child.decorator` here is a timb bomb that's going to give someone a really bad
+      # NB: Calling `child.decorator` here is a time bomb that's going to give someone a really bad
       # time. Any class that defines props and also overrides the `decorator_class` method is going
       # to reach this line before its override take effect, turning it into a no-op.
       child.decorator.add_prop_definition(name, copied_rules)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This change adjusts the runtime such that `override: true` in the `prop` DSL now permits overriding any `foo` and `foo=` methods in a parent class, instead of just parent props. As a result, we now also support `override: :get` and `override: :set`, or even `override: {get: {allow_incompatible: true}}`.

Currently, the runtime *only* checks whether the listed override happens at all, no typechecking. However, it does mean that the syntax is now valid, freeing it for use on the static side.


### Test plan

See included automated tests.
